### PR TITLE
test(perl-lexer): add checkpoint diff unit coverage (#0000)

### DIFF
--- a/crates/perl-lexer/src/checkpoint/diff.rs
+++ b/crates/perl-lexer/src/checkpoint/diff.rs
@@ -23,3 +23,63 @@ impl CheckpointDiff {
             || self.context_changed
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CheckpointDiff;
+
+    #[test]
+    fn has_state_changes_returns_false_when_only_position_differs() {
+        let diff = CheckpointDiff {
+            position_delta: 7,
+            mode_changed: false,
+            delimiter_stack_changed: false,
+            prototype_state_changed: false,
+            context_changed: false,
+        };
+
+        assert!(!diff.has_state_changes());
+    }
+
+    #[test]
+    fn has_state_changes_returns_true_when_mode_changes() {
+        let diff = CheckpointDiff {
+            position_delta: 0,
+            mode_changed: true,
+            delimiter_stack_changed: false,
+            prototype_state_changed: false,
+            context_changed: false,
+        };
+
+        assert!(diff.has_state_changes());
+    }
+
+    #[test]
+    fn has_state_changes_returns_true_when_any_non_position_flag_changes() {
+        for diff in [
+            CheckpointDiff {
+                position_delta: 0,
+                mode_changed: false,
+                delimiter_stack_changed: true,
+                prototype_state_changed: false,
+                context_changed: false,
+            },
+            CheckpointDiff {
+                position_delta: 0,
+                mode_changed: false,
+                delimiter_stack_changed: false,
+                prototype_state_changed: true,
+                context_changed: false,
+            },
+            CheckpointDiff {
+                position_delta: 0,
+                mode_changed: false,
+                delimiter_stack_changed: false,
+                prototype_state_changed: false,
+                context_changed: true,
+            },
+        ] {
+            assert!(diff.has_state_changes());
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve unit-test coverage for `CheckpointDiff::has_state_changes` to ensure its boolean-combination behavior is explicitly validated.

### Description
- Added focused unit tests in `crates/perl-lexer/src/checkpoint/diff.rs` (under `#[cfg(test)]`) that assert `has_state_changes` returns `false` for a position-only delta and `true` when `mode_changed` or any other non-position flag is set.

### Testing
- Ran `cargo test -p perl-lexer has_state_changes --locked` which passed (`3 passed; 0 failed`).
- Attempted `./scripts/cargo-safe test -p perl-lexer --profile agent --locked` but it was blocked by an environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37da6df8c8333b447a48fe5053ce4)