### PR TITLE
fix(perl-workspace): refresh surface parity expectations (#0000)

### DIFF
--- a/crates/perl-workspace-index/tests/surface_workspace_parity.rs
+++ b/crates/perl-workspace-index/tests/surface_workspace_parity.rs
@@ -95,10 +95,8 @@ fn surface_workspace_parity_bank() -> Result<()> {
             label: "method declaration",
             src: "class Clock { method tick () { 1 } }",
             symbol_name: "tick",
-            expect_core_match: false,
-            actionable_divergence: Some(
-                "workspace index currently misses methods declared inside `class { ... }` bodies",
-            ),
+            expect_core_match: true,
+            actionable_divergence: None,
         },
         ParityCase {
             label: "my variable declaration",
@@ -106,14 +104,14 @@ fn surface_workspace_parity_bank() -> Result<()> {
             symbol_name: "count",
             expect_core_match: false,
             actionable_divergence: Some(
-                "workspace index does not preserve variable declarator (`my` vs `our`)",
+                "workspace qualified variable names keep sigils (e.g. `main::$count`) while surface uses `main::count`",
             ),
         },
         ParityCase {
             label: "our variable declaration",
             src: "our $VERSION = '1.0';",
             symbol_name: "VERSION",
-            expect_core_match: false,
+            expect_core_match: true,
             actionable_divergence: Some(
                 "workspace index does not preserve variable declarator (`my` vs `our`)",
             ),
@@ -122,35 +120,33 @@ fn surface_workspace_parity_bank() -> Result<()> {
             label: "use constant",
             src: "package C; use constant PI => 3.14;",
             symbol_name: "PI",
-            expect_core_match: false,
-            actionable_divergence: Some("workspace index emits `use constant` as Subroutine kind"),
+            expect_core_match: true,
+            actionable_divergence: None,
         },
         ParityCase {
             label: "Const::Fast wrapper",
             src: "use Const::Fast; const my $MAX => 3;",
             symbol_name: "MAX",
-            expect_core_match: false,
+            expect_core_match: true,
             actionable_divergence: Some(
-                "workspace index extracts Const::Fast as Variable, not Constant",
+                "workspace index does not preserve constant declarator wrapper metadata",
             ),
         },
         ParityCase {
             label: "Readonly wrapper",
             src: "use Readonly; Readonly my $NAME => 'x';",
             symbol_name: "NAME",
-            expect_core_match: false,
+            expect_core_match: true,
             actionable_divergence: Some(
-                "workspace index extracts Readonly as Variable, not Constant",
+                "workspace index does not preserve constant declarator wrapper metadata",
             ),
         },
         ParityCase {
             label: "class declaration",
             src: "class Worker { }",
             symbol_name: "Worker",
-            expect_core_match: false,
-            actionable_divergence: Some(
-                "class container/qualification differs: surface seeds `main`, workspace stores top-level class",
-            ),
+            expect_core_match: true,
+            actionable_divergence: None,
         },
     ];
 
@@ -179,7 +175,16 @@ fn surface_workspace_parity_bank() -> Result<()> {
             );
             continue;
         }
-        let rhs = rhs.expect("rhs existence already checked");
+        let rhs = match rhs {
+            Some(rhs) => rhs,
+            None => {
+                return Err(anyhow!(
+                    "{}: missing workspace {}",
+                    case.label,
+                    case.symbol_name
+                ));
+            }
+        };
 
         let core_fields_match = lhs.name == rhs.name
             && lhs.qualified_name == rhs.qualified_name
@@ -220,7 +225,7 @@ fn surface_workspace_divergence_details_are_actionable() -> Result<()> {
     let w_const = find(&workspace_const, "PI").ok_or_else(|| anyhow!("workspace PI missing"))?;
 
     assert_eq!(s_const.kind, SymbolKind::Constant);
-    assert_eq!(w_const.kind, SymbolKind::Subroutine);
+    assert_eq!(w_const.kind, SymbolKind::Constant);
 
     let const_fast_surface = surface_views("use Const::Fast; const my $MAX => 3;")?;
     let const_fast_workspace = workspace_views("use Const::Fast; const my $MAX => 3;")?;
@@ -228,7 +233,7 @@ fn surface_workspace_divergence_details_are_actionable() -> Result<()> {
     let w_fast =
         find(&const_fast_workspace, "MAX").ok_or_else(|| anyhow!("workspace MAX missing"))?;
     assert_eq!(s_fast.kind, SymbolKind::Constant);
-    assert_eq!(w_fast.kind, SymbolKind::Variable(perl_symbol::VarKind::Scalar));
+    assert_eq!(w_fast.kind, SymbolKind::Constant);
 
     let readonly_surface = surface_views("use Readonly; Readonly my $NAME => 'x';")?;
     let readonly_workspace = workspace_views("use Readonly; Readonly my $NAME => 'x';")?;
@@ -237,7 +242,7 @@ fn surface_workspace_divergence_details_are_actionable() -> Result<()> {
     let w_readonly =
         find(&readonly_workspace, "NAME").ok_or_else(|| anyhow!("workspace NAME missing"))?;
     assert_eq!(s_readonly.kind, SymbolKind::Constant);
-    assert_eq!(w_readonly.kind, SymbolKind::Variable(perl_symbol::VarKind::Scalar));
+    assert_eq!(w_readonly.kind, SymbolKind::Constant);
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- The surface/workspace parity tests encoded stale divergence assumptions so the parity bank failed even when the core symbol extraction behavior now matches; the tests need to reflect current extractor behavior to keep parity checks actionable.

### Description

- Updated `crates/perl-workspace-index/tests/surface_workspace_parity.rs` to mark several cases as core-parity matches (method declarations, `our` variables, `use constant`, `Const::Fast`/`Readonly` wrappers, and class declarations), adjusted the actionable divergence message for `my` variable sigil/qualification, and changed a test `expect(...)` into explicit `Result` error handling for clearer failure semantics.

### Testing

- Ran `cargo test -p perl-workspace --test surface_workspace_parity`, which passed.
- Ran `cargo test -p perl-workspace surface_workspace_parity`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21f52e3fc83339caa67916ce81ef1)