### PR TITLE
test(perl-lsp-rs): expand e2e completion update coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_e2e_user_stories.rs
+++ b/crates/perl-lsp-rs/tests/lsp_e2e_user_stories.rs
@@ -247,6 +247,68 @@ pri  # Developer is typing 'print'
     Ok(())
 }
 
+#[test]
+fn test_user_story_completion_tracks_document_updates() -> TestResult {
+    let server = create_test_server();
+    initialize_server(&server);
+
+    let uri = "file:///test/completion_update.pl";
+    let original = r#"
+my $alpha = 1;
+my $beta = 2;
+
+$
+"#;
+    open_document(&server, uri, original);
+
+    let before = send_request(
+        &server,
+        "textDocument/completion",
+        Some(json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 4, "character": 1 }
+        })),
+    );
+
+    assert_completion_has_items(&before);
+    let before_val = before.ok_or("Expected completion response before update")?;
+    let before_items =
+        before_val["items"].as_array().ok_or("Expected completion items before update")?;
+    assert!(before_items.iter().any(|item| item["label"] == "$alpha"));
+    assert!(before_items.iter().any(|item| item["label"] == "$beta"));
+
+    let updated = r#"
+my $renamed_alpha = 1;
+my $beta = 2;
+
+$
+"#;
+    update_document(&server, uri, 2, updated);
+
+    let after = send_request(
+        &server,
+        "textDocument/completion",
+        Some(json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 4, "character": 1 }
+        })),
+    );
+
+    assert_completion_has_items(&after);
+    let after_val = after.ok_or("Expected completion response after update")?;
+    let after_items =
+        after_val["items"].as_array().ok_or("Expected completion items after update")?;
+
+    assert!(after_items.iter().any(|item| item["label"] == "$renamed_alpha"));
+    assert!(after_items.iter().any(|item| item["label"] == "$beta"));
+    assert!(
+        !after_items.iter().any(|item| item["label"] == "$alpha"),
+        "stale completion item from previous document version should not remain"
+    );
+
+    Ok(())
+}
+
 // ==================== USER STORY 3: GO TO DEFINITION ====================
 // As a Perl developer, I want to quickly navigate to where functions and variables are defined,
 // so that I can understand the code better.


### PR DESCRIPTION
### Motivation
- End-to-end coverage lacked an explicit check that completion results are refreshed after a `textDocument/didChange` update, allowing stale symbols to persist undetected.

### Description
- Added a focused E2E user-story test `test_user_story_completion_tracks_document_updates` to `crates/perl-lsp-rs/tests/lsp_e2e_user_stories.rs` that requests completions before and after a document update and asserts new symbols appear while removed symbols disappear.
- The test uses existing helpers `open_document`, `update_document`, `send_request`, and `assert_completion_has_items` to exercise the LSP completion pipeline and document synchronization.

### Testing
- Ran formatting verification with `./scripts/cargo-safe xtask fmt`, which completed successfully.
- Attempted `./scripts/cargo-safe test -p perl-lsp-rs --test lsp_e2e_user_stories --profile agent --locked`, but the test run was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so full test execution could not complete.
- Ran `./scripts/storage-doctor` to confirm environment state for diagnostics, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37db33670833392474f2769b39bd8)