### PR TITLE
docs(readme): emphasize behavioral status metrics (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,18 +25,23 @@ Perl has decades of real production code, but editor tooling still struggles wit
 
 ## Status at a glance
 
+These are behavioral and corpus-backed signals, not feature-inventory counts. Protocol coverage and full capability catalogs live in the generated status docs.
+
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 31 published crates after the v0.13 collapse |
-| LSP advertised features | 60/60 |
-| LSP protocol / DAP catalog | 119/119 |
+| Published crate surface | 31 crates after the v0.13 collapse |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
-| Project corpus | 100.0% clean (`95/95`) |
+| Project parser corpus | 100.0% clean (`95/95`) |
 | Parser NodeKind coverage | 65/69 |
 | Parser reliability | 0 project-corpus timeouts / 0 panics |
+| Workspace stale-index defects | 0 / 7 tested scenarios |
+| Multi-root workspace tests | 8 / 8 |
+| Editor UX scenarios | 23 scenario files tracked |
+| First-five-minutes UX workflows | 21 workflows tracked |
+| Issue-regression UX workflows | 13 workflows tracked |
 <!-- END: README_STATUS -->
 
 See [project status](docs/project/status/index.md) for generated metrics and current release-readiness notes.


### PR DESCRIPTION
### Motivation

- The README previously highlighted protocol-inventory counts in the top-line status table which obscures the practical signals editors and users care about when evaluating real-world trustworthiness.
- The change surfaces behavioral, corpus-backed, and workflow-backed metrics so the front page answers “Will this feel trustworthy in an editor, on real Perl?” rather than listing protocol coverage.

### Description

- Added an explanatory lead sentence above the status table: "These are behavioral and corpus-backed signals, not feature-inventory counts...".
- Removed the protocol-inventory headline rows and replaced them with trust-oriented signals including workspace and UX workflow metrics (`Workspace stale-index defects`, `Multi-root workspace tests`, `Editor UX scenarios`, `First-five-minutes UX workflows`, `Issue-regression UX workflows`).
- Adjusted phrasing for a few rows (e.g., `Published crate surface` -> "31 crates after the v0.13 collapse" and `Project parser corpus` label) and left the rest of the corpus/reliability metrics intact.
- This is a documentation-only change limited to `README.md` in the `Status at a glance` block.

### Testing

- Documentation-only change; no crate/unit tests were required or run for this edit.
- Verified the file edit and diff with `git diff -- README.md` which succeeded.
- Confirmed the updated section rendering and line ranges with `nl -ba README.md | sed -n '20,70p'` which succeeded.
- Committed the change with `git commit` which produced a successful commit entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365b884688333a5168a705a6c2634)