### PR TITLE
feat(queue-reconciler): project review receipt label repairs (#0000)

### DIFF
--- a/.ci/receipts/schemas/review-receipt-projection.schema.json
+++ b/.ci/receipts/schemas/review-receipt-projection.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/review-receipt-projection.schema.json",
+  "title": "Review Receipt Projection",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "schema_version",
+    "pr",
+    "sha",
+    "verdict",
+    "review_depth",
+    "fix_forward_applied",
+    "blocking_findings",
+    "labels_projected"
+  ],
+  "properties": {
+    "kind": { "const": "review_receipt" },
+    "schema_version": { "const": 1 },
+    "pr": { "type": "integer", "minimum": 1 },
+    "sha": { "type": "string", "minLength": 1 },
+    "verdict": {
+      "type": "string",
+      "enum": ["approved", "needs_builder", "needs_diff", "needs_ci"]
+    },
+    "review_depth": {
+      "type": "string",
+      "enum": ["haiku_first", "deep", "security"]
+    },
+    "fix_forward_applied": { "type": "boolean" },
+    "blocking_findings": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "labels_projected": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/docs/ci/review-receipts.md
+++ b/docs/ci/review-receipts.md
@@ -79,3 +79,13 @@ Every review receipt includes:
   "supersedes": null
 }
 ```
+
+## Label ownership
+
+Reviewer agents should emit review receipts (typically as PR comments) and must not treat labels as the source of truth.
+
+- Reviewers emit structured review receipts (`kind: review_receipt`, schema version `1`).
+- The queue reconciler reads only **current-head SHA** review receipts when projecting label repairs.
+- If no current review receipt exists, reconciler falls back to existing conservative label/timeline logic.
+
+This keeps labels as a projection of receipts rather than an agent-authored authority.

--- a/xtask/src/tasks/queue_reconciler.rs
+++ b/xtask/src/tasks/queue_reconciler.rs
@@ -86,6 +86,19 @@ const NEEDS_DEEP_REVIEW: &str = "needs-deep-review";
 const NEEDS_DIFF_FIX: &str = "needs-diff-fix";
 const NEEDS_BUILDER_FIX: &str = "needs-builder-fix";
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewReceiptProjection {
+    pub kind: String,
+    pub schema_version: u32,
+    pub pr: u64,
+    pub sha: String,
+    pub verdict: String,
+    pub review_depth: String,
+    pub fix_forward_applied: bool,
+    pub blocking_findings: Vec<String>,
+    pub labels_projected: Vec<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Data structures
 // ---------------------------------------------------------------------------
@@ -284,6 +297,9 @@ pub fn detect_contradictions(
     ci_outcome: CiOutcome,
 ) -> Vec<Contradiction> {
     let mut out = Vec::new();
+    if let Some(c) = detect_review_receipt_projection(pr) {
+        out.push(c);
+    }
 
     let has = |name: &str| pr.labels.iter().any(|l| l == name);
 
@@ -367,6 +383,99 @@ pub fn detect_contradictions(
     }
 
     out
+}
+
+fn detect_review_receipt_projection(pr: &OpenPr) -> Option<Contradiction> {
+    let receipt = fetch_current_review_receipt(pr).ok().flatten()?;
+    detect_review_receipt_projection_for_test(pr, Some(receipt))
+}
+
+fn detect_review_receipt_projection_for_test(
+    pr: &OpenPr,
+    receipt: Option<ReviewReceiptProjection>,
+) -> Option<Contradiction> {
+    let receipt = receipt?;
+    if receipt.sha != pr.head_ref_oid {
+        return None;
+    }
+
+    match receipt.verdict.as_str() {
+        "approved" => {
+            if pr.labels.iter().any(|label| label == NEEDS_BUILDER_FIX) {
+                Some(Contradiction {
+                    keep: REVIEW_REVIEWED.to_string(),
+                    strip: NEEDS_BUILDER_FIX.to_string(),
+                    reason: "current review receipt verdict=approved contradicts needs-builder-fix; stripping needs-builder-fix".to_string(),
+                })
+            } else if pr.labels.iter().any(|label| label == NEEDS_DIFF_FIX) {
+                Some(Contradiction {
+                    keep: DIFF_AUDITED.to_string(),
+                    strip: NEEDS_DIFF_FIX.to_string(),
+                    reason: "current review receipt verdict=approved contradicts needs-diff-fix; stripping needs-diff-fix".to_string(),
+                })
+            } else {
+                None
+            }
+        }
+        "needs_builder" => {
+            if pr.labels.iter().any(|label| label == REVIEW_REVIEWED) {
+                Some(Contradiction {
+                    keep: NEEDS_BUILDER_FIX.to_string(),
+                    strip: REVIEW_REVIEWED.to_string(),
+                    reason: "current review receipt verdict=needs_builder requires needs-builder-fix routing; stripping review-reviewed".to_string(),
+                })
+            } else {
+                None
+            }
+        }
+        "needs_diff" => {
+            if pr.labels.iter().any(|label| label == DIFF_AUDITED) {
+                Some(Contradiction {
+                    keep: NEEDS_DIFF_FIX.to_string(),
+                    strip: DIFF_AUDITED.to_string(),
+                    reason: "current review receipt verdict=needs_diff requires needs-diff-fix routing; stripping diff-audited".to_string(),
+                })
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn fetch_current_review_receipt(pr: &OpenPr) -> Result<Option<ReviewReceiptProjection>> {
+    let root = project_root()?;
+    let pr_str = pr.number.to_string();
+    let output = Command::new("gh")
+        .current_dir(&root)
+        .args(["pr", "view", &pr_str, "--json", "comments"])
+        .output()
+        .context("failed to execute gh pr view for review receipt")?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let val: serde_json::Value = serde_json::from_str(&raw)?;
+    let comments =
+        val.get("comments").and_then(serde_json::Value::as_array).cloned().unwrap_or_default();
+
+    for comment in comments.into_iter().rev() {
+        let Some(body) = comment.get("body").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if let Ok(receipt) = serde_json::from_str::<ReviewReceiptProjection>(body) {
+            if receipt.kind == "review_receipt"
+                && receipt.schema_version == 1
+                && receipt.pr == pr.number
+            {
+                return Ok(Some(receipt));
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 /// Resolve a contradicting pair that has no live ground truth using timeline events.
@@ -1010,6 +1119,81 @@ mod tests {
         ]);
         let pass1 = apply_pass(&mut state, &[], CiOutcome::Success);
         assert!(pass1.is_empty(), "clean PR should produce no strips");
+    }
+
+    #[test]
+    fn approved_current_sha_strips_needs_builder_fix() {
+        let pr = OpenPr {
+            number: 1,
+            labels: labels(&[NEEDS_BUILDER_FIX, REVIEW_REVIEWED]),
+            head_ref_oid: "sha-1".to_string(),
+        };
+        let receipt = ReviewReceiptProjection {
+            kind: "review_receipt".to_string(),
+            schema_version: 1,
+            pr: 1,
+            sha: "sha-1".to_string(),
+            verdict: "approved".to_string(),
+            review_depth: "deep".to_string(),
+            fix_forward_applied: true,
+            blocking_findings: vec![],
+            labels_projected: vec![],
+        };
+        let c = detect_review_receipt_projection_for_test(&pr, Some(receipt))
+            .expect("should project contradiction");
+        assert_eq!(c.strip, NEEDS_BUILDER_FIX);
+    }
+
+    #[test]
+    fn needs_builder_current_sha_strips_review_reviewed() {
+        let pr = OpenPr {
+            number: 1,
+            labels: labels(&[NEEDS_BUILDER_FIX, REVIEW_REVIEWED]),
+            head_ref_oid: "sha-1".to_string(),
+        };
+        let receipt = ReviewReceiptProjection {
+            kind: "review_receipt".to_string(),
+            schema_version: 1,
+            pr: 1,
+            sha: "sha-1".to_string(),
+            verdict: "needs_builder".to_string(),
+            review_depth: "deep".to_string(),
+            fix_forward_applied: true,
+            blocking_findings: vec!["x".to_string()],
+            labels_projected: vec![],
+        };
+        let c = detect_review_receipt_projection_for_test(&pr, Some(receipt))
+            .expect("should project contradiction");
+        assert_eq!(c.strip, REVIEW_REVIEWED);
+    }
+
+    #[test]
+    fn stale_sha_review_receipt_is_ignored() {
+        let pr = OpenPr {
+            number: 1,
+            labels: labels(&[NEEDS_BUILDER_FIX, REVIEW_REVIEWED]),
+            head_ref_oid: "sha-new".to_string(),
+        };
+        let receipt = ReviewReceiptProjection {
+            kind: "review_receipt".to_string(),
+            schema_version: 1,
+            pr: 1,
+            sha: "sha-old".to_string(),
+            verdict: "approved".to_string(),
+            review_depth: "deep".to_string(),
+            fix_forward_applied: false,
+            blocking_findings: vec![],
+            labels_projected: vec![],
+        };
+        let c = detect_review_receipt_projection_for_test(&pr, Some(receipt));
+        assert!(c.is_none(), "stale sha must be ignored");
+    }
+
+    #[test]
+    fn no_review_receipt_keeps_existing_behavior_safe() {
+        let pr = make_pr(1, &[REVIEW_REVIEWED, NEEDS_BUILDER_FIX]);
+        let c = detect_review_receipt_projection_for_test(&pr, None);
+        assert!(c.is_none());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Reviewer agents were acting as label authorities which produced stale/contradictory review labels and manual repair churn.
- Introduce a minimal, deterministic projection path so the reconciler can read structured review receipts and own label repairs.

### Description

- Added a minimal `ReviewReceiptProjection` struct and a new `.ci/receipts/schemas/review-receipt-projection.schema.json` schema describing the projection contract (`kind`, `schema_version`, `pr`, `sha`, `verdict`, `review_depth`, `fix_forward_applied`, `blocking_findings`, `labels_projected`).
- Reconciler now reads the most-recent PR comments via `gh pr view --json comments`, finds a `kind: "review_receipt"` projection, and only projects label repairs when the receipt `sha` matches the PR head SHA (stale-SHA receipts are ignored).
- Implemented verdict → projection mapping: `approved` projects stripping of `needs-builder-fix`/`needs-diff-fix`; `needs_builder` projects stripping of `review-reviewed`; `needs_diff` projects stripping of `diff-audited`; existing timeline/CI logic remains unchanged when no current receipt is present.
- Updated `docs/ci/review-receipts.md` to instruct reviewers to emit review receipts (typically as PR comments) and to document that the reconciler owns label projection/repairs.

### Testing

- Added unit tests in `xtask` covering: approved/current-SHA projects `needs-builder-fix` strip, `needs_builder`/current-SHA projects `review-reviewed` strip, stale-SHA receipts are ignored, and behavior when no receipt exists.
- Ran formatting: `cargo fmt --all` succeeded.
- Ran `cargo test -p xtask queue_reconciler` but the run was blocked by pre-existing, unrelated compile errors in `crates/perl-symbol` (duplicate imports) so the full test suite could not finish in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f88b7544833385fbe3ec988018aa)