### PR TITLE
test(xtask): expand pr-fast planner coverage (#0000)

### DIFF
--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -2683,6 +2683,57 @@ mod tests {
     }
 
     #[test]
+    fn pr_fast_docs_as_code_keeps_always_on_and_skips_rust_lanes()
+    -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            pr_gate("unit_core", GatePlanningRole::RustFallback, "cargo test -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("docs_as_code", &[], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt"]);
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_scoped", "unit_core"]);
+        assert!(!plan.fallback_used);
+        assert!(plan.skipped.iter().all(|gate| gate.reason.contains("diff_class=docs_as_code")));
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_ci_config_keeps_always_on_and_skips_rust_lanes() -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            pr_gate("unit_core", GatePlanningRole::RustFallback, "cargo test -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("ci_config", &[], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt"]);
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_scoped", "unit_core"]);
+        assert!(!plan.fallback_used);
+        assert!(plan.skipped.iter().all(|gate| gate.reason.contains("diff_class=ci_config")));
+        Ok(())
+    }
+
+    #[test]
     fn pr_fast_code_diff_selects_scoped_rust_lanes_with_full_package_scope()
     -> color_eyre::eyre::Result<()> {
         let gates = vec![
@@ -2760,6 +2811,32 @@ mod tests {
         assert!(!plan.scope_ok);
         assert!(plan.fallback_used);
         assert_eq!(plan.fallback_reason.as_deref(), Some("scope failed"));
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_code_diff_with_empty_package_set_uses_rust_fallback()
+    -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            pr_gate("clippy_core", GatePlanningRole::RustFallback, "cargo clippy -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("code", &[], &[], &[])),
+            true,
+            true,
+            Some("no scoped rust packages selected".to_string()),
+        )?;
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt", "clippy_core"]);
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_scoped"]);
+        assert!(plan.fallback_used);
+        assert_eq!(plan.fallback_reason.as_deref(), Some("no scoped rust packages selected"));
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Harden the PR-fast planner by adding focused tests asserting planner selections for non-code diffs and fallback behavior so the shared runner remains policy-backed and scoped correctly.

### Description
- Add unit tests in `xtask/src/tasks/gates.rs` to cover `docs_as_code` and `ci_config` diff classes ensuring only `always_on` gates are selected and rust lanes are skipped.
- Add a unit test for the code-diff empty-package-set fallback path asserting `rust_fallback` selection, skipped `rust_scoped`, and the fallback reason.
- Keep all existing planner tests and plan/assertion style intact so the implementation behavior and receipt shape remain unchanged.

### Testing
- Ran `cargo test -p xtask pr_fast_ -- --nocapture`; compilation started and the new tests in `xtask/src/tasks/gates.rs` are present, but the run failed due to unrelated compile errors in `crates/perl-symbol/src/surface/mod.rs` (duplicate re-exports), preventing a full test pass.
- The new tests assert plan structures (not shell output) and do not invoke expensive `clippy`/`test` gates during verification.
- No changes were made to the runtime `pr-fast` execution path (`cargo xtask gates --tier pr-fast --base origin/master --receipt`) or receipt output location (`target/receipts/`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f89793f88333bf59798d6bace5d8)