### PR TITLE
test(perl-workspace-index): broaden discovery property extension matrix (#0000)

### DIFF
--- a/crates/perl-workspace-index/tests/discovery_property_tests.rs
+++ b/crates/perl-workspace-index/tests/discovery_property_tests.rs
@@ -9,13 +9,23 @@ use std::fs;
 fn extension_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
         Just("pl".to_string()),
+        Just("PL".to_string()),
         Just("pm".to_string()),
+        Just("Pm".to_string()),
         Just("t".to_string()),
+        Just("T".to_string()),
         Just("psgi".to_string()),
+        Just("PSGI".to_string()),
+        Just("i".to_string()),
+        Just("I".to_string()),
         Just("xs".to_string()),
+        Just("XS".to_string()),
         Just("ep".to_string()),
+        Just("EP".to_string()),
         Just("tt".to_string()),
+        Just("TT".to_string()),
         Just("tt2".to_string()),
+        Just("TT2".to_string()),
         Just("md".to_string()),
         Just("txt".to_string()),
         Just("json".to_string()),
@@ -55,7 +65,7 @@ proptest! {
             prop_assert!(fs::create_dir_all(parent).is_ok());
             prop_assert!(fs::write(&path, "# generated\n").is_ok());
 
-            if matches!(ext.as_str(), "pl" | "pm" | "t" | "psgi" | "xs" | "ep" | "tt" | "tt2") {
+            if is_perl_discovery_path(&path) {
                 expected.insert(path);
             }
         }


### PR DESCRIPTION
### Motivation
- Increase randomized coverage of the workspace discovery property tests by exercising mixed-case and additional extension variants so discovery behavior is validated across case and extension edge-cases.
- Make the test's expected set derivation rely on the production predicate so the property test validates the same inclusion logic used by discovery.

### Description
- Expanded the extension generator in `crates/perl-workspace-index/tests/discovery_property_tests.rs` to include mixed-case variants for known Perl discovery extensions and to add `.i`/`.I` entries.
- Replaced the ad-hoc `matches!` extension check in `prop_discovery_returns_all_and_only_perl_files` with `is_perl_discovery_path(&path)` so expected membership is computed using the production predicate.
- Kept changes narrowly scoped to the single test file to improve property coverage without touching production code.

### Testing
- Attempted to run the property test via `./scripts/cargo-safe test -p perl-workspace-index --test discovery_property_tests --profile agent --locked`, but execution was blocked by the local devplane quota guard (DENY due to devplane cache policy).
- Ran `./scripts/storage-doctor`, which completed successfully and reported no repo-local `target/` directories and healthy storage state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d98e05c8333a8060fde5f92a4d6)