### PR TITLE
refactor(perl-ci-hygiene): split process helpers into submodule (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -9,19 +9,19 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::ffi::OsStr;
 use std::fs;
-use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::process::Command;
 use toml::Value as TomlValue;
 use walkdir::{DirEntry, WalkDir};
 
 mod cli;
 mod commands;
+mod process;
 
 use crate::cli::{Cli, CliCommand};
+use crate::process::*;
 
 const RED: &str = "\x1b[0;31m";
 const GREEN: &str = "\x1b[0;32m";
@@ -134,207 +134,6 @@ fn is_excluded_test_path(path: &Path) -> bool {
     }
 
     false
-}
-
-fn command_with_output(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<String> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
-    let status = output.status.code().unwrap_or(1);
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    if status != 0 {
-        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-        return Err(color_eyre::eyre::eyre!(
-            "command '{command}' failed (exit {status}): {stderr}"
-        ));
-    }
-    Ok(stdout)
-}
-
-fn command_with_output_all(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<String> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
-    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
-    if !output.stderr.is_empty() {
-        combined.push_str(&String::from_utf8_lossy(&output.stderr));
-    }
-    let status = output.status.code().unwrap_or(1);
-    if status != 0 {
-        return Err(color_eyre::eyre::eyre!(
-            "command '{command}' failed (exit {status}): {combined}"
-        ));
-    }
-    Ok(combined)
-}
-
-fn command_with_input_with_status(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-    stdin_payload: &str,
-) -> Result<(i32, String)> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
-
-    let mut child = child.spawn().wrap_err_with(|| format!("running {command}"))?;
-    {
-        let mut stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| color_eyre::eyre::eyre!("failed to open stdin for command {command}"))?;
-        stdin
-            .write_all(stdin_payload.as_bytes())
-            .wrap_err_with(|| format!("writing to stdin for {command}"))?;
-    }
-    let output = child.wait_with_output().wrap_err_with(|| format!("running {command}"))?;
-    let status = output.status.code().unwrap_or(1);
-    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
-    if !output.stderr.is_empty() {
-        combined.push_str(&String::from_utf8_lossy(&output.stderr));
-    }
-    Ok((status, combined))
-}
-
-fn command_output_with_status(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<(i32, String)> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
-    let status = output.status.code().unwrap_or(1);
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    Ok((status, stdout))
-}
-
-fn command_timed_status(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<(i32, Duration)> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdout(Stdio::null()).stderr(Stdio::null());
-    let start = Instant::now();
-    let status = child.status().wrap_err_with(|| format!("running {command}"))?;
-    let elapsed = start.elapsed();
-    Ok((status.code().unwrap_or(1), elapsed))
-}
-
-fn command_with_output_allow_empty_match(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<String> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
-    let status = output.status.code().unwrap_or(1);
-    if status != 0 && status != 1 {
-        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-        return Err(color_eyre::eyre::eyre!(
-            "command '{command}' failed (exit {status}): {stderr}"
-        ));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-}
-
-fn command_with_output_allow_failure(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<String> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    child.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-}
-
-fn command_status(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<i32> {
-    let mut child = Command::new(command);
-    child.current_dir(repo_root).args(args);
-    for (key, value) in env_vars {
-        child.env(key, value);
-    }
-    let status = child.status().wrap_err_with(|| format!("running {command}"))?;
-    Ok(status.code().unwrap_or(1))
-}
-
-fn command_status_strict(
-    repo_root: &Path,
-    command: &str,
-    args: &[&str],
-    env_vars: &[(&str, &str)],
-) -> Result<()> {
-    let status = command_status(repo_root, command, args, env_vars)?;
-    if status != 0 {
-        return Err(color_eyre::eyre::eyre!("{command} failed with code {status}"));
-    }
-    Ok(())
-}
-
-fn command_exists(command: &str) -> bool {
-    // Replaces `sh -c "command -v ..."` which is Unix-only.
-    // On Windows, also probe for .exe / .cmd / .bat extensions.
-    #[cfg(windows)]
-    let suffixes: &[&str] = &[".exe", ".cmd", ".bat", ""];
-    #[cfg(not(windows))]
-    let suffixes: &[&str] = &[""];
-    env::split_paths(&env::var_os("PATH").unwrap_or_default())
-        .any(|dir| suffixes.iter().any(|ext| dir.join(format!("{command}{ext}")).exists()))
-}
-
-fn command_output_lines(output: &str) -> Vec<String> {
-    output.lines().map(str::trim).filter(|line| !line.is_empty()).map(ToString::to_string).collect()
 }
 
 fn first_cfg_test_line_number(path: &Path) -> Result<usize> {

--- a/crates/perl-ci-hygiene/src/process.rs
+++ b/crates/perl-ci-hygiene/src/process.rs
@@ -1,0 +1,205 @@
+use color_eyre::eyre::{Context, Result};
+use std::env;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+pub(crate) fn command_with_output(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<String> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
+    let status = output.status.code().unwrap_or(1);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    if status != 0 {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(color_eyre::eyre::eyre!(
+            "command '{command}' failed (exit {status}): {stderr}"
+        ));
+    }
+    Ok(stdout)
+}
+
+pub(crate) fn command_with_output_all(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<String> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.stderr.is_empty() {
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    }
+    let status = output.status.code().unwrap_or(1);
+    if status != 0 {
+        return Err(color_eyre::eyre::eyre!(
+            "command '{command}' failed (exit {status}): {combined}"
+        ));
+    }
+    Ok(combined)
+}
+
+pub(crate) fn command_with_input_with_status(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+    stdin_payload: &str,
+) -> Result<(i32, String)> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = child.spawn().wrap_err_with(|| format!("running {command}"))?;
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| color_eyre::eyre::eyre!("failed to open stdin for command {command}"))?;
+        stdin
+            .write_all(stdin_payload.as_bytes())
+            .wrap_err_with(|| format!("writing to stdin for {command}"))?;
+    }
+    let output = child.wait_with_output().wrap_err_with(|| format!("running {command}"))?;
+    let status = output.status.code().unwrap_or(1);
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    if !output.stderr.is_empty() {
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    }
+    Ok((status, combined))
+}
+
+pub(crate) fn command_output_with_status(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<(i32, String)> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
+    let status = output.status.code().unwrap_or(1);
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    Ok((status, stdout))
+}
+
+pub(crate) fn command_timed_status(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<(i32, Duration)> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdout(Stdio::null()).stderr(Stdio::null());
+    let start = Instant::now();
+    let status = child.status().wrap_err_with(|| format!("running {command}"))?;
+    let elapsed = start.elapsed();
+    Ok((status.code().unwrap_or(1), elapsed))
+}
+
+pub(crate) fn command_with_output_allow_empty_match(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<String> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
+    let status = output.status.code().unwrap_or(1);
+    if status != 0 && status != 1 {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        return Err(color_eyre::eyre::eyre!(
+            "command '{command}' failed (exit {status}): {stderr}"
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+pub(crate) fn command_with_output_allow_failure(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<String> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    child.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let output = child.output().wrap_err_with(|| format!("running {command}"))?;
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+pub(crate) fn command_status(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<i32> {
+    let mut child = Command::new(command);
+    child.current_dir(repo_root).args(args);
+    for (key, value) in env_vars {
+        child.env(key, value);
+    }
+    let status = child.status().wrap_err_with(|| format!("running {command}"))?;
+    Ok(status.code().unwrap_or(1))
+}
+
+pub(crate) fn command_status_strict(
+    repo_root: &Path,
+    command: &str,
+    args: &[&str],
+    env_vars: &[(&str, &str)],
+) -> Result<()> {
+    let status = command_status(repo_root, command, args, env_vars)?;
+    if status != 0 {
+        return Err(color_eyre::eyre::eyre!("{command} failed with code {status}"));
+    }
+    Ok(())
+}
+
+pub(crate) fn command_exists(command: &str) -> bool {
+    #[cfg(windows)]
+    let suffixes: &[&str] = &[".exe", ".cmd", ".bat", ""];
+    #[cfg(not(windows))]
+    let suffixes: &[&str] = &[""];
+    env::split_paths(&env::var_os("PATH").unwrap_or_default())
+        .any(|dir| suffixes.iter().any(|ext| dir.join(format!("{command}{ext}")).exists()))
+}
+
+pub(crate) fn command_output_lines(output: &str) -> Vec<String> {
+    output.lines().map(str::trim).filter(|line| !line.is_empty()).map(ToString::to_string).collect()
+}


### PR DESCRIPTION
### Motivation

- `crates/perl-ci-hygiene/src/main.rs` mixed process/command execution helpers with CLI orchestration, violating single-responsibility and making the file large and harder to test.

### Description

- Moved command/process helper functions (process spawning, output capture, status helpers, and related utilities) into a new `crates/perl-ci-hygiene/src/process.rs` submodule.
- Updated `crates/perl-ci-hygiene/src/main.rs` to `mod process;` and `use crate::process::*;`, and removed the duplicated imports and function definitions from `main.rs` so orchestration logic remains focused there.
- No behavior changes to the helper APIs; functions remain `pub(crate)` and retained their previous signatures.

### Testing

- Ran `./scripts/cargo-safe check -p perl-ci-hygiene --all-targets --profile agent --locked`, which failed due to an environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`) and not due to code errors.
- Ran `cargo check -p perl-ci-hygiene --all-targets --locked`, which completed successfully.
- Ran `cargo test -p perl-ci-hygiene --locked`, which completed successfully (unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43372d5e4833380522054668f2296)