### PR TITLE
test(perl-lsp-rs-core): expand diagnostics snapshot coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/tests/diag_snap.rs
+++ b/crates/perl-lsp-rs-core/tests/diag_snap.rs
@@ -108,3 +108,16 @@ fn snapshot_syntax_error_with_follow_on_statement() {
     let snapshot = normalize(diagnostics_for(source));
     assert_snapshot!("syntax_error_with_follow_on_statement", snapshot);
 }
+
+#[test]
+fn snapshot_multiple_missing_pragmas_and_eval() {
+    let source = concat!(
+        "package Legacy::Script;\n",
+        "my $payload = q{print \"hello\\n\"};\n",
+        "eval $payload;\n",
+        "my $unused = 42;\n",
+        "1;\n",
+    );
+    let snapshot = normalize(diagnostics_for(source));
+    assert_snapshot!("multiple_missing_pragmas_and_eval", snapshot);
+}

--- a/crates/perl-lsp-rs-core/tests/snapshots/diag_snap__multiple_missing_pragmas_and_eval.snap
+++ b/crates/perl-lsp-rs-core/tests/snapshots/diag_snap__multiple_missing_pragmas_and_eval.snap
@@ -1,0 +1,8 @@
+---
+source: crates/perl-lsp-rs-core/tests/diag_snap.rs
+expression: snapshot
+---
+PL100 | Information | (0, 0) | Consider adding 'use strict;' for better error checking | Add 'use strict;' at the top of the file
+PL101 | Information | (0, 0) | Consider adding 'use warnings;' for better error detection | Add 'use warnings;' at the top of the file
+PL102 | Warning | (76, 83) | Variable '$unused' is declared but never used -- prefix with '_' or remove it | Prefix as '_unused'
+PL600 | Warning | (58, 71) | String eval is a security risk. Consider eval { } for exception handling. | Use eval { } for exception handling, or consider safer alternatives like Try::Tiny


### PR DESCRIPTION
### Motivation
- Improve diagnostic snapshot coverage by adding a mixed legacy-script fixture that exercises multiple concurrent findings (missing pragmas, string `eval`, and unused variable) so regressions in combined scenarios are caught.

### Description
- Add `snapshot_multiple_missing_pragmas_and_eval` to `crates/perl-lsp-rs-core/tests/diag_snap.rs` and the corresponding insta snapshot `crates/perl-lsp-rs-core/tests/snapshots/diag_snap__multiple_missing_pragmas_and_eval.snap` containing the normalized expected diagnostics.

### Testing
- Ran `MIN_FREE_GB=10 INSTA_UPDATE=always ./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked --test diag_snap` which updated the snapshot and completed successfully (`7 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d9eac388333a7eec3561b69aae5)