### PR TITLE
fix(ci): prevent label events from canceling CI (#0000)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -42,8 +42,8 @@ on:
 
 # Cancel in-flight runs on new pushes (saves minutes)
 concurrency:
-  group: ci-nightly-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-nightly-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
 # The preflight SHA-staleness check provides additional skip logic for superseded SHAs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 permissions:
   contents: read

--- a/.github/workflows/perl-version-matrix.yml
+++ b/.github/workflows/perl-version-matrix.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: perl-version-matrix-${{ github.ref }}
-  cancel-in-progress: true
+  group: perl-version-matrix-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 permissions:
   contents: read

--- a/docs/ci/workflow-trigger-policy.md
+++ b/docs/ci/workflow-trigger-policy.md
@@ -15,7 +15,7 @@ For each `required = true` check, the workflow must:
 - define `push` with `branches: [master]`
 - avoid top-level or event-level `paths` / `paths-ignore`
 - define event-aware concurrency:
-  - `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`
+  - `cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}`
 - exist at the configured path
 
 ## Commands

--- a/xtask/src/tasks/workflow_policy_lint.rs
+++ b/xtask/src/tasks/workflow_policy_lint.rs
@@ -199,6 +199,15 @@ fn lint_workflow_file(path: &Path, is_fixture: bool, issues: &mut Vec<LintIssue>
         });
     }
 
+    if pull_request_has_label_triggers(&workflow) && label_event_cancels_pr_run(&workflow) {
+        issues.push(LintIssue {
+            level: "error",
+            code: "LABEL_EVENT_CANCELS_PR_RUN",
+            workflow: workflow_name.clone(),
+            message: "pull_request labeled/unlabeled workflows must not cancel in-progress PR runs; use github.event.action == 'synchronize' or remove label triggers".to_string(),
+        });
+    }
+
     if POLICY_WARN_UNPINNED_ACTIONS {
         for action in collect_unpinned_actions(&workflow) {
             issues.push(LintIssue {
@@ -423,6 +432,49 @@ fn blanket_cancel_in_progress(workflow: &Value) -> bool {
     map.get(Value::String("cancel-in-progress".to_string()))
         .and_then(Value::as_bool)
         .unwrap_or(false)
+}
+
+fn pull_request_has_label_triggers(workflow: &Value) -> bool {
+    workflow
+        .get("on")
+        .and_then(Value::as_mapping)
+        .and_then(|mapping| mapping.get(Value::String("pull_request".to_string())))
+        .and_then(Value::as_mapping)
+        .and_then(|pull_request| pull_request.get(Value::String("types".to_string())))
+        .and_then(Value::as_sequence)
+        .is_some_and(|types| {
+            types
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|event| event == "labeled" || event == "unlabeled")
+        })
+}
+
+fn label_event_cancels_pr_run(workflow: &Value) -> bool {
+    let Some(concurrency) = workflow.get("concurrency") else {
+        return false;
+    };
+
+    if concurrency.as_bool().is_some_and(|value| value) {
+        return true;
+    }
+
+    let Some(mapping) = concurrency.as_mapping() else {
+        return false;
+    };
+
+    let Some(cancel_in_progress) = mapping.get(Value::String("cancel-in-progress".to_string()))
+    else {
+        return false;
+    };
+
+    if cancel_in_progress.as_bool().is_some_and(|value| value) {
+        return true;
+    }
+
+    cancel_in_progress
+        .as_str()
+        .is_some_and(|expr| expr.trim() == "${{ github.event_name == 'pull_request' }}")
 }
 
 fn collect_unpinned_actions(workflow: &Value) -> Vec<String> {

--- a/xtask/src/tasks/workflow_trigger_lint.rs
+++ b/xtask/src/tasks/workflow_trigger_lint.rs
@@ -10,7 +10,8 @@ use serde_yaml_ng::Value;
 
 use crate::utils::project_root;
 
-const REQUIRED_CANCEL_IN_PROGRESS: &str = "${{ github.event_name == 'pull_request' }}";
+const REQUIRED_CANCEL_IN_PROGRESS: &str =
+    "${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}";
 
 #[derive(Debug, Clone, Deserialize)]
 struct RequiredChecksPolicy {
@@ -159,6 +160,12 @@ fn evaluate_required_entry(
                     "concurrency.cancel-in-progress must be `{REQUIRED_CANCEL_IN_PROGRESS}`"
                 ));
             }
+            if pull_request_has_label_triggers(yaml) {
+                violations.push(
+                    "required CI workflows must not trigger on pull_request labeled/unlabeled"
+                        .to_string(),
+                );
+            }
         }
     }
 
@@ -266,6 +273,22 @@ fn has_path_filters(workflow: &Value) -> bool {
             _ => false,
         }
     })
+}
+
+fn pull_request_has_label_triggers(workflow: &Value) -> bool {
+    workflow
+        .get("on")
+        .and_then(Value::as_mapping)
+        .and_then(|on| on.get(Value::String("pull_request".to_string())))
+        .and_then(Value::as_mapping)
+        .and_then(|pr| pr.get(Value::String("types".to_string())))
+        .and_then(Value::as_sequence)
+        .is_some_and(|types| {
+            types
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|event| event == "labeled" || event == "unlabeled")
+        })
 }
 
 fn has_event_aware_concurrency(workflow: &Value) -> bool {


### PR DESCRIPTION
### Motivation
- Label add/remove events were cancelling in-progress PR CI runs because workflows used broad PR-only cancellation expressions or blanket `cancel-in-progress`, causing label churn to restart expensive/required CI runs.
- The goal is to ensure only new commits (`pull_request` `synchronize`) can cancel in-flight PR CI while still allowing labels to start optional jobs without killing required CI.

### Description
- Tighten required CI concurrency in `.github/workflows/ci.yml` so `concurrency.cancel-in-progress` is gated to `${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}` and use a PR-scoped concurrency group (`${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`).
- Update label-gated workflows `.github/workflows/ci-nightly.yml` and `.github/workflows/perl-version-matrix.yml` to use PR-aware concurrency groups and the same `synchronize`-only `cancel-in-progress` expression so new pushes can cancel stale runs but label events cannot.
- Enforce the policy in lint tooling by changing `xtask/src/tasks/workflow_trigger_lint.rs` to require the action-aware expression and adding a check that required workflows must not include `pull_request` `types` of `labeled`/`unlabeled`.
- Add a guard to `xtask/src/tasks/workflow_policy_lint.rs` (error code `LABEL_EVENT_CANCELS_PR_RUN`) that flags workflows which listen to label events but still use blanket cancellation (including `cancel-in-progress: true` or the old PR-only expression), and update `docs/ci/workflow-trigger-policy.md` to document the new required expression.

### Testing
- Ran `cargo xtask fmt` and it completed successfully.
- Ran `cargo xtask workflow-trigger-lint` and it passed (no violations for required workflows).
- Ran `cargo xtask workflow-policy-lint` and it passed with 2 warnings about unpinned third-party actions (these are pre-existing warnings and not related to the new label-cancellation rule).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33ca4402c833383d65b1380d3af3d)