### PR TITLE
chore(release): bump version to 0.13.0 (#0000)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**Latest Release**: 0.13.0-rc1 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
+**Latest Release**: 0.13.0 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
 
 ## Orchestration Model
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1490,14 +1490,14 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "perl-corpus"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-workspace",
  "serde",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-test-must",
  "serde",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lexer"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "memchr",
@@ -1607,11 +1607,11 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.13.0-rc1"
+version = "0.13.0"
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-subprocess-runtime",
  "perl-tdd-support",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs-core"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ux-tests"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-parser-core",
  "perl-tdd-support",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-bench"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-parser",
  "walkdir",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -1802,11 +1802,11 @@ dependencies = [
 
 [[package]]
 name = "perl-pod"
-version = "0.13.0-rc1"
+version = "0.13.0"
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "perl-ast",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "proptest",
  "thiserror",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-facts"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1875,14 +1875,14 @@ dependencies = [
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "lsp-types",
  "perl-parser-core",
@@ -1908,18 +1908,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.13.0-rc1"
+version = "0.13.0"
 
 [[package]]
 name = "perl-token"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "perl-lexer",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "perllsp"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -3170,7 +3170,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl-c"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-perl-rs"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "insta",
  "perl-ast",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.13.0-rc1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.13.0-rc1"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -212,26 +212,26 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.13.0-rc1" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.13.0" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.13.0-rc1" }
-perl-regex = { path = "crates/perl-regex", version = "0.13.0-rc1" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.13.0-rc1" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.13.0-rc1" }
-perl-ast = { path = "crates/perl-ast", version = "0.13.0-rc1" }
+perl-token = { path = "crates/perl-token", version = "0.13.0" }
+perl-regex = { path = "crates/perl-regex", version = "0.13.0" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.13.0" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.13.0" }
+perl-ast = { path = "crates/perl-ast", version = "0.13.0" }
 # Wave D absorbed (internal modules in perl-parser/src/):
 #   perl-heredoc-anti-patterns → perl-parser::heredoc_anti_patterns
 # Wave D absorbed (internal modules in perl-parser-core/src/syntax/):
 #   perl-quote, perl-heredoc, perl-error, perl-edit
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.13.0-rc1" }
-perl-symbol = { path = "crates/perl-symbol", version = "0.13.0-rc1" }
-perl-module = { path = 'crates/perl-module', version = "0.13.0-rc1" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.13.0" }
+perl-symbol = { path = "crates/perl-symbol", version = "0.13.0" }
+perl-module = { path = 'crates/perl-module', version = "0.13.0" }
 # Wave D absorbed: perl-qualified-name → perl-parser::qualified_name
-perl-line-index = { path = "crates/perl-line-index", version = "0.13.0-rc1" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.13.0" }
 # Wave D absorbed: perl-source-file → perl-parser::source_file
 # Wave D absorbed: perl-text-line → perl-parser-core::text_line
 # (perl-content-length-framing absorbed into perl-lsp-rs-core::transport::framing — Wave Final PR B)
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.13.0-rc1" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.13.0" }
 # (perl-lsp-document-highlight absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-document-links absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-performance absorbed into perl-lsp-rs-core::tooling::performance — Wave G3 step 5)
@@ -239,29 +239,29 @@ perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "
 # Wave D absorbed: perl-ast-utils → perl-parser::ast_utils
 # (perl-lsp-input-validation absorbed into perl-lsp-rs-core::runtime::input_validation — Wave G2)
 # (perl-lsp-text-utils absorbed into perl-lsp-rs-core::runtime::text_utils — Wave G2)
-perl-uri = { path = "crates/perl-uri", version = "0.13.0-rc1" }
+perl-uri = { path = "crates/perl-uri", version = "0.13.0" }
 # Wave D absorbed: perl-percentile → perl-parser::percentile
 # (perl-lsp-import-management absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-critic-parser absorbed into perl-lsp-rs-core::critic_parser — Wave G3 step 7)
 # (perl-lsp-protocol absorbed into perl-lsp-rs-core::protocol — Wave G3 step 2)
 # Wave D absorbed: perl-path-normalize → perl-parser-core::path_normalize
 # Wave D absorbed: perl-path-security → perl-parser-core::path_security
-perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.13.0-rc1" }
-perl-pod = { path = "crates/perl-pod", version = "0.13.0-rc1" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.13.0-rc1" }
-perl-dap = { path = "crates/perl-dap", version = "0.13.0-rc1" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.13.0-rc1" }
+perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.13.0" }
+perl-pod = { path = "crates/perl-pod", version = "0.13.0" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.13.0" }
+perl-dap = { path = "crates/perl-dap", version = "0.13.0" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.13.0" }
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.13.0-rc1" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.13.0" }
 # (perl-lsp-transport absorbed into perl-lsp-rs-core::transport — Wave G3 step 4)
 # (perl-lsp-tooling absorbed into perl-lsp-rs-core::tooling — Wave G3 step 6)
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.13.0-rc1" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.13.0" }
 # (perl-lsp-on-type-formatting absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting-types absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting absorbed into perl-lsp-rs-core::providers::formatting — Wave G1b)
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.13.0-rc1" }
-perl-test-must = { path = "crates/perl-test-must", version = "0.13.0-rc1" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.13.0" }
+perl-test-must = { path = "crates/perl-test-must", version = "0.13.0" }
 # (perl-lsp-diagnostics absorbed into perl-lsp-rs-core::providers::diagnostics — Wave G1b)
 # (perl-lsp-semantic-tokens absorbed into perl-lsp-rs-core::providers::semantic_tokens — Wave G1b)
 # (perl-lsp-inlay-hints absorbed into perl-lsp-rs-core::providers — Wave G1a)
@@ -285,28 +285,28 @@ perl-test-must = { path = "crates/perl-test-must", version = "0.13.0-rc1" }
 # (perl-lsp-code-actions absorbed into perl-lsp-rs-core::providers::code_actions — Wave G1b)
 # (perl-lsp-folding absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-selection-range absorbed into perl-lsp-rs-core::providers — Wave G1a)
-perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.13.0-rc1" }
+perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.13.0" }
 # Tier 3: Two-level dependencies
-perl-workspace = { path = "crates/perl-workspace-index", version = "0.13.0-rc1" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.13.0-rc1" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.13.0-rc1" }
+perl-workspace = { path = "crates/perl-workspace-index", version = "0.13.0" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.13.0" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.13.0" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.13.0-rc1" }
-perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.13.0-rc1" }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.13.0" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.13.0" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.13.0-rc1" }
-perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.13.0-rc1" }
-perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.13.0-rc1" }
+perl-parser = { path = "crates/perl-parser", version = "0.13.0" }
+perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.13.0" }
+perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.13.0" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.13.0-rc1" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.13.0" }
 
 # External dependencies
-tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.13.0-rc1" }
-tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.13.0-rc1" }
+tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.13.0" }
+tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.13.0" }
 tree-sitter = "0.26.8"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-ci-hygiene/src/version_sync.rs
+++ b/crates/perl-ci-hygiene/src/version_sync.rs
@@ -360,12 +360,12 @@ static BARE_VERSION_RE: LazyLock<Regex> =
     LazyLock::new(|| compile_regex(&format!(r#"^\s*version\s*=\s*"({VERSION_FRAGMENT})""#)));
 static WORKSPACE_DEP_WITH_VERSION_RE: LazyLock<Regex> = LazyLock::new(|| {
     compile_regex(&format!(
-        r#"\{{\s*path\s*=\s*"crates/[^"]+"[^}}]*version\s*=\s*"({VERSION_FRAGMENT})""#
+        r#"\{{\s*path\s*=\s*['"]crates/[^'"]+['"][^}}]*version\s*=\s*"({VERSION_FRAGMENT})""#
     ))
 });
 static CRATE_DEP_WITH_VERSION_RE: LazyLock<Regex> = LazyLock::new(|| {
     compile_regex(&format!(
-        r#"\{{\s*path\s*=\s*"\.\.?/[^"]+"[^}}]*version\s*=\s*"({VERSION_FRAGMENT})""#
+        r#"\{{\s*path\s*=\s*['"]\.\.?/[^'"]+['"][^}}]*version\s*=\s*"({VERSION_FRAGMENT})""#
     ))
 });
 static JSON_VERSION_RE: LazyLock<Regex> =
@@ -947,6 +947,14 @@ perl-token = { path = "../perl-token", version = "0.42.0" }
         let line = r#"perl-foo = { path = "crates/perl-foo", version = "0.13.0-rc1" }"#;
         let caps = WORKSPACE_DEP_WITH_VERSION_RE.captures(line);
         assert!(caps.is_some(), "WORKSPACE_DEP_WITH_VERSION_RE must match pre-release versions");
+        assert_eq!(&caps.unwrap()[1], "0.13.0-rc1");
+    }
+
+    #[test]
+    fn workspace_dep_re_matches_single_quoted_path() {
+        let line = r#"perl-module = { path = 'crates/perl-module', version = "0.13.0-rc1" }"#;
+        let caps = WORKSPACE_DEP_WITH_VERSION_RE.captures(line);
+        assert!(caps.is_some(), "WORKSPACE_DEP_WITH_VERSION_RE must match single-quoted paths");
         assert_eq!(&caps.unwrap()[1], "0.13.0-rc1");
     }
 

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-module"
-version = "0.13.0-rc1"
+version = "0.13.0"
 publish = true
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -8,7 +8,7 @@
 
 ## Current Framing
 
-- Workspace version line: `v0.13.0-rc1`
+- Workspace version line: `v0.13.0`
 - Latest published GitHub/editor release: `v0.12.4` (GitHub Releases and VS Code Marketplace, shipped 2026-04-12)
 - crates.io published line: `v0.12.2` (registry line, published 2026-04-08)
 - Active work: finish the `v0.13.0` public alpha announcement pass (demo assets, distribution-truth cleanup, post-release docs/automation cleanup) while keeping the shipped `v0.12.4` line stable across GitHub Releases and the editor marketplaces

--- a/features.toml
+++ b/features.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.13.0-rc1"
+version = "0.13.0"
 lsp_version = "3.18"
 compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 118/119 advertised
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.13.0-rc1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.13.0-rc1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.17",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.13.0-rc1",
+  "version": "0.13.0",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
Problem: Public alpha release metadata was still staged at 0.13.0-rc1, and version sync missed a single-quoted workspace dependency path.
Fix: Bump workspace, lockfile, crate, feature catalog, and extension metadata to 0.13.0; update version sync to catch single-quoted path dependencies.
Verification: cargo xtask check-version-sync passes; cargo test -p perl-ci-hygiene version_sync --locked passes; cargo xtask publish-closure passes; cargo xtask publish-manifest-check passes; cargo xtask published-crate-count passes; cargo fmt -p perl-ci-hygiene --check passes; git diff --check passes.