### PR TITLE
test(perl-pragma): cover quoted strict args in conditional pragmas (#0000)

### DIFF
--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -1675,6 +1675,35 @@ fn no_if_builtin_conditionally_removes_lexical_imports() -> Result<(), Box<dyn s
 }
 
 #[test]
+fn use_if_strict_with_single_quoted_whitespace_list_enables_selected_flags()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("if", &["$cond", "strict", "'vars subs'"], 0, 36)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+
+    assert!(state.strict_vars);
+    assert!(state.strict_subs);
+    assert!(!state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn no_if_strict_with_single_quoted_whitespace_list_disables_selected_flags()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 11),
+        no_node("if", &["$cond", "strict", "'vars subs'"], 12, 48),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+
+    assert!(!state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
 fn no_version_declaration_has_no_features() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("strict", &[], 0, 12)]);
     let map = PragmaTracker::build(&ast);


### PR DESCRIPTION
### Motivation
- Add focused test coverage for conditional `use if`/`no if` handling of single-quoted, whitespace-delimited strict argument lists (for example `'vars subs'`).

### Description
- Added two unit tests to `crates/perl-pragma/tests/comprehensive_unit_tests.rs` named `use_if_strict_with_single_quoted_whitespace_list_enables_selected_flags` and `no_if_strict_with_single_quoted_whitespace_list_disables_selected_flags` that build small ASTs and assert `PragmaState` flags (`strict_vars`, `strict_subs`, `strict_refs`).

### Testing
- Ran `cargo test -p perl-pragma use_if_strict_with_single_quoted_whitespace_list_enables_selected_flags` and it passed.
- Ran `cargo test -p perl-pragma no_if_strict_with_single_quoted_whitespace_list_disables_selected_flags` and it passed.
- Ran `cargo check --all-targets -p perl-pragma` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27a1206b483338e29f9edc88ab2ef)