### PR TITLE
refactor(xtask): separate SRP command submodule (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1033,11 +1033,10 @@ enum Commands {
         only: Option<update_status::StatusSubsystem>,
     },
 
-    /// Generate SRP microcrate inventory and split-candidate report
-    SrpMicrocrates {
-        /// Optional output path (default: docs/SRP_MICROCRATES.md)
-        #[arg(long)]
-        output: Option<PathBuf>,
+    /// Run SRP analysis and inventory tooling.
+    Srp {
+        #[command(subcommand)]
+        command: SrpCommand,
     },
 
     /// Enforce crate layer-dependency constraints (leaf crates must not depend on higher layers).
@@ -1694,6 +1693,16 @@ enum QueueCommand {
 }
 
 #[derive(Subcommand)]
+enum SrpCommand {
+    /// Generate SRP microcrate inventory and split-candidate report
+    Microcrates {
+        /// Optional output path (default: docs/SRP_MICROCRATES.md)
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
 enum AgentCommand {
     /// Lease lifecycle commands.
     Lease {
@@ -2125,7 +2134,9 @@ fn main() -> Result<()> {
             FixForwardCommand::ListPlaybooks => fix_forward::list_playbooks(),
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
-        Commands::SrpMicrocrates { output } => srp_microcrates::run(output),
+        Commands::Srp { command } => match command {
+            SrpCommand::Microcrates { output } => srp_microcrates::run(output),
+        },
         Commands::UnwiredScan { json, check, lsp_crate } => {
             unwired_scan::run(UnwiredScanConfig { lsp_crate, json, check })
         }


### PR DESCRIPTION
### Motivation

- Group SRP-related CLI functionality under a single namespace so future SRP subcommands can be added without expanding the top-level command enum.

### Description

- Replace the top-level `SrpMicrocrates` command variant with a new `Srp` command that owns SRP-focused subcommands via a `SrpCommand` enum.
- Add `SrpCommand::Microcrates { output }` to preserve the existing microcrate report behavior.
- Update the command dispatch to route `Commands::Srp { command }` to `srp_microcrates::run(output)` for the microcrates case.
- Change is confined to `xtask/src/main.rs` and preserves prior CLI semantics as `srp microcrates`.

### Testing

- Attempted `./scripts/cargo-safe check -p xtask --all-targets --profile agent --locked`, but the run was blocked by the environment storage policy (`DENY: /root/.cache/devplane/...`).
- No other automated tests could be executed in this environment; source changes are limited and compile-check was the intended verification step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f447c0c3048333aa9679c4decb4601)