### PR TITLE
test(perl-lsp-rs): add code-action declaration mutation guards (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -1021,6 +1021,30 @@ mod tests {
     }
 
     #[test]
+    fn test_find_declaration_range_prefers_same_line_binding() {
+        let source = "my $name = 'global';\nmy $name = 'local';\nprint $name;\n".to_string();
+        let provider = CodeActionsProvider::new(source.clone());
+        let near = source.find("print $name").unwrap_or(0);
+
+        let (start, end) =
+            must_some(source_utils::find_declaration_range(&provider, "$name", near));
+
+        assert_eq!(&source[start..end], "my $name = 'local';\n");
+    }
+
+    #[test]
+    fn test_find_declaration_range_without_semicolon_falls_back_to_pattern_length() {
+        let source = "my $unterminated\nprint $unterminated\n".to_string();
+        let provider = CodeActionsProvider::new(source.clone());
+        let near = source.find("print $unterminated").unwrap_or(0);
+
+        let (start, end) =
+            must_some(source_utils::find_declaration_range(&provider, "$unterminated", near));
+
+        assert_eq!(&source[start..end], "my $unterminated");
+    }
+
+    #[test]
     fn test_find_declaration_position_first_line() {
         let source = "print $x;".to_string();
         let provider = CodeActionsProvider::new(source);


### PR DESCRIPTION
### Motivation
- Tighten mutation-hardening for code-action source utilities by covering declaration-range edge cases that commonly survive search-order and no-semicolon mutations.

### Description
- Add focused unit tests in `crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs` that assert same-line declaration preference when multiple bindings exist and that declarations without a trailing semicolon fall back to the search-pattern length.

### Testing
- Attempted to run the verification command `./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked --lib source_utils::`, but automated test execution was blocked in this environment by a storage guard (`DENY: /root/.cache/devplane/perl-lsp`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4333691a4833396d4080b5c2c4fee)