### PR TITLE
feat(xtask): emit UX regression receipts (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -299,6 +299,21 @@ enum Commands {
         fixture: Option<PathBuf>,
     },
 
+    /// Emit a structured receipt from UX regression test output logs.
+    UxRegressionReceipt {
+        /// Path to captured UX test output (e.g. /tmp/ux-test-output.txt).
+        #[arg(long)]
+        input: PathBuf,
+
+        /// Optional path to write JSON receipt output.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Optional commit SHA to embed in the receipt.
+        #[arg(long)]
+        sha: Option<String>,
+    },
+
     /// Format code
     Fmt {
         /// Check formatting without making changes
@@ -1843,6 +1858,13 @@ fn main() -> Result<()> {
                 snapshot,
                 receipt,
                 fixture,
+            })
+        }
+        Commands::UxRegressionReceipt { input, receipt, sha } => {
+            ux_regression_receipt::run(ux_regression_receipt::UxRegressionReceiptConfig {
+                input,
+                receipt,
+                sha,
             })
         }
         Commands::Fmt { check, package } => fmt::run(check, package),

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -92,6 +92,7 @@ pub mod test_lsp;
 pub mod unwired_scan;
 pub mod update_homebrew;
 pub mod update_status;
+pub mod ux_regression_receipt;
 pub mod ux_scorecard;
 pub mod validate_workspace_exclusions;
 pub mod workflow_policy_lint;

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -1,0 +1,178 @@
+use std::fs;
+use std::path::PathBuf;
+
+use chrono::Utc;
+use color_eyre::eyre::{Context, Result};
+use serde::Serialize;
+
+#[derive(Debug, Clone)]
+pub struct UxRegressionReceiptConfig {
+    pub input: PathBuf,
+    pub receipt: Option<PathBuf>,
+    pub sha: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum FailureClass {
+    MatrixDrift,
+    BaselineDrift,
+    TestRace,
+    NewTestBug,
+    ProviderRegression,
+    ServerCrash,
+    Timeout,
+    Infra,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UxRegressionReceipt {
+    kind: &'static str,
+    schema_version: u32,
+    measured_at: String,
+    sha: String,
+    scenario: Option<String>,
+    test: Option<String>,
+    result: String,
+    failure_class: FailureClass,
+    panic_location: Option<String>,
+    repro: Option<String>,
+    first_failing_line: Option<String>,
+}
+
+pub fn run(config: UxRegressionReceiptConfig) -> Result<()> {
+    let raw = fs::read_to_string(&config.input)
+        .with_context(|| format!("reading {}", config.input.display()))?;
+    let receipt = classify(&raw, config.sha);
+    let payload = serde_json::to_string_pretty(&receipt)?;
+
+    if let Some(path) = config.receipt {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+        }
+        fs::write(&path, format!("{payload}\n"))
+            .with_context(|| format!("writing {}", path.display()))?;
+        println!("Wrote UX regression receipt: {}", path.display());
+    } else {
+        println!("{payload}");
+    }
+
+    Ok(())
+}
+
+fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
+    let lines: Vec<&str> = raw.lines().collect();
+    let first_fail_line =
+        lines.iter().find(|line| line.contains("FAILED")).map(|line| (*line).trim().to_string());
+    let test = lines.iter().find_map(|line| failed_test_name(line));
+    let panic_location = lines.iter().find_map(|line| panic_location(line));
+    let scenario = test.as_ref().and_then(|name| scenario_from_test_name(name));
+
+    let failure_class = infer_failure_class(raw);
+
+    let repro = test.as_ref().map(|name| {
+        format!("cargo test -p perl-lsp-ux-tests {name} -- --test-threads=1 --nocapture")
+    });
+
+    UxRegressionReceipt {
+        kind: "ux_regression_receipt",
+        schema_version: 1,
+        measured_at: Utc::now().to_rfc3339(),
+        sha: sha.unwrap_or_else(|| "unknown".to_string()),
+        scenario,
+        test,
+        result: if raw.contains("test result: ok") { "pass" } else { "fail" }.to_string(),
+        failure_class,
+        panic_location,
+        repro,
+        first_failing_line: first_fail_line,
+    }
+}
+
+fn scenario_from_test_name(test: &str) -> Option<String> {
+    let scenario = test.split("::").next()?;
+    if scenario.starts_with("ux_scenario_") { Some(format!("{scenario}.rs")) } else { None }
+}
+
+fn failed_test_name(line: &str) -> Option<String> {
+    let line = line.trim();
+    let rest = line.strip_prefix("test ")?;
+    let (name, _) = rest.split_once(" ... FAILED")?;
+    Some(name.to_string())
+}
+
+fn panic_location(line: &str) -> Option<String> {
+    if !line.contains("panicked at") {
+        return None;
+    }
+
+    let (_, candidate) = line.rsplit_once(", ")?;
+    let candidate = candidate.trim();
+    if is_source_location(candidate) { Some(candidate.to_string()) } else { None }
+}
+
+fn is_source_location(candidate: &str) -> bool {
+    let mut pieces = candidate.rsplitn(3, ':');
+    let Some(column) = pieces.next() else {
+        return false;
+    };
+    let Some(line) = pieces.next() else {
+        return false;
+    };
+    let Some(path) = pieces.next() else {
+        return false;
+    };
+
+    !path.is_empty()
+        && !line.is_empty()
+        && !column.is_empty()
+        && line.bytes().all(|byte| byte.is_ascii_digit())
+        && column.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn infer_failure_class(raw: &str) -> FailureClass {
+    let lower = raw.to_ascii_lowercase();
+    if lower.contains("fixture matrix") || lower.contains("matrix drift") {
+        FailureClass::MatrixDrift
+    } else if lower.contains("baseline") || lower.contains("snapshot") {
+        FailureClass::BaselineDrift
+    } else if lower.contains("timed out") || lower.contains("timeout") {
+        FailureClass::Timeout
+    } else if lower.contains("race") || lower.contains("flaky") {
+        FailureClass::TestRace
+    } else if lower.contains("panicked") && lower.contains("tests/ux_scenario_") {
+        FailureClass::NewTestBug
+    } else if lower.contains("panicked") || lower.contains("server exited") {
+        FailureClass::ServerCrash
+    } else if lower.contains("no such file") || lower.contains("permission denied") {
+        FailureClass::Infra
+    } else if lower.contains("assertion failed") || lower.contains("expected") {
+        FailureClass::ProviderRegression
+    } else {
+        FailureClass::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_extracts_structured_fields() -> Result<()> {
+        let log = "running 1 test\ntest ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix ... FAILED\nthread 'x' panicked at 'boom', crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5\ntest result: FAILED. 0 passed; 1 failed";
+        let receipt = classify(log, Some("abc123".to_string()));
+        assert_eq!(receipt.sha, "abc123");
+        assert_eq!(receipt.scenario.as_deref(), Some("ux_scenario_19_diagnostics_lifecycle.rs"));
+        assert_eq!(
+            receipt.test.as_deref(),
+            Some("ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix")
+        );
+        assert!(matches!(receipt.failure_class, FailureClass::NewTestBug));
+        assert_eq!(
+            receipt.panic_location.as_deref(),
+            Some("crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5")
+        );
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -1,9 +1,18 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
 use chrono::Utc;
 use color_eyre::eyre::{Context, Result};
+use regex::Regex;
 use serde::Serialize;
+
+static FAILED_TEST_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"test\s+([^\s]+)\s+\.\.\.\s+FAILED").expect("failed test regex must compile")
+});
+static PANIC_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"panicked at .*?,\s+([^:]+:\d+:\d+)").expect("panic regex must compile")
+});
 
 #[derive(Debug, Clone)]
 pub struct UxRegressionReceiptConfig {
@@ -65,8 +74,10 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
     let lines: Vec<&str> = raw.lines().collect();
     let first_fail_line =
         lines.iter().find(|line| line.contains("FAILED")).map(|line| (*line).trim().to_string());
-    let test = lines.iter().find_map(|line| failed_test_name(line));
-    let panic_location = lines.iter().find_map(|line| panic_location(line));
+    let test =
+        lines.iter().find_map(|line| FAILED_TEST_RE.captures(line).map(|cap| cap[1].to_string()));
+    let panic_location =
+        lines.iter().find_map(|line| PANIC_RE.captures(line).map(|cap| cap[1].to_string()));
     let scenario = test.as_ref().and_then(|name| scenario_from_test_name(name));
 
     let failure_class = infer_failure_class(raw);
@@ -93,42 +104,6 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
 fn scenario_from_test_name(test: &str) -> Option<String> {
     let scenario = test.split("::").next()?;
     if scenario.starts_with("ux_scenario_") { Some(format!("{scenario}.rs")) } else { None }
-}
-
-fn failed_test_name(line: &str) -> Option<String> {
-    let line = line.trim();
-    let rest = line.strip_prefix("test ")?;
-    let (name, _) = rest.split_once(" ... FAILED")?;
-    Some(name.to_string())
-}
-
-fn panic_location(line: &str) -> Option<String> {
-    if !line.contains("panicked at") {
-        return None;
-    }
-
-    let (_, candidate) = line.rsplit_once(", ")?;
-    let candidate = candidate.trim();
-    if is_source_location(candidate) { Some(candidate.to_string()) } else { None }
-}
-
-fn is_source_location(candidate: &str) -> bool {
-    let mut pieces = candidate.rsplitn(3, ':');
-    let Some(column) = pieces.next() else {
-        return false;
-    };
-    let Some(line) = pieces.next() else {
-        return false;
-    };
-    let Some(path) = pieces.next() else {
-        return false;
-    };
-
-    !path.is_empty()
-        && !line.is_empty()
-        && !column.is_empty()
-        && line.bytes().all(|byte| byte.is_ascii_digit())
-        && column.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn infer_failure_class(raw: &str) -> FailureClass {
@@ -159,20 +134,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn classify_extracts_structured_fields() -> Result<()> {
+    fn classify_extracts_structured_fields() {
         let log = "running 1 test\ntest ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix ... FAILED\nthread 'x' panicked at 'boom', crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5\ntest result: FAILED. 0 passed; 1 failed";
         let receipt = classify(log, Some("abc123".to_string()));
-        assert_eq!(receipt.sha, "abc123");
-        assert_eq!(receipt.scenario.as_deref(), Some("ux_scenario_19_diagnostics_lifecycle.rs"));
+        assert_eq!(receipt.sha, "abc123", "sha should match input");
+        assert_eq!(
+            receipt.scenario.as_deref(),
+            Some("ux_scenario_19_diagnostics_lifecycle.rs"),
+            "scenario should be extracted from test name"
+        );
         assert_eq!(
             receipt.test.as_deref(),
-            Some("ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix")
+            Some("ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix"),
+            "test name should be extracted from log"
         );
-        assert!(matches!(receipt.failure_class, FailureClass::NewTestBug));
+        assert!(
+            matches!(receipt.failure_class, FailureClass::NewTestBug),
+            "failure_class should be NewTestBug for panicked test in ux_scenario"
+        );
         assert_eq!(
             receipt.panic_location.as_deref(),
-            Some("crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5")
+            Some("crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5"),
+            "panic_location should be extracted from panic line"
         );
-        Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- UX Regression CI logs are noisy and expensive to triage because failures are unstructured and lack a machine-readable failure class, first-failing test, panic location, or repro command.

### Description

- Add a new xtask task implemented in `xtask/src/tasks/ux_regression_receipt.rs` that parses captured UX test output and emits a structured JSON receipt (`UxRegressionReceipt`) with `kind`, `schema_version`, `measured_at`, `sha`, `scenario`, `test`, `result`, `failure_class`, `panic_location`, `repro`, and `first_failing_line`.
- Infer failure classes (e.g., `matrix_drift`, `baseline_drift`, `test_race`, `new_test_bug`, `server_crash`, `timeout`, `infra`, `provider_regression`, `unknown`) and extract test/panic lines using regexes for downstream routing and triage.
- Wire the task into the CLI as `cargo xtask ux-regression-receipt --input <log> [--receipt <path>] [--sha <sha>]` by registering `UxRegressionReceipt` in `xtask/src/main.rs` and adding the module to `xtask/src/tasks/mod.rs`.
- Add a unit test `classify_extracts_structured_fields` verifying extraction logic for a canonical failure log.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p xtask ux_regression_receipt::tests::classify_extracts_structured_fields -- --exact` which compiled and executed the test successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20a5003e88333b8e3862b70149309)