### PR TITLE
fix(fmt): apply rustfmt to test cluster drift after Wave 2 merges (#0000)

### DIFF
--- a/crates/perl-dap/tests/dap_feature_flag_coverage_tests.rs
+++ b/crates/perl-dap/tests/dap_feature_flag_coverage_tests.rs
@@ -380,14 +380,9 @@ fn test_feature_gate_dap_breakpoints_function() {
 #[test]
 fn test_capability_dap_breakpoints_function_initialize_response() -> TestResult {
     let body = get_initialize_body()?;
-    let supports = body
-        .get("supportsFunctionBreakpoints")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    assert!(
-        supports,
-        "supportsFunctionBreakpoints must be true in the initialize response"
-    );
+    let supports =
+        body.get("supportsFunctionBreakpoints").and_then(|v| v.as_bool()).unwrap_or(false);
+    assert!(supports, "supportsFunctionBreakpoints must be true in the initialize response");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Apply `cargo xtask fmt` to fix formatting drift in `crates/perl-dap/tests/dap_feature_flag_coverage_tests.rs` introduced by Wave 2 PR merges
- Unblocks 8+ queued PRs whose PR Smoke CI fails on the `fmt` gate when rebased onto master
- Pure fmt-only change — no logic, behavior, or test coverage changes

## Changes

- `crates/perl-dap/tests/dap_feature_flag_coverage_tests.rs`: condense method chain and `assert!` call per rustfmt `use_small_heuristics = "Max"` workspace config

Note: The three files listed in CI logs (`dual_indexing_tests.rs`, `surface_refs.rs`, `import_export_visibility_regression_bank.rs`) were investigated and already pass `cargo xtask fmt --check` on master HEAD — no changes needed for them.

## Evidence

- **Commits**: 1
- **Tests**: 377 passed, 0 failed (`cargo test -p perl-dap --lib`)
- **Lint**: `cargo xtask fmt --check` exits 0 on current branch
- **Files**: 1 changed, +3/-8 lines

## Test Plan

- [ ] CI fmt gate passes (was failing before this PR)
- [ ] `cargo xtask fmt --check` exits 0
- [ ] `cargo test -p perl-dap --lib` — 377/377 pass
- [ ] `cargo build -p perl-workspace -p perl-symbol -p perl-semantic-analyzer` compiles clean

## Unknowns

- The three files mentioned in the original task description (`dual_indexing_tests.rs`, etc.) were already clean on master HEAD — they may have been fixed by a prior commit (`70b04140cc fix(fmt): apply cargo xtask fmt to PR #7018 files`). If CI still flags them, the issue is a different rustfmt version on CI vs local.