### PR TITLE
test(symbol_query): add property invariants for matching and ordering (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/symbol_query/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/symbol_query/mod.rs
@@ -108,6 +108,7 @@ fn is_subsequence(haystack: &str, needle: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{compare_names_by_query, matches_query};
+    use proptest::prelude::*;
 
     #[test]
     fn query_matching_covers_exact_prefix_contains_and_fuzzy() {
@@ -170,5 +171,23 @@ mod tests {
         assert_eq!(names[1], "logger", "tier 1: prefix");
         assert_eq!(names[2], "get_log", "tier 2: contains");
         assert_eq!(names[3], "lxoxg", "tier 3: fuzzy");
+    }
+
+    proptest! {
+        #[test]
+        fn case_insensitive_matching_is_equivalent(name in "[a-zA-Z]{1,24}", query in "[a-zA-Z]{0,12}") {
+            let expected = matches_query(&name.to_lowercase(), &query.to_lowercase());
+            let actual = matches_query(&name.to_uppercase(), &query.to_lowercase());
+
+            prop_assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn comparison_is_antisymmetric(a in "[a-zA-Z_]{1,20}", b in "[a-zA-Z_]{1,20}", query in "[a-zA-Z]{0,10}") {
+            let ab = compare_names_by_query(&a, &b, &query);
+            let ba = compare_names_by_query(&b, &a, &query);
+
+            prop_assert_eq!(ab, ba.reverse());
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Close a property-testing gap in the workspace symbol query logic by exercising key invariants that were only covered by fixed examples. 
- Ensure `matches_query` is truly case-insensitive and `compare_names_by_query` behaves consistently when arguments are swapped.

### Description

- Imported `proptest::prelude::*` into the symbol-query test module in `crates/perl-lsp-rs-core/src/providers/symbol_query/mod.rs` to enable property tests. 
- Added the `case_insensitive_matching_is_equivalent` property test to assert case-insensitive equivalence for `matches_query`. 
- Added the `comparison_is_antisymmetric` property test to assert that `compare_names_by_query(a, b, query)` is the reverse ordering of `compare_names_by_query(b, a, query)`.

### Testing

- Attempted `./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked providers::symbol_query::mod` but it was blocked by the environment storage policy (`DENY` cache); this is informational. 
- Ran `cargo test -p perl-lsp-rs-core symbol_query --locked` which executed the package test suite for the symbol query module and completed successfully. 
- Test summary: package tests including the new property tests passed (`9 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43331cc808333bf9b7f8e8ab67f5a)