### PR TITLE
feat(perl-semantic-analyzer): adapt ExportSymbolExtractor to ExportSet facts (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ version = "0.12.4"
 dependencies = [
  "perl-module",
  "perl-parser-core",
+ "perl-semantic-facts",
  "perl-symbol",
  "perl-tdd-support",
  "perl-test-generators",

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -30,6 +30,7 @@ perl-symbol = { workspace = true }
 regex.workspace = true
 rustc-hash = "2.1.2"
 tracing.workspace = true
+perl-semantic-facts = { workspace = true }
 
 [dev-dependencies]
 perl-tdd-support = { workspace = true }

--- a/crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs
@@ -27,6 +27,7 @@
 //! forms are extracted.
 
 use crate::ast::{Node, NodeKind};
+use perl_semantic_facts::{ExportSet, Provenance};
 use std::collections::{HashMap, HashSet};
 
 /// Information extracted from an Exporter-based module.
@@ -404,6 +405,29 @@ impl ExportSymbolExtractor {
             NodeKind::Identifier { name } => Some(name.clone()),
             _ => None,
         }
+    }
+}
+
+impl From<ExportInfo> for ExportSet {
+    fn from(info: ExportInfo) -> Self {
+        let mut export_tags = std::collections::BTreeMap::new();
+        for (tag, symbols) in info.export_tags {
+            export_tags.insert(tag, symbols.into_iter().collect());
+        }
+
+        ExportSet::new(
+            info.default_export.into_iter().collect(),
+            info.optional_export.into_iter().collect(),
+            export_tags,
+            Provenance::ImportExportInference,
+        )
+    }
+}
+
+impl ExportInfo {
+    /// Convert extracted Exporter analysis into canonical export facts.
+    pub fn to_export_set(self) -> ExportSet {
+        self.into()
     }
 }
 

--- a/crates/perl-semantic-analyzer/tests/import_export_visibility_regression_bank.rs
+++ b/crates/perl-semantic-analyzer/tests/import_export_visibility_regression_bank.rs
@@ -6,6 +6,7 @@
 
 use perl_semantic_analyzer::Parser;
 use perl_semantic_analyzer::analysis::export_analyzer::{ExportInfo, ExportSymbolExtractor};
+use perl_semantic_facts::Provenance;
 use std::error::Error;
 
 fn extract_export_info(code: &str) -> Result<ExportInfo, Box<dyn Error>> {
@@ -78,5 +79,55 @@ our @EXPORT_OK = qw(fake_optional);
         info.is_none(),
         "module without Exporter inheritance must not produce export info"
     );
