### PR TITLE
test(perl-lexer): add lexer config unit coverage (#0000)

### DIFF
--- a/crates/perl-lexer/src/config.rs
+++ b/crates/perl-lexer/src/config.rs
@@ -29,3 +29,35 @@ impl Default for LexerConfig {
         Self { parse_interpolation: true, track_positions: true, max_lookahead: 1024 }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::LexerConfig;
+
+    #[test]
+    fn default_enables_interpolation_and_position_tracking() {
+        let config = LexerConfig::default();
+
+        assert!(config.parse_interpolation);
+        assert!(config.track_positions);
+    }
+
+    #[test]
+    fn default_uses_expected_lookahead_limit() {
+        let config = LexerConfig::default();
+
+        assert_eq!(config.max_lookahead, 1024);
+    }
+
+    #[test]
+    fn clone_preserves_field_values() {
+        let config =
+            LexerConfig { parse_interpolation: false, track_positions: false, max_lookahead: 256 };
+
+        let cloned = config.clone();
+
+        assert!(!cloned.parse_interpolation);
+        assert!(!cloned.track_positions);
+        assert_eq!(cloned.max_lookahead, 256);
+    }
+}


### PR DESCRIPTION
### Motivation
- Cover basic invariants of `LexerConfig` (default flags, lookahead, and `Clone` semantics) with focused unit tests to prevent regressions.

### Description
- Add a `#[cfg(test)] mod tests` to `crates/perl-lexer/src/config.rs` containing three unit tests that assert default `parse_interpolation`/`track_positions`, default `max_lookahead == 1024`, and that `Clone` preserves all field values.

### Testing
- Ran `cargo test -p perl-lexer config::tests --locked` which passed; the higher-level `./scripts/cargo-safe test -p perl-lexer --profile agent --locked` run is blocked by the environment storage policy in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4332569cc833398f3bc713f88410d)