### PR TITLE
docs(readme): pivot status signals to UX and corpus metrics (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,32 @@ Perl has decades of real production code, but editor tooling still struggles wit
 ## Status at a glance
 
 <!-- BEGIN: README_STATUS -->
+These are behavioral and corpus-backed signals, not feature inventory counts. Protocol coverage and full feature catalogs live in the generated status docs.
+
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.0-alpha` release prep |
 | Published crate surface | 31 published crates after the v0.13 collapse |
-| LSP advertised features | 60/60 |
-| LSP protocol / DAP catalog | 119/119 |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
-| Project corpus | 100.0% clean (`95/95`) |
+| Project parser corpus | 100.0% clean (`95/95`) |
 | Parser NodeKind coverage | 65/69 |
 | Parser reliability | 0 project-corpus timeouts / 0 panics |
+| Editor UX scenarios | 23 scenario files tracked |
+| First-five-minutes UX workflows | 21 workflows tracked |
+| Issue-regression UX workflows | 13 workflows tracked |
+| Workspace stale-index defects | 0 / 7 tested scenarios |
+| Multi-root workspace tests | 8 / 8 |
 <!-- END: README_STATUS -->
 
-See [project status](docs/project/status/index.md) for generated metrics and current release-readiness notes.
+See [project status](docs/project/status/index.md), [parser status](docs/project/status/parser.md), [workspace status](docs/project/status/workspace.md), and [quality metrics](docs/project/status/quality.md) for generated details.
 
 ## What works
 
-- **Language server**: completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, and workspace symbols.
+- **Editor workflows**: completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, and workspace symbols.
+- **UX testing**: 23 tracked editor UX scenarios, including first-five-minutes flows, issue-regression guards, cross-file navigation, diagnostics-after-edit, workspace churn, and rename.
 - **Parser stack**: native lexer, parser-core, parser facade, corpus ratchets, and tree-sitter integration.
-- **Workspace intelligence**: module resolution, symbol indexing, cross-file navigation, and workspace-aware rename.
+- **Workspace intelligence**: module resolution, symbol indexing, stale-index guards, multi-root workspaces, and workspace-aware rename.
 - **Debug adapter**: breakpoints, stepping, stack frames, variables, evaluate, and launch/attach flows.
 - **Editor support**: VS Code, Open VSX, Neovim, Vim, Emacs, Helix, Zed, Sublime, and any editor with LSP support.
 


### PR DESCRIPTION
### Motivation

- The README front-page previously foregrounded protocol and feature-inventory counts that communicate surface completeness rather than editor experience or corpus-backed correctness. 
- The change shifts the top-level signal to behavioral and corpus metrics that better answer “does this parse real Perl and behave well in an editor?”.

### Description

- Added a framing line clarifying the README shows behavioral and corpus-backed signals and that protocol/catalog details live in generated status docs. 
- Removed the explicit front-page `LSP advertised features` and `LSP protocol / DAP catalog` rows and adjusted the parser corpus label to `Project parser corpus`. 
- Added UX and workspace correctness rows to the status table: `Editor UX scenarios`, `First-five-minutes UX workflows`, `Issue-regression UX workflows`, `Workspace stale-index defects`, and `Multi-root workspace tests`. 
- Reworded the “What works” section to emphasize editor workflows, UX testing coverage, and workspace intelligence behavior instead of protocol-surface framing.

### Testing

- Verified recent history with `git log --oneline -20` and located agent guidance with `rg --files -g 'AGENTS.md'`, both completing successfully. 
- Inspected impacted files with `rg -n "Status at a glance|advertised features|protocol"` and reviewed the `README.md` diff with `git diff -- README.md` and `git status --short`, all of which showed the intended docs-only edits. 
- Committed the change with `git commit -m "docs(readme): pivot status signals to UX and corpus metrics (#0000)"` and no code or CI changes were required because this is a documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3618f80a88333a3e466b28f29d0fd)