### PR TITLE
docs(release): stage v0.13.0-rc1 notes and version sync (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0-rc1] - 2026-04-30
+
+Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md)
+
 ### Fixed
 
 - **First-run error messaging now surfaces to users instead of silent logging** — When
@@ -1230,6 +1234,7 @@ During the alpha phase (pre-v0.15.0):
 For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HISTORY.md).
 
 <!-- Compare ranges -->
+[0.13.0-rc1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1
 [0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2
@@ -1240,4 +1245,4 @@ For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HIS
 [0.9.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.1
 [0.9.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.0
 [0.8.8]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.8.8
-[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...HEAD
+[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...HEAD

--- a/docs/releases/v0.13.0-rc1.md
+++ b/docs/releases/v0.13.0-rc1.md
@@ -1,0 +1,45 @@
+---
+version: "0.13.0-rc1"
+tag: "v0.13.0-rc1"
+release_date_utc: "2026-04-30"
+tag_commit: "TBD"
+previous_tag: "v0.12.4"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0-rc1"
+notes_status: canonical
+channels:
+  crates_io: pending
+  vscode_marketplace: pending
+  open_vsx: pending
+  docker: pending
+assets: []
+---
+
+# v0.13.0-rc1
+
+## Summary
+
+Release candidate for the v0.13 line. This RC packages the microcrate collapse,
+CI hardening updates, parser/semantic correctness improvements, and release
+orchestration tightening that landed since v0.12.4.
+
+## Highlights
+
+- **CI cancellation hardening** — pull-request label events no longer cancel
+  in-flight checks; only `synchronize` events trigger cancel-in-progress.
+- **Microcrate collapse completion** — v0.13 migration guide and crate-structure
+  consolidation are staged for RC validation.
+- **Release process hardening** — staged version synchronization and release
+  quality gates tightened ahead of stable promotion.
+
+## Validation focus
+
+- Confirm default-branch CI remains green after cancellation-policy change.
+- Validate extension/runtime version sync for `0.13.0-rc1`.
+- Exercise release orchestration workflow with all channels enabled.
+
+## Links
+
+- [Compare v0.12.4...v0.13.0-rc1](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release punch list](./0.13.0-rc1-punch-list.md)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.12.4",
+  "version": "0.13.0-rc1",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
### Motivation

- Remove release-surface drift where workspace and feature metadata were staged for `0.13.0-rc1` while the VS Code extension stayed at `0.12.4`, and provide canonical release notes for the RC.

### Description

- Bumped the VS Code extension version in `vscode-extension/package.json` to `0.13.0-rc1` to match workspace metadata.
- Added canonical release notes file `docs/releases/v0.13.0-rc1.md` with frontmatter, summary, highlights, and validation focus.
- Promoted the RC section in `CHANGELOG.md` by inserting `## [0.13.0-rc1] - 2026-04-30` and updating compare-link footers to reference the RC.

### Testing

- Ran `cargo xtask release-notes --tag v0.13.0-rc1` which completed successfully and produced the RC notes output.
- Verified there are no stale snapshot files with `git status --short | grep '\.snap\.new' && exit 1 || true` which returned clean.
- Attempted `just version-check` but it could not run in this environment because `just` is not installed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365bfc8b083338658eff353c2b7a1)