### PR TITLE
test(perl-lexer): add data-marker split edge coverage (#0000)

### DIFF
--- a/crates/perl-lexer/src/tokenizer/util.rs
+++ b/crates/perl-lexer/src/tokenizer/util.rs
@@ -36,11 +36,9 @@ pub fn code_slice(text: &str) -> &str {
 /// The data section starts at a lexed `__DATA__` or `__END__` marker and includes
 /// the marker line itself.
 pub fn split_code_and_data(text: &str) -> (&str, Option<&str>) {
-    if let Some(marker_start) = find_data_marker_byte_lexed(text) {
+    find_data_marker_byte_lexed(text).map_or((text, None), |marker_start| {
         (&text[..marker_start], Some(&text[marker_start..]))
-    } else {
-        (text, None)
-    }
+    })
 }
 
 /// Find the byte offset of a __DATA__ or __END__ marker in the source text.
@@ -96,5 +94,17 @@ mod tests {
 
         let with_end = "code;\n__END__\nvalue";
         assert_eq!(split_code_and_data(with_end), ("code;\n", Some("__END__\nvalue")));
+    }
+
+    #[test]
+    fn test_split_code_and_data_marker_at_start() {
+        let src = "__DATA__\nvalue";
+        assert_eq!(split_code_and_data(src), ("", Some("__DATA__\nvalue")));
+    }
+
+    #[test]
+    fn test_split_code_and_data_ignores_marker_with_trailing_junk() {
+        let src = "code;\n__DATA__ trailing\nvalue";
+        assert_eq!(split_code_and_data(src), (src, None));
     }
 }


### PR DESCRIPTION
### Motivation

- Improve robustness by exercising edge cases in `split_code_and_data` that were not directly covered by tests, specifically a marker at byte 0 and marker-like text with trailing junk. 
- Make a small readability refactor of `split_code_and_data` to a more concise `Option::map_or` form without changing behavior.

### Description

- Added two focused unit tests in `crates/perl-lexer/src/tokenizer/util.rs` named `test_split_code_and_data_marker_at_start` and `test_split_code_and_data_ignores_marker_with_trailing_junk` to cover the targeted edge cases. 
- Rewrote `split_code_and_data` to use `find_data_marker_byte_lexed(text).map_or(...)` for a smaller, equivalent implementation.

### Testing

- Ran `cargo test -p perl-lexer tokenizer::util::tests::test_split_code_and_data -- --nocapture` and it passed. 
- Ran `cargo check --all-targets -p perl-lexer` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d283d6c8333919206af2cd3d4e7)