### PR TITLE
fix(ci): prevent label events from canceling PR runs (#0000)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -42,8 +42,8 @@ on:
 
 # Cancel in-flight runs on new pushes (saves minutes)
 concurrency:
-  group: ci-nightly-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-nightly-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:
 # The preflight SHA-staleness check provides additional skip logic for superseded SHAs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 permissions:
   contents: read

--- a/.github/workflows/perl-version-matrix.yml
+++ b/.github/workflows/perl-version-matrix.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: perl-version-matrix-${{ github.ref }}
-  cancel-in-progress: true
+  group: perl-version-matrix-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 permissions:
   contents: read

--- a/docs/ci/workflow-trigger-policy.md
+++ b/docs/ci/workflow-trigger-policy.md
@@ -15,7 +15,7 @@ For each `required = true` check, the workflow must:
 - define `push` with `branches: [master]`
 - avoid top-level or event-level `paths` / `paths-ignore`
 - define event-aware concurrency:
-  - `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`
+  - `cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}`
 - exist at the configured path
 
 ## Commands
@@ -30,3 +30,5 @@ For each `required = true` check, the workflow must:
 ## CI workflow
 
 `.github/workflows/workflow-trigger-lint.yml` runs this lint on `pull_request`, `merge_group`, and `push` to `master` with no path filters. The job is currently advisory while legacy required workflows are migrated.
+
+- required workflows must not include `labeled` or `unlabeled` in `on.pull_request.types`

--- a/xtask/src/tasks/workflow_policy_lint.rs
+++ b/xtask/src/tasks/workflow_policy_lint.rs
@@ -199,6 +199,15 @@ fn lint_workflow_file(path: &Path, is_fixture: bool, issues: &mut Vec<LintIssue>
         });
     }
 
+    if pull_request_label_trigger_cancels_pr_run(&workflow) {
+        issues.push(LintIssue {
+            level: "error",
+            code: "LABEL_EVENT_CANCELS_PR_RUN",
+            workflow: workflow_name.clone(),
+            message: "pull_request labeled/unlabeled workflows must not cancel in-progress PR runs; use github.event.action == 'synchronize' or remove label triggers".to_string(),
+        });
+    }
+
     if POLICY_WARN_UNPINNED_ACTIONS {
         for action in collect_unpinned_actions(&workflow) {
             issues.push(LintIssue {
@@ -423,6 +432,49 @@ fn blanket_cancel_in_progress(workflow: &Value) -> bool {
     map.get(Value::String("cancel-in-progress".to_string()))
         .and_then(Value::as_bool)
         .unwrap_or(false)
+}
+
+fn pull_request_label_trigger_cancels_pr_run(workflow: &Value) -> bool {
+    if !pull_request_has_label_triggers(workflow) {
+        return false;
+    }
+
+    let Some(concurrency) = workflow.get("concurrency") else {
+        return false;
+    };
+
+    if concurrency.as_bool().is_some_and(|value| value) {
+        return true;
+    }
+
+    let Some(map) = concurrency.as_mapping() else {
+        return false;
+    };
+
+    let Some(cancel) = map.get(Value::String("cancel-in-progress".to_string())) else {
+        return false;
+    };
+
+    cancel.as_bool().is_some_and(|value| value)
+        || cancel
+            .as_str()
+            .is_some_and(|value| value.trim() == "${{ github.event_name == 'pull_request' }}")
+}
+
+fn pull_request_has_label_triggers(workflow: &Value) -> bool {
+    workflow
+        .get("on")
+        .and_then(Value::as_mapping)
+        .and_then(|mapping| mapping.get(Value::String("pull_request".to_string())))
+        .and_then(Value::as_mapping)
+        .and_then(|mapping| mapping.get(Value::String("types".to_string())))
+        .and_then(Value::as_sequence)
+        .is_some_and(|types| {
+            types
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|event| event == "labeled" || event == "unlabeled")
+        })
 }
 
 fn collect_unpinned_actions(workflow: &Value) -> Vec<String> {

--- a/xtask/src/tasks/workflow_trigger_lint.rs
+++ b/xtask/src/tasks/workflow_trigger_lint.rs
@@ -10,7 +10,8 @@ use serde_yaml_ng::Value;
 
 use crate::utils::project_root;
 
-const REQUIRED_CANCEL_IN_PROGRESS: &str = "${{ github.event_name == 'pull_request' }}";
+const REQUIRED_CANCEL_IN_PROGRESS: &str =
+    "${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}";
 
 #[derive(Debug, Clone, Deserialize)]
 struct RequiredChecksPolicy {
@@ -159,6 +160,12 @@ fn evaluate_required_entry(
                     "concurrency.cancel-in-progress must be `{REQUIRED_CANCEL_IN_PROGRESS}`"
                 ));
             }
+            if pull_request_has_label_triggers(yaml) {
+                violations.push(
+                    "required CI workflows must not trigger on pull_request labeled/unlabeled"
+                        .to_string(),
+                );
+            }
         }
     }
 
@@ -266,6 +273,22 @@ fn has_path_filters(workflow: &Value) -> bool {
             _ => false,
         }
     })
