### PR TITLE
test(perl-lsp-rs): expand e2e workspace symbol lifecycle coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_comprehensive_e2e_test.rs
+++ b/crates/perl-lsp-rs/tests/lsp_comprehensive_e2e_test.rs
@@ -941,6 +941,56 @@ sub function_in_file2 { }
     Ok(())
 }
 
+/// Test 16b: Workspace Symbols honor document lifecycle (open/close)
+#[test]
+fn test_e2e_workspace_symbols_document_close_lifecycle() -> TestResult {
+    let mut ctx = TestContext::new();
+    ctx.initialize();
+
+    let uri = "file:///test/lifecycle_symbols.pl";
+    let symbol_name = "lifecycle_unique_symbol";
+    let code = format!(
+        r#"
+sub {symbol_name} {{
+    return 1;
+}}
+"#
+    );
+    ctx.open_document(uri, &code);
+
+    let opened_result = ctx.send_request(
+        "workspace/symbol",
+        Some(json!({
+            "query": "lifecycle_unique_symbol"
+        })),
+    );
+    let opened_symbols = opened_result.ok_or("No workspace symbol result after opening document")?;
+    let opened_matches = opened_symbols
+        .as_array()
+        .ok_or("Expected workspace/symbol array after opening document")?
+        .iter()
+        .any(|symbol| symbol["name"] == symbol_name);
+    assert!(opened_matches, "Expected symbol to be indexed while document is open");
+
+    ctx.close_document(uri);
+
+    let closed_result = ctx.send_request(
+        "workspace/symbol",
+        Some(json!({
+            "query": "lifecycle_unique_symbol"
+        })),
+    );
+    let closed_symbols = closed_result.ok_or("No workspace symbol result after closing document")?;
+    let closed_matches = closed_symbols
+        .as_array()
+        .ok_or("Expected workspace/symbol array after closing document")?
+        .iter()
+        .any(|symbol| symbol["name"] == symbol_name);
+    assert!(!closed_matches, "Expected symbol to be removed after document close");
+
+    Ok(())
+}
+
 /// Test 17: Document Formatting
 #[test]
 fn test_e2e_document_formatting() -> TestResult {


### PR DESCRIPTION
### Motivation
- Improve end-to-end coverage for `workspace/symbol` to ensure symbols are indexed while a document is open and removed after `textDocument/didClose` to catch lifecycle regressions.

### Description
- Added a focused e2e test `test_e2e_workspace_symbols_document_close_lifecycle` in `crates/perl-lsp-rs/tests/lsp_comprehensive_e2e_test.rs` that opens a document, verifies the symbol is returned by `workspace/symbol`, closes the document, and verifies the symbol is no longer returned.
- The test reuses the existing `TestContext` harness to exercise `didOpen`/`didClose` notifications and `workspace/symbol` requests.

### Testing
- Attempted to verify with `./scripts/cargo-safe test -p perl-lsp-rs --test lsp_comprehensive_e2e_test --profile agent --locked`, but the run was blocked by an environment storage policy: `DENY: /root/.cache/devplane/perl-lsp` (no automated test result produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37db33670833392474f2769b39bd8)