### PR TITLE
refactor(xtask): route version tasks through ci-hygiene wrapper (#0000)

### DIFF
--- a/xtask/src/tasks/bump_version.rs
+++ b/xtask/src/tasks/bump_version.rs
@@ -1,46 +1,11 @@
 //! bump-version task wrapper.
 //!
-//! Delegates to the `perl-ci-hygiene bump-version` subcommand, which owns
-//! the canonical list of version sites. This keeps the bump command and
-//! the `check-version-sync` CI gate walking the same list — they cannot
-//! drift because they share a module.
-//!
-//! Mirrors the pattern used by `check_version_sync.rs`: prefer a pre-built
-//! binary if one is available (fast path for CI), otherwise fall back to
-//! `cargo run`.
+//! Delegates to the generic `ci-hygiene` passthrough runner so command
+//! execution policy (prefer fresh local binary, fallback to cargo run)
+//! stays centralized in one place.
 
-use crate::utils::project_root;
-use color_eyre::eyre::{Context, Result, bail};
-use std::process::Command;
+use color_eyre::eyre::Result;
 
 pub fn run(version: String) -> Result<()> {
-    let root = project_root()?;
-    let local_binary =
-        root.join(format!("target/debug/perl-ci-hygiene{}", std::env::consts::EXE_SUFFIX));
-    let mut command = if local_binary.exists() {
-        let mut cmd = Command::new(local_binary);
-        cmd.arg("bump-version").arg(&version);
-        cmd
-    } else {
-        let mut cmd = Command::new("cargo");
-        cmd.args([
-            "run",
-            "--quiet",
-            "--manifest-path",
-            root.join("Cargo.toml").to_string_lossy().as_ref(),
-            "-p",
-            "perl-ci-hygiene",
-            "--",
-            "bump-version",
-            &version,
-        ]);
-        cmd
-    };
-
-    let status = command.status().context("failed to run bump-version")?;
-    if !status.success() {
-        bail!("bump-version command failed");
-    }
-
-    Ok(())
+    super::ci_hygiene::run("bump-version".to_string(), vec![version])
 }

--- a/xtask/src/tasks/check_version_sync.rs
+++ b/xtask/src/tasks/check_version_sync.rs
@@ -1,39 +1,11 @@
 //! check-version-sync task wrapper.
 //!
-//! The historical shell script attempted to run a local `perl-ci-hygiene` binary
-//! if present and otherwise falls back to `cargo run`.
+//! Delegates to the generic `ci-hygiene` passthrough runner so command
+//! execution policy (prefer fresh local binary, fallback to cargo run)
+//! stays centralized in one place.
 
-use crate::utils::project_root;
-use color_eyre::eyre::{Context, Result, bail};
-use std::process::Command;
+use color_eyre::eyre::Result;
 
 pub fn run() -> Result<()> {
-    let root = project_root()?;
-    let local_binary =
-        root.join(format!("target/debug/perl-ci-hygiene{}", std::env::consts::EXE_SUFFIX));
-    let mut command = if local_binary.exists() {
-        let mut cmd = Command::new(local_binary);
-        cmd.arg("check-version-sync");
-        cmd
-    } else {
-        let mut cmd = Command::new("cargo");
-        cmd.args([
-            "run",
-            "--quiet",
-            "--manifest-path",
-            root.join("Cargo.toml").to_string_lossy().as_ref(),
-            "-p",
-            "perl-ci-hygiene",
-            "--",
-            "check-version-sync",
-        ]);
-        cmd
-    };
-
-    let status = command.status().context("failed to run check-version-sync")?;
-    if !status.success() {
-        bail!("check-version-sync command failed");
-    }
-
-    Ok(())
+    super::ci_hygiene::run("check-version-sync".to_string(), Vec::new())
 }


### PR DESCRIPTION
### Motivation
- `xtask` contained bespoke process-launching logic for the `check-version-sync` and `bump-version` tasks, duplicating behavior that is already implemented for `perl-ci-hygiene` invocation.
- Centralize the local-binary-vs-`cargo run` policy in a single helper so behavior is consistent and easier to maintain.

### Description
- Replaced the body of `xtask/src/tasks/check_version_sync.rs` with a thin delegating wrapper that calls `super::ci_hygiene::run("check-version-sync".to_string(), Vec::new())`.
- Replaced the body of `xtask/src/tasks/bump_version.rs` with a thin delegating wrapper that calls `super::ci_hygiene::run("bump-version".to_string(), vec![version])`.
- Removed duplicated `Command`-spawn and binary freshness-check logic from those two files and simplified imports to only `color_eyre::eyre::Result`.

### Testing
- Ran `cargo check -p xtask --all-targets --locked`, which completed successfully.
- An attempt to run `./scripts/cargo-safe check -p xtask --profile agent --locked` was blocked by the environment storage policy (DENY), so the canonical `cargo check` result was used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4331392108333ad5e9f4634d12cf4)