### PR TITLE
fix(ci): avoid label-triggered UX gate cancellations (#7286)

### DIFF
--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -10,7 +10,10 @@ name: UX Regression Gate
 on:
   pull_request:
     branches: [main, master]
-    types: [opened, synchronize, reopened, labeled]
+    # Deliberately exclude `labeled` / `unlabeled` — label application can
+    # retrigger this workflow and cancel the in-progress run under
+    # `cancel-in-progress`, creating avoidable CI churn.
+    types: [opened, synchronize, reopened]
     paths:
       - 'crates/perl-lsp*/**'
       - 'crates/perl-dap*/**'


### PR DESCRIPTION
### Motivation
- Prevent the UX Regression Gate from being retriggered and cancelling in-progress runs when labels are applied, which previously caused CI churn under `cancel-in-progress`.

### Description
- Update `.github/workflows/ux-regression-gate.yml` by removing `labeled` from `pull_request.types` and adding an inline comment explaining the exclusion.

### Testing
- Verified the change with `git diff -- .github/workflows/ux-regression-gate.yml` showing the trigger update and committed the change as `fix(ci): avoid label-triggered UX gate cancellations (#7286)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20566b8d0833396dedc5d123f6f41)