### PR TITLE
test(perl-parser): extend deletion property coverage (#0000)

### DIFF
--- a/crates/perl-parser/tests/prop_deletion.rs
+++ b/crates/perl-parser/tests/prop_deletion.rs
@@ -124,4 +124,42 @@ proptest! {
             );
         }
     }
+
+    #[test]
+    fn delete_is_idempotent(
+        s in "[a-zA-Z0-9 \t\n()\\[\\];:,.+=\\-*/!?%&|<>]+",
+    ) {
+        let once = delete_on_breakable(&s);
+        let twice = delete_on_breakable(&once);
+
+        prop_assert_eq!(
+            once,
+            twice,
+            "Deleting breakable whitespace should be idempotent for input {:?}",
+            s
+        );
+    }
+
+    #[test]
+    fn delete_preserves_leading_and_trailing_whitespace(
+        lead in r"[ \t\n]{0,8}",
+        body in "[a-zA-Z0-9()\\[\\];:,.+=\\-*]{1,64}",
+        trail in r"[ \t\n]{0,8}",
+    ) {
+        let s = format!("{lead}{body}{trail}");
+        let deleted = delete_on_breakable(&s);
+
+        prop_assert!(
+            deleted.starts_with(&lead),
+            "Leading whitespace changed: input {:?}, output {:?}",
+            s,
+            deleted
+        );
+        prop_assert!(
+            deleted.ends_with(&trail),
+            "Trailing whitespace changed: input {:?}, output {:?}",
+            s,
+            deleted
+        );
+    }
 }


### PR DESCRIPTION
### Motivation

- Strengthen property-test coverage for the deletion metamorphic transformations to catch regressions beyond mere token-preservation.
- Add invariants that document expected structural stability (idempotence and preservation of boundary whitespace) when removing breakable whitespace.

### Description

- Add `delete_is_idempotent` property test to assert `delete_on_breakable(delete_on_breakable(x)) == delete_on_breakable(x)` in `crates/perl-parser/tests/prop_deletion.rs`.
- Add `delete_preserves_leading_and_trailing_whitespace` property test to assert leading and trailing whitespace are preserved after deletion.
- Expand the generated character set for the idempotence test to include additional operator characters to exercise more token-boundary cases.

### Testing

- Attempted to run `./scripts/cargo-safe test -p perl-parser --test prop_deletion --profile agent --locked`, but the run was blocked by the environment storage guard (`DENY: /root/.cache/devplane/...`), so the property tests could not be executed here.
- A focused commit was created for the change (`test(perl-parser): extend deletion property coverage (#0000)`), ready for CI to run the full automated test suite when the branch is pushed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d98e05c8333a8060fde5f92a4d6)