### PR TITLE
fix(gates): emit explicit begin/end gate markers (#0000)

### DIFF
--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1221,12 +1221,24 @@ fn run_gate_plan(
 
     for (idx, planned_gate) in plan.selected.iter().enumerate() {
         let gate = &planned_gate.gate;
+        println!(
+            "BEGIN gate={} timeout={}s command={}",
+            gate.name, gate.timeout_seconds, gate.command
+        );
         if let Some(ref pb) = spinner {
             pb.set_position(idx as u64);
             pb.set_message(format!("Running {}...", gate.name));
         }
 
         let result = run_single_gate(gate, policy, &log_dir, config)?;
+        let exit_code = result
+            .exit_code
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "END gate={} status={} exit={} duration_ms={}",
+            gate.name, result.status, exit_code, result.duration_ms
+        );
 
         // Update tier summary
         let tier_summary = tier_summaries.entry(gate.tier.clone()).or_default();
@@ -3205,6 +3217,7 @@ mod tests {
 
         Ok(())
     }
+
 
     #[test]
     fn blocking_status_classification_includes_timeout_and_error() {


### PR DESCRIPTION
### Motivation
- Merge-gate runs could terminate (SIGTERM) without clear attribution of which gate was active, leaving CI logs and receipts insufficient for diagnosis.

### Description
- Emit deterministic plain-text markers before and after each gate in `run_gate_plan` (`xtask/src/tasks/gates.rs`) as `BEGIN gate=<name> timeout=<seconds>s command=<command>` and `END gate=<name> status=<status> exit=<exit_code> duration_ms=<ms>`.
- Markers are printed outside the spinner output so they are visible in non-interactive/CI logs.

### Testing
- `cargo test -p xtask gates::required_gate_timeout_reports_receipt_fields_and_blocks_overall_status -- --nocapture` was executed and passed.
- Attempted the agent-profile check `./scripts/cargo-safe test -p xtask --profile agent --locked ...` but it was blocked by local storage policy (`DENY: /root/.cache/devplane/perl-lsp`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3748c351883338fa2b5c9458fef42)