### PR TITLE
feat(ux): enrich regression receipt routing metadata (#0000)

### DIFF
--- a/.ci/schemas/ux-regression.schema.json
+++ b/.ci/schemas/ux-regression.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/schemas/ux-regression.schema.json",
+  "title": "perl-lsp UX regression receipt",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "measured_at",
+    "sha",
+    "result",
+    "failure_class",
+    "route"
+  ],
+  "properties": {
+    "kind": {"const": "ux_regression_receipt"},
+    "schema_version": {"const": 1},
+    "measured_at": {"type": "string", "format": "date-time"},
+    "sha": {"type": "string", "minLength": 1},
+    "workflow": {"type": ["string", "null"]},
+    "scenario_file": {"type": ["string", "null"]},
+    "scenario": {"type": ["string", "null"]},
+    "test": {"type": ["string", "null"]},
+    "result": {"enum": ["pass", "fail"]},
+    "failure_class": {
+      "enum": [
+        "matrix_drift",
+        "baseline_drift",
+        "test_race",
+        "new_test_bug",
+        "provider_regression",
+        "server_crash",
+        "timeout",
+        "infra",
+        "unknown"
+      ]
+    },
+    "panic_location": {"type": ["string", "null"]},
+    "repro": {"type": ["string", "null"]},
+    "first_failing_line": {"type": ["string", "null"]},
+    "route": {"type": "string", "minLength": 1}
+  },
+  "additionalProperties": false
+}

--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -219,16 +219,20 @@ jobs:
                   "See [UX_TESTING.md](docs/reference/UX_TESTING.md) for guidance on fixing failures.",
               ]
               if receipt:
+                  # Use `or` instead of dict.get() default for nullable JSON fields:
+                  # serde serializes Option::None as JSON null, which json.loads()
+                  # returns as Python None — dict.get(key, default) only falls back
+                  # on KeyError (missing key), not on null values.
                   summary_lines += [
                       "",
                       "### Structured Failure Receipt",
                       "",
                       f"- Receipt path: `{receipt_path}`",
-                      f"- Failure class: `{receipt.get('failure_class', 'unknown')}`",
-                      f"- First failing test: `{receipt.get('test', 'unknown')}`",
-                      f"- Panic location: `{receipt.get('panic_location', 'n/a')}`",
-                      f"- Repro command: `{receipt.get('repro', 'just ux-tests')}`",
-                      f"- Route: `{receipt.get('route', 'needs-triage')}`",
+                      f"- Failure class: `{receipt.get('failure_class') or 'unknown'}`",
+                      f"- First failing test: `{receipt.get('test') or 'unknown'}`",
+                      f"- Panic location: `{receipt.get('panic_location') or 'n/a'}`",
+                      f"- Repro command: `{receipt.get('repro') or 'just ux-tests'}`",
+                      f"- Route: `{receipt.get('route') or 'needs-triage'}`",
                   ]
           else:
               summary_lines.append("All UX scenarios passed.")

--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -120,11 +120,19 @@ jobs:
           just ux-tests 2>&1 | tee /tmp/ux-test-output.txt
           exit ${PIPESTATUS[0]}
 
+      - name: Emit structured UX regression receipt
+        if: failure() && steps.harness_check.outputs.harness_available == 'true'
+        run: |
+          cargo xtask ux-regression-receipt \
+            --input /tmp/ux-test-output.txt \
+            --receipt .ci/receipts/ux-regression.json \
+            --sha "${{ github.sha }}"
+
       - name: Parse and summarize UX test results
         if: always() && steps.harness_check.outputs.harness_available == 'true'
         run: |
           python3 - <<'PY'
-          import os, re, pathlib, sys
+          import json, os, re, pathlib, sys
 
           output_file = pathlib.Path("/tmp/ux-test-output.txt")
           summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
@@ -133,6 +141,13 @@ jobs:
               sys.exit(0)
 
           lines = output_file.read_text(encoding="utf-8").splitlines() if output_file.exists() else []
+          receipt_path = pathlib.Path(".ci/receipts/ux-regression.json")
+          receipt = None
+          if receipt_path.exists():
+              try:
+                  receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+              except Exception:
+                  receipt = None
 
           # Categories defined in the spec
           categories = {
@@ -203,6 +218,18 @@ jobs:
                   "",
                   "See [UX_TESTING.md](docs/reference/UX_TESTING.md) for guidance on fixing failures.",
               ]
