### PR TITLE
test(perl-parser): expand ast snapshot scenarios (#0000)

### DIFF
--- a/crates/perl-parser/tests/ast_snap.rs
+++ b/crates/perl-parser/tests/ast_snap.rs
@@ -178,6 +178,22 @@ fn ast_attributes_and_prototype_sub() {
     assert_snapshot!(parse_sexp("sub run ($$) :lvalue { $_[0] = $_[1]; }"));
 }
 
+#[test]
+fn ast_hash_slice_and_exists_delete_flow() {
+    // Hash slices plus exists/delete are common in config/option munging code.
+    assert_snapshot!(parse_sexp(
+        "my %opts = (foo => 1, bar => 2); my @pick = @opts{qw(foo bar)}; delete $opts{bar} if exists $opts{bar};",
+    ));
+}
+
+#[test]
+fn ast_lexical_filehandles_and_chomp_loop() {
+    // Lexical filehandle open/while/chomp is a ubiquitous IO pattern.
+    assert_snapshot!(parse_sexp(
+        "open my $fh, '<', $path; while (my $line = <$fh>) { chomp $line; push @rows, $line; }",
+    ));
+}
+
 // ---------------------------------------------------------------------------
 // 2. Error recovery AST snapshots (malformed input)
 // ---------------------------------------------------------------------------
@@ -251,6 +267,12 @@ fn recovery_broken_regex_then_followup_statement() {
     assert_snapshot!(parse_sexp("if ($text =~ /abc) { print 1; }\nmy $ok = 1;"));
 }
 
+#[test]
+fn recovery_broken_open_arguments_then_followup_statement() {
+    // Incomplete builtin argument list should recover to following statements.
+    assert_snapshot!(parse_sexp("open my $fh, '<';\nmy $ok = 1;"));
+}
+
 // ---------------------------------------------------------------------------
 // 3. Error message format snapshots
 // ---------------------------------------------------------------------------
@@ -293,6 +315,11 @@ fn errors_broken_regex_delimiter() {
 #[test]
 fn errors_unterminated_heredoc() {
     assert_snapshot!(parse_errors("my $sql = <<'SQL';\nselect * from users;\n"));
+}
+
+#[test]
+fn errors_broken_open_arguments_then_followup() {
+    assert_snapshot!(parse_errors("open my $fh, '<';\nmy $ok = 1;"));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perl-parser/tests/snapshots/ast_snap__ast_hash_slice_and_exists_delete_flow.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__ast_hash_slice_and_exists_delete_flow.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+expression: "parse_sexp(\"my %opts = (foo => 1, bar => 2); my @pick = @opts{qw(foo bar)}; delete $opts{bar} if exists $opts{bar};\",)"
+---
+(source_file (my_declaration (variable % opts)(hash ((string "foo") (number 1)) ((string "bar") (number 2)))) (my_declaration (variable @ pick)(binary_{} (variable @ opts) (array (string "'foo'") (string "'bar'")))) (statement_modifier_if (expression_statement (ambiguous_function_call_expression (function) (binary_{} (variable $ opts) (identifier bar)))) (ambiguous_function_call_expression (function) (binary_{} (variable $ opts) (identifier bar)))))

--- a/crates/perl-parser/tests/snapshots/ast_snap__ast_lexical_filehandles_and_chomp_loop.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__ast_lexical_filehandles_and_chomp_loop.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+expression: "parse_sexp(\"open my $fh, '<', $path; while (my $line = <$fh>) { chomp $line; push @rows, $line; }\",)"
+---
+(source_file (call open ((my_declaration (variable $ fh)) (string "'<'") (variable $ path))) (while (my_declaration (variable $ line)(glob $fh)) (block (expression_statement (ambiguous_function_call_expression (function) (variable $ line))) (expression_statement (call push ((variable @ rows) (variable $ line)))))))

--- a/crates/perl-parser/tests/snapshots/ast_snap__errors_broken_open_arguments_then_followup.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__errors_broken_open_arguments_then_followup.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+expression: "parse_errors(\"open my $fh, '<';\\nmy $ok = 1;\")"
+---
+

--- a/crates/perl-parser/tests/snapshots/ast_snap__recovery_broken_open_arguments_then_followup_statement.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__recovery_broken_open_arguments_then_followup_statement.snap
@@ -1,0 +1,5 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+expression: "parse_sexp(\"open my $fh, '<';\\nmy $ok = 1;\")"
+---
+(source_file (call open ((my_declaration (variable $ fh)) (string "'<'"))) (my_declaration (variable $ ok)(number 1)))


### PR DESCRIPTION
### Motivation

- Increase snapshot test coverage for common Perl idioms and a recovery path that was not covered previously.

### Description

- Added four new tests to `crates/perl-parser/tests/ast_snap.rs`: `ast_hash_slice_and_exists_delete_flow`, `ast_lexical_filehandles_and_chomp_loop`, `recovery_broken_open_arguments_then_followup_statement`, and `errors_broken_open_arguments_then_followup`.
- Committed the corresponding insta snapshot artifacts under `crates/perl-parser/tests/snapshots/` for the new AST, recovery, and error cases.

### Testing

- Ran `LC_ALL=C.UTF-8 INSTA_UPDATE=always cargo test -p perl-parser --test ast_snap`, which completed successfully with `50 passed; 0 failed` and updated/created the new snapshot files.
- Attempted the repository wrapper `./scripts/cargo-safe test -p perl-parser --test ast_snap --profile agent --locked`, which was blocked by an environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d9eac388333a7eec3561b69aae5)