### PR TITLE
feat(ux): classify and publish regression receipts (#0000)

### DIFF
--- a/.ci/schemas/ux-regression.schema.json
+++ b/.ci/schemas/ux-regression.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/schemas/ux-regression.schema.json",
+  "title": "UX regression receipt",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "measured_at",
+    "sha",
+    "result",
+    "failure_class",
+    "route"
+  ],
+  "properties": {
+    "kind": { "const": "ux_regression_receipt" },
+    "schema_version": { "type": "integer", "const": 1 },
+    "measured_at": { "type": "string", "format": "date-time" },
+    "sha": { "type": "string", "minLength": 1 },
+    "workflow": { "type": ["string", "null"] },
+    "scenario_file": { "type": ["string", "null"] },
+    "test": { "type": ["string", "null"] },
+    "result": { "type": "string", "enum": ["pass", "fail"] },
+    "failure_class": {
+      "type": "string",
+      "enum": [
+        "matrix_drift",
+        "baseline_drift",
+        "test_race",
+        "new_test_bug",
+        "provider_regression",
+        "server_crash",
+        "timeout",
+        "infra",
+        "unknown"
+      ]
+    },
+    "panic_location": { "type": ["string", "null"] },
+    "repro": { "type": ["string", "null"] },
+    "first_failing_line": { "type": ["string", "null"] },
+    "route": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -120,6 +120,14 @@ jobs:
           just ux-tests 2>&1 | tee /tmp/ux-test-output.txt
           exit ${PIPESTATUS[0]}
 
+      - name: Emit UX regression receipt
+        if: always() && steps.harness_check.outputs.harness_available == 'true'
+        run: |
+          cargo xtask ux-regression-receipt \
+            --input /tmp/ux-test-output.txt \
+            --receipt .ci/receipts/ux-regression.json \
+            --sha "${{ github.sha }}"
+
       - name: Parse and summarize UX test results
         if: always() && steps.harness_check.outputs.harness_available == 'true'
         run: |
@@ -222,6 +230,8 @@ jobs:
           summary_lines += [
               "",
               f"**Coverage metric**: {total} scenarios cover {covered_categories} categories of UX.",
+              "",
+              "UX receipt: `.ci/receipts/ux-regression.json`",
           ]
 
           pathlib.Path(summary_path).write_text("\n".join(summary_lines) + "\n", encoding="utf-8")

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -41,13 +41,15 @@ pub struct UxRegressionReceipt {
     schema_version: u32,
     measured_at: String,
     sha: String,
-    scenario: Option<String>,
+    workflow: Option<String>,
+    scenario_file: Option<String>,
     test: Option<String>,
     result: String,
     failure_class: FailureClass,
     panic_location: Option<String>,
     repro: Option<String>,
     first_failing_line: Option<String>,
+    route: String,
 }
 
 pub fn run(config: UxRegressionReceiptConfig) -> Result<()> {
@@ -78,32 +80,56 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
         lines.iter().find_map(|line| FAILED_TEST_RE.captures(line).map(|cap| cap[1].to_string()));
     let panic_location =
         lines.iter().find_map(|line| PANIC_RE.captures(line).map(|cap| cap[1].to_string()));
-    let scenario = test.as_ref().and_then(|name| scenario_from_test_name(name));
+    let scenario_file = test.as_ref().and_then(|name| scenario_from_test_name(name));
+    let workflow = scenario_file.as_ref().map(|name| workflow_from_scenario_file(name));
 
     let failure_class = infer_failure_class(raw);
+    let route = route_for_failure_class(&failure_class).to_string();
 
-    let repro = test.as_ref().map(|name| {
-        format!("cargo test -p perl-lsp-ux-tests {name} -- --test-threads=1 --nocapture")
-    });
+    let repro = test.as_ref().map(|name| format!("just ux-tests {name}"));
 
     UxRegressionReceipt {
         kind: "ux_regression_receipt",
         schema_version: 1,
         measured_at: Utc::now().to_rfc3339(),
         sha: sha.unwrap_or_else(|| "unknown".to_string()),
-        scenario,
+        workflow,
+        scenario_file,
         test,
         result: if raw.contains("test result: ok") { "pass" } else { "fail" }.to_string(),
         failure_class,
         panic_location,
         repro,
         first_failing_line: first_fail_line,
+        route,
     }
 }
 
 fn scenario_from_test_name(test: &str) -> Option<String> {
     let scenario = test.split("::").next()?;
     if scenario.starts_with("ux_scenario_") { Some(format!("{scenario}.rs")) } else { None }
+}
+
+
+fn workflow_from_scenario_file(scenario_file: &str) -> String {
+    scenario_file
+        .trim_end_matches(".rs")
+        .strip_prefix("ux_scenario_")
+        .map_or_else(|| scenario_file.to_string(), |name| name.to_string())
+}
+
+fn route_for_failure_class(failure_class: &FailureClass) -> &'static str {
+    match failure_class {
+        FailureClass::MatrixDrift => "needs-fixture-update",
+        FailureClass::BaselineDrift => "needs-baseline-update",
+        FailureClass::TestRace => "needs-test-fix",
+        FailureClass::NewTestBug => "needs-test-fix",
+        FailureClass::ProviderRegression => "needs-provider-fix",
+        FailureClass::ServerCrash => "needs-runtime-fix",
+        FailureClass::Timeout => "needs-timeout-triage",
+        FailureClass::Infra => "needs-infra-fix",
+        FailureClass::Unknown => "needs-investigation",
+    }
 }
 
 fn infer_failure_class(raw: &str) -> FailureClass {
@@ -139,9 +165,14 @@ mod tests {
         let receipt = classify(log, Some("abc123".to_string()));
         assert_eq!(receipt.sha, "abc123", "sha should match input");
         assert_eq!(
-            receipt.scenario.as_deref(),
+            receipt.scenario_file.as_deref(),
             Some("ux_scenario_19_diagnostics_lifecycle.rs"),
             "scenario should be extracted from test name"
+        );
+        assert_eq!(
+            receipt.workflow.as_deref(),
+            Some("19_diagnostics_lifecycle"),
+            "workflow should be derived from scenario file"
         );
         assert_eq!(
             receipt.test.as_deref(),
@@ -157,5 +188,6 @@ mod tests {
             Some("crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5"),
             "panic_location should be extracted from panic line"
         );
+        assert_eq!(receipt.route, "needs-test-fix");
     }
 }


### PR DESCRIPTION
### Motivation

- UX regression failures were opaque and required manual log spelunking to find the first failing test, panic location, repro, and triage route.
- A machine-readable, schema-backed receipt is needed so CI can surface actionable, routable failure evidence instead of generic failure prose.

### Description

- Extend the UX regression receipt emitted by `xtask` to include `workflow`, `scenario_file`, `route`, and a compact `repro` command, and derive `workflow` from the scenario file name.
- Add routing logic mapping `failure_class` to actionable triage buckets (for example, `needs-test-fix`, `needs-provider-fix`, `needs-timeout-triage`).
- Add a formal JSON schema at `.ci/schemas/ux-regression.schema.json` describing the receipt shape and allowed `failure_class` values.
- Wire the GitHub UX regression gate to run `cargo xtask ux-regression-receipt` and write `.ci/receipts/ux-regression.json`, and add a pointer to that receipt in the CI job summary.

### Testing

- Ran the unit test covering receipt classification with `cargo test -p xtask classify_extracts_structured_fields`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21adf0b58833391a7fdee3aaf011c)