### PR TITLE
docs(release): align rc1 changelog and notes (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0-rc1] - 2026-04-30
+
+Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md)
+
 ### Fixed
 
 - **First-run error messaging now surfaces to users instead of silent logging** — When
@@ -1240,4 +1244,5 @@ For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HIS
 [0.9.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.1
 [0.9.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.0
 [0.8.8]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.8.8
-[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...HEAD
+[0.13.0-rc1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1
+[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md)
 
 ### Fixed
 
+- **CI cancellation cascade fix — label events no longer cancel active runs** —
+  `cancel-in-progress` now scopes to `pull_request.synchronize` only, so applying
+  labels (e.g. `merge-ready`, `ci-green`) does not abort an in-flight CI run on
+  the same PR. Adds a `LABEL_EVENT_CANCELS_PR_RUN` xtask lint to prevent the
+  failure mode from re-entering. Resolves a recurring queue-blocker that
+  surfaced as `exit 143` SIGTERM aborts on PR Smoke and CI Gate. (#7581)
+
 - **First-run error messaging now surfaces to users instead of silent logging** — When
   workspace root is not detected (e.g., opening a single file without opening a folder),
   perl-lsp now sends a `window/showMessage` notification with actionable guidance:

--- a/docs/releases/v0.13.0-rc1.md
+++ b/docs/releases/v0.13.0-rc1.md
@@ -1,0 +1,41 @@
+---
+version: "0.13.0-rc1"
+tag: "v0.13.0-rc1"
+release_date_utc: "2026-04-30"
+previous_tag: "v0.12.4"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1"
+notes_status: canonical
+channels:
+  crates_io: pending
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: pending
+  docker: pending
+---
+
+# v0.13.0-rc1
+
+## Summary
+
+Release candidate that finalizes CI cancellation hardening and prepares the
+0.13.0 train for stable cut after one full green rehearsal.
+
+## Highlights
+
+- **CI cancellation cascade fix landed** — label events no longer cancel active
+  runs; cancellation now targets pull request synchronize updates only.
+- **Version staging alignment** — workspace and feature metadata remain on
+  `0.13.0-rc1`, with extension and changelog surfaces aligned for RC publish.
+- **Microcrate collapse migration continuity** — includes the migration guidance
+  and release-prep groundwork already staged in this train.
+
+## Install / upgrade
+
+- **VS Code**: install or update the [Perl Language Server](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) extension.
+- **Source/Binary**: consume this tag through the normal release orchestration
+  channels after assets are published.
+
+## Links
+
+- [Compare v0.12.4...v0.13.0-rc1](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.12.4",
+  "version": "0.13.0-rc1",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
### Motivation
- The repository was partially staged for `0.13.0-rc1` but release surfaces were inconsistent, leaving the VS Code extension and canonical release notes out of sync with workspace metadata. 
- This created a blocker for performing an RC publish rehearsal and for generating canonical release artifacts required by the release checklist.

### Description
- Bumped the VS Code extension version in `vscode-extension/package.json` from `0.12.4` to `0.13.0-rc1` to match workspace and feature metadata. 
- Promoted the existing Unreleased entries into a dated `## [0.13.0-rc1] - 2026-04-30` section in `CHANGELOG.md` and updated the compare link references. 
- Added canonical release notes file `docs/releases/v0.13.0-rc1.md` containing front matter and an RC summary/highlights/links. 
- Committed the changes as `docs(release): align rc1 changelog and notes (#0000)` and opened the PR.

### Testing
- Verified workspace diff with `git status --short` and ensured there are no stray `.snap.new` files (check passed). 
- Attempted to run `just version-check` and `just release-check`, but both commands could not run because `just` is not installed in the execution environment. 
- Ran `cargo xtask release-notes --tag v0.13.0-rc1`; the xtask started and compiled workspace crates in this environment (run produced build output but was non-interactively capped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365bfc8b083338658eff353c2b7a1)