### PR TITLE
refactor(perl-lsp-rs): extract runtime support types module (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -4,6 +4,10 @@
 //! that can be used with any LSP-compatible editor.
 
 use crate::runtime::diagnostics::PullDiagnosticsOrchestrator;
+use crate::runtime::types::{
+    DocumentScanView, PendingWorkspaceConfigurationRequest, source_path_from_uri,
+    workspace_folder_matches_doc_uri, workspace_folder_path,
+};
 use crate::runtime::workspace_folder::WorkspaceFolderState;
 
 mod client_requests;
@@ -30,6 +34,7 @@ mod symbol_extraction;
 mod test_api;
 mod test_runners;
 mod text_sync;
+mod types;
 mod window;
 mod workspace;
 mod workspace_folder;
@@ -109,7 +114,6 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering},
 };
-use std::time::Instant;
 use url::Url;
 
 #[cfg(feature = "workspace")]
@@ -121,80 +125,6 @@ use perl_position_tracking::{WireLocation, WirePosition, WireRange};
 
 #[cfg(feature = "workspace")]
 use crate::fallback::text::extract_text_based_symbols;
-
-pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    // On Windows, filesystem paths like `C:\file` can be misparsed by Url::parse()
-    // as having scheme `C`. Check for Windows drive letters first.
-    // Drive letter pattern: exactly one letter, followed by `:`, not followed by `//` (which would be a URL).
-    if uri.len() > 2 && uri.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
-        if uri.chars().nth(1) == Some(':') && !uri.starts_with("file://") {
-            // Looks like a Windows path (e.g., `C:\...`). Try to parse as path, not URL.
-            let path = Path::new(uri);
-            if path.is_absolute() {
-                return Some(path.to_path_buf());
-            }
-        }
-    }
-
-    if let Ok(value) = Url::parse(uri) {
-        return if value.scheme() == "file" { value.to_file_path().ok() } else { None };
-    }
-
-    let path = Path::new(uri);
-    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
-}
-
-fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {
-    folder.path.clone().or_else(|| source_path_from_uri(&folder.uri))
-}
-
-fn workspace_folder_matches_doc_uri(folder: &WorkspaceFolderState, doc_uri: &str) -> bool {
-    let doc_path = source_path_from_uri(doc_uri);
-    match (doc_path, workspace_folder_path(folder)) {
-        (Some(doc_path), Some(folder_path)) => doc_path.starts_with(folder_path),
-        _ => {
-            let folder_uri = folder.uri.trim_end_matches('/');
-            doc_uri == folder.uri
-                || doc_uri == folder_uri
-                || doc_uri.strip_prefix(folder_uri).is_some_and(|suffix| suffix.starts_with('/'))
-        }
-    }
-}
-
-/// Tracks metadata for a pending `workspace/configuration` reverse request.
-#[derive(Debug, Clone)]
-pub(crate) struct PendingWorkspaceConfigurationRequest {
-    /// Workspace folder URIs requested in this call.
-    pub(crate) folder_uris: Vec<String>,
-    /// Whether the response includes an unscoped global `perl` settings item first.
-    pub(crate) includes_global_item: bool,
-    /// Request creation time used for stale-request cleanup.
-    pub(crate) created_at: Instant,
-}
-
-/// Lightweight view of a document for scan-heavy operations
-///
-/// This struct provides the minimal data needed for workspace-wide scans
-/// (code lens resolve, reference counting) without requiring the full
-/// DocumentState. Using this snapshot pattern allows the documents lock
-/// to be released before CPU-intensive work begins.
-///
-/// ## Design Rationale
-/// - `uri`: Needed to construct LSP Location responses
-/// - `text`: Needed for text-based fallback searches (regex, line iteration)
-/// - `ast`: Arc clone allows AST traversal without deep copying the tree
-///
-/// The rope, line_starts cache, parent_map, and other fields are omitted
-/// as they're not typically needed for bulk scan operations.
-pub(crate) struct DocumentScanView {
-    /// Document URI for constructing Location responses
-    #[allow(dead_code)] // Preserved for future scan operations that build Location responses
-    pub uri: String,
-    /// Document text content for text-based searches
-    pub text: String,
-    /// Optional AST reference (Arc clone) for AST-based operations
-    pub ast: Option<Arc<perl_parser::ast::Node>>,
-}
 
 // Note: FQN_RE regex moved to language/navigation.rs
 

