### PR TITLE
test(perl-regex): extend code-execution property coverage (#0000)

### DIFF
--- a/crates/perl-regex/tests/prop_regex_validator.rs
+++ b/crates/perl-regex/tests/prop_regex_validator.rs
@@ -184,4 +184,46 @@ proptest! {
             s
         );
     }
+
+    /// Escaped opener sequences are treated as literals and never trigger detection.
+    #[test]
+    fn escaped_code_constructs_do_not_trigger_detection(
+        prefix in "[A-Za-z0-9]{0,10}",
+        suffix in "[A-Za-z0-9]{0,10}",
+    ) {
+        let escaped_block = format!(r"{prefix}\(?{{danger}}{suffix}");
+        prop_assert!(
+            !RegexValidator::new().detects_code_execution(&escaped_block),
+            "escaped (?{{ should not be detected in {:?}",
+            escaped_block
+        );
+
+        let escaped_deferred = format!(r"{prefix}\(??{{danger}}{suffix}");
+        prop_assert!(
+            !RegexValidator::new().detects_code_execution(&escaped_deferred),
+            "escaped (??{{ should not be detected in {:?}",
+            escaped_deferred
+        );
+    }
+
+    /// Candidate sequences inside character classes are literals and not executable.
+    #[test]
+    fn character_class_literals_do_not_trigger_detection(
+        prefix in "[A-Za-z0-9]{0,10}",
+        suffix in "[A-Za-z0-9]{0,10}",
+    ) {
+        let class_block = format!("{prefix}[(?{{abc}})]{suffix}");
+        prop_assert!(
+            !RegexValidator::new().detects_code_execution(&class_block),
+            "character class (?{{ literal should not be detected in {:?}",
+            class_block
+        );
+
+        let class_deferred = format!("{prefix}[(??{{abc}})]{suffix}");
+        prop_assert!(
+            !RegexValidator::new().detects_code_execution(&class_deferred),
+            "character class (??{{ literal should not be detected in {:?}",
+            class_deferred
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Close gaps in property-test coverage for regex code-execution detection to avoid false positives on escaped opener sequences and class-literal lookalikes.
- Keep the change narrowly scoped to property tests that assert conservative, non-executable cases remain unflagged.

### Description
- Added `escaped_code_constructs_do_not_trigger_detection` to assert `RegexValidator::detects_code_execution` does not flag escaped `(?{` and `(??{` sequences in `crates/perl-regex/tests/prop_regex_validator.rs`.
- Added `character_class_literals_do_not_trigger_detection` to assert the same for sequences appearing inside character classes in `crates/perl-regex/tests/prop_regex_validator.rs`.
- Change is limited to test coverage only and touches a single test file.

### Testing
- Attempted `./scripts/cargo-safe test -p perl-regex --profile agent --locked --test prop_regex_validator`, but the run was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp used=46% free=32G`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d98e05c8333a8060fde5f92a4d6)