### PR TITLE
test(perl-workspace-index): expand discovery bdd scenarios (#0000)

### DIFF
--- a/crates/perl-workspace-index/tests/discovery_bdd_tests.rs
+++ b/crates/perl-workspace-index/tests/discovery_bdd_tests.rs
@@ -221,3 +221,52 @@ fn given_git_workspace_with_perl_adjacent_extensions_when_discovering_then_git_s
 
     Ok(())
 }
+
+#[test]
+fn given_walk_discovery_with_only_skipped_dirs_when_discovering_then_sources_are_excluded() -> TestResult {
+    let tmp = TempDir::new()?;
+    let root = tmp.path();
+
+    create_file(root, "target/generated/Hidden.pm")?;
+    create_file(root, ".cache/index/AlsoHidden.pl")?;
+    create_file(root, "lib/Visible.pm")?;
+
+    let result = discover_perl_files(root);
+
+    assert_eq!(result.method, DiscoveryMethod::Walk);
+    assert_eq!(result.files.len(), 1);
+    assert!(result.files.iter().any(|path| path.ends_with("lib/Visible.pm")));
+    assert!(!result.files.iter().any(|path| path.to_string_lossy().contains("target/generated")));
+    assert!(!result.files.iter().any(|path| path.to_string_lossy().contains(".cache/index")));
+    assert!(result.excluded_count >= 2);
+
+    Ok(())
+}
+
+#[test]
+fn given_git_workspace_with_mixed_case_extensions_when_discovering_then_git_strategy_keeps_them()
+-> TestResult {
+    if !git_available() {
+        return Ok(());
+    }
+
+    let tmp = TempDir::new()?;
+    let root = tmp.path();
+
+    run_git(root, &["init", "--quiet"])?;
+    create_file(root, "templates/a.TT2")?;
+    create_file(root, "templates/b.eP")?;
+    create_file(root, "native/c.xS")?;
+    create_file(root, "notes.md")?;
+
+    let result = discover_perl_files(root);
+
+    assert_eq!(result.method, DiscoveryMethod::Git);
+    assert_eq!(result.files.len(), 3);
+    assert!(result.files.iter().any(|path| path.ends_with("templates/a.TT2")));
+    assert!(result.files.iter().any(|path| path.ends_with("templates/b.eP")));
+    assert!(result.files.iter().any(|path| path.ends_with("native/c.xS")));
+    assert!(!result.files.iter().any(|path| path.ends_with("notes.md")));
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Improve BDD coverage for workspace discovery by exercising skip-directory behavior in walk mode and case-insensitive Perl-adjacent extension handling in git mode.

### Description

- Added two focused BDD tests to `crates/perl-workspace-index/tests/discovery_bdd_tests.rs` that validate skipped-directory exclusions during walk discovery and inclusion of mixed-case extensions during git discovery.
- The new tests are `given_walk_discovery_with_only_skipped_dirs_when_discovering_then_sources_are_excluded` and `given_git_workspace_with_mixed_case_extensions_when_discovering_then_git_strategy_keeps_them` and assert method, discovered files, and `excluded_count` where appropriate.

### Testing

- New tests were added to the `discovery_bdd_tests` suite in `crates/perl-workspace-index` and are designed to be run with `./scripts/cargo-safe test -p perl-workspace-index --test discovery_bdd_tests --profile agent --locked`.
- Attempted to run the verification command but it was blocked by an environment storage guard: `DENY: /root/.cache/devplane/perl-lsp used=46% free=32G`, so automated test execution could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37daaa7488333923cef70c224db39)