### PR TITLE
test(perl-parser): add unicode incremental fuzz edits (#0000)

### DIFF
--- a/crates/perl-parser/tests/fuzz_incremental_parsing.rs
+++ b/crates/perl-parser/tests/fuzz_incremental_parsing.rs
@@ -258,6 +258,50 @@ proptest! {
             );
         }
     }
+
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn fuzz_incremental_unicode_edit_sequences_preserve_no_panic(
+        base in r"[\p{L}\p{N}_ \n\t]{1,80}",
+        edits in proptest::collection::vec((0usize..80, r"[\p{L}\p{N}\p{S} \n\t]{0,16}"), 1..10),
+    ) {
+        let mut script = base;
+
+        for (index_hint, payload) in edits {
+            let insertion_at = script
+                .char_indices()
+                .nth(index_hint.min(script.chars().count()))
+                .map_or(script.len(), |(idx, _)| idx);
+            script.insert_str(insertion_at, &payload);
+
+            if !script.is_empty() {
+                let mut starts = script.char_indices().map(|(idx, _)| idx).collect::<Vec<_>>();
+                starts.push(script.len());
+
+                let start_pos = (index_hint / 2).min(starts.len().saturating_sub(1));
+                let end_pos = (start_pos + payload.chars().count() / 2).min(starts.len() - 1);
+                let delete_start = starts[start_pos];
+                let delete_end = starts[end_pos];
+
+                if delete_start < delete_end {
+                    script.replace_range(delete_start..delete_end, "");
+                }
+            }
+
+            let mut parser = Parser::new(&script);
+            let parse_result = std::panic::catch_unwind(AssertUnwindSafe(|| parser.parse()));
+
+            prop_assert!(
+                parse_result.is_ok(),
+                "unicode incremental edit sequence caused parser panic for script: {:?}",
+                script
+            );
+        }
+    }
 }
 
 /// Test memory and performance characteristics under stress


### PR DESCRIPTION
Problem: parser fuzz coverage did not exercise Unicode edit sequences at character boundaries.
Fix: add a focused proptest that mutates Unicode-heavy scripts through insert/delete sequences and asserts parsing never panics, capped at 32 cases so it stays a PR-local gate.
Verification: `cargo test -p perl-parser --test fuzz_incremental_parsing --locked fuzz_incremental_unicode_edit_sequences_preserve_no_panic -- --nocapture`; `cargo check -p perl-parser --all-targets --locked`; `cargo clippy -p perl-parser --test fuzz_incremental_parsing --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`.

Note: this PR intentionally uses the focused added test as acceptance. The full `fuzz_incremental_parsing` target has pre-existing long stress cases that are not a useful review gate for this one added fast proptest.