### PR TITLE
test(perl-symbol): add property invariants for index queries (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,6 +1890,7 @@ dependencies = [
  "perl-parser-core",
  "perl-semantic-facts",
  "perl-tdd-support",
+ "proptest",
  "serde",
  "serde_json",
 ]

--- a/crates/perl-symbol/Cargo.toml
+++ b/crates/perl-symbol/Cargo.toml
@@ -36,6 +36,7 @@ criterion.workspace = true
 perl-ast = { workspace = true }
 perl-parser-core = { workspace = true }
 perl-tdd-support = { workspace = true }
+proptest = { workspace = true }
 serde_json = { workspace = true }
 
 [[bench]]

--- a/crates/perl-symbol/tests/prop_index_invariants.rs
+++ b/crates/perl-symbol/tests/prop_index_invariants.rs
@@ -1,0 +1,47 @@
+use perl_symbol::index::SymbolIndex;
+use proptest::prelude::*;
+
+fn symbol_strategy() -> impl Strategy<Value = String> {
+    prop::collection::vec("[A-Za-z][A-Za-z0-9_]{0,10}", 1..6).prop_map(|parts| parts.join("::"))
+}
+
+proptest! {
+    #[test]
+    fn prop_prefix_search_only_returns_matching_symbols(
+        symbols in prop::collection::vec(symbol_strategy(), 1..40),
+        prefix_len in 0usize..8,
+    ) {
+        let mut index = SymbolIndex::new();
+        for symbol in &symbols {
+            index.add_symbol(symbol.clone());
+        }
+
+        let seed = symbols.first().cloned().unwrap_or_default();
+        let prefix: String = seed.chars().take(prefix_len).collect();
+        let results = index.search_prefix(&prefix);
+
+        for result in &results {
+            prop_assert!(
+                result.starts_with(&prefix),
+                "non-matching symbol {result} returned for prefix {prefix}"
+            );
+        }
+    }
+
+    #[test]
+    fn prop_fuzzy_single_token_query_finds_source_symbol(
+        parts in prop::collection::vec("[a-z]{1,8}", 1..5),
+    ) {
+        let mut index = SymbolIndex::new();
+        let symbol = parts.join("_");
+        index.add_symbol(symbol.clone());
+
+        let query = parts[0].to_lowercase();
+        let results = index.search_fuzzy(&query);
+
+        prop_assert!(
+            results.contains(&symbol),
+            "expected symbol {symbol} to be discoverable via fuzzy query {query}"
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Strengthen property-based coverage for the `perl-symbol` index by asserting core invariants of prefix and fuzzy search behavior to catch regressions under random inputs.

### Description
- Add `crates/perl-symbol/tests/prop_index_invariants.rs` with two `proptest` invariants: `prop_prefix_search_only_returns_matching_symbols` and `prop_fuzzy_single_token_query_finds_source_symbol`.
- Wire `proptest` into `crates/perl-symbol/Cargo.toml` as a `dev-dependency` so the new tests compile and run.
- Update `Cargo.lock` to include the new test-time dependency.

### Testing
- Attempted `./scripts/cargo-safe test -p perl-symbol --profile agent --locked` was blocked by environment storage policy and so could not complete.
- Initial `cargo test -p perl-symbol --locked` failed due to an outdated `Cargo.lock` which was then updated; after a generator tweak to produce lowercase tokens the property test failed once locally and a failing case was recorded then fixed.
- Ran `cargo test -p perl-symbol --test prop_index_invariants` which passed.
- Ran full `cargo test -p perl-symbol` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43331cc808333bf9b7f8e8ab67f5a)