### PR TITLE
refactor(xtask): extract gate planning types submodule (#0000)

### DIFF
--- a/xtask/src/tasks/gates.rs
+++ b/xtask/src/tasks/gates.rs
@@ -36,7 +36,11 @@ use crate::tasks::ci_scope::{self, ScopeOutput};
 use crate::utils::project_root;
 
 mod first_failure;
+mod planning_types;
+
 pub use first_failure::{is_cargo_test_command, parse_first_failure};
+
+use planning_types::{GatePlan, PackageTargetIndex, PlannedGate, SkippedGate};
 
 // =============================================================================
 // CLI Types
@@ -532,44 +536,6 @@ pub struct MetricChange {
 // =============================================================================
 // Gate Runner Implementation
 // =============================================================================
-
-#[derive(Debug, Clone)]
-struct GatePlan {
-    tier: GateTier,
-    base: String,
-    scope: Option<ScopeOutput>,
-    scope_ok: bool,
-    fallback_used: bool,
-    fallback_reason: Option<String>,
-    package_args: Vec<String>,
-    selected: Vec<PlannedGate>,
-    skipped: Vec<SkippedGate>,
-}
-
-#[derive(Debug, Clone)]
-struct PlannedGate {
-    gate: GateDefinition,
-    role: GatePlanningRole,
-    reason: String,
-}
-
-#[derive(Debug, Clone)]
-struct SkippedGate {
-    name: String,
-    role: Option<GatePlanningRole>,
-    reason: String,
-}
-
-#[derive(Debug, Clone, Default)]
-struct PackageTargetIndex {
-    lib_packages: HashSet<String>,
-}
-
-impl PackageTargetIndex {
-    fn has_lib(&self, package: &str) -> bool {
-        self.lib_packages.contains(package)
-    }
-}
 
 /// Configuration for the gate runner
 pub struct GateRunnerConfig {

--- a/xtask/src/tasks/gates/planning_types.rs
+++ b/xtask/src/tasks/gates/planning_types.rs
@@ -1,0 +1,43 @@
+use std::collections::HashSet;
+
+use crate::tasks::ci_scope::ScopeOutput;
+
+use super::{GateDefinition, GatePlanningRole, GateTier};
+
+#[derive(Debug, Clone)]
+pub(super) struct GatePlan {
+    pub(super) tier: GateTier,
+    pub(super) base: String,
+    pub(super) scope: Option<ScopeOutput>,
+    pub(super) scope_ok: bool,
+    pub(super) fallback_used: bool,
+    pub(super) fallback_reason: Option<String>,
+    pub(super) package_args: Vec<String>,
+    pub(super) selected: Vec<PlannedGate>,
+    pub(super) skipped: Vec<SkippedGate>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PlannedGate {
+    pub(super) gate: GateDefinition,
+    pub(super) role: GatePlanningRole,
+    pub(super) reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct SkippedGate {
+    pub(super) name: String,
+    pub(super) role: Option<GatePlanningRole>,
+    pub(super) reason: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct PackageTargetIndex {
+    pub(super) lib_packages: HashSet<String>,
+}
+
+impl PackageTargetIndex {
+    pub(super) fn has_lib(&self, package: &str) -> bool {
+        self.lib_packages.contains(package)
+    }
+}


### PR DESCRIPTION
Problem: gate planning data structs were embedded in the large gate runner module, increasing review surface for future gate-planning changes.
Fix: move `GatePlan`, `PlannedGate`, `SkippedGate`, and `PackageTargetIndex` into a private `planning_types` submodule without changing behavior.
Verification: `cargo check -p xtask --all-targets --locked`; `cargo test -p xtask tasks::gates --locked -- --nocapture`; `git diff --check`.
