### PR TITLE
test(perl-parser): expand substitution fuzz coverage (#0000)

### DIFF
--- a/crates/perl-parser/tests/substitution_fuzz_tests.rs
+++ b/crates/perl-parser/tests/substitution_fuzz_tests.rs
@@ -168,6 +168,43 @@ fn generate_pathological_inputs() -> Vec<String> {
     inputs
 }
 
+/// Generate deterministic pseudo-fuzz inputs for substitution parsing.
+///
+/// This expands coverage beyond hand-authored regressions while still keeping
+/// the test run deterministic and debuggable.
+fn generate_deterministic_pseudo_fuzz_inputs() -> Vec<String> {
+    let delimiters = ['/', '!', '#', '%', '~', '{', '[', '(', '<'];
+    let mut inputs = Vec::new();
+
+    for seed in 0..64_u8 {
+        let delimiter = delimiters[(seed as usize) % delimiters.len()];
+        let (open_delim, close_delim) = match delimiter {
+            '{' => ('{', '}'),
+            '[' => ('[', ']'),
+            '(' => ('(', ')'),
+            '<' => ('<', '>'),
+            d => (d, d),
+        };
+
+        let escaped = format!("\\{}{}", open_delim, close_delim);
+        let pattern = format!("p{seed:02x}{escaped}");
+        let replacement = format!("r{seed:02x}{}", escaped.chars().rev().collect::<String>());
+
+        let modifiers = match seed % 4 {
+            0 => "g",
+            1 => "im",
+            2 => "xer",
+            _ => "",
+        };
+
+        inputs.push(format!(
+            "s{open_delim}{pattern}{close_delim}{open_delim}{replacement}{close_delim}{modifiers}"
+        ));
+    }
+
+    inputs
+}
+
 /// Run systematic property-based testing
 fn run_substitution_fuzz_tests() -> Result<(), Vec<String>> {
     let mut all_crashes = Vec::new();
@@ -285,4 +322,16 @@ fn test_substitution_comprehensive_fuzz() -> Result<(), Box<dyn std::error::Erro
         }
     }
     Ok(())
+}
+
+#[test]
+fn test_substitution_deterministic_pseudo_fuzz_inputs() {
+    let inputs = generate_deterministic_pseudo_fuzz_inputs();
+    let input_refs: Vec<&str> = inputs.iter().map(String::as_str).collect();
+    let crashes = test_substitution_batch(&input_refs);
+    assert!(
+        crashes.is_empty(),
+        "Found crashes in deterministic pseudo fuzz cases: {:?}",
+        crashes
+    );
 }


### PR DESCRIPTION
### Motivation
- Improve robustness of the substitution operator parsing tests by expanding coverage beyond hand-authored regressions to exercise more delimiters, escapes, and modifier combinations.

### Description
- Added a deterministic pseudo-fuzz generator `generate_deterministic_pseudo_fuzz_inputs()` that produces 64 corpus entries across multiple delimiter families (including balanced delimiters) with escaped content and varied modifiers in `crates/perl-parser/tests/substitution_fuzz_tests.rs`.
- Added a focused regression test `test_substitution_deterministic_pseudo_fuzz_inputs` that runs the generated inputs through the existing panic/invariant harness (`test_substitution_batch`) to assert non-panicking behavior.
- The changes keep the run deterministic and debuggable while broadening automated fuzz coverage for substitution parsing.

### Testing
- Ran `cargo test -p perl-parser test_substitution_deterministic_pseudo_fuzz_inputs --locked -- --exact` and the new test passed (`1 passed; 0 failed`).
- Attempted `./scripts/cargo-safe test -p perl-parser --profile agent --locked` but it was blocked by a storage guard (`DENY: /root/.cache/devplane/...`).
- CI/local full test-suite runs were not executed in this session beyond the focused test due to the storage guard and resource locking observed during compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37d9729e88333af4edc148636e78a)