### PR TITLE
test(fuzz): expand incremental edit input alphabet (#0000)

### DIFF
--- a/fuzz/fuzz_targets/incremental_edit_sequences.rs
+++ b/fuzz/fuzz_targets/incremental_edit_sequences.rs
@@ -6,6 +6,9 @@ use perl_parser::incremental::{apply_edits, Edit, IncrementalState};
 const MAX_INITIAL_CHARS: usize = 256;
 const MAX_EDIT_STEPS: usize = 32;
 const MAX_INSERT_CHARS: usize = 32;
+const ASCII_TOKEN_CHARS: &[u8] =
+    b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ ;(){}[]<>$@%&*+-=/\\\"'.,:#\n\r\t";
+const UNICODE_TOKEN_CHARS: &[char] = &['é', 'ß', 'λ', '中', '🦀', '🙂', '\u{2028}'];
 
 struct ByteCursor<'a> {
     data: &'a [u8],
@@ -34,9 +37,12 @@ impl<'a> ByteCursor<'a> {
     }
 
     fn next_char(&mut self) -> char {
-        const ALPHABET: &[u8] =
-            b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ ;(){}\n\t";
-        char::from(ALPHABET[usize::from(self.next_u8()) % ALPHABET.len()])
+        let selector = self.next_u8();
+        if selector % 5 == 0 {
+            return UNICODE_TOKEN_CHARS[usize::from(selector) % UNICODE_TOKEN_CHARS.len()];
+        }
+
+        char::from(ASCII_TOKEN_CHARS[usize::from(selector) % ASCII_TOKEN_CHARS.len()])
     }
 
     fn next_text(&mut self, max_chars: usize) -> String {


### PR DESCRIPTION
### Motivation
- The incremental edit-sequence fuzz target primarily produced ASCII identifiers and simple whitespace which left punctuation-heavy, sigil, CR/LF, and multi-byte Unicode edit paths under-exercised, reducing fuzz coverage for byte/char boundary and multi-byte scenarios.

### Description
- Add a broader ASCII alphabet constant `ASCII_TOKEN_CHARS` that includes punctuation, sigils, brackets, and CR/LF characters in `fuzz/fuzz_targets/incremental_edit_sequences.rs`.
- Add a small curated `UNICODE_TOKEN_CHARS` set with representative multi-byte characters to exercise UTF-8/UTF-16 boundaries.
- Update `ByteCursor::next_char()` to deterministically mix Unicode selections with the expanded ASCII set so generated edits include both single- and multi-byte characters while preserving bounded generation.

### Testing
- Ran `rustfmt fuzz/fuzz_targets/incremental_edit_sequences.rs` which completed successfully.
- Ran `cargo check --manifest-path fuzz/Cargo.toml --bin incremental_edit_sequences` which completed successfully (dev profile compiled without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28b6a51748333af02239c0a721608)