### PR TITLE
feat(perl-symbol): add SymbolRef occurrence facts adapter (#0000)

### DIFF
--- a/crates/perl-symbol/src/api.rs
+++ b/crates/perl-symbol/src/api.rs
@@ -25,6 +25,7 @@ pub use crate::index::SymbolIndex;
 
 // surface — full public surface
 pub use crate::surface::{
-    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, UnsupportedDeclFact,
-    extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    SymbolDecl, SymbolDeclSemanticFacts, SymbolRef, SymbolRefKind, SymbolRefSemanticFacts,
+    UnsupportedDeclFact, extract_symbol_decls, extract_symbol_refs, symbol_decls_to_semantic_facts,
+    symbol_refs_to_semantic_facts,
 };

--- a/crates/perl-symbol/src/surface/mod.rs
+++ b/crates/perl-symbol/src/surface/mod.rs
@@ -30,7 +30,9 @@
 pub mod decl;
 pub mod facts;
 pub mod r#ref;
+pub mod ref_facts;
 
 pub use decl::{SymbolDecl, extract_symbol_decls};
 pub use facts::{SymbolDeclSemanticFacts, UnsupportedDeclFact, symbol_decls_to_semantic_facts};
 pub use r#ref::{SymbolRef, SymbolRefKind, extract_symbol_refs};
+pub use ref_facts::{SymbolRefSemanticFacts, symbol_refs_to_semantic_facts};

--- a/crates/perl-symbol/src/surface/ref_facts.rs
+++ b/crates/perl-symbol/src/surface/ref_facts.rs
@@ -1,0 +1,136 @@
+use crate::surface::r#ref::{SymbolRef, SymbolRefKind};
+use perl_semantic_facts::{
+    AnchorFact, AnchorId, Confidence, EdgeFact, EdgeId, EdgeKind, EntityId, FileId, OccurrenceFact,
+    OccurrenceId, OccurrenceKind, Provenance,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolRefSemanticFacts {
+    pub anchors: Vec<AnchorFact>,
+    pub occurrences: Vec<OccurrenceFact>,
+    pub references_edges: Vec<EdgeFact>,
+}
+
+pub fn symbol_refs_to_semantic_facts(
+    refs: &[SymbolRef],
+    file_id: FileId,
+    resolve_entity_id: impl Fn(&SymbolRef) -> Option<EntityId>,
+) -> SymbolRefSemanticFacts {
+    let mut anchors = Vec::with_capacity(refs.len());
+    let mut occurrences = Vec::with_capacity(refs.len());
+    let mut references_edges = Vec::new();
+
+    for symbol_ref in refs {
+        let anchor_span = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
+        let anchor_id = AnchorId(stable_id("ref_anchor", &symbol_ref.qualified_name, anchor_span.0, anchor_span.1));
+        anchors.push(AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: anchor_span.0 as u32,
+            span_end_byte: anchor_span.1 as u32,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        let entity_id = resolve_entity_id(symbol_ref);
+        let occurrence_id = OccurrenceId(stable_id(
+            "ref_occurrence",
+            &symbol_ref.qualified_name,
+            symbol_ref.full_span.0,
+            symbol_ref.full_span.1,
+        ));
+        occurrences.push(OccurrenceFact {
+            id: occurrence_id,
+            kind: occurrence_kind(symbol_ref),
+            entity_id,
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        });
+
+        if let Some(to_entity_id) = entity_id {
+            let from_entity_id = EntityId(stable_id(
+                "ref_source_entity",
+                &symbol_ref.qualified_name,
+                symbol_ref.full_span.0,
+                symbol_ref.full_span.1,
+            ));
+            references_edges.push(EdgeFact {
+                id: EdgeId(stable_id("references_edge", &symbol_ref.qualified_name, from_entity_id.0 as usize, to_entity_id.0 as usize)),
+                kind: EdgeKind::References,
+                from_entity_id,
+                to_entity_id,
+                via_occurrence_id: Some(occurrence_id),
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            });
+        }
+    }
+
+    SymbolRefSemanticFacts { anchors, occurrences, references_edges }
+}
+
+fn occurrence_kind(symbol_ref: &SymbolRef) -> OccurrenceKind {
+    match symbol_ref.kind {
+        SymbolRefKind::Variable(_) => OccurrenceKind::Reference,
+        SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+    }
+}
+
+fn stable_id(namespace: &str, name: &str, start: usize, end: usize) -> u64 {
+    let mut hash = 14695981039346656037u64;
+    for byte in namespace
+        .as_bytes()
+        .iter()
+        .chain([0xff].iter())
+        .chain(name.as_bytes().iter())
+        .chain([0xff].iter())
+        .chain(start.to_le_bytes().iter())
+        .chain(end.to_le_bytes().iter())
+    {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(1099511628211);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::VarKind;
+
+    #[test]
+    fn symbol_refs_emit_occurrences_and_optional_reference_edges() {
+        let refs = vec![
+            SymbolRef {
+                kind: SymbolRefKind::SubroutineCall,
+                name: "run".into(),
+                qualified_name: "Foo::run".into(),
+                sigil: None,
+                package_qualifier: Some("Foo".into()),
+                full_span: (4, 12),
+                anchor_span: Some((4, 7)),
+            },
+            SymbolRef {
+                kind: SymbolRefKind::Variable(VarKind::Scalar),
+                name: "x".into(),
+                qualified_name: "x".into(),
+                sigil: Some("$".into()),
+                package_qualifier: None,
+                full_span: (13, 15),
+                anchor_span: Some((13, 15)),
+            },
+        ];
+
+        let facts = symbol_refs_to_semantic_facts(&refs, FileId(1), |r| {
+            (r.qualified_name == "Foo::run").then_some(EntityId(7))
+        });
+        assert_eq!(facts.anchors.len(), 2);
+        assert_eq!(facts.occurrences.len(), 2);
+        assert_eq!(facts.references_edges.len(), 1);
+        assert_eq!(facts.occurrences[0].kind, OccurrenceKind::Call);
+        assert_eq!(facts.occurrences[1].kind, OccurrenceKind::Reference);
+    }
+}

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -111,7 +111,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - AI inline completion (#3018) shipped in the live 0.12.x line — feature wired end-to-end via #3157–#3168, awaiting E2E user validation
 - Workspace-wide rename slice: multi-root support shipped in 0.12.x (#3984); workspace-wide rename/module-move remains roughly 30% complete and only conditionally in scope pending #3522 verification
 - Coroutine support issue #3539 is re-scoped: defer hypothetical core syntax, split upstream-tracking from CPAN-library IDE support planning
-- Semantic substrate migration status now tracks Wave 2 reality (facts vocabulary, SymbolDecl adapter, FileFactShard write-through, and DefinitionCandidate multimap landed; SymbolRef adapter, ExportInfo adapter, and typed-reference global index still staged) in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md); provider cutover remains explicitly deferred until Wave 3 foundations (`ImportSpec` + `visible_symbols_at`) are proven
+- Semantic substrate migration status now tracks Wave 2 reality (facts vocabulary, SymbolDecl adapter, FileFactShard write-through, and DefinitionCandidate multimap landed; SymbolRef adapter and typed-reference global index still staged; ExportInfo -> ExportSet landed) in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md); provider cutover remains explicitly deferred until Wave 3 foundations (`ImportSpec` + `visible_symbols_at`) are proven
 
 ### Next (v0.13.0 — public alpha announcement)
 


### PR DESCRIPTION
### Motivation

- Wave 2 lacked a `SymbolRef -> OccurrenceFact` adapter at the `perl-symbol` seam so reference sites were not emitted into the neutral fact pipeline.
- Emit high-confidence anchor/occurrence records for the phase-1 `SymbolRef` projection so downstream fact storage and scorecards can start consuming occurrences.
- Keep the neutral `perl-semantic-facts` crate as the vocabulary target and implement the adapter in `perl-symbol` so dependency direction remains correct.

### Description

- Added `crates/perl-symbol/src/surface/ref_facts.rs` with `symbol_refs_to_semantic_facts` which converts `SymbolRef` into `AnchorFact` + `OccurrenceFact` and emits optional `EdgeFact::References` when an entity resolver returns a target `EntityId`, using deterministic stable IDs.
- Re-exported the new adapter and its types via `crates/perl-symbol/src/surface/mod.rs` and the crate facade `crates/perl-symbol/src/api.rs` so downstream crates can consume the adapter without deep imports.
- Updated `docs/project/ROADMAP.md` to reflect that `ExportInfo -> ExportSet` is landed while `SymbolRef` adapter and typed-reference global index remain staged.

### Testing

- Ran `cargo test -p perl-symbol` and all tests passed, including the new `symbol_refs_emit_occurrences_and_optional_reference_edges` unit test.
- Ran `cargo test -p perl-semantic-facts` and all tests passed.
- Verified the new adapter compiles and is exported via the crate facade by running the package test suite for `perl-symbol` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d29b55708333b7d97d9e7670613c)