### PR TITLE
test(fuzz): expand regression target set (#0000)

### DIFF
--- a/justfile
+++ b/justfile
@@ -2163,6 +2163,9 @@ fuzz-regression duration='30':
     @just fuzz lsp_navigation {{duration}} || true
     @just fuzz utf16_roundtrip {{duration}} || true
     @just fuzz unicode_positions {{duration}} || true
+    @just fuzz lexer_tokenization {{duration}} || true
+    @just fuzz dap_eval_validator {{duration}} || true
+    @just fuzz dap_stack_parser {{duration}} || true
     @just fuzz-check-crashes
     @echo "✅ Fuzz regression testing complete"
 


### PR DESCRIPTION
### Motivation
- Bring the short-duration `fuzz-regression` recipe in `justfile` into parity with maintained fuzz targets so quick regression sweeps exercise more target-specific coverage.

### Description
- Added `lexer_tokenization`, `dap_eval_validator`, and `dap_stack_parser` to the `fuzz-regression` recipe in `justfile` so the short-run pass runs those fuzz targets (`fuzz-regression` now invokes these targets with `{{duration}}`).

### Testing
- Attempted a dry-run via `just --dry-run fuzz-regression duration=1`, which could not be executed in this environment because `just` is not installed (no automated test run completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f28b6a51748333af02239c0a721608)