### PR TITLE
test(perl-parser): add parser gap coverage for do/switch forms (#0000)

### DIFF
--- a/crates/perl-parser/tests/corpus_gap_tests.rs
+++ b/crates/perl-parser/tests/corpus_gap_tests.rs
@@ -230,6 +230,50 @@ mod corpus_gap_tests {
         Ok(())
     }
 
+    /// Coverage: parses `do { ... }` expression assignment used in lazy setup paths.
+    #[test]
+    fn test_do_block_expression_assignment() -> Result<(), Box<dyn std::error::Error>> {
+        let input = r#"
+            my $value = do {
+                my $tmp = 40;
+                $tmp + 2;
+            };
+        "#;
+        let mut parser = Parser::new(input);
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+
+        assert!(
+            !sexp.contains("ERROR"),
+            "expected no ERROR nodes for do-block expression assignment, got: {sexp}"
+        );
+        assert!(sexp.contains("do"), "expected do-block in AST, got: {sexp}");
+        Ok(())
+    }
+
+    /// Coverage: parses `given/when/default` switch syntax that still appears in legacy code.
+    #[test]
+    fn test_given_when_default_switch() -> Result<(), Box<dyn std::error::Error>> {
+        let input = r#"
+            use feature 'switch';
+            given ($code) {
+                when (/^2/) { return 'ok'; }
+                default { return 'other'; }
+            }
+        "#;
+        let mut parser = Parser::new(input);
+        let ast = parser.parse()?;
+        let sexp = ast.to_sexp();
+
+        assert!(
+            !sexp.contains("ERROR"),
+            "expected no ERROR nodes for given/when/default snippet, got: {sexp}"
+        );
+        assert!(sexp.contains("given"), "expected given node in AST, got: {sexp}");
+        assert!(sexp.contains("when"), "expected when node in AST, got: {sexp}");
+        Ok(())
+    }
+
     // Property-based test for delimiters
     #[test]
     fn test_arbitrary_delimiters() {


### PR DESCRIPTION
### Motivation

- Cover parser gaps for two real-world Perl constructs that were missing from corpus tests: `do { ... }` expression assignments and legacy `given/when/default` switch syntax.
- Ensure the parser does not regress for lazy `do` expressions and older `switch`-style code commonly found in legacy codebases.

### Description

- Added focused unit tests in `crates/perl-parser/tests/corpus_gap_tests.rs` named `test_do_block_expression_assignment` and `test_given_when_default_switch` that parse small snippets exercising the target constructs.
- Each test asserts the parser returns `Ok` (no crash) and that the AST `to_sexp()` contains no `ERROR` nodes and includes key nodes (`do`, `given`, `when`) as sanity checks.
- Committed as a single focused change with the message `test(perl-parser): add parser gap coverage for do/switch forms (#0000)`.

### Testing

- Attempted to run the test binary with `./scripts/cargo-safe test -p perl-parser --test corpus_gap_tests --profile agent --locked`, but execution was blocked by the environment storage policy (`DENY: /root/.cache/devplane/perl-lsp ...`).
- No automated tests completed successfully in this environment due to the storage policy denial. Please run the test command above in CI or a developer machine to verify all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f433458bd88333a54ee42843905c4c)