### PR TITLE
refactor(perl-lsp-rs): split code-actions provider into SRP submodules (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -4,52 +4,11 @@ use crate::features::diagnostics::Diagnostic;
 use perl_diagnostics::codes::DiagnosticCode;
 
 mod fixes;
+mod parse_errors;
 mod source_utils;
+mod types;
 
-/// Represents a code action (quick-fix) that can be applied to resolve a diagnostic
-///
-/// Code actions provide automated fixes and refactoring operations for Perl code.
-#[derive(Debug, Clone)]
-pub struct CodeAction {
-    /// Human-readable title describing the action
-    pub title: String,
-    /// The kind/category of code action
-    pub kind: CodeActionKind,
-    /// The text edit to apply
-    pub edit: TextEdit,
-    /// ID of the diagnostic this action fixes
-    pub diagnostic_id: Option<String>,
-    /// Exact diagnostic range this action was derived from
-    pub diagnostic_range: Option<(usize, usize)>,
-}
-
-/// Kind of code action
-///
-/// Categorizes the type of code action to help editors organize actions.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CodeActionKind {
-    /// Quick fix for a diagnostic issue
-    QuickFix,
-    /// General refactoring operation
-    Refactor,
-    /// Extract code into a new construct
-    RefactorExtract,
-    /// Inline a construct into its usage sites
-    RefactorInline,
-    /// Rewrite code using a different pattern
-    RefactorRewrite,
-}
-
-/// Text edit operation
-///
-/// Represents a change to be made to source code.
-#[derive(Debug, Clone)]
-pub struct TextEdit {
-    /// The range of text to replace (start, end)
-    pub range: (usize, usize),
-    /// The new text to insert
-    pub new_text: String,
-}
+pub use types::{CodeAction, CodeActionKind, TextEdit};
 
 /// Provides code actions (quick-fixes) for diagnostics
 ///
@@ -139,8 +98,10 @@ impl CodeActionsProvider {
             }
             // PL001 / PL002 are general parse error codes. Route known parse
             // message patterns through the same targeted parse quick-fixes.
-            Some("PL001") | Some("PL002") => parse_error_fix_code_from_message(&diagnostic.message)
-                .map_or_else(Vec::new, |code| fixes::fix_parse_error(self, diagnostic, code)),
+            Some("PL001") | Some("PL002") => {
+                parse_errors::parse_error_fix_code_from_message(&diagnostic.message)
+                    .map_or_else(Vec::new, |code| fixes::fix_parse_error(self, diagnostic, code))
+            }
             _ => Vec::new(),
         }
     }
@@ -148,26 +109,6 @@ impl CodeActionsProvider {
     pub(super) fn source(&self) -> &str {
         &self.source
     }
-}
-
-fn parse_error_fix_code_from_message(message: &str) -> Option<&'static str> {
-    let message_lower = message.to_ascii_lowercase();
-    if message_lower.contains("missing semicolon") {
-        return Some("parse-error-missingsemicolon");
-    }
-    if message_lower.contains("unclosed string") || message_lower.contains("unterminated string") {
-        return Some("parse-error-unclosedstring");
-    }
-    if message_lower.contains("unclosed parenthesis") {
-        return Some("parse-error-unclosedparen");
-    }
-    if message_lower.contains("unclosed brace")
-        || message_lower.contains("missing '}'")
-        || message_lower.contains("unclosed `{`")
-    {
-        return Some("parse-error-unclosedbrace");
-    }
-    None
 }
 
 #[cfg(test)]

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/parse_errors.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/parse_errors.rs
@@ -1,0 +1,19 @@
+pub(super) fn parse_error_fix_code_from_message(message: &str) -> Option<&'static str> {
+    let message_lower = message.to_ascii_lowercase();
+    if message_lower.contains("missing semicolon") {
+        return Some("parse-error-missingsemicolon");
+    }
+    if message_lower.contains("unclosed string") || message_lower.contains("unterminated string") {
+        return Some("parse-error-unclosedstring");
+    }
+    if message_lower.contains("unclosed parenthesis") {
+        return Some("parse-error-unclosedparen");
+    }
+    if message_lower.contains("unclosed brace")
+        || message_lower.contains("missing '}'")
+        || message_lower.contains("unclosed `{`")
+    {
+        return Some("parse-error-unclosedbrace");
+    }
+    None
+}

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/types.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/types.rs
@@ -1,0 +1,44 @@
+/// Represents a code action (quick-fix) that can be applied to resolve a diagnostic
+///
+/// Code actions provide automated fixes and refactoring operations for Perl code.
+#[derive(Debug, Clone)]
+pub struct CodeAction {
+    /// Human-readable title describing the action
+    pub title: String,
+    /// The kind/category of code action
+    pub kind: CodeActionKind,
+    /// The text edit to apply
+    pub edit: TextEdit,
+    /// ID of the diagnostic this action fixes
+    pub diagnostic_id: Option<String>,
+    /// Exact diagnostic range this action was derived from
+    pub diagnostic_range: Option<(usize, usize)>,
+}
+
+/// Kind of code action
+///
+/// Categorizes the type of code action to help editors organize actions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CodeActionKind {
+    /// Quick fix for a diagnostic issue
+    QuickFix,
+    /// General refactoring operation
+    Refactor,
+    /// Extract code into a new construct
+    RefactorExtract,
+    /// Inline a construct into its usage sites
+    RefactorInline,
+    /// Rewrite code using a different pattern
+    RefactorRewrite,
+}
+
+/// Text edit operation
+///
+/// Represents a change to be made to source code.
+#[derive(Debug, Clone)]
+pub struct TextEdit {
+    /// The range of text to replace (start, end)
+    pub range: (usize, usize),
+    /// The new text to insert
+    pub new_text: String,
+}


### PR DESCRIPTION
### Motivation
- The `code_actions_provider/mod.rs` combined domain types, parse-error heuristics, and provider orchestration in a single large file, making it harder to reason about each responsibility.
- Split responsibilities to follow the single-responsibility principle and make future maintenance and testing simpler.

### Description
- Extracted the code-action domain types (`CodeAction`, `CodeActionKind`, `TextEdit`) into `crates/perl-lsp-rs/src/features/code_actions_provider/types.rs` and re-exported them from `mod.rs` via `pub use types::{...}` to preserve the public surface.
- Moved the parse-error message-to-fix-code mapping into `crates/perl-lsp-rs/src/features/code_actions_provider/parse_errors.rs` and updated call sites to use `parse_errors::parse_error_fix_code_from_message(...)`.
- Kept `mod.rs` as the orchestration entrypoint and left existing tests in place; only module boundaries and the helper call site were changed.

### Testing
- Ran `cargo test -p perl-lsp-rs --locked`, which compiled the crate and workspace dependencies and produced warnings while progressing, but a full, clean test run was not captured to completion in this session.
- Attempted `./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked`, which was blocked by the environment storage policy (`DENY: /root/.cache/devplane/perl-lsp ...`).
- No production tests were disabled or modified as part of this refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f433bc95c88333b00b9bcb5a82cdab)