### PR TITLE
docs(semantic): refresh wave 2 adapter migration notes (#0000)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -111,7 +111,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - AI inline completion (#3018) shipped in the live 0.12.x line — feature wired end-to-end via #3157–#3168, awaiting E2E user validation
 - Workspace-wide rename slice: multi-root support shipped in 0.12.x (#3984); workspace-wide rename/module-move remains roughly 30% complete and only conditionally in scope pending #3522 verification
 - Coroutine support issue #3539 is re-scoped: defer hypothetical core syntax, split upstream-tracking from CPAN-library IDE support planning
-- Semantic substrate first-wave planning is documented as rails-first (facts schema, fixture banks, scorecards, migration contracts) in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md); provider cutover is explicitly deferred until Wave 2/3 foundations are proven
+- Semantic substrate first-wave planning is documented as rails-first (facts schema, fixture banks, scorecards, migration contracts) in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md); Wave 2 adapters/indexes are now implementation-started, but provider cutover remains explicitly deferred until Wave 3 (`ImportSpec` + `visible_symbols_at`) foundations are proven
 
 ### Next (v0.13.0 — public alpha announcement)
 

--- a/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
+++ b/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
@@ -94,19 +94,41 @@ rename_plan(entity, new_name)
 safe_delete_plan(entity)
 ```
 
-## Wave 2 (After First-Wave Rails Land)
+## Wave 2 (Current Implementation Status)
 
-1. `SymbolDecl -> EntityFact` adapter.
-2. `SymbolRef -> OccurrenceFact` adapter.
-3. `ExportInfo -> ExportSet` adapter.
-4. `FileFactShard` write-through in workspace store.
-5. Definition-candidate multimap behind compatibility APIs.
-6. Typed reference-edge global index behind compatibility APIs.
+Wave 2 implementation has started. The substrate now includes the following rails and adapter/index
+behaviors:
+
+### Exact facts emitted now
+
+- `EntityFact` is emitted from `SymbolDecl` adapter paths.
+- `OccurrenceFact` is emitted from `SymbolRef` adapter paths.
+- `ExportSet` is emitted from `ExportInfo` adapter paths.
+
+### Workspace storage / index status
+
+- `FileFactShard` is **write-through enabled** in workspace storage.
+- Definition candidate multimap is present as a **compatibility-layer backing index**.
+- Typed reference-edge global index is present as a **compatibility-layer backing index**.
+
+### Shadow compare + scorecard status
+
+- Shadow-compare receipts are available as an implementation receipt surface for parity tracking.
+- Semantic scorecard v1 harness is integrated; metrics remain intentionally staged while provider cutover is deferred.
+
+### Explicit non-goals (still true in Wave 2)
+
+- No provider cutover yet.
+- No rename/safe-delete cutover yet.
+- No full type inference.
 
 ## Wave 3 (User-Visible Cutover Staging)
 
+Wave 3 remains focused on landing the `ImportSpec` + `visible_symbols_at` bridge that unblocks
+provider-facing behavior:
+
 1. `ImportSpec` extraction.
-2. `VisibleSymbols` query implementation.
+2. `visible_symbols_at` query implementation (`VisibleSymbols` substrate query).
 3. Completion consumes `VisibleSymbols` behind a feature flag.
 4. Undefined diagnostics consume `VisibleSymbols` behind a feature flag.
 
@@ -129,4 +151,3 @@ safe_delete_plan(entity)
 - Capability truth: `features.toml`
 - Evidence-backed status: `docs/project/CURRENT_STATUS.md`
 - Canonical planning: `docs/project/ROADMAP.md`
-

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -35,4 +35,4 @@ Fixtures loaded: `12`
 | safe_delete_external_ref_detection | baseline_pending | n/a |
 | undefined_symbol_false_positive_rate | baseline_pending | n/a |
 
-Initial harness: metrics intentionally baseline_pending until semantic facts land.
+Initial harness: metrics intentionally baseline_pending during Wave 2 adapter/index bring-up and shadow-compare receipt collection. Provider-facing cutover remains deferred to Wave 3 (`ImportSpec` + `visible_symbols_at`).


### PR DESCRIPTION
### Motivation

- The Wave 2 semantic substrate work has moved from plan to partial implementation, and the docs needed to reflect the current adapter/index and parity-tracking status rather than future intent. 
- The repository now emits several exact facts and hosts write-through/index behaviors and shadow-compare receipts that must be recorded so the roadmap and scorecard remain accurate and actionable.

### Description

- Updated `docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md` to replace the Wave 2 planned checklist with a current-status section that documents exact facts emitted (`EntityFact`, `OccurrenceFact`, `ExportSet`), `FileFactShard` write-through behavior, compatibility-layer definition-candidate and typed-reference indexes, shadow-compare receipt availability, scorecard v1 staging, and retained non-goals. 
- Updated `docs/project/ROADMAP.md` to note that Wave 2 adapters/indexes are implementation-started while explicitly deferring provider cutover until Wave 3 (`ImportSpec` + `visible_symbols_at`).
- Updated `docs/project/status/semantic_scorecard.md` to clarify that the scorecard metrics are `baseline_pending` while Wave 2 adapter/index bring-up and shadow-compare receipt collection proceed and that provider-facing cutover is deferred to Wave 3.

### Testing

- Ran `cargo check --workspace --all-targets`, which progressed to compilation with warnings but without errors reported. 
- Re-ran `cargo check --workspace --all-targets -q` to verify the change in a quiet mode and observed no failing build errors. 
- No automated test changes were required for these doc-only updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cef089e08333a4245d111b8a2455)