### PR TITLE
chore(dev): add bounded build-plane contract for agent/worktree runs (#0000)

### DIFF
--- a/.cargo/config.local.toml.example
+++ b/.cargo/config.local.toml.example
@@ -1,0 +1,37 @@
+# .cargo/config.local.toml.example
+#
+# Copy to .cargo/config.local.toml for this checkout, or put equivalent
+# settings in ~/.cargo/config.toml / parent worktree-farm .cargo/config.toml.
+#
+# Do not commit .cargo/config.local.toml.
+
+[build]
+target-dir = "/mnt/devplane/perl-lsp/target/agent"
+build-dir = "/mnt/devplane/perl-lsp/build/agent"
+jobs = 2
+incremental = false
+rustc-wrapper = "sccache"
+
+[env]
+TMPDIR = { value = "/mnt/devplane/perl-lsp/tmp", force = false }
+SCCACHE_DIR = { value = "/mnt/devplane/perl-lsp/sccache", force = false }
+SCCACHE_CACHE_SIZE = { value = "15G", force = false }
+
+# Linux/macOS use colon separators.
+SCCACHE_BASEDIRS = { value = "/mnt/work/perl-lsp-worktrees:/mnt/devplane/worktrees", force = false }
+
+# Windows native example:
+#
+# [build]
+# target-dir = "D:/devplane/perl-lsp/target/agent"
+# build-dir = "D:/devplane/perl-lsp/build/agent"
+# jobs = 2
+# incremental = false
+# rustc-wrapper = "sccache"
+#
+# [env]
+# TEMP = { value = "D:\\devplane\\perl-lsp\\tmp", force = false }
+# TMP = { value = "D:\\devplane\\perl-lsp\\tmp", force = false }
+# SCCACHE_DIR = { value = "D:\\devplane\\perl-lsp\\sccache", force = false }
+# SCCACHE_CACHE_SIZE = { value = "15G", force = false }
+# SCCACHE_BASEDIRS = { value = "D:\\w\\perl-lsp-worktrees;D:\\devplane\\worktrees", force = false }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,33 +1,26 @@
 [alias]
 xtask = "run --package xtask --"
+
+# Agent/local-safe aliases. These do not choose machine paths.
+# Machine paths belong in .cargo/config.local.toml, ~/.cargo/config.toml,
+# or scripts/cargo-safe.
+agent-check = "check --workspace --all-targets --profile agent --locked"
+agent-test = "test --workspace --all-targets --profile agent --locked"
+agent-clippy = "clippy --workspace --all-targets --profile agent --locked -- -D warnings -A missing_docs"
+
 t2 = "test -- --test-threads=2"
 
-# Build configuration
 [build]
-# Feature flags that should always be enabled
-# This ensures AI tools and bare `cargo build` commands use the right features
-# Tell rustc which cfg(feature=...) values are valid, so clippy stays strict
 rustflags = []
 
-# Default target directory (shared across all crates)
-target-dir = "target"
-
-# Environment-specific settings
 [env]
-# Enable backtrace for better debugging
 RUST_BACKTRACE = "1"
 
-# Profile configurations are now in workspace Cargo.toml to avoid conflicts
-
-# Cargo configuration
 [term]
-# Use color in terminal output
 color = "auto"
 
 [net]
-# Retry failed downloads
 retry = 2
 
-# Registries configuration
 [registries.crates-io]
-protocol = "sparse"  # Use sparse index for faster updates 
+protocol = "sparse"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,9 +1,22 @@
 # Nextest configuration for LSP test stabilization
 # Phase 1: Retries and threading configuration for CI reliability
 
+# Nextest configuration for LSP test stabilization
+# Phase 1: Retries and threading configuration for CI reliability
+
+[store]
+dir = ".tmp/nextest/store"
+
 [profile.default]
 # Default profile for local development
 retries = 0
+
+[profile.agent]
+inherits = "default"
+test-threads = 2
+fail-fast = true
+status-level = "fail"
+final-status-level = "fail"
 
 [profile.ci]
 # CI profile with retry support for flaky tests
@@ -17,7 +30,7 @@ leak-timeout = "10s"
 
 [profile.ci.junit]
 # Generate JUnit reports for CI integration
-path = "target/nextest/ci/junit.xml"
+path = ".tmp/nextest/ci/junit.xml"
 
 [[profile.ci.overrides]]
 # LSP integration tests may need more time in CI

--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,26 @@ test_corpus/workspaces/xlarge/lib/
 test_corpus/workspaces/xlarge/bin/
 # Runtime scheduler lock file — ephemeral, never committed.
 /.claude/scheduled_tasks.lock
+
+
+# Cargo / Rust build output
+/target/
+/build/
+
+# Machine-local Cargo policy
+/.cargo/config.local.toml
+
+# Local build/cache plane aliases
+/.devplane/
+/.cache/
+
+# Agent/test scratch
+/.tmp/
+/test-results/
+/coverage/
+/lcov.info
+/*.profraw
+/*.profdata
+
+# Nextest local output
+/.nextest/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,14 +123,54 @@ No bare `unwrap()` in tests.
 
 ---
 
+
+## Build storage discipline
+
+This repo is often used with many disposable worktrees and agent sessions.
+Do not create large build output inside the worktree.
+
+Preferred commands:
+
+```bash
+just agent-check
+just agent-test
+just agent-clippy
+just agent-pr-fast
+```
+
+For direct Cargo, use:
+
+```bash
+./scripts/cargo-safe check -p <crate> --all-targets --profile agent --locked
+./scripts/cargo-safe test -p <crate> --profile agent --locked
+./scripts/cargo-safe clippy -p <crate> --profile agent --locked -- -D warnings -A missing_docs
+```
+
+Avoid:
+
+- `cargo test --workspace`
+- `cargo check --workspace --all-targets`
+- `cargo clean`
+- `rm -rf target`
+
+unless the orchestrator explicitly assigned a build lane.
+
+Storage invariant:
+
+`./scripts/storage-doctor`
+
+must not show large repo-local `target/` directories.
+
+---
+
 ## Verification before pushing
 
 ```bash
-cargo test -p <crate>            # crate under change
-cargo check --all-targets -p <crate>  # catches integration test bit-rot (--lib misses this)
-cargo xtask fmt                  # format (Windows-safe, per-crate)
-cargo clippy -p <crate>          # lint
-just pr-fast                     # full fast gate (required before opening PR)
+./scripts/cargo-safe test -p <crate> --profile agent --locked
+./scripts/cargo-safe check --all-targets -p <crate> --profile agent --locked
+./scripts/cargo-safe xtask fmt
+./scripts/cargo-safe clippy -p <crate> --profile agent --locked -- -D warnings -A missing_docs
+just agent-pr-fast
 ```
 
 For the canonical local merge gate (before a reviewer merges):

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,6 +343,16 @@ inherits = "release"
 lto = true
 codegen-units = 1
 
+
+[profile.agent]
+inherits = "dev"
+debug = "line-tables-only"
+incremental = false
+
+[profile.agent.build-override]
+debug = false
+incremental = false
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/justfile
+++ b/justfile
@@ -3,6 +3,8 @@
 # Install just: cargo install just
 
 # Default recipe (show available commands)
+cargo_safe := "./scripts/cargo-safe"
+
 default:
     @just --list
 
@@ -38,6 +40,34 @@ _timed name cmd:
         echo "<<< {{name}} FAILED in ${DURATION}s (exit $RC)"
         exit $RC
     fi
+
+
+# Initialize bounded build/cache directories.
+devplane-init:
+    ./scripts/devplane-init
+
+# Report repo-local build cruft and devplane state.
+storage-doctor:
+    ./scripts/storage-doctor
+
+agent-preflight: storage-doctor
+    @echo "agent preflight ok"
+
+# Agent-safe check: routed target/build dirs, incremental off, bounded sccache, build lock.
+agent-check:
+    {{cargo_safe}} check --workspace --all-targets --profile agent --locked
+
+agent-test:
+    {{cargo_safe}} test --workspace --all-targets --profile agent --locked
+
+agent-clippy:
+    {{cargo_safe}} clippy --workspace --all-targets --profile agent --locked -- -D warnings -A missing_docs
+
+agent-nextest:
+    {{cargo_safe}} nextest run --workspace --profile agent
+
+agent-pr-fast:
+    {{cargo_safe}} xtask gates --tier pr-fast --receipt
 
 # Tier: PR-fast (required for every PR iteration, must be fast ~1-2 min)
 pr-fast: _check-tools-basic

--- a/scripts/cargo-safe
+++ b/scripts/cargo-safe
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+repo_name="$(basename "$repo_root")"
+
+devplane="${DEVPLANE:-${XDG_CACHE_HOME:-$HOME/.cache}/devplane/$repo_name}"
+lock_root="$devplane/locks"
+
+mkdir -p \
+  "$devplane/cargo-home" \
+  "$devplane/target" \
+  "$devplane/build" \
+  "$devplane/sccache" \
+  "$devplane/tmp" \
+  "$lock_root"
+
+check_disk() {
+  local path="$1"
+  local min_free_gb="${MIN_FREE_GB:-40}"
+  local max_used_pct="${MAX_USED_PCT:-85}"
+
+  read -r used_pct avail_kb < <(
+    df -Pk "$path" | awk 'NR==2 { gsub("%","",$5); print $5, $4 }'
+  )
+
+  local avail_gb=$(( avail_kb / 1024 / 1024 ))
+
+  if [ "$used_pct" -ge "$max_used_pct" ] || [ "$avail_gb" -lt "$min_free_gb" ]; then
+    echo "DENY: $path used=${used_pct}% free=${avail_gb}G" >&2
+    exit 75
+  fi
+}
+
+export CARGO_HOME="${CARGO_HOME:-$devplane/cargo-home}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$devplane/target}"
+export CARGO_BUILD_BUILD_DIR="${CARGO_BUILD_BUILD_DIR:-$devplane/build}"
+export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
+export TMPDIR="${TMPDIR:-$devplane/tmp}"
+
+if command -v sccache >/dev/null 2>&1; then
+  export RUSTC_WRAPPER="${RUSTC_WRAPPER:-sccache}"
+  export SCCACHE_DIR="${SCCACHE_DIR:-$devplane/sccache}"
+  export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-15G}"
+
+  worktree_parent="$(dirname "$repo_root")"
+  export SCCACHE_BASEDIRS="${SCCACHE_BASEDIRS:-$worktree_parent}"
+fi
+
+heavy="${1:-}"
+
+case "$heavy" in
+  build|check|test|run|bench|doc|clippy|nextest)
+    check_disk "$devplane"
+
+    if command -v flock >/dev/null 2>&1; then
+      exec flock -w "${CARGO_LOCK_WAIT:-180}" \
+        "$lock_root/cargo-build.lock" \
+        cargo "$@"
+    else
+      exec cargo "$@"
+    fi
+    ;;
+  *)
+    exec cargo "$@"
+    ;;
+esac

--- a/scripts/devplane-init
+++ b/scripts/devplane-init
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+repo_name="$(basename "$repo_root")"
+devplane="${DEVPLANE:-${XDG_CACHE_HOME:-$HOME/.cache}/devplane/$repo_name}"
+
+mkdir -p \
+  "$devplane/cargo-home" \
+  "$devplane/target" \
+  "$devplane/build" \
+  "$devplane/sccache" \
+  "$devplane/tmp" \
+  "$devplane/locks"
+
+cat <<EOF2
+devplane ready:
+
+  DEVPLANE=$devplane
+  CARGO_HOME=$devplane/cargo-home
+  CARGO_TARGET_DIR=$devplane/target
+  CARGO_BUILD_BUILD_DIR=$devplane/build
+  SCCACHE_DIR=$devplane/sccache
+  TMPDIR=$devplane/tmp
+
+Recommended:
+
+  export DEVPLANE="$devplane"
+  ./scripts/cargo-safe check --workspace --all-targets --profile agent --locked
+EOF2

--- a/scripts/storage-doctor
+++ b/scripts/storage-doctor
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root"
+
+repo_name="$(basename "$repo_root")"
+devplane="${DEVPLANE:-${XDG_CACHE_HOME:-$HOME/.cache}/devplane/$repo_name}"
+
+fail=0
+
+echo "== disk =="
+df -h "$repo_root" "$devplane" 2>/dev/null || df -h "$repo_root"
+
+echo
+echo "== repo-local target dirs =="
+targets="$(
+  find "$repo_root" \
+    -type d -name target -prune \
+    -exec du -sk {} + 2>/dev/null || true
+)"
+
+if [ -z "$targets" ]; then
+  echo "none"
+else
+  echo "$targets" | sort -n | awk '{ printf "%.1fG\t%s\n", $1/1024/1024, $2 }'
+
+  while read -r kb path; do
+    [ -z "${kb:-}" ] && continue
+    if [ "$kb" -gt $((1024 * 1024)) ]; then
+      echo "ERROR: repo-local target dir exceeds 1G: $path" >&2
+      fail=1
+    fi
+  done <<< "$targets"
+fi
+
+echo
+echo "== devplane =="
+du -sh "$devplane"/* 2>/dev/null || echo "devplane not initialized: $devplane"
+
+echo
+echo "== cargo env =="
+printf 'DEVPLANE=%s\n' "${DEVPLANE:-}"
+printf 'CARGO_HOME=%s\n' "${CARGO_HOME:-}"
+printf 'CARGO_TARGET_DIR=%s\n' "${CARGO_TARGET_DIR:-}"
+printf 'CARGO_BUILD_BUILD_DIR=%s\n' "${CARGO_BUILD_BUILD_DIR:-}"
+printf 'CARGO_INCREMENTAL=%s\n' "${CARGO_INCREMENTAL:-}"
+printf 'CARGO_BUILD_JOBS=%s\n' "${CARGO_BUILD_JOBS:-}"
+printf 'RUSTC_WRAPPER=%s\n' "${RUSTC_WRAPPER:-}"
+printf 'SCCACHE_DIR=%s\n' "${SCCACHE_DIR:-}"
+printf 'SCCACHE_CACHE_SIZE=%s\n' "${SCCACHE_CACHE_SIZE:-}"
+
+echo
+echo "== sccache =="
+if command -v sccache >/dev/null 2>&1; then
+  sccache --show-stats || true
+else
+  echo "sccache not installed"
+fi
+
+exit "$fail"


### PR DESCRIPTION
### Motivation

- Prevent agents and disposable worktrees from recreating large repo-local `target/` artifacts and make build storage behavior explicit and machine-overridable.
- Provide a lightweight, non-incremental `agent` build profile for ephemeral agent runs to reduce debug-artifact bloat.
- Surface and enforce a storage invariant that agents can check before running workspace-wide builds.

### Description

- Removed the repo-committed `target-dir = "target"` default and added include/alias-based `.cargo/config.toml` agent aliases (`agent-check`, `agent-test`, `agent-clippy`).
- Added `Cargo.toml` `[profile.agent]` and a build-override to inherit from `dev` while disabling incremental builds and reducing debug output.
- Added `.cargo/config.local.toml.example` as a copy/paste template for machine-local build-plane configuration and updated `.gitignore` to exclude local config and repo-local build directories.
- Introduced `scripts/cargo-safe`, `scripts/devplane-init`, and `scripts/storage-doctor` to route build artifacts off-worktree, perform disk-safety checks, initialize a bounded devplane, and detect repo-local `target/` cruft.
- Moved nextest report output out of `target/nextest` into `.tmp/nextest` via `.config/nextest.toml` and added agent-focused `just` targets plus AGENTS.md guidance to prefer the safe wrappers.

### Testing

- Ran `./scripts/devplane-init`, which completed and created the devplane directories successfully.
- `./scripts/cargo-safe check -p perl-token --profile agent --locked` was blocked by the built-in disk guard at the default `MIN_FREE_GB=40` with a `DENY` (expected guard behavior), and then succeeded when re-run with `MIN_FREE_GB=1`.
- Ran `./scripts/storage-doctor`, which reported no repo-local `target/` directories and showed the devplane directories populated as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e39bb68c833389ddafea319b6ddd)