+              if receipt:
+                  summary_lines += [
+                      "",
+                      "### Structured Failure Receipt",
+                      "",
+                      f"- Receipt path: `{receipt_path}`",
+                      f"- Failure class: `{receipt.get('failure_class', 'unknown')}`",
+                      f"- First failing test: `{receipt.get('test', 'unknown')}`",
+                      f"- Panic location: `{receipt.get('panic_location', 'n/a')}`",
+                      f"- Repro command: `{receipt.get('repro', 'just ux-tests')}`",
+                      f"- Route: `{receipt.get('route', 'needs-triage')}`",
+                  ]
           else:
               summary_lines.append("All UX scenarios passed.")
 

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -10,8 +10,12 @@ use serde::Serialize;
 static FAILED_TEST_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"test\s+([^\s]+)\s+\.\.\.\s+FAILED").expect("failed test regex must compile")
 });
+// Matches both pre-1.73 format ("panicked at 'msg', path:row:col") and
+// post-1.73 format ("panicked at path:row:col:") where the location appears
+// directly after "panicked at " without a quoted message.
 static PANIC_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"panicked at .*?,\s+([^:]+:\d+:\d+)").expect("panic regex must compile")
+    Regex::new(r"panicked at (?:'[^']*',\s*)?([a-zA-Z][^:\s][^:]*:\d+:\d+)")
+        .expect("panic regex must compile")
 });
 
 #[derive(Debug, Clone)]
@@ -127,12 +131,15 @@ fn infer_failure_class(raw: &str) -> FailureClass {
         FailureClass::TestRace
     } else if lower.contains("panicked") && lower.contains("tests/ux_scenario_") {
         FailureClass::NewTestBug
-    } else if lower.contains("panicked") || lower.contains("server exited") {
-        FailureClass::ServerCrash
     } else if lower.contains("no such file") || lower.contains("permission denied") {
         FailureClass::Infra
     } else if lower.contains("assertion failed") || lower.contains("expected") {
+        // Check ProviderRegression before the generic panicked/ServerCrash catch-all:
+        // a typical assertion failure log contains both "panicked" and "assertion failed",
+        // so this branch must precede the ServerCrash arm to remain reachable.
         FailureClass::ProviderRegression
+    } else if lower.contains("panicked") || lower.contains("server exited") {
+        FailureClass::ServerCrash
     } else {
         FailureClass::Unknown
     }
