### PR TITLE
refactor(perl-ci-hygiene): split CI policy/process helpers into modules (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/ci_policy.rs
+++ b/crates/perl-ci-hygiene/src/ci_policy.rs
@@ -1,0 +1,34 @@
+use std::ffi::OsStr;
+use std::path::Path;
+
+const CI_REPORT_CRATES_EXCLUDE: [&str; 5] = [
+    "tree-sitter-perl-c",
+    "perl-parser-pest",
+    "perl-tdd-support",
+    "perl-test-must",
+    "perl-ci-hygiene",
+];
+
+const CI_TEST_FILE_SUFFIXES: [&str; 3] = ["_test.rs", "_tests.rs", "tests.rs"];
+
+pub(crate) fn is_excluded_test_path(path: &Path) -> bool {
+    if path.components().any(|component| {
+        let value = component.as_os_str();
+        value == OsStr::new("tests")
+            || value == OsStr::new("benches")
+            || value == OsStr::new("examples")
+            || value == OsStr::new("bin")
+    }) {
+        return true;
+    }
+
+    if let Some(file_name) = path.file_name().and_then(|name| name.to_str())
+        && CI_TEST_FILE_SUFFIXES.iter().any(|suffix| file_name.ends_with(suffix))
+    {
+        return true;
+    }
+
+    path.components().any(|component| {
+        CI_REPORT_CRATES_EXCLUDE.iter().any(|item| component.as_os_str() == OsStr::new(item))
+    })
+}

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -9,7 +9,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::ffi::OsStr;
 use std::fs;
-use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -18,10 +17,16 @@ use std::time::{Duration, Instant};
 use toml::Value as TomlValue;
 use walkdir::{DirEntry, WalkDir};
 
+mod ci_policy;
 mod cli;
 mod commands;
+mod process_io;
 
+use crate::ci_policy::is_excluded_test_path;
 use crate::cli::{Cli, CliCommand};
+use crate::process_io::{
+    command_with_input_with_status, command_with_output, command_with_output_all,
+};
 
 const RED: &str = "\x1b[0;31m";
 const GREEN: &str = "\x1b[0;32m";
@@ -98,125 +103,6 @@ fn run() -> Result<i32> {
         CliCommand::TestHeredocs => cmd_test_heredocs(&repo_root)?,
     };
     Ok(code)
-}
-
-const CI_REPORT_CRATES_EXCLUDE: [&str; 5] = [
-    "tree-sitter-perl-c",
-    "perl-parser-pest",
-    "perl-tdd-support",
-    "perl-test-must",
-    "perl-ci-hygiene",
-];
-
-const CI_TEST_FILE_SUFFIXES: [&str; 3] = ["_test.rs", "_tests.rs", "tests.rs"];
-
-fn is_excluded_test_path(path: &Path) -> bool {
-    if path.components().any(|component| {
-        let value = component.as_os_str();
-        value == OsStr::new("tests")
-            || value == OsStr::new("benches")
-            || value == OsStr::new("examples")
-            || value == OsStr::new("bin")
-    }) {
-        return true;
-    }
-
-    if let Some(file_name) = path.file_name().and_then(|name| name.to_str())
-        && CI_TEST_FILE_SUFFIXES.iter().any(|suffix| file_name.ends_with(suffix))
-    {
-        return true;
-    }
-
-    if path.components().any(|component| {
-        CI_REPORT_CRATES_EXCLUDE.iter().any(|item| component.as_os_str() == OsStr::new(item))
-    }) {
-        return true;
-    }
-
-    false
-}
-
-fn command_with_output(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<String> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
-    let status = output.status.code().unwrap_or(1);
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    if status != 0 {
-        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-        return Err(color_eyre::eyre::eyre!(
-            "command '{command}' failed (exit {status}): {stderr}"
-        ));
-    }
-    Ok(stdout)
-}
-
-fn command_with_output_all(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<String> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
-    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
-    if !output.stderr.is_empty() {
-        combined.push_str(&String::from_utf8_lossy(&output.stderr));
-    }
-    let status = output.status.code().unwrap_or(1);
-    if status != 0 {
-        return Err(color_eyre::eyre::eyre!(
-            "command '{command}' failed (exit {status}): {combined}"
-        ));
-    }
-    Ok(combined)
-}
-
-fn command_with_input_with_status(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-    stdin_payload: &str,
-) -> Result<(i32, String)> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
-
-    let mut child = child.spawn().wrap_err_with(|| format!("running {command}"))?;
-    {
-        let mut stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| color_eyre::eyre::eyre!("failed to open stdin for command {command}"))?;
-        stdin
-            .write_all(stdin_payload.as_bytes())
-            .wrap_err_with(|| format!("writing to stdin for {command}"))?;
-    }
-    let output = child.wait_with_output().wrap_err_with(|| format!("running {command}"))?;
-    let status = output.status.code().unwrap_or(1);
-    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
-    if !output.stderr.is_empty() {
-        combined.push_str(&String::from_utf8_lossy(&output.stderr));
-    }
-    Ok((status, combined))
 }
 
 fn command_output_with_status(

--- a/crates/perl-ci-hygiene/src/process_io.rs
+++ b/crates/perl-ci-hygiene/src/process_io.rs
@@ -1,0 +1,87 @@
+use color_eyre::eyre::{Result, WrapErr};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+pub(crate) fn command_with_output(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<String> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
+    let status = output.status.code().unwrap_or(1);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    if status != 0 {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(color_eyre::eyre::eyre!(
+            "command '{command}' failed (exit {status}): {stderr}"
+        ));
+    }
+    Ok(stdout)
+}
+
+pub(crate) fn command_with_output_all(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<String> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.stderr.is_empty() {
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    }
+    let status = output.status.code().unwrap_or(1);
+    if status != 0 {
+        return Err(color_eyre::eyre::eyre!(
+            "command '{command}' failed (exit {status}): {combined}"
+        ));
+    }
+    Ok(combined)
+}
+
+pub(crate) fn command_with_input_with_status(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+    stdin_payload: &str,
+) -> Result<(i32, String)> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = child.spawn().wrap_err_with(|| format!("running {command}"))?;
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| color_eyre::eyre::eyre!("failed to open stdin for command {command}"))?;
+        stdin
+            .write_all(stdin_payload.as_bytes())
+            .wrap_err_with(|| format!("writing to stdin for {command}"))?;
+    }
+    let output = child.wait_with_output().wrap_err_with(|| format!("running {command}"))?;
+    let status = output.status.code().unwrap_or(1);
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.stderr.is_empty() {
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    }
+    Ok((status, combined))
+}


