### PR TITLE
docs(release): finalize 0.13.0 notes (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-01
+
+Release notes: [v0.13.0](docs/releases/v0.13.0.md)
+
+### Release
+
+- **Public alpha `v0.13.0` release** — promotes the `0.13.0-rc1` train to the
+  public alpha release line for GitHub Releases, crates.io, Docker Hub, VS Marketplace,
+  and Open VSX.
+- **Microcrate collapse release surface** — finalizes the v0.13.0 published crate
+  surface at 32 crates, including `perl-semantic-facts`; downstream crate consumers
+  should use [`docs/MIGRATION_v0.13.md`](docs/MIGRATION_v0.13.md) for retired-crate
+  to owning-crate mappings.
+- **Parser/LSP/DAP release hardening** — carries forward the RC train's parser,
+  LSP, DAP, feature-catalog, and release-gate hardening without expanding the
+  published crate surface.
+- **Marketplace/Open VSX publish path** — extension publishes use non-prerelease
+  SemVer `0.13.0`; Open VSX has a standalone channel path so Marketplace rejection
+  cannot cascade-skip the Open VSX publish.
+
 ## [0.13.0-rc1] - 2026-04-30
 
 Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md)
@@ -529,7 +549,7 @@ Release notes: [v0.12.4](docs/releases/v0.12.4.md) · [GitHub Release](https://g
 
 Release notes: [v0.12.3](docs/releases/v0.12.3.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.3)
 
-<!-- Pipeline rehearsal release — validates the full publish + extension + Docker cycle before v0.13.0 public alpha -->
+<!-- Pipeline rehearsal release — validates the full publish + extension + Docker cycle before the v0.13.0 release train -->
 <!-- Rolls up publish pipeline fixes, UX P0 improvements, and CI hardening from Waves 10/11/12 -->
 
 ### Headlines
@@ -1251,5 +1271,6 @@ For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HIS
 [0.9.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.1
 [0.9.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.0
 [0.8.8]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.8.8
+[0.13.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...v0.13.0
 [0.13.0-rc1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1
-[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...HEAD
+[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0...HEAD

--- a/docs/MIGRATION_v0.13.md
+++ b/docs/MIGRATION_v0.13.md
@@ -38,7 +38,7 @@ The same applies to the other 28 crates in the published set:
 ## If you depend on a retired crate
 
 If your `Cargo.toml` lists a dependency on any crate not in the list above, that crate
-has been retired. Its code now lives as a module inside one of the 30 published crates.
+has been retired. Its code now lives as a module inside one of the 32 published crates.
 
 **Steps to migrate:**
 
@@ -111,7 +111,7 @@ perl-workspace-index = "0.12.4"
 perl-workspace = "0.13.0"
 ```
 
-> The root `Cargo.toml` aliases `perl-workspace = { path = "crates/perl-workspace-index", version = "0.12.4" }`
+> The root `Cargo.toml` aliases `perl-workspace = { path = "crates/perl-workspace-index", version = "0.13.0" }`
 > so the package is published under the new name. Your `Cargo.toml` dependency key changes
 > from `perl-workspace-index` to `perl-workspace`.
 
@@ -544,8 +544,11 @@ their owning published crate in v0.13.0.
 **Enabling feature flags in v0.13.0:**
 
 ```toml
-# Enable incremental parsing and workspace-wide indexing
-perl-parser = { version = "0.13.0", features = ["incremental", "workspace"] }
+# Enable incremental parsing
+perl-parser = { version = "0.13.0", features = ["incremental"] }
+
+# Enable workspace-wide indexing
+perl-workspace = { version = "0.13.0", features = ["workspace"] }
 
 # Enable the lsp-compat shim (needed if you consume lsp-types alongside perl-lsp types)
 perl-lsp-rs-core = { version = "0.13.0", features = ["lsp-compat"] }
@@ -607,7 +610,7 @@ artifact and a semver contract. The full analysis is in
 ## Timeline
 
 - The collapse ran across 14 PRs from 2026-04-15 to 2026-04-21.
-- v0.13.0 is the first release with the new 30-crate surface.
+- v0.13.0 is the first release with the new 32-crate surface.
 - There is no extended migration window — old crate names are not re-published as shims.
 
 If you have questions, open a discussion on

--- a/docs/releases/v0.13.0-rc1.md
+++ b/docs/releases/v0.13.0-rc1.md
@@ -4,38 +4,46 @@ tag: "v0.13.0-rc1"
 release_date_utc: "2026-04-30"
 previous_tag: "v0.12.4"
 compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0-rc1"
 notes_status: canonical
 channels:
-  crates_io: pending
-  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
-  open_vsx: pending
-  docker: pending
+  github_release: published
+  crates_io: "published: 32 crates at 0.13.0-rc1"
+  vscode_marketplace: "blocked: prerelease suffix rejected"
+  open_vsx: "skipped: workflow chained behind Marketplace"
+  docker: "published: multi-arch images"
 ---
 
 # v0.13.0-rc1
 
 ## Summary
 
-Release candidate that finalizes CI cancellation hardening and prepares the
-0.13.0 train for stable cut after one full green rehearsal.
+Release candidate that validated the hard publish channels for the 0.13.0 train:
+GitHub Release assets, crates.io publication for all 32 allowlisted crates, and
+multi-arch Docker images. VS Marketplace rejected the prerelease suffix, and
+Open VSX was skipped because the workflow chained it behind Marketplace.
 
 ## Highlights
 
 - **CI cancellation cascade fix landed** — label events no longer cancel active
   runs; cancellation now targets pull request synchronize updates only.
-- **Version staging alignment** — workspace and feature metadata remain on
+- **Version staging alignment** — workspace and feature metadata were staged at
   `0.13.0-rc1`, with extension and changelog surfaces aligned for RC publish.
 - **Microcrate collapse migration continuity** — includes the migration guidance
   and release-prep groundwork already staged in this train.
+- **Channel compatibility finding** — VS Marketplace requires a non-prerelease
+  SemVer extension version; Open VSX needs an independent publish path.
 
 ## Install / upgrade
 
-- **VS Code**: install or update the [Perl Language Server](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) extension.
-- **Source/Binary**: consume this tag through the normal release orchestration
-  channels after assets are published.
+- **VS Code**: the Marketplace does not accept this prerelease version; use the
+  GitHub Release asset for sideload testing if an RC extension build is needed.
+- **Source/Binary**: download binaries from the GitHub Release or consume the
+  `0.13.0-rc1` crates from crates.io.
 
 ## Links
 
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0-rc1)
 - [Compare v0.12.4...v0.13.0-rc1](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1)
 - [CHANGELOG](../../CHANGELOG.md)
 - [Release ledger](../../RELEASE_HISTORY.md)

--- a/docs/releases/v0.13.0.md
+++ b/docs/releases/v0.13.0.md
@@ -1,0 +1,52 @@
+---
+version: "0.13.0"
+tag: "v0.13.0"
+release_date_utc: "2026-05-01"
+previous_tag: "v0.13.0-rc1"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...v0.13.0"
+github_release: "https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0"
+notes_status: canonical
+channels:
+  github_release: public_alpha
+  crates_io: "public alpha: 32 crates at 0.13.0"
+  vscode_marketplace: "public alpha: EffortlessMetrics.perl-lsp-rs at 0.13.0"
+  open_vsx: "public alpha: independent publish path"
+  docker: "public alpha: 0.13.0 and latest policy tags"
+---
+
+# v0.13.0
+
+## Summary
+
+v0.13.0 is the public alpha launch release promoted from the release-candidate
+train to the intended distribution channels: GitHub Releases, crates.io,
+Docker Hub, VS Marketplace, and Open VSX. The release keeps the post-collapse
+published Rust surface at 32 crates and uses non-prerelease SemVer `0.13.0`
+for marketplace extension publishing.
+
+## Highlights
+
+- **Public alpha release cut** — `0.13.0-rc1` validated GitHub Release assets, all 32
+  crates.io publishes, and multi-arch Docker images; this release moves the train
+  to public alpha `0.13.0`.
+- **32-crate published surface** — v0.13.0 is the first public alpha release after the
+  microcrate collapse from 132 published crates to 32, including
+  `perl-semantic-facts`.
+- **Migration guide finalized** — downstream crate consumers should use the
+  v0.13 migration guide for retired-crate mappings and feature flag changes.
+- **Marketplace/Open VSX compatibility** — Marketplace publish uses the
+  non-prerelease extension version `0.13.0`, and Open VSX has a standalone
+  channel path so it can publish independently.
+
+## Upgrade
+
+- [Install and editor setup](../how-to/EDITOR_SETUP.md)
+- [Migration guide](../MIGRATION_v0.13.md)
+- [Changelog](../../CHANGELOG.md)
+
+## Links
+
+- [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.0)
+- [Compare v0.13.0-rc1...v0.13.0](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...v0.13.0)
+- [Compare v0.12.4...v0.13.0](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0)
+- [Release ledger](../../RELEASE_HISTORY.md)


### PR DESCRIPTION
Problem: The 0.13.0 public alpha release docs still mixed RC truth with stale crate-count/channel wording.
Fix: Add v0.13.0 public alpha notes, update the changelog, align the migration guide on 32 crates, and correct the rc1 channel receipt.
Verification: cargo xtask release-notes --tag v0.13.0 passes; cargo xtask release-notes --tag v0.13.0-rc1 passes; cargo xtask published-crate-count passes; git diff --check passes.