@@ -159,7 +166,9 @@ mod tests {
 
     #[test]
     fn classify_extracts_structured_fields() {
-        let log = "running 1 test\ntest ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix ... FAILED\nthread 'x' panicked at 'boom', crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5\ntest result: FAILED. 0 passed; 1 failed";
+        // Uses the Rust 1.73+ panic format: "panicked at path:row:col:" (no quoted message).
+        // The project toolchain is 1.92, so this is the format actual test output uses.
+        let log = "running 1 test\ntest ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix ... FAILED\nthread 'x' panicked at crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5:\nboom\ntest result: FAILED. 0 passed; 1 failed";
         let receipt = classify(log, Some("abc123".to_string()));
         assert_eq!(receipt.sha, "abc123", "sha should match input");
         assert_eq!(
@@ -184,8 +193,124 @@ mod tests {
         assert_eq!(
             receipt.panic_location.as_deref(),
             Some("crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5"),
-            "panic_location should be extracted from panic line"
+            "panic_location should be extracted from panic line (Rust 1.73+ format)"
         );
         assert_eq!(receipt.route, "needs-test-fix", "race/new test bug routes to test fix");
+    }
+
+    #[test]
+    fn classify_timeout_routes_to_ci_fix() {
+        let log = "running 1 test\ntest ux_scenario_01_startup::start_server ... FAILED\ntest timed out after 30s\ntest result: FAILED. 0 passed; 1 failed";
+        let receipt = classify(log, Some("sha1".to_string()));
+        assert!(
+            matches!(receipt.failure_class, FailureClass::Timeout),
+            "timed out log should classify as Timeout"
+        );
+        assert_eq!(receipt.route, "needs-ci-fix", "Timeout routes to needs-ci-fix");
+        assert_eq!(receipt.result, "fail");
+    }
+
+    #[test]
+    fn classify_server_crash_routes_to_provider_fix() {
+        // ServerCrash: panicked in non-ux_scenario path (e.g., the LSP server process itself).
+        // The panic message must not contain "assertion failed" or "expected" (which would
+        // trigger ProviderRegression instead), and must not contain "tests/ux_scenario_"
+        // (which would trigger NewTestBug).
+        let log = "running 1 test\ntest ux_scenario_02_open::open_file ... FAILED\nthread 'server' panicked at crates/perl-lsp-rs/src/provider.rs:55:9:\nserver crashed with SIGABRT\ntest result: FAILED. 0 passed; 1 failed";
+        let receipt = classify(log, Some("sha2".to_string()));
+        assert!(
+            matches!(receipt.failure_class, FailureClass::ServerCrash),
+            "non-ux_scenario panic should classify as ServerCrash, got {:?}",
+            receipt.failure_class
+        );
+        assert_eq!(receipt.route, "needs-provider-fix", "ServerCrash routes to needs-provider-fix");
+    }
+
+    #[test]
+    fn classify_matrix_drift_routes_to_fixture_fix() {
+        let log = "running 2 tests\ntest ux_scenario_05_matrix::check_matrix ... FAILED\nfixture matrix mismatch: expected 3 items, got 4\ntest result: FAILED. 1 passed; 1 failed";
+        let receipt = classify(log, Some("sha3".to_string()));
+        assert!(
+            matches!(receipt.failure_class, FailureClass::MatrixDrift),
+            "fixture matrix log should classify as MatrixDrift"
+        );
+        assert_eq!(receipt.route, "needs-fixture-fix", "MatrixDrift routes to needs-fixture-fix");
+    }
+
+    #[test]
+    fn classify_baseline_drift_routes_to_fixture_fix() {
+        let log = "running 1 test\ntest ux_scenario_10_hover::hover_type ... FAILED\nbaseline snapshot mismatch\ntest result: FAILED. 0 passed; 1 failed";
+        let receipt = classify(log, Some("sha4".to_string()));
+        assert!(
+            matches!(receipt.failure_class, FailureClass::BaselineDrift),
+            "baseline snapshot log should classify as BaselineDrift"
+        );
+        assert_eq!(
+            receipt.route, "needs-fixture-fix",
+            "BaselineDrift routes to needs-fixture-fix"
+        );
+    }
+
+    #[test]
+    fn classify_provider_regression_routes_to_provider_fix() {
+        // ProviderRegression: assertion failure without a panic in a ux_scenario_ path.
+        // Must reach the ProviderRegression branch (not be swallowed by ServerCrash).
+        let log = "running 1 test\ntest ux_scenario_07_completion::completions ... FAILED\nassertion failed: left == right\n  left: 3\n right: 5\ntest result: FAILED. 0 passed; 1 failed";
+        let receipt = classify(log, Some("sha5".to_string()));
+        assert!(
+            matches!(receipt.failure_class, FailureClass::ProviderRegression),
+            "assertion-failed log without panic-in-ux_scenario_ should classify as ProviderRegression, got {:?}",
+            receipt.failure_class
+        );
+        assert_eq!(
+            receipt.route, "needs-provider-fix",
+            "ProviderRegression routes to needs-provider-fix"
+        );
+    }
+
+    #[test]
+    fn classify_unknown_routes_to_triage() {
+        let log = "running 1 test\ntest ux_scenario_99_misc::misc_test ... FAILED\nsome completely unrecognized error message\ntest result: FAILED. 0 passed; 1 failed";
+        let receipt = classify(log, Some("sha6".to_string()));
+        assert!(
+            matches!(receipt.failure_class, FailureClass::Unknown),
+            "unrecognized log should classify as Unknown"
+        );
+        assert_eq!(receipt.route, "needs-triage", "Unknown routes to needs-triage");
+    }
+
+    #[test]
+    fn classify_sha_unknown_when_none() {
+        let log = "test result: FAILED. 0 passed; 1 failed";
+        let receipt = classify(log, None);
+        assert_eq!(receipt.sha, "unknown", "None sha should produce 'unknown' in receipt");
+    }
+
+    #[test]
+    fn classify_result_pass_on_ok_output() {
+        let log = "running 5 tests\ntest result: ok. 5 passed; 0 failed";
+        let receipt = classify(log, Some("sha7".to_string()));
+        assert_eq!(receipt.result, "pass", "log with 'test result: ok' should produce result=pass");
+    }
+
+    #[test]
+    fn workflow_from_test_name_returns_none_for_bare_name() {
+        // A test name with no "::" has no workflow segment.
+        assert_eq!(workflow_from_test_name("bare_test"), None);
+    }
+
+    #[test]
+    fn scenario_from_test_name_returns_none_for_non_ux_prefix() {
+        // Module not prefixed with "ux_scenario_" should not produce a scenario.
+        assert_eq!(scenario_from_test_name("other_module::some_test"), None);
+    }
+
+    #[test]
+    fn panic_re_matches_modern_rust_format() {
+        // Rust 1.73+ format: "panicked at path:row:col:" with no quoted message.
+        let line =
+            "thread 'test' panicked at crates/perl-lsp-rs/src/lib.rs:42:8:";
+        let cap = PANIC_RE.captures(line).expect("should match modern panic format");
+        assert_eq!(&cap[1], "crates/perl-lsp-rs/src/lib.rs:42:8");
     }
 }

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -41,6 +41,8 @@ pub struct UxRegressionReceipt {
     schema_version: u32,
     measured_at: String,
     sha: String,
+    workflow: Option<String>,
+    scenario_file: Option<String>,
     scenario: Option<String>,
     test: Option<String>,
     result: String,
@@ -48,6 +50,7 @@ pub struct UxRegressionReceipt {
     panic_location: Option<String>,
     repro: Option<String>,
     first_failing_line: Option<String>,
+    route: String,
 }
 
 pub fn run(config: UxRegressionReceiptConfig) -> Result<()> {
@@ -79,6 +82,7 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
     let panic_location =
         lines.iter().find_map(|line| PANIC_RE.captures(line).map(|cap| cap[1].to_string()));
     let scenario = test.as_ref().and_then(|name| scenario_from_test_name(name));
+    let workflow = test.as_ref().and_then(|name| workflow_from_test_name(name));
 
     let failure_class = infer_failure_class(raw);
 
@@ -86,11 +90,15 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
         format!("cargo test -p perl-lsp-ux-tests {name} -- --test-threads=1 --nocapture")
     });
 
+    let route = route_for_class(&failure_class).to_string();
+
     UxRegressionReceipt {
         kind: "ux_regression_receipt",
         schema_version: 1,
         measured_at: Utc::now().to_rfc3339(),
         sha: sha.unwrap_or_else(|| "unknown".to_string()),
+        workflow,
+        scenario_file: scenario.clone(),
         scenario,
         test,
         result: if raw.contains("test result: ok") { "pass" } else { "fail" }.to_string(),
@@ -98,6 +106,7 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
         panic_location,
         repro,
         first_failing_line: first_fail_line,
+        route,
     }
 }
 
@@ -129,6 +138,21 @@ fn infer_failure_class(raw: &str) -> FailureClass {
     }
 }
 
