### PR TITLE
refactor(xtask): separate SRP command submodule (#0000)

### DIFF
--- a/xtask/src/cli/mod.rs
+++ b/xtask/src/cli/mod.rs
@@ -1,0 +1,1 @@
+pub mod srp;

--- a/xtask/src/cli/srp.rs
+++ b/xtask/src/cli/srp.rs
@@ -1,0 +1,46 @@
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Args)]
+pub struct SrpMicrocratesArgs {
+    /// Optional output path (default: docs/SRP_MICROCRATES.md)
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct UnwiredScanArgs {
+    /// Emit JSON to stdout instead of human-readable output
+    #[arg(long)]
+    pub json: bool,
+
+    /// Exit 1 if any unwired crates are found (CI gate mode)
+    #[arg(long)]
+    pub check: bool,
+
+    /// Name of the root LSP crate to check (default: perl-lsp-rs)
+    #[arg(long, default_value = "perl-lsp-rs")]
+    pub lsp_crate: String,
+}
+
+#[derive(Subcommand)]
+pub enum SrpCommand {
+    /// Generate SRP microcrate inventory and split-candidate report
+    Microcrates(SrpMicrocratesArgs),
+
+    /// Enforce crate layer-dependency constraints (leaf crates must not depend on higher layers).
+    ///
+    /// Current rules:
+    ///   - perl-diagnostics must NOT depend on any perl-lsp-* crate.
+    LayerCheck,
+
+    /// Scan for built-but-not-wired crates: those with tests but zero import by perl-lsp
+    ///
+    /// Finds crates that have `#[test]` annotations but are not listed as direct
+    /// dependencies of `perl-lsp`. Also surfaces TODO/FIXME wiring comments.
+    /// Use `--check` to make CI fail when unwired crates are found.
+    UnwiredScan(UnwiredScanArgs),
+
+    /// Check that test-bearing Rust files are reachable from their module tree.
+    CheckTestWiring,
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4,9 +4,11 @@
 //! and maintaining the tree-sitter-perl project.
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use cli::srp::{SrpCommand, SrpMicrocratesArgs, UnwiredScanArgs};
 use color_eyre::eyre::{Result, eyre};
 use std::path::PathBuf;
 
+mod cli;
 mod tasks;
 mod types;
 mod utils;
@@ -1033,36 +1035,25 @@ enum Commands {
         only: Option<update_status::StatusSubsystem>,
     },
 
-    /// Generate SRP microcrate inventory and split-candidate report
-    SrpMicrocrates {
-        /// Optional output path (default: docs/SRP_MICROCRATES.md)
-        #[arg(long)]
-        output: Option<PathBuf>,
+    /// SRP-oriented crate topology and wiring checks.
+    Srp {
+        #[command(subcommand)]
+        command: SrpCommand,
     },
 
-    /// Enforce crate layer-dependency constraints (leaf crates must not depend on higher layers).
-    ///
-    /// Current rules:
-    ///   - perl-diagnostics must NOT depend on any perl-lsp-* crate.
+    /// Generate SRP microcrate inventory and split-candidate report.
+    SrpMicrocrates {
+        #[command(flatten)]
+        args: SrpMicrocratesArgs,
+    },
+
+    /// Enforce crate layer-dependency constraints.
     LayerCheck,
 
-    /// Scan for built-but-not-wired crates: those with tests but zero import by perl-lsp
-    ///
-    /// Finds crates that have `#[test]` annotations but are not listed as direct
-    /// dependencies of `perl-lsp`. Also surfaces TODO/FIXME wiring comments.
-    /// Use `--check` to make CI fail when unwired crates are found.
+    /// Scan for built-but-not-wired crates.
     UnwiredScan {
-        /// Emit JSON to stdout instead of human-readable output
-        #[arg(long)]
-        json: bool,
-
-        /// Exit 1 if any unwired crates are found (CI gate mode)
-        #[arg(long)]
-        check: bool,
-
-        /// Name of the root LSP crate to check (default: perl-lsp-rs)
-        #[arg(long, default_value = "perl-lsp-rs")]
-        lsp_crate: String,
+        #[command(flatten)]
+        args: UnwiredScanArgs,
     },
 
     /// Check that test-bearing Rust files are reachable from their module tree.
@@ -2125,10 +2116,23 @@ fn main() -> Result<()> {
             FixForwardCommand::ListPlaybooks => fix_forward::list_playbooks(),
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
-        Commands::SrpMicrocrates { output } => srp_microcrates::run(output),
-        Commands::UnwiredScan { json, check, lsp_crate } => {
-            unwired_scan::run(UnwiredScanConfig { lsp_crate, json, check })
-        }
+        Commands::Srp { command } => match command {
+            SrpCommand::Microcrates(args) => srp_microcrates::run(args.output),
+            SrpCommand::LayerCheck => layer_check::run(),
+            SrpCommand::UnwiredScan(args) => unwired_scan::run(UnwiredScanConfig {
+                lsp_crate: args.lsp_crate,
+                json: args.json,
+                check: args.check,
+            }),
+            SrpCommand::CheckTestWiring => check_test_wiring::run(),
+        },
+        Commands::SrpMicrocrates { args } => srp_microcrates::run(args.output),
+        Commands::LayerCheck => layer_check::run(),
+        Commands::UnwiredScan { args } => unwired_scan::run(UnwiredScanConfig {
+            lsp_crate: args.lsp_crate,
+            json: args.json,
+            check: args.check,
+        }),
         Commands::CheckTestWiring => check_test_wiring::run(),
         Commands::Metrics { command } => match command {
             MetricsCommand::ParserStats { input, json } => metrics::parser_stats::run(input, json),
@@ -2243,7 +2247,6 @@ fn main() -> Result<()> {
             swarm_summary::run(swarm_summary::SwarmSummaryConfig { ops_dir, since, limit, format })
         }
         Commands::PopulateBook => populate_book::run(),
-        Commands::LayerCheck => layer_check::run(),
         Commands::ValidateWorkspaceExclusions => validate_workspace_exclusions::run(),
         Commands::BuildTimingReceipt { clean, incremental, tests, output, baseline } => {
             build_timing::run_receipt(clean, incremental, tests, output, baseline)

--- a/xtask/tests/list_commands_cli.rs
+++ b/xtask/tests/list_commands_cli.rs
@@ -12,7 +12,12 @@ fn list_commands_emits_sorted_top_level_names() -> Result<()> {
 
     assert!(lines.contains(&"ci"));
     assert!(lines.contains(&"check-only"));
+    assert!(lines.contains(&"check-test-wiring"));
+    assert!(lines.contains(&"layer-check"));
     assert!(lines.contains(&"list-commands"));
+    assert!(lines.contains(&"srp"));
+    assert!(lines.contains(&"srp-microcrates"));
+    assert!(lines.contains(&"unwired-scan"));
 
     let mut sorted = lines.clone();
     sorted.sort_unstable();


### PR DESCRIPTION
Problem: SRP-oriented xtask command argument structs lived in the main command enum, making the CLI surface harder to split without risking existing command names.
Fix: move SRP command args into `xtask::cli::srp`, add grouped `cargo xtask srp ...` commands, and keep existing top-level `srp-microcrates`, `layer-check`, `unwired-scan`, and `check-test-wiring` commands intact.
Verification: `cargo check -p xtask --all-targets --locked`; `cargo test -p xtask --test unwired_scan_tests --locked -- --nocapture`; `cargo test -p xtask --test list_commands_cli --locked -- --nocapture`; `cargo run -p xtask -- --help`; `cargo run -p xtask -- srp --help`; `git diff --check`.
