### PR TITLE
docs(project): add Wave 2 curation and parity execution discipline (#7402)

### DIFF
--- a/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
+++ b/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
@@ -128,6 +128,49 @@ This section is the migration receipt for what has landed versus what remains st
 - No rename/safe-delete cutover yet.
 - No full type inference.
 
+## Wave 2 Execution Discipline (Curation + Test Floor)
+
+When duplicate Wave 2 candidates exist, run a curator pass before merging additional tracks.
+
+### Required Curator Output Shape
+
+```json
+{
+  "cluster": "typed_reference_index",
+  "keepers": [7348],
+  "close_as_superseded": [7362, 7363],
+  "port_from_losers": [
+    {
+      "from": 7363,
+      "detail": "count_usages test shape",
+      "to": 7348
+    }
+  ],
+  "review_notes": [
+    "verify ReferenceEdge shape lives in perl-semantic-facts"
+  ]
+}
+```
+
+### Parity Test Floor
+
+Before merging the workspace-facing boxes (4–7), fix and re-green the parity test floor:
+
+```bash
+cargo test -p perl-workspace surface_workspace_parity
+cargo test -p perl-workspace
+cargo check --workspace --all-targets
+```
+
+Interpret failures explicitly as one of: real regression, stale expected output, fixture drift, or documented legacy divergence.
+
+### Merge Train Discipline
+
+1. Merge boxes 1–3 (exact adapters) and verify workspace-wide checks.
+2. Merge one curated winner for each duplicate cluster (facts shard, typed refs, shadow receipts, scorecard rows).
+3. Re-check `perl-workspace` parity tests after each merge-train step.
+4. Close superseded PRs only after loser-test harvest is ported.
+
 ## Wave 3 (User-Visible Cutover Staging)
 
 1. `ImportSpec` extraction.


### PR DESCRIPTION
### Motivation
- Add explicit execution discipline to the Wave 2 plan so duplicate candidate clusters are curated with a required output shape and workspace-facing merges only proceed once the `perl-workspace` parity test floor is green.

### Description
- Inserted a new `Wave 2 execution discipline (curation + test floor)` section into `docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md` that defines a required curator JSON output shape, the `perl-workspace` parity verification commands (`cargo test -p perl-workspace surface_workspace_parity`, `cargo test -p perl-workspace`, `cargo check --workspace --all-targets`), failure interpretation categories, and merge-train rules including loser-test harvest before closing superseded PRs.

### Testing
- Automated tests: none required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21f52e3fc83339caa67916ce81ef1)