### PR TITLE
chore(release): sync 0.13.0-rc1 metadata surfaces (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0-rc1] - 2026-04-30
+
+Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0-rc1)
+
 ### Fixed
 
 - **First-run error messaging now surfaces to users instead of silent logging** — When
@@ -1230,6 +1234,7 @@ During the alpha phase (pre-v0.15.0):
 For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HISTORY.md).
 
 <!-- Compare ranges -->
+[0.13.0-rc1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1
 [0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2
@@ -1240,4 +1245,4 @@ For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HIS
 [0.9.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.1
 [0.9.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.0
 [0.8.8]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.8.8
-[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...HEAD
+[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...HEAD

--- a/docs/releases/v0.13.0-rc1.md
+++ b/docs/releases/v0.13.0-rc1.md
@@ -1,0 +1,73 @@
+---
+version: "0.13.0-rc1"
+tag: "v0.13.0-rc1"
+release_date_utc: "2026-04-30"
+tag_commit: "5ebb37aad3ebedec59fb8626a5d82f6878199f7b"
+previous_tag: "v0.12.4"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0-rc1"
+notes_status: canonical
+channels:
+  crates_io: deferred
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: pending
+  docker: pending
+assets:
+  - perllsp-0.13.0-rc1-aarch64-apple-darwin.tar.gz
+  - perllsp-0.13.0-rc1-aarch64-unknown-linux-gnu.tar.gz
+  - perllsp-0.13.0-rc1-aarch64-unknown-linux-musl.tar.gz
+  - perllsp-0.13.0-rc1-x86_64-apple-darwin.tar.gz
+  - perllsp-0.13.0-rc1-x86_64-pc-windows-msvc.zip
+  - perllsp-0.13.0-rc1-x86_64-unknown-linux-gnu.tar.gz
+  - perllsp-0.13.0-rc1-x86_64-unknown-linux-musl.tar.gz
+  - sbom-spdx.json
+  - SHA256SUMS
+---
+
+# v0.13.0-rc1
+
+## Summary
+
+Major patch release shipping inherited/role method navigation, pragma tracker
+correctness sweep, incremental parsing improvements, workspace file-operations
+refactoring, `workspace/configuration` reverse-request flow, Windows
+extended-length path fixes, and Perl::Critic diagnostics UX overhaul.
+
+~70 PRs merged across two sessions covering navigation, pragma scoping,
+incremental parsing, workspace refactoring, Windows hardening, diagnostics
+polish, hover improvements, completion ranking, and CI hygiene.
+
+## Highlights
+
+- **Inherited and role method navigation** — `goto-definition`, hover, and
+  workspace completion BFS through Moo/Moose `with 'Role'` and
+  `extends`/`use parent` chains. AUTOLOAD-backed method calls resolve through
+  the fallback path.
+- **Pragma tracker correctness sweep** — four independent false-negative paths
+  in `PragmaTracker` / `check_strict_warnings` fixed.
+- **Incremental parsing** — segment-based token cache with two-sided checkpoint
+  window replaces monolithic `TokenCache`.
+- **Workspace file-operations** — `workspace/willRenameFiles` plans edits across
+  unopened files; `workspace/willDeleteFiles` emits warnings for cross-file
+  reference breakage.
+- **`workspace/configuration` reverse-request** — server issues
+  `workspace/configuration` requests per folder when the client advertises the
+  capability.
+- **Windows extended-length path fix** — strips `\\?\` prefix before spawning
+  external commands (`perl.exe`, `prove`, `yath`).
+- **Perl::Critic diagnostics UX** — policy codes carry `source: "perlcritic"`,
+  missing binary and invalid profiles surface as workspace warnings.
+
+## Install / upgrade
+
+- **VS Code**: install or update the [Perl Language Server](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) extension.
+- **Binary**: download from [GitHub Release assets](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0-rc1). Verify with `SHA256SUMS`.
+- **Source**: `cargo install perllsp` (once crates.io publish completes).
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0-rc1)
+- [Compare v0.12.4...v0.13.0-rc1](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1)
+- [Tag commit](https://github.com/EffortlessMetrics/perl-lsp/commit/5ebb37aad3ebedec59fb8626a5d82f6878199f7b)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.12.4",
+  "version": "0.13.0-rc1",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
### Motivation

- Workspace and feature metadata were already staged for `0.13.0-rc1` while the VS Code extension, changelog release section, and canonical release notes were still inconsistent, blocking a clean RC rehearsal.
- The change centralizes release surfaces so the repository reports a single targeted RC version and enables the release preflight checks to operate on a consistent tree.

### Description

- Bumped `vscode-extension/package.json` `version` to `0.13.0-rc1` to match workspace staging.
- Promoted Unreleased changelog content into a dated `## [0.13.0-rc1] - 2026-04-30` section and updated compare/link references in `CHANGELOG.md`.
- Added canonical release notes file `docs/releases/v0.13.0-rc1.md` with updated RC metadata and links.
- Updated release-note metadata (compare range, release date, tag) in the new docs file to reflect the RC target.

### Testing

- Ran `./scripts/cargo-safe xtask fmt` which completed successfully.
- Ran `./scripts/cargo-safe xtask release-notes --tag v0.13.0-rc1` which completed successfully and generated the release notes content.
- Attempted `just version-check` in this environment but `just` is not available so that check was not run here (environment constraint).
- Verified the workspace contains no `.snap.new` snapshot files so there are no stale snapshot artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365bfc8b083338658eff353c2b7a1)