### PR TITLE
feat(perl-symbol): add SymbolRef occurrence fact adapter (#0000)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -25,6 +25,7 @@ pub use crate::index::SymbolIndex;
 
 // surface — full public surface
 pub use crate::surface::{
-    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, UnsupportedDeclFact,
-    extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefFactIds, SymbolRefKind,
+    SymbolRefOccurrenceFacts, UnsupportedDeclFact, extract_symbol_decls, extract_symbol_refs,
+    symbol_decls_to_semantic_facts, symbol_ref_to_occurrence_facts,
 };

--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -1,4 +1,5 @@
 use crate::surface::decl::SymbolDecl;
+use crate::surface::r#ref::{SymbolRef, SymbolRefKind};
 use crate::types::SymbolKind;
 use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
@@ -20,6 +21,18 @@ pub struct SymbolDeclSemanticFacts {
     pub entities: Vec<EntityFact>,
     pub defines_edges: Vec<EdgeFact>,
     pub unsupported: Vec<UnsupportedDeclFact>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct SymbolRefFactIds {
+    pub anchor_id: AnchorId,
+    pub occurrence_id: perl_semantic_facts::OccurrenceId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymbolRefOccurrenceFacts {
+    pub anchors: Vec<AnchorFact>,
+    pub occurrences: Vec<perl_semantic_facts::OccurrenceFact>,
 }
 
 pub fn symbol_decls_to_semantic_facts(
@@ -158,6 +171,51 @@ fn stable_id(namespace: &str, name: &str, start: usize, end: usize) -> u64 {
         hash = hash.wrapping_mul(1099511628211);
     }
     hash
+}
+
+pub fn symbol_ref_to_occurrence_facts(
+    symbol_refs: &[SymbolRef],
+    file_id: FileId,
+) -> SymbolRefOccurrenceFacts {
+    let mut anchors = Vec::with_capacity(symbol_refs.len());
+    let mut occurrences = Vec::with_capacity(symbol_refs.len());
+
+    for symbol_ref in symbol_refs {
+        let anchor_span = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
+        let anchor_id =
+            AnchorId(stable_id("ref-anchor", &symbol_ref.qualified_name, anchor_span.0, anchor_span.1));
+        anchors.push(AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: anchor_span.0 as u32,
+            span_end_byte: anchor_span.1 as u32,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        let occurrence_kind = match symbol_ref.kind {
+            SymbolRefKind::Variable(_) => perl_semantic_facts::OccurrenceKind::Reference,
+            SymbolRefKind::SubroutineCall => perl_semantic_facts::OccurrenceKind::Call,
+        };
+        let occurrence_id = perl_semantic_facts::OccurrenceId(stable_id(
+            "ref-occurrence",
+            &symbol_ref.qualified_name,
+            symbol_ref.full_span.0,
+            symbol_ref.full_span.1,
+        ));
+        occurrences.push(perl_semantic_facts::OccurrenceFact {
+            id: occurrence_id,
+            kind: occurrence_kind,
+            entity_id: None,
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+    }
+
+    SymbolRefOccurrenceFacts { anchors, occurrences }
 }
 
 #[cfg(test)]
@@ -386,6 +444,40 @@ mod tests {
             d_edge.from_entity_id, c_entity.id,
             "Defines edge for A::B::C::D must come FROM A::B::C"
         );
+    }
+
+    #[test]
+    fn symbol_ref_adapter_emits_occurrence_and_anchor_facts() {
+        let refs = vec![
+            SymbolRef {
+                kind: SymbolRefKind::Variable(VarKind::Scalar),
+                name: "x".to_string(),
+                qualified_name: "x".to_string(),
+                sigil: Some("$".to_string()),
+                package_qualifier: None,
+                full_span: (3, 5),
+                anchor_span: Some((3, 5)),
+            },
+            SymbolRef {
+                kind: SymbolRefKind::SubroutineCall,
+                name: "run".to_string(),
+                qualified_name: "Pkg::run".to_string(),
+                sigil: None,
+                package_qualifier: Some("Pkg".to_string()),
+                full_span: (8, 17),
+                anchor_span: Some((8, 11)),
+            },
+        ];
+
+        let facts = symbol_ref_to_occurrence_facts(&refs, FileId(77));
+        assert_eq!(facts.anchors.len(), 2);
+        assert_eq!(facts.occurrences.len(), 2);
+        assert_eq!(
+            facts.occurrences[0].kind,
+            perl_semantic_facts::OccurrenceKind::Reference
+        );
+        assert_eq!(facts.occurrences[1].kind, perl_semantic_facts::OccurrenceKind::Call);
+        assert!(facts.occurrences.iter().all(|fact| fact.entity_id.is_none()));
     }
 
     #[test]

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -32,5 +32,8 @@ pub mod facts;
 pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
-pub use facts::{SymbolDeclSemanticFacts, UnsupportedDeclFact, symbol_decls_to_semantic_facts};
+pub use facts::{
+    SymbolDeclSemanticFacts, SymbolRefFactIds, SymbolRefOccurrenceFacts, UnsupportedDeclFact,
+    symbol_decls_to_semantic_facts, symbol_ref_to_occurrence_facts,
+};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};


### PR DESCRIPTION
### Motivation

- Wave 2 semantic substrate lacked a `SymbolRef -> OccurrenceFact` adapter in the symbol projection layer, leaving reference occurrence facts un-emitted and blocking downstream fact indexing and scorecarding.

### Description

- Added `symbol_ref_to_occurrence_facts(...)` which converts `SymbolRef` entries into deterministic `AnchorFact` and `OccurrenceFact` rows and returns them in `SymbolRefOccurrenceFacts`.
- Introduced `SymbolRefFactIds` and `SymbolRefOccurrenceFacts` types and exported the new adapter and types from the `surface` module and the crate `api` facade so downstream crates can consume the adapter.
- Added a unit test `symbol_ref_adapter_emits_occurrence_and_anchor_facts` validating variable refs map to `OccurrenceKind::Reference`, call refs map to `OccurrenceKind::Call`, and `entity_id` remains `None` at this projection stage.

### Testing

- Ran `cargo test -p perl-symbol symbol_ref_adapter_emits_occurrence_and_anchor_facts`, which passed.
- Ran `cargo test -p perl-symbol symbol_ref_to_occurrence_facts -- --nocapture`, which completed successfully (tests filtered as expected).
- Ran `cargo check --all-targets -p perl-symbol`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d2a8bbc88333946bd7ecd204a309)