### PR TITLE
fix(clippy): unblock master CI Gate by fixing expect_used + collapsible_if errors (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
+++ b/crates/perl-lsp-rs/tests/lsp_bdd_workflows.rs
@@ -3091,7 +3091,8 @@ sub list {
 
 #[test]
 #[serial]
-fn bdd_document_highlight_marks_read_and_write_occurrences() -> Result<(), Box<dyn std::error::Error>> {
+fn bdd_document_highlight_marks_read_and_write_occurrences()
+-> Result<(), Box<dyn std::error::Error>> {
     let scenario = BddScenario::new("Document highlight includes read and write occurrences");
 
     let script = r#"use strict;

--- a/crates/perl-lsp-rs/tests/lsp_smoke_e2e.rs
+++ b/crates/perl-lsp-rs/tests/lsp_smoke_e2e.rs
@@ -341,7 +341,6 @@ my $value = gre
         "hover after bogus cancelRequest returned error: {post_cancel_response:#}"
     );
 
-
     // ── Step 10: textDocument/rename ─────────────────────────────────────
     let (rename_line, rename_col) = line_col(fixture_v2, 6, "greet()")?;
     let rename_response = send_request_with_timeout(
@@ -355,13 +354,8 @@ my $value = gre
         }),
         timeout,
     )?;
-    assert!(
-        rename_response.get("error").is_none(),
-        "rename returned error: {rename_response:#}"
-    );
-    let rename_result = rename_response
-        .get("result")
-        .ok_or("rename result should be present")?;
+    assert!(rename_response.get("error").is_none(), "rename returned error: {rename_response:#}");
+    let rename_result = rename_response.get("result").ok_or("rename result should be present")?;
     let rename_changes = rename_result
         .get("changes")
         .and_then(Value::as_object)

--- a/crates/perl-parser/tests/parser_bdd_scenarios.rs
+++ b/crates/perl-parser/tests/parser_bdd_scenarios.rs
@@ -360,7 +360,8 @@ fn bdd_given_state_vars_and_method_chaining_when_parsed_then_state_and_arrow_inv
 }
 
 #[test]
-fn bdd_given_map_and_grep_pipeline_when_parsed_then_higher_order_blocks_are_retained() -> TestResult {
+fn bdd_given_map_and_grep_pipeline_when_parsed_then_higher_order_blocks_are_retained() -> TestResult
+{
     // Given: a developer transforms and filters a list with map/grep blocks.
     let code = r#"
         my @nums = (1, 2, 3, 4, 5);

--- a/crates/perl-parser/tests/parser_boolean_logic_mutation_hardening.rs
+++ b/crates/perl-parser/tests/parser_boolean_logic_mutation_hardening.rs
@@ -316,7 +316,6 @@ fn test_statement_modifier_parsing_mutations() {
     }
 }
 
-
 /// Test block/terminator boundaries with trailing control tokens.
 /// This specifically targets statement terminator boolean mutations around `}` and EOF.
 #[test]
@@ -327,11 +326,7 @@ fn test_block_boundary_terminator_mutations() {
             true,
             "Braced if/else should terminate statements at closing braces",
         ),
-        (
-            r"while ($ready) { last if $done; }",
-            true,
-            "Loop body should terminate at closing brace",
-        ),
+        (r"while ($ready) { last if $done; }", true, "Loop body should terminate at closing brace"),
         (
             r"sub f { return 1; } f();",
             true,
@@ -342,16 +337,8 @@ fn test_block_boundary_terminator_mutations() {
             true,
             "Dangling else must fail quickly instead of looping",
         ),
-        (
-            r"sub g { my $x = 1; ",
-            true,
-            "Unclosed block at EOF must be handled without hanging",
-        ),
-        (
-            r"for my $i (1..3) { print $i; } }",
-            true,
-            "Extra closing brace must fail cleanly",
-        ),
+        (r"sub g { my $x = 1; ", true, "Unclosed block at EOF must be handled without hanging"),
+        (r"for my $i (1..3) { print $i; } }", true, "Extra closing brace must fail cleanly"),
     ];
 
     for (perl_code, should_succeed, description) in boundary_cases {
@@ -377,12 +364,7 @@ fn test_block_boundary_terminator_mutations() {
             perl_code
         );
 
-        assert_eq!(
-            parse_result.is_ok(),
-            should_succeed,
-            "{}",
-            description
-        );
+        assert_eq!(parse_result.is_ok(), should_succeed, "{}", description);
     }
 }
 

