### PR TITLE
test(perl-lexer): strengthen builtin lookup coverage (#0000)

### DIFF
--- a/crates/perl-lexer/src/builtins/phf_lookup.rs
+++ b/crates/perl-lexer/src/builtins/phf_lookup.rs
@@ -400,6 +400,11 @@ mod tests {
         assert_eq!(try_get_param_names("print"), Some(["FILEHANDLE", "LIST"].as_slice()));
         assert_eq!(try_get_param_names("not_a_builtin"), None);
     }
+
+    #[test]
+    fn get_param_names_returns_empty_slice_for_unknown_builtin() {
+        assert!(get_param_names("not_a_builtin").is_empty());
+    }
     #[test]
     fn returns_open_param_names() {
         assert_eq!(get_param_names("open"), ["FILEHANDLE", "MODE", "FILENAME"]);
@@ -411,6 +416,23 @@ mod tests {
         let targets =
             ["open", "print", "push", "pop", "splice", "map", "grep", "sort", "join", "split"];
         for name in &targets {
+            assert!(
+                BUILTIN_FULL_SIGS.contains_key(name),
+                "BUILTIN_FULL_SIGS should contain '{}'",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn shorthand_signature_entries_have_full_signature_coverage() {
+        let targets = ["printf", "system", "exec", "mkdir", "unlink", "stat"];
+        for name in &targets {
+            assert!(
+                try_get_param_names(name).is_some(),
+                "BUILTIN_SIGS should contain '{}'",
+                name
+            );
             assert!(
                 BUILTIN_FULL_SIGS.contains_key(name),
                 "BUILTIN_FULL_SIGS should contain '{}'",


### PR DESCRIPTION
### Motivation
- Add regression tests to ensure builtin lookup helpers handle unknown names and that shorthand signature entries are covered by full-signature mappings.

### Description
- Added unit tests in `crates/perl-lexer/src/builtins/phf_lookup.rs` to assert `get_param_names` returns an empty slice for unknown builtins and to verify representative shorthand entries (`printf`, `system`, `exec`, `mkdir`, `unlink`, `stat`) are present in both `BUILTIN_SIGS` and `BUILTIN_FULL_SIGS`.

### Testing
- Ran `cargo test -p perl-lexer` and `cargo check --all-targets -p perl-lexer`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27a1206b483338e29f9edc88ab2ef)