### PR TITLE
test(perl-token): add token metadata snapshot coverage (#0000)

### DIFF
--- a/crates/perl-token/tests/snapshots/token_kind_metadata_table.md
+++ b/crates/perl-token/tests/snapshots/token_kind_metadata_table.md
@@ -1,0 +1,136 @@
+# TokenKind metadata snapshot
+
+| TokenKind | display_name | category |
+|---|---|---|
+| My | 'my' | Keyword |
+| Our | 'our' | Keyword |
+| Local | 'local' | Keyword |
+| State | 'state' | Keyword |
+| Sub | 'sub' | Keyword |
+| If | 'if' | Keyword |
+| Elsif | 'elsif' | Keyword |
+| Else | 'else' | Keyword |
+| Unless | 'unless' | Keyword |
+| While | 'while' | Keyword |
+| Until | 'until' | Keyword |
+| For | 'for' | Keyword |
+| Foreach | 'foreach' | Keyword |
+| Return | 'return' | Keyword |
+| Package | 'package' | Keyword |
+| Use | 'use' | Keyword |
+| No | 'no' | Keyword |
+| Begin | 'BEGIN' | Keyword |
+| End | 'END' | Keyword |
+| Check | 'CHECK' | Keyword |
+| Init | 'INIT' | Keyword |
+| Unitcheck | 'UNITCHECK' | Keyword |
+| Eval | 'eval' | Keyword |
+| Do | 'do' | Keyword |
+| Given | 'given' | Keyword |
+| When | 'when' | Keyword |
+| Default | 'default' | Keyword |
+| Try | 'try' | Keyword |
+| Catch | 'catch' | Keyword |
+| Finally | 'finally' | Keyword |
+| Continue | 'continue' | Keyword |
+| Next | 'next' | Keyword |
+| Last | 'last' | Keyword |
+| Redo | 'redo' | Keyword |
+| Goto | 'goto' | Keyword |
+| Class | 'class' | Keyword |
+| Method | 'method' | Keyword |
+| Field | 'field' | Keyword |
+| Format | 'format' | Keyword |
+| Undef | 'undef' | Keyword |
+| Defer | 'defer' | Keyword |
+| Assign | '=' | Operator |
+| Plus | '+' | Operator |
+| Minus | '-' | Operator |
+| Star | '*' | Operator |
+| Slash | '/' | Operator |
+| Percent | '%' | Operator |
+| Power | '**' | Operator |
+| LeftShift | '<<' | Operator |
+| RightShift | '>>' | Operator |
+| BitwiseAnd | '&' | Operator |
+| BitwiseOr | '|' | Operator |
+| BitwiseXor | '^' | Operator |
+| BitwiseNot | '~' | Operator |
+| PlusAssign | '+=' | Operator |
+| MinusAssign | '-=' | Operator |
+| StarAssign | '*=' | Operator |
+| SlashAssign | '/=' | Operator |
+| PercentAssign | '%=' | Operator |
+| DotAssign | '.=' | Operator |
+| AndAssign | '&=' | Operator |
+| OrAssign | '|=' | Operator |
+| XorAssign | '^=' | Operator |
+| PowerAssign | '**=' | Operator |
+| LeftShiftAssign | '<<=' | Operator |
+| RightShiftAssign | '>>=' | Operator |
+| LogicalAndAssign | '&&=' | Operator |
+| LogicalOrAssign | '||=' | Operator |
+| DefinedOrAssign | '//=' | Operator |
+| Equal | '==' | Operator |
+| NotEqual | '!=' | Operator |
+| Match | '=~' | Operator |
+| NotMatch | '!~' | Operator |
+| SmartMatch | '~~' | Operator |
+| Less | '<' | Operator |
+| Greater | '>' | Operator |
+| LessEqual | '<=' | Operator |
+| GreaterEqual | '>=' | Operator |
+| Spaceship | '<=>' | Operator |
+| StringCompare | 'cmp' | Operator |
+| And | '&&' | Operator |
+| Or | '||' | Operator |
+| Not | '!' | Operator |
+| DefinedOr | '//' | Operator |
+| WordAnd | 'and' | Operator |
+| WordOr | 'or' | Operator |
+| WordNot | 'not' | Operator |
+| WordXor | 'xor' | Operator |
+| Arrow | '->' | Operator |
+| FatArrow | '=>' | Operator |
+| Dot | '.' | Operator |
+| Range | '..' | Operator |
+| Ellipsis | '...' | Operator |
+| Increment | '++' | Operator |
+| Decrement | '--' | Operator |
+| DoubleColon | '::' | Operator |
+| Question | '?' | Operator |
+| Colon | ':' | Operator |
+| Backslash | '\' | Operator |
+| LeftParen | '(' | Delimiter |
+| RightParen | ')' | Delimiter |
+| LeftBrace | '{' | Delimiter |
+| RightBrace | '}' | Delimiter |
+| LeftBracket | '[' | Delimiter |
+| RightBracket | ']' | Delimiter |
+| Semicolon | ';' | Delimiter |
+| Comma | ',' | Delimiter |
+| Number | number | Literal |
+| String | string | Literal |
+| Regex | regex | Literal |
+| Substitution | substitution (s///) | Literal |
+| Transliteration | transliteration (tr///) | Literal |
+| QuoteSingle | q// string | Literal |
+| QuoteDouble | qq// string | Literal |
+| QuoteWords | qw() word list | Literal |
+| QuoteCommand | qx// command | Literal |
+| HeredocStart | heredoc (<<) | Literal |
+| HeredocBody | heredoc body | Literal |
+| FormatBody | format body | Literal |
+| DataMarker | data marker (__DATA__ or __END__) | Literal |
+| DataBody | data section body | Literal |
+| VString | version string | Literal |
+| UnknownRest | unparsed remainder | Literal |
+| HeredocDepthLimit | heredoc depth limit exceeded | Literal |
+| Identifier | identifier | Identifier |
+| ScalarSigil | '$' | Identifier |
+| ArraySigil | '@' | Identifier |
+| HashSigil | '%' | Identifier |
+| SubSigil | '&' | Identifier |
+| GlobSigil | '*' | Identifier |
+| Eof | end of input | Special |
+| Unknown | unknown token | Special |

--- a/crates/perl-token/tests/token_metadata_snapshot_tests.rs
+++ b/crates/perl-token/tests/token_metadata_snapshot_tests.rs
@@ -1,0 +1,30 @@
+use std::error::Error;
+use std::fs;
+
+use perl_token::TokenKind;
+
+const SNAPSHOT_PATH: &str = "tests/snapshots/token_kind_metadata_table.md";
+
+fn render_metadata_table() -> String {
+    let mut output = String::from("# TokenKind metadata snapshot\n\n");
+    output.push_str("| TokenKind | display_name | category |\n");
+    output.push_str("|---|---|---|\n");
+
+    for kind in TokenKind::all() {
+        let metadata = kind.metadata();
+        output.push_str(&format!(
+            "| {:?} | {} | {:?} |\n",
+            kind, metadata.display_name, metadata.category
+        ));
+    }
+
+    output
+}
+
+#[test]
+fn token_kind_metadata_snapshot() -> Result<(), Box<dyn Error>> {
+    let expected = fs::read_to_string(SNAPSHOT_PATH)?;
+    let actual = render_metadata_table();
+    assert_eq!(actual, expected, "TokenKind metadata snapshot changed");
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Close a snapshot coverage gap by guarding the full `TokenKind` metadata (display name + category) to make metadata drift visible in review.

### Description
- Add a focused snapshot test `crates/perl-token/tests/token_metadata_snapshot_tests.rs` and commit the canonical snapshot `crates/perl-token/tests/snapshots/token_kind_metadata_table.md` which renders `TokenKind::all()` metadata and asserts equality against the file.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-token --test token_metadata_snapshot_tests` and `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-token`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4332a89d48333aaadf2895877a0df)