+fn workflow_from_test_name(test: &str) -> Option<String> {
+    let workflow = test.split("::").nth(1)?;
+    if workflow.is_empty() { None } else { Some(workflow.to_string()) }
+}
+
+fn route_for_class(class: &FailureClass) -> &'static str {
+    match class {
+        FailureClass::MatrixDrift | FailureClass::BaselineDrift => "needs-fixture-fix",
+        FailureClass::TestRace | FailureClass::NewTestBug => "needs-test-fix",
+        FailureClass::ProviderRegression | FailureClass::ServerCrash => "needs-provider-fix",
+        FailureClass::Timeout | FailureClass::Infra => "needs-ci-fix",
+        FailureClass::Unknown => "needs-triage",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,6 +168,11 @@ mod tests {
             "scenario should be extracted from test name"
         );
         assert_eq!(
+            receipt.workflow.as_deref(),
+            Some("scenario_19_diagnostics_clear_after_fix"),
+            "workflow should map to test function name"
+        );
+        assert_eq!(
             receipt.test.as_deref(),
             Some("ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix"),
             "test name should be extracted from log"
@@ -157,5 +186,6 @@ mod tests {
             Some("crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5"),
             "panic_location should be extracted from panic line"
         );
+        assert_eq!(receipt.route, "needs-test-fix", "race/new test bug routes to test fix");
     }
 }

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -260,10 +260,7 @@ mod tests {
             matches!(receipt.failure_class, FailureClass::BaselineDrift),
             "baseline snapshot log should classify as BaselineDrift"
         );
-        assert_eq!(
-            receipt.route, "needs-fixture-fix",
-            "BaselineDrift routes to needs-fixture-fix"
-        );
+        assert_eq!(receipt.route, "needs-fixture-fix", "BaselineDrift routes to needs-fixture-fix");
     }
 
     #[test]
