### PR TITLE
refactor(ci): route hygiene shell wrappers through xtask (#0000)

### DIFF
--- a/ci/check_doc_hygiene.sh
+++ b/ci/check_doc_hygiene.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-doc-hygiene "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-doc-hygiene "$@"
+ci_exec_hygiene check-doc-hygiene "$@"

--- a/ci/check_doc_paths.sh
+++ b/ci/check_doc_paths.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-doc-paths "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-doc-paths "$@"
+ci_exec_hygiene check-doc-paths "$@"

--- a/ci/check_ignored.sh
+++ b/ci/check_ignored.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-ignored "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-ignored "$@"
+ci_exec_hygiene check-ignored "$@"

--- a/ci/check_local.sh
+++ b/ci/check_local.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-local "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-local "$@"
+ci_exec_hygiene check-local "$@"

--- a/ci/check_missing_docs.sh
+++ b/ci/check_missing_docs.sh
@@ -1,12 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-missing-docs "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-missing-docs "$@"
+ci_exec_hygiene check-missing-docs "$@"

--- a/ci/check_p0_locks.sh
+++ b/ci/check_p0_locks.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-p0-locks "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-p0-locks "$@"
+ci_exec_hygiene check-p0-locks "$@"

--- a/ci/check_parse_errors.sh
+++ b/ci/check_parse_errors.sh
@@ -1,19 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 REPORT_FILE="$REPO_ROOT/corpus_audit_report.json"
 
 # Issue #3202: corpus-audit and check-parse-errors must run as SEPARATE
 # top-level cargo invocations on Windows. Run corpus-audit first to produce
 # the report file, then invoke check-parse-errors which only reads it.
-cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p xtask --no-default-features -- \
-  corpus-audit --fresh --corpus-path "$REPO_ROOT" --output "$REPORT_FILE"
+ci_run_xtask_package corpus-audit --fresh --corpus-path "$REPO_ROOT" --output "$REPORT_FILE"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-parse-errors "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-parse-errors "$@"
+ci_exec_hygiene check-parse-errors "$@"

--- a/ci/check_parser_matrix.sh
+++ b/ci/check_parser_matrix.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-parser-matrix "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-parser-matrix "$@"
+ci_exec_hygiene check-parser-matrix "$@"

--- a/ci/check_todos.sh
+++ b/ci/check_todos.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-todos "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-todos "$@"
+ci_exec_hygiene check-todos "$@"

--- a/ci/check_unsafe_prod.sh
+++ b/ci/check_unsafe_prod.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-unsafe-prod "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-unsafe-prod "$@"
+ci_exec_hygiene check-unsafe-prod "$@"

--- a/ci/check_unwraps_modules.sh
+++ b/ci/check_unwraps_modules.sh
@@ -1,12 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-unwraps-modules "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-unwraps-modules "$@"
+ci_exec_hygiene check-unwraps-modules "$@"

--- a/ci/check_unwraps_prod.sh
+++ b/ci/check_unwraps_prod.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-unwraps-prod "$@"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
+
+ci_exec_hygiene check-unwraps-prod "$@"

--- a/ci/quick_check.sh
+++ b/ci/quick_check.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" quick-check "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- quick-check "$@"
+ci_exec_hygiene quick-check "$@"

--- a/ci/test_heredocs.sh
+++ b/ci/test_heredocs.sh
@@ -1,12 +1,7 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/xtask_wrapper.sh"
 
-if [ -x "$BIN" ]; then
-  exec "$BIN" test-heredocs "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- test-heredocs "$@"
+ci_exec_hygiene test-heredocs "$@"

--- a/ci/xtask_wrapper.sh
+++ b/ci/xtask_wrapper.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ci_repo_root() {
+  local script_dir
+  script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  cd -- "$script_dir/.." && pwd
+}
+
+ci_resolve_cargo() {
+  local repo_root="$1"
+  local toolchain=""
+  local rustup_cmd=""
+
+  if [ -f "$repo_root/rust-toolchain.toml" ]; then
+    toolchain=$(awk -F'"' '/channel/{print $2; exit}' "$repo_root/rust-toolchain.toml")
+  fi
+
+  if command -v rustup >/dev/null 2>&1; then
+    rustup_cmd="$(command -v rustup)"
+  elif [ -n "${CARGO_HOME:-}" ] && [ -x "$CARGO_HOME/bin/rustup" ]; then
+    rustup_cmd="$CARGO_HOME/bin/rustup"
+  elif [ -n "${HOME:-}" ] && [ -x "$HOME/.cargo/bin/rustup" ]; then
+    rustup_cmd="$HOME/.cargo/bin/rustup"
+  fi
+
+  CI_CARGO_CMD=(cargo)
+  if [ -n "${toolchain:-}" ] && [ -n "$rustup_cmd" ]; then
+    CI_CARGO_CMD=("$rustup_cmd" run "$toolchain" cargo)
+  fi
+}
+
+ci_run_xtask_package() {
+  local repo_root
+  repo_root="$(ci_repo_root)"
+  ci_resolve_cargo "$repo_root"
+  cd "$repo_root"
+  "${CI_CARGO_CMD[@]}" run --quiet --manifest-path "$repo_root/Cargo.toml" -p xtask --no-default-features -- "$@"
+}
+
+ci_exec_xtask() {
+  local repo_root
+  repo_root="$(ci_repo_root)"
+  ci_resolve_cargo "$repo_root"
+  cd "$repo_root"
+  exec "${CI_CARGO_CMD[@]}" xtask "$@"
+}
+
+ci_exec_hygiene() {
+  local command="$1"
+  shift
+  ci_exec_xtask ci-hygiene "$command" "$@"
+}


### PR DESCRIPTION
Problem: CI hygiene shell wrappers duplicated cargo/perl-ci-hygiene invocation logic and failed when run outside the repo root.
Fix: add a shared `ci/xtask_wrapper.sh` that resolves the repo root and pinned rustup cargo, then route hygiene wrappers through `cargo xtask ci-hygiene`; preserve the separate corpus-audit pre-step for parse-error checks.
Verification: `bash -n ci/xtask_wrapper.sh ci/check_doc_hygiene.sh ci/check_doc_paths.sh ci/check_ignored.sh ci/check_local.sh ci/check_missing_docs.sh ci/check_p0_locks.sh ci/check_parse_errors.sh ci/check_parser_matrix.sh ci/check_todos.sh ci/check_unsafe_prod.sh ci/check_unwraps_modules.sh ci/check_unwraps_prod.sh ci/quick_check.sh ci/test_heredocs.sh`; from `%TEMP%`, `bash -lc '/mnt/h/Code/Rust2/perl-lsp/ci/check_p0_locks.sh'`; `cargo check -p xtask --all-targets --locked`; `git diff --check`.
