### PR TITLE
ci(tokmd): add tokmd receipt and advisory gate (#0000)

### DIFF
--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -16,10 +16,9 @@ name = "Methodology Gate"
 workflow = ".github/workflows/methodology-gate.yml"
 required = false
 
-[[check]]
+[[checks]]
 name = "tokmd Advisory"
 workflow = ".github/workflows/tokmd.yml"
-required = false
 # Phase 1: advisory-only (visibility gate, no merge blocking).
 # Promotion to required = true tracked in #4993 (Phase 2/3).
 

--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -16,6 +16,13 @@ name = "Methodology Gate"
 workflow = ".github/workflows/methodology-gate.yml"
 required = false
 
+[[check]]
+name = "tokmd Advisory"
+workflow = ".github/workflows/tokmd.yml"
+required = false
+# Phase 1: advisory-only (visibility gate, no merge blocking).
+# Promotion to required = true tracked in #4993 (Phase 2/3).
+
 [[checks]]
 name = "PR Smoke"
 workflow = ".github/workflows/ci.yml"

--- a/.github/workflows/tokmd.yml
+++ b/.github/workflows/tokmd.yml
@@ -1,0 +1,105 @@
+name: tokmd
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  tokmd:
+    name: tokmd Receipt and Gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate tokmd PR sensor comment
+        id: sensor
+        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
+        with:
+          version: '1.10.0'
+          mode: sensor
+          head: HEAD
+          artifact: 'false'
+          comment: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
+
+      - name: Generate tokmd repository receipt
+        id: receipt
+        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
+        with:
+          version: '1.10.0'
+          paths: |
+            crates
+            xtask
+            docs
+            book/src
+            scripts
+            .github/workflows
+            .ci/policies
+          module-roots: 'crates,xtask,docs,book,scripts'
+          top: '30'
+          format: 'json'
+          artifact: 'false'
+          comment: 'false'
+
+      - name: Run tokmd advisory gate
+        id: gate
+        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
+        with:
+          version: '1.10.0'
+          mode: gate
+          paths: .
+          artifact: 'false'
+          comment: 'false'
+
+      - name: Upload tokmd artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tokmd-${{ github.run_id }}
+          path: |
+            tokmd-*.json
+            tokmd-*.jsonl
+            tokmd-*.md
+            comment.md
+            extras/**
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Add tokmd summary to workflow run
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## tokmd"
+            echo
+            if [ -f comment.md ]; then
+              cat comment.md
+            elif [ -f tokmd-summary.md ]; then
+              cat tokmd-summary.md
+            else
+              echo "tokmd completed, but no Markdown summary was produced."
+            fi
+            echo
+            if [ -f tokmd-gate-verdict.json ]; then
+              echo "### Gate verdict"
+              echo
+              echo '```json'
+              cat tokmd-gate-verdict.json
+              echo
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tokmd.toml
+++ b/tokmd.toml
@@ -1,0 +1,47 @@
+[scan]
+exclude = [
+  "target/**",
+  "target-tests/**",
+  ".runs/**",
+  ".codex-worktrees/**",
+  ".claude/worktrees/**",
+  ".ops-perl-lsp/**",
+  "tree-sitter-perl/**",
+  "fuzz/**",
+  "archive/**",
+  "book/book/**",
+  "docs/assets/recordings/**",
+  "test_corpus/workspaces/xlarge/lib/**",
+  "test_corpus/workspaces/xlarge/bin/**"
+]
+
+[module]
+roots = ["crates", "xtask", "docs", "book", "scripts"]
+depth = 2
+
+[gate]
+fail_fast = false
+
+[[gate.rules]]
+name = "receipt_has_files"
+pointer = "/derived/totals/files"
+op = "gte"
+value = 1
+level = "error"
+message = "tokmd did not find any files; check workflow checkout, paths, or ignore rules."
+
+[[gate.rules]]
+name = "token_budget_visibility"
+pointer = "/derived/totals/tokens"
+op = "lte"
+value = 20000000
+level = "warn"
+message = "Repository token estimate exceeded 20M; inspect tokmd artifacts before tightening gates."
+
+[[gate.rules]]
+name = "doc_density_visibility"
+pointer = "/derived/doc_density/total/ratio"
+op = "gte"
+value = 0.02
+level = "warn"
+message = "Documentation density is below the initial visibility floor; do not make this blocking until a baseline is accepted."

--- a/tokmd.toml
+++ b/tokmd.toml
@@ -20,9 +20,11 @@ roots = ["crates", "xtask", "docs", "book", "scripts"]
 depth = 2
 
 [gate]
-# Phase 1: advisory-only. All rules are warn-level; fail_fast = false means
-# the gate collects full results without blocking merges. Promotion roadmap
-# and baseline acceptance criteria tracked in #4993 (Phase 2/3).
+# Phase 1: advisory-only. fail_fast = false means the gate collects all rule
+# violations before exiting rather than stopping at the first failure.
+# Merge non-blocking: tokmd Advisory has no required = true in required-checks.toml,
+# so a gate exit 1 does not prevent merge. Promotion roadmap and baseline
+# acceptance criteria tracked in #4993 (Phase 2/3).
 # SHA pinning: locked to v1.10.0 commit SHA (01f19c1c...) as accepted Phase 1
 # tech debt. Refresh cadence: update SHA when a tokmd release contains a rule
 # or config change relevant to perl-lsp. No automated tracking; manual review.

--- a/tokmd.toml
+++ b/tokmd.toml
@@ -20,6 +20,12 @@ roots = ["crates", "xtask", "docs", "book", "scripts"]
 depth = 2
 
 [gate]
+# Phase 1: advisory-only. All rules are warn-level; fail_fast = false means
+# the gate collects full results without blocking merges. Promotion roadmap
+# and baseline acceptance criteria tracked in #4993 (Phase 2/3).
+# SHA pinning: locked to v1.10.0 commit SHA (01f19c1c...) as accepted Phase 1
+# tech debt. Refresh cadence: update SHA when a tokmd release contains a rule
+# or config change relevant to perl-lsp. No automated tracking; manual review.
 fail_fast = false
 
 [[gate.rules]]


### PR DESCRIPTION
### Motivation

- Add repository-level tokmd instrumentation so PRs publish review metrics and an advisory gate without immediately becoming a required merge check.
- Stage the integration conservatively to avoid blocking merges while establishing a baseline and to surface tokmd data to reviewers.

### Description

- Add a workflow file at `.github/workflows/tokmd.yml` that runs on `pull_request` (master) and `workflow_dispatch`, checks out with `fetch-depth: 0`, uses a pinned `EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827` (binary `version: '1.10.0'`), runs a `sensor` comment, a repository `receipt` (JSON), and an advisory `gate`, uploads artifacts manually, and appends a summary to `$GITHUB_STEP_SUMMARY`.
- Add a conservative `tokmd.toml` with scan `exclude` entries, `module` roots/depth, `fail_fast = false`, one error-level sanity rule `receipt_has_files`, and warning-level visibility rules for token budget and doc density.
- Use least-privilege workflow permissions (`contents: read`, `pull-requests: write`) and disable fork PR comments to avoid permission failures.

### Testing

- Ran `git diff --check`, which produced no problems (passed).
- Ran `cargo xtask workflow-policy-lint --receipt target/receipts/workflow-policy.json`, which completed and reported `Workflow policy lint passed (0 error(s), 2 warning(s))` (warnings are existing unpinned-action notices unrelated to the new workflow).
- Ran `cargo xtask workflow-trigger-lint --policy .ci/policies/required-checks.toml --receipt target/receipts/workflow-trigger-lint.json --format json`, which returned `overall_ok: true` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31d64f7e88333aaa56ea91b4d712b)