### PR TITLE
test(perl-parser): cover invalid continue/redo fixtures (#0000)

### DIFF
--- a/crates/perl-parser/tests/parser_continue_redo_tests.rs
+++ b/crates/perl-parser/tests/parser_continue_redo_tests.rs
@@ -451,6 +451,27 @@ fn parser_all_valid_continue_redo_cases_parse() {
 }
 
 #[test]
+fn parser_invalid_continue_redo_cases_fail() {
+    let invalid_cases: Vec<_> = continue_redo_cases().iter().filter(|case| !case.should_parse).collect();
+    assert!(
+        !invalid_cases.is_empty(),
+        "Expected at least one invalid continue/redo fixture"
+    );
+
+    for case in invalid_cases {
+        let result = parse_code(case.source);
+        assert!(
+            result.is_err(),
+            "Expected invalid case '{}' to fail parsing
+Source:
+{}",
+            case.id,
+            case.source
+        );
+    }
+}
+
+#[test]
 fn parser_continue_redo_coverage() {
     let all_cases = continue_redo_cases();
     let valid_count = all_cases.iter().filter(|c| c.should_parse).count();


### PR DESCRIPTION
### Motivation
- The continue/redo corpus tests only asserted successful parsing for fixtures marked `should_parse = true`, leaving fixtures expected to fail unverified.

### Description
- Added a new test `parser_invalid_continue_redo_cases_fail` in `crates/perl-parser/tests/parser_continue_redo_tests.rs` that collects fixtures with `should_parse == false` and asserts that parsing each fixture returns an error.

### Testing
- Attempted to run `./scripts/cargo-safe test -p perl-parser --test parser_continue_redo_tests --profile agent --locked`, but the run was blocked by the environment storage policy (`DENY: /root/.cache/devplane/perl-lsp used=46% free=32G`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37dba51708333963c69a797ef52c6)