### PR TITLE
feat(ux): harden UX regression receipt routing (#0000)

### DIFF
--- a/.ci/schemas/ux-regression.schema.json
+++ b/.ci/schemas/ux-regression.schema.json
@@ -19,8 +19,7 @@
     "sha": {"type": "string", "minLength": 1},
     "workflow": {"type": ["string", "null"]},
     "scenario_file": {"type": ["string", "null"]},
-    "scenario": {"type": ["string", "null"]},
-    "test": {"type": ["string", "null"]},
+    "first_failing_test": {"type": ["string", "null"]},
     "result": {"enum": ["pass", "fail"]},
     "failure_class": {
       "enum": [
@@ -37,7 +36,6 @@
     },
     "panic_location": {"type": ["string", "null"]},
     "repro": {"type": ["string", "null"]},
-    "first_failing_line": {"type": ["string", "null"]},
     "route": {"type": "string", "minLength": 1}
   },
   "additionalProperties": false

--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -229,10 +229,11 @@ jobs:
                       "",
                       f"- Receipt path: `{receipt_path}`",
                       f"- Failure class: `{receipt.get('failure_class') or 'unknown'}`",
-                      f"- First failing test: `{receipt.get('test') or 'unknown'}`",
+                      f"- First failing test: `{receipt.get('first_failing_test') or 'unknown'}`",
                       f"- Panic location: `{receipt.get('panic_location') or 'n/a'}`",
                       f"- Repro command: `{receipt.get('repro') or 'just ux-tests'}`",
                       f"- Route: `{receipt.get('route') or 'needs-triage'}`",
+                      "- Receipt artifact: `ux-test-results-<sha>` (download from this workflow run)",
                   ]
           else:
               summary_lines.append("All UX scenarios passed.")
@@ -308,6 +309,7 @@ jobs:
           name: ux-test-results-${{ github.sha }}
           path: |
             /tmp/ux-test-output.txt
+            .ci/receipts/ux-regression.json
             target/ux-test-results/
           if-no-files-found: warn
           retention-days: 7

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -47,13 +47,11 @@ pub struct UxRegressionReceipt {
     sha: String,
     workflow: Option<String>,
     scenario_file: Option<String>,
-    scenario: Option<String>,
-    test: Option<String>,
+    first_failing_test: Option<String>,
     result: String,
     failure_class: FailureClass,
     panic_location: Option<String>,
     repro: Option<String>,
-    first_failing_line: Option<String>,
     route: String,
 }
 
@@ -79,18 +77,16 @@ pub fn run(config: UxRegressionReceiptConfig) -> Result<()> {
 
 fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
     let lines: Vec<&str> = raw.lines().collect();
-    let first_fail_line =
-        lines.iter().find(|line| line.contains("FAILED")).map(|line| (*line).trim().to_string());
-    let test =
+    let first_failing_test =
         lines.iter().find_map(|line| FAILED_TEST_RE.captures(line).map(|cap| cap[1].to_string()));
     let panic_location =
         lines.iter().find_map(|line| PANIC_RE.captures(line).map(|cap| cap[1].to_string()));
-    let scenario = test.as_ref().and_then(|name| scenario_from_test_name(name));
-    let workflow = test.as_ref().and_then(|name| workflow_from_test_name(name));
+    let scenario = first_failing_test.as_ref().and_then(|name| scenario_from_test_name(name));
+    let workflow = first_failing_test.as_ref().and_then(|name| workflow_from_test_name(name));
 
     let failure_class = infer_failure_class(raw);
 
-    let repro = test.as_ref().map(|name| {
+    let repro = first_failing_test.as_ref().map(|name| {
         format!("cargo test -p perl-lsp-ux-tests {name} -- --test-threads=1 --nocapture")
     });
 
@@ -103,13 +99,11 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
         sha: sha.unwrap_or_else(|| "unknown".to_string()),
         workflow,
         scenario_file: scenario.clone(),
-        scenario,
-        test,
+        first_failing_test,
         result: if raw.contains("test result: ok") { "pass" } else { "fail" }.to_string(),
         failure_class,
         panic_location,
         repro,
-        first_failing_line: first_fail_line,
         route,
     }
 }
@@ -154,10 +148,13 @@ fn workflow_from_test_name(test: &str) -> Option<String> {
 
 fn route_for_class(class: &FailureClass) -> &'static str {
     match class {
-        FailureClass::MatrixDrift | FailureClass::BaselineDrift => "needs-fixture-fix",
+        FailureClass::MatrixDrift => "needs-fixture-update",
+        FailureClass::BaselineDrift => "needs-baseline-update",
         FailureClass::TestRace | FailureClass::NewTestBug => "needs-test-fix",
-        FailureClass::ProviderRegression | FailureClass::ServerCrash => "needs-provider-fix",
-        FailureClass::Timeout | FailureClass::Infra => "needs-ci-fix",
+        FailureClass::ProviderRegression => "needs-provider-fix",
+        FailureClass::ServerCrash => "needs-crash-fix",
+        FailureClass::Timeout => "needs-timeout-triage",
+        FailureClass::Infra => "needs-ci-investigation",
         FailureClass::Unknown => "needs-triage",
     }
 }
@@ -173,18 +170,14 @@ mod tests {
         let log = "running 1 test\ntest ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix ... FAILED\nthread 'x' panicked at crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs:102:5:\nboom\ntest result: FAILED. 0 passed; 1 failed";
         let receipt = classify(log, Some("abc123".to_string()));
         assert_eq!(receipt.sha, "abc123", "sha should match input");
-        assert_eq!(
-            receipt.scenario.as_deref(),
-            Some("ux_scenario_19_diagnostics_lifecycle.rs"),
-            "scenario should be extracted from test name"
-        );
+        assert_eq!(receipt.scenario_file.as_deref(), Some("ux_scenario_19_diagnostics_lifecycle.rs"));
         assert_eq!(
             receipt.workflow.as_deref(),
             Some("scenario_19_diagnostics_clear_after_fix"),
             "workflow should map to test function name"
         );
         assert_eq!(
-            receipt.test.as_deref(),
+            receipt.first_failing_test.as_deref(),
             Some("ux_scenario_19_diagnostics_lifecycle::scenario_19_diagnostics_clear_after_fix"),
             "test name should be extracted from log"
         );
@@ -208,7 +201,7 @@ mod tests {
             matches!(receipt.failure_class, FailureClass::Timeout),
             "timed out log should classify as Timeout"
         );
-        assert_eq!(receipt.route, "needs-ci-fix", "Timeout routes to needs-ci-fix");
+        assert_eq!(receipt.route, "needs-timeout-triage", "Timeout routes to needs-timeout-triage");
         assert_eq!(receipt.result, "fail");
     }
 
@@ -223,7 +216,7 @@ mod tests {
             "non-ux_scenario panic should classify as ServerCrash, got {:?}",
             receipt.failure_class
         );
-        assert_eq!(receipt.route, "needs-provider-fix", "ServerCrash routes to needs-provider-fix");
+        assert_eq!(receipt.route, "needs-crash-fix", "ServerCrash routes to needs-crash-fix");
     }
 
     #[test]
