### PR TITLE
fix(gates): emit per-gate begin/end diagnostics (#0000)

### DIFF
--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1324,9 +1324,7 @@ fn emit_gate_begin(gate: &GateDefinition) {
 }
 
 fn emit_gate_end(gate: &GateDefinition, result: &GateResult) {
-    let exit = result
-        .exit_code
-        .map_or_else(|| "none".to_string(), |code| code.to_string());
+    let exit = result.exit_code.map_or_else(|| "none".to_string(), |code| code.to_string());
     println!(
         "END gate={} status={} exit={} duration_ms={}",
         gate.name, result.status, exit, result.duration_ms

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1221,12 +1221,14 @@ fn run_gate_plan(
 
     for (idx, planned_gate) in plan.selected.iter().enumerate() {
         let gate = &planned_gate.gate;
+        emit_gate_begin(gate);
         if let Some(ref pb) = spinner {
             pb.set_position(idx as u64);
             pb.set_message(format!("Running {}...", gate.name));
         }
 
         let result = run_single_gate(gate, policy, &log_dir, config)?;
+        emit_gate_end(gate, &result);
 
         // Update tier summary
         let tier_summary = tier_summaries.entry(gate.tier.clone()).or_default();
@@ -1310,6 +1312,25 @@ fn run_gate_plan(
         agent_receipt,
         diff_config: None,
     })
+}
+
+fn emit_gate_begin(gate: &GateDefinition) {
+    println!(
+        "BEGIN gate={} timeout={} command={}",
+        gate.name,
+        gate.timeout_seconds,
+        gate.command.trim()
+    );
+}
+
+fn emit_gate_end(gate: &GateDefinition, result: &GateResult) {
+    let exit = result
+        .exit_code
+        .map_or_else(|| "none".to_string(), |code| code.to_string());
+    println!(
+        "END gate={} status={} exit={} duration_ms={}",
+        gate.name, result.status, exit, result.duration_ms
+    );
 }
 
 /// Phase-1 agent-facing receipt shape contract (Issue #5020):


### PR DESCRIPTION
### Motivation

- Investigate and mitigate merge-gate runs that terminate with `SIGTERM` (exit 143) without a clear gate attribution or receipt by ensuring live logs name the currently executing gate. 

### Description

- Add `emit_gate_begin` and `emit_gate_end` helpers that print structured `BEGIN` and `END` markers for each gate with `name`, `timeout`, `command`, `status`, `exit`, and `duration_ms` fields. 
- Call `emit_gate_begin` immediately before and `emit_gate_end` immediately after `run_single_gate` inside `run_gate_plan` so gate activity is streamed to stdout in real time (`xtask/src/tasks/gates.rs`).

### Testing

- Attempted to run the focused unit test via `./scripts/cargo-safe test -p xtask --profile agent --locked gates::tests::required_gate_timeout_reports_receipt_fields_and_blocks_overall_status`, but execution was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so automated tests could not be completed in this session. 
- The change is limited to deterministic logging calls and a single-file edit, and a commit was created (`fix(gates): emit per-gate begin/end diagnostics (#0000)`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3748c351883338fa2b5c9458fef42)