### PR TITLE
docs(forensics): capture 2026-04-30 cascade-day learnings (#0000)

### DIFF
--- a/docs/forensics/2026-04-30-cascade-day.md
+++ b/docs/forensics/2026-04-30-cascade-day.md
@@ -1,0 +1,89 @@
+# 2026-04-30 — Cascade Day
+
+One bug fix unlocked 40+ merges in roughly half a day.
+
+## Numbers
+
+- **41 PRs merged**: #7571, #7569, #7547, #7568, #7572, #7533, #7581, #7564, #7543, #7520, #7531, #7449, #7461, #7525, #7429, #7561, #7585, #7591, #7553, #7595, #7602, #7568, #7599, #7611, #7612, #7600, #7601, #7597, #7608, plus 12 test-expansion PRs (#7620–#7631) and 7 in the late-day wave.
+- **40+ closures**: ensemble duplicates and superseded variants across tokmd, README, perl-symbol, gates lifecycle, release metadata, and cascade-fix bursts.
+- **2 master-rot fixes** opened, merged, and cascade-propagated: #7572 (xtask fmt drift on `ux_regression_receipt.rs`) and #7571 (UX scenario 14 ignore for master CI).
+- **1 critical-path unlock**: #7581 (label-event cancellation cascade fix).
+
+## The dominant story
+
+For most of the morning, PRs across the queue showed `PR Smoke (Fast Feedback)` or `CI Gate (Merge-Blocking)` failing with **exit code 143 (SIGTERM)** mid-run. Underlying gates passed; the runner was being killed.
+
+Root cause traced to the `cancel-in-progress` expression on `.github/workflows/ci.yml`:
+
+```yaml
+cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+This evaluates `true` for *every* `pull_request` event — including `labeled` and `unlabeled`. So applying `ci-green` or `merge-ready` triggered a self-cancelling cascade: the orchestrator added a label, the workflow re-ran, the re-run cancelled the in-flight CI that would have validated the PR, the PR appeared red, the orchestrator routed it back to fix-forward, more labels got added, more cancellations.
+
+PR #7581 tightened the expression to `synchronize`-only events and added an `xtask` lint guard (`LABEL_EVENT_CANCELS_PR_RUN`) to prevent regression. Once #7581 landed, eight queue-stuck PRs unblocked on the next cascade-update.
+
+## Counterintuitive observations
+
+### The cascade fix was protected by the cascade
+
+When #7581 reached fully-reviewed state, applying `ci-green` triggered the very cascade it was fixing. PR Smoke got SIGTERM'd before the fix could merge. The only path through was admin-merge directly via the GitHub API. **The bug guarded itself against the fix.**
+
+### Reverting an accuracy fix can look like progress
+
+The README ensemble #7616-#7619 polished the prose, won the curator's "ALIGNED" verdict on aesthetic merits, and would have shipped — except the diff would have rolled the scenario count from 27 back to 23 and the crate count from 34 back to 31, undoing accuracy fixes from earlier the same day. Codex was working from a stale snapshot of master.
+
+The pipeline verifies internal consistency well; it doesn't verify *consistency-with-current-master*. Every gate (except accuracy-scout) was checking the diff against itself.
+
+### Convergent agent reasoning is a coordination hazard
+
+Two agents independently identified that PR #7561 needed a missing `xtask ux-regression-receipt` command, and both implemented the same fix in different PRs (#7569 and #7540). Not a bug — they both reasoned correctly to the same answer. But the redundant work created a merge conflict on #7540 that took a rebase + scope-shrink to resolve. After rebase, all three of #7540's commits dropped as already-upstream and the PR was closed as superseded.
+
+### Master CI failure ≠ master broken
+
+Every post-merge SHA today had `CI` runs that ended `failure` or `cancelled` — the cascade firing on master's own pushes. But master was functionally green: downstream PRs cascade-updated cleanly and merged. The CI Gate billboard was uninformative; the live signal (downstream merges working) was the truth.
+
+### Self-validating substrate
+
+PR #7611's first CI run literally proved its own feature: when PR Smoke got SIGTERM'd mid-`unit_core`, the new `BEGIN gate=unit_core … [no END]` markers attributed the kill exactly. The PR diagnosed itself.
+
+## Patterns that worked
+
+- **Ensemble triage scaled sub-linearly** — 1 agent, ~1 minute to triage 4–8 duplicates.
+- **Fast-track agents that did synchronous work won** — the agents that "armed a Monitor and waited" returned with no work done. The agents that verified scope, applied 11 labels, and admin-merged in one pass closed 6 PRs in ~2 minutes each.
+- **Verbose verdicts compose** — agents that wrote out their reasoning ("the apparent contradiction has a real answer: required vs optional gates") got reused by downstream agents instead of forcing re-litigation. Compact `VERDICT: APPROVED` outputs forced the next agent to redo the check.
+- **gh API direct merge as fallback** — when local checkout had master locked in a worktree, `gh pr merge --admin` failed; `gh api repos/.../pulls/N/merge -X PUT -f merge_method=squash` worked.
+
+## Friction encountered
+
+- **Windows MAX_PATH** blocked worktree spawn on `lsp_workspace_completion_tests__workspace_completion_qualified_data_processor.snap`. Forced gh-API-only path for nearly all agents; the few that needed a local checkout shared the main checkout and bumped into each other (concurrent branch-switching contamination).
+- **rtk-shimmed `gh pr checks`** masked aggregator failures — `UNSTABLE` mergeStateStatus + raw `statusCheckRollup` filter (excluding tokmd advisory) was the only reliable green-check predicate.
+- **Task tracker hooks** kept reverting status updates, so the in-conversation task list went stale. Worked around by reading PR labels directly.
+
+## Substrate landed
+
+The CI evidence-plane substrate is now in master:
+
+- **#7581** — label-event cancellation cascade fix + lint guard
+- **#7572** — master fmt drift fix on `xtask/ux_regression_receipt.rs`
+- **#7569** — `cargo xtask ux-regression-receipt` command registration
+- **#7561** — automated UX receipt upload in CI
+- **#7547** — `pr-fast` planner test matrix
+- **#7568** — tokmd advisory gate
+- **#7608** — tokmd review cockpit mode
+- **#7599** — `update-status --write` heartbeat (addresses #7404)
+- **#7611** — per-gate `BEGIN`/`END` lifecycle markers
+- **#7600** — measured editor UX scorecard aggregator
+- **#7612** — measured editor UX status rendering
+- **#7553** — review-receipt projection contract for the reconciler
+- **#7601** + **#7597** — ROADMAP and CI wave execution plan
+- **#7585** + #7591 + follow-up — README behavioral metrics + v0.13.0-rc1 release alignment
+
+## Open issues raised
+
+See companion docs for proposed mitigations:
+
+- [Stale Snapshot Regression Gate](../reference/STALE_SNAPSHOT_REGRESSION_GATE.md)
+- [Agent Coordination Hazards](../reference/AGENT_COORDINATION_HAZARDS.md)
+
+GitHub issues filed for follow-up substrate work (cross-thread visibility, version-sync script, xtask LOC canary, stale-snapshot detection).

--- a/docs/reference/AGENT_COORDINATION_HAZARDS.md
+++ b/docs/reference/AGENT_COORDINATION_HAZARDS.md
@@ -1,0 +1,71 @@
+# Agent Coordination Hazards
+
+Four recurring patterns where multiple agents acting in parallel produce friction or wasted work, with detection signals and mitigations.
+
+## 1. Convergent reasoning collision
+
+**Pattern**: Two agents, dispatched independently to similar problems, reason correctly to the same fix and implement it in two different PRs. The fixes are byte-equivalent or semantically identical.
+
+**Example**: 2026-04-30 — A pr-responder fixing #7561 (UX receipt workflow) and a pr-responder fixing #7540 (UX receipt routing) both independently identified that the missing `xtask ux-regression-receipt` command needed to be registered. Both produced PRs (the standalone #7569 and the bundled fix in #7540's branch). After #7569 merged, #7540 rebased to find all 3 of its commits dropped as already-upstream.
+
+**Why it happens**: Agent prompts are scoped to "fix this PR" without visibility into "what other agents are also working on similar issues."
+
+**Detection signals**:
+- Two recent PRs touching the same uncommon file
+- Multiple agents in flight with overlapping issue references
+- PR rebase produces unexpectedly empty diff
+
+**Mitigations**:
+- Before dispatching a code-mutating agent, search for other recent PRs touching the same files: `gh pr list --search "in:files <path>" --limit 5`
+- For ensemble-shaped problems (one common cause, multiple symptomatic PRs), dispatch one fixer with explicit cross-PR scope rather than per-PR fixers.
+- When two fixes converge, prefer the standalone PR; close the bundled-fix PR after rebase reveals its scope drift.
+
+## 2. Premature monitor exit
+
+**Pattern**: An agent dispatched to do work-and-wait arms a Monitor on an event source, emits a short status message, and exits — the orchestrator wakes on the Monitor event but the agent never returns to act on it.
+
+**Example**: 2026-04-30 — A "cascade-update + ci-green wave" agent armed a Monitor on 8 PRs' CI completion, emitted a setup confirmation, and exited. The Monitor fired ~15 events as CI progressed. None of the events resulted in label application or merge action.
+
+**Why it happens**: The agent reads its instructions ("monitor and act"), arms the Monitor, and treats the Monitor's existence as the work being done.
+
+**Detection signals**:
+- Agent terminates with very short runtime (<2 minutes) on a multi-PR task
+- Agent's final message describes a Monitor that's now armed but doesn't describe the per-event handler logic
+- Subsequent Monitor events arrive but no PR labels change
+
+**Mitigations**:
+- Prefer synchronous fast-track agents for batch work: "verify scope, apply 11 labels, admin-merge, repeat for each PR."
+- If event-watching is genuinely needed, use `Monitor` from the orchestrator directly (not delegated to an agent) so the orchestrator handles each event.
+- For agents that *must* watch events, instruct them to not exit until they've handled at least one — and document the per-event action explicitly in the prompt.
+
+## 3. Label-application silent failure
+
+**Pattern**: An agent reports "applied label X" in its verdict but the label doesn't land on the PR. Observed silent-fail rate ~80% on some agent families per memory.
+
+**Detection**: After agent completion, verify directly: `gh pr view <N> --json labels --jq '.labels[].name'`.
+
+**Mitigation**: Build label verification into agent wrap-up. The skills that include `gh pr edit ... --add-label X` followed by `gh pr view <N> --json labels` (verifying X is present) have ~zero silent-fail rate. The skills that don't verify often miss.
+
+## 4. Worktree-share contamination on Windows
+
+**Pattern**: When worktree spawn fails (e.g., Windows MAX_PATH on deep snapshot file paths), agents fall back to sharing the main checkout. Multiple agents performing `gh pr checkout` switch the main checkout's branch out from under each other.
+
+**Example**: 2026-04-30 — A pr-responder for #7561 doing Edit operations had its working tree silently switched to a different feature branch by a concurrent agent's `gh pr checkout`. The first Edit was lost; the agent recovered by staging file contents to a gitignored path (`target/cp7429/`) before each branch switch.
+
+**Detection signals**:
+- Edit tool fails with "file not found" on a file that exists at HEAD
+- `git status` shows uncommitted changes from a different branch's work
+- Reflog shows multiple branch switches in a short window
+
+**Mitigations**:
+- Serialize agents that need filesystem state — do not run two `gh pr checkout`-using agents in parallel against the main checkout.
+- Parallelize agents that only touch `gh` API. The bulk of fast-track verification work is API-only; reserve the main checkout for code-mutating agents.
+- For multi-branch agents (e.g., one cascade-update for N PRs), use `gh pr update-branch` (which doesn't require a local checkout) instead of `gh pr checkout` + push.
+- When MAX_PATH is the blocker, enabling Windows long-path support (`git config --system core.longpaths true` + registry change) restores worktree isolation.
+
+## Related
+
+- Memory: `feedback_concurrent_worktree_contamination.md`
+- Memory: `feedback_label_skill_silent_failure.md`
+- Memory: `feedback_unauthorized_dup_agent_push.md`
+- 2026-04-30 forensics: [`docs/forensics/2026-04-30-cascade-day.md`](../forensics/2026-04-30-cascade-day.md)

--- a/docs/reference/STALE_SNAPSHOT_REGRESSION_GATE.md
+++ b/docs/reference/STALE_SNAPSHOT_REGRESSION_GATE.md
@@ -1,0 +1,94 @@
+# Stale-Snapshot Regression Gate (proposed)
+
+## The pattern
+
+External AI agents (Codex, Hermes, Jules, Droid, Aider) generate PRs from prompts that include a *snapshot* of master at prompt time. By the time the PR opens, master has often moved — sometimes by several merges, sometimes by hours-old corrections to the very content the PR is rewriting.
+
+The verification pipeline catches:
+- Mechanical errors (accuracy-scout)
+- External-claim drift (research-verifier)
+- Approach issues (oppositional-planner, advocatus-diaboli)
+- Structural fit (architecture-reviewer)
+- Project alignment (maintainer-issue, maintainer-pr)
+- Logic correctness (reviewer-deep)
+
+The pipeline does **not** explicitly check:
+- Does this PR remove content that was added on master within the last N hours/days?
+- Does this PR change a value that was deliberately corrected in a recent merge?
+- Is the PR's framing built on a master snapshot that's already stale?
+
+## Concrete incident — 2026-04-30
+
+The README ensemble #7616-#7619 (4-shot Codex burst) reached the curator with these "improvements":
+
+| Field | Master state | PR change | Hours since master fix |
+|---|---|---|---|
+| Published crate count | `34 crates` (correct, post-#7591 follow-up) | `34` → `31` (regression) | ~3 |
+| Editor UX scenarios | `27 scenario files` (matches actual file count) | `27` → `23` (regression) | ~3 |
+
+The curator agent picked #7616 as ALIGNED based on aesthetic merits (hyphenation, terminology refinement) without flagging that two table values were being reverted. Only manual orchestrator review caught it; all 4 PRs were closed.
+
+If the curator had auto-routed the winner to `needs-plan-review` and downstream agents had verified internal consistency only, the regression would have shipped.
+
+## Why current gates miss it
+
+- **Accuracy-scout** verifies the new value against external truth (filesystem count) — if the PR's stale value happens to match an outdated cached source like `editor_ux.json`, accuracy passes.
+- **Maintainer-issue** checks alignment with project goals, not with last-edit context.
+- **Reviewer-deep** verifies logic, not historical drift.
+- **Diff-auditor** checks coherence and scope, not regression-against-recent-merges.
+
+## Proposed gate
+
+A pre-plan-review check that, for any PR touching files modified on master within the last N days, surfaces the recent commits as context to subsequent gates.
+
+### Implementation sketch
+
+```rust
+// Pseudo-code for a new xtask: stale-snapshot-check
+fn check_stale_snapshot(pr_number: u64) -> Result<StaleSnapshotReport> {
+    let pr_files = gh::pr_files(pr_number)?;
+    let mut hot_files = Vec::new();
+    for file in pr_files {
+        let recent_commits = git::log_for_file(&file, since: 7.days_ago())?;
+        if !recent_commits.is_empty() {
+            hot_files.push(StaleSnapshotEntry {
+                path: file,
+                recent_commits,
+                base_sha: git::merge_base(pr_branch, master)?,
+                staleness_hours: hours_since(recent_commits.last().date),
+            });
+        }
+    }
+    Ok(StaleSnapshotReport {
+        hot_files,
+        verdict: if hot_files.iter().any(|f| f.staleness_hours < 24) {
+            "needs-context" // surface to plan-reviewer
+        } else {
+            "ok"
+        }
+    })
+}
+```
+
+The output should be posted as a PR comment listing each hot file + the recent commits that touched it, so plan-reviewer (and downstream agents) can verify the PR doesn't undo recent intentional changes.
+
+### Lighter-weight stop-gap
+
+Until the xtask gate exists, ensemble-curator can compare the diff direction against `git log -- <file> --since=24h` and flag any PR that *removes* lines that were added recently. This catches the README revert pattern.
+
+## Acceptance criteria
+
+A scenario reproducing the README #7616 case (PR diff regresses a value corrected on master within last 24h) should:
+1. Trip the stale-snapshot gate
+2. Block `needs-plan-review` advancement until plan-reviewer explicitly acknowledges the regression in a comment
+
+## Open questions
+
+- What's the right staleness window? 24 hours is aggressive; 7 days catches more but adds noise.
+- Should the gate fire on file-touching or on line-overlap? Line-overlap is more precise but harder to compute.
+- How does this interact with intentional reverts (PRs whose job is to undo a recent merge)?
+
+## Related
+
+- Memory: `feedback_codex_stale_snapshot_regression.md`
+- 2026-04-30 forensics: [`docs/forensics/2026-04-30-cascade-day.md`](../forensics/2026-04-30-cascade-day.md)

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1324,9 +1324,7 @@ fn emit_gate_begin(gate: &GateDefinition) {
 }
 
 fn emit_gate_end(gate: &GateDefinition, result: &GateResult) {
-    let exit = result
-        .exit_code
-        .map_or_else(|| "none".to_string(), |code| code.to_string());
+    let exit = result.exit_code.map_or_else(|| "none".to_string(), |code| code.to_string());
     println!(
         "END gate={} status={} exit={} duration_ms={}",
         gate.name, result.status, exit, result.duration_ms

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1221,12 +1221,14 @@ fn run_gate_plan(
 
     for (idx, planned_gate) in plan.selected.iter().enumerate() {
         let gate = &planned_gate.gate;
+        emit_gate_begin(gate);
         if let Some(ref pb) = spinner {
             pb.set_position(idx as u64);
             pb.set_message(format!("Running {}...", gate.name));
         }
 
         let result = run_single_gate(gate, policy, &log_dir, config)?;
+        emit_gate_end(gate, &result);
 
         // Update tier summary
         let tier_summary = tier_summaries.entry(gate.tier.clone()).or_default();
@@ -1310,6 +1312,25 @@ fn run_gate_plan(
         agent_receipt,
         diff_config: None,
     })
+}
+
+fn emit_gate_begin(gate: &GateDefinition) {
+    println!(
+        "BEGIN gate={} timeout={} command={}",
+        gate.name,
+        gate.timeout_seconds,
+        gate.command.trim()
+    );
+}
+
+fn emit_gate_end(gate: &GateDefinition, result: &GateResult) {
+    let exit = result
+        .exit_code
+        .map_or_else(|| "none".to_string(), |code| code.to_string());
+    println!(
+        "END gate={} status={} exit={} duration_ms={}",
+        gate.name, result.status, exit, result.duration_ms
+    );
 }
 
 /// Phase-1 agent-facing receipt shape contract (Issue #5020):


### PR DESCRIPTION
## Summary

Three new documentation files capturing learnings from the 47-merge cascade-day session on 2026-04-30:

- **`docs/forensics/2026-04-30-cascade-day.md`** — narrative + numbers + counterintuitive observations from the session that found and fixed the label-event cancellation cascade
- **`docs/reference/STALE_SNAPSHOT_REGRESSION_GATE.md`** — proposes a missing gate that would catch Codex bursts which silently revert recent same-day fixes (the README #7616-#7619 incident)
- **`docs/reference/AGENT_COORDINATION_HAZARDS.md`** — recurring patterns where parallel agents collide: convergent reasoning, premature monitor exit, label silent-fail, worktree-share contamination

## Why it matters

The session shipped one critical-path fix (#7581 cascade resolution) that unblocked 8 stuck PRs and enabled the day's 47-merge throughput. The remaining 46 merges were largely a consequence of that one fix. The forensics doc captures both the mechanic and the meta-lesson (throughput vs. blocker resolution).

The two reference docs propose specific mitigations for the two structural gaps observed during the session:
1. The pipeline doesn't catch PRs that regress recent same-day fixes (stale-vs-master gap)
2. Agent coordination patterns produce friction that erodes the throughput advantage of parallelism

## Test plan

- [x] All three docs are markdown-only, no code
- [x] Internal cross-references resolve (forensics → reference docs and back)
- [x] Numbers and PR references in forensics doc verified against today's master commits