### PR TITLE
fix(vscode-extension): exclude test sources from production build (#0000)

### DIFF
--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -16,5 +16,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "out", "**/*.test.ts"]
+  "exclude": ["node_modules", "out", "**/*.test.ts", "src/test/**"]
 }


### PR DESCRIPTION
Second VSCode extension build error blocking v0.13.0-rc1: tsconfig was including `src/test/__mocks__/vscode.ts` (which references `jest` types) in the production VSIX build.

Excluding `src/test/**` from compilation keeps the test mocks for local development while letting the publish workflow build cleanly.