### PR TITLE
docs(release): align 0.13.0 release truth (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ These are behavioral and corpus-backed signals, not feature inventory counts. Pr
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
-| Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 34 crates after the v0.13 collapse |
+| Release track | `v0.13.0` public alpha release prep |
+| Published crate surface | 32 crates after the v0.13 collapse |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
 | Project parser corpus | 100.0% clean (`95/95`) |

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -22,11 +22,12 @@
 
 | Metric | Value | Source |
 | --- | --- | --- |
-| **Workspace version line** | `v0.12.4` | [`Cargo.toml`](../../Cargo.toml) |
-| **Latest GitHub/editor release** | `v0.12.4`, 2026-04-12 | GitHub Releases, VS Code Marketplace |
-| **crates.io line** | `v0.12.2`, 2026-04-08 | crates.io |
+| **Workspace version line** | `v0.13.0-rc1` | [`Cargo.toml`](../../Cargo.toml) |
+| **Latest release candidate** | `v0.13.0-rc1`, 2026-04-30 | GitHub Releases, crates.io, Docker Hub |
+| **crates.io line** | `0.13.0-rc1` across 32 published crates | `[workspace.metadata.publish.allow]` |
+| **Editor marketplace line** | Non-prerelease `0.13.0` pending | VS Marketplace requires non-prerelease SemVer; Open VSX must publish independently |
 | **Release history** | [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) | Canonical cross-channel ledger |
-| **Active milestone** | `v0.13.0` public alpha announcement | [status/index.md](status/index.md) |
+| **Active milestone** | `v0.13.0` public alpha launch | [status/index.md](status/index.md) |
 | **Merge gate** | `nix develop -c just ci-gate` | [protocols/verification.md](protocols/verification.md) |
 | **LSP Coverage** | See [status/lsp.md](status/lsp.md) | Generated per-merge |
 | **Test counts** | See [status/tests.md](status/tests.md) | Generated per-merge |

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -9,12 +9,12 @@
 ## Current Framing
 
 - Workspace version line: `v0.13.0-rc1`
-- Latest published GitHub/editor release: `v0.12.4` (GitHub Releases and VS Code Marketplace, shipped 2026-04-12)
-- crates.io published line: `v0.12.2` (registry line, published 2026-04-08)
-- Active work: finish the `v0.13.0` public alpha announcement pass (demo assets, distribution-truth cleanup, post-release docs/automation cleanup) while keeping the shipped `v0.12.4` line stable across GitHub Releases and the editor marketplaces
+- Latest release candidate: `v0.13.0-rc1` (GitHub Releases, crates.io, and Docker Hub published 2026-04-30)
+- crates.io published line: `0.13.0-rc1` across 32 crates from `[workspace.metadata.publish.allow]`
+- Active work: finish the `v0.13.0` public alpha launch by aligning release truth, publishing the Marketplace-compatible extension version, splitting Open VSX from Marketplace, and capturing one final release verification receipt
 - Canonical local receipt: `nix develop -c just ci-gate`
 
-Publication discipline: public release truth is intentionally split right now. GitHub Releases and the editor marketplaces are on `v0.12.4`; crates.io remains on `v0.12.2` until the registry window reopens. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the full cross-channel ledger. Milestone sections below can describe the intended `0.12.x` breakdown, but they must not blur that channel split.
+Publication discipline: `v0.13.0-rc1` proved GitHub Releases, crates.io, and Docker Hub. Public alpha `v0.13.0` must not ship with the RC channel split unresolved: VS Marketplace publishes non-prerelease `0.13.0`, Open VSX reports independently, and all five intended channels are either green or explicitly deferred in the release receipt.
 
 ## How To Read This File
 
@@ -90,7 +90,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - End-to-end LSP feature development guide (#3027, PR #3115)
 - GIF recording guide and asset structure (#2336, PR #3130)
 
-## Active: Quality Cleanup (post-v0.12.3 / pre-v0.13.0)
+## Active: Public Alpha v0.13.0 Release Prep
 
 - Debug println removal from library code (in progress)
 - Unused dependency removal across 6 crates (in progress)
@@ -99,7 +99,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 
 ## Now / Next / Later
 
-### Now (post-v0.12.3 / pre-v0.13.0)
+### Now (v0.13.0 public alpha launch)
 
 - CI/control-plane Wave 2 substrate already landed and should not be re-implemented in parallel follow-up PRs:
   - Per-gate timeout regression coverage in gate receipts (#7525)
@@ -116,7 +116,9 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
   6. Merge-train planner/receipt protocol with stop conditions
   7. Tokmd advisory stabilization (explicitly non-required while calibrating signal)
 - Wave guardrails: no bulk stale-closure automation, no full merge bot scope, no global pre-push hooks, no broad CI architecture rewrite in this pass.
-- `v0.12.3` shipped to GitHub Releases, VS Code Marketplace, and Open VSX on 2026-04-09; crates.io remains on `v0.12.2`
+- `v0.13.0-rc1` shipped to GitHub Releases, crates.io, and Docker Hub; VS Marketplace rejected the prerelease suffix and Open VSX was skipped behind Marketplace
+- Release-channel follow-ups: Marketplace non-prerelease publishing (#7673), Open VSX independent publishing (#7674), and CI Gate timeout diagnostics (#7675)
+- Final release-truth alignment: README/status docs, migration guide, changelog/release notes, `0.13.0` version bump, and release verification receipt
 - Pre-announcement license badge fix (PR #3193): canonical SPDX text in all 126 LICENSE files
 - Pre-announcement Docker arm64 timeout fix (#3188 → PR #3191, merged)
 - Per-release dependency triage: 7 dependabot PRs merged 2026-04-07 (#3178–#3184)
@@ -129,12 +131,12 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Semantic substrate migration status now tracks Wave 2 reality (facts vocabulary, SymbolDecl adapter, FileFactShard write-through, and DefinitionCandidate multimap landed; SymbolRef adapter and typed-reference global index still staged; ExportInfo -> ExportSet landed) in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md); provider cutover remains explicitly deferred until Wave 3 foundations (`ImportSpec` + `visible_symbols_at`) are proven
 - CI/control-plane next-wave execution sequencing is tracked in [CI_WAVE_EXECUTION_PLAN.md](CI_WAVE_EXECUTION_PLAN.md), with #7404 (`update-status --write` streaming) as the top urgency lane.
 
-### Next (v0.13.0 — public alpha announcement)
+### Next (v0.13.0 public alpha)
 
 - The 0.12.x line has built confidence across parser, diagnostics, refactoring, and distribution
-- Quality cleanup PRs land, version bump to 0.13.0
-- Seamless install story verified across all distribution channels
-- Announcement blog post / release notes
+- Version surfaces move from `0.13.0-rc1` to public alpha `0.13.0`
+- Seamless install story verified across GitHub Releases, crates.io, Docker Hub, VS Marketplace, and Open VSX
+- Changelog and release notes link the migration guide and RC-to-0.13.0 compare
 
 ## Milestone Ladder
 
@@ -160,7 +162,7 @@ corpus confidence ratchet, and error-handling hygiene.
 ### v0.12.3
 
 GitHub/editor release line: status regeneration, corpus receipts, version-surface alignment,
-and readiness verification shipped on 2026-04-09 ahead of the public alpha announcement.
+and readiness verification shipped on 2026-04-09 ahead of the 0.13 release train.
 
 ### v0.12.4
 
@@ -169,13 +171,13 @@ Follow-on diagnostics and semantics scope retained on the prep track, not yet a 
 ### v0.12.5–v0.12.8
 
 Parser confidence, performance, distribution, and announcement-polish scopes retained on the prep track.
-Treat these as internal milestone slices until the next public GitHub release beyond `v0.12.3` is actually cut.
+Treat these as internal milestone slices that were absorbed into the `v0.13.0-rc1` release train.
 
 ### v0.13.0
 
-Initial public alpha announcement. The 0.12.x line built confidence
-across parser corpus, diagnostics, refactoring, and distribution.
-0.13.0 is the announcement version.
+Public alpha launch of the collapsed 32-crate published surface. The 0.12.x and RC lines
+built confidence across parser corpus, diagnostics, refactoring, distribution, and
+release automation. `0.13.0` is the non-prerelease marketplace/crates public alpha version.
 
 ### Beyond v0.13.0
 
@@ -207,7 +209,7 @@ For live capability posture, run `just status-check` or read [CURRENT_STATUS.md]
 | Topic | Source |
 | --- | --- |
 | Workspace version line | [`../../Cargo.toml`](../../Cargo.toml) |
-| Latest published release | GitHub Releases (`v0.12.3`) + crates.io API (`0.12.2` when channel split matters) |
+| Latest published release | GitHub Releases/crates.io/Docker Hub (`v0.13.0-rc1`) + public alpha channel receipt for `v0.13.0` when cut |
 | Capability catalog | [`../../features.toml`](../../features.toml) |
 | Evidence-backed metrics | [CURRENT_STATUS.md](CURRENT_STATUS.md) |
 | Top-level summary docs | [../../ROADMAP.md](../../ROADMAP.md), [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) |

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -5,7 +5,7 @@
 
 ## What's True Right Now
 
-- **Release posture**: GitHub Releases plus the editor channels (VS Code Marketplace and Open VSX) are live on `v0.12.3` as of 2026-04-09, the workspace version line is `v0.12.3`, crates.io intentionally remains on `v0.12.2`, and the active milestone is the `v0.13.0` public alpha announcement
+- **Release posture**: `v0.13.0-rc1` validated GitHub Releases, crates.io, and Docker Hub; all 32 crates in `[workspace.metadata.publish.allow]` are published at `0.13.0-rc1`; public alpha `v0.13.0` is pending marketplace-compatible extension publishing and final release verification
 - **Status discipline**: this file is for narrative, subsystem files are for evidence, and `just status-update` plus `just status-check` are the anti-drift workflow
 - **LSP server**: `features.toml` is the canonical capability catalog; 58 user-visible features at 100% coverage (116/116 including plumbing protocol methods and DAP handlers — corrected in PR #4107 after the DAP catalog undercount audit) — computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `cargo xtask ignored-tests` is the tracked-test-debt source
@@ -29,17 +29,17 @@
 
 ## What's Next
 
-**Now (active milestone: v0.13.0 public alpha announcement)**
-- Close out `#3302` demo-asset recording — the main remaining human-owned blocker before the `v0.13.0` public alpha announcement
-- Keep the public release split explicit: GitHub Releases, VS Code Marketplace, and Open VSX are on `v0.12.3`, while crates.io remains on `v0.12.2` until the registry window reopens
+**Now (active milestone: v0.13.0 public alpha launch)**
+- Merge release-channel fixes so VS Marketplace publishes only non-prerelease SemVer versions and Open VSX no longer depends on Marketplace success
+- Keep the public release split explicit: `v0.13.0-rc1` is live on GitHub Releases, crates.io, and Docker Hub; public alpha `v0.13.0` is pending across all five intended channels
 - Keep the three parser verification lanes explicit and green: `just corpus-sweep-check`, `just cpan-corpus-check`, and `just parser-audit`, with `just common-corpus-check` covering the pinned strict-clean subset
-- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line, the `perl-lsp-rs` extension package, and the delayed crates.io surface
-- Resume parser, corpus, and semantic hardening while the `v0.13.0` announcement pass stays open
+- Keep the top-level README, status docs, migration guide, changelog, and release notes aligned with the actual 32-crate published surface
+- Run one clean release verification receipt before tagging `v0.13.0`
 
 **Next (v0.13.0 public alpha)**
 - Keep all three parser corpus lanes current: Ubuntu system Perl, the cached CPAN top 1000 install, and the repo-owned corpus audit
 - Fold internal torture and edge-case suites into routine verification receipts
-- Publish benchmark and release-readiness receipts for the alpha burndown
+- Publish benchmark and release-readiness receipts for the public alpha launch
 
 **Later (post v0.13.0)**
 - DAP preview hardening (deeper live variables/evaluate, shim packaging, cross-editor native receipts)
@@ -68,5 +68,5 @@ See [ROADMAP.md](../ROADMAP.md) for milestone details.
 
 ---
 
-*Last Updated: 2026-04-09 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
+*Last Updated: 2026-05-01 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
 *Canonical docs: [ROADMAP.md](../ROADMAP.md), [../../features.toml](../../features.toml)*

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -11,7 +11,7 @@
 - **UX workflow harness**: 27 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; confidence signals (manual smoke, first-5-minutes coverage, issue-burndown regression guards) are tracked in `docs/project/status/editor_ux.json`
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Lexer performance scorecard**: `cargo bench -p perl-lexer --bench lexer_benchmarks` writes `benchmarks/results/lexer_scorecard.json` for trend comparisons
-- **Production Status**: LSP server public alpha (`just ci-gate` passing)
+- **Production Status**: LSP server public alpha for `v0.13.0` (`just ci-gate` passing)
 <!-- END: QUALITY_METRICS_BULLETS -->
 
 ## Per-Crate Engineering Health

--- a/docs/project/status/release.md
+++ b/docs/project/status/release.md
@@ -5,33 +5,34 @@
 
 ## Current Release Call
 
-**Latest GitHub/editor release**: `v0.12.3` (2026-04-09)
-**crates.io line**: `v0.12.2` (2026-04-07)
-**Release target**: `v0.13.0` public alpha announcement
-**Ship readiness**: `v0.12.3` is live on GitHub Releases, VS Code Marketplace, and Open VSX; the remaining launch work is announcement-path cleanup, with `#3302` demo assets still the main human-owned blocker before the `v0.13.0` public alpha announcement
+**Latest release candidate**: `v0.13.0-rc1` (2026-04-30)
+**crates.io line**: `0.13.0-rc1` across 32 published crates
+**Release target**: `v0.13.0` public alpha
+**Ship readiness**: RC1 validated GitHub Releases, crates.io, and Docker Hub. Public alpha release is pending Marketplace-compatible extension versioning, independent Open VSX publish, docs/version finalization, and one final release verification receipt.
 
 ## Active Blockers
 
-- `#3302` demo GIFs remain the main human-owned blocker before the `v0.13.0` public alpha announcement
-- Public install guidance must keep the channel split explicit while crates.io remains on `v0.12.2`
+- VS Marketplace must publish the non-prerelease extension version `0.13.0`, not prerelease `0.13.0-rc1`
+- Open VSX must run independently rather than cascading behind Marketplace
+- Master needs one clean release-verification cycle before tagging `v0.13.0`
 
-## 0.12.3 Ship Receipts (2026-04-09)
+## 0.13.0-rc1 Ship Receipts (2026-04-30)
 
-- GitHub release `v0.12.3` published 2026-04-09 against `cc801735`
-- `Release` workflow completed successfully and attached the cross-platform `perllsp` archives plus `SHA256SUMS`
-- `Publish VSCode Extension` completed successfully; `perl-lsp-rs` `0.12.3` is live on both VS Code Marketplace and Open VSX
-- workspace version line is `v0.12.3`; `check-version-sync` still expects all 140 version sites to agree with it
-- crates.io intentionally remains on `v0.12.2` as of 2026-04-09, so docs and install guidance must keep that split explicit
+- GitHub release `v0.13.0-rc1` published with cross-platform `perllsp`/`perl-dap` archives and `SHA256SUMS`
+- crates.io published all 32 crates listed in `[workspace.metadata.publish.allow]`, including `perl-semantic-facts`, at `0.13.0-rc1`
+- Docker Hub published multi-arch images for the RC
+- VS Marketplace rejected the prerelease suffix; non-prerelease `0.13.0` is the Marketplace publish version
+- Open VSX was skipped because it was sequenced behind Marketplace; the `0.13.0` path must report Open VSX separately
 
 ## Component Summary
 
 | Component | Status | Notes |
 | --- | --- | --- |
-| `perl-parser` | Public alpha | Native parser path |
-| `perl-lsp` | Public alpha | Coverage tracked via `features.toml` |
+| `perl-parser` | Public alpha 0.13.0 | Native parser path |
+| `perl-lsp` | Public alpha 0.13.0 | Coverage tracked via `features.toml` |
 | `perl-dap` | Preview (Native + Bridge) | Native adapter is present; compatibility path retained |
-| `perl-lexer` | Public alpha | Context-aware tokenizer |
-| `perl-corpus` | Public alpha | Corpus counts tracked in computed metrics |
+| `perl-lexer` | Public alpha 0.13.0 | Context-aware tokenizer |
+| `perl-corpus` | Public alpha 0.13.0 | Corpus counts tracked in computed metrics |
 
 ## DAP Stance
 
@@ -60,4 +61,4 @@ Native + Bridge preview. Harden preview flows is active work.
 
 ---
 
-*Last Updated: 2026-04-09*
+*Last Updated: 2026-05-01*

--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -21,7 +21,7 @@ use super::{replace_block, run_cmd_merged};
 
 static RUNNING_TEST_BINARY_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r"Running unittests[^\(]*\(target[^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+(?:\.exe)?\)",
+        r"Running unittests[^\(]*\([^\)]*deps[/\\]([a-zA-Z0-9_-]+)-[0-9a-f]+(?:\.exe)?\)",
     )
     .expect("running-test regex is valid")
 });
@@ -142,7 +142,7 @@ pub(super) fn generate_quality_status(root: &Path, original: &str) -> Result<Str
          - **Mutation testing**: {mutation_note}\n\
          - **Lexer performance scorecard**: `cargo bench -p perl-lexer --bench lexer_benchmarks` writes `benchmarks/results/lexer_scorecard.json` for trend comparisons
 \
-         - **Production Status**: LSP server public alpha (`just ci-gate` passing)"
+- **Production Status**: LSP server public alpha for `v0.13.0` (`just ci-gate` passing)"
     );
 
     let crate_table = format_crate_quality_table(&mutation_by_crate, &tests_by_crate);


### PR DESCRIPTION
Problem: README and status docs still described outdated 0.12/alpha channel truth despite the v0.13.0-rc1 release train.
Fix: Align release posture to the v0.13.0 public alpha launch, 0.13.0-rc1 RC receipts, non-prerelease marketplace versioning, and the 32-crate published surface; fix quality-status generation under external CARGO_TARGET_DIR.
Verification: cargo xtask update-status --write --only quality passes; cargo xtask update-status --check --only quality passes; cargo test -p xtask quality --locked passes; git diff --check passes.