### PR TITLE
test(perl-module): add use lib fuzz invariant coverage (#0000)

### DIFF
--- a/crates/perl-module/tests/use_lib_resolution_fuzz.rs
+++ b/crates/perl-module/tests/use_lib_resolution_fuzz.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+
+use perl_module::resolution::use_lib::{
+    extract_use_lib_operations, extract_use_lib_paths, resolve_use_lib_paths,
+};
+
+fn fuzz_string(state: &mut u64, max_len: usize) -> String {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+
+    let len = (*state as usize) % (max_len.saturating_add(1));
+    let mut out = String::with_capacity(len);
+    for _ in 0..len {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        let byte = match (*state % 16) as u8 {
+            0 => b'\n',
+            1 => b'\r',
+            2 => b'\t',
+            3 => b'"',
+            4 => b'\'',
+            5 => b';',
+            6 => b'(',
+            7 => b')',
+            8 => b'/',
+            9 => b'\\',
+            10 => b'.',
+            11 => b',',
+            _ => b'a' + ((*state % 26) as u8),
+        };
+        out.push(char::from(byte));
+    }
+    out
+}
+
+#[test]
+fn fuzz_use_lib_parser_and_resolver_preserve_core_invariants() {
+    let mut seed = 0x00C0_FFEE_F00D_BAAD_u64;
+
+    for _ in 0..5_000 {
+        let source = fuzz_string(&mut seed, 256);
+        let paths = extract_use_lib_paths(&source);
+        let ops = extract_use_lib_operations(&source);
+
+        for path in &paths {
+            assert!(
+                !path.path.is_empty(),
+                "extracted use lib path should never be empty; source={source:?}"
+            );
+        }
+
+        let resolved = resolve_use_lib_paths(
+            &paths,
+            Path::new("/workspace"),
+            Some(Path::new("/workspace/project/lib")),
+        );
+
+        for rel in resolved {
+            assert!(
+                !Path::new(&rel).is_absolute(),
+                "resolved include path should be relative to workspace: {rel:?}; source={source:?}"
+            );
+            assert!(
+                !Path::new(&rel)
+                    .components()
+                    .any(|component| component == std::path::Component::ParentDir),
+                "resolved include path should not contain parent traversals: {rel:?}; source={source:?}"
+            );
+        }
+
+        for op in &ops {
+            match op {
+                perl_module::resolution::use_lib::UseLibAction::Add(op_paths)
+                | perl_module::resolution::use_lib::UseLibAction::Remove(op_paths) => {
+                    for op_path in op_paths {
+                        assert!(
+                            !op_path.path.is_empty(),
+                            "operation paths should never be empty; source={source:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Close a fuzzing gap: there was broad unit coverage for `use lib` handling but no dedicated randomized invariants test exercising parser + resolver together under noisy inputs.

### Description
- Add `crates/perl-module/tests/use_lib_resolution_fuzz.rs` which implements a deterministic PRNG `fuzz_string` and a single fuzz-style test `fuzz_use_lib_parser_and_resolver_preserve_core_invariants` that drives `extract_use_lib_paths`, `extract_use_lib_operations`, and `resolve_use_lib_paths` over 5,000 randomized inputs.
- The test asserts core invariants: extracted paths are non-empty, resolved include entries are not absolute, and resolved entries do not contain `..` parent-traversal components.

### Testing
- `./scripts/cargo-safe test -p perl-module --profile agent --locked use_lib_resolution_fuzz` was attempted but blocked by environment storage guard (`DENY: /root/.cache/devplane/...`).
- `just agent-test -p perl-module` is not available in this environment (`just: command not found`).
- Local runs using `cargo test -p perl-module use_lib_resolution_fuzz` and `cargo test -p perl-module fuzz_use_lib_parser_and_resolver_preserve_core_invariants` completed and the new test passed (1 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4333c7a948333a64a999501f6f304)