### PR TITLE
docs(readme): tighten behavioral confidence framing (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ Perl has decades of real production code, but editor tooling still struggles wit
 
 ## Status at a glance
 
-These are behavioral and corpus-backed signals, not feature inventory counts. Protocol coverage and full feature catalogs live in the generated status docs.
+These are behavioral and corpus-backed signals, not feature-inventory counts. Protocol coverage and full capability catalogs live in the generated status docs.
 
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 34 crates after the v0.13 collapse |
+| Published crate surface | 31 crates |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
 | Project parser corpus | 100.0% clean (`95/95`) |
 | Parser NodeKind coverage | 65/69 |
 | Parser reliability | 0 project-corpus timeouts / 0 panics |
-| Editor UX scenarios | 27 scenario files tracked |
+| Editor UX harness | 23 scenario files tracked |
 | First-five-minutes UX workflows | 21 workflows tracked |
 | Issue-regression UX workflows | 13 workflows tracked |
 | Workspace stale-index defects | 0 / 7 tested scenarios |
@@ -50,7 +50,7 @@ See [project status](docs/project/status/index.md), [parser status](docs/project
 
 - **Editor workflows**: completion, diagnostics, hover, go-to-definition, references, rename, formatting, semantic tokens, inlay hints, code actions, code lens, and workspace symbols.
 - **Parser stack**: native lexer, parser-core, parser facade, corpus ratchets, and tree-sitter integration.
-- **UX testing**: 27 tracked editor UX scenarios, including first-five-minutes flows, issue-regression guards, cross-file navigation, diagnostics-after-edit, workspace churn, and rename.
+- **UX testing**: 23 tracked editor UX harness scenarios, including first-five-minutes flows, issue-regression guards, cross-file navigation, diagnostics-after-edit, workspace churn, and rename.
 - **Workspace intelligence**: module resolution, symbol indexing, stale-index guards, multi-root workspaces, and workspace-aware rename.
 - **Debug adapter**: breakpoints, stepping, stack frames, variables, evaluate, and launch/attach flows.
 - **Editor support**: VS Code, Open VSX, Neovim, Vim, Emacs, Helix, Zed, Sublime, and any editor with LSP support.


### PR DESCRIPTION
### Motivation

- Clarify that the front-page status table communicates behavioral and corpus-backed signals rather than feature-inventory counts, and avoid implying UX pass-rate or collapse narrative in the headline metric.

### Description

- Edit `README.md` to reword the status intro, update the `Published crate surface` value to `31 crates`, rename `Editor UX scenarios` to `Editor UX harness` with `23` tracked scenario files, and align the corresponding UX bullet in the "What works" section.

### Testing

- Documentation-only change; no crate-level tests were required and the `README.md` diff was reviewed to confirm the status phrasing and table updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37a9e4fd88333a0f236fdbd970968)