### PR TITLE
chore(release): align extension rc version metadata (#0000)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.12.4",
+  "version": "0.13.0-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.12.4",
+      "version": "0.13.0-rc1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.17",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.12.4",
+  "version": "0.13.0-rc1",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",
@@ -1020,7 +1020,7 @@
           {
             "id": "configure-settings",
             "title": "Configure Settings",
-            "description": "Two ways to configure Perl LSP:\n\n**Editor settings** (personal, not committed) \u2014 open `Settings` and search for `perl-lsp`. Set `perl-lsp.includePaths` if you see _Can't locate Foo/Bar.pm_ errors. Use `perl-lsp.perlcritic.enabled` and `perl-lsp.perlcritic.severity` for quick local Perl::Critic tuning, or run the `Perl: Run PerlCritic` / `Perl: Set PerlCritic Severity` commands from the palette. [Open Perl LSP Settings](command:perl-lsp.openConfigurationGuide)\n\n**`.perl-lsp.toml`** (team-wide, committed to your repo) \u2014 place this file in your project root, next to `.git/`. Key settings:\n- `[perl] include_paths = [\"lib\", \"local/lib/perl5\"]` \u2014 module search paths\n- `[diagnostics] perlcritic = true` \u2014 enable Perl::Critic linting (requires `perlcritic` on PATH)\n- `[features] inlay_hints = true` \u2014 toggle inlay hints\n\nCopy `.perl-lsp.toml.example` from the repo root to get started. Editor settings always override `.perl-lsp.toml`.",
+            "description": "Two ways to configure Perl LSP:\n\n**Editor settings** (personal, not committed) — open `Settings` and search for `perl-lsp`. Set `perl-lsp.includePaths` if you see _Can't locate Foo/Bar.pm_ errors. Use `perl-lsp.perlcritic.enabled` and `perl-lsp.perlcritic.severity` for quick local Perl::Critic tuning, or run the `Perl: Run PerlCritic` / `Perl: Set PerlCritic Severity` commands from the palette. [Open Perl LSP Settings](command:perl-lsp.openConfigurationGuide)\n\n**`.perl-lsp.toml`** (team-wide, committed to your repo) — place this file in your project root, next to `.git/`. Key settings:\n- `[perl] include_paths = [\"lib\", \"local/lib/perl5\"]` — module search paths\n- `[diagnostics] perlcritic = true` — enable Perl::Critic linting (requires `perlcritic` on PATH)\n- `[features] inlay_hints = true` — toggle inlay hints\n\nCopy `.perl-lsp.toml.example` from the repo root to get started. Editor settings always override `.perl-lsp.toml`.",
             "media": {
               "image": "media/walkthrough/configure-settings.svg",
               "altText": "Configure Settings"


### PR DESCRIPTION
### Motivation
- Align the VS Code extension metadata with the workspace-staged release (0.13.0-rc1) to remove version drift and satisfy release preflight checks.

### Description
- Updated `vscode-extension/package.json` and `vscode-extension/package-lock.json` version fields from `0.12.4` to `0.13.0-rc1` and committed the change as `chore(release): align extension rc version metadata (#0000)`.

### Testing
- Ran `cargo xtask check-version-sync` which reported all sites agree on `0.13.0-rc1` and exited successfully; `just version-check` was not available in this environment but the xtask check validates version sync.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f365bfc8b083338658eff353c2b7a1)