+    Ok(())
+}
+
+#[test]
+fn export_set_adapter_captures_default_optional_and_tags() -> Result<(), Box<dyn Error>> {
+    let code = r#"
+package AdapterFixture;
+use Exporter 'import';
+our @EXPORT = qw(default_one);
+our @EXPORT_OK = qw(optional_one optional_two);
+our %EXPORT_TAGS = (
+  all => [qw(default_one optional_one optional_two)],
+  opt => [qw(optional_one optional_two)],
+);
+1;
+"#;
+
+    let info = extract_export_info(code)?;
+    let export_set = info.to_export_set();
+
+    assert!(export_set.default_exports.contains("default_one"));
+    assert!(export_set.optional_exports.contains("optional_one"));
+    assert!(export_set.optional_exports.contains("optional_two"));
+    assert_eq!(export_set.provenance, Provenance::ImportExportInference);
+
+    let all_tag = export_set.export_tags.get("all").ok_or("missing :all tag")?;
+    assert!(all_tag.contains("default_one"));
+    assert!(all_tag.contains("optional_one"));
+    assert!(all_tag.contains("optional_two"));
+    Ok(())
+}
+
+#[test]
+fn export_set_adapter_supports_parent_exporter_inheritance_form() -> Result<(), Box<dyn Error>> {
+    let code = r#"
+package ParentAdapter;
+use parent 'Exporter';
+our @EXPORT = qw(alpha);
+our @EXPORT_OK = qw(beta);
+our %EXPORT_TAGS = (
+  both => [qw(alpha beta)],
+);
+1;
+"#;
+
+    let info = extract_export_info(code)?;
+    let export_set = info.to_export_set();
+    assert!(export_set.default_exports.contains("alpha"));
+    assert!(export_set.optional_exports.contains("beta"));
+    assert!(export_set.export_tags.contains_key("both"));
     Ok(())
 }

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -7,6 +7,7 @@
 //! storage backends.
 
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 
 macro_rules! id_newtype {
     ($name:ident) => {
@@ -154,6 +155,48 @@ pub struct DiagnosticFact {
     pub confidence: Confidence,
 }
 
+/// Canonical export surface for an exporting package.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ExportSet {
+    /// Symbols available by default import.
+    pub default_exports: BTreeSet<String>,
+    /// Symbols available for explicit opt-in import.
+    pub optional_exports: BTreeSet<String>,
+    /// Export tags/groups and their member symbols.
+    pub export_tags: BTreeMap<String, BTreeSet<String>>,
+    /// How this export information was inferred.
+    pub provenance: Provenance,
+}
+
+impl Default for ExportSet {
+    fn default() -> Self {
+        Self {
+            default_exports: BTreeSet::new(),
+            optional_exports: BTreeSet::new(),
+            export_tags: BTreeMap::new(),
+            provenance: Provenance::ImportExportInference,
+        }
+    }
+}
+
+impl ExportSet {
+    /// Build an [`ExportSet`] from normalized export collections.
+    pub fn new(
+        default_exports: BTreeSet<String>,
+        optional_exports: BTreeSet<String>,
+        export_tags: BTreeMap<String, BTreeSet<String>>,
+        provenance: Provenance,
+    ) -> Self {
+        Self {
+            default_exports,
+            optional_exports,
+            export_tags,
+            provenance,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,6 +287,24 @@ mod tests {
         let serialized = serde_json::to_string(&id)?;
         let decoded: EntityId = serde_json::from_str(&serialized)?;
         assert_eq!(decoded, id);
+        Ok(())
+    }
+
+    #[test]
+    fn export_set_roundtrips_through_json() -> Result<(), serde_json::Error> {
+        let mut facts = ExportSet {
+            default_exports: BTreeSet::from(["foo".to_string()]),
+            optional_exports: BTreeSet::from(["bar".to_string(), "baz".to_string()]),
+            export_tags: BTreeMap::new(),
+            provenance: Provenance::ImportExportInference,
+        };
+        facts
+            .export_tags
+            .insert("all".to_string(), BTreeSet::from(["foo".to_string(), "bar".to_string()]));
+
+        let serialized = serde_json::to_string(&facts)?;
+        let decoded: ExportSet = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, facts);
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Downstream semantic layers require a canonical, provenance-bearing representation of a package's export surface rather than the ad-hoc `ExportInfo` used by the extractor.
- Existing Exporter analysis already detects `@EXPORT`, `@EXPORT_OK`, and `%EXPORT_TAGS` and should be surfaced as deterministic semantic facts for import/export reasoning.

### Description

- Added a new `ExportSet` semantic fact type to `crates/perl-semantic-facts` capturing `default_exports`, `optional_exports`, `export_tags`, and `provenance`, plus `Default` and a `new` constructor.
- Implemented an adapter in `crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs` with `impl From<ExportInfo> for ExportSet` and `ExportInfo::to_export_set()` that maps extractor output into an `ExportSet` with `Provenance::ImportExportInference`.
- Wired `perl-semantic-analyzer` to depend on `perl-semantic-facts` by updating `Cargo.toml` and updated code to use the new type.
- Added tests: a JSON roundtrip test for `ExportSet` in `perl-semantic-facts` and regression tests in `perl-semantic-analyzer` that verify `@EXPORT`, `@EXPORT_OK`, `%EXPORT_TAGS`, and the `use parent 'Exporter'` inheritance path are correctly adapted.

### Testing

- Ran `cargo test -p perl-semantic-analyzer export` and the export-focused test suite passed.
- Ran `cargo test -p perl-semantic-facts` and all crate tests passed, including the new `export_set_roundtrips_through_json` test.
- Ran `cargo check --workspace --all-targets` and the workspace checked successfully with the new dependency and code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ceca55b48333ad43599204f3903c)