### PR TITLE
fix(perl-lexer): clamp invalid utf-8 byte offsets (#0000)

### DIFF
--- a/crates/perl-lexer/src/tokenizer/token_wrapper.rs
+++ b/crates/perl-lexer/src/tokenizer/token_wrapper.rs
@@ -80,8 +80,17 @@ impl<'a> PositionTracker<'a> {
 
     /// Calculate column number accounting for UTF-8
     fn calculate_column(&self, line_start: usize, byte: usize) -> u32 {
-        let line_slice = &self.source[line_start..byte.min(self.source.len())];
+        let byte = self.clamp_to_char_boundary(byte);
+        let line_slice = &self.source[line_start..byte];
         (line_slice.chars().count() + 1) as u32
+    }
+
+    fn clamp_to_char_boundary(&self, byte: usize) -> usize {
+        let mut clamped = byte.min(self.source.len());
+        while clamped > 0 && !self.source.is_char_boundary(clamped) {
+            clamped -= 1;
+        }
+        clamped
     }
 
     /// Wrap a token with position information
@@ -129,5 +138,19 @@ mod tests {
         assert_eq!(wrapped.start_pos.line, 1);
         assert_eq!(wrapped.start_pos.column, 1);
         assert_eq!(wrapped.end_pos.column, 3);
+    }
+
+    #[test]
+    fn test_byte_to_position_handles_non_char_boundary_offsets() {
+        let source = "éa\n";
+        let tracker = PositionTracker::new(source);
+
+        let pos = tracker.byte_to_position(1);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 1);
+
+        let pos = tracker.byte_to_position(2);
+        assert_eq!(pos.line, 1);
+        assert_eq!(pos.column, 2);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent panics when `PositionTracker::byte_to_position` is called with a byte offset that falls inside a multibyte UTF-8 codepoint by adding edge-case coverage and a small defensive change.

### Description
- Add a unit test `test_byte_to_position_handles_non_char_boundary_offsets` covering non-char-boundary offsets in `crates/perl-lexer/src/tokenizer/token_wrapper.rs`.
- Change `calculate_column` to clamp the requested byte offset to the previous UTF-8 character boundary via a new helper `clamp_to_char_boundary` before slicing the source.
- Preserve existing behavior for valid offsets while avoiding slicing panics for invalid offsets, and keep `wrap_token`/`byte_to_position` API surface unchanged.

### Testing
- Ran `cargo test -p perl-lexer tokenizer::token_wrapper::tests::test_byte_to_position_handles_non_char_boundary_offsets` and the test passed.
- Ran `cargo check --all-targets -p perl-lexer` and it completed successfully.
- Ran `cargo clippy -p perl-lexer --all-targets -- -D warnings` and it completed with no warnings.
- `just pr-fast` is not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d283d6c8333919206af2cd3d4e7)