### PR TITLE
fix(xtask): add semantic-scorecard check mode (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1153,6 +1153,9 @@ enum Commands {
         /// Optional path to generated status markdown.
         #[arg(long)]
         status_md: Option<PathBuf>,
+        /// Check mode: fail if generated outputs differ from committed files.
+        #[arg(long)]
+        check: bool,
     },
     /// Validate memory profiling functionality
     ValidateMemoryProfiler,
@@ -2179,8 +2182,8 @@ fn main() -> Result<()> {
             };
             ux_scorecard::run(format, input, output, status_md, ratchet_check)
         }
-        Commands::SemanticScorecard { manifest, output, status_md } => {
-            semantic_scorecard::run(manifest, output, status_md)
+        Commands::SemanticScorecard { manifest, output, status_md, check } => {
+            semantic_scorecard::run(manifest, output, status_md, check)
         }
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),
         Commands::E2eValidate { workspace_size, report, skip_workspace, skip_bench, verbose } => {

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1,5 +1,5 @@
 use crate::utils::project_root;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
@@ -63,6 +63,7 @@ pub fn run(
     manifest: Option<PathBuf>,
     output: Option<PathBuf>,
     status_md: Option<PathBuf>,
+    check: bool,
 ) -> Result<()> {
     let root = project_root()?;
     let manifest_path =
@@ -73,11 +74,21 @@ pub fn run(
     let manifest = load_manifest(&manifest_path)?;
     let artifact = build_artifact(manifest);
 
-    write_json(&output_path, &artifact)?;
+    let payload = serialize_json(&artifact)?;
+    let status_markdown = render_status_markdown(&artifact);
+
+    if check {
+        verify_file_matches(&output_path, &payload)?;
+        verify_file_matches(&status_path, &status_markdown)?;
+        println!("semantic scorecard check passed: outputs are current");
+        return Ok(());
+    }
+
+    write_json(&output_path, &payload)?;
     if let Some(parent) = status_path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
-    fs::write(&status_path, render_status_markdown(&artifact))
+    fs::write(&status_path, status_markdown)
         .with_context(|| format!("writing {}", status_path.display()))?;
 
     println!("semantic scorecard updated: {}", output_path.display());
@@ -113,12 +124,26 @@ fn build_artifact(manifest: SemanticManifest) -> Artifact {
     }
 }
 
-fn write_json(path: &Path, artifact: &Artifact) -> Result<()> {
+fn serialize_json(artifact: &Artifact) -> Result<String> {
+    Ok(format!("{}\n", serde_json::to_string_pretty(artifact)?))
+}
+
+fn write_json(path: &Path, payload: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
-    let payload = serde_json::to_string_pretty(artifact)?;
-    fs::write(path, format!("{payload}\n")).with_context(|| format!("writing {}", path.display()))
+    fs::write(path, payload).with_context(|| format!("writing {}", path.display()))
+}
+
+fn verify_file_matches(path: &Path, expected: &str) -> Result<()> {
+    let actual = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    if actual != expected {
+        bail!(
+            "{} is stale; run `cargo xtask semantic-scorecard` to refresh generated outputs",
+            path.display()
+        );
+    }
+    Ok(())
 }
 
 fn render_status_markdown(artifact: &Artifact) -> String {
@@ -236,6 +261,15 @@ mod tests {
             "fixture IDs must be identical regardless of input order"
         );
         assert_eq!(artifact_fwd.fixture_ids, vec!["alpha".to_string(), "beta".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn verify_file_matches_detects_drift() -> Result<()> {
+        let tmp = tempfile::NamedTempFile::new()?;
+        fs::write(tmp.path(), "actual\n")?;
+        let err = verify_file_matches(tmp.path(), "expected\n").expect_err("must fail on drift");
+        assert!(err.to_string().contains("is stale"));
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure the semantic scorecard can be verified in-place so CI or reviewers can detect when generated artifacts drift from committed outputs.
- Provide a non-destructive `--check` path that fails when the emitted JSON/markdown are stale without overwriting repository files.

### Description

- Added a `--check` flag to the `SemanticScorecard` CLI variant in `xtask` and threaded it into `semantic_scorecard::run` by changing the signature to accept `check: bool` and updating the command dispatch in `xtask/src/main.rs`. 
- Produce deterministic JSON and status markdown in-memory using `serialize_json` and `render_status_markdown`, and implement `verify_file_matches` to compare generated payloads to the committed files and fail with a clear remediation message when they differ. 
- Preserve existing write behavior when `--check` is not provided via `write_json` and status file writes. 
- Added a unit test `verify_file_matches_detects_drift` to cover drift-detection behavior and small refactors (`serialize_json`, `write_json`, `verify_file_matches`) in `xtask/src/tasks/semantic_scorecard.rs`.

### Testing

- Ran `cargo fmt -p xtask` which completed successfully. 
- Ran `cargo test -p xtask semantic_scorecard` which passed (unit tests for the task: 4 passed, 0 failed). 
- Ran `cargo check -p xtask --all-targets` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f205ad5bd48333aa5f84966698dc34)