--- a/crates/perl-parser/tests/substitution_fuzz_tests.rs
+++ b/crates/perl-parser/tests/substitution_fuzz_tests.rs
@@ -329,9 +329,5 @@ fn test_substitution_deterministic_pseudo_fuzz_inputs() {
     let inputs = generate_deterministic_pseudo_fuzz_inputs();
     let input_refs: Vec<&str> = inputs.iter().map(String::as_str).collect();
     let crashes = test_substitution_batch(&input_refs);
-    assert!(
-        crashes.is_empty(),
-        "Found crashes in deterministic pseudo fuzz cases: {:?}",
-        crashes
-    );
+    assert!(crashes.is_empty(), "Found crashes in deterministic pseudo fuzz cases: {:?}", crashes);
 }

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1088,10 +1088,10 @@ fn package_names_for_gate(
     package_names: &[String],
     target_index: Option<&PackageTargetIndex>,
 ) -> Vec<String> {
-    if gate_requires_lib(gate) {
-        if let Some(index) = target_index {
-            return package_names.iter().filter(|name| index.has_lib(name)).cloned().collect();
-        }
+    if gate_requires_lib(gate)
+        && let Some(index) = target_index
+    {
+        return package_names.iter().filter(|name| index.has_lib(name)).cloned().collect();
     }
     package_names.to_vec()
 }

--- a/xtask/src/tasks/update_status/mod.rs
+++ b/xtask/src/tasks/update_status/mod.rs
@@ -144,10 +144,10 @@ fn run_cmd(root: &Path, args: &[&str], timeout: Duration) -> String {
     if let Some(handle) = err_handle {
         combined.push_str(&handle.join().unwrap_or_default());
     }
-    if let Ok(status) = status {
-        if !status.success() {
-            eprintln!("[update-status] command exited with {status}: {}", args.join(" "));
-        }
+    if let Ok(status) = status
+        && !status.success()
+    {
+        eprintln!("[update-status] command exited with {status}: {}", args.join(" "));
     }
     combined
 }

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -7,12 +7,14 @@ use color_eyre::eyre::{Context, Result};
 use regex::Regex;
 use serde::Serialize;
 
+#[allow(clippy::expect_used, reason = "static LazyLock regex with known-good pattern")]
 static FAILED_TEST_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"test\s+([^\s]+)\s+\.\.\.\s+FAILED").expect("failed test regex must compile")
 });
 // Matches both pre-1.73 format ("panicked at 'msg', path:row:col") and
 // post-1.73 format ("panicked at path:row:col:") where the location appears
 // directly after "panicked at " without a quoted message.
+#[allow(clippy::expect_used, reason = "static LazyLock regex with known-good pattern")]
 static PANIC_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"panicked at (?:'[^']*',\s*)?([a-zA-Z][^:\s][^:]*:\d+:\d+)")
         .expect("panic regex must compile")


### PR DESCRIPTION
Three clippy errors blocking the merge-gate CI Gate (Merge-Blocking) on master, preventing release-orchestration from validating ci/merge-gate=success.

- xtask/src/tasks/ux_regression_receipt.rs:11,17 — `expect()` in static `LazyLock<Regex>` initializers; added `#[allow(clippy::expect_used)]` per CLAUDE.md exception.
- xtask/src/tasks/update_status/mod.rs:147 — collapsible_if; collapsed to let-chain.
- xtask/src/tasks/gates.rs:1091 — collapsible_if; collapsed to let-chain.

Locally verified `cargo clippy --workspace --lib` and `cargo clippy --workspace --bins` both clean.

Required to land the v0.13.0-rc1 release.