### PR TITLE
feat(status): render measured editor UX readiness (#0000)

### DIFF
--- a/.ci/metrics/editor_ux.json
+++ b/.ci/metrics/editor_ux.json
@@ -1,0 +1,1310 @@
+{
+  "schema_version": 1,
+  "measured_at": "2026-04-30T20:54:03.456684600+00:00",
+  "subsystem": "editor_ux",
+  "top_line": {
+    "workflow_pass_rate": {
+      "state": "insufficient_data",
+      "value": null,
+      "kind": "measured",
+      "basis": [
+        "no eligible receipts"
+      ],
+      "coverage": "receipts_included",
+      "confidence": "low",
+      "assumptions": [
+        "insufficient data"
+      ]
+    },
+    "workflow_stability_rate": {
+      "state": "insufficient_data",
+      "value": null,
+      "kind": "measured",
+      "basis": [
+        "no workflows with sufficient data"
+      ],
+      "coverage": "receipts_included",
+      "confidence": "low",
+      "assumptions": [
+        "insufficient data"
+      ]
+    },
+    "p95_time_to_first_useful_result_ms": {
+      "state": "insufficient_data",
+      "value": null,
+      "kind": "measured",
+      "basis": [
+        "no passing scenarios with timing data"
+      ],
+      "coverage": "receipts_included",
+      "confidence": "low",
+      "method": "p95",
+      "assumptions": [
+        "insufficient data"
+      ]
+    }
+  },
+  "components": {
+    "cross_file_definition_success_rate": {
+      "state": "insufficient_data",
+      "value": null,
+      "kind": "measured",
+      "basis": [
+        "no workflows measuring cross_file_definition_success_rate"
+      ],
+      "coverage": "receipts_included",
+      "confidence": "low",
+      "assumptions": [
+        "insufficient data"
+      ]
+    },
+    "module_resolution_workflow_success_rate": {
+      "state": "insufficient_data",
+      "value": null,
+      "kind": "measured",
+      "basis": [
+        "no workflows measuring module_resolution_workflow_success_rate"
+      ],
+      "coverage": "receipts_included",
+      "confidence": "low",
+      "assumptions": [
+        "insufficient data"
+      ]
+    },
+    "multi_root_workspace_navigation_success_rate": {
+      "state": "insufficient_data",
+      "value": null,
+      "kind": "measured",
+      "basis": [
+        "no workflows measuring multi_root_workspace_navigation_success_rate"
+      ],
+      "coverage": "receipts_included",
+      "confidence": "low",
+      "assumptions": [
+        "insufficient data"
+      ]
+    }
+  },
+  "workflows": [
+    {
+      "id": "simple_file_smoke",
+      "scenario": "ux_scenario_01_simple_file.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "missing_perltidy_graceful_degradation",
+      "scenario": "ux_scenario_02_missing_perltidy.rs",
+      "subsystem_owner": "engineering_health",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "missing_perl_graceful_degradation",
+      "scenario": "ux_scenario_03_missing_perl.rs",
+      "subsystem_owner": "engineering_health",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "missing_perlcritic_graceful_degradation",
+      "scenario": "ux_scenario_04_missing_perlcritic.rs",
+      "subsystem_owner": "engineering_health",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "bad_config_resilience",
+      "scenario": "ux_scenario_05_bad_config.rs",
+      "subsystem_owner": "engineering_health",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "large_file_open",
+      "scenario": "ux_scenario_06_large_file.rs",
+      "subsystem_owner": "engineering_health",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "multi_file_workspace_navigation",
+      "scenario": "ux_scenario_07_multi_file_workspace.rs",
+      "subsystem_owner": "workspace_indexing",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "shebang_detection",
+      "scenario": "ux_scenario_08_shebang_detection.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "encoding_and_bom_resilience",
+      "scenario": "ux_scenario_09_encoding.rs",
+      "subsystem_owner": "engineering_health",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "goto_definition_core",
+      "scenario": "ux_scenario_10_goto_definition.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "hover_core",
+      "scenario": "ux_scenario_11_hover.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "strict_diagnostics",
+      "scenario": "ux_scenario_12_diagnostics_strict.rs",
+      "subsystem_owner": "diagnostics",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "document_symbols_core",
+      "scenario": "ux_scenario_13_document_symbols.rs",
+      "subsystem_owner": "workspace_indexing",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "inc_conformance",
+      "scenario": "ux_scenario_14_inc_conformance.rs",
+      "subsystem_owner": "module_resolution",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "multi_root_workspace_symbols",
+      "scenario": "ux_scenario_15_workspace_symbols.rs",
+      "subsystem_owner": "workspace_indexing",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "workspace_folder_removal_freshness",
+      "scenario": "ux_scenario_16_workspace_folder_removal.rs",
+      "subsystem_owner": "workspace_indexing",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "deleted_file_churn_freshness",
+      "scenario": "ux_scenario_17_deleted_file_churn.rs",
+      "subsystem_owner": "workspace_indexing",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "goto_declaration_core",
+      "scenario": "ux_scenario_18_goto_declaration.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "template_language_mode_resilience",
+      "scenario": "ux_scenario_22_template_language_mode.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "diagnostics_after_edit_refresh",
+      "scenario": "ux_scenario_18_diagnostics_after_edit.rs",
+      "subsystem_owner": "diagnostics",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "real_repo_first_diagnostics_budget",
+      "scenario": "ux_scenario_18_real_repo_perf.rs",
+      "subsystem_owner": "diagnostics",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "rename_workflow_core",
+      "scenario": "ux_scenario_23_rename_workflow.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "workspace_folder_addition_freshness",
+      "scenario": "ux_scenario_19_workspace_folder_addition.rs",
+      "subsystem_owner": "workspace_indexing",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "live_edit_feedback_loop",
+      "scenario": "ux_scenario_24_live_edit_feedback.rs",
+      "subsystem_owner": "text_sync",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "completion_core",
+      "scenario": "ux_scenario_19_completion_core.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "incremental_text_sync_recovery",
+      "scenario": "ux_scenario_19_incremental_text_sync.rs",
+      "subsystem_owner": "text_sync",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "diagnostics_lifecycle_editing",
+      "scenario": "ux_scenario_19_diagnostics_lifecycle.rs",
+      "subsystem_owner": "diagnostics",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    }
+  ],
+  "provenance": {
+    "fixture_matrix": "H:\\Code\\Rust2\\perl-lsp\\crates\\perl-lsp-ux-tests\\fixtures\\editor_ux_fixture_matrix.json",
+    "harness": "crates/perl-lsp-ux-tests",
+    "tiers": []
+  }
+}

--- a/.ci/schemas/editor-ux.schema.json
+++ b/.ci/schemas/editor-ux.schema.json
@@ -160,6 +160,13 @@
             "low"
           ]
         },