@@ -323,8 +320,7 @@ mod tests {
     #[test]
     fn panic_re_matches_modern_rust_format() {
         // Rust 1.73+ format: "panicked at path:row:col:" with no quoted message.
-        let line =
-            "thread 'test' panicked at crates/perl-lsp-rs/src/lib.rs:42:8:";
+        let line = "thread 'test' panicked at crates/perl-lsp-rs/src/lib.rs:42:8:";
         let cap = PANIC_RE.captures(line).expect("should match modern panic format");
         assert_eq!(&cap[1], "crates/perl-lsp-rs/src/lib.rs:42:8");
     }

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -133,10 +133,12 @@ fn infer_failure_class(raw: &str) -> FailureClass {
         FailureClass::NewTestBug
     } else if lower.contains("no such file") || lower.contains("permission denied") {
         FailureClass::Infra
-    } else if lower.contains("assertion failed") || lower.contains("expected") {
+    } else if lower.contains("assertion failed") {
         // Check ProviderRegression before the generic panicked/ServerCrash catch-all:
         // a typical assertion failure log contains both "panicked" and "assertion failed",
         // so this branch must precede the ServerCrash arm to remain reachable.
+        // Note: we do NOT match on bare "expected" because it appears as a substring of
+        // unrelated words like "unexpectedly", causing false positives on ServerCrash logs.
         FailureClass::ProviderRegression
     } else if lower.contains("panicked") || lower.contains("server exited") {
         FailureClass::ServerCrash
@@ -213,9 +215,7 @@ mod tests {
     #[test]
     fn classify_server_crash_routes_to_provider_fix() {
         // ServerCrash: panicked in non-ux_scenario path (e.g., the LSP server process itself).
-        // The panic message must not contain "assertion failed" or "expected" (which would
-        // trigger ProviderRegression instead), and must not contain "tests/ux_scenario_"
-        // (which would trigger NewTestBug).
+        // Must not contain "tests/ux_scenario_" (NewTestBug) or "assertion failed" (ProviderRegression).
         let log = "running 1 test\ntest ux_scenario_02_open::open_file ... FAILED\nthread 'server' panicked at crates/perl-lsp-rs/src/provider.rs:55:9:\nserver crashed with SIGABRT\ntest result: FAILED. 0 passed; 1 failed";
         let receipt = classify(log, Some("sha2".to_string()));
         assert!(
@@ -224,6 +224,21 @@ mod tests {
             receipt.failure_class
         );
         assert_eq!(receipt.route, "needs-provider-fix", "ServerCrash routes to needs-provider-fix");
+    }
+
+    #[test]
+    fn classify_server_exited_unexpectedly_is_server_crash_not_provider() {
+        // "unexpectedly" contains the substring "expected", but ProviderRegression only
+        // triggers on "assertion failed" — not bare "expected" — so this must classify
+        // as ServerCrash, not ProviderRegression.
+        let log = "running 1 test\ntest ux_scenario_03_diag::diag_test ... FAILED\nthread 'main' panicked at crates/perl-lsp-rs/src/server.rs:10:1:\nserver exited unexpectedly\ntest result: FAILED. 0 passed; 1 failed";
+        let receipt = classify(log, Some("sha8".to_string()));
+        assert!(
+            matches!(receipt.failure_class, FailureClass::ServerCrash),
+            "log with 'unexpectedly' (substring of 'expected') should be ServerCrash, got {:?}",
+            receipt.failure_class
+        );
+        assert_eq!(receipt.route, "needs-provider-fix");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- UX regression failures were hard to triage because receipts lacked workflow-oriented fields and CI summaries required manual log spelunking to find first-failing test, panic location, repro, or routing hint.
- Adding deterministic routing and a formal receipt contract lets the gate surface actionable next-steps automatically instead of returning a generic failure.

### Description

- Extend the UX regression receipt with `workflow`, `scenario_file`, and a deterministic `route` derived from the inferred `failure_class` in `xtask/src/tasks/ux_regression_receipt.rs` and populate them in the classifier.  (adds `workflow_from_test_name` and `route_for_class`).
- Add unit coverage to assert workflow extraction and routing behavior for a representative failing scenario log in the `xtask` tests.
- Wire the GitHub Actions UX gate to run the `xtask` receipt emitter on failure and include structured receipt details (failure class, first failing test, panic location, repro, route) in the job summary by writing `.ci/receipts/ux-regression.json` from the workflow (`.github/workflows/ux-regression-gate.yml`).
- Add a formal JSON schema for the UX regression receipt at `.ci/schemas/ux-regression.schema.json` to document the contract and allowed `failure_class` values.

### Testing

- Ran `cargo test -p xtask ux_regression_receipt`, and the unit test `classify_extracts_structured_fields` passed.  (xtask test run completed successfully.)
- No changes were made to existing UX scenarios or production LSP code; the change is limited to the `xtask` receipt classifier, CI workflow, and the new schema file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21adf0b58833391a7fdee3aaf011c)