### PR TITLE
feat(perl-symbol): add SymbolRef -> OccurrenceFact adapter (#0000)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -25,6 +25,7 @@ pub use crate::index::SymbolIndex;
 
 // surface — full public surface
 pub use crate::surface::{
-    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, UnsupportedDeclFact,
-    extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, SymbolRefSemanticFacts,
+    UnsupportedDeclFact, extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    symbol_refs_to_semantic_facts,
 };

--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -1,8 +1,9 @@
 use crate::surface::decl::SymbolDecl;
+use crate::surface::r#ref::{SymbolRef, SymbolRefKind};
 use crate::types::SymbolKind;
 use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
-    FileId, Provenance,
+    FileId, OccurrenceFact, OccurrenceId, OccurrenceKind, Provenance,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -20,6 +21,13 @@ pub struct SymbolDeclSemanticFacts {
     pub entities: Vec<EntityFact>,
     pub defines_edges: Vec<EdgeFact>,
     pub unsupported: Vec<UnsupportedDeclFact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymbolRefSemanticFacts {
+    pub anchors: Vec<AnchorFact>,
+    pub occurrences: Vec<OccurrenceFact>,
+    pub reference_edges: Vec<EdgeFact>,
 }
 
 pub fn symbol_decls_to_semantic_facts(
@@ -129,6 +137,81 @@ pub fn symbol_decls_to_semantic_facts(
     SymbolDeclSemanticFacts { anchors, entities, defines_edges, unsupported }
 }
 
+pub fn symbol_refs_to_semantic_facts(
+    refs: &[SymbolRef],
+    file_id: FileId,
+    resolved_entities: &BTreeMap<String, EntityId>,
+) -> SymbolRefSemanticFacts {
+    let mut anchors = Vec::with_capacity(refs.len());
+    let mut occurrences = Vec::with_capacity(refs.len());
+    let mut reference_edges = Vec::new();
+
+    for symbol_ref in refs {
+        let anchor_span = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
+        let anchor_id = AnchorId(stable_id(
+            "ref-anchor",
+            &symbol_ref.qualified_name,
+            anchor_span.0,
+            anchor_span.1,
+        ));
+        anchors.push(AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: anchor_span.0 as u32,
+            span_end_byte: anchor_span.1 as u32,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        let occurrence_kind = match symbol_ref.kind {
+            SymbolRefKind::Variable(_) => OccurrenceKind::Reference,
+            SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+        };
+        let occurrence_id = OccurrenceId(stable_id(
+            "occurrence",
+            &symbol_ref.qualified_name,
+            symbol_ref.full_span.0,
+            symbol_ref.full_span.1,
+        ));
+        let entity_id = resolved_entities.get(&symbol_ref.qualified_name).copied();
+        occurrences.push(OccurrenceFact {
+            id: occurrence_id,
+            kind: occurrence_kind,
+            entity_id,
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        if let Some(entity_id) = entity_id {
+            let edge_kind = match occurrence_kind {
+                OccurrenceKind::Reference => EdgeKind::References,
+                OccurrenceKind::Call => EdgeKind::Calls,
+                _ => continue,
+            };
+            let edge_id = EdgeId(stable_id(
+                "ref-edge",
+                &symbol_ref.qualified_name,
+                occurrence_id.0 as usize,
+                entity_id.0 as usize,
+            ));
+            reference_edges.push(EdgeFact {
+                id: edge_id,
+                kind: edge_kind,
+                from_entity_id: entity_id,
+                to_entity_id: entity_id,
+                via_occurrence_id: Some(occurrence_id),
+                provenance: Provenance::NameHeuristic,
+                confidence: Confidence::Low,
+            });
+        }
+    }
+
+    SymbolRefSemanticFacts { anchors, occurrences, reference_edges }
+}
+
 fn symbol_kind_to_entity_kind(kind: SymbolKind) -> Option<EntityKind> {
     match kind {
         SymbolKind::Package => Some(EntityKind::Package),
@@ -163,6 +246,7 @@ fn stable_id(namespace: &str, name: &str, start: usize, end: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::surface::{SymbolRef, SymbolRefKind};
     use crate::types::VarKind;
 
     #[test]
@@ -409,5 +493,40 @@ mod tests {
             facts.unsupported[0].reason,
             "symbol kind is not yet representable as EntityFact"
         );
+    }
+
+    #[test]
+    fn symbol_ref_adapter_emits_occurrences_and_optional_edges() {
+        let refs = vec![
+            SymbolRef {
+                kind: SymbolRefKind::SubroutineCall,
+                name: "run".to_string(),
+                qualified_name: "Foo::run".to_string(),
+                sigil: None,
+                package_qualifier: Some("Foo".to_string()),
+                full_span: (100, 110),
+                anchor_span: Some((100, 107)),
+            },
+            SymbolRef {
+                kind: SymbolRefKind::Variable(VarKind::Scalar),
+                name: "missing".to_string(),
+                qualified_name: "missing".to_string(),
+                sigil: Some("$".to_string()),
+                package_qualifier: None,
+                full_span: (120, 128),
+                anchor_span: Some((120, 128)),
+            },
+        ];
+        let mut resolved = BTreeMap::new();
+        resolved.insert("Foo::run".to_string(), EntityId(7));
+
+        let facts = symbol_refs_to_semantic_facts(&refs, FileId(3), &resolved);
+        assert_eq!(facts.anchors.len(), 2);
+        assert_eq!(facts.occurrences.len(), 2);
+        assert_eq!(facts.reference_edges.len(), 1);
+        assert_eq!(facts.occurrences[0].kind, OccurrenceKind::Call);
+        assert_eq!(facts.occurrences[0].entity_id, Some(EntityId(7)));
+        assert_eq!(facts.occurrences[1].kind, OccurrenceKind::Reference);
+        assert_eq!(facts.occurrences[1].entity_id, None);
     }
 }

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -32,5 +32,8 @@ pub mod facts;
 pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
-pub use facts::{SymbolDeclSemanticFacts, UnsupportedDeclFact, symbol_decls_to_semantic_facts};
+pub use facts::{
+    SymbolDeclSemanticFacts, SymbolRefSemanticFacts, UnsupportedDeclFact,
+    symbol_decls_to_semantic_facts, symbol_refs_to_semantic_facts,
+};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};


### PR DESCRIPTION
### Motivation

- Wave 2 needs a producer-side adapter that converts `SymbolRef` projection output into deterministic semantic facts without making the neutral `perl-semantic-facts` crate depend on producer crates.
- This adapter enables emitting `AnchorFact` + `OccurrenceFact` rows (and optional typed reference/call edges) from `SymbolRef` inputs so downstream indexing/scorecard plumbing can consume reference facts.

### Description

- Added `symbol_refs_to_semantic_facts` in `crates/perl-symbol/src/surface/facts.rs` which emits deterministic `AnchorFact`, `OccurrenceFact`, and optional typed `EdgeFact` rows when entity identity is known.
- Introduced `SymbolRefSemanticFacts` result type and deterministic `stable_id` usage for anchors/occurrences/edges.
- Exported the new adapter and result type via the `surface` facade and crate root API (`symbol_refs_to_semantic_facts`, `SymbolRefSemanticFacts`).
- Added a unit test `symbol_ref_adapter_emits_occurrences_and_optional_edges` validating occurrence emission and optional edge creation for resolved/unresolved refs.

### Testing

- Ran `cargo test -p perl-symbol` and all tests in the `perl-symbol` crate passed.
- Ran `cargo check --workspace --all-targets`; checks were executed across workspace crates and no compile errors were observed in the visible run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d2c1e2588333b7c7538e37a96f4c)