### PR TITLE
fix(fmt): apply rustfmt across post-wave test additions (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
@@ -3091,7 +3091,8 @@ sub list {
 
 #[test]
 #[serial]
-fn bdd_document_highlight_marks_read_and_write_occurrences() -> Result<(), Box<dyn std::error::Error>> {
+fn bdd_document_highlight_marks_read_and_write_occurrences()
+-> Result<(), Box<dyn std::error::Error>> {
     let scenario = BddScenario::new("Document highlight includes read and write occurrences");
 
     let script = r#"use strict;

--- a/crates/perl-lsp-rs/tests/lsp_smoke_e2e.rs
+++ b/crates/perl-lsp-rs/tests/lsp_smoke_e2e.rs
@@ -341,7 +341,6 @@ my $value = gre
         "hover after bogus cancelRequest returned error: {post_cancel_response:#}"
     );
 
-
     // ── Step 10: textDocument/rename ─────────────────────────────────────
     let (rename_line, rename_col) = line_col(fixture_v2, 6, "greet()")?;
     let rename_response = send_request_with_timeout(
@@ -355,13 +354,8 @@ my $value = gre
         }),
         timeout,
     )?;
-    assert!(
-        rename_response.get("error").is_none(),
-        "rename returned error: {rename_response:#}"
-    );
-    let rename_result = rename_response
-        .get("result")
-        .ok_or("rename result should be present")?;
+    assert!(rename_response.get("error").is_none(), "rename returned error: {rename_response:#}");
+    let rename_result = rename_response.get("result").ok_or("rename result should be present")?;
     let rename_changes = rename_result
         .get("changes")
         .and_then(Value::as_object)

--- a/crates/perl-parser/tests/parser_bdd_scenarios.rs
+++ b/crates/perl-parser/tests/parser_bdd_scenarios.rs
@@ -360,7 +360,8 @@ fn bdd_given_state_vars_and_method_chaining_when_parsed_then_state_and_arrow_inv
 }
 
 #[test]
-fn bdd_given_map_and_grep_pipeline_when_parsed_then_higher_order_blocks_are_retained() -> TestResult {
+fn bdd_given_map_and_grep_pipeline_when_parsed_then_higher_order_blocks_are_retained() -> TestResult
+{
     // Given: a developer transforms and filters a list with map/grep blocks.
     let code = r#"
         my @nums = (1, 2, 3, 4, 5);

--- a/crates/perl-parser/tests/parser_boolean_logic_mutation_hardening.rs
+++ b/crates/perl-parser/tests/parser_boolean_logic_mutation_hardening.rs
@@ -316,7 +316,6 @@ fn test_statement_modifier_parsing_mutations() {
     }
 }
 
-
 /// Test block/terminator boundaries with trailing control tokens.
 /// This specifically targets statement terminator boolean mutations around `}` and EOF.
 #[test]
@@ -327,11 +326,7 @@ fn test_block_boundary_terminator_mutations() {
             true,
             "Braced if/else should terminate statements at closing braces",
         ),
-        (
-            r"while ($ready) { last if $done; }",
-            true,
-            "Loop body should terminate at closing brace",
-        ),
+        (r"while ($ready) { last if $done; }", true, "Loop body should terminate at closing brace"),
         (
             r"sub f { return 1; } f();",
             true,
@@ -342,16 +337,8 @@ fn test_block_boundary_terminator_mutations() {
             true,
             "Dangling else must fail quickly instead of looping",
         ),
-        (
-            r"sub g { my $x = 1; ",
-            true,
-            "Unclosed block at EOF must be handled without hanging",
-        ),
-        (
-            r"for my $i (1..3) { print $i; } }",
-            true,
-            "Extra closing brace must fail cleanly",
-        ),
+        (r"sub g { my $x = 1; ", true, "Unclosed block at EOF must be handled without hanging"),
+        (r"for my $i (1..3) { print $i; } }", true, "Extra closing brace must fail cleanly"),
     ];
 
     for (perl_code, should_succeed, description) in boundary_cases {
@@ -377,12 +364,7 @@ fn test_block_boundary_terminator_mutations() {
             perl_code
         );
 
-        assert_eq!(
-            parse_result.is_ok(),
-            should_succeed,
-            "{}",
-            description
-        );
+        assert_eq!(parse_result.is_ok(), should_succeed, "{}", description);
     }
 }
 

--- a/crates/perl-parser/tests/substitution_fuzz_tests.rs
+++ b/crates/perl-parser/tests/substitution_fuzz_tests.rs
@@ -329,9 +329,5 @@ fn test_substitution_deterministic_pseudo_fuzz_inputs() {
     let inputs = generate_deterministic_pseudo_fuzz_inputs();
     let input_refs: Vec<&str> = inputs.iter().map(String::as_str).collect();
     let crashes = test_substitution_batch(&input_refs);
-    assert!(
-        crashes.is_empty(),
-        "Found crashes in deterministic pseudo fuzz cases: {:?}",
-        crashes
-    );
+    assert!(crashes.is_empty(), "Found crashes in deterministic pseudo fuzz cases: {:?}", crashes);
 }


### PR DESCRIPTION
Master fmt drift across 5 test files from today's wave-4 merges. Required to unblock release-orchestration v0.13.0-rc1 (CI Gate posts ci/merge-gate only when fmt passes).