### PR TITLE
fix(fmt): apply rustfmt to xtask/ux_regression_receipt.rs (#0000)

### DIFF
--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -81,9 +81,8 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
     let lines: Vec<&str> = raw.lines().collect();
     let first_fail_line =
         lines.iter().find(|line| line.contains("FAILED")).map(|line| (*line).trim().to_string());
-    let first_failing_test = lines
-        .iter()
-        .find_map(|line| FAILED_TEST_RE.captures(line).map(|cap| cap[1].to_string()));
+    let first_failing_test =
+        lines.iter().find_map(|line| FAILED_TEST_RE.captures(line).map(|cap| cap[1].to_string()));
     let panic_location =
         lines.iter().find_map(|line| PANIC_RE.captures(line).map(|cap| cap[1].to_string()));
     let scenario = first_failing_test.as_ref().and_then(|name| scenario_from_test_name(name));
@@ -253,7 +252,10 @@ mod tests {
             matches!(receipt.failure_class, FailureClass::MatrixDrift),
             "fixture matrix log should classify as MatrixDrift"
         );
-        assert_eq!(receipt.route, "needs-fixture-update", "MatrixDrift routes to needs-fixture-update");
+        assert_eq!(
+            receipt.route, "needs-fixture-update",
+            "MatrixDrift routes to needs-fixture-update"
+        );
     }
 
     #[test]
@@ -264,7 +266,10 @@ mod tests {
             matches!(receipt.failure_class, FailureClass::BaselineDrift),
             "baseline snapshot log should classify as BaselineDrift"
         );
-        assert_eq!(receipt.route, "needs-baseline-update", "BaselineDrift routes to needs-baseline-update");
+        assert_eq!(
+            receipt.route, "needs-baseline-update",
+            "BaselineDrift routes to needs-baseline-update"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Master has fmt drift in `xtask/src/tasks/ux_regression_receipt.rs` introduced after #7569 / merge cascade. PR Smoke (Fast Feedback) fails on every PR after `update-branch` because `cargo xtask gates --tier pr-fast` runs fmt-check and emits diffs at lines 81, 253, 264.

Failing PRs blocked by this drift:
- #7525 (run 25160986121, job 73755138777)
- #7449 (run 25160988297, job 73755113784)

Fix: rustfmt with project config (`max_width=100, use_small_heuristics=Max`).

This is a 1-line semantic fix (literal whitespace re-flow only — no behavior change).

## Test plan

- [x] `rustfmt --check` passes locally on the file
- [ ] PR Smoke green
- [ ] After admin-merge, cascade-update #7525 and #7449