### PR TITLE
fix(ci): stop label-triggered UX gate cancellations (#7286)

### DIFF
--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -10,7 +10,9 @@ name: UX Regression Gate
 on:
   pull_request:
     branches: [main, master]
-    types: [opened, synchronize, reopened, labeled]
+    # Keep label churn from cancelling in-flight UX gate runs under cancel-in-progress.
+    # Mirrors the main CI cascade fix in .github/workflows/ci.yml.
+    types: [opened, synchronize, reopened]
     paths:
       - 'crates/perl-lsp*/**'
       - 'crates/perl-dap*/**'


### PR DESCRIPTION
### Motivation

- The UX Regression Gate workflow included `pull_request.labeled` in its trigger types which could cancel in-flight runs under `cancel-in-progress`, recreating the CI cancellation cascade seen previously in the main CI workflow.

### Description

- Removed `labeled` from the `pull_request.types` list in `.github/workflows/ux-regression-gate.yml` so label changes no longer retrigger/cancel in-flight UX gate runs.
- Added an inline comment explaining the rationale and that this mirrors the main CI cascade fix.

### Testing

- Inspected the workflow diff with `git diff -- .github/workflows/ux-regression-gate.yml` to verify the intended edit was applied.
- Ran `git diff --check` to ensure no whitespace or formatting issues, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20566b8d0833396dedc5d123f6f41)