### PR TITLE
test(dap): add feature-gate coverage for dap.breakpoints.function (#5498)

### DIFF
--- a/crates/perl-dap/tests/dap_feature_flag_coverage_tests.rs
+++ b/crates/perl-dap/tests/dap_feature_flag_coverage_tests.rs
@@ -1,7 +1,6 @@
 //! DAP Feature Flag Coverage Tests
 //!
-//! Explicit test coverage for 8 DAP features that previously had no dedicated
-//! feature-gate validation:
+//! Explicit test coverage for DAP features with dedicated feature-gate validation:
 //!
 //! - AC0: dap.core
 //! - AC1: dap.breakpoints.basic
@@ -11,13 +10,16 @@
 //! - AC5: dap.exceptions.die
 //! - AC6: dap.inline_values
 //! - AC7: dap.modules
+//! - AC8: dap.exceptions.warn
+//! - AC9: dap.watchpoints
+//! - AC10: dap.breakpoints.function (#5498)
 //!
 //! Each feature gets:
 //! 1. Feature gate test: `has_feature("dap.X")` returns true
 //! 2. Capability test: initialize response advertises the feature correctly
 //! 3. Functional test: feature-gated code path works when enabled
 //!
-//! Related issues: #2784, #435, #2783
+//! Related issues: #2784, #435, #2783, #5498
 
 use perl_dap::feature_catalog::has_feature;
 use perl_dap::{DapMessage, DebugAdapter};
@@ -995,15 +997,149 @@ fn test_functional_dap_watchpoints_data_breakpoint_roundtrip() -> TestResult {
 }
 
 // ---------------------------------------------------------------------------
+// AC10: dap.breakpoints.function
+// ---------------------------------------------------------------------------
+
+/// Feature gate: dap.breakpoints.function is registered in the catalog.
+#[test]
+fn test_feature_gate_dap_breakpoints_function() {
+    assert!(
+        has_feature("dap.breakpoints.function"),
+        "dap.breakpoints.function must be registered in the feature catalog"
+    );
+}
+
+/// Capability test: initialize advertises supportsFunctionBreakpoints when dap.core is enabled.
+///
+/// `supportsFunctionBreakpoints` is tied to core DAP support (process.rs:171) rather than
+/// to the `dap.breakpoints.function` feature flag directly, because function breakpoints
+/// are part of the baseline adapter capability set.
+#[test]
+fn test_capability_dap_breakpoints_function_initialize_response() -> TestResult {
+    let body = get_initialize_body()?;
+
+    let supports_fn_bp =
+        body.get("supportsFunctionBreakpoints").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    if has_feature("dap.core") {
+        assert!(
+            supports_fn_bp,
+            "supportsFunctionBreakpoints must be true when dap.core is enabled"
+        );
+    }
+    Ok(())
+}
+
+/// Functional test: setFunctionBreakpoints accepts a simple boolean-like condition string.
+///
+/// The DAP protocol accepts any string in the condition field; semantic evaluation
+/// is delegated to the Perl debugger at runtime. The adapter must not reject a
+/// well-formed function name just because the condition isn't syntactically validated.
+#[test]
+fn test_functional_dap_function_breakpoints_with_condition() -> TestResult {
+    if !has_feature("dap.breakpoints.function") {
+        return Ok(());
+    }
+
+    let mut adapter = initialize_adapter();
+    let args = json!({
+        "breakpoints": [{
+            "name": "main::test_func",
+            "condition": "$debug_flag"
+        }]
+    });
+    let response = adapter.handle_request(2, "setFunctionBreakpoints", Some(args));
+    let body = expect_success_body(response, "setFunctionBreakpoints")?;
+
+    let bps = body
+        .get("breakpoints")
+        .and_then(|v| v.as_array())
+        .ok_or("missing breakpoints array")?;
+    assert_eq!(bps.len(), 1, "setFunctionBreakpoints must return one record");
+    let verified = bps[0].get("verified").and_then(|v| v.as_bool()).unwrap_or(false);
+    assert!(verified, "breakpoint with valid name and condition must be verified");
+    Ok(())
+}
+
+/// Functional test: setFunctionBreakpoints accepts a scalar variable as condition.
+///
+/// Perl uses scalar truthiness for conditionals; `$count` is a valid condition
+/// that evaluates true when non-zero/non-empty. The protocol layer must not
+/// reject it — runtime truthiness is Perl's concern, not the adapter's.
+#[test]
+fn test_functional_dap_function_breakpoints_scalar_condition() -> TestResult {
+    if !has_feature("dap.breakpoints.function") {
+        return Ok(());
+    }
+
+    let mut adapter = initialize_adapter();
+    let args = json!({
+        "breakpoints": [{
+            "name": "My::Module::handler",
+            "condition": "$count"
+        }]
+    });
+    let response = adapter.handle_request(2, "setFunctionBreakpoints", Some(args));
+    let body = expect_success_body(response, "setFunctionBreakpoints")?;
+
+    let bps = body
+        .get("breakpoints")
+        .and_then(|v| v.as_array())
+        .ok_or("missing breakpoints array")?;
+    assert_eq!(bps.len(), 1, "setFunctionBreakpoints must return one record");
+    let verified = bps[0].get("verified").and_then(|v| v.as_bool()).unwrap_or(false);
+    assert!(
+        verified,
+        "breakpoint with scalar condition `$count` must be verified (protocol accepts; runtime evaluates Perl truthiness)"
+    );
+    Ok(())
+}
+
+/// Functional test: setFunctionBreakpoints accepts a compound boolean condition.
+///
+/// Compound conditions using `&&` and function calls like `defined()` are valid
+/// Perl boolean expressions. The adapter stores the condition string verbatim
+/// for the debugger to evaluate — no protocol-layer validation of expression form.
+#[test]
+fn test_functional_dap_function_breakpoints_complex_condition() -> TestResult {
+    if !has_feature("dap.breakpoints.function") {
+        return Ok(());
+    }
+
+    let mut adapter = initialize_adapter();
+    let args = json!({
+        "breakpoints": [{
+            "name": "process_request",
+            "condition": "defined($ENV{DEBUG}) && $ENV{DEBUG} > 0"
+        }]
+    });
+    let response = adapter.handle_request(2, "setFunctionBreakpoints", Some(args));
+    let body = expect_success_body(response, "setFunctionBreakpoints")?;
+
+    let bps = body
+        .get("breakpoints")
+        .and_then(|v| v.as_array())
+        .ok_or("missing breakpoints array")?;
+    assert_eq!(bps.len(), 1, "setFunctionBreakpoints must return one record");
+    let verified = bps[0].get("verified").and_then(|v| v.as_bool()).unwrap_or(false);
+    assert!(
+        verified,
+        "breakpoint with compound condition must be verified (adapter does not validate condition syntax)"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Cross-feature: feature catalog completeness
 // ---------------------------------------------------------------------------
 
-/// All 10 DAP features must be registered in the feature catalog.
+/// All 11 DAP features must be registered in the feature catalog.
 #[test]
 fn test_all_dap_features_registered_in_catalog() {
     let dap_features = [
         "dap.core",
         "dap.breakpoints.basic",
+        "dap.breakpoints.function",
         "dap.breakpoints.hit_condition",
         "dap.breakpoints.logpoints",
         "dap.completions",

--- a/features.toml
+++ b/features.toml
@@ -635,7 +635,7 @@ area = "debug"
 maturity = "ga"
 advertised = true
 counts_in_coverage = false
-tests = ["crates/perl-dap/tests/dap_comprehensive_test.rs", "crates/perl-dap/tests/dap_non_regression_tests.rs"]
+tests = ["crates/perl-dap/tests/dap_comprehensive_test.rs", "crates/perl-dap/tests/dap_non_regression_tests.rs", "crates/perl-dap/tests/dap_feature_flag_coverage_tests.rs"]
 description = "Function breakpoints (setFunctionBreakpoints) by subroutine name"
 
 [[feature]]


### PR DESCRIPTION
## Summary

Closes #5498.

Adds dedicated feature-gate validation tests for `dap.breakpoints.function` — the only GA-maturity DAP feature that had no coverage in `dap_feature_flag_coverage_tests.rs`. Prior coverage was limited to serde round-trip tests in `dap_coverage_audit_tests.rs`, which verified serialization only, not the actual `setFunctionBreakpoints` handler behavior.

## What was missing

Issue #5498 identified that the test suite had a coverage gap:
- `dap_coverage_audit_tests.rs:498` (`test_function_breakpoint_round_trip`): tests JSON serde round-trip, not handler behavior
- `dap_feature_flag_coverage_tests.rs`: covered 10 features but not `dap.breakpoints.function`
- The cross-feature completeness test (`test_all_dap_features_registered_in_catalog`) also omitted `dap.breakpoints.function`

## What was added

**5 new tests in `dap_feature_flag_coverage_tests.rs`:**

| Test | What it verifies |
|------|-----------------|
| `test_feature_gate_dap_breakpoints_function` | Feature is registered in the catalog (`has_feature("dap.breakpoints.function")`) |
| `test_capability_dap_breakpoints_function_initialize_response` | `supportsFunctionBreakpoints` advertised in initialize response when `dap.core` is enabled |
| `test_functional_dap_function_breakpoints_with_condition` | `setFunctionBreakpoints` accepts a simple condition string (`$debug_flag`) and returns `verified: true` for a valid name |
| `test_functional_dap_function_breakpoints_scalar_condition` | Scalar variable condition (`$count`) is accepted — Perl truthiness is evaluated by the debugger, not the adapter |
| `test_functional_dap_function_breakpoints_complex_condition` | Compound boolean expression (`defined($ENV{DEBUG}) && $ENV{DEBUG} > 0`) is accepted verbatim |

**Header updated:** Module docstring now lists all 11 AC sections (was "8 features").

**Cross-feature completeness test updated:** `test_all_dap_features_registered_in_catalog` now includes `dap.breakpoints.function` in the checked feature set (count: 10 → 11).

**`features.toml` updated:** `dap.breakpoints.function` feature entry now lists `dap_feature_flag_coverage_tests.rs` in its `tests` field.

## Design rationale

The key invariant these tests document: the adapter validates only the **function name** (regex `^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$`) and stores the **condition string verbatim** without semantic validation. Perl condition truthiness is delegated to the debugger runtime. The tests explicitly assert this contract with three representative condition shapes:

1. Simple flag (`$debug_flag`) — most common production use case
2. Scalar variable (`$count`) — exercises non-explicitly-boolean truthiness
3. Compound expression (`defined($ENV{DEBUG}) && $ENV{DEBUG} > 0`) — exercises operators and function calls

All three are correctly accepted at the protocol layer, matching the DAP 1.0 spec behavior.

## Verification

```
test test_feature_gate_dap_breakpoints_function ... ok
test test_capability_dap_breakpoints_function_initialize_response ... ok
test test_functional_dap_function_breakpoints_with_condition ... ok
test test_functional_dap_function_breakpoints_scalar_condition ... ok
test test_functional_dap_function_breakpoints_complex_condition ... ok
test test_all_dap_features_registered_in_catalog ... ok

test result: ok. 49 passed; 0 failed; 0 ignored
```

Total: 44 → 49 tests passing in `dap_feature_flag_coverage_tests`.

## Files changed

- `crates/perl-dap/tests/dap_feature_flag_coverage_tests.rs` — 141 lines added
- `features.toml` — 1 line updated (test file registration)

## Test plan

- [x] `cargo test -p perl-dap --test dap_feature_flag_coverage_tests` — all 49 pass
- [x] `cargo check -p perl-dap --tests` — compiles clean
- [x] No changes to production code in `crates/` or protocol definitions
- [x] No changes to spec-planner files (Fix B from #5498 remains deferred)

https://claude.ai/code/session_012JeBwxDfoqNbsmZbG7SC7W

---
_Generated by [Claude Code](https://claude.ai/code/session_012JeBwxDfoqNbsmZbG7SC7W)_