### PR TITLE
docs(release): start v0.13.0-rc1 prep notes (#0000)

### DIFF
--- a/docs/releases/v0.13.0rc1.md
+++ b/docs/releases/v0.13.0rc1.md
@@ -1,0 +1,54 @@
+---
+version: "0.13.0-rc1"
+tag: "v0.13.0-rc1"
+release_date_utc: pending
+tag_commit: pending
+previous_tag: "v0.12.4"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0-rc1"
+notes_status: draft
+channels:
+  crates_io: planned
+  vscode_marketplace: planned
+  open_vsx: planned
+  docker: planned
+assets:
+  - perllsp-0.13.0-rc1-aarch64-apple-darwin.tar.gz
+  - perllsp-0.13.0-rc1-aarch64-unknown-linux-gnu.tar.gz
+  - perllsp-0.13.0-rc1-aarch64-unknown-linux-musl.tar.gz
+  - perllsp-0.13.0-rc1-x86_64-apple-darwin.tar.gz
+  - perllsp-0.13.0-rc1-x86_64-pc-windows-msvc.zip
+  - perllsp-0.13.0-rc1-x86_64-unknown-linux-gnu.tar.gz
+  - perllsp-0.13.0-rc1-x86_64-unknown-linux-musl.tar.gz
+  - sbom-spdx.json
+  - SHA256SUMS
+---
+
+# v0.13.0-rc1 (draft)
+
+## Purpose
+
+Start release-candidate prep for the v0.13 line by creating a canonical notes
+stub and artifact checklist for `0.13.0-rc1`.
+
+## Candidate release scope (to finalize)
+
+- Microcrate collapse landing set for the v0.13 clean break.
+- Migration guide validation (`docs/MIGRATION_v0.13.md`) against published APIs.
+- Release evidence bundle generation and verification.
+
+## Preflight checklist
+
+- [ ] Run version bump workflow for `0.13.0-rc1`.
+- [ ] Regenerate lockfiles/manifests and run formatting.
+- [ ] Run `just pr-fast` on the release-prep branch.
+- [ ] Run `cargo xtask release evidence --version 0.13.0-rc1`.
+- [ ] Run `cargo xtask release verify-evidence --version 0.13.0-rc1 --receipt target/receipts/release-evidence.json`.
+- [ ] Draft release notes highlights from merged PR clusters.
+- [ ] Validate install docs for asset naming (`perllsp-<version>-<target>`).
+
+## Links
+
+- [Migration Guide (v0.13.0)](../MIGRATION_v0.13.md)
+- [Publishing Runbook](../PUBLISHING.md)
+- [Release Evidence Contract](../ci/release-evidence.md)


### PR DESCRIPTION
### Motivation
- Provide a canonical draft release-notes stub and preflight checklist to anchor release-candidate prep for the upcoming v0.13.0 line.

### Description
- Add `docs/releases/v0.13.0rc1.md` containing front-matter metadata, planned channels and asset names, candidate scope, a concrete preflight checklist, and links to the migration and publishing runbooks.

### Testing
- This is a docs-only change; verified repository state with `git status`, created the commit `docs(release): start v0.13.0-rc1 prep notes (#0000)`, and inspected the new file contents with `nl`/`sed` (all commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f204ec46bc8333908c7635a1f43770)