### PR TITLE
feat(ci): add tokmd review cockpit workflow (#0000)

### DIFF
--- a/.github/workflows/tokmd.yml
+++ b/.github/workflows/tokmd.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   tokmd:
-    name: tokmd Receipt and Gate
+    name: tokmd PR Review
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -26,56 +26,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate tokmd PR sensor comment
-        id: sensor
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
+      - name: Generate tokmd review cockpit
+        id: review
+        uses: EffortlessMetrics/tokmd@v1
         with:
-          version: '1.10.0'
-          mode: sensor
+          version: '1.11.0'
+          mode: review
+          base: origin/${{ github.base_ref }}
           head: HEAD
-          artifact: 'false'
-          comment: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
-
-      - name: Generate tokmd repository receipt
-        id: receipt
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
-        with:
-          version: '1.10.0'
-          paths: |
-            crates
-            xtask
-            docs
-            book/src
-            scripts
-            .github/workflows
-            .ci/policies
-          module-roots: 'crates,xtask,docs,book,scripts'
-          top: '30'
-          format: 'json'
-          artifact: 'false'
-          comment: 'false'
-
-      - name: Run tokmd advisory gate
-        id: gate
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
-        with:
-          version: '1.10.0'
-          mode: gate
-          paths: .
-          artifact: 'false'
-          comment: 'false'
+          out-dir: .tokmd/review
+          config: tokmd.review.toml
+          gate-config: tokmd-review-gate.toml
+          gate: advisory
+          comment: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'auto' || 'false' }}
+          artifact: true
 
       - name: Upload tokmd artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: tokmd-${{ github.run_id }}
-          path: |
-            tokmd-*.json
-            tokmd-*.jsonl
-            tokmd-*.md
-            comment.md
-            extras/**
+          path: .tokmd/review/**
           if-no-files-found: warn
           retention-days: 14
 
@@ -84,22 +55,11 @@ jobs:
         shell: bash
         run: |
           {
-            echo "## tokmd"
+            echo "## tokmd Review Cockpit"
             echo
-            if [ -f comment.md ]; then
-              cat comment.md
-            elif [ -f tokmd-summary.md ]; then
-              cat tokmd-summary.md
+            if [ -f .tokmd/review/comment.md ]; then
+              cat .tokmd/review/comment.md
             else
-              echo "tokmd completed, but no Markdown summary was produced."
-            fi
-            echo
-            if [ -f tokmd-gate-verdict.json ]; then
-              echo "### Gate verdict"
-              echo
-              echo '```json'
-              cat tokmd-gate-verdict.json
-              echo
-              echo '```'
+              echo "tokmd review completed, but no comment.md was produced."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ci/tokmd-review-cockpit.md
+++ b/docs/ci/tokmd-review-cockpit.md
@@ -1,0 +1,53 @@
+# tokmd PR Review Cockpit
+
+`tokmd` runs in `mode: review` for pull requests targeting `master`.
+
+## Generated artifacts
+
+Each run writes a review packet in `.tokmd/review/`:
+
+- `comment.md`
+- `review-map.md`
+- `review-map.json`
+- `cockpit.json`
+- `analysis-risk.json`
+- `duplication.json`
+- `complexity.json`
+- `evidence.json`
+- `manifest.json`
+
+## perl-lsp workspace-oriented review areas
+
+The review config (`tokmd.review.toml`) maps changed files into architecture areas:
+
+- `parser`: parser, lexer, token, tree-sitter crates
+- `lsp`: LSP host, core, and formatter integration crates
+- `workspace`: workspace index, semantic analyzer, and module crates
+- `dap`: debug adapter crate
+- `ci`: workflow and xtask automation
+- `docs`: user and contributor documentation
+
+Each area has a weight and suggested verification command. This makes the review map prioritize files by architectural risk, not only by line count.
+
+## Expected review output shape
+
+The review comment and map should surface:
+
+- risk and health summary
+- contract/change-surface changes (API, CLI, schema)
+- complexity and near-duplicate findings
+- evidence gaps (for example missing mutation or diff-coverage evidence)
+- prioritized `P1/P2/P3` review path with file-level reasons and suggested checks
+
+## Local reproduction
+
+```bash
+tokmd review \
+  --base origin/master \
+  --head HEAD \
+  --out-dir .tokmd/review \
+  --config tokmd.review.toml \
+  --near-dup \
+  --detail-functions \
+  --gate advisory
+```

--- a/tokmd-review-gate.toml
+++ b/tokmd-review-gate.toml
@@ -1,0 +1,49 @@
+fail_fast = false
+allow_missing = false
+
+[[rules]]
+name = "review_path_exists"
+pointer = "/review_map/review_path/0/path"
+op = "exists"
+level = "warn"
+message = "No review path was generated."
+
+[[rules]]
+name = "critical_risk_visible"
+pointer = "/review_map/overall/risk_score"
+op = "lte"
+value = 89
+level = "warn"
+message = "Critical-risk PR. Review P1 items before merge."
+
+[[rules]]
+name = "complexity_findings_visible"
+pointer = "/review_map/overall/complexity_findings"
+op = "lte"
+value = 0
+level = "warn"
+message = "Complexity findings detected. Inspect review-map complexity section."
+
+[[rules]]
+name = "duplication_findings_visible"
+pointer = "/review_map/overall/duplication_findings"
+op = "lte"
+value = 0
+level = "warn"
+message = "Near-duplicate findings detected. Inspect review-map duplication section."
+
+[[rules]]
+name = "evidence_gaps_visible"
+pointer = "/review_map/overall/evidence_gaps"
+op = "lte"
+value = 0
+level = "warn"
+message = "Evidence gaps detected. Inspect review-map evidence section."
+
+[[rules]]
+name = "health_not_f"
+pointer = "/cockpit/code_health/grade"
+op = "ne"
+value = "F"
+level = "warn"
+message = "Code health is F. Inspect the generated review path."

--- a/tokmd.review.toml
+++ b/tokmd.review.toml
@@ -1,0 +1,85 @@
+[review]
+max_items = 12
+include_evidence_gaps = true
+include_duplication = true
+include_complexity = true
+include_hotspots = true
+include_contracts = true
+
+[review.thresholds]
+high_risk_score = 70
+critical_risk_score = 90
+large_file_lines = 500
+high_complexity = 15
+near_dup_similarity = 0.86
+max_priority_items = 8
+
+[review.commands]
+parser = "cargo test -p perl-parser -p perl-parser-core -p perl-lexer"
+lsp = "cargo test -p perl-lsp-rs-core -p perl-lsp-rs"
+workspace = "cargo test -p perl-workspace-index -p perl-semantic-analyzer -p perl-module-index"
+dap = "cargo test -p perl-dap"
+ci = "cargo xtask workflow-policy-lint --receipt target/receipts/workflow-policy.json"
+
+[[review.area]]
+name = "parser"
+paths = [
+  "crates/perl-parser/**",
+  "crates/perl-parser-core/**",
+  "crates/perl-lexer/**",
+  "crates/perl-token/**",
+  "crates/tree-sitter-perl-rs/**",
+  "crates/tree-sitter-perl-c/**"
+]
+weight = 1.4
+suggested_command = "parser"
+
+[[review.area]]
+name = "lsp"
+paths = [
+  "crates/perl-lsp-rs/**",
+  "crates/perl-lsp-rs-core/**",
+  "crates/perl-lsp-perltidy/**"
+]
+weight = 1.3
+suggested_command = "lsp"
+
+[[review.area]]
+name = "workspace"
+paths = [
+  "crates/perl-workspace-index/**",
+  "crates/perl-module*/**",
+  "crates/perl-semantic-analyzer/**",
+  "crates/perl-semantic-facts/**"
+]
+weight = 1.2
+suggested_command = "workspace"
+
+[[review.area]]
+name = "dap"
+paths = ["crates/perl-dap/**"]
+weight = 1.1
+suggested_command = "dap"
+
+[[review.area]]
+name = "ci"
+paths = [
+  ".github/workflows/**",
+  ".ci/**",
+  "xtask/**",
+  "justfile",
+  "scripts/**"
+]
+weight = 1.2
+suggested_command = "ci"
+
+[[review.area]]
+name = "docs"
+paths = [
+  "docs/**",
+  "book/src/**",
+  "README.md",
+  "CONTRIBUTING.md",
+  "AGENTS.md"
+]
+weight = 0.7


