### PR TITLE
test(perl-parser): expand incremental fuzz edit coverage (#0000)

### DIFF
--- a/crates/perl-parser/tests/fuzz_incremental_parsing.rs
+++ b/crates/perl-parser/tests/fuzz_incremental_parsing.rs
@@ -225,6 +225,39 @@ proptest! {
                 // - Validate UTF-8 safety in symbol names
             }
     }
+
+    #[test]
+    fn fuzz_incremental_edit_sequences_preserve_no_panic(
+        base in "[ -~\n\t]{1,120}",
+        edits in proptest::collection::vec((0usize..120, "[ -~\n\t]{0,24}"), 1..12),
+    ) {
+        let mut script = base;
+
+        for (index_hint, payload) in edits {
+            let insertion_at = index_hint.min(script.len());
+            script.insert_str(insertion_at, &payload);
+
+            // Exercise delete/replace-like mutations without invalid byte indices.
+            if !script.is_empty() {
+                let delete_start = (index_hint / 2).min(script.len().saturating_sub(1));
+                let delete_end = (delete_start + payload.len() / 2).min(script.len());
+
+                if delete_start < delete_end {
+                    script.replace_range(delete_start..delete_end, "");
+                }
+            }
+
+            let mut parser = Parser::new(&script);
+            let parse_result =
+                std::panic::catch_unwind(AssertUnwindSafe(|| parser.parse()));
+
+            prop_assert!(
+                parse_result.is_ok(),
+                "incremental edit sequence caused parser panic for script: {:?}",
+                script
+            );
+        }
+    }
 }
 
 /// Test memory and performance characteristics under stress


### PR DESCRIPTION
### Motivation

- Incremental parser fuzzing previously exercised fixed mutation templates but did not cover realistic editor-style sequences combining multiple insertions and bounded deletes/replacements, which can reveal different panic paths.

### Description

- Add a new property-based test `fuzz_incremental_edit_sequences_preserve_no_panic` in `crates/perl-parser/tests/fuzz_incremental_parsing.rs` that generates a base script and a bounded sequence of randomized insert/delete edit operations.
- Each intermediate script is parsed with `Parser::new(...).parse()` inside `std::panic::catch_unwind(AssertUnwindSafe(...))` and the test asserts the parser never panics for any intermediate state.
- The change is narrowly scoped to improving incremental-edit fuzz coverage and does not modify production code.

### Testing

- Ran `./scripts/storage-doctor` which completed successfully.
- Attempted `./scripts/cargo-safe test -p perl-parser --profile agent --locked fuzz_incremental_parsing` but the run was blocked by a local devplane disk gate (`DENY: /root/.cache/devplane/perl-lsp ...`), so the property test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d9729e88333af4edc148636e78a)