### PR TITLE
ci(tokmd): switch to advisory review cockpit workflow (#0000)

### DIFF
--- a/.ci/policies/required-checks.toml
+++ b/.ci/policies/required-checks.toml
@@ -17,7 +17,7 @@ workflow = ".github/workflows/methodology-gate.yml"
 required = false
 
 [[checks]]
-name = "tokmd Advisory"
+name = "tokmd PR Review"
 workflow = ".github/workflows/tokmd.yml"
 # Phase 1: advisory-only (visibility gate, no merge blocking).
 # Promotion to required = true tracked in #4993 (Phase 2/3).

--- a/.ci/policies/tokmd-cockpit.toml
+++ b/.ci/policies/tokmd-cockpit.toml
@@ -1,0 +1,49 @@
+fail_fast = false
+allow_missing = false
+
+[[rules]]
+name = "review_plan_exists"
+pointer = "/review_plan/0/path"
+op = "exists"
+level = "warn"
+message = "No cockpit review plan was generated. This may be docs/config-only, or review-plan generation needs tuning."
+
+[[rules]]
+name = "risk_not_critical"
+pointer = "/risk/score"
+op = "lte"
+value = 89
+level = "warn"
+message = "Critical-risk PR. Review P1 cockpit items before merge."
+
+[[rules]]
+name = "health_at_least_c"
+pointer = "/code_health/score"
+op = "gte"
+value = 60
+level = "warn"
+message = "Low code-health score. Inspect code health warnings and priority review items."
+
+[[rules]]
+name = "large_files_visible"
+pointer = "/code_health/large_files_touched"
+op = "lte"
+value = 0
+level = "warn"
+message = "Large changed files detected. Review cockpit Code Health section."
+
+[[rules]]
+name = "breaking_indicators_visible"
+pointer = "/contracts/breaking_indicators"
+op = "lte"
+value = 0
+level = "warn"
+message = "Breaking-change indicators detected. Review cockpit Contracts section."
+
+[[rules]]
+name = "evidence_not_failed"
+pointer = "/evidence/overall_status"
+op = "ne"
+value = "fail"
+level = "warn"
+message = "Cockpit evidence status is fail. Review evidence gates before merge."

--- a/.github/workflows/tokmd.yml
+++ b/.github/workflows/tokmd.yml
@@ -1,4 +1,4 @@
-name: tokmd
+name: tokmd PR Review
 
 on:
   pull_request:
@@ -15,8 +15,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  tokmd:
-    name: tokmd Receipt and Gate
+  review:
+    name: tokmd Review Cockpit
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
@@ -26,80 +26,229 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate tokmd PR sensor comment
-        id: sensor
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
-        with:
-          version: '1.10.0'
-          mode: sensor
-          head: HEAD
-          artifact: 'false'
-          comment: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
+      - name: Install tokmd
+        shell: bash
+        run: |
+          set -euo pipefail
 
-      - name: Generate tokmd repository receipt
-        id: receipt
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
-        with:
-          version: '1.10.0'
-          paths: |
-            crates
-            xtask
-            docs
-            book/src
-            scripts
-            .github/workflows
-            .ci/policies
-          module-roots: 'crates,xtask,docs,book,scripts'
-          top: '30'
-          format: 'json'
-          artifact: 'false'
-          comment: 'false'
+          version="1.10.0"
+          asset="tokmd-linux-amd64"
+          url="https://github.com/EffortlessMetrics/tokmd/releases/download/v${version}/${asset}"
+          sums="https://github.com/EffortlessMetrics/tokmd/releases/download/v${version}/checksums.txt"
 
-      - name: Run tokmd advisory gate
-        id: gate
-        uses: EffortlessMetrics/tokmd@01f19c1c3a8a6b2ef498f52d424870dda4b98827
-        with:
-          version: '1.10.0'
-          mode: gate
-          paths: .
-          artifact: 'false'
-          comment: 'false'
+          curl -fsSL "$url" -o "$asset"
+          curl -fsSL "$sums" -o checksums.txt
 
-      - name: Upload tokmd artifacts
+          expected="$(grep -E "^[a-f0-9]+[[:space:]]+\\*?${asset}$" checksums.txt | awk '{print $1}')"
+          actual="$(sha256sum "$asset" | awk '{print $1}')"
+
+          if [ -z "$expected" ]; then
+            echo "::error::Checksum for ${asset} not found"
+            exit 1
+          fi
+
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::tokmd checksum mismatch"
+            echo "expected=$expected"
+            echo "actual=$actual"
+            exit 1
+          fi
+
+          install -m 0755 "$asset" /usr/local/bin/tokmd
+          tokmd --version
+
+      - name: Generate cockpit review
+        id: cockpit
+        shell: bash
+        run: |
+          set +e
+          mkdir -p .tokmd/cockpit
+
+          git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+          tokmd cockpit \
+            --base "origin/${{ github.base_ref }}" \
+            --head HEAD \
+            --diff-range three-dot \
+            --format md \
+            --output .tokmd/cockpit/review.md \
+            --artifacts-dir .tokmd/cockpit
+
+          status=$?
+
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "## tokmd Review Cockpit"
+              echo
+              echo "tokmd cockpit could not generate a review for this PR."
+              echo
+              echo "- Status: \`$status\`"
+              echo "- This workflow is advisory and did not fail the PR."
+            } > .tokmd/cockpit/comment.md
+
+            echo "::warning::tokmd cockpit failed with status $status"
+          fi
+
+          exit 0
+
+      - name: Generate risk, complexity, and duplication analysis
+        shell: bash
+        run: |
+          set +e
+          mkdir -p .tokmd/analysis
+
+          tokmd analyze . \
+            --preset risk \
+            --format json \
+            --git \
+            --detail-functions \
+            --near-dup \
+            --near-dup-threshold 0.86 \
+            --near-dup-scope module \
+            --near-dup-max-files 2000 \
+            --near-dup-max-pairs 2000 \
+            --output-dir .tokmd/analysis
+
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::tokmd risk/duplication analysis failed with status $status"
+            echo "{\"status\":\"failed\",\"exit_code\":$status}" > .tokmd/analysis/status.json
+          fi
+
+          exit 0
+
+      - name: Run advisory cockpit policy
+        shell: bash
+        run: |
+          set +e
+          mkdir -p .tokmd/gate
+
+          if [ -f .tokmd/cockpit/cockpit.json ] && [ -f .ci/policies/tokmd-cockpit.toml ]; then
+            tokmd gate .tokmd/cockpit/cockpit.json \
+              --policy .ci/policies/tokmd-cockpit.toml \
+              --format json \
+              > .tokmd/gate/cockpit-gate.json
+
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              echo "::warning::tokmd advisory cockpit policy reported findings"
+            fi
+          else
+            echo "::notice::Skipping tokmd advisory policy; cockpit receipt or policy file not found"
+            echo "{\"status\":\"skipped\"}" > .tokmd/gate/cockpit-gate.json
+          fi
+
+          exit 0
+
+      - name: Add agent handoff section
         if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: tokmd-${{ github.run_id }}
