### PR TITLE
fix(fmt): restore current formatting drift (#0000)

### DIFF
--- a/crates/perl-lexer/src/builtins/phf_lookup.rs
+++ b/crates/perl-lexer/src/builtins/phf_lookup.rs
@@ -428,11 +428,7 @@ mod tests {
     fn shorthand_signature_entries_have_full_signature_coverage() {
         let targets = ["printf", "system", "exec", "mkdir", "unlink", "stat"];
         for name in &targets {
-            assert!(
-                try_get_param_names(name).is_some(),
-                "BUILTIN_SIGS should contain '{}'",
-                name
-            );
+            assert!(try_get_param_names(name).is_some(), "BUILTIN_SIGS should contain '{}'", name);
             assert!(
                 BUILTIN_FULL_SIGS.contains_key(name),
                 "BUILTIN_FULL_SIGS should contain '{}'",

--- a/crates/perl-lexer/src/checkpoint.rs
+++ b/crates/perl-lexer/src/checkpoint.rs
@@ -521,13 +521,15 @@ mod tests {
         // - checkpoint at 12 falls inside edit and resets to position 10 with Normal context.
         cache.apply_edit(10, 5, 2);
 
-        let reset = cache.find_before(10).ok_or("checkpoint inside edit should reset to edit start")?;
+        let reset =
+            cache.find_before(10).ok_or("checkpoint inside edit should reset to edit start")?;
         assert_eq!(reset.position, 10);
         assert_eq!(reset.context, CheckpointContext::Normal);
         assert_eq!(reset.mode, LexerMode::ExpectTerm);
 
-        let shifted =
-            cache.find_after(11).ok_or("checkpoint after edit should still be present and shifted")?;
+        let shifted = cache
+            .find_after(11)
+            .ok_or("checkpoint after edit should still be present and shifted")?;
         assert_eq!(shifted.position, 27);
         Ok(())
     }

--- a/crates/perl-lexer/src/tokenizer/util.rs
+++ b/crates/perl-lexer/src/tokenizer/util.rs
@@ -123,5 +123,4 @@ mod tests {
         let src = "say 1;\n__END__\ntrailer";
         assert_eq!(find_data_marker_byte(src), find_data_marker_byte_lexed(src));
     }
-
 }

--- a/crates/perl-workspace-index/tests/discovery_fuzz_tests.rs
+++ b/crates/perl-workspace-index/tests/discovery_fuzz_tests.rs
@@ -59,9 +59,8 @@ fn fuzz_randomized_workspace_layouts_preserve_discovery_invariants() -> TestResu
         ".cache/precompiled",
         ".git/hooks",
     ];
-    let extensions = [
-        "pl", "pm", "t", "psgi", "xs", "i", "tt", "tt2", "ep", "txt", "md", "json", "rs",
-    ];
+    let extensions =
+        ["pl", "pm", "t", "psgi", "xs", "i", "tt", "tt2", "ep", "txt", "md", "json", "rs"];
 
     let mut rng = XorShift64::new(0xA11C_E55D_1234_5678);
 


### PR DESCRIPTION
Problem: current master fails cargo fmt --check after recent test merges.\nFix: apply the mechanical rustfmt output for the affected perl-lexer and perl-workspace test files only.\nVerification: cargo fmt --check -p perl-lexer -p perl-workspace passes; cargo test -p perl-lexer --lib passes; cargo test -p perl-workspace --test discovery_fuzz_tests passes; git diff --check passes.