### PR TITLE
refactor(ci): route hygiene shell wrappers through xtask (#0000)

### DIFF
--- a/ci/check_doc_hygiene.sh
+++ b/ci/check_doc_hygiene.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-doc-hygiene "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-doc-hygiene "$@"
+exec cargo xtask ci-hygiene check-doc-hygiene "$@"

--- a/ci/check_doc_paths.sh
+++ b/ci/check_doc_paths.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-doc-paths "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-doc-paths "$@"
+exec cargo xtask ci-hygiene check-doc-paths "$@"

--- a/ci/check_ignored.sh
+++ b/ci/check_ignored.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-ignored "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-ignored "$@"
+exec cargo xtask ci-hygiene check-ignored "$@"

--- a/ci/check_local.sh
+++ b/ci/check_local.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-local "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-local "$@"
+exec cargo xtask ci-hygiene check-local "$@"

--- a/ci/check_missing_docs.sh
+++ b/ci/check_missing_docs.sh
@@ -1,12 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-missing-docs "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-missing-docs "$@"
+exec cargo xtask ci-hygiene check-missing-docs "$@"

--- a/ci/check_p0_locks.sh
+++ b/ci/check_p0_locks.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-p0-locks "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-p0-locks "$@"
+exec cargo xtask ci-hygiene check-p0-locks "$@"

--- a/ci/check_parser_matrix.sh
+++ b/ci/check_parser_matrix.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-parser-matrix "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-parser-matrix "$@"
+exec cargo xtask ci-hygiene check-parser-matrix "$@"

--- a/ci/check_todos.sh
+++ b/ci/check_todos.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-todos "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-todos "$@"
+exec cargo xtask ci-hygiene check-todos "$@"

--- a/ci/check_unsafe_prod.sh
+++ b/ci/check_unsafe_prod.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-unsafe-prod "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-unsafe-prod "$@"
+exec cargo xtask ci-hygiene check-unsafe-prod "$@"

--- a/ci/check_unwraps_modules.sh
+++ b/ci/check_unwraps_modules.sh
@@ -1,12 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" check-unwraps-modules "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-unwraps-modules "$@"
+exec cargo xtask ci-hygiene check-unwraps-modules "$@"

--- a/ci/check_unwraps_prod.sh
+++ b/ci/check_unwraps_prod.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- check-unwraps-prod "$@"
+exec cargo xtask ci-hygiene check-unwraps-prod "$@"

--- a/ci/quick_check.sh
+++ b/ci/quick_check.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" quick-check "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- quick-check "$@"
+exec cargo xtask ci-hygiene quick-check "$@"

--- a/ci/test_heredocs.sh
+++ b/ci/test_heredocs.sh
@@ -1,12 +1,4 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BIN="$REPO_ROOT/target/debug/perl-ci-hygiene"
-
-if [ -x "$BIN" ]; then
-  exec "$BIN" test-heredocs "$@"
-fi
-
-exec cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p perl-ci-hygiene -- test-heredocs "$@"
+exec cargo xtask ci-hygiene test-heredocs "$@"


### PR DESCRIPTION
### Motivation

- Reduce duplicated local-binary detection and `cargo run` fallback logic that lived in many CI wrapper scripts by delegating execution to the existing `xtask` plumbing.

### Description

- Replaced per-script local-binary detection and `cargo run` fallbacks with a simple `exec cargo xtask ci-hygiene <subcommand> "$@"` invocation in 13 scripts under `ci/`.
- Normalized shebangs and strict failure flags to `#!/usr/bin/env bash` and `set -euo pipefail` where applicable.
- Affected files: `ci/check_doc_hygiene.sh`, `ci/check_doc_paths.sh`, `ci/check_ignored.sh`, `ci/check_local.sh`, `ci/check_missing_docs.sh`, `ci/check_p0_locks.sh`, `ci/check_parser_matrix.sh`, `ci/check_todos.sh`, `ci/check_unsafe_prod.sh`, `ci/check_unwraps_modules.sh`, `ci/check_unwraps_prod.sh`, `ci/quick_check.sh`, and `ci/test_heredocs.sh`.

### Testing

- Ran shell syntax checks with `bash -n` across all updated scripts which passed.
- Attempted `./scripts/cargo-safe check -p xtask --all-targets --profile agent --locked` but it was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so the `xtask` build check did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f432fddeb08333b1b3e4e85e6d4003)