### PR TITLE
feat(perl-semantic-analyzer): adapt ExportSymbolExtractor to ExportSet facts (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ version = "0.12.4"
 dependencies = [
  "perl-module",
  "perl-parser-core",
+ "perl-semantic-facts",
  "perl-symbol",
  "perl-tdd-support",
  "perl-test-generators",

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -27,6 +27,7 @@ perl-parser-core = { workspace = true }
 perl-module = { workspace = true }
 perl-workspace = { workspace = true }
 perl-symbol = { workspace = true }
+perl-semantic-facts = { workspace = true }
 regex.workspace = true
 rustc-hash = "2.1.2"
 tracing.workspace = true

--- a/crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs
@@ -27,6 +27,7 @@
 //! forms are extracted.
 
 use crate::ast::{Node, NodeKind};
+use perl_semantic_facts::{Confidence, ExportSet, ExportTag, Provenance};
 use std::collections::{HashMap, HashSet};
 
 /// Information extracted from an Exporter-based module.
@@ -38,6 +39,45 @@ pub struct ExportInfo {
     pub optional_export: HashSet<String>,
     /// Tag-based exports via `%EXPORT_TAGS` (tag name -> symbols)
     pub export_tags: HashMap<String, Vec<String>>,
+}
+
+
+
+impl ExportInfo {
+    /// Convert extracted exporter data into canonical semantic export facts.
+    ///
+    /// This adapter is intentionally conservative: only statically recognized
+    /// `@EXPORT`, `@EXPORT_OK`, and `%EXPORT_TAGS` assignments are represented.
+    pub fn to_export_set(&self) -> ExportSet {
+        let mut default_exports: Vec<String> = self.default_export.iter().cloned().collect();
+        default_exports.sort();
+
+        let mut optional_exports: Vec<String> = self.optional_export.iter().cloned().collect();
+        optional_exports.sort();
+
+        let mut tags: Vec<ExportTag> = self
+            .export_tags
+            .iter()
+            .map(|(tag, symbols)| {
+                let mut symbols = symbols.clone();
+                symbols.sort();
+                symbols.dedup();
+                ExportTag {
+                    tag: tag.clone(),
+                    symbols,
+                }
+            })
+            .collect();
+        tags.sort_by(|a, b| a.tag.cmp(&b.tag));
+
+        ExportSet {
+            default_exports,
+            optional_exports,
+            tags,
+            provenance: Provenance::ImportExportInference,
+            confidence: Confidence::High,
+        }
+    }
 }
 
 /// Detection method for Exporter inheritance.
@@ -651,4 +691,50 @@ our @EXPORT = qw(multi_func);
         let info = info.unwrap();
         assert!(info.default_export.contains("multi_func"));
     }
+
+
+    #[test]
+    fn export_info_to_export_set_captures_default_optional_and_tags() -> Result<(), Box<dyn std::error::Error>> {
+        let code = r#"
+package Demo;
+use Exporter 'import';
+our @EXPORT = qw(foo);
+our @EXPORT_OK = qw(bar baz);
+our %EXPORT_TAGS = (
+    all => [qw(foo bar baz)],
+);
+1;
+"#;
+        let info = parse_and_extract(code).ok_or("expected export info")?;
+        let export_set = info.to_export_set();
+
+        assert_eq!(export_set.default_exports, vec!["foo".to_string()]);
+        assert_eq!(export_set.optional_exports, vec!["bar".to_string(), "baz".to_string()]);
+        assert_eq!(export_set.tags.len(), 1);
+        assert_eq!(export_set.tags[0].tag, "all");
+        assert_eq!(
+            export_set.tags[0].symbols,
+            vec!["bar".to_string(), "baz".to_string(), "foo".to_string()]
+        );
+        assert_eq!(export_set.provenance, Provenance::ImportExportInference);
+        Ok(())
+    }
+
+    #[test]
+    fn export_info_to_export_set_supports_parent_exporter_inheritance() -> Result<(), Box<dyn std::error::Error>> {
+        let code = r#"
+package ParentStyle;
+use parent 'Exporter';
+our @EXPORT = qw(alpha);
+1;
+"#;
+        let info = parse_and_extract(code).ok_or("expected export info")?;
+        let export_set = info.to_export_set();
+
+        assert_eq!(export_set.default_exports, vec!["alpha".to_string()]);
+        assert!(export_set.optional_exports.is_empty());
+        assert!(export_set.tags.is_empty());
+        Ok(())
+    }
+
 }

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -142,6 +142,22 @@ pub struct EdgeFact {
     pub confidence: Confidence,
 }
 
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportTag {
+    pub tag: String,
+    pub symbols: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExportSet {
+    pub default_exports: Vec<String>,
+    pub optional_exports: Vec<String>,
+    pub tags: Vec<ExportTag>,
+    pub provenance: Provenance,
+    pub confidence: Confidence,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiagnosticFact {
     pub id: DiagnosticId,
@@ -232,6 +248,26 @@ mod tests {
         assert_eq!(decoded, fact);
         // entity_id: None must serialize as JSON null, not be omitted.
         assert!(serialized.contains("\"entity_id\":null"), "entity_id null must be explicit in JSON");
+        Ok(())
+    }
+
+
+    #[test]
+    fn export_set_roundtrips_with_tags() -> Result<(), serde_json::Error> {
+        let set = ExportSet {
+            default_exports: vec!["foo".to_string()],
+            optional_exports: vec!["bar".to_string(), "baz".to_string()],
+            tags: vec![ExportTag {
+                tag: "all".to_string(),
+                symbols: vec!["foo".to_string(), "bar".to_string(), "baz".to_string()],
+            }],
+            provenance: Provenance::ImportExportInference,
+            confidence: Confidence::High,
+        };
+
+        let serialized = serde_json::to_string(&set)?;
+        let decoded: ExportSet = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, set);
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- The exporter analysis produced `ExportInfo` internals but there was no canonical semantic-facts representation to carry deterministic default/optional/tag export data with provenance.

### Description

- Add `ExportTag` and `ExportSet` types to `crates/perl-semantic-facts/src/lib.rs` including `provenance` and `confidence` fields to represent export facts.
- Implement `ExportInfo::to_export_set()` in `crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs` to adapt extractor output into a deterministic `ExportSet` with sorted lists, deduped tag members, and `Provenance::ImportExportInference` and `Confidence::High`.
- Wire `perl-semantic-analyzer` to depend on `perl-semantic-facts` by updating `crates/perl-semantic-analyzer/Cargo.toml`.
- Add tests that exercise `to_export_set()` for `@EXPORT`, `@EXPORT_OK`, `%EXPORT_TAGS`, and a `use parent 'Exporter'` inheritance form, and add an `ExportSet` JSON roundtrip test in `perl-semantic-facts`.

### Testing

- Ran `cargo test -p perl-semantic-analyzer export` which passed all related tests.
- Ran `cargo test -p perl-semantic-facts` which passed the new `ExportSet` roundtrip test.
- Ran `cargo check --workspace --all-targets` which completed successfully (only existing workspace warnings were emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ceca55b48333ad43599204f3903c)