### PR TITLE
docs(ci): codify next-wave execution plan (#0000)

### DIFF
--- a/docs/project/CI_WAVE_EXECUTION_PLAN.md
+++ b/docs/project/CI_WAVE_EXECUTION_PLAN.md
@@ -1,0 +1,60 @@
+# CI Wave Execution Plan (Post-Substrate)
+
+This plan captures the **next independent implementation slices** after the substrate already merged in #7449, #7525, #7547, #7561, #7568, and #7569.
+
+## Why this exists
+
+The control-plane failure mode is no longer "missing infrastructure". The open risks are:
+
+1. long-running status regeneration that can look idle to GitHub Actions (#7404), and
+2. queue/projection logic making decisions without enough evidence.
+
+This plan keeps each lane reviewable, testable, and independently mergeable.
+
+## Landed substrate (do not redo)
+
+- Per-gate timeout receipt coverage exists.
+- Bounded build-plane storage contract exists (`cargo-safe`, `storage-doctor`, agent profile).
+- UX receipt command registration and artifact upload are already wired.
+- PR-fast planner matrix tests already cover widening/selection cases.
+- Tokmd is intentionally advisory, not merge-blocking.
+
+## Seven independent lanes (merge in this order)
+
+1. **Update-status streaming (urgent)**  
+   Fix `cargo xtask update-status --write` inactivity by streaming progress and naming subsystem failures with repro commands.
+2. **CI trigger regression lint**  
+   Keep label-trigger + cancel-in-progress regressions from re-entering merge-critical workflows.
+3. **Expected-skip / stale-check normalizer**  
+   Normalize checks into `passed|failed|pending|expected_skip|unexpected_skip|stale` for reconciler consumption.
+4. **Review receipt → label projection**  
+   Reconciler projects labels from current-SHA review receipts, repairs contradictory labels, and ignores stale receipts.
+5. **PR disposition receipt / closure guard**  
+   Require machine-readable evidence before duplicate/superseded/absorbed/extracted closure decisions.
+6. **Merge-train planner / receipt**  
+   Add train-level pre-merge verification protocol and receipt output; stop on stale/conflict/red/unsafe-skip.
+7. **Tokmd advisory stabilization**  
+   Keep tokmd useful and diagnosable while remaining non-required.
+
+## Lane-level definition of done
+
+Every lane should satisfy all of the following:
+
+- One concern per PR, with focused tests.
+- No workflow timeout-only workaround for #7404 (must stream progress).
+- No "all skips are green" and no "all skips are red" shortcuts.
+- No bulk stale/age closure logic without structured evidence links.
+- No CI weakening and no required-check policy broadening unless explicitly scoped.
+
+## Reviewability contract
+
+For each lane PR:
+
+- Include exact reproduction commands in failure paths and/or docs.
+- Include fixtures/tests for the new decision surface.
+- Keep advisory systems advisory unless a separate policy PR changes required checks.
+- Prefer extending existing receipt/schema/normalization seams over introducing a parallel framework.
+
+## Operator note
+
+When spawning parallel agents, ensure each lane starts from current `master` and does not depend on sibling PRs.

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -112,6 +112,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Workspace-wide rename slice: multi-root support shipped in 0.12.x (#3984); workspace-wide rename/module-move remains roughly 30% complete and only conditionally in scope pending #3522 verification
 - Coroutine support issue #3539 is re-scoped: defer hypothetical core syntax, split upstream-tracking from CPAN-library IDE support planning
 - Semantic substrate migration status now tracks Wave 2 reality (facts vocabulary, SymbolDecl adapter, FileFactShard write-through, and DefinitionCandidate multimap landed; SymbolRef adapter and typed-reference global index still staged; ExportInfo -> ExportSet landed) in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md); provider cutover remains explicitly deferred until Wave 3 foundations (`ImportSpec` + `visible_symbols_at`) are proven
+- CI/control-plane next-wave execution sequencing is tracked in [CI_WAVE_EXECUTION_PLAN.md](CI_WAVE_EXECUTION_PLAN.md), with #7404 (`update-status --write` streaming) as the top urgency lane.
 
 ### Next (v0.13.0 — public alpha announcement)
 


### PR DESCRIPTION
### Motivation

- Provide a single, reviewable plan for the post-substrate CI/control-plane wave so parallel agents avoid redoing landed work and prioritize remaining risks (notably #7404: `update-status --write` inactivity).

### Description

- Add `docs/project/CI_WAVE_EXECUTION_PLAN.md` listing seven independent lanes, recommended merge order, lane-level done criteria, and a reviewability contract.
- Link the new plan from the roadmap `Now` section by adding a single-line reference to `docs/project/ROADMAP.md` so the plan is discoverable from project planning docs.
- Keep the change focused to documentation only and preserve existing implementation and receipt seams for later lanes.

### Testing

- Ran the formatting/validation driver `./scripts/cargo-safe xtask fmt`, which began a cold toolchain/dependency build in this environment but did not complete within the session window (format check therefore inconclusive).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36fb5d9a483338693837377bee002)