### PR TITLE
refactor(perl-lsp-rs): split hover extraction and tests into submodules (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -6,52 +6,11 @@ use super::super::*;
 use crate::cancellation::RequestCleanupGuard;
 use crate::protocol::{req_position, req_uri};
 
-/// Intermediate result from phase-1 hover extraction (under document lock).
-///
-/// The document lock must be released before calling module resolution to avoid
-/// deadlock, so we extract what we need first and resolve afterwards.
-enum HoverExtracted {
-    /// Hover content fully built (symbol, builtin, or token hover).
-    Complete(Value),
-    /// A `use Module` was found; module name needs resolution without lock.
-    /// Carries (module_name, doc_text, doc_uri, doc_offset) for use lib / FindBin wiring.
-    UseModule(String, String, String, usize),
-    /// Cursor is on a `->method()` call where the method belongs to an inherited or
-    /// role-composed ancestor class. Carries (receiver_pkg, method_name, doc_uri).
-    /// Phase 2 resolves the hover using the workspace index BFS (same logic as
-    /// `inherited_method_definition_location` in navigation.rs).
-    InheritedMethod(String, String, String),
-    /// Cursor is on a package-name token (contains `::`) that was not handled by an
-    /// earlier semantic or `use` path. Carries (package_name, doc_text, doc_uri, doc_offset).
-    /// Phase 2 resolves it via `build_module_hover` (same as `UseModule`).
-    PossiblePackage(String, String, String, usize),
-    /// Nothing hoverable at this position.
-    None,
-}
-
+mod hover_extracted;
 #[cfg(test)]
-mod tests {
-    use super::LspServer;
+mod hover_tests;
 
-    #[test]
-    fn test_internal_pl_sv_yes_hover_from_sigiled_token() {
-        let text = "print $PL_sv_yes;\n";
-        let offset = text.find('$').expect("sigil should exist");
-
-        assert_eq!(
-            LspServer::extract_special_variable(text, offset).as_deref(),
-            Some("$PL_sv_yes")
-        );
-
-        let hover = LspServer::get_special_variable_hover("$PL_sv_yes")
-            .expect("hover should exist for $PL_sv_yes");
-        let value = hover["contents"]["value"].as_str().expect("markdown hover text");
-        assert!(
-            value.contains("true scalar"),
-            "hover should describe the shared true scalar: {value}"
-        );
-    }
-}
+use hover_extracted::HoverExtracted;
 
 impl LspServer {
     /// Handle textDocument/hover request for symbol information display

--- a/crates/perl-lsp-rs/src/runtime/language/hover/hover_extracted.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover/hover_extracted.rs
@@ -1,0 +1,24 @@
+use super::Value;
+
+/// Intermediate result from phase-1 hover extraction (under document lock).
+///
+/// The document lock must be released before calling module resolution to avoid
+/// deadlock, so we extract what we need first and resolve afterwards.
+pub(super) enum HoverExtracted {
+    /// Hover content fully built (symbol, builtin, or token hover).
+    Complete(Value),
+    /// A `use Module` was found; module name needs resolution without lock.
+    /// Carries (module_name, doc_text, doc_uri, doc_offset) for use lib / FindBin wiring.
+    UseModule(String, String, String, usize),
+    /// Cursor is on a `->method()` call where the method belongs to an inherited or
+    /// role-composed ancestor class. Carries (receiver_pkg, method_name, doc_uri).
+    /// Phase 2 resolves the hover using the workspace index BFS (same logic as
+    /// `inherited_method_definition_location` in navigation.rs).
+    InheritedMethod(String, String, String),
+    /// Cursor is on a package-name token (contains `::`) that was not handled by an
+    /// earlier semantic or `use` path. Carries (package_name, doc_text, doc_uri, doc_offset).
+    /// Phase 2 resolves it via `build_module_hover` (same as `UseModule`).
+    PossiblePackage(String, String, String, usize),
+    /// Nothing hoverable at this position.
+    None,
+}

--- a/crates/perl-lsp-rs/src/runtime/language/hover/hover_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover/hover_tests.rs
@@ -1,0 +1,14 @@
+use super::LspServer;
+use perl_tdd_support::must_some;
+
+#[test]
+fn test_internal_pl_sv_yes_hover_from_sigiled_token() {
+    let text = "print $PL_sv_yes;\n";
+    let offset = must_some(text.find('$'));
+
+    assert_eq!(LspServer::extract_special_variable(text, offset).as_deref(), Some("$PL_sv_yes"));
+
+    let hover = must_some(LspServer::get_special_variable_hover("$PL_sv_yes"));
+    let value = must_some(hover["contents"]["value"].as_str());
+    assert!(value.contains("true scalar"), "hover should describe the shared true scalar: {value}");
+}


### PR DESCRIPTION
### Motivation
- `hover.rs` mixed request-handling logic, phase-1 extraction state, and inline unit tests, making the module large and violating single-responsibility principles.

### Description
- Moved the phase-1 hover extraction enum into a dedicated SRP submodule `crates/perl-lsp-rs/src/runtime/language/hover_extracted.rs` and exposed it as `pub(super) HoverExtracted`.
- Extracted the hover unit test into `crates/perl-lsp-rs/src/runtime/language/hover_tests.rs` and switched to `perl_tdd_support::must_some` for assertions to match repo test style.
- Wired the new files into `hover.rs` via `mod hover_extracted;` and `mod hover_tests;` and replaced the in-file enum and test code with a `use hover_extracted::HoverExtracted;` import.

### Testing
- Ran `./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked`, which was blocked by the environment storage guard and did not complete (`DENY: /root/.cache/devplane/perl-lsp`).
- Ran `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked`, which was also blocked by the same storage guard and did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f433602fd48333a8299c992bc967b4)