### PR TITLE
docs(release): fix MIGRATION_v0.13.md accuracy + add CHANGELOG entry (#7292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-server workspace configurations, each `LspServer` instance tracks its own shown
   state rather than sharing a process-level `Once`. (#4178)
 
+### Migration
+
+- **Microcrate collapse complete — migration guide available** — v0.13.0 drops the
+  published crate count from 132 to 32 across 10+ collapse waves. All ~100 retired
+  crate names stop appearing on crates.io after this release; their code lives as
+  subfolder modules inside the owning published crate. See
+  [`docs/MIGRATION_v0.13.md`](docs/MIGRATION_v0.13.md) for the complete
+  old-path → new-path mapping for every retired crate, feature flag changes
+  (`lsp-ga-lock`, `incremental`, `workspace_refactor`), and the breaking-changes
+  summary per wave. (#7292, #4410)
+
 ### Internal
 
 - **Release prep: start `v0.13.0-rc1` version staging** — bumped workspace and internal crate dependency versions to `0.13.0-rc1`, updated the feature catalog metadata version, and refreshed the top-level README release line for release-candidate signaling. (#0000)

--- a/docs/MIGRATION_v0.13.md
+++ b/docs/MIGRATION_v0.13.md
@@ -7,7 +7,7 @@ This guide is for downstream users of perl-lsp crates who are upgrading to v0.13
 
 ## What's changing in v0.13.0
 
-v0.13.0 is a **clean break** release. The published crate count drops from 132 to **30**.
+v0.13.0 is a **clean break** release. The published crate count drops from 132 to **32**.
 Approximately 100 product-internal microcrates stop being published. Their code moves
 into subfolder modules inside the owning published crate. There are no bridge crates
 or re-export shims — old crate names will no longer appear on crates.io after this release.
@@ -21,20 +21,19 @@ This is a deliberate one-time cost to eliminate a permanent operational burden. 
 published under the same names. Their public APIs are not affected by the internal module
 reorganization.
 
-The same applies to the other 24 crates in the published set:
+The same applies to the other 28 crates in the published set:
 
 - `tree-sitter-perl-c`, `tree-sitter-perl-rs`
-- `perl-parser-pest`
-- `perl-lexer`, `perl-token`, `perl-line-index`, `perl-uri`, `perl-pod`
+- `perl-parser-pest`, `perl-parser-core`, `perl-parser-bench`
+- `perl-lexer`, `perl-token`, `perl-ast`, `perl-ast-v2`, `perl-pragma`
+- `perl-line-index`, `perl-uri`, `perl-pod`, `perl-regex`, `perl-position-tracking`
 - `perl-diagnostics` (renamed from `perl-diagnostics-codes`, see Wave E below)
-- `perl-lsp-protocol`, `perl-content-length-framing` (kept published — shared by LSP+DAP)
-- `perl-semantic-analyzer`, `perl-module`, `perl-workspace`
+- `perl-semantic-analyzer`, `perl-semantic-facts`, `perl-module`, `perl-workspace`
 - `perl-symbol`
 - `perl-lsp-rs-core` (new in v0.13.0 — implementation sibling of `perl-lsp-rs`)
 - `perl-lsp-perltidy`
-- `perl-subprocess-runtime`, `perl-lsp-text-utils`
+- `perl-subprocess-runtime`
 - `perl-corpus`, `perl-tdd-support`, `perl-test-must`, `perl-test-generators`
-- `perl-parser-core`
 
 ## If you depend on a retired crate
 
@@ -376,10 +375,6 @@ perl-lsp-rs-core = "0.13.0"
 | `perl-lsp-input-validation` | `perl-lsp-rs-core` | `use perl_lsp_input_validation::` | `use perl_lsp_rs_core::runtime::input_validation::` |
 | `perl-lsp-text-utils` | `perl-lsp-rs-core` | `use perl_lsp_text_utils::` | `use perl_lsp_rs_core::runtime::text_utils::` |
 
-> **Note:** `perl-lsp-text-utils` remains published at v0.13.0 for external consumers who use it
-> independently. The absorption into `perl-lsp-rs-core::runtime::text_utils` provides an
-> additional access path; the standalone crate is still published.
-
 **Cargo.toml change:**
 
 ```toml
@@ -589,9 +584,9 @@ downstream `impl` blocks:
 | Milestone | Published crates | Notes |
 |---|---|---|
 | v0.12.4 (baseline) | 132 | Before collapse |
-| v0.13.0 (final) | **30** | After all 10+ waves land |
+| v0.13.0 (final) | **32** | After all 10+ waves land |
 
-The collapse removed ~102 crates from the publish surface and added 2 new ones
+The collapse removed ~100 crates from the publish surface and added 2 new ones
 (`perl-symbol` and `perl-lsp-rs-core`), for a net reduction of 100.
 
 Waves that added a new crate: Wave B (perl-symbol NEW), Wave F (perl-lsp-rs-core NEW).


### PR DESCRIPTION
## Summary

Closes #7292.

This PR corrects four accuracy bugs in `docs/MIGRATION_v0.13.md` and adds a migration-guide pointer to `CHANGELOG.md`. Both fixes are documentation-only — no code changes, no Cargo.toml changes, no test changes.

---

## What changed and why

### `docs/MIGRATION_v0.13.md` — four accuracy corrections

The migration guide was written before the final published-crate count was reconciled. As a result it contained stale numbers and wrong crate membership:

| Location | Was | Now | Why |
|---|---|---|---|
| Intro paragraph | `132 to **30**` | `132 to **32**` | `cargo xtask published-crate-count` confirms 32 published crates, not 30 |
| "same applies" list | "other **24** crates" with wrong members | "other **28** crates" with correct members | 24 is wrong (28 = 32 − 4 named above the list); list contained three absorbed crates (`perl-lsp-protocol`, `perl-content-length-framing`, `perl-lsp-text-utils`) that do **not** appear on crates.io, and was missing eight actually-published crates (`perl-position-tracking`, `perl-ast`, `perl-ast-v2`, `perl-pragma`, `perl-regex`, `perl-semantic-facts`, `perl-parser-bench`, `perl-parser-core`, `perl-parser-pest`) |
| Wave G2 section | Note: "perl-lsp-text-utils remains published at v0.13.0" | Note removed | False — `perl-lsp-text-utils` was absorbed into `perl-lsp` in Wave G2; it is not published |
| Count table footer | `**30**` | `**32**` | Consistency with corrected body text |

### `CHANGELOG.md` — new Migration section

Users upgrading to v0.13.0 who read the changelog need to know about the migration guide. Without this entry the guide is effectively invisible. Added a `### Migration` section under `[Unreleased]` (before `### Internal`) that:

- Summarises the scope: 132 → 32 published crates across 10+ collapse waves
- Explains what "retired" means (code lives as subfolder modules, crate names stop appearing on crates.io)
- Links directly to `docs/MIGRATION_v0.13.md`
- Notes the three key breaking-change areas covered by the guide: import paths, feature flags, and per-wave breaking changes
- References issues #7292 and #4410

---

## Verification

```
cargo xtask published-crate-count
# → OK (32 crates, baseline 32)
```

No Rust compilation changes, so no `cargo check` needed. Both files pass `cargo xtask fmt` (docs are excluded from the formatter, CHANGELOG has no formatting rules).

## Test plan

- [ ] `cargo xtask published-crate-count` returns `OK (32 crates, baseline 32)`
- [ ] `docs/MIGRATION_v0.13.md` no longer mentions 30 published crates anywhere
- [ ] `docs/MIGRATION_v0.13.md` Wave G2 section no longer claims `perl-lsp-text-utils` is published
- [ ] `CHANGELOG.md` `[Unreleased]` section contains a `### Migration` entry linking to the guide

https://claude.ai/code/session_015kMbeNeVbiUTufYfmFnk8K

---
_Generated by [Claude Code](https://claude.ai/code/session_015kMbeNeVbiUTufYfmFnk8K)_