### PR TITLE
test(perl-lexer): expand data marker edge coverage and refactor prefilter (#0000)

### DIFF
--- a/crates/perl-lexer/src/tokenizer/util.rs
+++ b/crates/perl-lexer/src/tokenizer/util.rs
@@ -10,7 +10,8 @@
 /// Returns the byte offset of the start of the marker, or None if not found.
 pub fn find_data_marker_byte_lexed(s: &str) -> Option<usize> {
     // Cheap prefilter: avoid constructing the lexer when marker substrings are absent.
-    if !s.contains("__DATA__") && !s.contains("__END__") {
+    const MARKERS: [&str; 2] = ["__DATA__", "__END__"];
+    if !MARKERS.iter().any(|marker| s.contains(marker)) {
         return None;
     }
 
@@ -84,6 +85,25 @@ mod tests {
         // With __END__ marker
         let src2 = "code;\n__END__\ndata";
         assert_eq!(code_slice(src2), "code;\n");
+    }
+
+
+    #[test]
+    fn test_split_code_and_data_prefers_first_marker() {
+        let src = "print 'a';\n__DATA__\none\n__END__\ntwo";
+        assert_eq!(
+            split_code_and_data(src),
+            ("print 'a';\n", Some("__DATA__\none\n__END__\ntwo"))
+        );
+    }
+
+    #[test]
+    fn test_find_data_marker_ignores_markers_inside_heredoc_and_pod() {
+        let heredoc = "my $x = <<'TXT';\n__DATA__\nTXT\nprint $x;\n";
+        assert_eq!(find_data_marker_byte_lexed(heredoc), None);
+
+        let pod = "=pod\n__END__\n=cut\nprint 'ok';\n";
+        assert_eq!(find_data_marker_byte_lexed(pod), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve robustness of data-section splitting by covering edge cases where both `__DATA__` and `__END__` appear and where marker-like text appears inside heredocs/POD.
- Avoid unnecessary lexer construction by making the cheap prefilter clearer and shared. 

### Description
- Added two focused unit tests in `crates/perl-lexer/src/tokenizer/util.rs`: `test_split_code_and_data_prefers_first_marker` and `test_find_data_marker_ignores_markers_inside_heredoc_and_pod` to cover precedence and false-positive cases.
- Replaced the ad-hoc substring checks in `find_data_marker_byte_lexed` with a `const MARKERS` array and an `iter().any(...)` prefilter to centralize marker handling before lexing.
- No public API changes; the changes are internal tests and a small local refactor in the tokenizer utilities. 

### Testing
- Ran `cargo test -p perl-lexer tokenizer::util` and the new tests passed (all relevant unit tests succeeded).
- Ran `cargo check --all-targets -p perl-lexer` and the crate type checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d283d6c8333919206af2cd3d4e7)