### PR TITLE
test(perl-dap): harden evaluator mutation coverage (#0000)

### DIFF
--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -410,6 +410,33 @@ mod tests {
     }
 
     #[test]
+    fn test_comparison_operators_not_misclassified_as_assignments() {
+        let evaluator = SafeEvaluator::new();
+
+        assert!(evaluator.validate("$x == 1").is_ok());
+        assert!(evaluator.validate("$x != 1").is_ok());
+        assert!(evaluator.validate("$x <= 1").is_ok());
+        assert!(evaluator.validate("$x >= 1").is_ok());
+    }
+
+    #[test]
+    fn test_core_qualified_dangerous_operations_are_blocked() {
+        let evaluator = SafeEvaluator::new();
+
+        assert!(evaluator.validate("CORE::print 'hello'").is_err());
+        assert!(evaluator.validate("CORE::GLOBAL::system('ls')").is_err());
+    }
+
+    #[test]
+    fn test_code_dereference_and_method_call_with_sigils_are_blocked() {
+        let evaluator = SafeEvaluator::new();
+
+        assert!(evaluator.validate("&$system").is_err());
+        assert!(evaluator.validate("$obj->$print").is_err());
+        assert!(evaluator.validate("&{ $exec }").is_err());
+    }
+
+    #[test]
     fn test_single_quoted_strings() {
         let evaluator = SafeEvaluator::new();
 


### PR DESCRIPTION
### Motivation
- Improve mutation testing coverage by adding targeted tests to exercise branches that previously allowed mutation-surviving regressions (operator classification, CORE qualification, and sigil handling).

### Description
- Adds three focused unit tests to `crates/perl-dap/src/eval/validator.rs` that verify comparison operators are not misclassified as assignments, that `CORE::`/`CORE::GLOBAL::` qualified dangerous operations are blocked, and that sigil-based code-dereference/method-call forms are rejected.

### Testing
- Attempted `DEVPLANE=1 ./scripts/cargo-safe test -p perl-dap --profile agent --locked` but the run was blocked by an environment guard (`DENY: ...`); `./scripts/storage-doctor` completed successfully and the new tests were added and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37da29258833381599af60bdeefec)