### PR TITLE
test(perl-workspace): broaden workspace folder fuzz coverage (#0000)

### DIFF
--- a/crates/perl-workspace-index/tests/workspace_folder_fuzz.rs
+++ b/crates/perl-workspace-index/tests/workspace_folder_fuzz.rs
@@ -21,8 +21,13 @@ impl XorShift64 {
 }
 
 fn fuzz_string(state: &mut XorShift64, max_len: usize) -> String {
-    let len = (state.next_u64() as usize % max_len).saturating_add(1);
-    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz/::._ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789%";
+    if max_len == 0 {
+        return String::new();
+    }
+
+    let len = state.next_u64() as usize % (max_len + 1);
+    const ALPHABET: &[u8] =
+        b"abcdefghijklmnopqrstuvwxyz/::._ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789%?&#=+-\\";
     let mut out = String::with_capacity(len);
 
     for _ in 0..len {
@@ -33,14 +38,43 @@ fn fuzz_string(state: &mut XorShift64, max_len: usize) -> String {
     out
 }
 
+fn assert_no_file_uri_leak(input: &str) {
+    let parsed = workspace_folder_to_path(input);
+    assert!(
+        !parsed.to_string_lossy().contains("file://"),
+        "output path leaked URI scheme for input: {input:?}"
+    );
+}
+
 #[test]
 fn fuzz_workspace_folder_inputs_do_not_panic_or_produce_file_uris() {
     let mut rng = XorShift64::new(0x5EED_BEEF_DEAD_BEEF);
 
-    for _ in 0..2_500 {
-        let input = fuzz_string(&mut rng, 48);
-        let parsed = workspace_folder_to_path(&input);
+    for _ in 0..5_000 {
+        let input = fuzz_string(&mut rng, 96);
+        assert_no_file_uri_leak(&input);
+    }
+}
 
-        assert!(!parsed.to_string_lossy().contains("file://"));
+#[test]
+fn fuzz_workspace_folder_targeted_uri_like_inputs() {
+    let samples = [
+        "",
+        "file://",
+        "file:///tmp/project",
+        "FILE:///UPPER",
+        "file://C:/Users/test/project",
+        "vscode-remote://ssh-remote+host/workspace",
+        "perl://module/Foo::Bar",
+        "%66%69%6c%65://encoded",
+        "./relative/path",
+        "C:\\workspace\\project",
+        "\\\\server\\share\\project",
+        "file:///%2e%2e/%2e%2e/etc/passwd",
+        "file://?query=1#frag",
+    ];
+
+    for sample in samples {
+        assert_no_file_uri_leak(sample);
     }
 }


### PR DESCRIPTION
### Motivation

- Improve fuzz-driven test coverage for workspace-folder parsing to exercise longer, empty, and URI/path-like inputs and catch edge-case regressions while preserving the invariant that no output contains a `file://` scheme.

### Description

- Broadened the random fuzz generator by allowing zero-length outputs, increasing the max input length, and expanding the punctuation alphabet in `fuzz_string` in `crates/perl-workspace-index/tests/workspace_folder_fuzz.rs`.
- Added a reusable assertion helper `assert_no_file_uri_leak` that checks the `file://` invariant with a diagnostic failure message.
- Increased randomized iterations from `2_500` to `5_000` and max length from `48` to `96` to raise coverage density for the randomized test.
- Added a targeted corpus-style test `fuzz_workspace_folder_targeted_uri_like_inputs` with empty, URI-like, encoded, relative, Windows, and UNC path samples to exercise known edge cases.

### Testing

- Ran `cargo test -p perl-workspace --test workspace_folder_fuzz` and the two tests passed (`ok`); the fuzz tests completed successfully.
- Ran `cargo check --all-targets -p perl-workspace` which completed successfully with no errors.
- Ran `cargo clippy -p perl-workspace --test workspace_folder_fuzz -- -D warnings` which completed successfully with no warnings.
- Note: an initial `cargo test -p perl-workspace-index --test workspace_folder_fuzz` failed due to using the wrong package name (the crate is published as `perl-workspace`), and the corrected invocations above were used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28b6a51748333af02239c0a721608)