### PR TITLE
test(perl-dap): harden regex mutation survivor coverage (#0000)

### DIFF
--- a/crates/perl-dap/src/eval/validator.rs
+++ b/crates/perl-dap/src/eval/validator.rs
@@ -154,18 +154,18 @@ impl SafeEvaluator {
             return Ok(());
         };
 
-        if let Some(mat) = re.find(expression) {
+        for mat in re.find_iter(expression) {
             let op = mat.as_str();
             let start = mat.start();
 
             // Allow sigil-prefixed identifiers ($s, $tr, $y)
             if is_sigil_prefixed_identifier(expression, start) {
-                return Ok(());
+                continue;
             }
 
             // Allow escape sequences like \s, \y
             if is_escape_sequence(expression, start) {
-                return Ok(());
+                continue;
             }
 
             return Err(ValidationError::RegexMutation(op.trim().to_string()));
@@ -397,6 +397,21 @@ mod tests {
         assert!(evaluator.validate("s/foo/bar/").is_err());
         assert!(evaluator.validate("tr/a-z/A-Z/").is_err());
         assert!(evaluator.validate("y/abc/xyz/").is_err());
+    }
+
+    #[test]
+    fn test_regex_mutation_detected_after_allowed_identifier() {
+        let evaluator = SafeEvaluator::new();
+
+        assert!(evaluator.validate("$s + s/foo/bar/").is_err());
+        assert!(evaluator.validate("$tr + tr/a-z/A-Z/").is_err());
+    }
+
+    #[test]
+    fn test_regex_mutation_detected_after_allowed_escape_sequence() {
+        let evaluator = SafeEvaluator::new();
+
+        assert!(evaluator.validate("/\\s+/ && s/foo/bar/").is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The regex-mutation validator in `crates/perl-dap/src/eval/validator.rs` only inspected the first regex match, allowing an early allowed token (e.g. `$s` or `\s`) to mask a later dangerous `s///`/`tr///` operator.
- Add focused tests to ensure dangerous regex mutation operators are detected even when they appear after allowed identifiers or escape sequences.

### Description
- Update `check_regex_mutation` to iterate all matches using `re.find_iter(...)` and `continue` on allowed cases instead of returning after the first match in `crates/perl-dap/src/eval/validator.rs`.
- Replace early `return Ok(())` paths with `continue` so later matches are still examined.
- Add unit tests `test_regex_mutation_detected_after_allowed_identifier` and `test_regex_mutation_detected_after_allowed_escape_sequence` alongside the existing test suite in `crates/perl-dap/src/eval/validator.rs` to cover the regression.

### Testing
- Added unit tests in `crates/perl-dap/src/eval/validator.rs` that assert `s///` and `tr///` are detected when placed after allowed tokens.
- Attempted to run the validator tests with `./scripts/cargo-safe test -p perl-dap --profile agent --locked eval::validator` but the run was blocked by the environment storage policy (`DENY: /root/.cache/devplane/perl-lsp used=46% free=32G`), so local verification is pending and will be exercised in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4333691a4833396d4080b5c2c4fee)