### PR TITLE
docs(readme): reframe status metrics around behavior (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,33 @@ Perl has decades of real production code, but editor tooling still struggles wit
 
 ## Status at a glance
 
+These are behavioral and corpus-backed signals, not feature inventory counts. Protocol coverage and full feature catalogs live in the generated status docs.
+
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 31 published crates after the v0.13 collapse |
-| LSP advertised features | 60/60 |
-| LSP protocol / DAP catalog | 119/119 |
+| Published crate surface | 31 crates after the v0.13 collapse |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
-| Project corpus | 100.0% clean (`95/95`) |
+| Project parser corpus | 100.0% clean (`95/95`) |
 | Parser NodeKind coverage | 65/69 |
 | Parser reliability | 0 project-corpus timeouts / 0 panics |
+| Editor UX scenarios | 23 scenario files tracked |
+| First-five-minutes UX workflows | 21 workflows tracked |
+| Issue-regression UX workflows | 13 workflows tracked |
+| Workspace stale-index defects | 0 / 7 tested scenarios |
+| Multi-root workspace tests | 8 / 8 |
 <!-- END: README_STATUS -->
 
-See [project status](docs/project/status/index.md) for generated metrics and current release-readiness notes.
+See [project status](docs/project/status/index.md), [parser status](docs/project/status/parser.md), [workspace status](docs/project/status/workspace.md), and [quality metrics](docs/project/status/quality.md) for generated details.
 
 ## What works
 
-- **Language server**: completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, and workspace symbols.
+- **Editor workflows**: completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, and workspace symbols.
+- **UX testing**: 23 tracked editor UX scenarios, including first-five-minutes flows, issue-regression guards, cross-file navigation, diagnostics-after-edit, workspace churn, and rename.
 - **Parser stack**: native lexer, parser-core, parser facade, corpus ratchets, and tree-sitter integration.
-- **Workspace intelligence**: module resolution, symbol indexing, cross-file navigation, and workspace-aware rename.
+- **Workspace intelligence**: module resolution, symbol indexing, stale-index guards, multi-root workspaces, and workspace-aware rename.
 - **Debug adapter**: breakpoints, stepping, stack frames, variables, evaluate, and launch/attach flows.
 - **Editor support**: VS Code, Open VSX, Neovim, Vim, Emacs, Helix, Zed, Sublime, and any editor with LSP support.
 


### PR DESCRIPTION
### Motivation

- The README front-page emphasized feature/protocol inventory counts (e.g. `60/60`, `119/119`) which do not directly demonstrate real editor behavior, parser reliability, or cross-file workspace correctness.
- The intent is to surface behavioral and corpus-backed signals (parser accuracy, UX harness coverage, workspace index correctness, and release posture) as the primary README evidence.

### Description

- Clarify the README `Status at a glance` header to state these are behavioral/corpus-backed signals and that protocol/feature catalogs live in generated status docs. 
- Remove the front-page `LSP advertised features` and `LSP protocol / DAP catalog` inventory rows and replace them with parser, UX-harness, and workspace-index signals (Ubuntu/CPAN/project parser corpus stats, NodeKind coverage, parser reliability, editor UX scenarios, first-five-minutes workflows, issue-regression workflows, stale-index defects, and multi-root tests). 
- Update the `What works` language to emphasize `Editor workflows` and `UX testing` and adjust workspace intelligence wording to call out `stale-index guards` and `multi-root workspaces`.
- Add links to the generated status pages (`docs/project/status/parser.md`, `docs/project/status/workspace.md`, and `docs/project/status/quality.md`) from the README status callout.

### Testing

- Verification was performed by reviewing the README diff with `git diff -- README.md` to confirm the change is scoped to documentation only and the intended rows/text were updated. 
- The updated README was inspected with `nl -ba README.md | sed -n '20,90p'` to validate the inserted framing sentence and table rows appeared as intended. 
- Repository searches (`rg`) were used to confirm the referenced generated status files exist and contain the detailed evidence; no automated crate tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3618f80a88333a3e466b28f29d0fd)