+        "value": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
         "method": {
           "type": "string"
         },

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -4,24 +4,24 @@
       "name": "manual_editor_smoke",
       "owner": "perl-lsp-ux-tests",
       "state": "tracked",
-      "workflow_count": 22
+      "workflow_count": 26
     },
     {
       "name": "first_five_minutes_harness",
       "owner": "perl-lsp-ux-tests",
       "state": "tracked",
-      "workflow_count": 21
+      "workflow_count": 25
     },
     {
       "name": "issue_burndown_regression_guard",
       "owner": "perl-lsp-ux-tests",
       "state": "tracked",
-      "workflow_count": 13
+      "workflow_count": 17
     }
   ],
   "harness": {
     "crate": "crates/perl-lsp-ux-tests",
-    "scenario_count": 23,
+    "scenario_count": 27,
     "scenario_files": [
       "crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_02_missing_perltidy.rs",
@@ -43,9 +43,13 @@
       "crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_core.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_text_sync.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_22_template_language_mode.rs",
-      "crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs"
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs"
     ]
   },
   "integration_points": {
@@ -54,24 +58,395 @@
     "release_lane": "just ux-tests-full",
     "status_update": "cargo xtask update-status --only quality"
   },
-  "receipt_kind": "planning_scaffold",
+  "known_blockers": [
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_relative_include_path"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_include_path_completion_external_module"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_use_lib_lexical"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_absolute_include_path"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_no_lib_cancellation"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_findbin_relative"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_system_inc"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_nested_module_relative_include_path"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_include_path_missing_module_consistency"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_include_path_missing_module_completion_consistency"
+    },
+    {
+      "component": "module_resolution",
+      "failure_class": "provider_regression",
+      "issue": 7570,
+      "owner": "@maintainer",
+      "route": "provider_fix",
+      "state": "active",
+      "test_name": "ux_scenario_14_inc_conformance::scenario_14_system_inc_completion_opt_in_enabled"
+    }
+  ],
+  "receipt_kind": "measured_status",
   "schema_version": 1,
   "scorecard": "editor_ux",
   "top_line_metrics": [
     {
+      "assumptions": [
+        "insufficient data"
+      ],
+      "basis": [
+        "no eligible receipts"
+      ],
+      "confidence": "low",
+      "coverage": "receipts_included",
       "name": "workflow_pass_rate",
-      "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "insufficient_data",
+      "value": null
     },
     {
+      "assumptions": [
+        "insufficient data"
+      ],
+      "basis": [
+        "no workflows with sufficient data"
+      ],
+      "confidence": "low",
+      "coverage": "receipts_included",
       "name": "workflow_stability_rate",
-      "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "insufficient_data",
+      "value": null
     },
     {
+      "assumptions": [
+        "insufficient data"
+      ],
+      "basis": [
+        "no passing scenarios with timing data"
+      ],
+      "confidence": "low",
+      "coverage": "receipts_included",
+      "method": "p95",
       "name": "p95_time_to_first_useful_result_ms",
-      "owner": "perl-lsp-ux-tests",
-      "state": "planned"
+      "state": "insufficient_data",
+      "value_ms": null
+    }
+  ],
+  "workflow_results": [
+    {
+      "id": "simple_file_smoke",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_01_simple_file.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "missing_perltidy_graceful_degradation",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_02_missing_perltidy.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "engineering_health"
+    },
+    {
+      "id": "missing_perl_graceful_degradation",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_03_missing_perl.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "engineering_health"
+    },
+    {
+      "id": "missing_perlcritic_graceful_degradation",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_04_missing_perlcritic.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "engineering_health"
+    },
+    {
+      "id": "bad_config_resilience",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_05_bad_config.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "engineering_health"
+    },
+    {
+      "id": "large_file_open",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_06_large_file.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "engineering_health"
+    },
+    {
+      "id": "multi_file_workspace_navigation",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_07_multi_file_workspace.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "workspace_indexing"
+    },
+    {
+      "id": "shebang_detection",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_08_shebang_detection.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "encoding_and_bom_resilience",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_09_encoding.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "engineering_health"
+    },
+    {
+      "id": "goto_definition_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_10_goto_definition.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "hover_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_11_hover.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "strict_diagnostics",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_12_diagnostics_strict.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "diagnostics"
+    },
+    {
+      "id": "document_symbols_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_13_document_symbols.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "workspace_indexing"
+    },
+    {
+      "id": "inc_conformance",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_14_inc_conformance.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "module_resolution"
+    },
+    {
+      "id": "multi_root_workspace_symbols",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_15_workspace_symbols.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "workspace_indexing"
+    },
+    {
+      "id": "workspace_folder_removal_freshness",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_16_workspace_folder_removal.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "workspace_indexing"
+    },
+    {
+      "id": "deleted_file_churn_freshness",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_17_deleted_file_churn.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "workspace_indexing"
+    },
+    {
+      "id": "goto_declaration_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_18_goto_declaration.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "template_language_mode_resilience",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_22_template_language_mode.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "diagnostics_after_edit_refresh",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_18_diagnostics_after_edit.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "diagnostics"
+    },
+    {
+      "id": "real_repo_first_diagnostics_budget",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_18_real_repo_perf.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "diagnostics"
+    },
+    {
+      "id": "rename_workflow_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_23_rename_workflow.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "workspace_folder_addition_freshness",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_19_workspace_folder_addition.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "workspace_indexing"
+    },
+    {
+      "id": "live_edit_feedback_loop",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_24_live_edit_feedback.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "text_sync"
+    },
+    {
+      "id": "completion_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_19_completion_core.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "incremental_text_sync_recovery",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_19_incremental_text_sync.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "text_sync"
+    },
+    {
+      "id": "diagnostics_lifecycle_editing",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_19_diagnostics_lifecycle.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "diagnostics"
     }
   ]
 }

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,8 +8,9 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 23 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; confidence signals (manual smoke, first-5-minutes coverage, issue-burndown regression guards) are tracked in `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 27 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; confidence signals (manual smoke, first-5-minutes coverage, issue-burndown regression guards) are tracked in `docs/project/status/editor_ux.json`
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
+- **Lexer performance scorecard**: `cargo bench -p perl-lexer --bench lexer_benchmarks` writes `benchmarks/results/lexer_scorecard.json` for trend comparisons
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->
 
@@ -20,27 +21,32 @@
 |-------|---------------|-------------|
 | perl-ast | — | 2 |
 | perl-ast-v2 | — | 2 |
-| perl-corpus | — | 135 |
-| perl-dap | — | 378 |
+| perl-ci-hygiene | — | 18 |
+| perl-corpus | — | 158 |
+| perl-dap | — | 384 |
 | perl-diagnostics | — | 4 |
-| perl-lexer | — | 55 |
-| perl-lsp | — | 477 |
-| perl-lsp-rs-core | — | 955 |
-| perl-lsp-ux-tests | — | 18 |
-| perl-parser | — | 219 |
-| perl-parser-core | — | 583 |
+| perl-lexer | — | 88 |
+| perl-line-index | — | 7 |
+| perl-lsp | — | 512 |
+| perl-lsp-rs-core | — | 1010 |
+| perl-lsp-ux-tests | — | 67 |
+| perl-parser | — | 233 |
+| perl-parser-core | — | 584 |
 | perl-parser-pest | — | 10 |
 | perl-position-tracking | — | 33 |
-| perl-refactoring | — | 110 |
-| perl-semantic-analyzer | — | 132 |
-| perl-subprocess-runtime | — | 6 |
-| perl-symbol | — | 25 |
+| perl-refactoring | — | 113 |
+| perl-regex | — | 35 |
+| perl-semantic-analyzer | — | 154 |
+| perl-semantic-facts | — | 8 |
+| perl-subprocess-runtime | — | 16 |
+| perl-symbol | — | 31 |
 | perl-tdd-support | — | 15 |
 | perl-test-generators | — | 11 |
 | perl-test-must | — | 6 |
-| perl-uri | — | 23 |
-| perl-workspace | — | 254 |
-| tree-sitter-perl-c | — | 11 |
+| perl-token | — | 35 |
+| perl-uri | — | 33 |
+| perl-workspace | — | 276 |
+| tree-sitter-perl-c | — | 13 |
 | tree-sitter-perl-rs | — | 48 |
 <!-- END: QUALITY_CRATE_TABLE -->
 

--- a/xtask/src/tasks/update_status/editor_ux.rs
+++ b/xtask/src/tasks/update_status/editor_ux.rs
@@ -10,6 +10,10 @@ use std::path::Path;
 use color_eyre::eyre::{Context, Result};
 use serde::Deserialize;
 
+use crate::tasks::metrics::lsp_stats::{
+    LatencyMetric, MeasuredEditorUxScorecard, RateMetric, WorkflowResult,
+};
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -26,6 +30,27 @@ struct EditorUxWorkflow {
     #[allow(dead_code)]
     ci_tier: String,
     confidence_signals: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UxFlakeLedger {
+    entries: Vec<UxFlakeEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UxFlakeEntry {
+    test: String,
+    state: String,
+    #[serde(default)]
+    failure_class: Option<String>,
+    #[serde(default)]
+    component: Option<String>,
+    #[serde(default)]
+    route: Option<String>,
+    #[serde(default)]
+    issue: Option<u64>,
+    #[serde(default)]
+    owner: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -85,21 +110,21 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     let scenario_files = collect_ux_scenario_files(root);
     let scenario_count = scenario_files.len();
     let confidence_counts = collect_editor_ux_confidence_counts(root)?;
+    let measured_scorecard = load_measured_scorecard(root)?;
+    let known_blockers = load_active_known_blockers(root)?;
 
     let receipt = serde_json::json!({
         "schema_version": 1,
-        "receipt_kind": "planning_scaffold",
+        "receipt_kind": if measured_scorecard.is_some() { "measured_status" } else { "planning_scaffold" },
         "scorecard": "editor_ux",
         "harness": {
             "crate": "crates/perl-lsp-ux-tests",
             "scenario_count": scenario_count,
             "scenario_files": scenario_files,
         },
-        "top_line_metrics": [
-            { "name": "workflow_pass_rate", "state": "planned", "owner": "perl-lsp-ux-tests" },
-            { "name": "workflow_stability_rate", "state": "planned", "owner": "perl-lsp-ux-tests" },
-            { "name": "p95_time_to_first_useful_result_ms", "state": "planned", "owner": "perl-lsp-ux-tests" },
-        ],
+        "top_line_metrics": top_line_metric_rows(measured_scorecard.as_ref()),
+        "workflow_results": workflow_rows(measured_scorecard.as_ref()),
+        "known_blockers": known_blockers,
         "confidence_signals": [
             {
                 "name": "manual_editor_smoke",
@@ -131,6 +156,131 @@ pub(super) fn generate_editor_ux_receipt(root: &Path) -> Result<String> {
     serde_json::to_string_pretty(&receipt).context("serializing editor UX receipt")
 }
 
+fn load_measured_scorecard(root: &Path) -> Result<Option<MeasuredEditorUxScorecard>> {
+    let path = root.join(".ci/metrics/editor_ux.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let scorecard: MeasuredEditorUxScorecard =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(Some(scorecard))
+}
+
+fn load_active_known_blockers(root: &Path) -> Result<Vec<serde_json::Value>> {
+    let path = root.join(".ci/ux-flakes.json");
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let raw = fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    let ledger: UxFlakeLedger =
+        serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    let blockers = ledger
+        .entries
+        .into_iter()
+        .filter(|entry| entry.state == "active")
+        .map(|entry| {
+            let route =
+                entry.route.or_else(|| route_for_failure_class(entry.failure_class.as_deref()));
+            serde_json::json!({
+                "test_name": entry.test,
+                "state": entry.state,
+                "failure_class": entry.failure_class,
+                "component": entry.component,
+                "route": route,
+                "issue": entry.issue,
+                "owner": entry.owner,
+            })
+        })
+        .collect();
+    Ok(blockers)
+}
+
+fn top_line_metric_rows(scorecard: Option<&MeasuredEditorUxScorecard>) -> Vec<serde_json::Value> {
+    let Some(scorecard) = scorecard else {
+        return vec![
+            planned_metric_row("workflow_pass_rate"),
+            planned_metric_row("workflow_stability_rate"),
+            planned_metric_row("p95_time_to_first_useful_result_ms"),
+        ];
+    };
+
+    vec![
+        rate_metric_row("workflow_pass_rate", &scorecard.top_line.workflow_pass_rate),
+        rate_metric_row("workflow_stability_rate", &scorecard.top_line.workflow_stability_rate),
+        latency_metric_row(
+            "p95_time_to_first_useful_result_ms",
+            &scorecard.top_line.p95_time_to_first_useful_result_ms,
+        ),
+    ]
+}
+
+fn workflow_rows(scorecard: Option<&MeasuredEditorUxScorecard>) -> Vec<serde_json::Value> {
+    scorecard
+        .map(|scorecard| scorecard.workflows.iter().map(workflow_row).collect())
+        .unwrap_or_default()
+}
+
+fn planned_metric_row(name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "state": "planned",
+        "owner": "perl-lsp-ux-tests",
+    })
+}
+
+fn rate_metric_row(name: &str, metric: &RateMetric) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "state": metric.state,
+        "value": metric.value,
+        "basis": metric.basis,
+        "coverage": metric.coverage,
+        "confidence": metric.confidence,
+        "assumptions": metric.assumptions,
+    })
+}
+
+fn latency_metric_row(name: &str, metric: &LatencyMetric) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "state": metric.state,
+        "value_ms": metric.value,
+        "basis": metric.basis,
+        "coverage": metric.coverage,
+        "confidence": metric.confidence,
+        "method": metric.method,
+        "assumptions": metric.assumptions,
+    })
+}
+
+fn workflow_row(workflow: &WorkflowResult) -> serde_json::Value {
+    serde_json::json!({
+        "id": workflow.id,
+        "scenario": workflow.scenario,
+        "subsystem_owner": workflow.subsystem_owner,
+        "pass_rate_state": workflow.pass_rate.state,
+        "stability_rate_state": workflow.stability_rate.state,
+        "p95_time_to_first_useful_result_state": workflow.p95_time_to_first_useful_result_ms.state,
+        "quarantine_age_days": workflow.quarantine_age_days,
+    })
+}
+
+fn route_for_failure_class(failure_class: Option<&str>) -> Option<String> {
+    let route = match failure_class? {
+        "provider_regression" => "provider_fix",
+        "server_crash" => "crash_fix",
+        "timeout" => "timeout_triage",
+        "infra" => "ci_investigation",
+        "matrix_drift" => "fixture_update",
+        "baseline_drift" => "baseline_update",
+        "test_race" | "new_test_bug" => "test_fix",
+        "unknown" => "triage",
+        _ => return None,
+    };
+    Some(route.to_owned())
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -146,7 +296,10 @@ mod tests {
         let receipt_raw = generate_editor_ux_receipt(&root)?;
         let receipt: serde_json::Value = serde_json::from_str(&receipt_raw)?;
         assert_eq!(receipt["schema_version"], 1);
-        assert_eq!(receipt["receipt_kind"], "planning_scaffold");
+        assert!(
+            receipt["receipt_kind"] == "planning_scaffold"
+                || receipt["receipt_kind"] == "measured_status"
+        );
         assert_eq!(receipt["scorecard"], "editor_ux");
         assert_eq!(receipt["harness"]["crate"], "crates/perl-lsp-ux-tests");
         assert_eq!(
@@ -168,6 +321,8 @@ mod tests {
             ])
         );
         assert_eq!(receipt["integration_points"]["ci_lane"], "just ux-tests");
+        assert!(receipt["workflow_results"].is_array());
+        assert!(receipt["known_blockers"].is_array());
         let confidence_signals = receipt["confidence_signals"]
             .as_array()
             .ok_or_else(|| eyre!("confidence_signals must be an array"))?;
@@ -197,6 +352,24 @@ mod tests {
             );
             assert!(receipt_count > 0, "signal `{name}` has zero workflow coverage");
         }
+        Ok(())
+    }
+
+    #[test]
+    fn active_known_blockers_are_rendered_from_flake_ledger() -> Result<()> {
+        let root = crate::utils::project_root()?;
+        let blockers = load_active_known_blockers(&root)?;
+        assert!(
+            blockers.iter().any(|entry| {
+                entry["test_name"]
+                    == "ux_scenario_14_inc_conformance::scenario_14_system_inc_completion_opt_in_enabled"
+                    && entry["failure_class"] == "provider_regression"
+                    && entry["component"] == "module_resolution"
+                    && entry["route"] == "provider_fix"
+                    && entry["issue"] == 7570
+            }),
+            "scenario_14 known blocker should remain visible"
+        );
         Ok(())
     }
 }

--- a/xtask/src/tasks/update_status/mod.rs
+++ b/xtask/src/tasks/update_status/mod.rs
@@ -163,9 +163,17 @@ fn run_cmd_merged(root: &Path, args: &[&str], timeout: Duration) -> String {
     if args.is_empty() {
         return String::new();
     }
-    let shell_args: Vec<String> =
-        args.iter().map(|&a| format!("'{}'", a.replace('\'', "'\\''"))).collect();
-    let shell_cmd = format!("{} 2>&1", shell_args.join(" "));
+    #[cfg(unix)]
+    let shell_cmd = {
+        let shell_args: Vec<String> =
+            args.iter().map(|&a| format!("'{}'", a.replace('\'', "'\\''"))).collect();
+        format!("{} 2>&1", shell_args.join(" "))
+    };
+    #[cfg(not(unix))]
+    let shell_cmd = {
+        let shell_args: Vec<String> = args.iter().map(|&a| a.to_owned()).collect();
+        format!("{} 2>&1", shell_args.join(" "))
+    };
     #[cfg(unix)]
     let merged = ["sh", "-c", &shell_cmd];
     #[cfg(not(unix))]

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -20,8 +20,10 @@ use super::flaky::{collect_flaky_test_summary, format_flaky_tests_section};
 use super::{replace_block, run_cmd_merged};
 
 static RUNNING_TEST_BINARY_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+\)")
-        .expect("running-test regex is valid")
+    Regex::new(
+        r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+(?:\.exe)?\)",
+    )
+    .expect("running-test regex is valid")
 });
 
 static TEST_LIST_LINE_RE: LazyLock<Regex> =
@@ -249,7 +251,7 @@ mod tests {
             (target/debug/deps/perl_parser_core-abc123)\n\
             lexer_edge_case: test\nparser_smoke: test\n\
             Running unittests src/lib.rs \
-            (target\\debug\\deps\\perl_workspace_index-123def)\n\
+            (target\\debug\\deps\\perl_workspace_index-123def.exe)\n\
             index_builds: test\n";
         let counts = parse_per_crate_test_counts(output);
         assert_eq!(counts.get("perl-parser-core"), Some(&2));


### PR DESCRIPTION
Problem: Editor UX status still rendered the planning scaffold and could not validate the first measured scorecard artifact.
Fix: Render `.ci/metrics/editor_ux.json` into `docs/project/status/editor_ux.json`, keep active UX blockers visible, add the initial insufficient-data scorecard, and fix the editor UX schema so `value` validates.
Verification: `cargo check -p xtask --all-targets`; `cargo test -p xtask update_status::editor_ux`; `cargo test -p xtask update_status::quality`; `cargo test -p xtask lsp_stats`; `cargo xtask update-status --only quality`; `npx --yes ajv-cli validate -s .ci/schemas/editor-ux.schema.json -d .ci/metrics/editor_ux.json --strict=false`; `cargo fmt --package xtask --check`; `git diff --cached --check`.