### PR TITLE
fix(vscode-extension): bump engines.vscode to ^1.116.0 (#0000)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -7,7 +7,7 @@
   "preview": true,
   "markdown": "github",
   "engines": {
-    "vscode": "^1.88.0"
+    "vscode": "^1.116.0"
   },
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
Third VSCode extension build error blocking v0.13.0-rc1: `@types/vscode ^1.116.0 greater than engines.vscode ^1.88.0`. Bumps engines.vscode to match @types/vscode.