### PR TITLE
test(perl-parser): extend ast snapshot coverage (#0000)

### DIFF
--- a/crates/perl-parser/tests/ast_snap.rs
+++ b/crates/perl-parser/tests/ast_snap.rs
@@ -166,6 +166,18 @@ fn ast_state_variable_and_default_operator() {
     assert_snapshot!(parse_sexp("state $counter = 0; $counter //= 1;"));
 }
 
+#[test]
+fn ast_here_doc_assignment() {
+    // Heredocs are pervasive in tests/config emitters and stress multiline lexing.
+    assert_snapshot!(parse_sexp("my $sql = <<'SQL';\nselect * from users;\nSQL\n"));
+}
+
+#[test]
+fn ast_attributes_and_prototype_sub() {
+    // Sub prototypes + attributes appear in older CPAN modules and parser pragmas.
+    assert_snapshot!(parse_sexp("sub run ($$) :lvalue { $_[0] = $_[1]; }"));
+}
+
 // ---------------------------------------------------------------------------
 // 2. Error recovery AST snapshots (malformed input)
 // ---------------------------------------------------------------------------
@@ -276,6 +288,11 @@ fn errors_unclosed_hash_subscript_and_followup() {
 #[test]
 fn errors_broken_regex_delimiter() {
     assert_snapshot!(parse_errors("if ($text =~ /abc) { print 1; }\nmy $ok = 1;"));
+}
+
+#[test]
+fn errors_unterminated_heredoc() {
+    assert_snapshot!(parse_errors("my $sql = <<'SQL';\nselect * from users;\n"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perl-parser/tests/snapshots/ast_snap__ast_attributes_and_prototype_sub.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__ast_attributes_and_prototype_sub.snap
@@ -1,0 +1,6 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+assertion_line: 178
+expression: "parse_sexp(\"sub run ($$) :lvalue { $_[0] = $_[1]; }\")"
+---
+(source_file (sub run :lvalue ((prototype)) (block (expression_statement (assignment_assign (binary_[] (variable $ _) (number 0)) (binary_[] (variable $ _) (number 1)))))))

--- a/crates/perl-parser/tests/snapshots/ast_snap__ast_here_doc_assignment.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__ast_here_doc_assignment.snap
@@ -1,0 +1,6 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+assertion_line: 172
+expression: "parse_sexp(\"my $sql = <<'SQL';\\nselect * from users;\\nSQL\\n\")"
+---
+(source_file (my_declaration (variable $ sql)(heredoc "SQL" "select * from users;")))

--- a/crates/perl-parser/tests/snapshots/ast_snap__errors_unterminated_heredoc.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__errors_unterminated_heredoc.snap
@@ -1,0 +1,6 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+assertion_line: 295
+expression: "parse_errors(\"my $sql = <<'SQL';\\nselect * from users;\\n\")"
+---
+Invalid syntax at position 40: Unterminated heredoc: SQL


### PR DESCRIPTION
### Motivation

- Improve AST snapshot coverage for parsing edge-cases that were previously untested: heredoc assignments, subroutine prototypes/attributes, and unterminated heredoc diagnostics.
- Prevent regressions by capturing concrete baselines for these lexer/parser behaviors.

### Description

- Added three focused snapshot tests in `crates/perl-parser/tests/ast_snap.rs`: `ast_here_doc_assignment`, `ast_attributes_and_prototype_sub`, and `errors_unterminated_heredoc`.
- Added corresponding snapshot baseline files under `crates/perl-parser/tests/snapshots/` for the new tests.
- Changes are committed as a single focused test change: `test(perl-parser): extend ast snapshot coverage (#0000)`.

### Testing

- Attempted `./scripts/cargo-safe test -p perl-parser --test ast_snap --profile agent --locked` but it was blocked by a local storage guard and did not run.
- Ran `cargo test -p perl-parser --test ast_snap`, which initially reported 3 failing tests due to new snapshots being produced (insta new snapshots), then the new baselines were added.
- Final `cargo test -p perl-parser --test ast_snap` passed with `49 passed, 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d9eac388333a7eec3561b69aae5)