### PR TITLE
fix(perl-lsp-rs): avoid PATH-hijacked which probe (#0000)

### DIFF
--- a/crates/perl-lsp-rs/Cargo.toml
+++ b/crates/perl-lsp-rs/Cargo.toml
@@ -80,6 +80,7 @@ ropey = { version = "1.6.1" }
 tokio = { workspace = true }
 once_cell.workspace = true
 tracing.workspace = true
+which = "8.0.2"
 
 [build-dependencies]
 
@@ -126,7 +127,6 @@ tempfile.workspace = true
 proptest.workspace = true
 perl-tdd-support = { workspace = true }
 # Wave Final PR B: perl-content-length-framing absorbed into perl-lsp-rs-core::transport::framing
-which = "8.0.2"
 parking_lot.workspace = true
 criterion.workspace = true
 perl-corpus = { workspace = true }

--- a/crates/perl-lsp-rs/src/execute_command/provider.rs
+++ b/crates/perl-lsp-rs/src/execute_command/provider.rs
@@ -949,18 +949,7 @@ pub(crate) fn select_test_runner(
 
 /// Check whether a command exists in the current PATH.
 pub fn command_exists(command: &str) -> bool {
-    let cmd = if cfg!(windows) {
-        let mut cmd = std::process::Command::new("where");
-        cmd.arg(command);
-        cmd
-    } else {
-        let mut cmd = std::process::Command::new("which");
-        cmd.arg(command);
-        cmd
-    };
-    crate::util::run_command_with_timeout(cmd, 2)
-        .map(|output| output.status.success())
-        .unwrap_or(false)
+    which::which(command).is_ok()
 }
 
 /// Return the supported executeCommand identifiers.

--- a/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
@@ -243,6 +243,49 @@ fn test_empty_workspace_roots_enforces_cwd_boundary() -> Result<(), Box<dyn Erro
     Ok(())
 }
 
+
+#[cfg(unix)]
+#[test]
+fn test_command_exists_does_not_execute_path_hijacked_which() -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = TempDir::new()?;
+    let which_path = temp_dir.path().join("which");
+    let marker_path = temp_dir.path().join("which-executed.marker");
+
+    fs::write(
+        &which_path,
+        format!(
+            "#!/bin/sh
+printf 'executed' > '{}'
+exit 0
+",
+            marker_path.display()
+        ),
+    )?;
+    fs::set_permissions(&which_path, fs::Permissions::from_mode(0o755))?;
+
+    let original_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut path_entries = vec![temp_dir.path().to_path_buf()];
+    path_entries.extend(std::env::split_paths(&original_path));
+    let joined_path = std::env::join_paths(path_entries)?;
+
+    // SAFETY: test-only PATH mutation; restored before returning.
+    unsafe {
+        std::env::set_var("PATH", &joined_path);
+    }
+    let _ = perl_lsp::execute_command::command_exists("perlcritic");
+    // SAFETY: restore process environment for test isolation.
+    unsafe {
+        std::env::set_var("PATH", original_path);
+    }
+
+    assert!(
+        !Path::new(&marker_path).exists(),
+        "security regression: command_exists executed a PATH-hijacked 'which' probe"
+    );
+    Ok(())
+}
 #[cfg(unix)]
 #[test]
 fn test_command_exists_does_not_execute_candidate_binary() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
### Motivation
- The Unix branch of `command_exists` spawned an external `which` via `Command::new("which")`, which is resolved through `PATH` and can be hijacked by an attacker-controlled `which` binary.
- Tool detection (e.g. for `perltidy`/`perlcritic`) runs during server startup and diagnostics, making this probe reachable without explicit user action and creating an unacceptable local command-execution risk.

### Description
- Replaced the external probe with an in-process lookup by changing `command_exists` to use `which::which(command).is_ok()` so no PATH-resolved helper binary is executed. 
- Promoted the `which` crate from a dev-dependency into normal `[dependencies]` in `crates/perl-lsp-rs/Cargo.toml` because production code now depends on it. 
- Added a Unix regression test `test_command_exists_does_not_execute_path_hijacked_which` which prepends a malicious `which` into `PATH` and asserts it is not executed by `command_exists`.

### Testing
- Ran `cargo test -p perl-lsp-rs --test execute_command_security_tests` and the test binary completed with all tests passing (15 passed, 0 failed). 
- Ran `cargo check --all-targets -p perl-lsp-rs` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17b674bac8333a431009573aa9f00)