### PR TITLE
feat(perl-semantic-facts): add SymbolRef occurrence adapter (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
 name = "perl-semantic-facts"
 version = "0.12.4"
 dependencies = [
+ "perl-symbol",
  "serde",
  "serde_json",
 ]

--- a/crates/perl-semantic-facts/Cargo.toml
+++ b/crates/perl-semantic-facts/Cargo.toml
@@ -26,6 +26,7 @@ doctest = false
 
 [dependencies]
 serde = { workspace = true }
+perl-symbol = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/perl-semantic-facts/src/adapters/mod.rs
+++ b/crates/perl-semantic-facts/src/adapters/mod.rs
@@ -1,0 +1,5 @@
+pub mod symbol_ref;
+
+pub use symbol_ref::{
+    SymbolRefFactIds, SymbolRefOccurrenceFacts, symbol_ref_to_occurrence_facts,
+};

--- a/crates/perl-semantic-facts/src/adapters/symbol_ref.rs
+++ b/crates/perl-semantic-facts/src/adapters/symbol_ref.rs
@@ -1,0 +1,73 @@
+use crate::{
+    AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityId, FileId, OccurrenceFact,
+    OccurrenceId, OccurrenceKind, Provenance, ScopeId,
+};
+use perl_symbol::surface::{SymbolRef, SymbolRefKind};
+
+/// Deterministic ID assignment for `SymbolRef` -> semantic occurrence facts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SymbolRefFactIds {
+    pub anchor_id: AnchorId,
+    pub occurrence_id: OccurrenceId,
+    pub edge_id: EdgeId,
+}
+
+/// Canonical semantic facts emitted for one projected `SymbolRef`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolRefOccurrenceFacts {
+    pub anchor: AnchorFact,
+    pub occurrence: OccurrenceFact,
+    pub references_edge: Option<EdgeFact>,
+}
+
+/// Adapter for phase-1 `SymbolRef` extraction into canonical semantic occurrence facts.
+///
+/// Intentional phase-2 exclusions remain the same as `SymbolRef` extraction:
+/// static/instance method calls, coderef/indirect call families, and typeglob aliases.
+pub fn symbol_ref_to_occurrence_facts(
+    symbol_ref: &SymbolRef,
+    ids: SymbolRefFactIds,
+    file_id: FileId,
+    scope_id: Option<ScopeId>,
+    from_entity_id: Option<EntityId>,
+    to_entity_id: Option<EntityId>,
+) -> SymbolRefOccurrenceFacts {
+    let anchor = AnchorFact {
+        id: ids.anchor_id,
+        file_id,
+        span_start_byte: symbol_ref.full_span.0 as u32,
+        span_end_byte: symbol_ref.full_span.1 as u32,
+        scope_id,
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+    };
+
+    let occurrence = OccurrenceFact {
+        id: ids.occurrence_id,
+        kind: occurrence_kind_for_symbol_ref_kind(&symbol_ref.kind),
+        entity_id: to_entity_id,
+        anchor_id: ids.anchor_id,
+        scope_id,
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+    };
+
+    let references_edge = from_entity_id.zip(to_entity_id).map(|(from, to)| EdgeFact {
+        id: ids.edge_id,
+        kind: EdgeKind::References,
+        from_entity_id: from,
+        to_entity_id: to,
+        via_occurrence_id: Some(ids.occurrence_id),
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+    });
+
+    SymbolRefOccurrenceFacts { anchor, occurrence, references_edge }
+}
+
+fn occurrence_kind_for_symbol_ref_kind(kind: &SymbolRefKind) -> OccurrenceKind {
+    match kind {
+        SymbolRefKind::Variable(_) => OccurrenceKind::Reference,
+        SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+    }
+}

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -8,6 +8,8 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod adapters;
+
 macro_rules! id_newtype {
     ($name:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/crates/perl-semantic-facts/tests/symbol_ref_adapter.rs
+++ b/crates/perl-semantic-facts/tests/symbol_ref_adapter.rs
@@ -1,0 +1,63 @@
+use perl_semantic_facts::adapters::{SymbolRefFactIds, symbol_ref_to_occurrence_facts};
+use perl_semantic_facts::{AnchorId, EdgeId, EntityId, FileId, OccurrenceId, OccurrenceKind, ScopeId};
+use perl_symbol::surface::{SymbolRef, SymbolRefKind};
+use perl_symbol::VarKind;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[test]
+fn variable_ref_maps_to_reference_occurrence_without_edge_when_entities_unknown() -> Result<()> {
+    let symbol_ref = SymbolRef {
+        kind: SymbolRefKind::Variable(VarKind::Scalar),
+        name: "count".to_string(),
+        qualified_name: "My::Pkg::count".to_string(),
+        sigil: Some("$".to_string()),
+        package_qualifier: Some("My::Pkg".to_string()),
+        full_span: (10, 15),
+        anchor_span: Some((10, 15)),
+    };
+
+    let facts = symbol_ref_to_occurrence_facts(
+        &symbol_ref,
+        SymbolRefFactIds { anchor_id: AnchorId(1), occurrence_id: OccurrenceId(2), edge_id: EdgeId(3) },
+        FileId(7),
+        Some(ScopeId(9)),
+        None,
+        None,
+    );
+
+    assert_eq!(facts.anchor.span_start_byte, 10);
+    assert_eq!(facts.anchor.span_end_byte, 15);
+    assert_eq!(facts.occurrence.kind, OccurrenceKind::Reference);
+    assert_eq!(facts.references_edge, None);
+    Ok(())
+}
+
+#[test]
+fn subroutine_call_maps_to_call_occurrence_and_references_edge() -> Result<()> {
+    let symbol_ref = SymbolRef {
+        kind: SymbolRefKind::SubroutineCall,
+        name: "run".to_string(),
+        qualified_name: "My::Pkg::run".to_string(),
+        sigil: None,
+        package_qualifier: Some("My::Pkg".to_string()),
+        full_span: (20, 27),
+        anchor_span: Some((20, 27)),
+    };
+
+    let facts = symbol_ref_to_occurrence_facts(
+        &symbol_ref,
+        SymbolRefFactIds { anchor_id: AnchorId(11), occurrence_id: OccurrenceId(12), edge_id: EdgeId(13) },
+        FileId(2),
+        None,
+        Some(EntityId(101)),
+        Some(EntityId(202)),
+    );
+
+    assert_eq!(facts.occurrence.kind, OccurrenceKind::Call);
+    let edge = facts.references_edge.as_ref().ok_or("expected references edge")?;
+    assert_eq!(edge.from_entity_id, EntityId(101));
+    assert_eq!(edge.to_entity_id, EntityId(202));
+    assert_eq!(edge.via_occurrence_id, Some(OccurrenceId(12)));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Phase-1 `SymbolRef` projection existed but there was no canonical adapter to emit semantic occurrence/reference facts for downstream consumers.

### Description

- Add a new `adapters` module and export it from the `perl-semantic-facts` crate root via `pub mod adapters;`.
- Implement `symbol_ref_to_occurrence_facts` in `adapters/symbol_ref.rs` which produces `AnchorFact`, `OccurrenceFact`, and an optional `EdgeFact` (`EdgeKind::References`) and preserves phase-2 exclusions.
- Introduce deterministic helper types `SymbolRefFactIds` and `SymbolRefOccurrenceFacts` to carry IDs and assembled facts.
- Add tests in `crates/perl-semantic-facts/tests/symbol_ref_adapter.rs` and add `perl-symbol` as a dependency in `crates/perl-semantic-facts/Cargo.toml` to consume `SymbolRef` input types.

### Testing

- Ran `cargo test -p perl-symbol` which completed successfully with all existing symbol tests passing.
- Ran `cargo test -p perl-semantic-facts` which completed successfully including the two new adapter tests that assert variable and subroutine mappings.
- Ran `cargo check --workspace --all-targets` which completed successfully (workspace-only warnings were unchanged and unrelated to the adapter).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cec583048333b20c4580ce7913c9)