### PR TITLE
refactor(perl-parser): add facade and compatibility modules (#0000)

### DIFF
--- a/crates/perl-parser/src/compat.rs
+++ b/crates/perl-parser/src/compat.rs
@@ -1,0 +1,67 @@
+#![allow(unused_imports)] // Compatibility shim intentionally centralizes broad re-exports.
+//! Backwards-compatible re-exports.
+//! Prefer `perl_parser::prelude::*` or canonical domain modules.
+
+pub use crate::analysis::declaration;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::analysis::index;
+pub use crate::analysis::scope_analyzer;
+pub use crate::analysis::semantic;
+pub use crate::analysis::symbol;
+pub use crate::analysis::type_inference;
+pub use crate::ast_utils;
+pub use crate::builtins::builtin_signatures;
+pub use crate::builtins::builtin_signatures_phf;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::dead_code as dead_code_detector;
+pub use crate::engine::ast;
+pub use crate::engine::ast_v2;
+pub use crate::engine::edit;
+pub use crate::engine::heredoc_collector;
+pub use crate::engine::parser_context;
+pub use crate::engine::pragma_tracker;
+pub use crate::engine::quote_parser;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::error::classifier as error_classifier;
+pub use crate::error::recovery as error_recovery;
+#[cfg(feature = "incremental")]
+pub use crate::incremental::incremental_advanced_reuse;
+#[cfg(feature = "incremental")]
+pub use crate::incremental::incremental_checkpoint;
+#[cfg(feature = "incremental")]
+pub use crate::incremental::incremental_document;
+#[cfg(feature = "incremental")]
+pub use crate::incremental::incremental_edit;
+#[cfg(feature = "incremental")]
+pub use crate::incremental::incremental_handler_v2;
+#[cfg(feature = "incremental")]
+pub use crate::incremental::incremental_integration;
+#[cfg(feature = "incremental")]
+pub use crate::incremental::incremental_simple;
+#[cfg(feature = "incremental")]
+pub use crate::incremental::incremental_v2;
+pub use crate::path_normalize;
+pub use crate::path_security;
+pub use crate::percentile;
+pub use crate::qualified_name;
+pub use crate::refactor::import_optimizer;
+pub use crate::refactor::modernize;
+pub use crate::refactor::modernize_refactored;
+pub use crate::refactor::refactoring;
+pub use crate::source_file;
+pub use crate::tdd::tdd_basic;
+#[cfg(test)]
+pub use crate::tdd::tdd_workflow;
+pub use crate::tdd::test_generator;
+pub use crate::tdd::test_runner;
+pub use crate::text_line;
+pub use crate::tokens::token_stream;
+pub use crate::tokens::token_wrapper;
+pub use crate::tokens::trivia;
+pub use crate::tokens::trivia_parser;
+pub use crate::util;
+pub use crate::workspace::document_store;
+pub use crate::workspace::workspace_index;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::workspace::workspace_refactor;
+pub use crate::workspace::workspace_rename;

--- a/crates/perl-parser/src/core.rs
+++ b/crates/perl-parser/src/core.rs
@@ -1,0 +1,10 @@
+//! Facade over `perl-parser-core`.
+//!
+//! Canonical parser kernel implementation lives in `perl-parser-core`.
+
+pub use perl_parser_core::ast::{Node, NodeKind, SourceLocation};
+pub use perl_parser_core::error::{ParseError, ParseOutput, ParseResult};
+pub use perl_parser_core::parser::Parser;
+
+pub use perl_parser_core::engine;
+pub use perl_parser_core::engine::{error, parser, position};

--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -369,6 +369,8 @@ pub mod engine;
 /// Legacy module aliases for moved engine components.
 pub use engine::{error, parser, position};
 
+/// Recursive descent Perl parser with error recovery and AST generation.
+pub use core::{Node, NodeKind, ParseError, ParseOutput, ParseResult, Parser, SourceLocation};
 /// Abstract Syntax Tree (AST) definitions for Perl parsing.
 pub use engine::ast;
 /// Experimental second-generation AST (work in progress).
@@ -377,8 +379,6 @@ pub use engine::ast_v2;
 pub use engine::edit;
 /// Heredoc content collector with FIFO ordering and indent stripping.
 pub use engine::heredoc_collector;
-/// Recursive descent Perl parser with error recovery and AST generation.
-pub use engine::parser::Parser;
 /// Parser context with error recovery support.
 pub use engine::parser_context;
 /// Pragma tracking for `use` and related directives.
@@ -398,21 +398,27 @@ pub use perl_parser_core::line_index;
 /// Line ending detection and UTF-16 position mapping for LSP compliance.
 pub use position::{LineEnding, PositionMapper};
 
-/// Semantic analysis, scope resolution, and type inference.
+/// Facade over `perl-semantic-analyzer` for compatibility imports.
 pub mod analysis;
 /// Perl builtin function signatures and metadata.
 pub mod builtins;
+/// Facade over parser-kernel types from `perl-parser-core`.
+pub mod core;
 #[cfg(feature = "incremental")]
 /// Incremental parsing for efficient re-parsing during editing.
 pub mod incremental;
+/// Canonical convenience imports for consumers.
+pub mod prelude;
 /// Code refactoring, modernization, and import optimization.
 pub mod refactor;
 /// Test-driven development support and test generation.
 pub mod tdd;
 /// Token stream, trivia, and token wrapper utilities.
 pub mod tokens;
-/// Workspace indexing, document store, and cross-file operations.
+/// Facade over `perl-workspace` for compatibility imports.
 pub mod workspace;
+
+pub mod compat;
 
 // =============================================================================
 // Wave D absorbed satellite crates (as internal modules)
@@ -525,9 +531,8 @@ pub use workspace::workspace_refactor;
 pub use workspace::workspace_rename;
 
 /// AST node, node kind enum, and source location types.
-pub use ast::{Node, NodeKind, SourceLocation};
 /// Parse error and result types for parser output.
-pub use error::{ParseError, ParseResult, RecoverySalvageClass, RecoverySalvageProfile};
+pub use error::{RecoverySalvageClass, RecoverySalvageProfile};
 #[cfg(feature = "incremental")]
 /// Checkpointed incremental parser with simple edit tracking.
 pub use incremental_checkpoint::{CheckpointedIncrementalParser, SimpleEdit};

--- a/crates/perl-parser/src/prelude.rs
+++ b/crates/perl-parser/src/prelude.rs
@@ -1,0 +1,14 @@
+//! Canonical convenience imports for `perl-parser` consumers.
+
+pub use crate::analysis;
+pub use crate::core::{
+    Node, NodeKind, ParseError, ParseOutput, ParseResult, Parser, SourceLocation,
+};
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::dead_code::{
+    DeadCode, DeadCodeAnalysis, DeadCodeDetector, DeadCodeStats, DeadCodeType,
+};
+#[cfg(feature = "incremental")]
+pub use crate::incremental::{Edit, IncrementalState, apply_edits};
+pub use crate::refactor;
+pub use crate::workspace;


### PR DESCRIPTION
Problem: `perl-parser` lacked clear facade/prelude/compat entry points, so consumers had to rely on scattered module imports.
Fix: add `core`, `prelude`, and `compat` modules while preserving existing top-level parser exports and feature-gated incremental imports.
Verification: `cargo check -p perl-parser --all-targets --locked`; `cargo check -p perl-parser --all-targets --features incremental --locked`; `cargo test -p perl-parser --locked --lib -- --nocapture`; `cargo clippy -p perl-parser --lib --locked -- -D warnings -A missing_docs`; `git diff --check`.
