### PR TITLE
chore(release): start v0.13.0-rc1 prep (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,7 +1479,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1488,14 +1488,14 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "chrono",
  "clap",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "perl-corpus"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-workspace",
  "serde",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-test-must",
  "serde",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lexer"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "criterion",
  "memchr",
@@ -1604,11 +1604,11 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.12.4"
+version = "0.13.0-rc1"
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-subprocess-runtime",
  "perl-tdd-support",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs-core"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ux-tests"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-parser-core",
  "perl-tdd-support",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-bench"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-parser",
  "walkdir",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -1797,11 +1797,11 @@ dependencies = [
 
 [[package]]
 name = "perl-pod"
-version = "0.12.4"
+version = "0.13.0-rc1"
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "criterion",
  "perl-ast",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "proptest",
  "thiserror",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-facts"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1869,14 +1869,14 @@ dependencies = [
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "lsp-types",
  "perl-parser-core",
@@ -1901,18 +1901,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.12.4"
+version = "0.13.0-rc1"
 
 [[package]]
 name = "perl-token"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "criterion",
  "perl-lexer",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "perllsp"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -3162,7 +3162,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl-c"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-perl-rs"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "insta",
  "perl-ast",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.12.4"
+version = "0.13.0-rc1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.12.4"
+version = "0.13.0-rc1"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -212,26 +212,26 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.12.4" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.13.0-rc1" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.12.4" }
-perl-regex = { path = "crates/perl-regex", version = "0.12.4" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.12.4" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.12.4" }
-perl-ast = { path = "crates/perl-ast", version = "0.12.4" }
+perl-token = { path = "crates/perl-token", version = "0.13.0-rc1" }
+perl-regex = { path = "crates/perl-regex", version = "0.13.0-rc1" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.13.0-rc1" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.13.0-rc1" }
+perl-ast = { path = "crates/perl-ast", version = "0.13.0-rc1" }
 # Wave D absorbed (internal modules in perl-parser/src/):
 #   perl-heredoc-anti-patterns → perl-parser::heredoc_anti_patterns
 # Wave D absorbed (internal modules in perl-parser-core/src/syntax/):
 #   perl-quote, perl-heredoc, perl-error, perl-edit
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.12.4" }
-perl-symbol = { path = "crates/perl-symbol", version = "0.12.4" }
-perl-module = { path = 'crates/perl-module', version = "0.12.4" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.13.0-rc1" }
+perl-symbol = { path = "crates/perl-symbol", version = "0.13.0-rc1" }
+perl-module = { path = 'crates/perl-module', version = "0.13.0-rc1" }
 # Wave D absorbed: perl-qualified-name → perl-parser::qualified_name
-perl-line-index = { path = "crates/perl-line-index", version = "0.12.4" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.13.0-rc1" }
 # Wave D absorbed: perl-source-file → perl-parser::source_file
 # Wave D absorbed: perl-text-line → perl-parser-core::text_line
 # (perl-content-length-framing absorbed into perl-lsp-rs-core::transport::framing — Wave Final PR B)
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.12.4" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.13.0-rc1" }
 # (perl-lsp-document-highlight absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-document-links absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-performance absorbed into perl-lsp-rs-core::tooling::performance — Wave G3 step 5)
@@ -239,29 +239,29 @@ perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "
 # Wave D absorbed: perl-ast-utils → perl-parser::ast_utils
 # (perl-lsp-input-validation absorbed into perl-lsp-rs-core::runtime::input_validation — Wave G2)
 # (perl-lsp-text-utils absorbed into perl-lsp-rs-core::runtime::text_utils — Wave G2)
-perl-uri = { path = "crates/perl-uri", version = "0.12.4" }
+perl-uri = { path = "crates/perl-uri", version = "0.13.0-rc1" }
 # Wave D absorbed: perl-percentile → perl-parser::percentile
 # (perl-lsp-import-management absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-critic-parser absorbed into perl-lsp-rs-core::critic_parser — Wave G3 step 7)
 # (perl-lsp-protocol absorbed into perl-lsp-rs-core::protocol — Wave G3 step 2)
 # Wave D absorbed: perl-path-normalize → perl-parser-core::path_normalize
 # Wave D absorbed: perl-path-security → perl-parser-core::path_security
-perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.12.4" }
-perl-pod = { path = "crates/perl-pod", version = "0.12.4" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.12.4" }
-perl-dap = { path = "crates/perl-dap", version = "0.12.4" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.12.4" }
+perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.13.0-rc1" }
+perl-pod = { path = "crates/perl-pod", version = "0.13.0-rc1" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.13.0-rc1" }
+perl-dap = { path = "crates/perl-dap", version = "0.13.0-rc1" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.13.0-rc1" }
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.12.4" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.13.0-rc1" }
 # (perl-lsp-transport absorbed into perl-lsp-rs-core::transport — Wave G3 step 4)
 # (perl-lsp-tooling absorbed into perl-lsp-rs-core::tooling — Wave G3 step 6)
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.12.4" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.13.0-rc1" }
 # (perl-lsp-on-type-formatting absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting-types absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting absorbed into perl-lsp-rs-core::providers::formatting — Wave G1b)
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.12.4" }
-perl-test-must = { path = "crates/perl-test-must", version = "0.12.4" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.13.0-rc1" }
+perl-test-must = { path = "crates/perl-test-must", version = "0.13.0-rc1" }
 # (perl-lsp-diagnostics absorbed into perl-lsp-rs-core::providers::diagnostics — Wave G1b)
 # (perl-lsp-semantic-tokens absorbed into perl-lsp-rs-core::providers::semantic_tokens — Wave G1b)
 # (perl-lsp-inlay-hints absorbed into perl-lsp-rs-core::providers — Wave G1a)
@@ -285,28 +285,28 @@ perl-test-must = { path = "crates/perl-test-must", version = "0.12.4" }
 # (perl-lsp-code-actions absorbed into perl-lsp-rs-core::providers::code_actions — Wave G1b)
 # (perl-lsp-folding absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-selection-range absorbed into perl-lsp-rs-core::providers — Wave G1a)
-perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.12.4" }
+perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.13.0-rc1" }
 # Tier 3: Two-level dependencies
-perl-workspace = { path = "crates/perl-workspace-index", version = "0.12.4" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.12.4" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.12.4" }
+perl-workspace = { path = "crates/perl-workspace-index", version = "0.13.0-rc1" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.13.0-rc1" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.13.0-rc1" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.12.4" }
-perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.12.4" }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.13.0-rc1" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.13.0-rc1" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.12.4" }
-perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.12.4" }
-perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.12.4" }
+perl-parser = { path = "crates/perl-parser", version = "0.13.0-rc1" }
+perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.13.0-rc1" }
+perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.13.0-rc1" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.12.4" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.13.0-rc1" }
 
 # External dependencies
-tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.12.4" }
-tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.12.4" }
+tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.13.0-rc1" }
+tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.13.0-rc1" }
 tree-sitter = "0.26.8"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For a full walkthrough, see [Getting Started](docs/tutorials/GETTING_STARTED.md)
 
 ## Status
 
-**v0.12.4** — public alpha. See [status](docs/project/status/index.md) for live metrics and [roadmap](docs/project/ROADMAP.md) for the v0.13.0 milestone.
+**v0.13.0-rc1** — release candidate 1. See [status](docs/project/status/index.md) for live metrics and [roadmap](docs/project/ROADMAP.md) for the v0.13.0 milestone.
 
 ## Contributing
 

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-module"
-version = "0.12.4"
+version = "0.13.0-rc1"
 publish = true
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
### Motivation
- Begin release-candidate preparation by moving the workspace and crate versions from `0.12.4` to `0.13.0-rc1` so the repo reflects the v0.13.0-rc1 release graph.
- Update the project `README.md` status line to communicate RC1 status to users.

### Description
- Updated the workspace package version and all workspace dependency pins in `Cargo.toml` from `0.12.4` to `0.13.0-rc1`.
- Bumped the `crates/perl-module/Cargo.toml` package version to `0.13.0-rc1` to align with the workspace dependency graph.
- Updated the status line in `README.md` to `v0.13.0-rc1`.
- Regenerated `Cargo.lock` entries so locked package versions reflect `0.13.0-rc1`.

### Testing
- Ran `cargo check --all-targets -p perl-lsp-rs`, which completed successfully.
- No tests were changed; `cargo check` emitted warnings about unused test helpers but no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f204ec46bc8333908c7635a1f43770)