### PR TITLE
fix(gates): emit begin/end gate lifecycle markers (#0000)

### DIFF
--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1221,12 +1221,26 @@ fn run_gate_plan(
 
     for (idx, planned_gate) in plan.selected.iter().enumerate() {
         let gate = &planned_gate.gate;
+        println!(
+            "BEGIN gate={} timeout={}s command={}",
+            gate.name,
+            gate.timeout_seconds,
+            gate.command.trim()
+        );
         if let Some(ref pb) = spinner {
             pb.set_position(idx as u64);
             pb.set_message(format!("Running {}...", gate.name));
         }
 
         let result = run_single_gate(gate, policy, &log_dir, config)?;
+        let exit_code = result
+            .exit_code
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "none".to_string());
+        println!(
+            "END gate={} status={} exit={} duration_ms={}",
+            result.gate_name, result.status, exit_code, result.duration_ms
+        );
 
         // Update tier summary
         let tier_summary = tier_summaries.entry(gate.tier.clone()).or_default();


### PR DESCRIPTION
### Motivation
- Merge-gate runs could be terminated (signal 15 / exit 143) without naming the active gate or emitting traceable lifecycle metadata, making CI interruptions hard to attribute and investigate.

### Description
- Add unconditional lifecycle log lines in `run_gate_plan` that print `BEGIN gate=<name> timeout=<seconds>s command=<command>` before each gate and `END gate=<name> status=<status> exit=<exit_code|none> duration_ms=<ms>` after each gate to improve CI traceability.

### Testing
- Attempted to run the focused test `./scripts/cargo-safe test -p xtask --profile agent --locked gates::required_gate_timeout_reports_receipt_fields_and_blocks_overall_status`, but execution was blocked by the environment storage guardrail (`DENY: /root/.cache/devplane/perl-lsp ...`).
- The change was committed locally as `fix(gates): emit begin/end gate lifecycle markers (#0000)` and is ready for CI verification where the test suite should exercise the new logs during gate timeout/failure scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3748c351883338fa2b5c9458fef42)