### PR TITLE
docs(readme): emphasize behavioral status signals (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,33 @@ Perl has decades of real production code, but editor tooling still struggles wit
 
 ## Status at a glance
 
+These are behavioral and corpus-backed signals, not feature inventory counts. Protocol coverage and full feature catalogs live in the generated status docs.
+
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 31 published crates after the v0.13 collapse |
-| LSP advertised features | 60/60 |
-| LSP protocol / DAP catalog | 119/119 |
+| Published crate surface | 31 crates after the v0.13 collapse |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
-| Project corpus | 100.0% clean (`95/95`) |
+| Project parser corpus | 100.0% clean (`95/95`) |
 | Parser NodeKind coverage | 65/69 |
 | Parser reliability | 0 project-corpus timeouts / 0 panics |
+| Editor UX scenarios | 23 scenario files tracked |
+| First-five-minutes UX workflows | 21 workflows tracked |
+| Issue-regression UX workflows | 13 workflows tracked |
+| Workspace stale-index defects | 0 / 7 tested scenarios |
+| Multi-root workspace tests | 8 / 8 |
 <!-- END: README_STATUS -->
 
-See [project status](docs/project/status/index.md) for generated metrics and current release-readiness notes.
+See [project status](docs/project/status/index.md), [parser status](docs/project/status/parser.md), [workspace status](docs/project/status/workspace.md), and [quality metrics](docs/project/status/quality.md) for generated details.
 
 ## What works
 
-- **Language server**: completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, and workspace symbols.
+- **Editor workflows**: completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, and workspace symbols.
+- **UX testing**: 23 tracked editor UX scenarios, including first-five-minutes flows, issue-regression guards, cross-file navigation, diagnostics-after-edit, workspace churn, and rename.
 - **Parser stack**: native lexer, parser-core, parser facade, corpus ratchets, and tree-sitter integration.
-- **Workspace intelligence**: module resolution, symbol indexing, cross-file navigation, and workspace-aware rename.
+- **Workspace intelligence**: module resolution, symbol indexing, stale-index guards, multi-root workspaces, and workspace-aware rename.
 - **Debug adapter**: breakpoints, stepping, stack frames, variables, evaluate, and launch/attach flows.
 - **Editor support**: VS Code, Open VSX, Neovim, Vim, Emacs, Helix, Zed, Sublime, and any editor with LSP support.
 


### PR DESCRIPTION
### Motivation

- The README front-page used feature-inventory counts (e.g. LSP catalog completeness) that do not demonstrate editor behavior or user-facing trust signals.
- The intent is to surface behavioral and corpus-backed metrics (parser accuracy, UX scenarios, workspace correctness) as the primary quick-read signals.

### Description

- Updated `README.md` to prepend a framing line clarifying the status table is "behavioral and corpus-backed signals, not feature inventory counts.".
- Replaced / softened front-page LSP catalog metrics in the status table and added parser, UX scenario, and workspace correctness rows (e.g., editor UX scenarios, first-five-minutes workflows, stale-index and multi-root test signals). 
- Updated the "What works" section to use workflow-centric wording and added an explicit UX-testing scope line. 
- Updated status doc links to point readers to generated `project`, `parser`, `workspace`, and `quality` status pages for full inventories.

### Testing

- No automated tests were necessary because this is a documentation-only change and no code paths were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3618f80a88333a3e466b28f29d0fd)