### PR TITLE
docs(semantic): update wave-2 adapter/index migration status (#0000)

### DIFF
--- a/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
+++ b/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
@@ -94,14 +94,29 @@ rename_plan(entity, new_name)
 safe_delete_plan(entity)
 ```
 
-## Wave 2 (After First-Wave Rails Land)
+## Wave 2 (Adapter/Index Bring-Up)
 
-1. `SymbolDecl -> EntityFact` adapter.
-2. `SymbolRef -> OccurrenceFact` adapter.
-3. `ExportInfo -> ExportSet` adapter.
-4. `FileFactShard` write-through in workspace store.
-5. Definition-candidate multimap behind compatibility APIs.
-6. Typed reference-edge global index behind compatibility APIs.
+Wave 2 began implementation and is intentionally **adapter/index only**. Current state:
+
+1. `SymbolDecl -> EntityFact` adapter: **in progress / partial**.
+2. `SymbolRef -> OccurrenceFact` adapter: **in progress / partial**.
+3. `ExportInfo -> ExportSet` adapter: **in progress / partial**.
+4. `FileFactShard` write-through in workspace store: **write-through only** (no provider cutover).
+5. Definition-candidate multimap behind compatibility APIs: **staged behind compatibility surface**.
+6. Typed reference-edge global index behind compatibility APIs: **staged behind compatibility surface**.
+7. Workspace shadow-compare receipt shape: **planning scaffold in place; behavioral receipts pending**.
+
+### Exact fact surface currently modeled
+
+Wave 2 adapters target the canonical vocabulary from `perl-semantic-facts`:
+
+- Anchor facts (`AnchorFact`)
+- Entity facts (`EntityFact`)
+- Occurrence facts (`OccurrenceFact`)
+- Edge facts (`EdgeFact`)
+- Diagnostic facts (`DiagnosticFact`)
+
+This means adapter work is constrained to translating existing semantic producers into these fact records with typed IDs/provenance/confidence, without changing provider behavior yet.
 
 ## Wave 3 (User-Visible Cutover Staging)
 
@@ -110,9 +125,13 @@ safe_delete_plan(entity)
 3. Completion consumes `VisibleSymbols` behind a feature flag.
 4. Undefined diagnostics consume `VisibleSymbols` behind a feature flag.
 
+Wave 3 is explicitly where `ImportSpec` + `visible_symbols_at(...)` become the bridge from substrate rails to provider-facing behavior.
+
 ## Out of Scope for First Wave
 
 - Full provider migration.
+- Rename/safe-delete provider cutover.
+- Full type inference.
 - Broad rewrite of existing semantic producers.
 - Claiming implementation completeness before fixtures and scorecards prove behavior.
 
@@ -129,4 +148,3 @@ safe_delete_plan(entity)
 - Capability truth: `features.toml`
 - Evidence-backed status: `docs/project/CURRENT_STATUS.md`
 - Canonical planning: `docs/project/ROADMAP.md`
-

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -36,3 +36,24 @@ Fixtures loaded: `12`
 | undefined_symbol_false_positive_rate | baseline_pending | n/a |
 
 Initial harness: metrics intentionally baseline_pending until semantic facts land.
+
+## Wave 2 adapter/index migration status
+
+| Area | Status | Notes |
+|---|---|---|
+| Exact facts emitted | In progress | Canonical fact model is fixed (`AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, `DiagnosticFact`); adapters are being wired incrementally. |
+| Fact shard write-through | Active (write-through only) | Workspace ingestion is substrate-only and intentionally not provider-facing yet. |
+| Definition candidate multimap | Staged | Compatibility-layer path exists for staged adoption; not yet cut over as sole definition source. |
+| Typed reference index | Staged | Typed-edge/index groundwork is staged behind compatibility behavior. |
+| Shadow-compare receipts | Planning scaffold | Receipt shape/planning exists; full behavior parity receipts are pending. |
+| Scorecard v1 | Scaffold/baseline pending | Fixture bank is live; metric rows stay `baseline_pending` until adapters/indexes are fully producing stable comparable outputs. |
+
+### Explicit non-goals for this wave
+
+- No provider cutover yet.
+- No rename/safe-delete cutover yet.
+- No full type inference.
+
+### Wave 3 pointer
+
+Next substantive cutover work is intentionally centered on `ImportSpec` extraction + `visible_symbols_at` implementation.


### PR DESCRIPTION
### Motivation

- Keep the semantic-substrate docs accurate now that Wave 2 adapter/index work is underway and prevent readers from treating Wave 2 as purely future planning. 
- Make explicit what the adapters currently emit, the write-through-only staging, and which behaviors are intentionally deferred to later waves. 
- Point future implementers at the concrete Wave 3 integration targets (`ImportSpec` + `visible_symbols_at`) so cutover work is scoped.

### Description

- Convert the Wave 2 checklist into a current-state snapshot in `docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md`, marking adapters as in-progress/partial and `FileFactShard` as write-through only. 
- Add the exact fact vocabulary currently modeled (`AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, `DiagnosticFact`) to the Wave 2 section. 
- Clarify explicit non-goals (no provider cutover, no rename/safe-delete cutover, no full type inference) and add a Wave 3 pointer to `ImportSpec` + `visible_symbols_at`. 
- Add a Wave 2 adapter/index migration status table and the same explicit non-goals to `docs/project/status/semantic_scorecard.md` so status surfaces reflect implementation staging.

### Testing

- Ran `cargo check --workspace --all-targets` which completed successfully (warnings are present from unrelated, existing code). 
- No unit tests were modified or disabled; the change is documentation-only and does not alter runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1cef089e08333a4245d111b8a2455)