--- a/crates/perl-lsp-rs/src/runtime/types.rs
+++ b/crates/perl-lsp-rs/src/runtime/types.rs
@@ -1,0 +1,81 @@
+use super::workspace_folder::WorkspaceFolderState;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+use url::Url;
+
+pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
+    // On Windows, filesystem paths like `C:\file` can be misparsed by Url::parse()
+    // as having scheme `C`. Check for Windows drive letters first.
+    // Drive letter pattern: exactly one letter, followed by `:`, not followed by `//` (which would be a URL).
+    if uri.len() > 2 && uri.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        if uri.chars().nth(1) == Some(':') && !uri.starts_with("file://") {
+            // Looks like a Windows path (e.g., `C:\...`). Try to parse as path, not URL.
+            let path = Path::new(uri);
+            if path.is_absolute() {
+                return Some(path.to_path_buf());
+            }
+        }
+    }
+
+    if let Ok(value) = Url::parse(uri) {
+        return if value.scheme() == "file" { value.to_file_path().ok() } else { None };
+    }
+
+    let path = Path::new(uri);
+    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
+}
+
+pub(super) fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {
+    folder.path.clone().or_else(|| source_path_from_uri(&folder.uri))
+}
+
+pub(super) fn workspace_folder_matches_doc_uri(
+    folder: &WorkspaceFolderState,
+    doc_uri: &str,
+) -> bool {
+    let doc_path = source_path_from_uri(doc_uri);
+    match (doc_path, workspace_folder_path(folder)) {
+        (Some(doc_path), Some(folder_path)) => doc_path.starts_with(folder_path),
+        _ => {
+            let folder_uri = folder.uri.trim_end_matches('/');
+            doc_uri == folder.uri
+                || doc_uri == folder_uri
+                || doc_uri.strip_prefix(folder_uri).is_some_and(|suffix| suffix.starts_with('/'))
+        }
+    }
+}
+
+/// Tracks metadata for a pending `workspace/configuration` reverse request.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingWorkspaceConfigurationRequest {
+    /// Workspace folder URIs requested in this call.
+    pub(crate) folder_uris: Vec<String>,
+    /// Whether the response includes an unscoped global `perl` settings item first.
+    pub(crate) includes_global_item: bool,
+    /// Request creation time used for stale-request cleanup.
+    pub(crate) created_at: Instant,
+}
+
+/// Lightweight view of a document for scan-heavy operations
+///
+/// This struct provides the minimal data needed for workspace-wide scans
+/// (code lens resolve, reference counting) without requiring the full
+/// DocumentState. Using this snapshot pattern allows the documents lock
+/// to be released before CPU-intensive work begins.
+///
+/// ## Design Rationale
+/// - `uri`: Needed to construct LSP Location responses
+/// - `text`: Needed for text-based fallback searches (regex, line iteration)
+/// - `ast`: Arc clone allows AST traversal without deep copying the tree
+///
+/// The rope, line_starts cache, parent_map, and other fields are omitted
+/// as they're not typically needed for bulk scan operations.
+pub(crate) struct DocumentScanView {
+    /// Document URI for constructing Location responses
+    #[allow(dead_code)] // Preserved for future scan operations that build Location responses
+    pub uri: String,
+    /// Document text content for text-based searches
+    pub text: String,
+    /// Optional AST reference (Arc clone) for AST-based operations
+    pub ast: Option<std::sync::Arc<perl_parser::ast::Node>>,
+}


### PR DESCRIPTION
### Motivation

- Reduce responsibility concentration in `runtime/mod.rs` by moving URI/path helpers and small runtime support types into a dedicated submodule so the core server orchestration remains focused.
- Improve SRP and make the runtime module easier to navigate and maintain by grouping related helper functions and lightweight view structs.

### Description

- Added `crates/perl-lsp-rs/src/runtime/types.rs` and moved `source_path_from_uri`, `workspace_folder_path`, `workspace_folder_matches_doc_uri`, `PendingWorkspaceConfigurationRequest`, and `DocumentScanView` into it.
- Updated `crates/perl-lsp-rs/src/runtime/mod.rs` to `mod types;` and to import the extracted items from `crate::runtime::types` (removing the moved definitions from the root runtime file).
- Adjusted `use` statements in `runtime/mod.rs` (removed direct `Path` import and re-exported the helper symbols from the new `types` submodule).

### Testing

- Ran `./scripts/cargo-safe xtask fmt` which completed successfully.
- Attempted `./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked` but the run was blocked by the environment storage policy (`DENY: /root/.cache/devplane/perl-lsp used=50% free=30G`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f433a5d49883339108000cac277294)