### PR TITLE
ci(release): harden public-alpha publish channels (#7674)

### DIFF
--- a/.ci/GATE_REGISTRY.toml
+++ b/.ci/GATE_REGISTRY.toml
@@ -51,7 +51,7 @@ id = "test-lib"
 name = "Library Tests"
 type = "correctness"
 blocking = true
-timeout_seconds = 600
+timeout_seconds = 1800
 command = "cargo test --workspace --lib --locked"
 evidence_pattern = "test result: .* ([0-9]+) passed"
 threshold = { type = "exit_code", pass = 0 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   pr-smoke:
     name: PR Smoke (Fast Feedback)
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 35
     needs: [draft-pr-check, preflight-latest-check]
     if: needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
     steps:
@@ -146,7 +146,20 @@ jobs:
         run: cargo build -p xtask --locked
 
       - name: Run PR-fast via shared xtask gate runner
-        run: ./target/debug/xtask gates --tier pr-fast --base origin/master --receipt
+        run: |
+          set +e
+          echo "PR-fast timeout policy: GitHub job 35m, outer runner watchdog 30m, per-gate timeouts recorded in target/receipts/receipt.json"
+          timeout --signal=TERM --kill-after=60s 1800s ./target/debug/xtask gates --tier pr-fast --base origin/master --receipt
+          status=$?
+          case "$status" in
+            124)
+              echo "::error::PR-fast hit the 30m runner watchdog before xtask produced a final receipt"
+              ;;
+            137|143)
+              echo "::error::PR-fast was cancelled by the runner or process group (exit $status)"
+              ;;
+          esac
+          exit "$status"
 
       - name: Upload PR-fast receipt
         if: always()

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,6 +1,6 @@
 name: Publish VSCode Extension
 
-# Publish VSCode extension to marketplace
+# Publish VSCode extension packages to VS Code Marketplace and Open VSX.
 # Cost: ~$0.05 per publish
 
 on:
@@ -16,15 +16,19 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  publish:
+  prepare-vsix:
+    name: Prepare VSIX
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    env:
-      VSCE_PAT: ${{ secrets.VSCE_PAT }}
-      OVSX_PAT: ${{ secrets.OVSX_PAT }}
+    outputs:
+      artifact_name: ${{ steps.version.outputs.artifact_name }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      version: ${{ steps.version.outputs.version }}
+      vsix_file: ${{ steps.package.outputs.vsix_file }}
 
     steps:
       - name: Checkout
@@ -41,7 +45,7 @@ jobs:
         working-directory: vscode-extension
         run: |
           npm ci
-          npm install -g @vscode/vsce ovsx
+          npm install -g @vscode/vsce
 
       - name: Set version
         working-directory: vscode-extension
@@ -57,6 +61,18 @@ jobs:
             fi
           fi
 
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::Invalid extension version: $VERSION"
+            exit 1
+          fi
+
+          if [[ "$VERSION" == *-* ]]; then
+            IS_PRERELEASE=true
+            echo "::notice::Prerelease version $VERSION will be packaged for GitHub/Open VSX; VS Code Marketplace publish will be skipped."
+          else
+            IS_PRERELEASE=false
+          fi
+
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           if [ "$CURRENT_VERSION" = "$VERSION" ]; then
@@ -64,21 +80,73 @@ jobs:
           else
             npm version "$VERSION" --no-git-tag-version
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          echo "artifact_name=perl-lsp-rs-${VERSION}.vsix" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "release_tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build release VSIX
         working-directory: vscode-extension
+        id: package
         run: |
           npm run verify:marketplace
 
-          MARKETPLACE_VSIX=$(ls -1 perl-lsp-rs-*.vsix | head -n 1)
+          shopt -s nullglob
+          vsix_files=(perl-lsp-rs-*.vsix)
+          if [ "${#vsix_files[@]}" -ne 1 ]; then
+            echo "::error::Expected one VSIX package, found ${#vsix_files[@]}"
+            printf '%s\n' "${vsix_files[@]}"
+            exit 1
+          fi
 
-          echo "VSIX_FILE=$MARKETPLACE_VSIX" >> "$GITHUB_ENV"
-          echo "OPENVSX_VSIX_FILE=$MARKETPLACE_VSIX" >> "$GITHUB_ENV"
+          echo "vsix_file=${vsix_files[0]}" >> "$GITHUB_OUTPUT"
 
-      - name: Publish to VSCode Marketplace
-        if: ${{ env.VSCE_PAT != '' }}
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.version.outputs.artifact_name }}
+          path: vscode-extension/${{ steps.package.outputs.vsix_file }}
+          retention-days: 30
+
+  publish-vscode-marketplace:
+    name: Publish VS Code Marketplace
+    needs: prepare-vsix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      VERSION: ${{ needs.prepare-vsix.outputs.version }}
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      VSIX_FILE: ${{ needs.prepare-vsix.outputs.vsix_file }}
+
+    steps:
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.prepare-vsix.outputs.artifact_name }}
+          path: vscode-extension
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install Marketplace publisher
+        run: npm install -g @vscode/vsce
+
+      - name: Skip prerelease Marketplace publish
+        if: ${{ needs.prepare-vsix.outputs.is_prerelease == 'true' }}
+        run: |
+          echo "::notice::VS Code Marketplace publish skipped for prerelease $VERSION; Marketplace accepts non-prerelease SemVer package versions only."
+
+      - name: Require Marketplace publish token
+        if: ${{ needs.prepare-vsix.outputs.is_prerelease != 'true' && env.VSCE_PAT == '' }}
+        run: |
+          echo "::error::VSCE_PAT is not configured; VS Code Marketplace publish cannot run."
+          exit 1
+
+      - name: Publish to VS Code Marketplace
+        if: ${{ needs.prepare-vsix.outputs.is_prerelease != 'true' && env.VSCE_PAT != '' }}
         working-directory: vscode-extension
         run: |
           # Idempotency guard: skip if this version is already on the marketplace.
