### PR TITLE
fix(xtask): enforce per-gate command timeouts (#0000)

### DIFF
--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1612,7 +1612,8 @@ fn run_single_gate(
     // Run through the platform shell because gate commands are policy strings.
     // Linux CI uses bash; Windows local runs use cmd.exe to keep `cargo`/`just`
     // lookup and simple command chaining available without requiring Git Bash.
-    let result = shell_command(command).stderr_to_stdout().stdout_capture().unchecked().run();
+    let (gate_cmd, timeout_enforced) = shell_command_with_timeout(command, timeout_secs);
+    let result = gate_cmd.stderr_to_stdout().stdout_capture().unchecked().run();
 
     let duration_ms = start.elapsed().as_millis() as u64;
 
@@ -1626,8 +1627,8 @@ fn run_single_gate(
                 eprintln!("Warning: Failed to write log file: {}", e);
             }
 
-            // Check if timed out
-            let timed_out = duration_ms > (timeout_secs * 1000);
+            // `timeout` exits 124 on hard timeout. Keep duration guard for fallback/local behavior.
+            let timed_out = (timeout_enforced && exit_code == 124) || duration_ms > (timeout_secs * 1000);
 
             let status = if timed_out {
                 "timeout".to_string()
@@ -1638,7 +1639,13 @@ fn run_single_gate(
             };
 
             // Extract output summary (last 10 lines or error message)
-            let output_summary = extract_output_summary(&stdout, 10);
+            let mut output_summary = extract_output_summary(&stdout, 10);
+            if timed_out {
+                output_summary = format!(
+                    "Timed out after {timeout_secs}s while running `{command}`. See logs/{}.log. {output_summary}",
+                    gate.name
+                );
+            }
 
             // Parse metrics if this is a test gate
             let metrics = if gate.tags.contains(&"test".to_string()) {
@@ -1694,15 +1701,15 @@ fn run_single_gate(
 }
 
 #[cfg(windows)]
-fn shell_command(command: &str) -> duct::Expression {
-    cmd!("cmd", "/C", command)
+fn shell_command_with_timeout(command: &str, _timeout_secs: u64) -> (duct::Expression, bool) {
+    (cmd!("cmd", "/C", command), false)
 }
 
 #[cfg(not(windows))]
-fn shell_command(command: &str) -> duct::Expression {
-    cmd!("bash", "-lc", command)
+fn shell_command_with_timeout(command: &str, timeout_secs: u64) -> (duct::Expression, bool) {
+    // GNU timeout enforces per-gate limits before the outer workflow timeout.
+    (cmd!("timeout", "--signal=TERM", format!("{}s", timeout_secs), "bash", "-lc", command), true)
 }
-
 fn run_internal_xtask_gate(
     gate: &GateDefinition,
     log_path: &std::path::Path,


### PR DESCRIPTION
### Motivation
- Gate-level command runs could be terminated by outer workflow timeouts and surface opaque exit codes (e.g., SIGTERM/143), making triage hard and losing which gate actually timed out.

### Description
- Wrap shell-backed gate commands with a per-gate timeout helper (`shell_command_with_timeout`) that uses GNU `timeout` on non-Windows and falls back to unwrapped execution on Windows.
- Detect hard timeouts by recognizing `timeout`'s exit code (`124`) and keep a duration-based fallback to mark a gate as `timeout` when appropriate.
- Enrich the gate `output_summary` when a timeout occurs to include the timeout duration, the exact command, and the gate log path for faster attribution and repro.
- Adjusted the main gate execution path to use the new helper while preserving existing internal-xtask gate dispatch behavior.

### Testing
- Ran `cargo check -p xtask`, which completed successfully with only pre-existing warnings.
- Verified the xtask binary builds locally after the change (`cargo check`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21d5b01948333b33b5741c74a731f)