### PR TITLE
fix(perl-corpus): guard empty sidecar fixture stems (#0000)

### DIFF
--- a/crates/perl-corpus/src/sidecar.rs
+++ b/crates/perl-corpus/src/sidecar.rs
@@ -103,7 +103,12 @@ pub fn expected_fixture_path(sidecar_path: &Path) -> Result<PathBuf> {
         bail!("sidecar filename must end with .meta.toml: {}", sidecar_path.display());
     }
 
-    let fixture_name = file_name.trim_end_matches(".meta.toml").to_string() + ".pl";
+    let fixture_stem = file_name.trim_end_matches(".meta.toml");
+    if fixture_stem.is_empty() {
+        bail!("fixture stem must not be empty: {}", sidecar_path.display());
+    }
+
+    let fixture_name = fixture_stem.to_string() + ".pl";
     let parent = sidecar_path.parent().unwrap_or_else(|| Path::new("."));
     Ok(parent.join(fixture_name))
 }
@@ -210,6 +215,7 @@ fn collect_concept_ids(value: &toml::Value, concept_ids: &mut HashSet<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn expectation_mode_rejects_unknown_value() {
@@ -226,5 +232,21 @@ mode = "mystery"
 
         let parsed = toml::from_str::<FixtureExpectationSidecar>(raw);
         assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn expected_fixture_path_rejects_empty_fixture_stem() {
+        let result = expected_fixture_path(Path::new(".meta.toml"));
+        assert!(result.is_err(), "empty fixture stem should be rejected");
+        let error = result.err().map(|err| err.to_string()).unwrap_or_default();
+        assert!(error.contains("fixture stem must not be empty"));
+    }
+
+    #[test]
+    fn expected_fixture_path_resolves_valid_sidecar_name() {
+        let result = expected_fixture_path(Path::new("quote_like/delimiter.meta.toml"));
+        assert!(result.is_ok(), "valid sidecar name should resolve to fixture path");
+        let path = result.ok().unwrap_or_default();
+        assert_eq!(path, Path::new("quote_like/delimiter.pl"));
     }
 }


### PR DESCRIPTION
### Motivation

- Sidecar filenames like `.meta.toml` were being accepted and resolved to `.pl`, which hides invalid sidecar naming and weakens validation of fixture pairs.
- Add focused edge-case coverage to drive a red-green-refactor for `expected_fixture_path` behavior.

### Description

- Added a guard in `expected_fixture_path` to detect and `bail!` when the fixture stem (the portion before `.meta.toml`) is empty.
- Preserved existing behavior for valid filenames by constructing the fixture name as `<stem>.pl` and joining with the sidecar parent directory.
- Added two unit tests: `expected_fixture_path_rejects_empty_fixture_stem` and `expected_fixture_path_resolves_valid_sidecar_name` and imported `std::path::Path` into the test module.
- Adjusted test assertions to avoid panicking on `Result` by checking `is_err()`/`is_ok()` and extracting error strings safely.

### Testing

- Ran `cargo test -p perl-corpus expected_fixture_path_ -- --nocapture` and the two new tests passed.
- Ran `cargo check --all-targets -p perl-corpus` and it completed successfully.
- Ran `cargo clippy -p perl-corpus -- -D warnings` and the lint run passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d1c16b483339c288a7edb14166c)