### PR TITLE
fix(ci): upload UX regression receipts and logs (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,10 +353,59 @@ jobs:
         run: cargo build -p perl-lsp-rs
 
       - name: Run UX regression tests
+        id: ux_tests
         env:
           PERL_LSP_BIN: ${{ github.workspace }}/target/debug/perl-lsp
           RUST_TEST_THREADS: "1"
-        run: just ux-tests
+        run: |
+          mkdir -p target/receipts
+          just ux-tests 2>&1 | tee target/receipts/ux-test-output.log
+          exit ${PIPESTATUS[0]}
+
+      - name: Emit structured UX regression receipt
+        if: always()
+        run: |
+          cargo xtask ux-regression-receipt \
+            --input target/receipts/ux-test-output.log \
+            --receipt target/receipts/ux-regression.json \
+            --sha "${{ github.sha }}"
+
+      - name: UX receipt summary
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if not summary_path:
+              raise SystemExit(0)
+
+          receipt_path = Path("target/receipts/ux-regression.json")
+          lines = ["### UX Regression Receipt", ""]
+          if receipt_path.exists():
+              data = json.loads(receipt_path.read_text(encoding="utf-8"))
+              lines.append(f"- Receipt: `{receipt_path}`")
+              lines.append(f"- Result: `{data.get('result', 'unknown')}`")
+              lines.append(f"- Failure class: `{data.get('failure_class') or 'none'}`")
+              lines.append(f"- First failing test: `{data.get('test') or 'n/a'}`")
+          else:
+              lines.append("- Receipt not found")
+
+          Path(summary_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Upload UX regression receipt and logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ux-regression-receipt-${{ github.sha }}
+          path: |
+            target/receipts/ux-regression.json
+            target/receipts/ux-test-output.log
+          if-no-files-found: warn
+          retention-days: 7
 
   # ── Compile All Targets: catch integration-test + bench bit-rot ───────
   check-all-targets:

--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -117,15 +117,16 @@ jobs:
         if: steps.harness_check.outputs.harness_available == 'true'
         run: |
           echo "Running UX regression tests..."
-          just ux-tests 2>&1 | tee /tmp/ux-test-output.txt
+          mkdir -p target/receipts
+          just ux-tests 2>&1 | tee target/receipts/ux-test-output.log
           exit ${PIPESTATUS[0]}
 
       - name: Emit structured UX regression receipt
-        if: failure() && steps.harness_check.outputs.harness_available == 'true'
+        if: always() && steps.harness_check.outputs.harness_available == 'true'
         run: |
           cargo xtask ux-regression-receipt \
-            --input /tmp/ux-test-output.txt \
-            --receipt .ci/receipts/ux-regression.json \
+            --input target/receipts/ux-test-output.log \
+            --receipt target/receipts/ux-regression.json \
             --sha "${{ github.sha }}"
 
       - name: Parse and summarize UX test results
@@ -134,14 +135,14 @@ jobs:
           python3 - <<'PY'
           import json, os, re, pathlib, sys
 
-          output_file = pathlib.Path("/tmp/ux-test-output.txt")
+          output_file = pathlib.Path("target/receipts/ux-test-output.log")
           summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
 
           if not summary_path:
               sys.exit(0)
 
           lines = output_file.read_text(encoding="utf-8").splitlines() if output_file.exists() else []
-          receipt_path = pathlib.Path(".ci/receipts/ux-regression.json")
+          receipt_path = pathlib.Path("target/receipts/ux-regression.json")
           receipt = None
           if receipt_path.exists():
               try:
@@ -236,6 +237,15 @@ jobs:
                   ]
           else:
               summary_lines.append("All UX scenarios passed.")
+              if receipt:
+                  summary_lines += [
+                      "",
+                      "### Structured Receipt",
+                      "",
+                      f"- Receipt path: `{receipt_path}`",
+                      f"- Result: `{receipt.get('result') or 'pass'}`",
+                      f"- Failure class: `{receipt.get('failure_class') or 'none'}`",
+                  ]
 
           summary_lines += [
               "",
@@ -301,14 +311,14 @@ jobs:
           pathlib.Path(summary_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
           PY
 
-      - name: Upload UX test results on failure
-        if: failure() && steps.harness_check.outputs.harness_available == 'true'
+      - name: Upload UX regression receipt and logs
+        if: always() && steps.harness_check.outputs.harness_available == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: ux-test-results-${{ github.sha }}
+          name: ux-regression-receipt-${{ github.sha }}
           path: |
-            /tmp/ux-test-output.txt
-            target/ux-test-results/
+            target/receipts/ux-regression.json
+            target/receipts/ux-test-output.log
           if-no-files-found: warn
           retention-days: 7
 


### PR DESCRIPTION
### Motivation

- UX regression failures required manual log dives because structured receipts were not consistently generated and uploaded from CI artifacts, making triage and repairs slow.

### Description

- Capture UX test output by tee’ing logs to `target/receipts/ux-test-output.log` and preserve the original test exit status via `PIPESTATUS` in the UX jobs.
- Always run the classifier `cargo xtask ux-regression-receipt --input target/receipts/ux-test-output.log --receipt target/receipts/ux-regression.json --sha "${{ github.sha }}"` after UX tests in both the main CI `ux-tests` job and the dedicated `UX Regression Gate` job.
- Add a GitHub step summary that points to the receipt and includes key classified fields (result, failure class, first failing test) and ensure the structured receipt is recorded under `target/receipts/` following existing artifact conventions.
- Upload `target/receipts/ux-regression.json` and `target/receipts/ux-test-output.log` as workflow artifacts on both success and failure while preserving the gate’s failure signaling semantics.

### Testing

- Ran the unit test target for the classifier with `cargo test -p xtask ux_regression_receipt`, which could not complete due to a pre-existing unrelated compile error in `crates/perl-symbol` causing the test run to fail (classifier code itself was exercised during compilation and the workflow edits were validated by inspection).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2f87b146c8333b27d7fe3fa968cb9)