### PR TITLE
test(perl-parser): add snapshot coverage for quote-like operators (#0000)

### DIFF
--- a/crates/perl-parser/tests/ast_snap.rs
+++ b/crates/perl-parser/tests/ast_snap.rs
@@ -194,6 +194,20 @@ fn ast_lexical_filehandles_and_chomp_loop() {
     ));
 }
 
+#[test]
+fn ast_quote_like_operators() {
+    // Quote-like operators have delimiter-sensitive tokenization and are frequent in CPAN.
+    assert_snapshot!(parse_sexp(
+        "my $single = q{literal}; my $double = qq|hello $name|; my @words = qw(foo bar baz);",
+    ));
+}
+
+#[test]
+fn ast_transliteration_and_substitution() {
+    // Transliteration and substitution operators are parser edge cases with regex-like delimiters.
+    assert_snapshot!(parse_sexp("$_ =~ tr/a-z/A-Z/; $text =~ s{foo}{bar}g;"));
+}
+
 // ---------------------------------------------------------------------------
 // 2. Error recovery AST snapshots (malformed input)
 // ---------------------------------------------------------------------------
@@ -236,6 +250,11 @@ fn recovery_truncated_array() {
 #[test]
 fn recovery_partial_if() {
     assert_snapshot!(parse_sexp("if ($x > 0) {"));
+}
+
+#[test]
+fn recovery_unterminated_quote_like_operator() {
+    assert_snapshot!(parse_sexp("my @vals = qw(foo bar;\nmy $ok = 1;"));
 }
 
 #[test]

--- a/crates/perl-parser/tests/snapshots/ast_snap__ast_quote_like_operators.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__ast_quote_like_operators.snap
@@ -1,0 +1,6 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+assertion_line: 200
+expression: "parse_sexp(\"my $single = q{literal}; my $double = qq|hello $name|; my @words = qw(foo bar baz);\",)"
+---
+(source_file (my_declaration (variable $ single)(string "q{literal}")) (my_declaration (variable $ double)(string_interpolated "qq|hello $name|")) (my_declaration (variable @ words)(array (string "foo") (string "bar") (string "baz"))))

--- a/crates/perl-parser/tests/snapshots/ast_snap__ast_transliteration_and_substitution.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__ast_transliteration_and_substitution.snap
@@ -1,0 +1,6 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+assertion_line: 208
+expression: "parse_sexp(\"$_ =~ tr/a-z/A-Z/; $text =~ s{foo}{bar}g;\")"
+---
+(source_file (transliteration (variable $ _) "a-z" "A-Z" "") (substitution (variable $ text) "foo" "bar" "g"))

--- a/crates/perl-parser/tests/snapshots/ast_snap__recovery_unterminated_quote_like_operator.snap
+++ b/crates/perl-parser/tests/snapshots/ast_snap__recovery_unterminated_quote_like_operator.snap
@@ -1,0 +1,6 @@
+---
+source: crates/perl-parser/tests/ast_snap.rs
+assertion_line: 257
+expression: "parse_sexp(\"my @vals = qw(foo bar;\\nmy $ok = 1;\")"
+---
+(source_file (ERROR "expected expression, found unknown token at position 11"))


### PR DESCRIPTION
Problem: parser AST snapshots did not cover quote-like operators, transliteration/substitution forms, or recovery for an unterminated quote-like operator.
Fix: add three focused `ast_snap` tests and checked-in Insta snapshots for the observed AST/recovery output.
Verification: `cargo test -p perl-parser --test ast_snap --locked -- --nocapture` passes with 56 tests; `cargo check -p perl-parser --all-targets --locked` passes; `cargo clippy -p perl-parser --test ast_snap --locked -- -D warnings -A missing_docs` passes; `git diff --check` passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4332a89d48333aaadf2895877a0df)