@@ -86,40 +154,77 @@ jobs:
             | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['versions'][0]['version'])" \
             2>/dev/null || echo "")
           if [ "$PUBLISHED_VERSION" = "$VERSION" ]; then
-            echo "::warning::VSCode Marketplace already has version $VERSION — skipping publish."
+            echo "::warning::VS Code Marketplace already has version $VERSION; skipping publish."
             exit 0
           fi
-          vsce publish --pat "$VSCE_PAT" --packagePath "${{ env.VSIX_FILE }}"
+          vsce publish --pat "$VSCE_PAT" --packagePath "$VSIX_FILE"
+
+  publish-open-vsx:
+    name: Publish Open VSX
+    needs: prepare-vsix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      OVSX_PAT: ${{ secrets.OVSX_PAT }}
+      VERSION: ${{ needs.prepare-vsix.outputs.version }}
+      VSIX_FILE: ${{ needs.prepare-vsix.outputs.vsix_file }}
+
+    steps:
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.prepare-vsix.outputs.artifact_name }}
+          path: vscode-extension
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install Open VSX publisher
+        run: npm install -g ovsx
 
       - name: Verify Open VSX CLI
-        working-directory: vscode-extension
+        run: ovsx --version
+
+      - name: Require Open VSX publish token
+        if: ${{ env.OVSX_PAT == '' }}
         run: |
-          npm run check:openvsx
+          echo "::error::OVSX_PAT is not configured; Open VSX publish cannot run."
+          exit 1
 
       - name: Publish to Open VSX
         if: ${{ env.OVSX_PAT != '' }}
         working-directory: vscode-extension
         run: |
-          # --skip-duplicate exits 0 with a notice if the version already exists (idempotent).
-          ovsx publish "${{ env.OPENVSX_VSIX_FILE }}" --pat "$OVSX_PAT" --skip-duplicate
+          # --skip-duplicate exits 0 with a notice if the version already exists.
+          ovsx publish "$VSIX_FILE" --pat "$OVSX_PAT" --skip-duplicate
 
-      - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v7
+  github-release-asset:
+    name: Attach VSIX to GitHub Release
+    needs: prepare-vsix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.prepare-vsix.outputs.release_tag }}
+      VSIX_FILE: ${{ needs.prepare-vsix.outputs.vsix_file }}
+
+    steps:
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v8
         with:
-          name: perl-lsp-rs-${{ env.VERSION }}.vsix
-          path: vscode-extension/${{ env.VSIX_FILE }}
-          retention-days: 30
+          name: ${{ needs.prepare-vsix.outputs.artifact_name }}
+          path: vscode-extension
 
       - name: Create GitHub Release asset
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
         run: |
           for attempt in $(seq 1 30); do
-            if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
-              gh release upload "${RELEASE_TAG}" \
-                "vscode-extension/${{ env.VSIX_FILE }}" \
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              gh release upload "$RELEASE_TAG" \
+                "vscode-extension/$VSIX_FILE" \
                 --clobber
               exit 0
             fi
