### PR TITLE
test(perl-lsp-rs): extend document symbol BDD recovery coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_ux_document_symbols_bdd.rs
+++ b/crates/perl-lsp-rs/tests/lsp_ux_document_symbols_bdd.rs
@@ -163,3 +163,44 @@ fn bdd_document_symbols_track_new_declaration_without_reopen()
 
     Ok(())
 }
+
+#[test]
+#[serial]
+fn bdd_document_symbols_recover_after_temporary_syntax_error()
+-> Result<(), Box<dyn std::error::Error>> {
+    let scenario = Scenario::new("Document symbols recover after transient parse error");
+
+    let valid = "package Demo;\nsub alpha { return 1; }\nsub beta { return alpha(); }\n1;\n";
+    let broken = "package Demo;\nsub alpha { return 1;\nsub beta { return alpha(); }\n1;\n";
+    let recovered = "package Demo;\nsub alpha { return 1; }\nsub beta { return alpha(); }\nsub gamma { return beta(); }\n1;\n";
+
+    scenario.given("an open document with valid document symbols");
+    let (mut harness, workspace) = setup_workspace(&[("lib/Demo.pm", valid)])?;
+    let uri = workspace.uri("lib/Demo.pm");
+    harness.open_document(&uri, valid)?;
+    let baseline = wait_for_symbol_names(
+        &mut harness,
+        &uri,
+        &["Demo", "alpha", "beta"],
+        &["gamma"],
+        Duration::from_secs(3),
+    )?;
+    assert!(baseline.contains("alpha"));
+    assert!(baseline.contains("beta"));
+
+    scenario.when("the user introduces and then fixes a syntax error via didChange");
+    harness.change_full(&uri, 2, broken)?;
+    harness.change_full(&uri, 3, recovered)?;
+
+    scenario.then("documentSymbol converges to the recovered declarations");
+    let names = wait_for_symbol_names(
+        &mut harness,
+        &uri,
+        &["Demo", "alpha", "beta", "gamma"],
+        &[],
+        Duration::from_secs(3),
+    )?;
+    assert!(names.contains("gamma"));
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Improve BDD coverage for document-symbol behavior by verifying the server recovers symbol outlines after a transient parse error during live editing.

### Description
- Add `bdd_document_symbols_recover_after_temporary_syntax_error` to `crates/perl-lsp-rs/tests/lsp_ux_document_symbols_bdd.rs`, which opens a workspace file, injects a broken edit, applies a recovery edit, and asserts document symbols converge to the recovered set.
- The new scenario reuses existing helpers such as `LspHarness`, `TempWorkspace`, and `wait_for_symbol_names` to keep the change focused and minimal.

### Testing
- Executed `./scripts/cargo-safe test -p perl-lsp-rs --test lsp_ux_document_symbols_bdd --profile agent --locked`, which could not complete in this environment due to a storage policy denial: `DENY: /root/.cache/devplane/perl-lsp used=46% free=32G`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37daaa7488333923cef70c224db39)