### PR DESCRIPTION
### Motivation
- Reduce `main.rs` responsibility by isolating CI path-filtering policy and process I/O helpers so each file follows the single-responsibility principle.
- Make the CI hygiene utilities easier to test and evolve independently from the command orchestration logic.

### Description
- Extracted the test-path exclusion policy and related constants into `crates/perl-ci-hygiene/src/ci_policy.rs` and exposed `is_excluded_test_path`.
- Moved command execution helpers into `crates/perl-ci-hygiene/src/process_io.rs` and exposed `command_with_output`, `command_with_output_all`, and `command_with_input_with_status`.
- Updated `crates/perl-ci-hygiene/src/main.rs` to `mod ci_policy` and `mod process_io`, and imported the new functions via focused `use` statements, removing the inlined implementations.
- No behavioral changes to exported command APIs; this is a refactor to improve code organization and SRP boundaries.

### Testing
- Ran `cargo check -p perl-ci-hygiene --all-targets --locked`, which completed successfully.
- Ran `./scripts/cargo-safe xtask fmt`, which completed successfully and formatted sources.
- Attempted `./scripts/cargo-safe check -p perl-ci-hygiene --all-targets --profile agent --locked`, but it was blocked by the environment storage guard (`DENY: /root/.cache/devplane/...`), so the agent-level check could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43372d5e4833380522054668f2296)