@@ -131,14 +236,31 @@ jobs:
           echo "::error::Release ${RELEASE_TAG} was not available in time for VSIX attachment."
           exit 1
 
+  publish-summary:
+    name: Publish Extension Summary
+    needs:
+      - prepare-vsix
+      - publish-vscode-marketplace
+      - publish-open-vsx
+      - github-release-asset
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
       - name: Post publish summary
-        if: always()
         run: |
           {
             echo "## VS Code extension publish"
             echo ""
-            echo "- Marketplace VSIX: ${{ env.VSIX_FILE }}"
-            echo "- Open VSX VSIX: ${{ env.OPENVSX_VSIX_FILE }}"
+            echo "- Version: ${{ needs.prepare-vsix.outputs.version }}"
+            echo "- VSIX artifact: ${{ needs.prepare-vsix.outputs.artifact_name }}"
+            echo "- VS Code Marketplace job: ${{ needs.publish-vscode-marketplace.result }}"
+            echo "- Open VSX job: ${{ needs.publish-open-vsx.result }}"
+            echo "- GitHub release asset job: ${{ needs.github-release-asset.result }}"
+            if [ "${{ needs.prepare-vsix.outputs.is_prerelease }}" = "true" ]; then
+              echo "- Marketplace prerelease policy: skipped; publish Marketplace only for non-prerelease SemVer versions."
+            fi
             echo "- Marketplace: https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"
             echo "- Open VSX: https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -286,7 +286,7 @@ jobs:
             echo "- ~~Publish to crates.io~~ (skipped)" >> "$GITHUB_STEP_SUMMARY"
           fi
           if [ "${{ github.event.inputs.skip_extension }}" != "true" ]; then
-            echo "- [Publish VSCode Extension](https://github.com/${{ github.repository }}/actions/workflows/publish-extension.yml)" >> "$GITHUB_STEP_SUMMARY"
+            echo "- [Publish VSCode Extension](https://github.com/${{ github.repository }}/actions/workflows/publish-extension.yml) - Marketplace and Open VSX jobs report separately" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- ~~Publish VSCode Extension~~ (skipped)" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -40,7 +40,7 @@ jobs:
   ux-regression-gate:
     name: UX Regression Gate
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/crates/perl-parser-core/src/engine/parser/heredoc_security_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/heredoc_security_tests.rs
@@ -157,14 +157,23 @@ fn test_nested_heredocs_within_limit() {
 #[test]
 fn test_deeply_nested_heredocs_hit_limit() {
     // Test that exceeding 100 heredocs triggers the depth limit
-    let mut code = String::from("my @h = (");
-    for i in 0..150 {
+    let mut code = String::from("print ");
+    for i in 0..101 {
         code.push_str(&format!("<<EOF{}, ", i));
     }
-    code.push_str(");\n");
+    code.push_str(";\n");
 
+    for i in 0..101 {
+        code.push_str(&format!("Content for heredoc {}\n", i));
+        code.push_str(&format!("EOF{}\n", i));
+    }
+
+    let start = Instant::now();
     let mut parser = Parser::new(&code);
     let _result = parser.parse();
+    let duration = start.elapsed();
+
+    assert!(duration.as_secs() < 2, "Parser should hit heredoc depth limit efficiently");
 
     let errors = parser.errors();
     assert!(

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -19,7 +19,7 @@ The perl-lsp release process is fully automated and supports:
 - **Multi-platform binaries**: Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
 - **Package managers**: Homebrew, Scoop, Chocolatey
 - **Docker images**: Multi-arch (linux/amd64, linux/arm64)
-- **VSCode extension**: VSCode Marketplace and Open VSX
+- **VSCode extension**: VSCode Marketplace and Open VSX, published by independent jobs
 - **crates.io**: Crates in `[workspace.metadata.publish.allow]`
 
 ### Release Architecture
@@ -164,7 +164,7 @@ Monitor the following workflows:
 
 1. **Release** - Builds binaries and creates GitHub release
 2. **Publish to crates.io** - Publishes crates in `[workspace.metadata.publish.allow]`
-3. **Publish VSCode Extension** - Publishes to VSCode Marketplace and Open VSX
+3. **Publish VSCode Extension** - Builds one VSIX, then publishes VSCode Marketplace and Open VSX in separate jobs
 4. **Publish Docker Images** - Builds and pushes multi-arch images
 5. **Homebrew Auto-Bump** - Creates PR to Homebrew
 6. **Scoop Auto-Bump** - Creates PR to Scoop
@@ -188,6 +188,7 @@ After all workflows complete, verify:
 3. **VSCode Extension**
    - Check VSCode Marketplace for new version
    - Check Open VSX for new version
+   - Confirm the workflow summary reports Marketplace and Open VSX as separate channel statuses
    - Test extension installation
 
 4. **Docker Images**
@@ -321,6 +322,12 @@ VSCode extension is published to:
 - VSCode Marketplace: `EffortlessMetrics.perl-lsp-rs`
 - Open VSX: `EffortlessMetrics.perl-lsp-rs`
 
+The `Publish VSCode Extension` workflow builds a single VSIX and then runs separate
+`publish-vscode-marketplace` and `publish-open-vsx` jobs. A Marketplace failure must
+not prevent Open VSX from attempting its publish. Marketplace accepts non-prerelease SemVer
+extension versions, so prerelease versions such as `0.13.0-rc1` are packaged as VSIX
+assets for GitHub release/sideload validation and are skipped for Marketplace publish.
+
 **Installation:**
 ```bash
 # From VSCode Marketplace
@@ -428,6 +435,11 @@ For a complete rollback:
 - Check Dockerfile syntax
 - Verify base image is available
 - Check for platform-specific issues
+
+**Issue: VS Code Marketplace rejects a prerelease version**
+- Publish Marketplace only for non-prerelease SemVer versions such as `0.13.0`
+- Use the GitHub release VSIX asset for prerelease sideload validation
+- Check the Open VSX job separately; it does not depend on Marketplace success
 
 ### Binary Issues
 

--- a/docs/reference/CI_ARCHITECTURE.md
+++ b/docs/reference/CI_ARCHITECTURE.md
@@ -55,8 +55,9 @@ CI hasn't broken since their last look).
 
 | Job | Timeout | Scope |
 |-----|---------|-------|
-| `pr-smoke` | 10 min | Format, scoped clippy, scoped test, integration-test compile |
-| `merge-gate` | 30 min | Full `just gates` via gate policy (see Section 2) |
+| `pr-smoke` | 35 min | Format, scoped clippy, scoped test, integration-test compile |
+| `merge-gate-shards` | 20 min | Bounded merge-gate shards via gate policy (see Section 2) |
+| `merge-gate` | 2 min | Aggregates shard results into the required merge-blocking status |
 | `ux-tests` | 15 min | UX regression suite against live binary |
 | `check-all-targets` | 10 min | `cargo check --workspace --all-targets` (bit-rot guard) |
 | `windows-guardrails` | 20 min | Three Windows-specific lanes (compile, module-sep, sandbox) |
@@ -304,6 +305,22 @@ If `ci-scope` fails (timeout, cargo metadata error, or other failure), the pr-sm
 falls back to a hardcoded baseline: `just clippy-core` and `just test-core`. This ensures
 a broken `ci-scope` does not produce a false-green PR — it produces a broader (slower)
 check rather than no check.
+
+### Timeout Classification
+
+`pr-smoke` has a 35-minute GitHub job timeout and wraps `xtask gates --tier pr-fast`
+with a 30-minute runner watchdog. Individual shell-backed gates still use their
+`.ci/gate-policy.yaml` `timeout_seconds` values. On Unix runners, xtask delegates those
+per-gate deadlines to GNU `timeout` when available so a timed-out cargo or test command
+terminates as a process group, writes a receipt entry with `status: "timeout"`, and does
+not continue running until the outer job timeout cancels the runner.
+
+`merge-gate-shards` runs bounded groups of required gates with per-shard receipts and a
+20-minute GitHub job timeout. The gate runner writes a receipt and log for each shard,
+truncates very large gate logs before summarizing them, and records per-gate timeout
+status from `.ci/gate-policy.yaml`. The `merge-gate` aggregate job reports those shard
+results as the required merge-blocking status instead of hiding failures behind one
+monolithic runner timeout.
 
 ---
 

--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -1719,7 +1719,7 @@ fn run_shell_command_with_timeout(
         .try_clone()
         .with_context(|| format!("Failed to clone log file handle: {}", log_path.display()))?;
 
-    let mut child = shell_command_process(command)
+    let mut child = shell_command_process(command, timeout_secs)
         .stdout(Stdio::from(log_file))
         .stderr(Stdio::from(log_file_err))
         .spawn()
@@ -1727,13 +1727,13 @@ fn run_shell_command_with_timeout(
 
     let start = Instant::now();
     let mut last_heartbeat = start;
-    let timeout = Duration::from_secs(timeout_secs);
+    let timeout = shell_command_watchdog_timeout(timeout_secs);
 
     // Poll until the process exits or the deadline elapses.
     // Capture exit_code inside the loop so the timed-out branch never calls
     // wait() a second time (which would be a double-wait and returns an error
     // on Windows). Synthetic exit code 124 follows the GNU timeout(1) convention.
-    let (timed_out, exit_code) = loop {
+    let (watchdog_timed_out, exit_code) = loop {
         if let Some(status) = child.try_wait().context("Failed waiting on gate process")? {
             break (false, status.code().unwrap_or(-1));
         }
@@ -1753,6 +1753,7 @@ fn run_shell_command_with_timeout(
         thread::sleep(Duration::from_millis(100));
     };
 
+    let timed_out = watchdog_timed_out || exit_code == 124;
     println!(
         "gate command exited exit_code={} timed_out={} elapsed_ms={} log_path={}",
         exit_code,
@@ -1807,18 +1808,27 @@ fn read_gate_output(log_path: &Path) -> String {
 }
 
 #[cfg(windows)]
-fn shell_command_process(command: &str) -> Command {
+fn shell_command_process(command: &str, _timeout_secs: u64) -> Command {
     let mut cmd = Command::new("cmd");
     cmd.args(["/C", command]);
     cmd
 }
 
 #[cfg(not(windows))]
-fn shell_command_process(command: &str) -> Command {
+fn shell_command_process(command: &str, timeout_secs: u64) -> Command {
     use std::os::unix::process::CommandExt;
 
     let mut cmd = Command::new("bash");
-    cmd.args(["-lc", command]);
+    let timeout_arg = format!("{timeout_secs}s");
+    cmd.arg("-lc")
+        .arg(
+            "if command -v timeout >/dev/null 2>&1; then \
+             exec timeout --signal=TERM --kill-after=60s \"$1\" bash -lc \"$2\"; \
+             else exec bash -lc \"$2\"; fi",
+        )
+        .arg("xtask-gate-timeout")
+        .arg(timeout_arg)
+        .arg(command);
     cmd.process_group(0);
     cmd
 }
@@ -1835,6 +1845,16 @@ fn terminate_shell_command(child: &mut Child) {
     thread::sleep(Duration::from_secs(1));
     Command::new("kill").args(["-KILL", &process_group]).status().ok();
     child.kill().ok();
+}
+
+#[cfg(windows)]
+fn shell_command_watchdog_timeout(timeout_secs: u64) -> Duration {
+    Duration::from_secs(timeout_secs)
+}
+
+#[cfg(not(windows))]
+fn shell_command_watchdog_timeout(timeout_secs: u64) -> Duration {
+    Duration::from_secs(timeout_secs.saturating_add(75))
 }
 
 fn run_internal_xtask_gate(


### PR DESCRIPTION
Problem: public-alpha publishing needs Marketplace-safe non-prerelease version handling, independent Open VSX publishing, and clearer CI/UX timeout diagnostics.
Fix: Split VSIX preparation from Marketplace/Open VSX jobs, skip Marketplace for prerelease versions, report extension channel statuses separately, fail missing publish-token channels explicitly, narrow extension workflow token permissions, add CI Gate, PR Smoke, gate-runner, and UX gate timeout headroom/classification, and bound the heredoc depth fixture that was blocking PR Smoke from reaching the intended gate outcome.
Verification: `cargo xtask gate-policy check` passes; `cargo xtask workflow-policy-lint` passes with 2 pre-existing unpinned-action warnings; `cargo xtask workflow-trigger-lint` passes; `cargo test -p xtask shell_command_timeout_marks_execution_and_writes_log --locked` passes; `cargo test -p xtask shell_command_natural_exit_preserves_actual_exit_code --locked` passes; `cargo test -p perl-parser-core test_deeply_nested_heredocs_hit_limit --lib --locked` passes; `cargo test -p perl-parser -p perl-lexer -p perl-parser-core --lib --locked -- --test-threads=4` passes; `cargo fmt -p xtask -p perl-parser-core --check` passes; `git diff --check` passes.

Closes #7673.
Closes #7674.
Closes #7675.