### PR TITLE
feat(perl-symbol): add SymbolRef -> OccurrenceFact adapter (#0000)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -25,6 +25,7 @@ pub use crate::index::SymbolIndex;
 
 // surface — full public surface
 pub use crate::surface::{
-    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, UnsupportedDeclFact,
-    extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, SymbolRefSemanticFacts,
+    UnsupportedDeclFact, extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    symbol_refs_to_semantic_facts,
 };

--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -1,8 +1,9 @@
 use crate::surface::decl::SymbolDecl;
+use crate::surface::r#ref::{SymbolRef, SymbolRefKind};
 use crate::types::SymbolKind;
 use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
-    FileId, Provenance,
+    FileId, OccurrenceFact, OccurrenceId, OccurrenceKind, Provenance,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -20,6 +21,79 @@ pub struct SymbolDeclSemanticFacts {
     pub entities: Vec<EntityFact>,
     pub defines_edges: Vec<EdgeFact>,
     pub unsupported: Vec<UnsupportedDeclFact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymbolRefSemanticFacts {
+    pub anchors: Vec<AnchorFact>,
+    pub occurrences: Vec<OccurrenceFact>,
+    pub reference_edges: Vec<EdgeFact>,
+}
+
+pub fn symbol_refs_to_semantic_facts(
+    refs: &[SymbolRef],
+    file_id: FileId,
+    entity_ids_by_qualified_name: &BTreeMap<String, EntityId>,
+) -> SymbolRefSemanticFacts {
+    let mut anchors = Vec::with_capacity(refs.len());
+    let mut occurrences = Vec::with_capacity(refs.len());
+    let mut reference_edges = Vec::new();
+
+    for symbol_ref in refs {
+        let anchor_span = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
+        let anchor_id =
+            AnchorId(stable_id("ref-anchor", &symbol_ref.qualified_name, anchor_span.0, anchor_span.1));
+        anchors.push(AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: anchor_span.0 as u32,
+            span_end_byte: anchor_span.1 as u32,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        let occurrence_kind = match symbol_ref.kind {
+            SymbolRefKind::Variable(_) => OccurrenceKind::Read,
+            SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+        };
+        let entity_id = entity_ids_by_qualified_name.get(&symbol_ref.qualified_name).copied();
+        let occurrence_id = OccurrenceId(stable_id(
+            "occurrence",
+            &symbol_ref.qualified_name,
+            symbol_ref.full_span.0,
+            symbol_ref.full_span.1,
+        ));
+        occurrences.push(OccurrenceFact {
+            id: occurrence_id,
+            kind: occurrence_kind,
+            entity_id,
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        if let Some(to_entity_id) = entity_id {
+            let from_entity_id = EntityId(stable_id("ref-source", &symbol_ref.qualified_name, 0, 0));
+            reference_edges.push(EdgeFact {
+                id: EdgeId(stable_id(
+                    "references",
+                    &symbol_ref.qualified_name,
+                    from_entity_id.0 as usize,
+                    to_entity_id.0 as usize,
+                )),
+                kind: EdgeKind::References,
+                from_entity_id,
+                to_entity_id,
+                via_occurrence_id: Some(occurrence_id),
+                provenance: Provenance::NameHeuristic,
+                confidence: Confidence::Low,
+            });
+        }
+    }
+
+    SymbolRefSemanticFacts { anchors, occurrences, reference_edges }
 }
 
 pub fn symbol_decls_to_semantic_facts(
@@ -409,5 +483,42 @@ mod tests {
             facts.unsupported[0].reason,
             "symbol kind is not yet representable as EntityFact"
         );
+    }
+
+    #[test]
+    fn symbol_ref_adapter_emits_occurrences_and_optional_reference_edges() {
+        use crate::types::VarKind;
+
+        let refs = vec![
+            SymbolRef {
+                kind: SymbolRefKind::SubroutineCall,
+                name: "run".to_string(),
+                qualified_name: "Foo::run".to_string(),
+                sigil: None,
+                package_qualifier: Some("Foo".to_string()),
+                full_span: (10, 20),
+                anchor_span: Some((12, 15)),
+            },
+            SymbolRef {
+                kind: SymbolRefKind::Variable(VarKind::Scalar),
+                name: "x".to_string(),
+                qualified_name: "x".to_string(),
+                sigil: Some("$".to_string()),
+                package_qualifier: None,
+                full_span: (21, 23),
+                anchor_span: None,
+            },
+        ];
+        let mut entity_map = BTreeMap::new();
+        entity_map.insert("Foo::run".to_string(), EntityId(42));
+
+        let facts = symbol_refs_to_semantic_facts(&refs, FileId(7), &entity_map);
+        assert_eq!(facts.anchors.len(), 2);
+        assert_eq!(facts.occurrences.len(), 2);
+        assert_eq!(facts.reference_edges.len(), 1);
+        assert_eq!(facts.occurrences[0].kind, OccurrenceKind::Call);
+        assert_eq!(facts.occurrences[1].kind, OccurrenceKind::Read);
+        assert_eq!(facts.occurrences[0].entity_id, Some(EntityId(42)));
+        assert_eq!(facts.occurrences[1].entity_id, None);
     }
 }

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -32,5 +32,8 @@ pub mod facts;
 pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
-pub use facts::{SymbolDeclSemanticFacts, UnsupportedDeclFact, symbol_decls_to_semantic_facts};
+pub use facts::{
+    SymbolDeclSemanticFacts, SymbolRefSemanticFacts, UnsupportedDeclFact, symbol_decls_to_semantic_facts,
+    symbol_refs_to_semantic_facts,
+};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};


### PR DESCRIPTION
### Motivation

- Wave 2 needed a producer-side adapter to convert `SymbolRef` projections into semantic fact rows so occurrence/reference fact flow is available for downstream indexing and scorecarding.

### Description

- Add `SymbolRefSemanticFacts` and `symbol_refs_to_semantic_facts(...)` in `crates/perl-symbol/src/surface/facts.rs` to emit deterministic `AnchorFact`, `OccurrenceFact`, and optional `EdgeFact::References` rows from `SymbolRef` inputs.
- Map `SymbolRefKind::Variable(_)` to `OccurrenceKind::Read` and `SymbolRefKind::SubroutineCall` to `OccurrenceKind::Call`, and produce deterministic IDs using the existing `stable_id` helper.
- Export the new adapter and type through the surface re-exports in `crates/perl-symbol/src/surface/mod.rs` and the crate public API in `crates/perl-symbol/src/api.rs` as `symbol_refs_to_semantic_facts` and `SymbolRefSemanticFacts`.
- Keep dependency direction clean by implementing the adapter in `perl-symbol` and consuming the neutral `perl-semantic-facts` types (no reverse dependency introduced).

### Testing

- Ran `cargo test -p perl-symbol` and all tests passed.
- Ran `cargo test -p perl-semantic-facts` and all tests passed.
- Ran `cargo check --workspace --all-targets` and the workspace check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d2c1e2588333b7c7538e37a96f4c)