### PR TITLE
test(xtask): harden mutation collector blank package handling (#0000)

### DIFF
--- a/xtask/src/tasks/update_status/quality.rs
+++ b/xtask/src/tasks/update_status/quality.rs
@@ -44,7 +44,9 @@ pub(super) fn collect_per_crate_mutation(root: &Path) -> BTreeMap<String, usize>
     };
     let mut by_crate: BTreeMap<String, usize> = BTreeMap::new();
     for entry in entries {
-        if let Some(pkg) = entry.get("package").and_then(|v| v.as_str()) {
+        if let Some(pkg) = entry.get("package").and_then(|v| v.as_str())
+            && !pkg.trim().is_empty()
+        {
             *by_crate.entry(pkg.to_string()).or_default() += 1;
         }
     }
@@ -210,6 +212,23 @@ mod tests {
         let result = collect_per_crate_mutation(dir.path());
         assert_eq!(result.len(), 1);
         assert_eq!(result.get("perl-quote"), Some(&2));
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_per_crate_mutation_ignores_blank_package_names() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let out_dir = dir.path().join("mutants.out");
+        fs::create_dir_all(&out_dir)?;
+        let json = r#"[
+            {"package":"perl-quote","file":"crates/perl-quote/src/lib.rs"},
+            {"package":"","file":"crates/perl-parser/src/lib.rs"},
+            {"package":"   ","file":"crates/perl-parser/src/lib.rs"}
+        ]"#;
+        fs::write(out_dir.join("mutants.json"), json)?;
+        let result = collect_per_crate_mutation(dir.path());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get("perl-quote"), Some(&1));
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- The per-crate mutation aggregator accepted empty or whitespace-only `package` names from `mutants.out/mutants.json`, which could produce misleading rows and leave a mutation-testing gap.

### Description
- Skip entries whose `package` value is empty/whitespace in `collect_per_crate_mutation` and add a focused regression test to ensure blank package names are ignored; changes live in `xtask/src/tasks/update_status/quality.rs`.

### Testing
- Ran the focused test command `./scripts/cargo-safe test -p xtask --profile agent --locked quality::tests::test_collect_per_crate_mutation_ignores_blank_package_names`, which was blocked in this environment by a devplane storage `DENY`; ran `./scripts/storage-doctor` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4333691a4833396d4080b5c2c4fee)