-          path: |
-            tokmd-*.json
-            tokmd-*.jsonl
-            tokmd-*.md
-            comment.md
-            extras/**
-          if-no-files-found: warn
-          retention-days: 14
+        shell: bash
+        run: |
+          mkdir -p .tokmd/cockpit
 
-      - name: Add tokmd summary to workflow run
+          comment=".tokmd/cockpit/comment.md"
+          if [ ! -f "$comment" ]; then
+            if [ -f .tokmd/cockpit/review.md ]; then
+              cp .tokmd/cockpit/review.md "$comment"
+            else
+              echo "## tokmd Review Cockpit" > "$comment"
+              echo >> "$comment"
+              echo "No tokmd review was generated." >> "$comment"
+            fi
+          fi
+
+          {
+            echo
+            echo "### Agent handoff"
+            echo
+            echo "Machine-readable artifacts are attached to this workflow run:"
+            echo
+            echo "- \`.tokmd/cockpit/cockpit.json\` — PR review receipt"
+            echo "- \`.tokmd/cockpit/review.md\` — full human review surface"
+            echo "- \`.tokmd/analysis/\` — risk, complexity, and near-duplicate analysis"
+            echo "- \`.tokmd/gate/cockpit-gate.json\` — advisory policy findings"
+            echo
+            echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } >> "$comment"
+
+      - name: Write workflow summary
         if: always()
         shell: bash
         run: |
           {
-            echo "## tokmd"
+            echo "## tokmd Review Cockpit"
             echo
-            if [ -f comment.md ]; then
-              cat comment.md
-            elif [ -f tokmd-summary.md ]; then
-              cat tokmd-summary.md
+            if [ -f .tokmd/cockpit/review.md ]; then
+              cat .tokmd/cockpit/review.md
+            elif [ -f .tokmd/cockpit/comment.md ]; then
+              cat .tokmd/cockpit/comment.md
             else
-              echo "tokmd completed, but no Markdown summary was produced."
+              echo "No tokmd cockpit output was produced."
             fi
-            echo
-            if [ -f tokmd-gate-verdict.json ]; then
-              echo "### Gate verdict"
+
+            if [ -f .tokmd/gate/cockpit-gate.json ]; then
+              echo
+              echo "## Advisory cockpit policy"
               echo
               echo '```json'
-              cat tokmd-gate-verdict.json
+              cat .tokmd/gate/cockpit-gate.json
               echo
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+
+            const marker = '<!-- tokmd-review-cockpit -->';
+            const path = '.tokmd/cockpit/comment.md';
+
+            if (!fs.existsSync(path)) {
+              core.warning(`No tokmd comment file found at ${path}`);
+              return;
+            }
+
+            const body = `${marker}\n${fs.readFileSync(path, 'utf8')}`;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.data.find(comment =>
+              comment.body && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Upload tokmd review artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tokmd-review-${{ github.run_id }}
+          path: .tokmd/
+          if-no-files-found: warn
+          retention-days: 14

--- a/tokmd.toml
+++ b/tokmd.toml
@@ -18,38 +18,3 @@ exclude = [
 [module]
 roots = ["crates", "xtask", "docs", "book", "scripts"]
 depth = 2
-
-[gate]
-# Phase 1: advisory-only. fail_fast = false means the gate collects all rule
-# violations before exiting rather than stopping at the first failure.
-# Merge non-blocking: tokmd Advisory has no required = true in required-checks.toml,
-# so a gate exit 1 does not prevent merge. Promotion roadmap and baseline
-# acceptance criteria tracked in #4993 (Phase 2/3).
-# SHA pinning: locked to v1.10.0 commit SHA (01f19c1c...) as accepted Phase 1
-# tech debt. Refresh cadence: update SHA when a tokmd release contains a rule
-# or config change relevant to perl-lsp. No automated tracking; manual review.
-fail_fast = false
-
-[[gate.rules]]
-name = "receipt_has_files"
-pointer = "/derived/totals/files"
-op = "gte"
-value = 1
-level = "error"
-message = "tokmd did not find any files; check workflow checkout, paths, or ignore rules."
-
-[[gate.rules]]
-name = "token_budget_visibility"
-pointer = "/derived/totals/tokens"
-op = "lte"
-value = 20000000
-level = "warn"
-message = "Repository token estimate exceeded 20M; inspect tokmd artifacts before tightening gates."
-
-[[gate.rules]]
-name = "doc_density_visibility"
-pointer = "/derived/doc_density/total/ratio"
-op = "gte"
-value = 0.02
-level = "warn"
-message = "Documentation density is below the initial visibility floor; do not make this blocking until a baseline is accepted."


### PR DESCRIPTION
### Motivation

- The previous tokmd job combined receipt and a `gate` mode that could cause advisory findings to fail CI and churn PR queues. 
- The intent is to make tokmd a non-failing review helper that comments a concise review cockpit and provides machine-readable artifacts for agents. 
- Gate rules that apply at repo scale should not live in `tokmd.toml` because accidental `tokmd gate .` runs produce noisy red checks. 

### Description

- Replaced `.github/workflows/tokmd.yml` with a `tokmd PR Review` workflow that installs and checksum-verifies `tokmd`, runs `tokmd cockpit` to produce Markdown review and artifacts, runs `tokmd analyze` for risk/duplication outputs, evaluates an advisory policy against the cockpit JSON, and never fails the job for advisory findings. 
- The workflow posts/updates a single PR comment using the marker `<!-- tokmd-review-cockpit -->` and uploads `.tokmd/` as artifacts. 
- Removed the repo-level `[gate]` and `[[gate.rules]]` from `tokmd.toml`, leaving only `scan` and `module` configuration. 
- Added a cockpit-specific advisory policy at `.ci/policies/tokmd-cockpit.toml` and updated `.ci/policies/required-checks.toml` to reference the new `tokmd PR Review` check name. 

### Testing

- Ran `cargo xtask workflow-policy-lint --receipt target/receipts/workflow-policy.json`, which wrote a receipt and reported the policy lint passed (0 error(s), 2 warning(s)).
- Ran `cargo xtask workflow-trigger-lint --policy .ci/policies/required-checks.toml --receipt target/receipts/workflow-trigger-lint.json --format json`, which completed with `overall_ok: true` and no violations. 
- Manual end-to-end verification on GitHub (open test PR to confirm comment/artifacts) is recommended but was not executed in this local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36fe9ccb0833399a7976cdb7edbc8)