### PR TITLE
feat(queue-reconciler): project review receipt label repairs (#0000)

### DIFF
--- a/.ci/receipts/schemas/review-receipt.schema.json
+++ b/.ci/receipts/schemas/review-receipt.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/review-receipt.schema.json",
+  "title": "Review Receipt Projection Contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "schema_version",
+    "pr",
+    "sha",
+    "verdict",
+    "review_depth",
+    "fix_forward_applied",
+    "blocking_findings",
+    "labels_projected"
+  ],
+  "properties": {
+    "kind": { "const": "review_receipt" },
+    "schema_version": { "const": 1 },
+    "pr": { "type": "integer", "minimum": 1 },
+    "sha": { "type": "string", "minLength": 1 },
+    "verdict": {
+      "type": "string",
+      "enum": ["approved", "needs_builder", "needs_diff", "needs_ci"]
+    },
+    "review_depth": {
+      "type": "string",
+      "enum": ["haiku_first", "deep", "security"]
+    },
+    "fix_forward_applied": { "type": "boolean" },
+    "blocking_findings": { "type": "array", "items": { "type": "string" } },
+    "labels_projected": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/docs/ci/review-receipts.md
+++ b/docs/ci/review-receipts.md
@@ -3,6 +3,11 @@
 Review receipts are **evidence-only** JSON artifacts emitted by review agents. They document what was checked, what was not observed, and what route should happen next. They do not mutate labels and they do not implement state-building logic.
 
 Schema: `.ci/receipts/schemas/review.schema.json`.
+Projection contract for reconciler-owned labels: `.ci/receipts/schemas/review-receipt.schema.json`.
+
+## Label authority
+
+Reviewer agents emit review receipts/comments only; they are not label authorities. The queue reconciler consumes current-SHA `review_receipt` evidence and projects/removes labels (`review-reviewed`, `diff-audited`, `needs-builder-fix`, `needs-diff-fix`) to repair contradictions.
 
 ## Required fields
 

--- a/xtask/src/tasks/queue_reconciler.rs
+++ b/xtask/src/tasks/queue_reconciler.rs
@@ -86,6 +86,29 @@ const NEEDS_DEEP_REVIEW: &str = "needs-deep-review";
 const NEEDS_DIFF_FIX: &str = "needs-diff-fix";
 const NEEDS_BUILDER_FIX: &str = "needs-builder-fix";
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewReceiptVerdict {
+    Approved,
+    NeedsBuilder,
+    NeedsDiff,
+    NeedsCi,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewReceipt {
+    pub kind: String,
+    pub schema_version: u32,
+    pub pr: u64,
+    pub sha: String,
+    pub verdict: ReviewReceiptVerdict,
+    pub review_depth: String,
+    pub fix_forward_applied: bool,
+    pub blocking_findings: Vec<String>,
+    pub labels_projected: Vec<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Data structures
 // ---------------------------------------------------------------------------
@@ -283,9 +306,24 @@ pub fn detect_contradictions(
     events: &[LabelEvent],
     ci_outcome: CiOutcome,
 ) -> Vec<Contradiction> {
+    detect_contradictions_with_review_receipt(pr, events, ci_outcome, None)
+}
+
+pub fn detect_contradictions_with_review_receipt(
+    pr: &OpenPr,
+    events: &[LabelEvent],
+    ci_outcome: CiOutcome,
+    review_receipt: Option<&ReviewReceipt>,
+) -> Vec<Contradiction> {
     let mut out = Vec::new();
 
     let has = |name: &str| pr.labels.iter().any(|l| l == name);
+
+    for contradiction in detect_review_receipt_contradictions(pr, review_receipt) {
+        if !out.iter().any(|existing: &Contradiction| existing.strip == contradiction.strip) {
+            out.push(contradiction);
+        }
+    }
 
     // --- CI-specific: live state is ground truth ---
 
@@ -367,6 +405,72 @@ pub fn detect_contradictions(
     }
 
     out
+}
+
+fn detect_review_receipt_contradictions(
+    pr: &OpenPr,
+    review_receipt: Option<&ReviewReceipt>,
+) -> Vec<Contradiction> {
+    let Some(receipt) = review_receipt else { return Vec::new() };
+    if receipt.kind != "review_receipt" || receipt.schema_version != 1 || receipt.pr != pr.number {
+        return Vec::new();
+    }
+    if receipt.sha != pr.head_ref_oid {
+        return Vec::new();
+    }
+
+    let mut contradictions = Vec::new();
+    let has = |name: &str| pr.labels.iter().any(|l| l == name);
+    match receipt.verdict {
+        ReviewReceiptVerdict::Approved => {
+            if has(NEEDS_BUILDER_FIX) {
+                contradictions.push(Contradiction {
+                    keep: REVIEW_REVIEWED.to_string(),
+                    strip: NEEDS_BUILDER_FIX.to_string(),
+                    reason: "current review receipt verdict=approved supersedes needs-builder-fix"
+                        .to_string(),
+                });
+            }
+            if has(NEEDS_DIFF_FIX) {
+                contradictions.push(Contradiction {
+                    keep: DIFF_AUDITED.to_string(),
+                    strip: NEEDS_DIFF_FIX.to_string(),
+                    reason: "current review receipt verdict=approved supersedes needs-diff-fix"
+                        .to_string(),
+                });
+            }
+        }
+        ReviewReceiptVerdict::NeedsBuilder => {
+            if has(REVIEW_REVIEWED) {
+                contradictions.push(Contradiction {
+                    keep: NEEDS_BUILDER_FIX.to_string(),
+                    strip: REVIEW_REVIEWED.to_string(),
+                    reason: "current review receipt verdict=needs_builder strips approval labels"
+                        .to_string(),
+                });
+            }
+            if has(MAINTAINER_PR_REVIEWED) {
+                contradictions.push(Contradiction {
+                    keep: NEEDS_BUILDER_FIX.to_string(),
+                    strip: MAINTAINER_PR_REVIEWED.to_string(),
+                    reason: "current review receipt verdict=needs_builder strips approval labels"
+                        .to_string(),
+                });
+            }
+        }
+        ReviewReceiptVerdict::NeedsDiff => {
+            if has(DIFF_AUDITED) {
+                contradictions.push(Contradiction {
+                    keep: NEEDS_DIFF_FIX.to_string(),
+                    strip: DIFF_AUDITED.to_string(),
+                    reason: "current review receipt verdict=needs_diff strips diff-audited"
+                        .to_string(),
+                });
+            }
+        }
+        ReviewReceiptVerdict::NeedsCi => {}
+    }
+    contradictions
 }
 
 /// Resolve a contradicting pair that has no live ground truth using timeline events.
@@ -740,6 +844,20 @@ mod tests {
 
     const TEST_TS: &str = "2026-04-27T00:00:00Z";
 
+    fn make_review_receipt(pr: u64, sha: &str, verdict: ReviewReceiptVerdict) -> ReviewReceipt {
+        ReviewReceipt {
+            kind: "review_receipt".to_string(),
+            schema_version: 1,
+            pr,
+            sha: sha.to_string(),
+            verdict,
+            review_depth: "deep".to_string(),
+            fix_forward_applied: false,
+            blocking_findings: Vec::new(),
+            labels_projected: Vec::new(),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // CI-specific detection (live state is ground truth)
     // -----------------------------------------------------------------------
@@ -931,6 +1049,43 @@ mod tests {
         assert_eq!(c.len(), 1);
         assert_eq!(c[0].keep, REVIEW_REVIEWED);
         assert_eq!(c[0].strip, NEEDS_BUILDER_FIX);
+    }
+
+    #[test]
+    fn approved_review_receipt_current_sha_projects_positive_repair() {
+        let pr = make_pr(1, &[REVIEW_REVIEWED, NEEDS_BUILDER_FIX]);
+        let receipt = make_review_receipt(1, "sha-1", ReviewReceiptVerdict::Approved);
+        let c =
+            detect_contradictions_with_review_receipt(&pr, &[], CiOutcome::Pending, Some(&receipt));
+        assert!(c.iter().any(|item| item.strip == NEEDS_BUILDER_FIX));
+    }
+
+    #[test]
+    fn needs_builder_review_receipt_current_sha_strips_approval_labels() {
+        let pr = make_pr(1, &[REVIEW_REVIEWED, MAINTAINER_PR_REVIEWED, NEEDS_BUILDER_FIX]);
+        let receipt = make_review_receipt(1, "sha-1", ReviewReceiptVerdict::NeedsBuilder);
+        let c =
+            detect_contradictions_with_review_receipt(&pr, &[], CiOutcome::Pending, Some(&receipt));
+        assert!(c.iter().any(|item| item.strip == REVIEW_REVIEWED));
+        assert!(c.iter().any(|item| item.strip == MAINTAINER_PR_REVIEWED));
+    }
+
+    #[test]
+    fn stale_sha_review_receipt_is_ignored() {
+        let pr = make_pr(1, &[REVIEW_REVIEWED, NEEDS_BUILDER_FIX]);
+        let receipt = make_review_receipt(1, "different-sha", ReviewReceiptVerdict::NeedsBuilder);
+        let c =
+            detect_contradictions_with_review_receipt(&pr, &[], CiOutcome::Pending, Some(&receipt));
+        assert!(c.iter().all(|item| item.strip != REVIEW_REVIEWED));
+    }
+
+    #[test]
+    fn needs_diff_review_receipt_repairs_contradictory_diff_labels() {
+        let pr = make_pr(1, &[DIFF_AUDITED, NEEDS_DIFF_FIX]);
+        let receipt = make_review_receipt(1, "sha-1", ReviewReceiptVerdict::NeedsDiff);
+        let c =
+            detect_contradictions_with_review_receipt(&pr, &[], CiOutcome::Pending, Some(&receipt));
+        assert!(c.iter().any(|item| item.strip == DIFF_AUDITED));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent reviewer agents from being label authorities by having the queue reconciler consume structured, current-SHA review receipts and project/repair label state to avoid stale or contradictory labels.

### Description

- Add a minimal `review_receipt` v1 contract and in-memory model (`ReviewReceipt` + `ReviewReceiptVerdict`) and a JSON schema at `.ci/receipts/schemas/review-receipt.schema.json` for the projection contract.
- Introduce `detect_contradictions_with_review_receipt` and `detect_review_receipt_contradictions` so receipt-driven projection is applied when a current-SHA `review_receipt` is present while preserving existing CI- and timeline-driven contradiction detection as a fallback.
- Implement projection rules: `approved` repairs `needs-builder-fix`/`needs-diff-fix`, `needs_builder` strips approval labels (`review-reviewed`, `maintainer-pr-reviewed`), `needs_diff` strips `diff-audited`, and receipts with stale/mismatched SHA are ignored.
- Update docs (`docs/ci/review-receipts.md`) to clarify that reviewers emit receipts/comments only and the reconciler owns label projection/repair.

### Testing

- Ran `cargo fmt --all`, which completed successfully.
- Ran `cargo test -p xtask queue_reconciler`, but the test run could not complete due to an unrelated pre-existing compile error in `crates/perl-symbol/src/surface/mod.rs` (duplicate imports), so the new unit tests were added but could not be executed end-to-end in this environment.
- Added focused unit tests covering approved/current-SHA projection, needs_builder/current-SHA stripping of approvals, stale-SHA receipts ignored, and needs_diff repair (tests are present under `xtask/src/tasks/queue_reconciler.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f88b7544833385fbe3ec988018aa)