@@ -238,7 +231,7 @@ mod tests {
             "log with 'unexpectedly' (substring of 'expected') should be ServerCrash, got {:?}",
             receipt.failure_class
         );
-        assert_eq!(receipt.route, "needs-provider-fix");
+        assert_eq!(receipt.route, "needs-crash-fix");
     }
 
     #[test]
@@ -249,7 +242,10 @@ mod tests {
             matches!(receipt.failure_class, FailureClass::MatrixDrift),
             "fixture matrix log should classify as MatrixDrift"
         );
-        assert_eq!(receipt.route, "needs-fixture-fix", "MatrixDrift routes to needs-fixture-fix");
+        assert_eq!(
+            receipt.route, "needs-fixture-update",
+            "MatrixDrift routes to needs-fixture-update"
+        );
     }
 
     #[test]
@@ -260,7 +256,10 @@ mod tests {
             matches!(receipt.failure_class, FailureClass::BaselineDrift),
             "baseline snapshot log should classify as BaselineDrift"
         );
-        assert_eq!(receipt.route, "needs-fixture-fix", "BaselineDrift routes to needs-fixture-fix");
+        assert_eq!(
+            receipt.route, "needs-baseline-update",
+            "BaselineDrift routes to needs-baseline-update"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- UX regression failure receipts were too heterogeneous and not operator-actionable, making triage slow and error-prone.  
- The routing taxonomy and payload shape needed normalization so automation and humans can route first-failure, panic location, repro, and failure classification reliably.

### Description

- Hardened the single existing UX regression receipt emitter (`xtask/src/tasks/ux_regression_receipt.rs`) to emit `first_failing_test`, preserve `scenario_file`, include `panic_location`, and build a repro command from the first failing test.  
- Normalized failure_class → route mappings to the requested actionable set (e.g. `matrix_drift -> needs-fixture-update`, `baseline_drift -> needs-baseline-update`, `server_crash -> needs-crash-fix`, `timeout -> needs-timeout-triage`, `infra -> needs-ci-investigation`, `unknown -> needs-triage`).  
- Updated unit test expectations in the xtask receipt test coverage to match the new field names and route behavior.  
- Updated schema and CI wiring: `.ci/schemas/ux-regression.schema.json` now matches the hardened payload (`first_failing_test` present; legacy `scenario/test/first_failing_line` fields removed), and the UX regression workflow summary (`.github/workflows/ux-regression-gate.yml`) now references `first_failing_test` and uploads the receipt artifact for operator access (`.ci/receipts/ux-regression.json` is included in uploaded files on failure).

### Testing

- Ran `cargo test -p xtask ux_regression_receipt` and `cargo check -p xtask --all-targets`; both runs were attempted but the workspace build is currently blocked by an existing, unrelated compile error in `crates/perl-symbol/src/surface/mod.rs` (duplicate reexports), preventing the xtask tests from completing.  
- Unit tests in `xtask/src/tasks/ux_regression_receipt.rs` were updated to assert the new fields and routing; they were executed as part of the attempted test run but could not finish due to the unrelated compile failure.  
- The change is limited to the single receipt emitter, schema, and workflow summary so it does not create a parallel receipt system and keeps the emitter as the single source of truth.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f8e21f088333bcdef519d4c45ce9)