### PR TITLE
refactor(xtask): move merge-ready hashing into core crate (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/hashing.rs
+++ b/crates/perl-lsp-rs-core/src/hashing.rs
@@ -1,0 +1,41 @@
+//! Hashing utilities shared by core crates and workspace tools.
+
+/// Compute an FNV-1a 64-bit hash and return it as a tagged hex string.
+#[must_use]
+pub fn fnv1a64_hex(bytes: &[u8]) -> String {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("fnv1a64:{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fnv1a64_hex;
+    use std::error::Error;
+
+    #[test]
+    fn fnv1a64_hex_matches_known_vectors() -> Result<(), Box<dyn Error>> {
+        assert_eq!(fnv1a64_hex(b""), "fnv1a64:cbf29ce484222325");
+        assert_eq!(fnv1a64_hex(b"hello"), "fnv1a64:a430d84680aabd0b");
+        Ok(())
+    }
+
+    #[test]
+    fn fnv1a64_hex_is_deterministic() -> Result<(), Box<dyn Error>> {
+        let h1 = fnv1a64_hex(b"hello");
+        let h2 = fnv1a64_hex(b"hello");
+        assert_eq!(h1, h2);
+        Ok(())
+    }
+
+    #[test]
+    fn fnv1a64_hex_differs_on_different_input() -> Result<(), Box<dyn Error>> {
+        let h1 = fnv1a64_hex(b"hello");
+        let h2 = fnv1a64_hex(b"world");
+        assert_ne!(h1, h2);
+        Ok(())
+    }
+}

--- a/crates/perl-lsp-rs-core/src/lib.rs
+++ b/crates/perl-lsp-rs-core/src/lib.rs
@@ -16,6 +16,8 @@ pub mod feature_catalog;
 pub mod features;
 /// Policy and governance APIs for feature profiles and rollout controls.
 pub mod governance;
+/// Hashing helpers shared by workspace tooling and verification pipelines.
+pub mod hashing;
 /// Performance-focused caches and allocation strategies for large workspaces.
 pub mod performance;
 /// Cross-platform interpreter and toolchain detection helpers.

--- a/xtask/src/tasks/merge_ready.rs
+++ b/xtask/src/tasks/merge_ready.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::utils::project_root;
+use perl_lsp_rs_core::hashing::fnv1a64_hex;
 
 const SCHEMA_VERSION: u32 = 1;
 const CHECK_NAME: &str = "merge-readiness";
@@ -327,15 +328,6 @@ fn is_required_workflow_candidate(path: &Path) -> bool {
     };
 
     name.contains("ci") || name.contains("gate") || name.contains("merge")
-}
-
-fn fnv1a64_hex(bytes: &[u8]) -> String {
-    let mut hash: u64 = 0xcbf29ce484222325;
-    for byte in bytes {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    format!("fnv1a64:{hash:016x}")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Problem: merge-ready hashing lived inside xtask even though it is reusable core utility behavior.
Fix: move the FNV-1a merge-ready hash helper into `perl-lsp-rs-core` and keep xtask calling the shared implementation.
Verification: `cargo check -p perl-lsp-rs-core -p xtask --all-targets --locked` passes; `cargo test -p perl-lsp-rs-core --locked hashing -- --nocapture` passes; `cargo test -p xtask --bin xtask merge_ready --locked -- --nocapture` passes; `cargo clippy -p perl-lsp-rs-core --lib --locked -- -D warnings -A missing_docs` passes; `git diff --check` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43779c5688333b6b68781df918f32)