### PR TITLE
ci: relax pr-fast scoped unit timeout (#0000)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -285,10 +285,10 @@ gates:
     description: "Scope-aware library tests for ci-scope selected crates"
     required: true
     command: cargo test --locked --lib {package_args}
-    timeout_seconds: 180
+    timeout_seconds: 240
     retry_count: 1
     budgets:
-      max_duration_ms: 150000
+      max_duration_ms: 220000
     quarantine: false
     tags:
       - test


### PR DESCRIPTION
Problem: PR-fast can false-red scoped Rust PRs when unit tests exit successfully just over the current 180s unit_scoped limit.\nFix: Raise the unit_scoped timeout and duration budget to match observed successful scoped runs.\nVerification: \git diff --check\ passes; conflict-marker scan passes.