### PR TITLE
fix(ci): restrict CI token permissions for merge_group safety (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -236,6 +234,9 @@ jobs:
     timeout-minutes: 30
     needs: [draft-pr-check, pr-smoke, preflight-latest-check]
     if: needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
+    permissions:
+      contents: read
+      statuses: write
     # Run on every PR push and on push to main/master
     # Earlier gating > label-gated gating (see #4675)
     # Frequent commits will queue; preflight skips superseded SHAs.


### PR DESCRIPTION
### Motivation

- The workflow enabled `merge_group` while granting write-capable `GITHUB_TOKEN` permissions at the top level, which lets PR-controlled code execute under a more privileged context and creates a supply-chain/token-exfiltration risk.

### Description

- Reduced top-level workflow permissions in `.github/workflows/ci.yml` from write-scoped (`contents: write`, `pull-requests: write`, `statuses: write`) to `contents: read` only.
- Scoped `statuses: write` (and `contents: read`) to the `merge-gate` job which actually sets commit status so only the status-setting job retains write capability.
- Kept checkout behavior and CI steps unchanged so job functionality and status reporting remain intact while minimizing token scope for most jobs.

### Testing

- Verified the edited YAML is syntactically valid with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'YAML_OK'"`, which printed `YAML_OK`.
- A `python3`-based YAML load check failed in the environment due to missing `PyYAML` (environment issue), not because of the repository file.
- No crate-level tests were modified or required for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f050092b1c8333bb958076b711c1ee)