+}
+
+fn pull_request_has_label_triggers(workflow: &Value) -> bool {
+    workflow
+        .get("on")
+        .and_then(Value::as_mapping)
+        .and_then(|on| on.get(Value::String("pull_request".to_string())))
+        .and_then(Value::as_mapping)
+        .and_then(|pr| pr.get(Value::String("types".to_string())))
+        .and_then(Value::as_sequence)
+        .is_some_and(|types| {
+            types
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|event| event == "labeled" || event == "unlabeled")
+        })
 }
 
 fn has_event_aware_concurrency(workflow: &Value) -> bool {

--- a/xtask/tests/fixtures/workflows/missing-merge-group.yml
+++ b/xtask/tests/fixtures/workflows/missing-merge-group.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: required-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   lint:

--- a/xtask/tests/fixtures/workflows/path-filtered.yml
+++ b/xtask/tests/fixtures/workflows/path-filtered.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: required-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   lint:

--- a/xtask/tests/fixtures/workflows/valid-required.yml
+++ b/xtask/tests/fixtures/workflows/valid-required.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: required-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 jobs:
   lint:


### PR DESCRIPTION
### Motivation

- Label add/remove events were being treated as generic PR events and could cancel in-progress CI runs, causing a cancellation cascade on label churn.
- Required CI should only auto-cancel on new commits (`synchronize`) so non-code PR events cannot kill active runs.
- The linting policy must enforce this pattern and block required workflows from listening to `labeled`/`unlabeled` PR events.

### Description

- Update workflow concurrency expressions in `.github/workflows/ci.yml`, `.github/workflows/ci-nightly.yml`, and `.github/workflows/perl-version-matrix.yml` to use `cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}` and switch nightly/matrix groups to include `github.event.pull_request.number || github.ref`.
- Tighten `REQUIRED_CANCEL_IN_PROGRESS` in `xtask/src/tasks/workflow_trigger_lint.rs` to the action-aware expression and add `pull_request_has_label_triggers` to fail required workflows that include `labeled`/`unlabeled` in `on.pull_request.types`.
- Add `LABEL_EVENT_CANCELS_PR_RUN` guard to `xtask/src/tasks/workflow_policy_lint.rs` via `pull_request_label_trigger_cancels_pr_run` and `pull_request_has_label_triggers` helpers to reject workflows that listen to label events while using blanket cancellation.
- Update `docs/ci/workflow-trigger-policy.md` and the test fixtures in `xtask/tests/fixtures/workflows/` to reflect the new required concurrency expression.

### Testing

- Ran `cargo xtask fmt` which completed successfully. 
- Ran `cargo check --all-targets -p xtask` which completed successfully. 
- Ran `cargo test -p xtask workflow_trigger_lint -- --nocapture` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f33ca4402c833383d65b1380d3af3d)