### PR TITLE
refactor(perl-parser): add facade core/prelude/compat modules (#0000)

### DIFF
--- a/crates/perl-parser/src/compat.rs
+++ b/crates/perl-parser/src/compat.rs
@@ -1,0 +1,4 @@
+//! Backwards-compatible re-exports.
+//! Prefer `perl_parser::prelude::*` or canonical domain modules.
+
+pub use crate::engine::{error, parser, position};

--- a/crates/perl-parser/src/core.rs
+++ b/crates/perl-parser/src/core.rs
@@ -1,0 +1,6 @@
+//! Facade over parser kernel types from `perl-parser-core`.
+
+pub use crate::engine::{ast, error, parser, position};
+pub use perl_parser_core::ast::{Node, NodeKind, SourceLocation};
+pub use perl_parser_core::error::{ParseError, ParseOutput, ParseResult};
+pub use perl_parser_core::parser::Parser;

--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -366,19 +366,22 @@
 
 /// Parser engine components and supporting utilities.
 pub mod engine;
+/// Canonical parser-kernel facade and types.
+pub mod core;
+/// Canonical convenience imports for parser consumers.
+pub mod prelude;
+mod compat;
 /// Legacy module aliases for moved engine components.
-pub use engine::{error, parser, position};
+pub use compat::{error, parser, position};
 
 /// Abstract Syntax Tree (AST) definitions for Perl parsing.
-pub use engine::ast;
+pub use core::ast;
 /// Experimental second-generation AST (work in progress).
 pub use engine::ast_v2;
 /// Edit tracking for incremental parsing.
 pub use engine::edit;
 /// Heredoc content collector with FIFO ordering and indent stripping.
 pub use engine::heredoc_collector;
-/// Recursive descent Perl parser with error recovery and AST generation.
-pub use engine::parser::Parser;
 /// Parser context with error recovery support.
 pub use engine::parser_context;
 /// Pragma tracking for `use` and related directives.
@@ -525,9 +528,9 @@ pub use workspace::workspace_refactor;
 pub use workspace::workspace_rename;
 
 /// AST node, node kind enum, and source location types.
-pub use ast::{Node, NodeKind, SourceLocation};
-/// Parse error and result types for parser output.
-pub use error::{ParseError, ParseResult, RecoverySalvageClass, RecoverySalvageProfile};
+pub use core::{Node, NodeKind, ParseError, ParseOutput, ParseResult, Parser, SourceLocation};
+/// Parse recovery profile classifications for resilient parsing.
+pub use error::{RecoverySalvageClass, RecoverySalvageProfile};
 #[cfg(feature = "incremental")]
 /// Checkpointed incremental parser with simple edit tracking.
 pub use incremental_checkpoint::{CheckpointedIncrementalParser, SimpleEdit};

--- a/crates/perl-parser/src/prelude.rs
+++ b/crates/perl-parser/src/prelude.rs
@@ -1,0 +1,3 @@
+//! Canonical convenience imports for common parser workflows.
+
+pub use crate::core::{Node, NodeKind, ParseError, ParseOutput, ParseResult, Parser, SourceLocation};


### PR DESCRIPTION
### Motivation

- Reduce root-level export surface by introducing a small, well-defined facade for parser-kernel types and convenience imports to clarify canonical import paths and separate compatibility shims.
- Prepare `perl-parser` for a measured SRP-driven reorganization (incremental, dead_code, parser includes) by isolating legacy re-exports into a single compatibility module.

### Description

- Added `crates/perl-parser/src/core.rs` as a minimal facade that re-exports canonical kernel types from `perl-parser-core` including `Parser`, AST types, and parse result/error types.
- Added `crates/perl-parser/src/prelude.rs` providing convenient, canonical imports for common parser workflows (`Node`, `NodeKind`, `Parser`, `ParseError`, etc.).
- Added `crates/perl-parser/src/compat.rs` to host backwards-compatible re-exports (`error`, `parser`, `position`) and keep noisy legacy aliases out of the primary facade.
- Updated `crates/perl-parser/src/lib.rs` to introduce `core`, `prelude`, and `compat` modules and route root-level canonical exports through `core` while preserving compatibility aliases via `compat`.

### Testing

- Ran `cargo check -p perl-parser --all-targets --locked` and it completed successfully.
- Attempted the recommended guarded check `./scripts/cargo-safe check -p perl-parser --all-targets --profile agent --locked`, but it was blocked by the environment storage policy (`DENY: /root/.cache/devplane/perl-lsp`), so that script did not run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44f673d70833388f3e944ae9787cb)