### PR TITLE
fix(ci): prevent label-triggered UX gate restarts (#7286)

### DIFF
--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -10,7 +10,10 @@ name: UX Regression Gate
 on:
   pull_request:
     branches: [main, master]
-    types: [opened, synchronize, reopened, labeled]
+    # Deliberately exclude `labeled` / `unlabeled` — label application should not
+    # restart this workflow under `cancel-in-progress`, or operators lose active CI
+    # runs to label churn instead of code changes.
+    types: [opened, synchronize, reopened]
     paths:
       - 'crates/perl-lsp*/**'
       - 'crates/perl-dap*/**'


### PR DESCRIPTION
### Motivation

- Prevent label events from cancelling and restarting the UX Regression Gate under `cancel-in-progress`, which recreated the CI cancellation cascade and interfered with normal non-admin merges.

### Description

- Removed `labeled`/`unlabeled` label-trigger coverage from the `pull_request` `types` in `.github/workflows/ux-regression-gate.yml` and added an inline comment explaining why label events are intentionally excluded.

### Testing

- Verified the change and committed it: `git diff -- .github/workflows/ux-regression-gate.yml` shows the labeled trigger removal and explanatory comment, and `git commit` completed; no unit tests apply to this workflow YAML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20566b8d0833396dedc5d123f6f41)