### PR TITLE
test(perl-lsp-rs-core): expand diagnostics snapshot scenarios (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/tests/diag_snap.rs
+++ b/crates/perl-lsp-rs-core/tests/diag_snap.rs
@@ -121,3 +121,30 @@ fn snapshot_multiple_missing_pragmas_and_eval() {
     let snapshot = normalize(diagnostics_for(source));
     assert_snapshot!("multiple_missing_pragmas_and_eval", snapshot);
 }
+
+#[test]
+fn snapshot_duplicate_declaration_and_shadowing() {
+    let source = concat!(
+        "use strict;\n",
+        "use warnings;\n",
+        "my $value = 1;\n",
+        "my $value = 2;\n",
+        "print $value;\n",
+    );
+    let snapshot = normalize(diagnostics_for(source));
+    assert_snapshot!("duplicate_declaration_and_shadowing", snapshot);
+}
+
+#[test]
+fn snapshot_suspicious_regex_and_tainted_system_call() {
+    let source = concat!(
+        "use strict;\n",
+        "use warnings;\n",
+        "my $input = <STDIN>;\n",
+        "if ($input =~ /^(a+)+$/) {\n",
+        "    system($input);\n",
+        "}\n",
+    );
+    let snapshot = normalize(diagnostics_for(source));
+    assert_snapshot!("suspicious_regex_and_tainted_system_call", snapshot);
+}

--- a/crates/perl-lsp-rs-core/tests/snapshots/diag_snap__duplicate_declaration_and_shadowing.snap
+++ b/crates/perl-lsp-rs-core/tests/snapshots/diag_snap__duplicate_declaration_and_shadowing.snap
@@ -1,0 +1,7 @@
+---
+source: crates/perl-lsp-rs-core/tests/diag_snap.rs
+assertion_line: 122
+expression: snapshot
+---
+PL105 | Error | (44, 50) | Variable '$value' is declared again in the same scope -- remove the duplicate 'my' | Remove the duplicate 'my' keyword
+PL200 | Warning | (0, 0) | This file has no package declaration. Add 'package MyModule;' to declare the package namespace. | Add 'package MyModule;' at the top of the file

--- a/crates/perl-lsp-rs-core/tests/snapshots/diag_snap__suspicious_regex_and_tainted_system_call.snap
+++ b/crates/perl-lsp-rs-core/tests/snapshots/diag_snap__suspicious_regex_and_tainted_system_call.snap
@@ -1,0 +1,8 @@
+---
+source: crates/perl-lsp-rs-core/tests/diag_snap.rs
+assertion_line: 136
+expression: snapshot
+---
+PL002 | Error | (61, 62) | Nested quantifiers detected (possible backtracking risk) | <none>
+PL200 | Warning | (0, 0) | This file has no package declaration. Add 'package MyModule;' to declare the package namespace. | Add 'package MyModule;' at the top of the file
+PL603 | Warning | (78, 92) | system() executes a shell command. Ensure input is sanitized. | Use the list form: system($cmd, @args) instead of system("$cmd @args") to avoid shell injection


### PR DESCRIPTION
### Motivation
- Improve snapshot coverage for diagnostics that previously lacked end-to-end verification.
- Specifically target duplicate lexical declarations and combined regex+shell-risk patterns which can regress silently.

### Description
- Add two new insta-based tests to `crates/perl-lsp-rs-core/tests/diag_snap.rs` that exercise duplicate declaration shadowing and suspicious regex + tainted `system()` usage.
- Add the corresponding approved snapshot fixtures under `crates/perl-lsp-rs-core/tests/snapshots/` to pin expected diagnostic code, severity, ranges, message text and suggestion content.

### Testing
- Ran `cargo test -p perl-lsp-rs-core --test diag_snap --locked`, which initially produced `.snap.new` files when the snapshots were missing and caused the snapshot assertions to fail.
- After adding the generated snapshot fixtures, re-running `cargo test -p perl-lsp-rs-core --test diag_snap --locked` completed successfully with `8 passed; 0 failed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d9eac388333a7eec3561b69aae5)