### PR TITLE
refactor(xtask): group SRP commands under submodule tree (#0000)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1033,11 +1033,10 @@ enum Commands {
         only: Option<update_status::StatusSubsystem>,
     },
 
-    /// Generate SRP microcrate inventory and split-candidate report
-    SrpMicrocrates {
-        /// Optional output path (default: docs/SRP_MICROCRATES.md)
-        #[arg(long)]
-        output: Option<PathBuf>,
+    /// SRP-focused reporting and decomposition utilities.
+    Srp {
+        #[command(subcommand)]
+        command: SrpCommand,
     },
 
     /// Enforce crate layer-dependency constraints (leaf crates must not depend on higher layers).
@@ -1744,6 +1743,16 @@ enum AgentReceiptCommand {
     },
 }
 
+#[derive(Subcommand)]
+enum SrpCommand {
+    /// Generate SRP microcrate inventory and split-candidate report
+    Microcrates {
+        /// Optional output path (default: docs/SRP_MICROCRATES.md)
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+}
+
 #[derive(ValueEnum, Clone)]
 enum PrepCratesMode {
     Core,
@@ -2125,7 +2134,9 @@ fn main() -> Result<()> {
             FixForwardCommand::ListPlaybooks => fix_forward::list_playbooks(),
         },
         Commands::UpdateStatus { write, check, only } => update_status::run(write, check, only),
-        Commands::SrpMicrocrates { output } => srp_microcrates::run(output),
+        Commands::Srp { command } => match command {
+            SrpCommand::Microcrates { output } => srp_microcrates::run(output),
+        },
         Commands::UnwiredScan { json, check, lsp_crate } => {
             unwired_scan::run(UnwiredScanConfig { lsp_crate, json, check })
         }


### PR DESCRIPTION
### Motivation
- Group SRP-related utilities under an `srp` command namespace to keep the `xtask` top-level command surface cohesive as SRP features expand.

### Description
- Replace the top-level `SrpMicrocrates` command with a `Srp` subcommand that contains a new `SrpCommand` enum and move the microcrates action to `SrpCommand::Microcrates`, updating the dispatch in `xtask/src/main.rs` accordingly.

### Testing
- Attempted `./scripts/cargo-safe check -p xtask --all-targets --profile agent --locked`, but the check was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp ...`), so no successful automated checks were completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f447c0c3048333aa9679c4decb4601)