### PR TITLE
fix(fmt): apply rustfmt to master HEAD drift (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
@@ -243,7 +243,6 @@ fn test_empty_workspace_roots_enforces_cwd_boundary() -> Result<(), Box<dyn Erro
     Ok(())
 }
 
-
 #[cfg(unix)]
 #[test]
 fn test_command_exists_does_not_execute_path_hijacked_which() -> Result<(), Box<dyn Error>> {

--- a/crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs
@@ -693,11 +693,13 @@ our %EXPORT_TAGS = (all => [qw(foo bar baz)]);
         assert!(info.default_export.contains("foo"));
         assert!(info.optional_export.contains("bar"));
         assert!(info.optional_export.contains("baz"));
-        assert_eq!(info.export_tags.get("core").unwrap(), &vec!["foo".to_string(), "bar".to_string()]);
+        assert_eq!(
+            info.export_tags.get("core").unwrap(),
+            &vec!["foo".to_string(), "bar".to_string()]
+        );
         assert_eq!(
             info.export_tags.get("all").unwrap(),
             &vec!["foo".to_string(), "bar".to_string(), "baz".to_string()]
         );
     }
-
 }


### PR DESCRIPTION
## Summary

Narrow fmt-only fix for master HEAD drift introduced by admin-merges #7388-#7390.

Three changes, two files:

- `crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs:696` — split long `assert_eq!` to multi-line form (rustfmt line-length rule)
- `crates/perl-semantic-analyzer/src/analysis/export_analyzer.rs` — remove trailing blank line before closing `}` of test module
- `crates/perl-lsp-rs/tests/execute_command_security_tests.rs:246` — remove extra blank line before `#[cfg(unix)]` attribute

## Verification

- `cargo xtask fmt --check` exits 0 (clean)
- `cargo build -p perl-semantic-analyzer -p perl-lsp-rs` exits 0 (no compile errors)
- Diff is exactly 2 files, 4 insertions, 3 deletions — no functional changes

## Intent

Unblocks the PR Smoke check queue. Admin-merge candidate once Compile + PR Smoke pass.