### PR TITLE
feat(semantic-facts): add ImportSpec and VisibleSymbol fact types (#0000)

### DIFF
--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -180,6 +180,69 @@ pub struct ExportTag {
     pub members: Vec<String>,
 }
 
+/// Canonical import specification inferred for a single import site.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportSpec {
+    /// Imported module or package name.
+    pub module: String,
+    /// Syntactic import shape used at the site.
+    pub kind: ImportKind,
+    /// Symbol selection policy represented at the site.
+    pub symbols: ImportSymbols,
+    /// Import site provenance.
+    pub provenance: Provenance,
+    /// Confidence for inferred import semantics.
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ImportKind {
+    Use,
+    UseEmpty,
+    UseExplicitList,
+    UseTag,
+    Require,
+    RequireThenImport,
+    UseConstant,
+    DynamicRequire,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ImportSymbols {
+    Default,
+    None,
+    Explicit(Vec<String>),
+    Tags(Vec<String>),
+    Mixed { tags: Vec<String>, names: Vec<String> },
+    Dynamic,
+}
+
+/// One symbol visible at a query point with source attribution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VisibleSymbol {
+    /// Symbol display name visible at the query point.
+    pub name: String,
+    /// Optional backing entity when known.
+    pub entity_id: Option<EntityId>,
+    /// Visibility source classification.
+    pub source: VisibleSymbolSource,
+    /// Visibility confidence.
+    pub confidence: Confidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VisibleSymbolSource {
+    LocalLexical,
+    LocalPackage,
+    ExplicitImport,
+    DefaultExport,
+    ExportTag,
+    Constant,
+    Generated,
+    External,
+    DynamicUnknown,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -273,6 +336,54 @@ mod tests {
         let serialized = serde_json::to_string(&id)?;
         let decoded: EntityId = serde_json::from_str(&serialized)?;
         assert_eq!(decoded, id);
+        Ok(())
+    }
+
+    #[test]
+    fn import_spec_roundtrips_through_json() -> Result<(), serde_json::Error> {
+        let spec = ImportSpec {
+            module: "Foo::Bar".to_string(),
+            kind: ImportKind::RequireThenImport,
+            symbols: ImportSymbols::Mixed {
+                tags: vec!["all".to_string()],
+                names: vec!["$X".to_string(), "@Y".to_string()],
+            },
+            provenance: Provenance::ImportExportInference,
+            confidence: Confidence::Medium,
+        };
+
+        let serialized = serde_json::to_string(&spec)?;
+        let decoded: ImportSpec = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, spec);
+        Ok(())
+    }
+
+    #[test]
+    fn import_symbols_debug_is_deterministic() {
+        let symbols = ImportSymbols::Mixed {
+            tags: vec!["io".to_string(), "all".to_string()],
+            names: vec!["open".to_string(), "close".to_string()],
+        };
+        assert_eq!(
+            format!("{symbols:?}"),
+            "Mixed { tags: [\"io\", \"all\"], names: [\"open\", \"close\"] }"
+        );
+    }
+
+    #[test]
+    fn visible_symbol_pretty_json_is_stable() -> Result<(), serde_json::Error> {
+        let visible = VisibleSymbol {
+            name: "slurp".to_string(),
+            entity_id: Some(EntityId(17)),
+            source: VisibleSymbolSource::ExplicitImport,
+            confidence: Confidence::High,
+        };
+
+        let json = serde_json::to_string_pretty(&visible)?;
+        assert_eq!(
+            json,
+            "{\n  \"name\": \"slurp\",\n  \"entity_id\": 17,\n  \"source\": \"ExplicitImport\",\n  \"confidence\": \"High\"\n}"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
### Motivation

- Provide neutral serializable types to seed Wave 3 visibility work so import/visibility work can be implemented without migrating providers.
- Keep the fact crate strictly a neutral substrate and add deterministic tests to ensure stable JSON/debug representations.

### Description

- Added `ImportSpec`, `ImportKind`, and `ImportSymbols` types to represent inferred import sites and symbol selection policies in `crates/perl-semantic-facts/src/lib.rs`.
- Added `VisibleSymbol` and `VisibleSymbolSource` types to represent one visible symbol at a query point with source attribution and confidence.
- Added deterministic roundtrip and debug/pretty-JSON tests for the new types to ensure serialization and debug output are stable.
- No provider behavior, workspace indexing, or query APIs were changed by this PR; these are neutral type additions only.

### Testing

- Ran `cargo test -p perl-semantic-facts` and all tests passed (8 tests: roundtrip and deterministic/debug assertions succeeded).
- Ran `cargo check --workspace --all-targets`, which failed due to a pre-existing duplicate re-export error in `crates/perl-symbol/src/surface/mod.rs` (not introduced by this change), so full workspace check did not complete.
- Commands executed: `cargo test -p perl-semantic-facts` and `cargo check --workspace --all-targets`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f8d3ccf8833390455e9a2d786685)