### PR TITLE
fix(perl-corpus): align fixture_expectation_sidecars test with merged sidecar API (#0000)

### DIFF
--- a/crates/perl-corpus/tests/fixture_expectation_sidecars.rs
+++ b/crates/perl-corpus/tests/fixture_expectation_sidecars.rs
@@ -1,7 +1,5 @@
 use anyhow::{Context, Result};
-use perl_corpus::fixture_expectations::{
-    ConceptRegistry, ValidationIssue, discover_sidecars, parse_sidecar, validate_sidecar,
-};
+use perl_corpus::{ConceptRegistry, discover_sidecars, load_and_validate_sidecar};
 use std::path::PathBuf;
 
 fn workspace_root() -> Result<PathBuf> {
@@ -16,34 +14,39 @@ fn workspace_root() -> Result<PathBuf> {
 fn seeded_sidecars_parse_and_validate() -> Result<()> {
     let root = workspace_root()?;
     let sidecar_root = root.join("tests/perl-corpus");
-    let sidecars = discover_sidecars(&sidecar_root);
+    let sidecars = discover_sidecars(&sidecar_root)?;
     assert!(!sidecars.is_empty(), "expected seeded parser sidecars");
 
     let registry_path = sidecar_root.join("concepts.toml");
-    let registry = ConceptRegistry::from_optional_file(&registry_path)?;
+    let registry = if registry_path.exists() {
+        Some(
+            ConceptRegistry::load(&registry_path)
+                .with_context(|| format!("loading registry {}", registry_path.display()))?,
+        )
+    } else {
+        None
+    };
 
-    for sidecar in sidecars {
-        let expectation = parse_sidecar(&sidecar)
-            .with_context(|| format!("sidecar should parse: {}", sidecar.display()))?;
-        let report = validate_sidecar(&sidecar, &expectation, registry.as_ref());
+    for sidecar in &sidecars {
+        let validation = load_and_validate_sidecar(sidecar, registry.as_ref())
+            .with_context(|| format!("sidecar should load and validate: {}", sidecar.display()))?;
 
         assert!(
-            !report
-                .issues
-                .iter()
-                .any(|issue| matches!(issue, ValidationIssue::MissingFixtureFile(_))),
-            "fixture file should exist for {}",
-            sidecar.display()
+            !validation.errors.iter().any(|error| error.contains("fixture file does not exist")),
+            "fixture file should exist for {}\nerrors: {:?}",
+            sidecar.display(),
+            validation.errors,
         );
 
         if registry.is_none() {
             assert!(
-                report
-                    .issues
+                validation
+                    .warnings
                     .iter()
-                    .any(|issue| matches!(issue, ValidationIssue::PendingConceptRegistry(_))),
-                "missing registry should report pending concept resolution for {}",
-                sidecar.display()
+                    .any(|warning| warning.contains("concept resolution pending")),
+                "missing registry should report pending concept resolution for {}\nwarnings: {:?}",
+                sidecar.display(),
+                validation.warnings,
             );
         }
     }

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -2504,10 +2504,11 @@ mod tests {
         PackageTargetIndex, Receipt, blocking_failure_gate_names, build_pr_fast_plan_from_scope,
         build_pr_fast_plan_from_scope_with_targets, compare_receipts, determine_overall_status,
         extend_plan_with_non_pr_fast_static_gates, extend_plan_with_static_tiers, failure_guidance,
-        is_blocking_gate_status, is_cargo_test_command, load_policy, parse_first_failure,
+        is_blocking_gate_status, is_cargo_test_command, load_policy_for_inspection,
+        parse_first_failure,
     };
     use crate::tasks::ci_scope::{
-        ArchWidener, DirectCrate, PlatformOverrides, RevDepCrate, ScopeOutput,
+        ArchWidener, DirectCrate, LaneDecisions, PlatformOverrides, RevDepCrate, ScopeOutput,
     };
 
     fn gate_result(name: &str, status: &str, required: bool) -> GateResult {
@@ -2611,7 +2612,7 @@ mod tests {
             platform_overrides: PlatformOverrides::default(),
             selected_lanes: Vec::new(),
             selected_heavy_lanes: Vec::new(),
-            lanes: BTreeMap::new(),
+            lanes: LaneDecisions::default(),
             explanations: BTreeMap::new(),
         }
     }
@@ -2839,7 +2840,7 @@ mod tests {
     fn pr_fast_policy_planning_roles_are_complete() -> color_eyre::eyre::Result<()> {
         let root = crate::utils::project_root()?;
         let policy_path = root.join(".ci/gate-policy.yaml");
-        let policy = load_policy(&policy_path)?;
+        let policy = load_policy_for_inspection(&policy_path)?;
 
         for gate in policy.gates.iter().filter(|gate| gate.tier == "pr_fast") {
             let Some(planning) = &gate.planning else {


### PR DESCRIPTION
## Summary

- Rewrite `crates/perl-corpus/tests/fixture_expectation_sidecars.rs` to match the merged sidecar API from `#7143`/`#7153`/`#7135`: imports from `perl_corpus::` (not `fixture_expectations::`), uses `load_and_validate_sidecar`, checks `validation.errors`/`validation.warnings` strings instead of `ValidationIssue` enum
- Fix `xtask/src/tasks/gates.rs` test bit-rot: rename `load_policy` → `load_policy_for_inspection` and fix `lanes: BTreeMap::new()` → `lanes: LaneDecisions::default()` after `ScopeOutput` struct update

## Root cause

Three PRs merged in sequence renamed and restructured the sidecar API but the integration test file (`fixture_expectation_sidecars.rs`) and xtask test helpers were not updated to match.

## Test plan

- [x] `cargo build -p perl-corpus -p xtask --tests` passes clean (was 9 errors before)
- [x] `cargo test -p perl-corpus` — 167 passed, 6 ignored
- [x] `cargo xtask fmt` — exit 0
- [x] `cargo clippy -p perl-corpus -p xtask` — 0 errors (1 pre-existing warning at gates.rs:1088, not in this diff)