### PR TITLE
refactor(scripts): route toolchain shell check through xtask (#0000)

### DIFF
--- a/docs/issues/DEVELOPER_FRICTION.md
+++ b/docs/issues/DEVELOPER_FRICTION.md
@@ -119,7 +119,7 @@ just doctor-env
 #### Proposed Solutions
 | Solution | Effort | Status |
 |----------|--------|--------|
-| Automatic version check in justfile | Low | Implemented via `scripts/check-rust-toolchain.sh` |
+| Automatic version check in justfile | Low | Implemented via `cargo xtask check-toolchain` (legacy wrapper: `scripts/check-rust-toolchain.sh`) |
 | Better error messages for version mismatch | Low | Proposed |
 
 #### Related Documentation

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,7 @@ Run these locally during normal contribution work.
 | Script | Purpose |
 |--------|---------|
 | `install-githooks.sh` | Install the pre-push hook (run once after cloning) |
-| `check-rust-toolchain.sh` | Verify MSRV compatibility before building |
+| `check-rust-toolchain.sh` | Legacy wrapper to `cargo xtask check-toolchain` (MSRV compatibility check) |
 | `devex-doctor.sh` | Environment diagnostics (tool availability, paths) |
 | `devex-targeted-checks.sh` | Targeted subset of diagnostics for a specific area |
 | `preflight.sh` | Quick pre-flight checks before a PR |

--- a/scripts/check-rust-toolchain.sh
+++ b/scripts/check-rust-toolchain.sh
@@ -2,48 +2,39 @@
 set -euo pipefail
 
 MODE="${1:-check}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
-pass() { printf '✅ %s\n' "$1"; }
-warn() { printf '⚠️  %s\n' "$1"; }
-fail() { printf '❌ %s\n' "$1"; }
-
-if [ ! -f rust-toolchain.toml ]; then
-  warn "rust-toolchain.toml not found; skipping pinned toolchain check"
-  exit 0
+TOOLCHAIN=""
+if [ -f "$REPO_ROOT/rust-toolchain.toml" ]; then
+  TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' "$REPO_ROOT/rust-toolchain.toml")
 fi
 
-REQUIRED_TOOLCHAIN=$(awk -F'"' '/channel/{print $2; exit}' rust-toolchain.toml)
-if [ -z "${REQUIRED_TOOLCHAIN:-}" ]; then
-  warn "Could not parse pinned toolchain from rust-toolchain.toml"
-  exit 0
+RUSTUP_CMD=""
+if command -v rustup >/dev/null 2>&1; then
+  RUSTUP_CMD="$(command -v rustup)"
+elif [ -n "${CARGO_HOME:-}" ] && [ -x "$CARGO_HOME/bin/rustup" ]; then
+  RUSTUP_CMD="$CARGO_HOME/bin/rustup"
+elif [ -n "${HOME:-}" ] && [ -x "$HOME/.cargo/bin/rustup" ]; then
+  RUSTUP_CMD="$HOME/.cargo/bin/rustup"
 fi
 
-REQUIRED_VERSION="$REQUIRED_TOOLCHAIN"
-CURRENT_VERSION=""
-if command -v rustc >/dev/null 2>&1; then
-  CURRENT_VERSION=$(rustc --version 2>/dev/null | awk '{print $2}')
+CARGO_CMD=(cargo)
+if [ -n "${TOOLCHAIN:-}" ] && [ -n "$RUSTUP_CMD" ]; then
+  CARGO_CMD=("$RUSTUP_CMD" run "$TOOLCHAIN" cargo)
 fi
 
-if [ -z "$CURRENT_VERSION" ]; then
-  fail "rustc is not available; install Rust via https://rustup.rs"
-  exit 1
-fi
-
-if [ "$CURRENT_VERSION" = "$REQUIRED_VERSION" ]; then
-  pass "Rust toolchain matches pinned version: $CURRENT_VERSION"
-  exit 0
-fi
-
-LOWEST=$(printf '%s\n%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)
-if [ "$LOWEST" = "$REQUIRED_VERSION" ]; then
-  if [ "$MODE" = "doctor" ]; then
-    warn "Using Rust $CURRENT_VERSION while rust-toolchain.toml pins $REQUIRED_VERSION; builds should still work, but use 'rustup override set $REQUIRED_TOOLCHAIN' for exact parity"
-  else
-    pass "Rust $CURRENT_VERSION satisfies pinned MSRV $REQUIRED_VERSION"
-  fi
-  exit 0
-fi
-
-fail "Rust $CURRENT_VERSION is older than pinned MSRV $REQUIRED_VERSION"
-printf '   Fix: rustup toolchain install %s && rustup override set %s\n' "$REQUIRED_TOOLCHAIN" "$REQUIRED_TOOLCHAIN"
-exit 1
+case "$MODE" in
+  check)
+    cd "$REPO_ROOT"
+    exec "${CARGO_CMD[@]}" xtask check-toolchain
+    ;;
+  doctor)
+    cd "$REPO_ROOT"
+    exec "${CARGO_CMD[@]}" xtask check-toolchain --doctor
+    ;;
+  *)
+    echo "Usage: $0 [check|doctor]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Problem: `scripts/check-rust-toolchain.sh` duplicated toolchain-version logic and could drift from the canonical xtask implementation.
Fix: replace it with a mode-aware wrapper around `cargo xtask check-toolchain`, resolving the repo root and pinned rustup toolchain so non-login shells do not fall back to stale system Cargo before xtask can run.
Verification: `bash scripts/check-rust-toolchain.sh invalid` exits 2; `bash scripts/check-rust-toolchain.sh check` passes; `bash scripts/check-rust-toolchain.sh doctor` passes; `cargo check -p xtask --all-targets --locked` passes; `git diff --check` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f432fddeb08333b1b3e4e85e6d4003)