### PR TITLE
test(perl-token): cover empty unknown spans in checked constructors (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -140,7 +140,7 @@ impl<'src> TokenRef<'src> {
     ///
     /// Rules:
     /// - `start <= end`
-    /// - zero-length spans are accepted only for EOF tokens
+    /// - zero-length spans are accepted for EOF and explicit synthetic unknown tokens
     pub fn new_checked(
         kind: TokenKind,
         text: &'src str,
@@ -148,7 +148,7 @@ impl<'src> TokenRef<'src> {
         end: usize,
     ) -> Result<Self, TokenSpanError> {
         let token = Self::try_new(kind, text, start, end)?;
-        if token.is_empty() && token.kind != TokenKind::Eof {
+        if token.is_empty() && !matches!(token.kind, TokenKind::Eof | TokenKind::Unknown) {
             return Err(TokenSpanError::EmptySpanNotAllowed { kind: token.kind, at: token.start });
         }
 
@@ -230,7 +230,7 @@ impl Token {
     ///
     /// Rules:
     /// - `start <= end`
-    /// - zero-length spans are accepted only for EOF tokens
+    /// - zero-length spans are accepted for EOF and explicit synthetic unknown tokens
     pub fn new_checked(
         kind: TokenKind,
         text: impl Into<Arc<str>>,
@@ -238,7 +238,7 @@ impl Token {
         end: usize,
     ) -> Result<Self, TokenSpanError> {
         let token = Self::try_new(kind, text, start, end)?;
-        if token.is_empty() && token.kind != TokenKind::Eof {
+        if token.is_empty() && !matches!(token.kind, TokenKind::Eof | TokenKind::Unknown) {
             return Err(TokenSpanError::EmptySpanNotAllowed { kind: token.kind, at: token.start });
         }
 

--- a/crates/perl-token/tests/borrowed_token_tests.rs
+++ b/crates/perl-token/tests/borrowed_token_tests.rs
@@ -106,6 +106,15 @@ fn token_ref_new_checked_rejects_empty_non_eof() -> TestResult {
 }
 
 #[test]
+fn token_ref_new_checked_allows_empty_unknown() -> TestResult {
+    let token = TokenRef::new_checked(TokenKind::Unknown, "<synthetic>", 21, 21)?;
+    assert_eq!(token.kind, TokenKind::Unknown);
+    assert_eq!(token.span(), (21, 21));
+    assert!(token.is_empty());
+    Ok(())
+}
+
+#[test]
 fn token_ref_new_checked_allows_empty_eof() -> TestResult {
     let token = TokenRef::new_checked(TokenKind::Eof, "", 12, 12)?;
     assert_eq!(token.kind, TokenKind::Eof);

--- a/crates/perl-token/tests/span_invariant_tests.rs
+++ b/crates/perl-token/tests/span_invariant_tests.rs
@@ -29,6 +29,16 @@ fn new_checked_allows_empty_eof_tokens() -> Result<(), Box<dyn std::error::Error
     Ok(())
 }
 
+
+#[test]
+fn new_checked_allows_empty_unknown_tokens() -> Result<(), Box<dyn std::error::Error>> {
+    let tok = Token::new_checked(TokenKind::Unknown, "<synthetic>", 11, 11)?;
+    assert_eq!(tok.kind, TokenKind::Unknown);
+    assert_eq!(tok.start, 11);
+    assert_eq!(tok.end, 11);
+    assert!(tok.is_empty());
+    Ok(())
+}
 #[test]
 fn eof_at_preserves_position() -> Result<(), Box<dyn std::error::Error>> {
     let eof = Token::eof_at(123);


### PR DESCRIPTION
### Motivation
- Checked token constructors rejected zero-length `Unknown` tokens even though synthetic `Unknown` tokens are supported via `Token::unknown_at`, so callers using checked constructors had inconsistent behavior and edge-case gaps.

### Description
- Allow zero-length spans for `TokenKind::Unknown` in both `Token::new_checked` and `TokenRef::new_checked` by updating the empty-span guard to permit `Eof` and `Unknown` kinds.
- Update documentation comments to state that zero-length spans are accepted for EOF and explicit synthetic unknown tokens.
- Add unit tests `new_checked_allows_empty_unknown_tokens` in `span_invariant_tests.rs` and `token_ref_new_checked_allows_empty_unknown` in `borrowed_token_tests.rs` to cover the owned and borrowed checked-constructor cases.

### Testing
- Ran `cargo test -p perl-token` and all tests passed.
- Ran `cargo check --all-targets -p perl-token` and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d283d6c8333919206af2cd3d4e7)