### PR TITLE
test(perl-module): expand rename property invariants (#0000)

### DIFF
--- a/crates/perl-module/tests/module_rename_prop.rs
+++ b/crates/perl-module/tests/module_rename_prop.rs
@@ -6,6 +6,10 @@ fn module_name_strategy() -> impl Strategy<Value = String> {
         .prop_map(|segments| segments.join("::"))
 }
 
+fn identifier_strategy() -> impl Strategy<Value = String> {
+    "[A-Za-z_][A-Za-z0-9_]{0,10}".prop_map(|segment| segment)
+}
+
 proptest! {
     #[test]
     fn rename_preserves_non_target_lines(old_module in module_name_strategy(), new_module in module_name_strategy()) {
@@ -36,5 +40,46 @@ proptest! {
             prop_assert!(edit.line < line_count);
             prop_assert_eq!(edit.start_character, 0);
         }
+    }
+
+    #[test]
+    fn rename_is_noop_when_module_not_present(
+        old_module in module_name_strategy(),
+        new_module in module_name_strategy(),
+        left in identifier_strategy(),
+        right in identifier_strategy(),
+    ) {
+        prop_assume!(old_module != new_module);
+        prop_assume!(left != old_module && left != new_module);
+        prop_assume!(right != old_module && right != new_module);
+
+        let source = format!(
+            "package {left};\nmy $value = {right}::helper();\n# extends {right}\n"
+        );
+
+        let edits = plan_module_rename_edits(&source, &old_module, &new_module);
+        let rewritten = apply_module_rename_edits(&source, &edits);
+
+        prop_assert!(edits.is_empty());
+        prop_assert_eq!(rewritten, source);
+    }
+
+    #[test]
+    fn applying_same_rename_plan_is_idempotent(
+        old_module in module_name_strategy(),
+        new_module in module_name_strategy(),
+        trailer in "[a-z]{0,8}",
+    ) {
+        prop_assume!(old_module != new_module);
+
+        let source = format!(
+            "use {old_module};\n{old_module}::work();\npackage {old_module};\n# {trailer}\n"
+        );
+
+        let edits = plan_module_rename_edits(&source, &old_module, &new_module);
+        let rewritten_once = apply_module_rename_edits(&source, &edits);
+        let rewritten_twice = apply_module_rename_edits(&rewritten_once, &edits);
+
+        prop_assert_eq!(rewritten_once, rewritten_twice);
     }
 }


### PR DESCRIPTION
### Motivation

- Strengthen property-based coverage for module rename workflows by asserting negative and stability invariants that were previously untested.

### Description

- Add an `identifier_strategy` generator and new proptest cases in `crates/perl-module/tests/module_rename_prop.rs`.
- Add `rename_is_noop_when_module_not_present` to assert `plan_module_rename_edits` returns no edits and `apply_module_rename_edits` preserves the source when the target module is absent.
- Add `applying_same_rename_plan_is_idempotent` to assert applying the same planned edits twice yields the same output (idempotence).

### Testing

- Ran `cargo test -p perl-module --locked`, which completed successfully with all tests passing.
- Attempted the preferred `./scripts/cargo-safe test -p perl-module --profile agent --locked`, but it was blocked by an environment storage policy and could not be run in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d98e05c8333a8060fde5f92a4d6)