### PR TITLE
test(perl-lexer): expand data marker utility coverage (#0000)

### DIFF
--- a/crates/perl-lexer/src/tokenizer/util.rs
+++ b/crates/perl-lexer/src/tokenizer/util.rs
@@ -97,4 +97,31 @@ mod tests {
         let with_end = "code;\n__END__\nvalue";
         assert_eq!(split_code_and_data(with_end), ("code;\n", Some("__END__\nvalue")));
     }
+
+    #[test]
+    fn test_find_data_marker_ignores_pod_and_heredoc_content() {
+        let pod = "=head1 NAME\n__DATA__\n=cut\nprint 'done';\n";
+        assert_eq!(find_data_marker_byte_lexed(pod), None);
+
+        let heredoc = "my $text = <<\"TXT\";\n__END__\nTXT\nprint $text;\n";
+        assert_eq!(find_data_marker_byte_lexed(heredoc), None);
+    }
+
+    #[test]
+    fn test_split_code_and_data_prefers_first_lexed_marker() {
+        let src = "print 'prelude';\n__DATA__\nchunk\n__END__\nignored";
+        assert_eq!(
+            split_code_and_data(src),
+            ("print 'prelude';\n", Some("__DATA__\nchunk\n__END__\nignored"))
+        );
+    }
+
+    #[test]
+    // Allow deprecated call to verify compatibility wrapper behavior.
+    #[allow(deprecated)]
+    fn test_find_data_marker_deprecated_matches_lexed_helper() {
+        let src = "say 1;\n__END__\ntrailer";
+        assert_eq!(find_data_marker_byte(src), find_data_marker_byte_lexed(src));
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Cover edge cases in the data-marker helpers so `__DATA__`/`__END__` inside POD or heredocs do not produce false positives.
- Verify `split_code_and_data` chooses the first lexed data marker and preserves the remaining payload.
- Ensure the deprecated compatibility wrapper behaves the same as the new lexed helper.

### Description

- Added focused unit tests in `crates/perl-lexer/src/tokenizer/util.rs` that assert POD and heredoc content do not trigger `find_data_marker_byte_lexed`.
- Added a test to confirm `split_code_and_data` splits at the first lexed marker and retains the rest of the data section.
- Added a compatibility test for the deprecated `find_data_marker_byte` and annotated it with `#[allow(deprecated)]` to document the justification.

### Testing

- Ran `cargo test -p perl-lexer tokenizer::util::tests --quiet` and the targeted unit tests passed (6 passed; 0 failed).
- Ran `cargo check --all-targets -p perl-lexer` and it completed successfully with only an expected deprecation warning suppressed in tests.
- Full crate checks for `perl-lexer` finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27a1206b483338e29f9edc88ab2ef)