### PR TITLE
fix(xtask): add semantic-scorecard check mode (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1153,6 +1153,9 @@ enum Commands {
         /// Optional path to generated status markdown.
         #[arg(long)]
         status_md: Option<PathBuf>,
+        /// Verify generated files are up to date without writing changes.
+        #[arg(long)]
+        check: bool,
     },
     /// Validate memory profiling functionality
     ValidateMemoryProfiler,
@@ -2179,8 +2182,8 @@ fn main() -> Result<()> {
             };
             ux_scorecard::run(format, input, output, status_md, ratchet_check)
         }
-        Commands::SemanticScorecard { manifest, output, status_md } => {
-            semantic_scorecard::run(manifest, output, status_md)
+        Commands::SemanticScorecard { manifest, output, status_md, check } => {
+            semantic_scorecard::run(manifest, output, status_md, check)
         }
         Commands::ValidateMemoryProfiler => compare::validate_memory_profiling(),
         Commands::E2eValidate { workspace_size, report, skip_workspace, skip_bench, verbose } => {

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -63,6 +63,7 @@ pub fn run(
     manifest: Option<PathBuf>,
     output: Option<PathBuf>,
     status_md: Option<PathBuf>,
+    check: bool,
 ) -> Result<()> {
     let root = project_root()?;
     let manifest_path =
@@ -73,12 +74,18 @@ pub fn run(
     let manifest = load_manifest(&manifest_path)?;
     let artifact = build_artifact(manifest);
 
-    write_json(&output_path, &artifact)?;
-    if let Some(parent) = status_path.parent() {
-        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    let expected_json = format!("{}\n", serde_json::to_string_pretty(&artifact)?);
+    let expected_status = render_status_markdown(&artifact);
+
+    if check {
+        verify_file_matches(&output_path, &expected_json)?;
+        verify_file_matches(&status_path, &expected_status)?;
+        println!("semantic scorecard artifacts are up to date");
+        return Ok(());
     }
-    fs::write(&status_path, render_status_markdown(&artifact))
-        .with_context(|| format!("writing {}", status_path.display()))?;
+
+    write_file(&output_path, &expected_json)?;
+    write_file(&status_path, &expected_status)?;
 
     println!("semantic scorecard updated: {}", output_path.display());
     println!("status page updated: {}", status_path.display());
@@ -113,12 +120,24 @@ fn build_artifact(manifest: SemanticManifest) -> Artifact {
     }
 }
 
-fn write_json(path: &Path, artifact: &Artifact) -> Result<()> {
+fn write_file(path: &Path, contents: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }
-    let payload = serde_json::to_string_pretty(artifact)?;
-    fs::write(path, format!("{payload}\n")).with_context(|| format!("writing {}", path.display()))
+    fs::write(path, contents).with_context(|| format!("writing {}", path.display()))
+}
+
+fn verify_file_matches(path: &Path, expected_contents: &str) -> Result<()> {
+    let current_contents =
+        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    if current_contents == expected_contents {
+        return Ok(());
+    }
+
+    color_eyre::eyre::bail!(
+        "{} is out of date; run `cargo xtask semantic-scorecard`",
+        path.display()
+    );
 }
 
 fn render_status_markdown(artifact: &Artifact) -> String {
@@ -236,6 +255,23 @@ mod tests {
             "fixture IDs must be identical regardless of input order"
         );
         assert_eq!(artifact_fwd.fixture_ids, vec!["alpha".to_string(), "beta".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn verify_file_matches_accepts_identical_content() -> Result<()> {
+        let tmp = tempfile::NamedTempFile::new()?;
+        fs::write(tmp.path(), "same\n")?;
+        verify_file_matches(tmp.path(), "same\n")
+    }
+
+    #[test]
+    fn verify_file_matches_rejects_drift() -> Result<()> {
+        let tmp = tempfile::NamedTempFile::new()?;
+        fs::write(tmp.path(), "old\n")?;
+        let err = verify_file_matches(tmp.path(), "new\n").expect_err("drift should fail");
+        let message = err.to_string();
+        assert!(message.contains("out of date"));
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a verification mode for the semantic scorecard so CI can detect when committed generated artifacts have drifted from the expected outputs. 
- Make it possible to fail fast in CI with a clear remediation message instead of silently regenerating or masking drift.

### Description

- Add a `--check` flag to the `SemanticScorecard` command and thread it through the CLI dispatch in `xtask/src/main.rs` so callers can request verification-only behavior. 
- Extend `xtask::tasks::semantic_scorecard::run` to compute the expected JSON and markdown outputs and either write them or, in check mode, validate on-disk files against the expected contents. 
- Implement `verify_file_matches` and `write_file` helpers, update the function signature to accept `check: bool`, and make failures emit a clear remediation message referencing `cargo xtask semantic-scorecard`. 
- Add unit tests for the new verification helper to cover both matching and mismatching content cases.

### Testing

- Ran `cargo test -p xtask semantic_scorecard` and the test suite for the semantic scorecard passed. 
- Ran `cargo check -p xtask --all-targets` which completed successfully. 
- Executed `cargo xtask semantic-scorecard` to generate artifacts and then `cargo xtask semantic-scorecard --check` which reported the artifacts as up to date.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f205ad5bd48333aa5f84966698dc34)