### PR TITLE
test(perl-parser-core): cover path normalization edge cases (#0000)

### DIFF
--- a/crates/perl-parser-core/src/syntax/path_normalize.rs
+++ b/crates/perl-parser-core/src/syntax/path_normalize.rs
@@ -94,4 +94,28 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn rejects_absolute_paths() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let workspace = temp_dir.path().canonicalize()?;
+
+        let absolute = workspace.join("lib").join("Foo.pm");
+        let result = normalize_path_within_workspace(&absolute, &workspace);
+        assert!(matches!(result, Err(NormalizePathError::PathTraversalAttempt(_))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn normalizes_mixed_current_and_parent_components() -> TestResult {
+        let temp_dir = tempfile::tempdir()?;
+        let workspace = temp_dir.path().canonicalize()?;
+
+        let normalized =
+            normalize_path_within_workspace(&PathBuf::from("./lib/./../bin/tool.pl"), &workspace)?;
+        assert_eq!(normalized, workspace.join("bin").join("tool.pl"));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Motivation
- Path normalization unit tests did not explicitly cover rejection of absolute-path inputs or normalization of mixed `.` and `..` components, leaving a small gap in safety guarantees.

### Description
- Added two focused unit tests in `crates/perl-parser-core/src/syntax/path_normalize.rs`: `rejects_absolute_paths` which asserts absolute inputs produce `NormalizePathError::PathTraversalAttempt`, and `normalizes_mixed_current_and_parent_components` which verifies `./lib/./../bin/tool.pl` normalizes to the expected workspace-relative path.

### Testing
- Ran the focused tests with `cargo test -p perl-parser-core --locked path_normalize::tests::` and they passed.
- Attempted a full suite run with `cargo test -p perl-parser-core --locked -q` but the environment killed a long-running test (SIGKILL) before completion; a guarded `./scripts/cargo-safe test -p perl-parser-core --profile agent --locked` was blocked by the storage policy in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4332569cc833398f3bc713f88410d)