### PR TITLE
docs(semantic): update Wave 2 adapter/index status notes (#0000)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -112,6 +112,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Workspace-wide rename slice: multi-root support shipped in 0.12.x (#3984); workspace-wide rename/module-move remains roughly 30% complete and only conditionally in scope pending #3522 verification
 - Coroutine support issue #3539 is re-scoped: defer hypothetical core syntax, split upstream-tracking from CPAN-library IDE support planning
 - Semantic substrate first-wave planning is documented as rails-first (facts schema, fixture banks, scorecards, migration contracts) in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md); provider cutover is explicitly deferred until Wave 2/3 foundations are proven
+- Wave 2 adapter/index reality check: exact fact adapters are landed, fact shards are write-through, and definition-candidate + typed-reference indexes remain compatibility-only (shadow-compare/scorecard stage) before `ImportSpec` + `visible_symbols_at` Wave 3 cutover.
 
 ### Next (v0.13.0 — public alpha announcement)
 

--- a/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
+++ b/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
@@ -94,6 +94,42 @@ rename_plan(entity, new_name)
 safe_delete_plan(entity)
 ```
 
+## Wave 2 (Adapter / Index Implementation Status)
+
+Status legend used below:
+
+- ✅ Landed and wired
+- 🟡 Landed behind compatibility/write-through rails
+- ⏳ Planned next in Wave 2
+
+### Exact facts emitted now
+
+- ✅ `SymbolDecl -> EntityFact` adapter is landed.
+- ✅ `SymbolRef -> OccurrenceFact` adapter is landed.
+- ✅ `ExportInfo -> ExportSet` adapter is landed.
+
+### Workspace / index rollout status
+
+- 🟡 `FileFactShard` write-through is active in the workspace store; existing read paths remain authoritative.
+- 🟡 Definition-candidate multimap is present behind compatibility APIs and is not yet provider-facing.
+- 🟡 Typed reference-edge global index is present behind compatibility APIs and is not yet provider-facing.
+
+### Shadow-compare / receipts / scorecards
+
+- 🟡 Workspace shadow-compare receipt shape is defined and available for migration validation.
+- 🟡 Semantic scorecard v1 harness is wired, with metrics still in `baseline_pending` while provider cutover remains deferred.
+
+### Explicit non-goals for this phase
+
+- No LSP provider cutover yet.
+- No rename/safe-delete cutover yet.
+- No full type inference rollout.
+
+### Remaining Wave 2→3 bridge work
+
+- ⏳ Validate `ImportSpec` extraction as the bridge into provider-visible symbol queries.
+- ⏳ Implement `visible_symbols_at(uri, pos, context)` as the explicit Wave 3 provider-entry contract.
+
 ## Wave 2 (After First-Wave Rails Land)
 
 1. `SymbolDecl -> EntityFact` adapter.
@@ -129,4 +165,3 @@ safe_delete_plan(entity)
 - Capability truth: `features.toml`
 - Evidence-backed status: `docs/project/CURRENT_STATUS.md`
 - Canonical planning: `docs/project/ROADMAP.md`
-

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -35,4 +35,12 @@ Fixtures loaded: `12`
 | safe_delete_external_ref_detection | baseline_pending | n/a |
 | undefined_symbol_false_positive_rate | baseline_pending | n/a |
 
-Initial harness: metrics intentionally baseline_pending until semantic facts land.
+Initial harness: metrics intentionally baseline_pending while Wave 2 stays in adapter/index + shadow-compare mode.
+
+Wave 2 status snapshot:
+
+- Exact fact adapters are landed (`SymbolDecl -> EntityFact`, `SymbolRef -> OccurrenceFact`, `ExportInfo -> ExportSet`).
+- Fact shards are write-through in workspace storage.
+- Definition-candidate multimap and typed reference index are compatibility-only.
+- Provider cutover, rename/safe-delete cutover, and full type inference remain explicit non-goals.
+- Wave 3 migration target is `ImportSpec` + `visible_symbols_at` provider wiring.


### PR DESCRIPTION
### Motivation

- Keep the semantic-substrate documentation accurate to the current Wave 2 adapter/index rollout posture.  
- Make clear which facts and adapters are already emitted, which indexes are write-through or compatibility-only, and which behaviors remain explicit non-goals for provider cutover.  
- Point Wave 3 work at the concrete migration targets `ImportSpec` and `visible_symbols_at`.

### Description

- Updated `docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md` to add a Wave 2 “Adapter / Index Implementation Status” section including a status legend, the exact facts now emitted, workspace/index rollout notes (write-through `FileFactShard`, compatibility-only definition-candidate multimap and typed-reference index), shadow-compare/receipt status, explicit non-goals, and Wave 2→3 bridge items.  
- Added a concise Wave 2 reality-check bullet to `docs/project/ROADMAP.md` so the roadmap narrative matches the current adapter/index migration posture.  
- Revised `docs/project/status/semantic_scorecard.md` to reflect that the scorecard harness remains `baseline_pending` while Wave 2 runs adapters/indexes + shadow-compare, and documented the current migration boundaries and non-goals.  
- No code logic changes; only documentation updates across the three files named above.

### Testing

- Ran `cargo check --workspace --all-targets`, which completed successfully (warnings present but non-fatal).  
- No other automated test changes were required because this PR only edits documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cef089e08333a4245d111b8a2455)