### PR TITLE
docs(readme): tighten behavioral status framing (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Perl has decades of real production code, but editor tooling still struggles wit
 
 ## Status at a glance
 
-These are behavioral and corpus-backed signals, not feature inventory counts. Protocol coverage and full feature catalogs live in the generated status docs.
+These are behavioral and corpus-backed signals, not feature-inventory counts. Protocol coverage and full capability catalogs live in the generated status docs.
 
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 34 crates after the v0.13 collapse |
+| Published crate surface | 31 crates |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
 | Project parser corpus | 100.0% clean (`95/95`) |
 | Parser NodeKind coverage | 65/69 |
 | Parser reliability | 0 project-corpus timeouts / 0 panics |
-| Editor UX scenarios | 27 scenario files tracked |
+| Editor UX harness | 23 scenario files tracked |
 | First-five-minutes UX workflows | 21 workflows tracked |
 | Issue-regression UX workflows | 13 workflows tracked |
 | Workspace stale-index defects | 0 / 7 tested scenarios |
@@ -50,7 +50,7 @@ See [project status](docs/project/status/index.md), [parser status](docs/project
 
 - **Editor workflows**: completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, and workspace symbols.
 - **Parser stack**: native lexer, parser-core, parser facade, corpus ratchets, and tree-sitter integration.
-- **UX testing**: 27 tracked editor UX scenarios, including first-five-minutes flows, issue-regression guards, cross-file navigation, diagnostics-after-edit, workspace churn, and rename.
+- **UX testing**: 23 tracked editor UX harness scenarios, including first-five-minutes flows, issue-regression guards, cross-file navigation, diagnostics-after-edit, workspace churn, and rename.
 - **Workspace intelligence**: module resolution, symbol indexing, stale-index guards, multi-root workspaces, and workspace-aware rename.
 - **Debug adapter**: breakpoints, stepping, stack frames, variables, evaluate, and launch/attach flows.
 - **Editor support**: VS Code, Open VSX, Neovim, Vim, Emacs, Helix, Zed, Sublime, and any editor with LSP support.
@@ -65,7 +65,7 @@ Do not install `perl-lsp` from crates.io; that is a different project.
 
 ## Crate surface
 
-The v0.13 architecture collapsed the old microcrate graph into a smaller published surface. Most implementation detail now lives in modules behind focused public crates.
+The v0.13 architecture consolidated the old microcrate graph into a smaller public surface with focused facades and internal modules. Most implementation detail now lives in modules behind focused public crates.
 
 | Need | Crate |
 |---|---|


### PR DESCRIPTION
### Motivation
- The README mixed behavioral confidence signals with inventory-style wording and contained stale UX/status counts so the front-page messaging needed tightening.

### Description
- Updated the "Status at a glance" intro to emphasize behavioral/corpus-backed signals, changed `Published crate surface` to `31 crates`, renamed `Editor UX scenarios` to `Editor UX harness` with `23 scenario files tracked`, adjusted the UX bullet to match the harness wording, and reworded the v0.13 crate-surface line to avoid the phrase "after collapse".

### Testing
- Verified the documentation change with `git diff -- README.md`, committed the update, and created PR metadata; those commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37a9e4fd88333a0f236fdbd970968)