### PR TITLE
refactor(workspace): extract config response applier (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -36,6 +36,8 @@ use std::time::Instant;
 use url::Url;
 
 #[cfg(feature = "workspace")]
+mod configuration_response;
+#[cfg(feature = "workspace")]
 mod text_decode;
 
 const WORKSPACE_CONFIGURATION_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -193,35 +195,14 @@ impl LspServer {
             );
             return;
         };
-        let global_settings = if pending.includes_global_item { results.first() } else { None };
-        let folder_results_start = usize::from(pending.includes_global_item);
-
         let mut folders = self.workspace_folders.lock();
-        for (idx, folder_uri) in pending.folder_uris.iter().enumerate() {
-            let Some(folder) = folders.iter_mut().find(|folder| &folder.uri == folder_uri) else {
-                continue;
-            };
-
-            let mut effective_config = perl_lsp_rs_core::config::WorkspaceConfig::default();
-            if let Some(project_config) = &folder.project_config {
-                project_config.apply_to_workspace_config(&mut effective_config);
-            }
-
-            if let Some(global_settings) = global_settings {
-                effective_config.update_from_value(global_settings);
-            }
-            if let Some(perl_settings) = results.get(folder_results_start + idx) {
-                effective_config.update_from_value(perl_settings);
-            } else {
-                tracing::warn!(
-                    request_id = id,
-                    folder_uri = %folder_uri,
-                    "workspace/configuration response missing folder item; using TOML/default config for folder"
-                );
-            }
-
-            folder.effective_workspace_config = effective_config;
-        }
+        configuration_response::apply_workspace_configuration_results(
+            &mut folders,
+            &pending.folder_uris,
+            pending.includes_global_item,
+            results,
+            id,
+        );
     }
 
     /// Handle workspace/symbol request (v2 implementation with lifecycle-aware dispatch)

--- a/crates/perl-lsp-rs/src/runtime/workspace/configuration_response.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace/configuration_response.rs
@@ -1,0 +1,40 @@
+use crate::runtime::workspace_folder::WorkspaceFolderState;
+use serde_json::Value;
+
+pub(super) fn apply_workspace_configuration_results(
+    folders: &mut [WorkspaceFolderState],
+    folder_uris: &[String],
+    includes_global_item: bool,
+    results: &[Value],
+    request_id: i64,
+) {
+    let global_settings = if includes_global_item { results.first() } else { None };
+    let folder_results_start = usize::from(includes_global_item);
+
+    for (idx, folder_uri) in folder_uris.iter().enumerate() {
+        let Some(folder) = folders.iter_mut().find(|folder| &folder.uri == folder_uri) else {
+            continue;
+        };
+
+        let mut effective_config = perl_lsp_rs_core::config::WorkspaceConfig::default();
+        if let Some(project_config) = &folder.project_config {
+            project_config.apply_to_workspace_config(&mut effective_config);
+        }
+
+        if let Some(global_settings) = global_settings {
+            effective_config.update_from_value(global_settings);
+        }
+
+        if let Some(perl_settings) = results.get(folder_results_start + idx) {
+            effective_config.update_from_value(perl_settings);
+        } else {
+            tracing::warn!(
+                request_id,
+                folder_uri = %folder_uri,
+                "workspace/configuration response missing folder item; using TOML/default config for folder"
+            );
+        }
+
+        folder.effective_workspace_config = effective_config;
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce complexity in `handle_client_response` by moving per-folder workspace configuration application into a single-responsibility submodule. 
- Improve readability and testability by isolating the folder-level merge logic (project config + global + folder settings + missing-item warning).

### Description

- Added `crates/perl-lsp-rs/src/runtime/workspace/configuration_response.rs` which implements `apply_workspace_configuration_results` to perform the per-folder merge and assign `effective_workspace_config` for matching folders. 
- Replaced the inline loop in `crates/perl-lsp-rs/src/runtime/workspace.rs::handle_client_response` with a call to `configuration_response::apply_workspace_configuration_results`, keeping behavior intact. 
- Preserved existing semantics: project config applied first, optional global settings merged, per-folder settings applied when present, and a `tracing::warn!` when a folder result is missing. 
- Committed as a single focused change in one commit titled `refactor(workspace): extract config response applier (#0000)`.

### Testing

- Ran `rustfmt crates/perl-lsp-rs/src/runtime/workspace.rs crates/perl-lsp-rs/src/runtime/workspace/configuration_response.rs` which completed successfully. 
- Attempted `./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked` but it was blocked by local environment policy: `DENY: /root/.cache/devplane/perl-lsp used=46% free=32G` so the full `cargo` verification could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4336407d483338ebef63c7d10d788)