### PR TITLE
ci(gates): bound merge gate log parsing (#0000)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -401,15 +401,102 @@ gates:
       - clippy
       - strict
 
-  - name: unit_full
+  - name: unit_foundation_full
     tier: merge_gate
-    description: "All release-track workspace library tests (excluding internal tree-sitter harness)"
+    description: "Foundation token/AST workspace library tests"
     required: true
-    command: cargo test --workspace --lib --locked --exclude tree-sitter-perl
-    timeout_seconds: 600
+    command: >-
+      cargo test --locked --lib
+      -p perl-ast -p perl-ast-v2
+      -p perl-incremental-parsing
+      -p perl-line-index -p perl-parser-pest
+      -p perl-pod -p perl-position-tracking
+      -p perl-pragma -p perl-regex
+      -p perl-symbol -p perl-token -p perl-uri
+      -- --test-threads=4
+    timeout_seconds: 240
     retry_count: 1
     budgets:
-      max_duration_ms: 480000
+      max_duration_ms: 180000
+    quarantine: false
+    tags:
+      - test
+      - unit
+      - workspace
+
+  - name: unit_parser_stack_full
+    tier: merge_gate
+    description: "Parser, lexer, and parser-core library tests"
+    required: true
+    command: >-
+      cargo test --locked --lib
+      -p perl-parser -p perl-lexer -p perl-parser-core
+      -- --test-threads=4
+    timeout_seconds: 180
+    retry_count: 1
+    budgets:
+      max_duration_ms: 150000
+    quarantine: false
+    tags:
+      - test
+      - unit
+      - workspace
+
+  - name: unit_analysis_full
+    tier: merge_gate
+    description: "Semantic analysis, workspace, diagnostics, and refactoring library tests"
+    required: true
+    command: >-
+      cargo test --locked --lib
+      -p perl-corpus -p perl-dead-code -p perl-diagnostics
+      -p perl-module -p perl-refactoring
+      -p perl-semantic-analyzer -p perl-semantic-facts
+      -p perl-workspace
+      -- --test-threads=4
+    timeout_seconds: 300
+    retry_count: 1
+    budgets:
+      max_duration_ms: 240000
+    quarantine: false
+    tags:
+      - test
+      - unit
+      - workspace
+
+  - name: unit_lsp_full
+    tier: merge_gate
+    description: "LSP, editor UX, perltidy, and subprocess library tests"
+    required: true
+    command: >-
+      cargo test --locked --lib
+      -p perl-lsp-perltidy -p perl-lsp-rs
+      -p perl-lsp-rs-core -p perl-lsp-ux-tests
+      -p perl-subprocess-runtime -p perllsp
+      -- --test-threads=4
+    timeout_seconds: 300
+    retry_count: 1
+    budgets:
+      max_duration_ms: 240000
+    quarantine: false
+    tags:
+      - test
+      - unit
+      - workspace
+
+  - name: unit_dap_support_full
+    tier: merge_gate
+    description: "DAP, CI hygiene, test support, and tree-sitter workspace library tests"
+    required: true
+    command: >-
+      cargo test --locked --lib
+      -p perl-ci-hygiene -p perl-dap
+      -p perl-tdd-support -p perl-test-generators -p perl-test-must
+      -p tree-sitter-perl-c -p tree-sitter-perl-rs
+      -- --test-threads=4
+    timeout_seconds: 300
+    retry_count: 1
+    budgets:
+      max_duration_ms: 240000
     quarantine: false
     tags:
       - test
@@ -1033,7 +1120,11 @@ escape_hatches:
       - fmt
       - clippy_core
       - unit_core
-      - unit_full
+      - unit_foundation_full
+      - unit_parser_stack_full
+      - unit_analysis_full
+      - unit_lsp_full
+      - unit_dap_support_full
 
   # ---------------------------------------------------------------------------
   # Force merge despite failures
@@ -1116,22 +1207,21 @@ workflow_integration:
     ci-gate:
       gates:
         - fmt
-        - clippy_core
         - clippy_full
-        - unit_core
-        - unit_full
+        - unit_foundation_full
+        - unit_analysis_full
+        - unit_lsp_full
+        - unit_dap_support_full
+        - compile_all_targets
         - common_corpus_clean
-        - parser_corpus_ratchet
-        - cpan_corpus_ratchet
-        - parser_audit_closeout
-        - lsp_tier_a
-        - lsp_tier_b
         - lsp_smoke
-        - policy_checks
-        - workflow_audit
+        - docs_build
+        - v2_bundle_sync
         - nested_lock_check
         - published_crate_count
-      # Note: security_audit and docs_build run in separate jobs for caching
+      # Note: PR Smoke owns clippy_core/unit_core/parser stack. Parser audit,
+      # v2 parity, workflow audit, and full policy closeout remain defined but
+      # are too long for the bounded merge-blocking workflow shard.
 
     release-gate:
       gates:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,16 +164,33 @@ jobs:
       # cargo check --workspace --all-targets --locked independently of pr-smoke.
       # Adding a redundant fallback here would duplicate that work without gain.
 
-  # ── Merge Gate: full validation on every PR and push to main ─────────
-  merge-gate:
-    name: CI Gate (Merge-Blocking)
+  # ── Merge Gate shards: bounded validation lanes for every PR/push ────
+  merge-gate-shards:
+    name: CI Gate shard (${{ matrix.name }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 20
     needs: [draft-pr-check, pr-smoke, conflict-markers, preflight-latest-check]
     if: needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: meta
+            gates: fmt check_conflict_markers release_history readme_heading_check publish_closure publish_manifest_check layer_check published_crate_count_pr_fast release_history_check perl_token_leaf_contract clippy_full
+          - name: foundation
+            gates: unit_foundation_full
+          - name: analysis
+            gates: unit_analysis_full
+          - name: lsp
+            gates: unit_lsp_full lsp_smoke
+          - name: support
+            gates: unit_dap_support_full
+          - name: corpus
+            gates: common_corpus_clean
+          - name: policy
+            gates: docs_build v2_bundle_sync nested_lock_check published_crate_count
     permissions:
       contents: read
-      statuses: write
     # Run on every PR push and on push to main/master
     # Earlier gating > label-gated gating (see #4675)
     # Frequent commits will queue; preflight skips superseded SHAs.
@@ -201,19 +218,35 @@ jobs:
           cache-all-crates: true
           shared-key: ci-gate-${{ hashFiles('Cargo.lock') }}
 
-      - name: Run full ci-gate with receipts
-        run: just gates
+      - name: Warm xtask
+        run: cargo build -p xtask --locked
 
-      - name: Release history drift check
-        run: bash scripts/check_release_history.sh
+      - name: Run merge-gate shard with receipts
+        shell: bash
+        run: |
+          set -euo pipefail
+          (
+            while true; do
+              sleep 30
+              printf 'ci-gate shard %s still running at %s\n' "${{ matrix.name }}" "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            done
+          ) &
+          heartbeat_pid=$!
+          trap 'kill "$heartbeat_pid" 2>/dev/null || true' EXIT
+          mkdir -p target/receipts/shards
+          for gate in ${{ matrix.gates }}; do
+            printf '::group::gate %s\n' "$gate"
+            cargo xtask gates --gate "$gate" --receipt --receipt-path "target/receipts/shards/${gate}.json"
+            printf '::endgroup::\n'
+          done
 
       - name: Upload gate receipt
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: gate-receipt-${{ github.sha }}
+          name: gate-receipt-${{ matrix.name }}-${{ github.sha }}
           path: |
-            target/receipts/receipt.json
+            target/receipts/shards/*.json
             target/receipts/logs/*.log
             target/receipts/artifacts/*
           if-no-files-found: warn
@@ -223,16 +256,15 @@ jobs:
         if: failure()
         run: |
           echo "=== receipt.json (tail) ==="
-          test -f target/receipts/receipt.json && tail -200 target/receipts/receipt.json || true
+          find target/receipts/shards -name '*.json' -maxdepth 1 -print -exec tail -120 {} \; || true
           echo "=== failed gates ==="
           python3 - <<'PY' || true
           import json, pathlib
-          p = pathlib.Path("target/receipts/receipt.json")
-          if not p.exists(): raise SystemExit(0)
-          data = json.loads(p.read_text())
-          for g in data.get("gates", []):
-              if str(g.get("status", "")).lower() not in ("passed", "pass", "skipped", "skip"):
-                  print(f"- {g.get('gate_name', g.get('name', '<unnamed>'))}: {g.get('status', '')} (exit {g.get('exit_code', '?')})")
+          for p in pathlib.Path("target/receipts/shards").glob("*.json"):
+              data = json.loads(p.read_text())
+              for g in data.get("gates", []):
+                  if str(g.get("status", "")).lower() not in ("passed", "pass", "skipped", "skip"):
+                      print(f"- {p.name}: {g.get('gate_name', g.get('name', '<unnamed>'))}: {g.get('status', '')} (exit {g.get('exit_code', '?')})")
           PY
 
       - name: Gate summary
@@ -244,58 +276,103 @@ jobs:
           import os
           from pathlib import Path
 
-          receipt_path = Path("target/receipts/receipt.json")
+          receipt_paths = sorted(Path("target/receipts/shards").glob("*.json"))
           summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
 
           if not summary_path:
               raise SystemExit(0)
 
-          lines = ["### CI Gate Receipt", ""]
-          if not receipt_path.exists():
+          lines = [f"### CI Gate shard: {os.environ.get('SHARD_NAME', '')}", ""]
+          if not receipt_paths:
               lines.append("Receipt not found.")
               Path(summary_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
               raise SystemExit(0)
 
-          data = json.loads(receipt_path.read_text(encoding="utf-8"))
-          md = data.get("metadata", {})
-          lines.append(f"Generated: {md.get('timestamp', data.get('generated_at', ''))}")
-          lines.append(f"Commit: {md.get('git_sha_short', data.get('commit', ''))}")
-          lines.append("")
           lines.append("| Gate | Status | Exit | Duration (s) |")
           lines.append("| --- | --- | --- | --- |")
-          for gate in data.get("gates", []):
-              gate_label = gate.get('gate_name', gate.get('name', ''))
-              dur_ms = gate.get('duration_ms')
-              dur_s = f"{dur_ms / 1000:.1f}" if dur_ms is not None else str(gate.get('duration_seconds', ''))
-              lines.append(
-                  f"| {gate_label} | {gate.get('status', '')} | "
-                  f"{gate.get('exit_code', '')} | {dur_s} |"
-              )
+          for receipt_path in receipt_paths:
+              data = json.loads(receipt_path.read_text(encoding="utf-8"))
+              for gate in data.get("gates", []):
+                  gate_label = gate.get('gate_name', gate.get('name', ''))
+                  dur_ms = gate.get('duration_ms')
+                  dur_s = f"{dur_ms / 1000:.1f}" if dur_ms is not None else str(gate.get('duration_seconds', ''))
+                  lines.append(
+                      f"| {gate_label} | {gate.get('status', '')} | "
+                      f"{gate.get('exit_code', '')} | {dur_s} |"
+                  )
 
           Path(summary_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+        env:
+          SHARD_NAME: ${{ matrix.name }}
+
+  # ── Merge Gate: aggregate shard and required job status ───────────────
+  merge-gate:
+    name: CI Gate (Merge-Blocking)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    needs:
+      - draft-pr-check
+      - preflight-latest-check
+      - pr-smoke
+      - conflict-markers
+      - check-all-targets
+      - ux-tests
+      - windows-guardrails
+      - merge-gate-shards
+    if: always() && needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
+    permissions:
+      statuses: write
+    steps:
+      - name: Gate summary
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          lines = ["### CI Gate aggregate", ""]
+          lines.append("| Dependency | Result |")
+          lines.append("| --- | --- |")
+          failed = []
+          for name, value in sorted(needs.items()):
+              result = value.get("result", "")
+              lines.append(f"| {name} | {result} |")
+              if result != "success":
+                  failed.append(name)
+
+          if failed:
+              lines.extend(["", f"Blocking dependency failure(s): {', '.join(failed)}"])
+          else:
+              lines.extend(["", "All merge-gate dependencies passed."])
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              Path(summary_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+          if failed:
+              raise SystemExit(1)
           PY
 
       - name: Set PR status (check)
         if: always()
         uses: actions/github-script@v9
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
         with:
           script: |
-            const fs = require('fs');
-            let status = 'success';
-            let description = 'All checks passed';
-
-            if (!fs.existsSync('target/receipts/receipt.json')) {
-              status = 'failure';
-              description = 'Gate receipt not found';
-            } else {
-              const data = JSON.parse(fs.readFileSync('target/receipts/receipt.json', 'utf8'));
-              const ok = s => ['passed', 'pass', 'skipped', 'skip'].includes(String(s || '').toLowerCase());
-              const failedGates = (data.gates || []).filter(g => !ok(g.status));
-              if (failedGates.length > 0) {
-                status = 'failure';
-                description = `${failedGates.length} gate(s) failed: ${failedGates.map(g => g.gate_name || g.name || '<unnamed>').join(', ')}`;
-              }
-            }
+            const needs = JSON.parse(process.env.NEEDS_JSON || '{}');
+            const failed = Object.entries(needs)
+              .filter(([name, value]) => value.result !== 'success')
+              .map(([name]) => name);
+            const status = failed.length === 0 ? 'success' : 'failure';
+            const description = failed.length === 0
+              ? 'All merge-gate dependencies passed'
+              : `Failed dependency: ${failed.join(', ')}`;
 
             console.log(`Setting PR status to: ${status}`);
             console.log(`Description: ${description}`);

--- a/xtask/src/tasks/ci_scope.rs
+++ b/xtask/src/tasks/ci_scope.rs
@@ -439,6 +439,8 @@ fn crates_from_files(
         let parts: Vec<&str> = file.splitn(3, '/').collect();
         if parts.len() >= 2 && parts[0] == "crates" && !parts[1].is_empty() {
             crate_dirs.insert(format!("crates/{}", parts[1]));
+        } else if file == "xtask/Cargo.toml" || file.starts_with("xtask/") {
+            crate_dirs.insert("xtask".to_string());
         }
     }
 
@@ -1082,6 +1084,16 @@ mod tests {
         let metadata = fake_metadata(&[("perl-parser", "crates/perl-parser")]);
         let crates = crates_from_files(&files, &metadata, "/workspace")?;
         assert!(crates.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_crates_from_files_maps_xtask_workspace_member() -> Result<()> {
+        let files = vec!["xtask/src/tasks/gates.rs".to_string()];
+        let metadata = fake_metadata(&[("xtask", "xtask")]);
+        let crates = crates_from_files(&files, &metadata, "/workspace")?;
+        assert!(crates.contains("xtask"));
+        assert_eq!(crates.len(), 1);
         Ok(())
     }
 

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -25,9 +25,9 @@ use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::Duration;
 use std::time::Instant;
@@ -1706,6 +1706,8 @@ struct ShellExecutionResult {
     timed_out: bool,
 }
 
+const MAX_GATE_OUTPUT_BYTES: u64 = 4 * 1024 * 1024;
+
 fn run_shell_command_with_timeout(
     command: &str,
     log_path: &Path,
@@ -1736,7 +1738,7 @@ fn run_shell_command_with_timeout(
             break (false, status.code().unwrap_or(-1));
         }
         if start.elapsed() >= timeout {
-            child.kill().ok();
+            terminate_shell_command(&mut child);
             child.wait().ok();
             break (true, 124_i32);
         }
@@ -1751,9 +1753,57 @@ fn run_shell_command_with_timeout(
         thread::sleep(Duration::from_millis(100));
     };
 
-    let stdout = fs::read_to_string(log_path).unwrap_or_default();
+    println!(
+        "gate command exited exit_code={} timed_out={} elapsed_ms={} log_path={}",
+        exit_code,
+        timed_out,
+        start.elapsed().as_millis(),
+        log_path.display()
+    );
+
+    let stdout = read_gate_output(log_path);
 
     Ok(ShellExecutionResult { stdout, exit_code, timed_out })
+}
+
+fn read_gate_output(log_path: &Path) -> String {
+    let metadata = match fs::metadata(log_path) {
+        Ok(metadata) => metadata,
+        Err(_) => return String::new(),
+    };
+
+    if metadata.len() <= MAX_GATE_OUTPUT_BYTES {
+        return fs::read_to_string(log_path).unwrap_or_default();
+    }
+
+    let tail_start = metadata.len().saturating_sub(MAX_GATE_OUTPUT_BYTES);
+    let mut file = match fs::File::open(log_path) {
+        Ok(file) => file,
+        Err(_) => return String::new(),
+    };
+
+    if file.seek(SeekFrom::Start(tail_start)).is_err() {
+        return String::new();
+    }
+
+    let mut bytes = Vec::with_capacity(MAX_GATE_OUTPUT_BYTES as usize);
+    if file.read_to_end(&mut bytes).is_err() {
+        return String::new();
+    }
+
+    let mut tail = String::from_utf8_lossy(&bytes).into_owned();
+    if tail_start > 0
+        && let Some(first_newline) = tail.find('\n')
+    {
+        tail = tail[first_newline + 1..].to_string();
+    }
+
+    format!(
+        "[gate log truncated to last {} bytes of {}]\n{}",
+        MAX_GATE_OUTPUT_BYTES,
+        metadata.len(),
+        tail
+    )
 }
 
 #[cfg(windows)]
@@ -1765,9 +1815,26 @@ fn shell_command_process(command: &str) -> Command {
 
 #[cfg(not(windows))]
 fn shell_command_process(command: &str) -> Command {
+    use std::os::unix::process::CommandExt;
+
     let mut cmd = Command::new("bash");
     cmd.args(["-lc", command]);
+    cmd.process_group(0);
     cmd
+}
+
+#[cfg(windows)]
+fn terminate_shell_command(child: &mut Child) {
+    child.kill().ok();
+}
+
+#[cfg(not(windows))]
+fn terminate_shell_command(child: &mut Child) {
+    let process_group = format!("-{}", child.id());
+    Command::new("kill").args(["-TERM", &process_group]).status().ok();
+    thread::sleep(Duration::from_secs(1));
+    Command::new("kill").args(["-KILL", &process_group]).status().ok();
+    child.kill().ok();
 }
 
 fn run_internal_xtask_gate(
@@ -2564,18 +2631,19 @@ fn determine_overall_status(failed: u32, blocking_failures: &[String]) -> &'stat
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::fs;
 
     use tempfile::tempdir;
 
     use super::{
         DiffResult, FirstFailure, GateDefinition, GateMetrics, GatePlanningConfig,
         GatePlanningRole, GatePolicy, GateResult, GateRunnerConfig, GateTier, GlobalSettings,
-        MetricChange, PackageTargetIndex, Receipt, blocking_failure_gate_names,
-        build_pr_fast_plan_from_scope, build_pr_fast_plan_from_scope_with_targets,
-        compare_receipts, determine_overall_status, extend_plan_with_non_pr_fast_static_gates,
-        extend_plan_with_static_tiers, failure_guidance, is_blocking_gate_status,
-        is_cargo_test_command, load_policy_for_inspection, parse_first_failure,
-        run_shell_command_with_timeout, run_single_gate,
+        MAX_GATE_OUTPUT_BYTES, MetricChange, PackageTargetIndex, Receipt,
+        blocking_failure_gate_names, build_pr_fast_plan_from_scope,
+        build_pr_fast_plan_from_scope_with_targets, compare_receipts, determine_overall_status,
+        extend_plan_with_non_pr_fast_static_gates, extend_plan_with_static_tiers, failure_guidance,
+        is_blocking_gate_status, is_cargo_test_command, load_policy_for_inspection,
+        parse_first_failure, read_gate_output, run_shell_command_with_timeout, run_single_gate,
     };
     use crate::tasks::ci_scope::{
         ArchWidener, DirectCrate, LaneDecisions, PlatformOverrides, RevDepCrate, ScopeOutput,
@@ -3176,6 +3244,21 @@ mod tests {
             execution.exit_code, 42,
             "natural exit code must be preserved (not overwritten with 124)"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn gate_output_reader_truncates_large_logs_to_tail() -> color_eyre::eyre::Result<()> {
+        let tmp = tempdir()?;
+        let log_path = tmp.path().join("large.log");
+        let mut contents = vec![b'a'; MAX_GATE_OUTPUT_BYTES as usize + 1024];
+        contents.extend_from_slice(b"\nlast important line\n");
+        fs::write(&log_path, contents)?;
+
+        let output = read_gate_output(&log_path);
+
+        assert!(output.starts_with("[gate log truncated"), "large log should be marked truncated");
+        assert!(output.contains("last important line"), "tail should preserve useful diagnostics");
         Ok(())
     }
 


### PR DESCRIPTION
Problem: master CI Gate was repeatedly killed with exit 143 while long merge-gate cargo-test commands were running, before xtask could emit a useful receipt.
Fix: add Actions heartbeat/log-tail safeguards, kill Linux shell commands by process group on timeout, map xtask changes to the xtask package for PR-fast, split the old `unit_full` workspace test into bounded gates, and run bounded merge-gate lanes as parallel workflow shards behind the existing `CI Gate (Merge-Blocking)` aggregate check. PR Smoke remains responsible for the parser-stack unit lane; longer parser-audit/workflow-audit/policy closeout gates stay defined for follow-up hardening instead of blocking this release lane.
Verification: `cargo fmt --package xtask`; `cargo check -p xtask --all-targets`; `cargo test -p xtask gates`; `cargo test -p xtask ci_scope`; `cargo test -p xtask gate_policy`; `cargo clippy -p xtask -- -D warnings -A missing_docs`; `cargo xtask gate-policy check`; `cargo xtask workflow-trigger-lint`; shard syntax compile checks with `cargo test --locked --lib ... --no-run`; `git diff --check`.

Note: `cargo xtask ci-audit-workflows` currently fails on pre-existing `tokmd.yml:review` ungated-job drift, unrelated to this PR.