### PR TITLE
feat(xtask): emit UX regression failure receipts (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1142,6 +1142,19 @@ enum Commands {
         ratchet_check: bool,
     },
 
+    /// Emit structured UX regression receipt from a failing ux-tests log.
+    UxRegressionReceipt {
+        /// Input log path captured from `just ux-tests` failure output.
+        #[arg(long)]
+        input: PathBuf,
+        /// Optional output path for receipt JSON.
+        #[arg(long)]
+        output: Option<PathBuf>,
+        /// Optional SHA for the triggering commit.
+        #[arg(long)]
+        sha: Option<String>,
+    },
+
     /// Publish semantic fixture scorecard artifact/status.
     SemanticScorecard {
         /// Optional path to semantic fixture manifest JSON.
@@ -2172,6 +2185,13 @@ fn main() -> Result<()> {
             }
             MetricsCommand::SweepStats { input } => metrics::sweep_stats::run(input),
         },
+        Commands::UxRegressionReceipt { input, output, sha } => {
+            ux_regression_receipt::run(ux_regression_receipt::UxRegressionReceiptConfig {
+                input,
+                output,
+                sha,
+            })
+        }
         Commands::UxScorecard { format, input, output, status_md, ratchet_check } => {
             let format = match format {
                 UxScorecardOutputFormat::Human => UxScorecardFormat::Human,

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -92,6 +92,7 @@ pub mod test_lsp;
 pub mod unwired_scan;
 pub mod update_homebrew;
 pub mod update_status;
+pub mod ux_regression_receipt;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
 pub mod workflow_policy_lint;

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -1,0 +1,148 @@
+use std::fs;
+use std::path::PathBuf;
+
+use color_eyre::eyre::{Context, Result};
+use regex::Regex;
+use serde::Serialize;
+
+#[derive(Debug, Clone)]
+pub struct UxRegressionReceiptConfig {
+    pub input: PathBuf,
+    pub output: Option<PathBuf>,
+    pub sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureClass {
+    MatrixDrift,
+    BaselineDrift,
+    TestRace,
+    NewTestBug,
+    ProviderRegression,
+    ServerCrash,
+    Timeout,
+    Infra,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UxRegressionReceipt {
+    pub kind: &'static str,
+    pub schema_version: u8,
+    pub sha: String,
+    pub scenario: Option<String>,
+    pub test: Option<String>,
+    pub result: &'static str,
+    pub failure_class: FailureClass,
+    pub panic_location: Option<String>,
+    pub repro: Option<String>,
+    pub first_failing_line: Option<String>,
+}
+
+pub fn run(config: UxRegressionReceiptConfig) -> Result<()> {
+    let raw = fs::read_to_string(&config.input)
+        .with_context(|| format!("reading {}", config.input.display()))?;
+    let receipt = classify_log(&raw, config.sha);
+    let rendered = format!("{}\n", serde_json::to_string_pretty(&receipt)?);
+
+    if let Some(output) = config.output {
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(&output, rendered).with_context(|| format!("writing {}", output.display()))?;
+        println!("Wrote UX regression receipt: {}", output.display());
+    } else {
+        print!("{rendered}");
+    }
+
+    Ok(())
+}
+
+fn classify_log(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
+    let test = find_capture(raw, r"----\s+([^\s]+)\s+stdout\s+----");
+    let panic_location = find_capture(raw, r"panicked at .+?,\s+([^\n]+:\d+:\d+)");
+    let first_failing_line = find_capture(raw, r"assertion failed:\s+([^\n]+)");
+    let scenario = test
+        .as_deref()
+        .and_then(|name| name.split("::").next())
+        .map(std::string::ToString::to_string);
+
+    let failure_class = classify_failure(raw, &panic_location, test.as_deref());
+    let repro = test.as_ref().map(|name| format!("just ux-tests {name}"));
+
+    UxRegressionReceipt {
+        kind: "ux_regression_receipt",
+        schema_version: 1,
+        sha: sha.unwrap_or_else(|| "unknown".to_string()),
+        scenario,
+        test,
+        result: "fail",
+        failure_class,
+        panic_location,
+        repro,
+        first_failing_line,
+    }
+}
+
+fn classify_failure(
+    raw: &str,
+    panic_location: &Option<String>,
+    test_name: Option<&str>,
+) -> FailureClass {
+    let lower = raw.to_ascii_lowercase();
+    if lower.contains("editor_ux_fixture_matrix") || lower.contains("covers_all_scenarios") {
+        return FailureClass::MatrixDrift;
+    }
+    if lower.contains("baseline") && lower.contains("drift") {
+        return FailureClass::BaselineDrift;
+    }
+    if lower.contains("timed out") || lower.contains("timeout") {
+        return FailureClass::Timeout;
+    }
+    if lower.contains("connection reset") || lower.contains("broken pipe") {
+        return FailureClass::Infra;
+    }
+    if lower.contains("panic") && lower.contains("perl-lsp-rs") {
+        return FailureClass::ServerCrash;
+    }
+    if let Some(name) = test_name
+        && name.contains("scenario_19_diagnostics_clear_after_fix")
+    {
+        return FailureClass::TestRace;
+    }
+    if let Some(location) = panic_location
+        && location.contains("crates/perl-lsp-ux-tests/tests/")
+    {
+        return FailureClass::NewTestBug;
+    }
+    if panic_location.is_some() {
+        return FailureClass::ProviderRegression;
+    }
+    FailureClass::Unknown
+}
+
+fn find_capture(haystack: &str, pattern: &str) -> Option<String> {
+    let re = Regex::new(pattern).ok()?;
+    re.captures(haystack).and_then(|caps| caps.get(1)).map(|m| m.as_str().trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FailureClass, classify_log};
+
+    #[test]
+    fn classifies_matrix_drift() {
+        let raw = "test editor_ux_fixture_matrix_covers_all_scenarios ... FAILED";
+        let receipt = classify_log(raw, Some("abc".to_string()));
+        assert_eq!(receipt.failure_class, FailureClass::MatrixDrift);
+    }
+
+    #[test]
+    fn classifies_scenario_19_race() {
+        let raw = "---- scenario_19_diagnostics_clear_after_fix stdout ----\nthread 'x' panicked at 'oops', crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:9\nassertion failed: cleared";
+        let receipt = classify_log(raw, Some("abc".to_string()));
+        assert_eq!(receipt.failure_class, FailureClass::TestRace);
+        assert_eq!(receipt.scenario.as_deref(), Some("scenario_19_diagnostics_clear_after_fix"));
+    }
+}


### PR DESCRIPTION
### Motivation

- UX regression failures currently require manual log spelunking and do not produce a structured receipt for routing and triage.  
- A machine-readable receipt with scenario/test, failure class, panic location, repro, and first-failing-line will speed classification and automated handling of UX regressions.  

### Description

- Add a new xtask task `ux_regression_receipt` implemented at `xtask/src/tasks/ux_regression_receipt.rs` that parses failing `just ux-tests`/cargo test logs and emits a JSON `ux_regression_receipt` with fields `kind`, `schema_version`, `sha`, `scenario`, `test`, `result`, `failure_class`, `panic_location`, `repro`, and `first_failing_line`.  
- Introduce a `FailureClass` enum with buckets aligned to routing needs (`matrix_drift`, `baseline_drift`, `test_race`, `new_test_bug`, `provider_regression`, `server_crash`, `timeout`, `infra`, `unknown`).  
- Wire the new module into the xtask registry (`xtask/src/tasks/mod.rs`) and add a CLI subcommand in `xtask/src/main.rs` to run it as `cargo xtask ux-regression-receipt --input <log> [--output <path>] [--sha <sha>]`.  
- Add focused unit tests for the classifier heuristics to ensure basic capture and classification behavior.  

### Testing

- Ran `cargo check -p xtask -q` which completed successfully.  
- Ran `cargo fmt` on the modified files to normalize formatting.  
- Added unit tests in `xtask/src/tasks/ux_regression_receipt.rs` for classifier heuristics (these tests are included in the PR for CI to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20a5003e88333b8e3862b70149309)