### PR TITLE
refactor(perl-lexer): split checkpoint impl into submodule (#0000)

### DIFF
--- a/crates/perl-lexer/src/checkpoint_impl.rs
+++ b/crates/perl-lexer/src/checkpoint_impl.rs
@@ -1,0 +1,66 @@
+use crate::*;
+
+impl Checkpointable for PerlLexer<'_> {
+    fn checkpoint(&self) -> LexerCheckpoint {
+        use checkpoint::CheckpointContext;
+
+        // Determine the checkpoint context based on current state
+        let context = if matches!(self.mode, LexerMode::InFormatBody) {
+            CheckpointContext::Format {
+                start_position: self.position.saturating_sub(100), // Approximate
+            }
+        } else if !self.delimiter_stack.is_empty() {
+            // We're in some kind of quote-like construct
+            CheckpointContext::QuoteLike {
+                operator: String::new(), // Would need to track this
+                delimiter: self.delimiter_stack.last().copied().unwrap_or('\0'),
+                is_paired: true,
+            }
+        } else {
+            CheckpointContext::Normal
+        };
+
+        LexerCheckpoint {
+            position: self.position,
+            mode: self.mode,
+            delimiter_stack: self.delimiter_stack.clone(),
+            in_prototype: self.in_prototype,
+            prototype_depth: self.prototype_depth,
+            after_sub: self.after_sub,
+            after_arrow: self.after_arrow,
+            hash_brace_depth: self.hash_brace_depth,
+            after_var_subscript: self.after_var_subscript,
+            paren_depth: self.paren_depth,
+            current_pos: self.current_pos,
+            context,
+        }
+    }
+
+    fn restore(&mut self, checkpoint: &LexerCheckpoint) {
+        self.position = checkpoint.position;
+        self.mode = checkpoint.mode;
+        self.delimiter_stack.clone_from(&checkpoint.delimiter_stack);
+        self.in_prototype = checkpoint.in_prototype;
+        self.prototype_depth = checkpoint.prototype_depth;
+        self.after_sub = checkpoint.after_sub;
+        self.after_arrow = checkpoint.after_arrow;
+        self.hash_brace_depth = checkpoint.hash_brace_depth;
+        self.after_var_subscript = checkpoint.after_var_subscript;
+        self.paren_depth = checkpoint.paren_depth;
+        self.current_pos = checkpoint.current_pos;
+
+        // Handle special contexts
+        use checkpoint::CheckpointContext;
+        if let CheckpointContext::Format { .. } = &checkpoint.context {
+            // Ensure we're in format body mode
+            if !matches!(self.mode, LexerMode::InFormatBody) {
+                self.mode = LexerMode::InFormatBody;
+            }
+        }
+    }
+
+    fn can_restore(&self, checkpoint: &LexerCheckpoint) -> bool {
+        // Can restore if the position is valid for our input
+        checkpoint.position <= self.input.len()
+    }
+}

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -3288,73 +3288,10 @@ fn is_compound_operator(first: char, second: char) -> bool {
 }
 
 // Checkpoint support for incremental parsing
-impl Checkpointable for PerlLexer<'_> {
-    fn checkpoint(&self) -> LexerCheckpoint {
-        use checkpoint::CheckpointContext;
 
-        // Determine the checkpoint context based on current state
-        let context = if matches!(self.mode, LexerMode::InFormatBody) {
-            CheckpointContext::Format {
-                start_position: self.position.saturating_sub(100), // Approximate
-            }
-        } else if !self.delimiter_stack.is_empty() {
-            // We're in some kind of quote-like construct
-            CheckpointContext::QuoteLike {
-                operator: String::new(), // Would need to track this
-                delimiter: self.delimiter_stack.last().copied().unwrap_or('\0'),
-                is_paired: true,
-            }
-        } else {
-            CheckpointContext::Normal
-        };
-
-        LexerCheckpoint {
-            position: self.position,
-            mode: self.mode,
-            delimiter_stack: self.delimiter_stack.clone(),
-            in_prototype: self.in_prototype,
-            prototype_depth: self.prototype_depth,
-            after_sub: self.after_sub,
-            after_arrow: self.after_arrow,
-            hash_brace_depth: self.hash_brace_depth,
-            after_var_subscript: self.after_var_subscript,
-            paren_depth: self.paren_depth,
-            current_pos: self.current_pos,
-            context,
-        }
-    }
-
-    fn restore(&mut self, checkpoint: &LexerCheckpoint) {
-        self.position = checkpoint.position;
-        self.mode = checkpoint.mode;
-        self.delimiter_stack.clone_from(&checkpoint.delimiter_stack);
-        self.in_prototype = checkpoint.in_prototype;
-        self.prototype_depth = checkpoint.prototype_depth;
-        self.after_sub = checkpoint.after_sub;
-        self.after_arrow = checkpoint.after_arrow;
-        self.hash_brace_depth = checkpoint.hash_brace_depth;
-        self.after_var_subscript = checkpoint.after_var_subscript;
-        self.paren_depth = checkpoint.paren_depth;
-        self.current_pos = checkpoint.current_pos;
-
-        // Handle special contexts
-        use checkpoint::CheckpointContext;
-        if let CheckpointContext::Format { .. } = &checkpoint.context {
-            // Ensure we're in format body mode
-            if !matches!(self.mode, LexerMode::InFormatBody) {
-                self.mode = LexerMode::InFormatBody;
-            }
-        }
-    }
-
-    fn can_restore(&self, checkpoint: &LexerCheckpoint) -> bool {
-        // Can restore if the position is valid for our input
-        checkpoint.position <= self.input.len()
-    }
-}
+mod checkpoint_impl;
 
 #[cfg(test)]
 mod test_format_debug;
-
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Problem: `perl-lexer` still kept `Checkpointable` wiring in the large crate root after the test module split landed.

Fix: Move the `PerlLexer` checkpoint implementation into `checkpoint_impl.rs` and leave `lib.rs` as the module composition point.

Verification: `cargo fmt --package perl-lexer`, `cargo check -p perl-lexer --all-targets --locked`, `cargo test -p perl-lexer --locked`, `cargo clippy -p perl-lexer --all-targets --locked -- -D warnings`, and `git diff --check origin/master...HEAD` pass.