### PR TITLE
ci(tokmd): switch to review cockpit workflow (#0000)

### DIFF
--- a/.github/workflows/tokmd.yml
+++ b/.github/workflows/tokmd.yml
@@ -1,4 +1,4 @@
-name: tokmd
+name: tokmd PR Review
 
 on:
   pull_request:
@@ -15,8 +15,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  tokmd:
-    name: tokmd Receipt and Gate
+  review:
+    name: tokmd PR Review
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -26,80 +26,33 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate tokmd PR sensor comment
-        id: sensor
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
+      - name: Run tokmd review cockpit
+        id: review
+        uses: EffortlessMetrics/tokmd@v1
         with:
-          version: '1.10.0'
-          mode: sensor
+          version: '1.11.0'
+          mode: review
+          base: origin/${{ github.base_ref }}
           head: HEAD
-          artifact: 'false'
-          comment: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
+          out-dir: .tokmd/review
+          config: tokmd.review.toml
+          gate: advisory
+          gate-config: tokmd-review-gate.toml
+          near-dup: 'true'
+          detail-functions: 'true'
+          comment: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'auto' || 'false' }}
+          artifact: 'true'
 
-      - name: Generate tokmd repository receipt
-        id: receipt
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
-        with:
-          version: '1.10.0'
-          paths: |
-            crates
-            xtask
-            docs
-            book/src
-            scripts
-            .github/workflows
-            .ci/policies
-          module-roots: 'crates,xtask,docs,book,scripts'
-          top: '30'
-          format: 'json'
-          artifact: 'false'
-          comment: 'false'
-
-      - name: Run tokmd advisory gate
-        id: gate
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
-        with:
-          version: '1.10.0'
-          mode: gate
-          paths: .
-          artifact: 'false'
-          comment: 'false'
-
-      - name: Upload tokmd artifacts
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: tokmd-${{ github.run_id }}
-          path: |
-            tokmd-*.json
-            tokmd-*.jsonl
-            tokmd-*.md
-            comment.md
-            extras/**
-          if-no-files-found: warn
-          retention-days: 14
-
-      - name: Add tokmd summary to workflow run
+      - name: Add tokmd review summary to workflow run
         if: always()
         shell: bash
         run: |
           {
-            echo "## tokmd"
+            echo "## tokmd Review Cockpit"
             echo
-            if [ -f comment.md ]; then
-              cat comment.md
-            elif [ -f tokmd-summary.md ]; then
-              cat tokmd-summary.md
+            if [ -f .tokmd/review/comment.md ]; then
+              cat .tokmd/review/comment.md
             else
-              echo "tokmd completed, but no Markdown summary was produced."
-            fi
-            echo
-            if [ -f tokmd-gate-verdict.json ]; then
-              echo "### Gate verdict"
-              echo
-              echo '```json'
-              cat tokmd-gate-verdict.json
-              echo
-              echo '```'
+              echo "tokmd review completed, but no comment.md was produced."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ci/tokmd-review-cockpit.md
+++ b/docs/ci/tokmd-review-cockpit.md
@@ -1,0 +1,59 @@
+# tokmd Review Cockpit
+
+`tokmd` runs in review mode on pull requests and publishes a reviewer map tailored to the
+`perl-lsp` workspace layout.
+
+## Workflow behavior
+
+The CI workflow in `.github/workflows/tokmd.yml` runs:
+
+```bash
+tokmd review \
+  --base origin/<base-ref> \
+  --head HEAD \
+  --out-dir .tokmd/review \
+  --config tokmd.review.toml \
+  --gate advisory \
+  --near-dup \
+  --detail-functions
+```
+
+Artifacts are written to `.tokmd/review/` and include:
+
+- `comment.md`
+- `review-map.md`
+- `review-map.json`
+- `cockpit.json`
+- `analysis-risk.json`
+- `duplication.json`
+- `complexity.json`
+- `evidence.json`
+- `manifest.json`
+
+## perl-lsp area model
+
+`tokmd.review.toml` maps changed files into weighted review areas:
+
+- `parser`: parser/lexer/token/tree-sitter crates (highest weight)
+- `lsp`: LSP server and providers
+- `workspace`: indexing, module resolution, and semantic analysis
+- `dap`: debugger adapter surface
+- `ci`: workflows, xtask, and scripts
+- `docs`: docs and contributor-facing markdown
+
+Each area can suggest targeted verification commands so reviewers can run the smallest
+high-signal checks first.
+
+## Gate posture
+
+`tokmd-review-gate.toml` is advisory and checks reviewer-map quality signals instead of
+repository-size metrics:
+
+- review path exists
+- risk score visibility
+- complexity findings visibility
+- duplication findings visibility
+- evidence gap visibility
+- health grade not `F`
+
+Warnings are surfaced in review artifacts and PR comments without blocking merges.

--- a/tokmd-review-gate.toml
+++ b/tokmd-review-gate.toml
@@ -1,0 +1,49 @@
+fail_fast = false
+allow_missing = false
+
+[[rules]]
+name = "review_path_exists"
+pointer = "/review_map/review_path/0/path"
+op = "exists"
+level = "warn"
+message = "No review path was generated."
+
+[[rules]]
+name = "critical_risk_visible"
+pointer = "/review_map/overall/risk_score"
+op = "lte"
+value = 89
+level = "warn"
+message = "Critical-risk PR. Review P1 items before merge."
+
+[[rules]]
+name = "complexity_findings_visible"
+pointer = "/review_map/overall/complexity_findings"
+op = "lte"
+value = 0
+level = "warn"
+message = "Complexity findings detected. Inspect review-map complexity section."
+
+[[rules]]
+name = "duplication_findings_visible"
+pointer = "/review_map/overall/duplication_findings"
+op = "lte"
+value = 0
+level = "warn"
+message = "Near-duplicate findings detected. Inspect review-map duplication section."
+
+[[rules]]
+name = "evidence_gaps_visible"
+pointer = "/review_map/overall/evidence_gaps"
+op = "lte"
+value = 0
+level = "warn"
+message = "Evidence gaps detected. Inspect review-map evidence section."
+
+[[rules]]
+name = "health_not_f"
+pointer = "/cockpit/code_health/grade"
+op = "ne"
+value = "F"
+level = "warn"
+message = "Code health is F. Inspect the generated review path."

--- a/tokmd.review.toml
+++ b/tokmd.review.toml
@@ -1,0 +1,87 @@
+[review]
+max_items = 12
+include_evidence_gaps = true
+include_duplication = true
+include_complexity = true
+include_hotspots = true
+include_contracts = true
+
+[review.thresholds]
+high_risk_score = 70
+critical_risk_score = 90
+large_file_lines = 500
+high_complexity = 15
+near_dup_similarity = 0.86
+max_priority_items = 8
+
+[review.commands]
+parser = "cargo test -p perl-parser -p perl-parser-core -p perl-lexer"
+lsp = "cargo test -p perl-lsp-rs-core -p perl-lsp-rs"
+workspace = "cargo test -p perl-workspace-index -p perl-semantic-analyzer"
+dap = "cargo test -p perl-dap"
+ci = "cargo xtask workflow-policy-lint --receipt target/receipts/workflow-policy.json"
+
+[[review.area]]
+name = "parser"
+paths = [
+  "crates/perl-parser/**",
+  "crates/perl-parser-core/**",
+  "crates/perl-lexer/**",
+  "crates/perl-token/**",
+  "crates/tree-sitter-perl-rs/**",
+  "crates/tree-sitter-perl-c/**"
+]
+weight = 1.4
+suggested_command = "parser"
+
+[[review.area]]
+name = "lsp"
+paths = [
+  "crates/perl-lsp-rs/**",
+  "crates/perl-lsp-rs-core/**",
+  "crates/perl-lsp-perltidy/**"
+]
+weight = 1.3
+suggested_command = "lsp"
+
+[[review.area]]
+name = "workspace"
+paths = [
+  "crates/perl-workspace-index/**",
+  "crates/perl-module/**",
+  "crates/perl-semantic-analyzer/**",
+  "crates/perl-semantic-facts/**"
+]
+weight = 1.2
+suggested_command = "workspace"
+
+[[review.area]]
+name = "dap"
+paths = [
+  "crates/perl-dap/**"
+]
+weight = 1.1
+suggested_command = "dap"
+
+[[review.area]]
+name = "ci"
+paths = [
+  ".github/workflows/**",
+  ".ci/**",
+  "xtask/**",
+  "justfile",
+  "scripts/**"
+]
+weight = 1.2
+suggested_command = "ci"
+
+[[review.area]]
+name = "docs"
+paths = [
+  "docs/**",
+  "book/src/**",
+  "README.md",
+  "CONTRIBUTING.md",
+  "AGENTS.md"
+]
+weight = 0.7


### PR DESCRIPTION
### Motivation

- The existing tokmd pipeline produced generic receipts and gates but did not generate a reviewer-focused cockpit that highlights complexity, duplication, hotspots, review path, evidence gaps, and contract/change surface. 
- The repo needs a repo-scoped review configuration and advisory gate so tokmd can emit a prioritized review map and writable artifacts for use in PR comments and reviewer guidance.

### Description

- Replace the existing tokmd workflow with a PR-focused review workflow in `.github/workflows/tokmd.yml` that runs `tokmd review` (`mode: review`, `version: '1.11.0'`) and writes artifacts to `.tokmd/review`, enabling `near-dup` and `detail-functions`, advisory gating, and automatic comment/artifact publishing. 
- Add `tokmd.review.toml` to map repository areas (parser, lsp, workspace, dap, ci, docs), weights, thresholds, and suggested verification commands to drive a prioritized review path. 
- Add `tokmd-review-gate.toml` to replace generic size/visibility checks with advisory rules that assert review-map quality (review path presence, risk/complexity/duplication/evidence visibility, and health grade). 
- Add documentation at `docs/ci/tokmd-review-cockpit.md` describing the review cockpit artifacts, command shape, area model, and advisory gate posture.

### Testing

- Ran `cargo xtask fmt` to ensure formatting and workspace xtask formatting integration, and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f336a3255083338dcf8a5d8bf17e3f)