### PR TITLE
feat(semantic-substrate): add SymbolRef occurrence facts + typed ReferenceEdge index (#0000)

### DIFF
--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -1,8 +1,11 @@
-use crate::surface::decl::SymbolDecl;
+use crate::surface::{
+    decl::SymbolDecl,
+    r#ref::{SymbolRef, SymbolRefKind},
+};
 use crate::types::SymbolKind;
 use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
-    FileId, Provenance,
+    FileId, OccurrenceFact, OccurrenceId, OccurrenceKind, Provenance,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -160,6 +163,82 @@ fn stable_id(namespace: &str, name: &str, start: usize, end: usize) -> u64 {
     hash
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymbolRefSemanticFacts {
+    pub anchors: Vec<AnchorFact>,
+    pub occurrences: Vec<OccurrenceFact>,
+    pub reference_edges: Vec<EdgeFact>,
+}
+
+pub fn symbol_refs_to_semantic_facts(
+    refs: &[SymbolRef],
+    file_id: FileId,
+    resolved_entities: &std::collections::BTreeMap<String, EntityId>,
+) -> SymbolRefSemanticFacts {
+    let mut anchors = Vec::with_capacity(refs.len());
+    let mut occurrences = Vec::with_capacity(refs.len());
+    let mut reference_edges = Vec::new();
+
+    for symbol_ref in refs {
+        let anchor_span = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
+        let anchor_id = AnchorId(stable_id(
+            "ref-anchor",
+            &symbol_ref.qualified_name,
+            anchor_span.0,
+            anchor_span.1,
+        ));
+        anchors.push(AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: anchor_span.0 as u32,
+            span_end_byte: anchor_span.1 as u32,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        let kind = match symbol_ref.kind {
+            SymbolRefKind::Variable(_) => OccurrenceKind::Reference,
+            SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+        };
+        let entity_id = resolved_entities.get(&symbol_ref.qualified_name).copied();
+        let occurrence_id = OccurrenceId(stable_id(
+            "occurrence",
+            &symbol_ref.qualified_name,
+            symbol_ref.full_span.0,
+            symbol_ref.full_span.1,
+        ));
+        occurrences.push(OccurrenceFact {
+            id: occurrence_id,
+            kind,
+            entity_id,
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        if let Some(to_entity_id) = entity_id {
+            let from_entity_id = to_entity_id;
+            reference_edges.push(EdgeFact {
+                id: EdgeId(stable_id(
+                    "references",
+                    &symbol_ref.qualified_name,
+                    symbol_ref.full_span.0,
+                    symbol_ref.full_span.1,
+                )),
+                kind: EdgeKind::References,
+                from_entity_id,
+                to_entity_id,
+                via_occurrence_id: Some(occurrence_id),
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            });
+        }
+    }
+
+    SymbolRefSemanticFacts { anchors, occurrences, reference_edges }
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -32,5 +32,8 @@ pub mod facts;
 pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
-pub use facts::{SymbolDeclSemanticFacts, UnsupportedDeclFact, symbol_decls_to_semantic_facts};
+pub use facts::{
+    SymbolDeclSemanticFacts, SymbolRefSemanticFacts, UnsupportedDeclFact,
+    symbol_decls_to_semantic_facts, symbol_refs_to_semantic_facts,
+};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};

--- a/crates/perl-workspace-index/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace-index/src/workspace/workspace_index.rs
@@ -1061,6 +1061,21 @@ pub struct SymbolReference {
     pub kind: ReferenceKind,
 }
 
+#[derive(Debug, Clone)]
+/// Typed global reference edge retained by the workspace index.
+pub struct ReferenceEdge {
+    /// Location of the reference site.
+    pub location: Location,
+    /// Occurrence classification for this edge.
+    pub occurrence_kind: perl_semantic_facts::OccurrenceKind,
+    /// Confidence for this edge classification.
+    pub confidence: perl_semantic_facts::Confidence,
+    /// Provenance used to derive this edge.
+    pub provenance: perl_semantic_facts::Provenance,
+    /// Stable symbol key used in the global reference map.
+    pub symbol_key: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Classification of how a symbol is referenced in Navigate/Analyze workflows.
 pub enum ReferenceKind {
@@ -1166,6 +1181,8 @@ pub struct WorkspaceIndex {
     /// Aggregated from per-file `FileIndex::references` during `index_file()`.
     /// Provides O(1) lookup for `find_references()` instead of iterating all files.
     global_references: Arc<RwLock<HashMap<String, Vec<Location>>>>,
+    /// Global typed reference edges (symbol name -> semantic reference edges).
+    global_reference_edges: Arc<RwLock<HashMap<String, Vec<ReferenceEdge>>>>,
     /// Write-through semantic fact shards keyed by normalized URI.
     fact_shards: Arc<RwLock<HashMap<String, FileFactShard>>>,
     /// Document store for in-memory text
@@ -1509,6 +1526,7 @@ impl WorkspaceIndex {
             files: Arc::new(RwLock::new(HashMap::new())),
             symbols: Arc::new(RwLock::new(HashMap::new())),
             global_references: Arc::new(RwLock::new(HashMap::new())),
+            global_reference_edges: Arc::new(RwLock::new(HashMap::new())),
             fact_shards: Arc::new(RwLock::new(HashMap::new())),
             document_store: DocumentStore::new(),
             workspace_folders: Arc::new(RwLock::new(Vec::new())),
@@ -1548,6 +1566,7 @@ impl WorkspaceIndex {
             files: Arc::new(RwLock::new(HashMap::with_capacity(estimated_files))),
             symbols: Arc::new(RwLock::new(HashMap::with_capacity(sym_cap))),
             global_references: Arc::new(RwLock::new(HashMap::with_capacity(ref_cap))),
+            global_reference_edges: Arc::new(RwLock::new(HashMap::with_capacity(ref_cap))),
             fact_shards: Arc::new(RwLock::new(HashMap::with_capacity(estimated_files))),
             document_store: DocumentStore::new(),
             workspace_folders: Arc::new(RwLock::new(Vec::new())),
@@ -1608,6 +1627,21 @@ impl WorkspaceIndex {
                 locs.retain(|loc| loc.uri != file_uri);
                 if locs.is_empty() {
                     global_refs.remove(name);
+                }
+            }
+        }
+    }
+
+    fn remove_file_global_reference_edges(
+        global_edges: &mut HashMap<String, Vec<ReferenceEdge>>,
+        file_index: &FileIndex,
+        file_uri: &str,
+    ) {
+        for name in file_index.references.keys() {
+            if let Some(edges) = global_edges.get_mut(name) {
+                edges.retain(|edge| edge.location.uri != file_uri);
+                if edges.is_empty() {
+                    global_edges.remove(name);
                 }
             }
         }
@@ -1704,6 +1738,8 @@ impl WorkspaceIndex {
             if let Some(old_index) = files.get(&key) {
                 let mut global_refs = self.global_references.write();
                 Self::remove_file_global_refs(&mut global_refs, old_index, &uri_str);
+                let mut global_edges = self.global_reference_edges.write();
+                Self::remove_file_global_reference_edges(&mut global_edges, old_index, &uri_str);
             }
 
             // Incrementally remove old symbols before inserting new file
@@ -1720,10 +1756,34 @@ impl WorkspaceIndex {
 
             if let Some(file_index) = files.get(&key) {
                 let mut global_refs = self.global_references.write();
+                let mut global_edges = self.global_reference_edges.write();
                 for (name, refs) in &file_index.references {
                     let entry = global_refs.entry(name.clone()).or_default();
+                    let edge_entry = global_edges.entry(name.clone()).or_default();
                     for reference in refs {
                         entry.push(Location { uri: reference.uri.clone(), range: reference.range });
+                        edge_entry.push(ReferenceEdge {
+                            location: Location {
+                                uri: reference.uri.clone(),
+                                range: reference.range,
+                            },
+                            occurrence_kind: match reference.kind {
+                                ReferenceKind::Definition => {
+                                    perl_semantic_facts::OccurrenceKind::Definition
+                                }
+                                ReferenceKind::Import => {
+                                    perl_semantic_facts::OccurrenceKind::Import
+                                }
+                                ReferenceKind::Read => perl_semantic_facts::OccurrenceKind::Read,
+                                ReferenceKind::Write => perl_semantic_facts::OccurrenceKind::Write,
+                                ReferenceKind::Usage => {
+                                    perl_semantic_facts::OccurrenceKind::Reference
+                                }
+                            },
+                            confidence: perl_semantic_facts::Confidence::High,
+                            provenance: perl_semantic_facts::Provenance::ExactAst,
+                            symbol_key: name.clone(),
+                        });
                     }
                 }
             }
@@ -1784,6 +1844,8 @@ impl WorkspaceIndex {
             // Remove from global reference index
             let mut global_refs = self.global_references.write();
             Self::remove_file_global_refs(&mut global_refs, &file_index, &uri_str);
+            let mut global_edges = self.global_reference_edges.write();
+            Self::remove_file_global_reference_edges(&mut global_edges, &file_index, &uri_str);
         }
     }
 
@@ -2192,50 +2254,35 @@ impl WorkspaceIndex {
     /// returning only actual usage sites. This is used by code lens to show
     /// "N references" where N means call sites, not the definition itself.
     pub fn count_usages(&self, symbol_name: &str) -> usize {
-        let files = self.files.read();
+        let global_edges = self.global_reference_edges.read();
         let mut seen: HashSet<(String, u32, u32, u32, u32)> = HashSet::new();
-
-        for (_uri_key, file_index) in files.iter() {
-            if let Some(refs) = file_index.references.get(symbol_name) {
-                for r in refs.iter().filter(|r| r.kind != ReferenceKind::Definition) {
-                    seen.insert((
-                        r.uri.clone(),
-                        r.range.start.line,
-                        r.range.start.column,
-                        r.range.end.line,
-                        r.range.end.column,
-                    ));
-                }
+        let mut collect = |edges: &Vec<ReferenceEdge>| {
+            for edge in edges
+                .iter()
+                .filter(|e| e.occurrence_kind != perl_semantic_facts::OccurrenceKind::Definition)
+            {
+                let r = &edge.location.range;
+                seen.insert((
+                    edge.location.uri.clone(),
+                    r.start.line,
+                    r.start.column,
+                    r.end.line,
+                    r.end.column,
+                ));
             }
-
-            if let Some(idx) = symbol_name.rfind("::") {
-                let bare_name = &symbol_name[idx + 2..];
-                if let Some(refs) = file_index.references.get(bare_name) {
-                    for r in refs.iter().filter(|r| r.kind != ReferenceKind::Definition) {
-                        seen.insert((
-                            r.uri.clone(),
-                            r.range.start.line,
-                            r.range.start.column,
-                            r.range.end.line,
-                            r.range.end.column,
-                        ));
-                    }
-                }
-            } else {
-                for (name, refs) in &file_index.references {
-                    if !Self::is_qualified_variant_of(name, symbol_name) {
-                        continue;
-                    }
-
-                    for r in refs.iter().filter(|r| r.kind != ReferenceKind::Definition) {
-                        seen.insert((
-                            r.uri.clone(),
-                            r.range.start.line,
-                            r.range.start.column,
-                            r.range.end.line,
-                            r.range.end.column,
-                        ));
-                    }
+        };
+        if let Some(edges) = global_edges.get(symbol_name) {
+            collect(edges);
+        }
+        if let Some(idx) = symbol_name.rfind("::") {
+            let bare_name = &symbol_name[idx + 2..];
+            if let Some(edges) = global_edges.get(bare_name) {
+                collect(edges);
+            }
+        } else {
+            for (name, edges) in global_edges.iter() {
+                if Self::is_qualified_variant_of(name, symbol_name) {
+                    collect(edges);
                 }
             }
         }
@@ -2333,6 +2380,7 @@ impl WorkspaceIndex {
         self.files.write().clear();
         self.symbols.write().clear();
         self.global_references.write().clear();
+        self.global_reference_edges.write().clear();
         self.fact_shards.write().clear();
     }
 

--- a/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
+++ b/docs/project/SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md
@@ -118,7 +118,7 @@ This section is the migration receipt for what has landed versus what remains st
 
 ### Still staged
 
-- **`SymbolRef -> OccurrenceFact` adapter:** not landed; occurrence facts are not yet emitted from reference sites.
+- **`SymbolRef -> OccurrenceFact` adapter:** landed in `perl-symbol` for phase-1 variable/call refs; remaining expansion to later reference forms stays staged.
 - **`ExportInfo -> ExportSet` adapter:** not landed; export analysis remains in legacy format.
 - **Typed reference-edge global index:** not landed; typed-reference behavior is constrained to fixture/regression banks rather than a provider-facing global index.
 


### PR DESCRIPTION
### Motivation

- Wave 2 lacked a clean `SymbolRef -> OccurrenceFact` adapter at the `perl-symbol` seam and a typed global reference index in the workspace, which blocks making the semantic scorecard and shadow-compare receipts read real facts.
- Adding occurrence facts and typed reference edges preserves legacy provider APIs while surfacing richer semantic edges needed for future `count_usages`, rename, and safe-delete work.

### Description

- Added `symbol_refs_to_semantic_facts` in `crates/perl-symbol/src/surface/facts.rs` to emit `AnchorFact`, `OccurrenceFact` (variable → `Reference`, call → `Call`), and optional `EdgeFact::References` when a target entity is known. 
- Introduced a typed `ReferenceEdge` and a `global_reference_edges: Arc<RwLock<HashMap<String, Vec<ReferenceEdge>>>>` in `WorkspaceIndex`, populated during `index_file` and cleaned during `remove_file`/reindex so typed edges have proper lifecycle and do not leak stale entries. 
- Preserved legacy `global_references` and `find_references(...) -> Vec<Location>` behavior, while switching `count_usages` to consult typed `global_reference_edges` and exclude definition occurrences by `OccurrenceKind::Definition`; also updated the Wave 2 status doc to reflect the phase-1 landing.

### Testing

- `cargo test -p perl-symbol` was run and passed.
- `cargo test -p perl-workspace reference` was run and passed.
- `cargo check -p perl-workspace` and `cargo check -p perl-symbol` were run and completed; builds succeeded (warnings about missing docs surfaced but did not block checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d29b55708333b7d97d9e7670613c)