### PR TITLE
fix(xtask): stream update-status subprocess output (#0000)

### DIFF
--- a/xtask/src/tasks/update_status/mod.rs
+++ b/xtask/src/tasks/update_status/mod.rs
@@ -15,8 +15,9 @@
 //! Also keeps docs/project/ROADMAP.md compliance table in sync when lsp subsystem runs.
 
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use color_eyre::eyre::{Context, Result, eyre};
@@ -74,22 +75,63 @@ fn run_cmd(root: &Path, args: &[&str], timeout: Duration) -> String {
         return String::new();
     };
 
-    let result = Command::new(program).args(rest).current_dir(root).output();
+    // Timeout handling is retained for API compatibility. Most update-status
+    // invocations are short-lived; streaming output is prioritized here to avoid
+    // CI inactivity timeouts when a child process is chatty but long-running.
+    let _ = timeout;
 
-    let output = match result {
-        Ok(o) => o,
+    let mut child = match Command::new(program)
+        .args(rest)
+        .current_dir(root)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
         Err(_) => return String::new(),
     };
 
-    // Basic timeout emulation: we cannot use `std::process::Command` timeout
-    // directly, so we rely on the process completing.  The Python version used
-    // subprocess.run with timeout; here we accept the default behavior but keep
-    // the parameter for API compatibility and future improvement.
-    let _ = timeout;
+    let Some(stdout) = child.stdout.take() else {
+        let _ = child.kill();
+        return String::new();
+    };
+    let Some(stderr) = child.stderr.take() else {
+        let _ = child.kill();
+        return String::new();
+    };
 
-    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
-    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    let stdout_thread = std::thread::spawn(move || stream_and_capture(stdout, false));
+    let stderr_thread = std::thread::spawn(move || stream_and_capture(stderr, true));
+
+    let _ = child.wait();
+
+    let mut combined = stdout_thread.join().unwrap_or_default();
+    combined.push_str(&stderr_thread.join().unwrap_or_default());
     combined
+}
+
+fn stream_and_capture<R: Read>(mut reader: R, is_stderr: bool) -> String {
+    let mut buf = [0_u8; 8192];
+    let mut out = Vec::new();
+
+    loop {
+        let bytes = match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+
+        let chunk = &buf[..bytes];
+        out.extend_from_slice(chunk);
+
+        if is_stderr {
+            eprint!("{}", String::from_utf8_lossy(chunk));
+        } else {
+            print!("{}", String::from_utf8_lossy(chunk));
+        }
+    }
+
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// Like `run_cmd` but merges stderr into stdout via shell `2>&1`.


### PR DESCRIPTION
### Motivation

- `xtask update-status` used buffered subprocess capture which can produce long stretches of silence on stdout/stderr and trigger GitHub Actions inactivity timeouts. 

### Description

- Replaced buffered `Command::output()` usage in `xtask/src/tasks/update_status/mod.rs` with spawning a piped child and streaming stdout/stderr live while still capturing their contents. 
- Added a `stream_and_capture` helper and switched `run_cmd` to `Command::spawn()` with `Stdio::piped()` and per-stream reader threads, preserving the combined output return value for downstream parsing. 

### Testing

- Ran `cargo test -p xtask update_status -- --nocapture`, which exercised the changed `update-status` runner but could not complete due to a pre-existing compile error in `crates/perl-symbol/src/surface/mod.rs` (duplicate imports), so the test run did not finish successfully. 
- Ran `cargo check -p xtask --all-targets`, which also failed to finish for the same unrelated `perl-symbol` compile error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ea1efcec8333882e540b6a17f51a)