### PR TITLE
test(perl-lsp-rs): add workspace symbol package snapshot (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_workspace_symbol_snap.rs
+++ b/crates/perl-lsp-rs/tests/lsp_workspace_symbol_snap.rs
@@ -110,6 +110,36 @@ fn workspace_symbol_native_class_snapshot() -> TestResult {
 }
 
 #[test]
+fn workspace_symbol_package_and_member_snapshot() -> TestResult {
+    let mut harness = LspHarness::new();
+    let _init = harness.initialize(None)?;
+
+    harness.open(
+        "file:///ws_package_symbols.pl",
+        r#"package Acme::Inventory;
+
+sub ws_snap_build_index {
+    return {};
+}
+
+class Acme::Inventory::Query {
+    method ws_snap_lookup_sku {
+        return shift;
+    }
+}
+
+1;
+"#,
+    )?;
+
+    let response = harness.request("workspace/symbol", json!({ "query": "Acme::Inventory" }))?;
+    let normalized = normalize_symbols(&response)?;
+
+    assert_yaml_snapshot!("workspace_symbol_package_and_members", normalized);
+    Ok(())
+}
+
+#[test]
 fn workspace_symbol_capability_shape_snapshot() -> TestResult {
     let mut harness = LspHarness::new();
     let init_response = harness.initialize(None)?;

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_workspace_symbol_snap__workspace_symbol_package_and_members.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_workspace_symbol_snap__workspace_symbol_package_and_members.snap
@@ -1,0 +1,24 @@
+---
+source: crates/perl-lsp-rs/tests/lsp_workspace_symbol_snap.rs
+expression: normalized
+---
+- name: "Acme::Inventory"
+  kind: 2
+  container_name: ~
+  uri: "file:///ws_package_symbols.pl"
+  start_line: 0
+- name: "Acme::Inventory::Query"
+  kind: 5
+  container_name: "Acme::Inventory"
+  uri: "file:///ws_package_symbols.pl"
+  start_line: 6
+- name: ws_snap_build_index
+  kind: 12
+  container_name: "Acme::Inventory"
+  uri: "file:///ws_package_symbols.pl"
+  start_line: 2
+- name: ws_snap_lookup_sku
+  kind: 6
+  container_name: "Acme::Inventory::Query"
+  uri: "file:///ws_package_symbols.pl"
+  start_line: 7


### PR DESCRIPTION
### Motivation

- Cover a snapshot testing gap for `workspace/symbol` queries that should return package, nested class, and member symbols in the same result set.

### Description

- Added a focused test `workspace_symbol_package_and_member_snapshot` in `crates/perl-lsp-rs/tests/lsp_workspace_symbol_snap.rs` that opens a file with a package, a nested class, and members and asserts an Insta snapshot for the normalized symbol shapes.
- Checked-in the corresponding snapshot fixture at `crates/perl-lsp-rs/tests/snapshots/lsp_workspace_symbol_snap__workspace_symbol_package_and_members.snap` which records expected symbol names, kinds, container relationships, URIs, and start lines.

### Testing

- Ran `cargo test -p perl-lsp-rs --test lsp_workspace_symbol_snap` which passed (4 tests, 0 failed) and updated/created the snapshot file successfully.
- Attempted `INSTA_UPDATE=always ./scripts/cargo-safe test -p perl-lsp-rs --test lsp_workspace_symbol_snap --profile agent --locked` but it was blocked by the storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so the `cargo-safe` run was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4332a89d48333aaadf2895877a0df)