### PR TITLE
test(perl-lexer): add checkpoint state reset coverage (#0000)

### DIFF
--- a/crates/perl-lexer/src/checkpoint/tests.rs
+++ b/crates/perl-lexer/src/checkpoint/tests.rs
@@ -53,6 +53,47 @@ fn test_checkpoint_edit_start_boundary_no_change()
 }
 
 #[test]
+fn test_checkpoint_helpers_and_validity() {
+    let start = LexerCheckpoint::new();
+    assert!(start.is_at_start());
+    assert!(start.is_valid_for("abc"));
+
+    let at_two = LexerCheckpoint::at_position(2);
+    assert!(!at_two.is_at_start());
+    assert!(at_two.is_valid_for("abc"));
+    assert!(!LexerCheckpoint::at_position(4).is_valid_for("abc"));
+}
+
+#[test]
+fn test_checkpoint_edit_overlap_resets_state_fields() {
+    let mut cp = LexerCheckpoint::at_position(15);
+    cp.mode = LexerMode::ExpectOperator;
+    cp.delimiter_stack = vec!['{', '('];
+    cp.in_prototype = true;
+    cp.prototype_depth = 2;
+    cp.after_sub = true;
+    cp.after_arrow = true;
+    cp.hash_brace_depth = 3;
+    cp.after_var_subscript = true;
+    cp.paren_depth = 4;
+    cp.context = CheckpointContext::Regex { delimiter: '/', flags_position: Some(1) };
+
+    cp.apply_edit(10, 10, 3);
+
+    assert_eq!(cp.position, 10);
+    assert_eq!(cp.mode, LexerMode::ExpectTerm);
+    assert!(cp.delimiter_stack.is_empty());
+    assert!(!cp.in_prototype);
+    assert_eq!(cp.prototype_depth, 0);
+    assert!(!cp.after_sub);
+    assert!(!cp.after_arrow);
+    assert_eq!(cp.hash_brace_depth, 0);
+    assert!(!cp.after_var_subscript);
+    assert_eq!(cp.paren_depth, 0);
+    assert_eq!(cp.context, CheckpointContext::Normal);
+}
+
+#[test]
 fn test_checkpoint_cache() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let mut cache = CheckpointCache::new(3);
     cache.add(LexerCheckpoint::at_position(10));


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for the lexer checkpoint behavior, specifically helper predicates and the full state reset semantics when an edit overlaps a checkpoint.

### Description
- Added focused tests in `crates/perl-lexer/src/checkpoint/tests.rs`: `test_checkpoint_helpers_and_validity` which exercises `LexerCheckpoint::new`, `is_at_start`, and `is_valid_for`, and `test_checkpoint_edit_overlap_resets_state_fields` which verifies that `apply_edit` fully resets all mutable state fields when an edit invalidates a checkpoint.

### Testing
- Ran `cargo test -p perl-lexer --locked` and the test suite completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37da6df8c8333b447a48fe5053ce4)