### PR DESCRIPTION
### Motivation

- The existing tokmd integration emitted a generic sensor/receipt/gate flow that does not produce a prioritized, reviewer-focused output for maintainers.  
- We need a stable Review Cockpit that synthesizes complexity, duplication, hotspots, contracts, evidence gaps, and a prioritized review path into artifacts for PR review.  
- The repo needs a repo-specific `tokmd` review configuration so review signals are mapped to the perl-lsp architecture rather than raw metrics.

### Description

- Replace the previous `sensor`/`receipt`/`gate` steps with a single first-class `mode: review` GitHub Actions job in `.github/workflows/tokmd.yml` that runs `tokmd` in review mode and writes artifacts to `.tokmd/review/`.  
- Add `tokmd.review.toml` which defines perl-lsp area-aware review configuration (areas: `parser`, `lsp`, `workspace`, `dap`, `ci`, `docs`), thresholds, and suggested verification commands.  
- Add `tokmd-review-gate.toml` to run advisory review-quality checks focused on review-map presence and visibility of risk, complexity, duplication, evidence gaps, and health grade (warn-only initially).  
- Add `docs/ci/tokmd-review-cockpit.md` documenting expected artifacts, review-area mapping, and a local `tokmd review` reproduction command, and update the workflow to upload `.tokmd/review/**` and render `.tokmd/review/comment.md` into the step summary.  

### Testing

- Validated the new workflow YAML parses successfully with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/tokmd.yml'); puts 'yaml ok'"`, which printed `yaml ok`.  
- A Python YAML parse attempt failed in the environment due to a missing `PyYAML` module (environment issue, not a YAML syntax failure).  
- The changes were committed locally and the repository shows the new files staged and recorded in a commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f336a3255083338dcf8a5d8bf17e3f)