### PR TITLE
test(perl-workspace): expand discovery fuzz coverage (#0000)

### DIFF
--- a/crates/perl-workspace-index/tests/discovery_fuzz_tests.rs
+++ b/crates/perl-workspace-index/tests/discovery_fuzz_tests.rs
@@ -59,7 +59,9 @@ fn fuzz_randomized_workspace_layouts_preserve_discovery_invariants() -> TestResu
         ".cache/precompiled",
         ".git/hooks",
     ];
-    let extensions = ["pl", "pm", "t", "psgi", "xs", "txt", "md", "json", "rs"];
+    let extensions = [
+        "pl", "pm", "t", "psgi", "xs", "i", "tt", "tt2", "ep", "txt", "md", "json", "rs",
+    ];
 
     let mut rng = XorShift64::new(0xA11C_E55D_1234_5678);
 
@@ -68,12 +70,25 @@ fn fuzz_randomized_workspace_layouts_preserve_discovery_invariants() -> TestResu
         let root = tmp.path();
 
         let file_count = 8 + rng.next_usize(48);
+        let mut expected_perl_like_non_skipped = 0usize;
+
         for file_idx in 0..file_count {
             let directory = directories[rng.next_usize(directories.len())];
             let extension = extensions[rng.next_usize(extensions.len())];
             let suffix = rng.next_usize(10_000);
             let relative = format!("{directory}/f_{case_idx}_{file_idx}_{suffix}.{extension}");
             create_file(root, &relative)?;
+
+            let path = root.join(&relative);
+            let is_skipped_dir = Path::new(&relative).components().any(|component| {
+                component.as_os_str() == "node_modules"
+                    || component.as_os_str() == "target"
+                    || component.as_os_str() == ".cache"
+                    || component.as_os_str() == ".git"
+            });
+            if !is_skipped_dir && is_perl_discovery_path(&path) {
+                expected_perl_like_non_skipped += 1;
+            }
         }
 
         let result = discover_perl_files(root);
@@ -84,6 +99,12 @@ fn fuzz_randomized_workspace_layouts_preserve_discovery_invariants() -> TestResu
             assert!(is_perl_discovery_path(path));
             assert!(seen.insert(path.clone()));
         }
+
+        assert_eq!(
+            result.files.len(),
+            expected_perl_like_non_skipped,
+            "mismatch for case index {case_idx}"
+        );
     }
 
     Ok(())


### PR DESCRIPTION
### Motivation
- Improve fuzzing coverage for workspace discovery by exercising additional discovery-eligible extensions and verifying that discovered file counts match an oracle that respects skipped-directory semantics.

### Description
- Broadened the randomized fuzz test in `crates/perl-workspace-index/tests/discovery_fuzz_tests.rs` to include extra extensions (`i`, `tt`, `tt2`, `ep`) and added an oracle that computes `expected_perl_like_non_skipped` using `Path::components()` to detect skipped directories (`node_modules`, `target`, `.cache`, `.git`) and then assert the discovered count equals the oracle.

### Testing
- Ran `cargo test -p perl-workspace --test discovery_fuzz_tests` which passed. 
- Ran `cargo check --all-targets -p perl-workspace` which passed. 
- Ran `cargo clippy -p perl-workspace --all-targets -- -D warnings` which failed due to pre-existing clippy violations in unrelated files (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28b6a51748333af02239c0a721608)