### PR TITLE
fix(queue-reconciler): project review receipt contradictions (#0000)

### DIFF
--- a/docs/reference/RECEIPT_SCHEMA.md
+++ b/docs/reference/RECEIPT_SCHEMA.md
@@ -227,6 +227,30 @@ It uses `kind` instead of `check` (a pre-unification inconsistency — see §7).
 Constraint: `verdict: "clean"` requires `next_routes` to contain `"signoff_clean"` and
 `material_observations` must be non-empty (the schema enforces this via `allOf`).
 
+### 4.4.1 Review label projection receipt (`kind: "review_receipt"`)
+
+Reviewer agents should emit a structured review receipt and/or matching PR comment for the
+**current PR head SHA**; the queue reconciler is the label authority and projects/repairs labels
+from this evidence. Reviewers should not treat manual label edits as the primary control path.
+
+```json
+{
+  "kind": "review_receipt",
+  "schema_version": 1,
+  "pr": 1234,
+  "sha": "abcdef1234567890abcdef1234567890abcdef12",
+  "verdict": "approved",
+  "review_depth": "deep",
+  "fix_forward_applied": false,
+  "blocking_findings": [],
+  "labels_projected": []
+}
+```
+
+`verdict` vocabulary: `approved | needs_builder | needs_diff | needs_ci`
+
+`review_depth` vocabulary: `haiku_first | deep | security`
+
 ### 4.5 Aggregator (`check: "aggregator"`)
 
 **Schema file:** `.ci/receipts/schemas/aggregator-receipt.schema.json`

--- a/xtask/src/tasks/queue_reconciler.rs
+++ b/xtask/src/tasks/queue_reconciler.rs
@@ -147,6 +147,19 @@ pub struct OpenPr {
     pub head_ref_oid: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewReceipt {
+    pub kind: String,
+    pub schema_version: u32,
+    pub pr: u64,
+    pub sha: String,
+    pub verdict: String,
+    pub review_depth: String,
+    pub fix_forward_applied: bool,
+    pub blocking_findings: Vec<String>,
+    pub labels_projected: Vec<String>,
+}
+
 /// Live CI state for a PR head SHA.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum CiOutcome {
@@ -283,9 +296,64 @@ pub fn detect_contradictions(
     events: &[LabelEvent],
     ci_outcome: CiOutcome,
 ) -> Vec<Contradiction> {
+    detect_contradictions_with_review_receipt(pr, events, ci_outcome, None)
+}
+
+pub fn detect_contradictions_with_review_receipt(
+    pr: &OpenPr,
+    events: &[LabelEvent],
+    ci_outcome: CiOutcome,
+    review_receipt: Option<&ReviewReceipt>,
+) -> Vec<Contradiction> {
     let mut out = Vec::new();
 
     let has = |name: &str| pr.labels.iter().any(|l| l == name);
+
+    if let Some(receipt) = review_receipt
+        && receipt.kind == "review_receipt"
+        && receipt.schema_version == 1
+        && receipt.pr == pr.number
+        && receipt.sha == pr.head_ref_oid
+    {
+        match receipt.verdict.as_str() {
+            "approved" => {
+                if has(NEEDS_BUILDER_FIX) {
+                    out.push(Contradiction {
+                        keep: REVIEW_REVIEWED.to_string(),
+                        strip: NEEDS_BUILDER_FIX.to_string(),
+                        reason: "current review_receipt verdict=approved projects review labels and strips needs-builder-fix".to_string(),
+                    });
+                }
+            }
+            "needs_builder" => {
+                if has(REVIEW_REVIEWED) {
+                    out.push(Contradiction {
+                        keep: NEEDS_BUILDER_FIX.to_string(),
+                        strip: REVIEW_REVIEWED.to_string(),
+                        reason: "current review_receipt verdict=needs_builder strips approval labels".to_string(),
+                    });
+                }
+                if has(MAINTAINER_PR_REVIEWED) {
+                    out.push(Contradiction {
+                        keep: NEEDS_BUILDER_FIX.to_string(),
+                        strip: MAINTAINER_PR_REVIEWED.to_string(),
+                        reason: "current review_receipt verdict=needs_builder strips approval labels".to_string(),
+                    });
+                }
+            }
+            "needs_diff" => {
+                if has(DIFF_AUDITED) {
+                    out.push(Contradiction {
+                        keep: NEEDS_DIFF_FIX.to_string(),
+                        strip: DIFF_AUDITED.to_string(),
+                        reason: "current review_receipt verdict=needs_diff strips diff-audited".to_string(),
+                    });
+                }
+            }
+            "needs_ci" => {}
+            _ => {}
+        }
+    }
 
     // --- CI-specific: live state is ground truth ---
 
@@ -740,6 +808,20 @@ mod tests {
 
     const TEST_TS: &str = "2026-04-27T00:00:00Z";
 
+    fn make_review_receipt(pr: u64, sha: &str, verdict: &str) -> ReviewReceipt {
+        ReviewReceipt {
+            kind: "review_receipt".to_string(),
+            schema_version: 1,
+            pr,
+            sha: sha.to_string(),
+            verdict: verdict.to_string(),
+            review_depth: "deep".to_string(),
+            fix_forward_applied: false,
+            blocking_findings: vec![],
+            labels_projected: vec![],
+        }
+    }
+
     // -----------------------------------------------------------------------
     // CI-specific detection (live state is ground truth)
     // -----------------------------------------------------------------------
@@ -941,6 +1023,40 @@ mod tests {
         let c = detect_contradictions(&pr, &[], CiOutcome::Pending);
         let strips: Vec<_> = c.iter().filter(|x| x.strip == NEEDS_BUILDER_FIX).collect();
         assert_eq!(strips.len(), 1, "exactly one strip of needs-builder-fix");
+    }
+
+    #[test]
+    fn approved_current_sha_strips_needs_builder_fix() {
+        let pr = make_pr(77, &[REVIEW_REVIEWED, NEEDS_BUILDER_FIX]);
+        let receipt = make_review_receipt(77, &pr.head_ref_oid, "approved");
+        let c = detect_contradictions_with_review_receipt(&pr, &[], CiOutcome::Pending, Some(&receipt));
+        assert!(c.iter().any(|x| x.strip == NEEDS_BUILDER_FIX));
+    }
+
+    #[test]
+    fn needs_builder_current_sha_strips_approval_labels() {
+        let pr = make_pr(78, &[REVIEW_REVIEWED, MAINTAINER_PR_REVIEWED, NEEDS_BUILDER_FIX]);
+        let receipt = make_review_receipt(78, &pr.head_ref_oid, "needs_builder");
+        let c = detect_contradictions_with_review_receipt(&pr, &[], CiOutcome::Pending, Some(&receipt));
+        assert!(c.iter().any(|x| x.strip == REVIEW_REVIEWED));
+        assert!(c.iter().any(|x| x.strip == MAINTAINER_PR_REVIEWED));
+    }
+
+    #[test]
+    fn stale_sha_review_receipt_is_ignored() {
+        let pr = make_pr(79, &[REVIEW_REVIEWED, NEEDS_BUILDER_FIX]);
+        let receipt = make_review_receipt(79, "stale-sha", "needs_builder");
+        let c = detect_contradictions_with_review_receipt(&pr, &[], CiOutcome::Pending, Some(&receipt));
+        assert_eq!(c.len(), 1);
+        assert_eq!(c[0].strip, NEEDS_BUILDER_FIX);
+    }
+
+    #[test]
+    fn needs_diff_current_sha_repairs_contradiction() {
+        let pr = make_pr(80, &[DIFF_AUDITED, NEEDS_DIFF_FIX]);
+        let receipt = make_review_receipt(80, &pr.head_ref_oid, "needs_diff");
+        let c = detect_contradictions_with_review_receipt(&pr, &[], CiOutcome::Pending, Some(&receipt));
+        assert!(c.iter().any(|x| x.strip == DIFF_AUDITED));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Move review-state authority from ad-hoc agent-applied labels to structured, current-SHA review receipts so the reconciler can project and repair label state deterministically.

### Description

- Added a minimal `ReviewReceipt` contract (`kind`, `schema_version`, `pr`, `sha`, `verdict`, `review_depth`, `fix_forward_applied`, `blocking_findings`, `labels_projected`) to the reconciler in `xtask/src/tasks/queue_reconciler.rs`.
- Introduced `detect_contradictions_with_review_receipt` and made the original `detect_contradictions` delegate to it, so existing behavior is preserved when no receipt is provided.
- Implemented receipt-driven projection/repair for current-SHA receipts: `approved` projects approval (strips `needs-builder-fix`), `needs_builder` strips approval labels (`review-reviewed`, `maintainer-pr-reviewed`), and `needs_diff` strips `diff-audited` (stale or SHA-mismatched receipts are ignored).
- Added unit tests covering approved/current-SHA, `needs_builder`/current-SHA, stale-SHA ignored, and `needs_diff` repair; and updated `docs/reference/RECEIPT_SCHEMA.md` with the new `review_receipt` example and vocabulary guidance.

### Testing

- Added unit tests in `xtask` for the four acceptance scenarios described above (`approved_current_sha_strips_needs_builder_fix`, `needs_builder_current_sha_strips_approval_labels`, `stale_sha_review_receipt_is_ignored`, `needs_diff_current_sha_repairs_contradiction`).
- Attempted to run `cargo test -p xtask -- --nocapture`, but the test run was blocked by unrelated pre-existing compile errors in `crates/perl-symbol` (duplicate imports) and so the CI/test run did not complete locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f88b7544833385fbe3ec988018aa)