### PR TITLE
fix(ci): prevent UX gate label-trigger cancellation cascade (#7286)

### DIFF
--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -10,7 +10,10 @@ name: UX Regression Gate
 on:
   pull_request:
     branches: [main, master]
-    types: [opened, synchronize, reopened, labeled]
+    # Deliberately exclude `labeled` / `unlabeled` — label application can trigger a
+    # fresh run that cancels the prior in-progress run under `cancel-in-progress`.
+    # Mirror main CI behavior to avoid label-driven cancellation cascades.
+    types: [opened, synchronize, reopened]
     paths:
       - 'crates/perl-lsp*/**'
       - 'crates/perl-dap*/**'


### PR DESCRIPTION
### Motivation
- The UX Regression Gate listened to `pull_request` `labeled` events while using `cancel-in-progress`, allowing label changes to cancel and restart in-flight UX runs and creating cancellation cascades.

### Description
- Removed `labeled` from the `pull_request.types` list in `.github/workflows/ux-regression-gate.yml` and added an explanatory comment mirroring the main CI rationale to avoid label-driven cancellations.

### Testing
- Verified the change with `git diff -- .github/workflows/ux-regression-gate.yml` and `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20566b8d0833396dedc5d123f6f41)