### PR TITLE
test(perl-workspace): harden workspace folder fuzz authority coverage (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/folder/mod.rs
+++ b/crates/perl-workspace-index/src/folder/mod.rs
@@ -75,8 +75,17 @@ fn file_uri_has_remote_host(value: &str) -> bool {
     url::Url::parse(value)
         .ok()
         .filter(|u| u.scheme() == "file")
-        .and_then(|u| u.host_str().map(|h| !matches!(h, "" | "localhost")))
+        .and_then(|u| u.host_str().map(|h| !is_local_file_host(h)))
         .unwrap_or(false)
+}
+
+fn is_local_file_host(host: &str) -> bool {
+    let normalized = host
+        .trim_end_matches('.')
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_ascii_lowercase();
+    matches!(normalized.as_str(), "" | "localhost" | "127.0.0.1" | "::1")
 }
 
 fn parse_file_uri_fallback(workspace_folder: &str) -> Option<PathBuf> {
@@ -95,7 +104,8 @@ fn parse_file_uri_fallback(workspace_folder: &str) -> Option<PathBuf> {
     }
 
     match parsed.host_str() {
-        None | Some("") | Some("localhost") => Some(PathBuf::from(path)),
+        None => Some(PathBuf::from(path)),
+        Some(host) if is_local_file_host(host) => Some(PathBuf::from(path)),
         Some(_) => None,
     }
 }
@@ -295,6 +305,19 @@ mod tests {
         let parsed = workspace_folder_to_path("file://localhost/tmp/project");
         assert!(parsed.to_string_lossy().contains("tmp"));
         assert!(parsed.to_string_lossy().contains("project"));
+    }
+
+    #[test]
+    fn parses_file_uri_with_localhost_variants() {
+        for uri in [
+            "file://LOCALHOST/tmp/project",
+            "file://localhost./tmp/project",
+            "file://127.0.0.1/tmp/project",
+            "file://[::1]/tmp/project",
+        ] {
+            let parsed = workspace_folder_to_path(uri);
+            assert!(!parsed.to_string_lossy().contains("file://"), "uri leaked: {uri}");
+        }
     }
 
     #[test]

--- a/crates/perl-workspace-index/tests/workspace_folder_fuzz.rs
+++ b/crates/perl-workspace-index/tests/workspace_folder_fuzz.rs
@@ -78,3 +78,21 @@ fn fuzz_workspace_folder_targeted_uri_like_inputs() {
         assert_no_file_uri_leak(sample);
     }
 }
+
+#[test]
+fn fuzz_workspace_folder_authority_edge_cases_do_not_leak_uri_scheme() {
+    let samples = [
+        "file://LOCALHOST/tmp/case-insensitive",
+        "file://localhost./tmp/trailing-dot",
+        "file://127.0.0.1/tmp/loopback-ipv4",
+        "file://[::1]/tmp/loopback-ipv6",
+        "file://%6cocalhost/tmp/percent-host",
+        "file://localhost/%2Ftmp%2Fencoded-slashes",
+        "file://localhost/tmp/space%20here",
+        "file:///tmp/emoji-%F0%9F%A6%80",
+    ];
+
+    for sample in samples {
+        assert_no_file_uri_leak(sample);
+    }
+}


### PR DESCRIPTION
### Motivation
- Fuzzing discovered authority variants (e.g. case variants, trailing-dot, loopback hosts) that could cause `file://` scheme leakage when parsing workspace-folder URIs.
- The parser needed a deterministic, secure classification for "local" file hosts so fallback trimming never leaks remote hostnames into returned `PathBuf` values.

### Description
- Added an authority-focused fuzz unit test `fuzz_workspace_folder_authority_edge_cases_do_not_leak_uri_scheme` in `crates/perl-workspace-index/tests/workspace_folder_fuzz.rs` that covers `localhost` variants, IPv4/IPv6 loopback, percent-encoded host/path, and other edge cases.
- Introduced `is_local_file_host(host: &str)` helper in `crates/perl-workspace-index/src/folder/mod.rs` which normalizes the host (trim trailing dots and brackets, lower-case) and treats `""`, `"localhost"`, `"127.0.0.1"`, and `"::1"` as local.
- Updated `file_uri_has_remote_host` and the `parse_file_uri_fallback` host matching to use `is_local_file_host`, preventing fallback trimming from exposing remote hostnames.
- Added unit coverage `parses_file_uri_with_localhost_variants` to assert these variants are handled without leaking `file://` scheme into the resolved path.

### Testing
- Ran `cargo test -p perl-workspace --test workspace_folder_fuzz` and the new fuzz/integration tests passed (all tests in that test target succeeded).
- Ran `cargo test -p perl-workspace parses_file_uri_with_localhost_variants` which passed.
- Verified the updated `workspace_folder` unit tests in `crates/perl-workspace-index` all succeed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4333c7a948333a64a999501f6f304)