### PR TITLE
refactor(perl-lsp-rs): split text sync classification helpers (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync/classification.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync/classification.rs
@@ -1,0 +1,13 @@
+const TEMPLATE_EXTENSIONS: [&str; 4] = ["ep", "tt", "tt2", "mason"];
+
+pub(super) fn is_embedded_template_uri(uri: &str) -> bool {
+    perl_uri::uri_extension(uri)
+        .is_some_and(|ext| TEMPLATE_EXTENSIONS.iter().any(|template| template.eq_ignore_ascii_case(ext)))
+}
+
+pub(super) fn is_perl_language_id(language_id: &str) -> bool {
+    matches!(
+        language_id.to_ascii_lowercase().as_str(),
+        "perl" | "perl5" | "perl-cpanfile" | "embedded-perl" | "mojolicious"
+    )
+}

--- a/crates/perl-lsp-rs/src/runtime/text_sync/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync/mod.rs
@@ -8,26 +8,15 @@
 //! reparsed — incremental *parsing* is future work.  The sync kind is about
 //! how document text is transferred, not the parsing strategy.
 
+mod classification;
+
 use super::*;
 use crate::protocol::invalid_params;
+use crate::runtime::text_sync::classification::{is_embedded_template_uri, is_perl_language_id};
 use crate::state::DegradationTier;
 #[cfg(feature = "workspace")]
 use perl_parser::workspace_index::{IndexPhase, IndexState};
 use perl_parser_core::source_file::is_binary_content;
-
-const TEMPLATE_EXTENSIONS: [&str; 4] = ["ep", "tt", "tt2", "mason"];
-
-fn is_embedded_template_uri(uri: &str) -> bool {
-    perl_uri::uri_extension(uri)
-        .is_some_and(|ext| TEMPLATE_EXTENSIONS.iter().any(|t| t.eq_ignore_ascii_case(ext)))
-}
-
-fn is_perl_language_id(language_id: &str) -> bool {
-    matches!(
-        language_id.to_ascii_lowercase().as_str(),
-        "perl" | "perl5" | "perl-cpanfile" | "embedded-perl" | "mojolicious"
-    )
-}
 
 #[cfg(feature = "incremental")]
 fn build_incremental_edit_set(


### PR DESCRIPTION
### Motivation

- Reduce responsibility creep in `runtime/text_sync` by separating document/language classification helpers from synchronization logic so each module has a single responsibility.

### Description

- Move classification constants and helper functions into a dedicated submodule at `crates/perl-lsp-rs/src/runtime/text_sync/classification.rs`.
- Rename `crates/perl-lsp-rs/src/runtime/text_sync.rs` to `crates/perl-lsp-rs/src/runtime/text_sync/mod.rs` and add `mod classification;` to the module.
- Update imports in `text_sync` to use `crate::runtime::text_sync::classification::{is_embedded_template_uri, is_perl_language_id}`.

### Testing

- Ran `./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked`, which was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so a full local check could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f433a5d49883339108000cac277294)