### PR TITLE
fix(perl-lexer): re-sort cache after checkpoint edits (#0000)

### DIFF
--- a/crates/perl-lexer/src/checkpoint.rs
+++ b/crates/perl-lexer/src/checkpoint.rs
@@ -318,6 +318,10 @@ impl CheckpointCache {
         // Remove invalid checkpoints
         self.checkpoints
             .retain(|(_, cp)| !matches!(cp.context, CheckpointContext::Normal) || cp.position > 0);
+
+        // Edits can move checkpoints backward (or to the same position), so
+        // restore the sorted-order invariant required by binary-search lookups.
+        self.checkpoints.sort_unstable_by_key(|(pos, _)| *pos);
     }
 }
 
@@ -525,6 +529,32 @@ mod tests {
             mid.is_none_or(|cp| cp.position != 20),
             "middle checkpoint (20) must be evicted when capacity=2 and total=3"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_checkpoint_cache_apply_edit_resorts_positions()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut cache = CheckpointCache::new(10);
+        for pos in [10usize, 20, 30] {
+            cache.add(LexerCheckpoint::at_position(pos));
+        }
+
+        // Edit [15, 35) resets checkpoints at 20 and 30 to position 15.
+        // Without re-sorting, cache order becomes [10, 15, 15] by position but
+        // stored entries can be out of order, breaking binary-search lookups.
+        cache.apply_edit(15, 20, 0);
+
+        let before = cache
+            .find_before(15)
+            .ok_or("find_before should locate checkpoint at edited boundary")?;
+        assert_eq!(before.position, 15);
+
+        let after = cache
+            .find_after(15)
+            .ok_or("find_after should locate checkpoint at edited boundary")?;
+        assert_eq!(after.position, 15);
+
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Edits applied via `CheckpointCache::apply_edit` can move checkpoints backward (or to the same position) and break the sorted-order invariant relied on by binary-search lookups (`find_before`/`find_after`).

### Description

- Re-sorts the internal `checkpoints` vector with `sort_unstable_by_key(|(pos, _)| *pos)` at the end of `CheckpointCache::apply_edit` to restore the sorted-order invariant.
- Adds an edge-case unit test `test_checkpoint_cache_apply_edit_resorts_positions` that applies an in-edit reset and verifies `find_before`/`find_after` still locate the edited-boundary checkpoint. 
- Change is localized to `crates/perl-lexer/src/checkpoint.rs` and preserves existing behavior while fixing the binary-search correctness assumption.

### Testing

- Ran `cargo test -p perl-lexer test_checkpoint_cache_apply_edit_resorts_positions` and it passed.
- Ran full crate test `cargo test -p perl-lexer` and it passed (all tests OK).
- Ran `cargo check --all-targets -p perl-lexer` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d1c16b483339c288a7edb14166c)