### PR TITLE
refactor(xtask): move ci-hygiene path helpers into crate (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/lib.rs
+++ b/crates/perl-ci-hygiene/src/lib.rs
@@ -3,7 +3,45 @@
 //! This module is primarily used to enable `cargo test --lib` CI runs.
 //! The primary entry point is the binary in `main.rs`.
 
+use std::fs;
+use std::path::{Path, PathBuf};
+
 pub mod version_sync;
+
+pub const PACKAGE_NAME: &str = "perl-ci-hygiene";
+
+#[must_use]
+pub fn binary_path(root: &Path) -> PathBuf {
+    let mut path = root.join("target").join("debug").join(PACKAGE_NAME);
+    if cfg!(windows) {
+        path.set_extension(std::env::consts::EXE_EXTENSION);
+    }
+    path
+}
+
+#[must_use]
+pub fn source_paths(root: &Path) -> Vec<PathBuf> {
+    let crate_root = root.join("crates").join(PACKAGE_NAME);
+    let mut paths = vec![crate_root.join("Cargo.toml")];
+    collect_rust_sources(&crate_root.join("src"), &mut paths);
+    paths.sort();
+    paths
+}
+
+fn collect_rust_sources(dir: &Path, paths: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rust_sources(&path, paths);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            paths.push(path);
+        }
+    }
+}
 
 /// Categorize an `#[ignore]` reason/context into a policy bucket.
 pub fn categorize_ignore(reason: &str, context: &str) -> String {
@@ -140,4 +178,46 @@ pub fn categorize_ignore(reason: &str, context: &str) -> String {
         return "feature".to_string();
     }
     "other".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::source_paths;
+    use std::error::Error;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_repo_dir(label: &str) -> Result<PathBuf, Box<dyn Error>> {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let dir = std::env::temp_dir()
+            .join(format!("perl-ci-hygiene-lib-{label}-{}-{nanos}", std::process::id()));
+        fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
+
+    fn contains_path(paths: &[PathBuf], suffix: &Path) -> bool {
+        paths.iter().any(|path| path.ends_with(suffix))
+    }
+
+    #[test]
+    fn source_paths_include_split_rust_modules() -> Result<(), Box<dyn Error>> {
+        let root = unique_temp_repo_dir("source-paths")?;
+        let crate_root = root.join("crates").join("perl-ci-hygiene");
+        let commands_dir = crate_root.join("src").join("commands");
+        fs::create_dir_all(&commands_dir)?;
+        fs::write(crate_root.join("Cargo.toml"), "")?;
+        fs::write(crate_root.join("src").join("main.rs"), "")?;
+        fs::write(crate_root.join("src").join("process.rs"), "")?;
+        fs::write(commands_dir.join("mod.rs"), "")?;
+
+        let paths = source_paths(&root);
+        assert!(contains_path(&paths, Path::new("crates/perl-ci-hygiene/Cargo.toml")));
+        assert!(contains_path(&paths, Path::new("crates/perl-ci-hygiene/src/main.rs")));
+        assert!(contains_path(&paths, Path::new("crates/perl-ci-hygiene/src/process.rs")));
+        assert!(contains_path(&paths, Path::new("crates/perl-ci-hygiene/src/commands/mod.rs")));
+
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -24,6 +24,7 @@ serde_json.workspace = true
 anyhow.workspace = true
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 perl-lsp-rs-core = { workspace = true }
+perl-ci-hygiene = { workspace = true }
 indicatif = "0.18.4"
 console = "0.16.2"
 chrono = { version = "0.4.43", features = ["serde"] }
@@ -31,7 +32,6 @@ perl-parser = { workspace = true }
 perl-corpus = { workspace = true }
 perl-lsp-ux-tests = { workspace = true }
 perl-parser-pest = { workspace = true, optional = true }
-perl-ci-hygiene = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-perl-c = { path = "../crates/tree-sitter-perl-c", optional = true }
 regex.workspace = true

--- a/xtask/src/tasks/ci_hygiene.rs
+++ b/xtask/src/tasks/ci_hygiene.rs
@@ -5,18 +5,16 @@
 
 use color_eyre::eyre::{Context, Result, bail};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use crate::utils::project_root;
 
-const CI_HYGIENE_PACKAGE: &str = "perl-ci-hygiene";
-
 pub fn run(command: String, args: Vec<String>) -> Result<()> {
     let root = project_root()?;
     let status = {
-        let local_binary = local_binary_path(&root);
-        if local_binary_is_fresh(&root, &local_binary) {
+        let local_binary = perl_ci_hygiene::binary_path(&root);
+        if local_binary_is_fresh(&local_binary, &root) {
             Command::new(local_binary)
                 .arg(&command)
                 .args(&args)
@@ -26,7 +24,7 @@ pub fn run(command: String, args: Vec<String>) -> Result<()> {
             let mut cargo_command = Command::new("cargo");
             cargo_command
                 .current_dir(&root)
-                .args(["run", "--quiet", "-p", CI_HYGIENE_PACKAGE, "--", &command])
+                .args(["run", "--quiet", "-p", perl_ci_hygiene::PACKAGE_NAME, "--", &command])
                 .args(args)
                 .status()
                 .context("Failed to run perl-ci-hygiene via cargo")?
@@ -40,15 +38,7 @@ pub fn run(command: String, args: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn local_binary_path(root: &Path) -> PathBuf {
-    let mut path = root.join("target").join("debug").join(CI_HYGIENE_PACKAGE);
-    if cfg!(windows) {
-        path.set_extension(std::env::consts::EXE_EXTENSION);
-    }
-    path
-}
-
-fn local_binary_is_fresh(root: &Path, local_binary: &Path) -> bool {
+fn local_binary_is_fresh(local_binary: &Path, root: &Path) -> bool {
     let Ok(binary_meta) = fs::metadata(local_binary) else {
         return false;
     };
@@ -56,7 +46,7 @@ fn local_binary_is_fresh(root: &Path, local_binary: &Path) -> bool {
         return false;
     };
 
-    for source in ci_hygiene_sources(root) {
+    for source in perl_ci_hygiene::source_paths(root) {
         let Ok(source_meta) = fs::metadata(source) else {
             return false;
         };
@@ -69,11 +59,4 @@ fn local_binary_is_fresh(root: &Path, local_binary: &Path) -> bool {
     }
 
     true
-}
-
-fn ci_hygiene_sources(root: &Path) -> [PathBuf; 2] {
-    [
-        root.join("crates").join(CI_HYGIENE_PACKAGE).join("Cargo.toml"),
-        root.join("crates").join(CI_HYGIENE_PACKAGE).join("src").join("main.rs"),
-    ]
 }

--- a/xtask/src/tasks/forbid_fatal_constructs.rs
+++ b/xtask/src/tasks/forbid_fatal_constructs.rs
@@ -1,47 +1,9 @@
 //! Wrapper task for forbidden-fatal-construct checks.
-//!
-//! Delegates to `perl-ci-hygiene forbid-fatal-constructs`, preferring the
-//! locally built binary when available for speed.
 
-use color_eyre::eyre::{Context, Result, bail};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use color_eyre::eyre::Result;
 
-use crate::utils::project_root;
-
-const CI_HYGIENE_PACKAGE: &str = "perl-ci-hygiene";
-
-fn local_binary_path(root: &Path) -> PathBuf {
-    let mut path = root.join("target").join("debug").join(CI_HYGIENE_PACKAGE);
-    if cfg!(windows) {
-        path.set_extension(std::env::consts::EXE_EXTENSION);
-    }
-    path
-}
+use crate::tasks::ci_hygiene;
 
 pub fn run(args: Vec<String>) -> Result<()> {
-    let root = project_root()?;
-    let local_binary = local_binary_path(&root);
-
-    let build_status = Command::new("cargo")
-        .current_dir(&root)
-        .args(["build", "--quiet", "-p", CI_HYGIENE_PACKAGE])
-        .status()
-        .context("Failed to build perl-ci-hygiene before running forbid-fatal-constructs")?;
-
-    if !build_status.success() {
-        bail!("Failed to build perl-ci-hygiene before forbid-fatal-constructs");
-    }
-
-    let status = Command::new(local_binary)
-        .arg("forbid-fatal-constructs")
-        .args(&args)
-        .status()
-        .context("Failed to execute local perl-ci-hygiene binary")?;
-
-    if !status.success() {
-        bail!("forbid-fatal-constructs failed (exit code: {status})");
-    }
-
-    Ok(())
+    ci_hygiene::run("forbid-fatal-constructs".to_string(), args)
 }


### PR DESCRIPTION
Problem: xtask duplicated perl-ci-hygiene binary/source path helpers, and freshness checks only watched `main.rs` instead of split hygiene modules.
Fix: expose `perl-ci-hygiene` package/path helpers from the crate and reuse them from xtask, with recursive source discovery for split Rust modules.
Verification: `cargo check -p perl-ci-hygiene -p xtask --all-targets --locked`; `cargo test -p perl-ci-hygiene --locked`; `cargo test -p perl-ci-hygiene source_paths --locked -- --nocapture`; `cargo clippy -p perl-ci-hygiene --all-targets --locked -- -D warnings -A missing_docs`; `git diff --check`.
