### PR TITLE
feat(perl-symbol): add SymbolRef -> semantic-facts adapter (#0000)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -25,6 +25,7 @@ pub use crate::index::SymbolIndex;
 
 // surface — full public surface
 pub use crate::surface::{
-    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, UnsupportedDeclFact,
-    extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, SymbolRefSemanticFacts,
+    UnsupportedDeclFact, extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    symbol_refs_to_semantic_facts,
 };

--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -1,8 +1,9 @@
 use crate::surface::decl::SymbolDecl;
+use crate::surface::r#ref::{SymbolRef, SymbolRefKind};
 use crate::types::SymbolKind;
 use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
-    FileId, Provenance,
+    FileId, OccurrenceFact, OccurrenceId, OccurrenceKind, Provenance,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -20,6 +21,13 @@ pub struct SymbolDeclSemanticFacts {
     pub entities: Vec<EntityFact>,
     pub defines_edges: Vec<EdgeFact>,
     pub unsupported: Vec<UnsupportedDeclFact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymbolRefSemanticFacts {
+    pub anchors: Vec<AnchorFact>,
+    pub occurrences: Vec<OccurrenceFact>,
+    pub reference_edges: Vec<EdgeFact>,
 }
 
 pub fn symbol_decls_to_semantic_facts(
@@ -127,6 +135,94 @@ pub fn symbol_decls_to_semantic_facts(
     }
 
     SymbolDeclSemanticFacts { anchors, entities, defines_edges, unsupported }
+}
+
+pub fn symbol_refs_to_semantic_facts(
+    refs: &[SymbolRef],
+    file_id: FileId,
+    entity_by_name: &BTreeMap<String, EntityId>,
+) -> SymbolRefSemanticFacts {
+    let mut anchors = Vec::with_capacity(refs.len());
+    let mut occurrences = Vec::with_capacity(refs.len());
+    let mut reference_edges = Vec::new();
+
+    for symbol_ref in refs {
+        let anchor_span = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
+        let anchor_id = AnchorId(stable_id(
+            "ref-anchor",
+            &symbol_ref.qualified_name,
+            anchor_span.0,
+            anchor_span.1,
+        ));
+        anchors.push(AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: anchor_span.0 as u32,
+            span_end_byte: anchor_span.1 as u32,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        let occurrence_kind = symbol_ref_kind_to_occurrence_kind(&symbol_ref.kind);
+        let entity_id = entity_by_name.get(&symbol_ref.qualified_name).copied();
+        let occurrence_id = OccurrenceId(stable_id(
+            "ref-occurrence",
+            &symbol_ref.qualified_name,
+            symbol_ref.full_span.0,
+            symbol_ref.full_span.1,
+        ));
+        occurrences.push(OccurrenceFact {
+            id: occurrence_id,
+            kind: occurrence_kind,
+            entity_id,
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        if let Some(to_entity_id) = entity_id {
+            let from_entity_id = EntityId(stable_id(
+                "ref-from",
+                &symbol_ref.qualified_name,
+                symbol_ref.full_span.0,
+                symbol_ref.full_span.1,
+            ));
+            reference_edges.push(EdgeFact {
+                id: EdgeId(stable_id(
+                    "ref-edge",
+                    &symbol_ref.qualified_name,
+                    from_entity_id.0 as usize,
+                    to_entity_id.0 as usize,
+                )),
+                kind: occurrence_kind_to_reference_edge_kind(occurrence_kind),
+                from_entity_id,
+                to_entity_id,
+                via_occurrence_id: Some(occurrence_id),
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::Medium,
+            });
+        }
+    }
+
+    SymbolRefSemanticFacts { anchors, occurrences, reference_edges }
+}
+
+fn symbol_ref_kind_to_occurrence_kind(kind: &SymbolRefKind) -> OccurrenceKind {
+    match kind {
+        SymbolRefKind::Variable(_) => OccurrenceKind::Read,
+        SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+    }
+}
+
+fn occurrence_kind_to_reference_edge_kind(kind: OccurrenceKind) -> EdgeKind {
+    match kind {
+        OccurrenceKind::Call => EdgeKind::Calls,
+        OccurrenceKind::Read => EdgeKind::Reads,
+        OccurrenceKind::Write => EdgeKind::Writes,
+        _ => EdgeKind::References,
+    }
 }
 
 fn symbol_kind_to_entity_kind(kind: SymbolKind) -> Option<EntityKind> {
@@ -284,6 +380,40 @@ mod tests {
             "unsupported should be empty; got: {:?}",
             facts.unsupported
         );
+    }
+
+    #[test]
+    fn symbol_ref_adapter_emits_occurrences_and_optional_edges() {
+        let refs = vec![
+            SymbolRef {
+                kind: SymbolRefKind::SubroutineCall,
+                name: "run".to_string(),
+                qualified_name: "Foo::run".to_string(),
+                sigil: None,
+                package_qualifier: Some("Foo".to_string()),
+                full_span: (10, 19),
+                anchor_span: Some((10, 19)),
+            },
+            SymbolRef {
+                kind: SymbolRefKind::Variable(VarKind::Scalar),
+                name: "missing".to_string(),
+                qualified_name: "missing".to_string(),
+                sigil: Some("$".to_string()),
+                package_qualifier: None,
+                full_span: (20, 28),
+                anchor_span: Some((20, 28)),
+            },
+        ];
+        let mut entity_by_name = BTreeMap::new();
+        entity_by_name.insert("Foo::run".to_string(), EntityId(77));
+        let facts = symbol_refs_to_semantic_facts(&refs, FileId(1), &entity_by_name);
+        assert_eq!(facts.anchors.len(), 2);
+        assert_eq!(facts.occurrences.len(), 2);
+        assert_eq!(facts.occurrences[0].kind, OccurrenceKind::Call);
+        assert_eq!(facts.occurrences[1].kind, OccurrenceKind::Read);
+        assert_eq!(facts.reference_edges.len(), 1);
+        assert_eq!(facts.reference_edges[0].kind, EdgeKind::Calls);
+        assert_eq!(facts.reference_edges[0].to_entity_id, EntityId(77));
     }
 
     /// When a decl's container is not itself present as a declaration, the

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -32,5 +32,8 @@ pub mod facts;
 pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
-pub use facts::{SymbolDeclSemanticFacts, UnsupportedDeclFact, symbol_decls_to_semantic_facts};
+pub use facts::{
+    SymbolDeclSemanticFacts, SymbolRefSemanticFacts, UnsupportedDeclFact,
+    symbol_decls_to_semantic_facts, symbol_refs_to_semantic_facts,
+};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};


### PR DESCRIPTION
### Motivation

- Wave 2 requires a producer-side `SymbolRef -> OccurrenceFact` adapter so reference sites emit fact rows without making the neutral `perl-semantic-facts` crate depend on producer crates.

### Description

- Added `SymbolRefSemanticFacts` and `symbol_refs_to_semantic_facts` in `crates/perl-symbol/src/surface/facts.rs` to emit deterministic `AnchorFact` and `OccurrenceFact` rows and optional typed reference `EdgeFact`s when an `EntityId` is known.
- Implemented mapping helpers `symbol_ref_kind_to_occurrence_kind` and `occurrence_kind_to_reference_edge_kind` to translate `SymbolRefKind` into `OccurrenceKind` and `EdgeKind` respectively.
- Exported the new adapter and types via `crates/perl-symbol/src/surface/mod.rs` and the crate-level API in `crates/perl-symbol/src/api.rs` so downstream consumers can call `symbol_refs_to_semantic_facts`.
- Added a focused unit test `symbol_ref_adapter_emits_occurrences_and_optional_edges` validating occurrence kinds, optional edge emission, and edge kind mapping.

### Testing

- Ran the crate test suite with `cargo test -p perl-symbol`, and all `perl-symbol` unit tests passed.
- The new unit test `symbol_ref_adapter_emits_occurrences_and_optional_edges` executes successfully as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d2c1e2588333b7c7538e37a96f4c)