### PR TITLE
feat(perl-symbol): add SymbolRef semantic fact adapter (#0000)

### DIFF
--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -1,8 +1,9 @@
 use crate::surface::decl::SymbolDecl;
+use crate::surface::r#ref::{SymbolRef, SymbolRefKind};
 use crate::types::SymbolKind;
 use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
-    FileId, Provenance,
+    FileId, OccurrenceFact, OccurrenceId, OccurrenceKind, Provenance,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -20,6 +21,85 @@ pub struct SymbolDeclSemanticFacts {
     pub entities: Vec<EntityFact>,
     pub defines_edges: Vec<EdgeFact>,
     pub unsupported: Vec<UnsupportedDeclFact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymbolRefSemanticFacts {
+    pub anchors: Vec<AnchorFact>,
+    pub occurrences: Vec<OccurrenceFact>,
+    pub reference_edges: Vec<EdgeFact>,
+}
+
+pub fn symbol_refs_to_semantic_facts(
+    refs: &[SymbolRef],
+    file_id: FileId,
+    entity_by_name: &BTreeMap<String, EntityId>,
+) -> SymbolRefSemanticFacts {
+    let mut anchors = Vec::with_capacity(refs.len());
+    let mut occurrences = Vec::with_capacity(refs.len());
+    let mut reference_edges = Vec::new();
+
+    for symbol_ref in refs {
+        let anchor_span = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
+        let anchor_id = AnchorId(stable_id(
+            "ref_anchor",
+            &symbol_ref.qualified_name,
+            anchor_span.0,
+            anchor_span.1,
+        ));
+        anchors.push(AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: anchor_span.0 as u32,
+            span_end_byte: anchor_span.1 as u32,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        let entity_id =
+            entity_by_name.get(&symbol_ref.qualified_name).or_else(|| entity_by_name.get(&symbol_ref.name)).copied();
+        let occurrence_id = OccurrenceId(stable_id(
+            "occurrence",
+            &symbol_ref.qualified_name,
+            symbol_ref.full_span.0,
+            symbol_ref.full_span.1,
+        ));
+        occurrences.push(OccurrenceFact {
+            id: occurrence_id,
+            kind: symbol_ref_kind_to_occurrence_kind(&symbol_ref.kind),
+            entity_id,
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        if let Some(target_entity_id) = entity_id {
+            let source_entity_id = EntityId(stable_id(
+                "ref_entity",
+                &symbol_ref.qualified_name,
+                symbol_ref.full_span.0,
+                symbol_ref.full_span.1,
+            ));
+            reference_edges.push(EdgeFact {
+                id: EdgeId(stable_id(
+                    "references",
+                    &symbol_ref.qualified_name,
+                    source_entity_id.0 as usize,
+                    target_entity_id.0 as usize,
+                )),
+                kind: EdgeKind::References,
+                from_entity_id: source_entity_id,
+                to_entity_id: target_entity_id,
+                via_occurrence_id: Some(occurrence_id),
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            });
+        }
+    }
+
+    SymbolRefSemanticFacts { anchors, occurrences, reference_edges }
 }
 
 pub fn symbol_decls_to_semantic_facts(
@@ -143,6 +223,13 @@ fn symbol_kind_to_entity_kind(kind: SymbolKind) -> Option<EntityKind> {
     }
 }
 
+fn symbol_ref_kind_to_occurrence_kind(kind: &SymbolRefKind) -> OccurrenceKind {
+    match kind {
+        SymbolRefKind::Variable(_) => OccurrenceKind::Reference,
+        SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+    }
+}
+
 fn stable_id(namespace: &str, name: &str, start: usize, end: usize) -> u64 {
     let mut hash = 14695981039346656037u64;
     for byte in namespace
@@ -163,6 +250,7 @@ fn stable_id(namespace: &str, name: &str, start: usize, end: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::surface::r#ref::SymbolRefKind;
     use crate::types::VarKind;
 
     #[test]
@@ -409,5 +497,42 @@ mod tests {
             facts.unsupported[0].reason,
             "symbol kind is not yet representable as EntityFact"
         );
+    }
+
+    #[test]
+    fn symbol_ref_adapter_emits_occurrences_and_reference_edges() {
+        let refs = vec![
+            SymbolRef {
+                kind: SymbolRefKind::SubroutineCall,
+                name: "run".to_string(),
+                qualified_name: "Foo::run".to_string(),
+                sigil: None,
+                package_qualifier: Some("Foo".to_string()),
+                full_span: (10, 18),
+                anchor_span: Some((10, 18)),
+            },
+            SymbolRef {
+                kind: SymbolRefKind::Variable(VarKind::Scalar),
+                name: "missing".to_string(),
+                qualified_name: "missing".to_string(),
+                sigil: Some("$".to_string()),
+                package_qualifier: None,
+                full_span: (20, 28),
+                anchor_span: Some((20, 28)),
+            },
+        ];
+        let mut entity_by_name = BTreeMap::new();
+        entity_by_name.insert("Foo::run".to_string(), EntityId(900));
+
+        let facts = symbol_refs_to_semantic_facts(&refs, FileId(4), &entity_by_name);
+        assert_eq!(facts.anchors.len(), 2);
+        assert_eq!(facts.occurrences.len(), 2);
+        assert_eq!(facts.reference_edges.len(), 1);
+        assert_eq!(facts.occurrences[0].kind, OccurrenceKind::Call);
+        assert_eq!(facts.occurrences[1].kind, OccurrenceKind::Reference);
+        assert_eq!(facts.occurrences[0].entity_id, Some(EntityId(900)));
+        assert_eq!(facts.occurrences[1].entity_id, None);
+        assert_eq!(facts.reference_edges[0].kind, EdgeKind::References);
+        assert_eq!(facts.reference_edges[0].to_entity_id, EntityId(900));
     }
 }

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -32,5 +32,8 @@ pub mod facts;
 pub mod r#ref;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
-pub use facts::{SymbolDeclSemanticFacts, UnsupportedDeclFact, symbol_decls_to_semantic_facts};
+pub use facts::{
+    SymbolDeclSemanticFacts, SymbolRefSemanticFacts, UnsupportedDeclFact,
+    symbol_decls_to_semantic_facts, symbol_refs_to_semantic_facts,
+};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};


### PR DESCRIPTION
### Motivation

- Wave 2 lacked a `SymbolRef -> OccurrenceFact` adapter at the correct seam, leaving reference sites out of the canonical semantic-fact substrate.
- The change implements the missing adapter in `perl-symbol` so references can be emitted as first-class occurrence facts without introducing circular crate dependencies.

### Description

- Added `SymbolRefSemanticFacts` and a new adapter `symbol_refs_to_semantic_facts(refs, file_id, entity_by_name)` that emits `AnchorFact`, `OccurrenceFact`, and optional `EdgeFact::References` when a target entity is known.
- Mapped `SymbolRefKind` to `perl_semantic_facts::OccurrenceKind` via `symbol_ref_kind_to_occurrence_kind` and introduced stable deterministic IDs for anchors/occurrences/edges with `stable_id`.
- Exported the new types and function from `surface::mod` so downstream consumers can call `symbol_refs_to_semantic_facts` directly.
- Added unit tests validating occurrence emission, unresolved-reference behavior (`entity_id: None`), and conditional reference-edge creation.

### Testing

- Ran `cargo test -p perl-symbol` and all unit tests in the crate passed.
- Ran `cargo test -p perl-semantic-facts` and its tests passed.
- Ran `cargo check --workspace --all-targets`; the workspace-wide check was exercised and progressed across crates with no adapter-related errors observed, while unrelated crates produced warnings during the long-running check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d29b55708333b7d97d9e7670613c)