### PR TITLE
refactor(perl-parser): add SRP-oriented refactor facades (#0000)

### DIFF
--- a/crates/perl-parser/src/refactor/mod.rs
+++ b/crates/perl-parser/src/refactor/mod.rs
@@ -10,3 +10,6 @@ pub mod workspace_rename;
 
 #[cfg(test)]
 mod scoped_rename_tests;
+
+/// SRP-oriented namespaces for refactor features.
+pub mod srp;

--- a/crates/perl-parser/src/refactor/srp.rs
+++ b/crates/perl-parser/src/refactor/srp.rs
@@ -1,0 +1,17 @@
+//! SRP-oriented facades over refactoring capabilities.
+
+/// Import analysis and organization APIs.
+pub mod imports {
+    pub use crate::refactor::import_optimizer::{
+        DuplicateImport, ImportAnalysis, ImportEntry, ImportOptimizer, MissingImport,
+        OrganizationSuggestion, SuggestionPriority, UnusedImport,
+    };
+}
+
+/// Core refactoring engine APIs.
+pub mod engine {
+    pub use crate::refactor::refactoring::{
+        ModernizationPattern, RefactoringConfig, RefactoringEngine, RefactoringOperation,
+        RefactoringResult, RefactoringScope, RefactoringType,
+    };
+}


### PR DESCRIPTION
### Motivation
- Group existing refactoring APIs into single-responsibility facades so consumers can discover and import focused surfaces instead of the whole `refactor` module.

### Description
- Add `crates/perl-parser/src/refactor/srp.rs` providing `imports` and `engine` SRP submodules and expose it from `crates/perl-parser/src/refactor/mod.rs` via `pub mod srp;` with no functional changes.

### Testing
- Verification: `cargo check -p perl-parser --lib --locked` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43386f0288333a3736cdb2b49a3f0)