### PR TITLE
docs(readme): switch status table to behavioral metrics (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,23 @@ Perl has decades of real production code, but editor tooling still struggles wit
 
 ## Status at a glance
 
+These are behavioral and corpus-backed signals, not feature-inventory counts. Protocol coverage and full capability catalogs live in the generated status docs.
+
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 31 published crates after the v0.13 collapse |
-| LSP advertised features | 60/60 |
-| LSP protocol / DAP catalog | 119/119 |
+| Published crate surface | 31 crates after the v0.13 collapse |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
-| Project corpus | 100.0% clean (`95/95`) |
+| Project parser corpus | 100.0% clean (`95/95`) |
 | Parser NodeKind coverage | 65/69 |
 | Parser reliability | 0 project-corpus timeouts / 0 panics |
+| Workspace stale-index defects | 0 / 7 tested scenarios |
+| Multi-root workspace tests | 8 / 8 |
+| Editor UX scenarios | 23 scenario files tracked |
+| First-five-minutes UX workflows | 21 workflows tracked |
+| Issue-regression UX workflows | 13 workflows tracked |
 <!-- END: README_STATUS -->
 
 See [project status](docs/project/status/index.md) for generated metrics and current release-readiness notes.


### PR DESCRIPTION
### Motivation

- Surface behavioral, corpus-backed, and workflow-backed signals on the README front page so readers can answer “Will this feel trustworthy in an editor, on real Perl?” instead of leading with protocol-inventory counts.

### Description

- Replaced the README "Status at a glance" block with a short guiding sentence and the specified trust-focused metric set (release track, published crate surface, Ubuntu system Perl corpus, CPAN top 1000, project parser corpus, NodeKind coverage, parser reliability, workspace stale-index defects, multi-root tests, editor UX scenarios, first-five-minutes workflows, and issue-regression workflows). 
- Removed the front-page protocol-inventory rows (`LSP advertised features` and `LSP protocol / DAP catalog`) and adjusted labels (e.g., `Project corpus` -> `Project parser corpus`).

### Testing

- No crate/build tests were required for this docs-only change.
- Verified the edit with `git diff -- README.md` and inspected the file region with `nl -ba README.md | sed -n '20,60p'`, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365b884688333a5168a705a6c2634)