### PR TITLE
feat(ux): classify and route UX regression receipts (#0000)

### DIFF
--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -41,13 +41,15 @@ pub struct UxRegressionReceipt {
     schema_version: u32,
     measured_at: String,
     sha: String,
-    scenario: Option<String>,
+    workflow: Option<String>,
+    scenario_file: Option<String>,
     test: Option<String>,
     result: String,
     failure_class: FailureClass,
     panic_location: Option<String>,
     repro: Option<String>,
     first_failing_line: Option<String>,
+    route: String,
 }
 
 pub fn run(config: UxRegressionReceiptConfig) -> Result<()> {
@@ -78,12 +80,17 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
         lines.iter().find_map(|line| FAILED_TEST_RE.captures(line).map(|cap| cap[1].to_string()));
     let panic_location =
         lines.iter().find_map(|line| PANIC_RE.captures(line).map(|cap| cap[1].to_string()));
-    let scenario = test.as_ref().and_then(|name| scenario_from_test_name(name));
+    let workflow = test
+        .as_ref()
+        .and_then(|name| name.split("::").nth(1))
+        .map(std::string::ToString::to_string);
+    let scenario_file = test.as_ref().and_then(|name| scenario_from_test_name(name));
 
     let failure_class = infer_failure_class(raw);
+    let route = route_for_failure_class(&failure_class);
 
     let repro = test.as_ref().map(|name| {
-        format!("cargo test -p perl-lsp-ux-tests {name} -- --test-threads=1 --nocapture")
+        format!("just ux-tests {name}")
     });
 
     UxRegressionReceipt {
@@ -91,13 +98,15 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
         schema_version: 1,
         measured_at: Utc::now().to_rfc3339(),
         sha: sha.unwrap_or_else(|| "unknown".to_string()),
-        scenario,
+        workflow,
+        scenario_file,
         test,
         result: if raw.contains("test result: ok") { "pass" } else { "fail" }.to_string(),
         failure_class,
         panic_location,
         repro,
         first_failing_line: first_fail_line,
+        route: route.to_string(),
     }
 }
 
@@ -129,6 +138,16 @@ fn infer_failure_class(raw: &str) -> FailureClass {
     }
 }
 
+fn route_for_failure_class(class: &FailureClass) -> &'static str {
+    match class {
+        FailureClass::MatrixDrift | FailureClass::BaselineDrift => "needs-fixture-update",
+        FailureClass::TestRace | FailureClass::NewTestBug => "needs-test-fix",
+        FailureClass::ProviderRegression | FailureClass::ServerCrash => "needs-provider-fix",
+        FailureClass::Timeout | FailureClass::Infra => "needs-ci-investigation",
+        FailureClass::Unknown => "needs-triage",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,9 +158,14 @@ mod tests {
         let receipt = classify(log, Some("abc123".to_string()));
         assert_eq!(receipt.sha, "abc123", "sha should match input");
         assert_eq!(
-            receipt.scenario.as_deref(),
+            receipt.scenario_file.as_deref(),
             Some("ux_scenario_19_diagnostics_lifecycle.rs"),
             "scenario should be extracted from test name"
+        );
+        assert_eq!(
+            receipt.workflow.as_deref(),
+            Some("scenario_19_diagnostics_clear_after_fix"),
+            "workflow should be the test fn name"
         );
         assert_eq!(
             receipt.test.as_deref(),
@@ -157,5 +181,6 @@ mod tests {
             Some("crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5"),
             "panic_location should be extracted from panic line"
         );
+        assert_eq!(receipt.route, "needs-test-fix");
     }
 }


### PR DESCRIPTION
### Motivation
- UX regression failures required manual log spelunking and lacked explicit routing metadata to triage quickly.
- The change makes receipts actionable by adding structured fields and a routing hint so CI/owners can immediately route failures.

### Description
- Emit `workflow` (test fn name) and `scenario_file` in the UX regression receipt by parsing the failing test name in `xtask/src/tasks/ux_regression_receipt.rs`.
- Add a `route` derived from `failure_class` via `route_for_failure_class` so receipts include a short triage action (`needs-test-fix`, `needs-fixture-update`, `needs-provider-fix`, `needs-ci-investigation`, `needs-triage`).
- Replace the long `cargo test` repro with an operator-friendly `just ux-tests <test>` repro string in the receipt.
- Extend the unit test in `xtask` to validate the new `workflow`, `scenario_file`, and `route` fields are extracted and classified correctly.

### Testing
- Ran `cargo test -p xtask ux_regression_receipt -- --nocapture`, which executed the updated unit test and passed.
- Ran the `xtask` test harness during the change verification and observed `xtask` unit tests complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21adf0b58833391a7fdee3aaf011c)