### PR TITLE
test(xtask): harden pr-fast planner role matrix (#0000)

### DIFF
--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -2683,6 +2683,57 @@ mod tests {
     }
 
     #[test]
+    fn pr_fast_docs_as_code_keeps_always_on_and_skips_rust_lanes()
+    -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            pr_gate("unit_core", GatePlanningRole::RustFallback, "cargo test -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("docs_as_code", &[], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt"]);
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_scoped", "unit_core"]);
+        assert!(!plan.fallback_used);
+        assert!(plan.skipped.iter().all(|gate| gate.reason.contains("diff_class=docs_as_code")));
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_ci_config_keeps_always_on_and_skips_rust_lanes() -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            pr_gate("unit_core", GatePlanningRole::RustFallback, "cargo test -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("ci_config", &[], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt"]);
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_scoped", "unit_core"]);
+        assert!(!plan.fallback_used);
+        assert!(plan.skipped.iter().all(|gate| gate.reason.contains("diff_class=ci_config")));
+        Ok(())
+    }
+
+    #[test]
     fn pr_fast_code_diff_selects_scoped_rust_lanes_with_full_package_scope()
     -> color_eyre::eyre::Result<()> {
         let gates = vec![
@@ -2819,6 +2870,31 @@ mod tests {
             vec!["fmt", "perl_token_leaf_contract", "unit_core"]
         );
         assert!(plan.fallback_used);
+        Ok(())
+    }
+
+    #[test]
+    fn pr_fast_code_diff_with_empty_package_set_uses_fallback() -> color_eyre::eyre::Result<()> {
+        let gates = vec![
+            pr_gate("fmt", GatePlanningRole::AlwaysOn, "cargo xtask fmt --check"),
+            pr_gate("clippy_scoped", GatePlanningRole::RustScoped, "cargo clippy {package_args}"),
+            pr_gate("clippy_core", GatePlanningRole::RustFallback, "cargo clippy -p perl-parser"),
+        ];
+
+        let plan = build_pr_fast_plan_from_scope(
+            GateTier::PrFast,
+            "origin/master".to_string(),
+            gates,
+            Some(scope_output("code", &[], &[], &[])),
+            true,
+            false,
+            None,
+        )?;
+
+        assert_eq!(selected_gate_names(&plan), vec!["fmt", "clippy_core"]);
+        assert_eq!(skipped_gate_names(&plan), vec!["clippy_scoped"]);
+        assert!(plan.fallback_used);
+        assert_eq!(plan.fallback_reason.as_deref(), Some("empty scoped package set"));
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Prevent planner regressions by adding explicit unit tests that encode expected `pr-fast` selection behavior for non-code diffs and fallback cases.
- Ensure the shared runner remains policy-backed and that tests assert structured plan fields rather than relying on shell output.

### Description
- Added unit tests in `xtask/src/tasks/gates.rs` to cover `docs_as_code` and `ci_config` diff classes asserting only `always_on` gates are selected and rust lanes are skipped. 
- Added a unit test for a `code` diff with an empty scoped package set asserting fallback to `rust_fallback` gates and a stable `fallback_reason` of `empty scoped package set`.
- Tests assert planner outputs (`selected`, `skipped`, `package_args`, `fallback_used`, `fallback_reason`) using the existing `scope_output` helper and keep all runtime planner behavior unchanged.

### Testing
- Added tests are framework unit tests in `xtask` and were exercised with `cargo test -p xtask pr_fast_ -- --nocapture` but the run failed during workspace compilation due to unrelated pre-existing compile errors in `crates/perl-symbol/src/surface/mod.rs` (duplicate imports / E0252). 
- The new tests are structured to assert the in-memory `GatePlan` and do not invoke expensive `cargo clippy`/`cargo test` commands as required by acceptance criteria.
- No runtime changes to `cargo xtask gates --tier pr-fast --base origin/master --receipt` or receipt output paths were made by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f89793f88333bf59798d6bace5d8)