### PR TITLE
docs(readme): tighten status signals framing (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,23 @@ Perl has decades of real production code, but editor tooling still struggles wit
 
 ## Status at a glance
 
-These are behavioral and corpus-backed signals, not feature inventory counts. Protocol coverage and full feature catalogs live in the generated status docs.
+These are behavioral and corpus-backed signals, not feature-inventory counts. Protocol coverage and full capability catalogs live in the generated status docs.
 
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 34 crates after the v0.13 collapse |
+| Published crate surface | 31 crates |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
 | Project parser corpus | 100.0% clean (`95/95`) |
 | Parser NodeKind coverage | 65/69 |
 | Parser reliability | 0 project-corpus timeouts / 0 panics |
-| Editor UX scenarios | 27 scenario files tracked |
-| First-five-minutes UX workflows | 21 workflows tracked |
-| Issue-regression UX workflows | 13 workflows tracked |
 | Workspace stale-index defects | 0 / 7 tested scenarios |
 | Multi-root workspace tests | 8 / 8 |
+| Editor UX harness | 23 scenario files tracked |
+| First-five-minutes UX workflows | 21 workflows tracked |
+| Issue-regression UX workflows | 13 workflows tracked |
 <!-- END: README_STATUS -->
 
 See [project status](docs/project/status/index.md), [parser status](docs/project/status/parser.md), [workspace status](docs/project/status/workspace.md), and [quality metrics](docs/project/status/quality.md) for generated details.


### PR DESCRIPTION
### Motivation

- Make the README "Status at a glance" honest and user-facing by emphasizing behavioral and corpus-backed confidence signals rather than inventory-style or clunky metric labels.

### Description

- Rewrote the status intro sentence to stress that these are "behavioral and corpus-backed signals" and moved protocol/feature inventory to the generated status docs. 
- Simplified the crate-surface wording to `Published crate surface | 31 crates` and removed the parenthetical "after the v0.13 collapse" phrasing. 
- Adjusted the status table rows and labels to use harness/coverage language, including renaming `Editor UX scenarios` to `Editor UX harness` with `23 scenario files tracked`, and reordered workspace rows ahead of UX rows.

### Testing

- Verified file changes with `rg -n` and `git diff -- README.md` which showed the intended edits. 
- Ran formatting via `./scripts/cargo-safe xtask fmt` which completed successfully. 
- Committed the content-only README update and confirmed `git status --short` showed the change as committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37a9e4fd88333a0f236fdbd970968)