### PR TITLE
ci(gates): keep pr smoke alive (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   pr-smoke:
     name: PR Smoke (Fast Feedback)
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 25
     needs: [draft-pr-check, preflight-latest-check]
     if: needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
     steps:
@@ -146,7 +146,7 @@ jobs:
         run: cargo build -p xtask --locked
 
       - name: Run PR-fast via shared xtask gate runner
-        run: cargo xtask gates --tier pr-fast --base origin/master --receipt
+        run: ./target/debug/xtask gates --tier pr-fast --base origin/master --receipt
 
       - name: Upload PR-fast receipt
         if: always()

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1724,6 +1724,7 @@ fn run_shell_command_with_timeout(
         .with_context(|| format!("Failed to spawn gate command: {command}"))?;
 
     let start = Instant::now();
+    let mut last_heartbeat = start;
     let timeout = Duration::from_secs(timeout_secs);
 
     // Poll until the process exits or the deadline elapses.
@@ -1738,6 +1739,14 @@ fn run_shell_command_with_timeout(
             child.kill().ok();
             child.wait().ok();
             break (true, 124_i32);
+        }
+        if last_heartbeat.elapsed() >= Duration::from_secs(30) {
+            println!(
+                "gate command still running elapsed_ms={} timeout_seconds={}",
+                start.elapsed().as_millis(),
+                timeout_secs
+            );
+            last_heartbeat = Instant::now();
         }
         thread::sleep(Duration::from_millis(100));
     };


### PR DESCRIPTION
Problem: PR Smoke can exceed the current job budget while child gate output is redirected to logs, producing exit 143 without useful progress evidence.  
Fix: Increase the PR Smoke job timeout and emit periodic gate-runner heartbeats while a child command is still running.  
Verification: cargo fmt --package xtask; cargo check -p xtask --all-targets; cargo test -p xtask gates; git diff --check.