### PR TITLE
refactor(perl-dap): extract server lifecycle from lib facade (#0000)

### DIFF
--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -370,6 +370,8 @@ pub mod configuration;
 pub mod debug_adapter;
 /// DAP feature catalog and capability gating helpers.
 pub mod feature_catalog;
+/// DAP server configuration and lifecycle.
+pub mod server;
 
 // Wave H collapsed modules (in DAG order — command_args before platform, platform before shell, value before variables)
 /// Explicit public API re-exports from all collapsed satellite modules.
@@ -424,6 +426,7 @@ pub use configuration::{
     create_launch_json_snippet,
 };
 pub use debug_adapter::{DapMessage, DebugAdapter};
+pub use server::{DapConfig, DapMode, DapServer};
 
 // Re-export Phase 2 public types
 pub use breakpoints::{BreakpointRecord, BreakpointStore};
@@ -449,93 +452,3 @@ pub use protocol::{
     TerminateThreadsArguments, Thread, ThreadsResponseBody, VariablesArguments,
     VariablesResponseBody,
 };
-
-/// Debug adapter operating mode
-///
-/// Controls whether the DAP server uses its native `perl -d` adapter
-/// or proxies to Perl::LanguageServer's DAP implementation.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum DapMode {
-    /// Native adapter using `perl -d` directly
-    #[default]
-    Native,
-    /// Bridge adapter proxying to Perl::LanguageServer
-    Bridge,
-}
-
-/// DAP server configuration
-///
-/// Controls the operating mode, logging, and workspace context for the DAP server.
-pub struct DapConfig {
-    /// Logging level for DAP operations
-    pub log_level: String,
-    /// Operating mode (native or bridge)
-    pub mode: DapMode,
-    /// Workspace root directory
-    pub workspace_root: Option<std::path::PathBuf>,
-}
-
-/// DAP server
-///
-/// Supports two operating modes:
-/// - **Native** (default): Uses the built-in [`DebugAdapter`] with `perl -d`
-/// - **Bridge**: Proxies DAP messages to Perl::LanguageServer via [`BridgeAdapter`]
-pub struct DapServer {
-    /// Server configuration
-    pub config: DapConfig,
-    /// The underlying debug adapter (used in Native mode)
-    adapter: DebugAdapter,
-}
-
-impl DapServer {
-    /// Create a new DAP server instance
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - Server configuration including operating mode
-    ///
-    /// # Errors
-    ///
-    /// Currently always succeeds. Phase 2 will add validation and initialization errors.
-    pub fn new(config: DapConfig) -> anyhow::Result<Self> {
-        Ok(Self { config, adapter: DebugAdapter::new() })
-    }
-
-    /// Run the DAP server
-    ///
-    /// Dispatches to the appropriate transport based on the configured [`DapMode`]:
-    /// - [`DapMode::Native`]: Starts the stdio transport loop via `DebugAdapter::run`
-    /// - [`DapMode::Bridge`]: Spawns Perl::LanguageServer and proxies DAP messages
-    ///   via [`BridgeAdapter`] using a tokio async runtime
-    pub fn run(&mut self) -> anyhow::Result<()> {
-        match self.config.mode {
-            DapMode::Native => self.adapter.run().map_err(Into::into),
-            DapMode::Bridge => {
-                tracing::info!("Starting DAP server in bridge mode");
-                let rt = tokio::runtime::Runtime::new()?;
-                rt.block_on(async {
-                    let mut bridge = BridgeAdapter::new();
-                    bridge.spawn_pls_dap().await?;
-                    bridge.proxy_messages().await?;
-                    bridge.shutdown().await?;
-                    Ok(())
-                })
-            }
-        }
-    }
-
-    /// Run the DAP server over TCP socket transport.
-    ///
-    /// This binds to `127.0.0.1:<port>` and serves one DAP client session.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if bridge mode is selected, since socket transport
-    /// is only supported for native mode.
-    pub fn run_socket(&mut self, port: u16) -> anyhow::Result<()> {
-        if self.config.mode == DapMode::Bridge {
-            anyhow::bail!("Socket transport is not supported in bridge mode");
-        }
-        self.adapter.run_socket(port).map_err(Into::into)
-    }
-}

--- a/crates/perl-dap/src/server/config.rs
+++ b/crates/perl-dap/src/server/config.rs
@@ -1,0 +1,13 @@
+use crate::server::mode::DapMode;
+
+/// DAP server configuration.
+///
+/// Controls the operating mode, logging, and workspace context for the DAP server.
+pub struct DapConfig {
+    /// Logging level for DAP operations.
+    pub log_level: String,
+    /// Operating mode (native or bridge).
+    pub mode: DapMode,
+    /// Workspace root directory.
+    pub workspace_root: Option<std::path::PathBuf>,
+}

--- a/crates/perl-dap/src/server/lifecycle.rs
+++ b/crates/perl-dap/src/server/lifecycle.rs
@@ -1,0 +1,69 @@
+use crate::bridge_adapter::BridgeAdapter;
+use crate::debug_adapter::DebugAdapter;
+use crate::server::config::DapConfig;
+use crate::server::mode::DapMode;
+
+/// DAP server.
+///
+/// Supports two operating modes:
+/// - **Native** (default): Uses the built-in [`DebugAdapter`] with `perl -d`.
+/// - **Bridge**: Proxies DAP messages to Perl::LanguageServer via [`BridgeAdapter`].
+pub struct DapServer {
+    /// Server configuration.
+    pub config: DapConfig,
+    /// The underlying debug adapter (used in Native mode).
+    adapter: DebugAdapter,
+}
+
+impl DapServer {
+    /// Create a new DAP server instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Server configuration including operating mode.
+    ///
+    /// # Errors
+    ///
+    /// Currently always succeeds. Phase 2 will add validation and initialization errors.
+    pub fn new(config: DapConfig) -> anyhow::Result<Self> {
+        Ok(Self { config, adapter: DebugAdapter::new() })
+    }
+
+    /// Run the DAP server.
+    ///
+    /// Dispatches to the appropriate transport based on the configured [`DapMode`]:
+    /// - [`DapMode::Native`]: Starts the stdio transport loop via `DebugAdapter::run`.
+    /// - [`DapMode::Bridge`]: Spawns Perl::LanguageServer and proxies DAP messages
+    ///   via [`BridgeAdapter`] using a tokio async runtime.
+    pub fn run(&mut self) -> anyhow::Result<()> {
+        match self.config.mode {
+            DapMode::Native => self.adapter.run().map_err(Into::into),
+            DapMode::Bridge => {
+                tracing::info!("Starting DAP server in bridge mode");
+                let rt = tokio::runtime::Runtime::new()?;
+                rt.block_on(async {
+                    let mut bridge = BridgeAdapter::new();
+                    bridge.spawn_pls_dap().await?;
+                    bridge.proxy_messages().await?;
+                    bridge.shutdown().await?;
+                    Ok(())
+                })
+            }
+        }
+    }
+
+    /// Run the DAP server over TCP socket transport.
+    ///
+    /// This binds to `127.0.0.1:<port>` and serves one DAP client session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if bridge mode is selected, since socket transport
+    /// is only supported for native mode.
+    pub fn run_socket(&mut self, port: u16) -> anyhow::Result<()> {
+        if self.config.mode == DapMode::Bridge {
+            anyhow::bail!("Socket transport is not supported in bridge mode");
+        }
+        self.adapter.run_socket(port).map_err(Into::into)
+    }
+}

--- a/crates/perl-dap/src/server/mod.rs
+++ b/crates/perl-dap/src/server/mod.rs
@@ -1,0 +1,9 @@
+//! DAP server configuration and lifecycle.
+
+mod config;
+mod lifecycle;
+mod mode;
+
+pub use config::DapConfig;
+pub use lifecycle::DapServer;
+pub use mode::DapMode;

--- a/crates/perl-dap/src/server/mode.rs
+++ b/crates/perl-dap/src/server/mode.rs
@@ -1,0 +1,12 @@
+/// Debug adapter operating mode.
+///
+/// Controls whether the DAP server uses its native `perl -d` adapter
+/// or proxies to Perl::LanguageServer's DAP implementation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum DapMode {
+    /// Native adapter using `perl -d` directly.
+    #[default]
+    Native,
+    /// Bridge adapter proxying to Perl::LanguageServer.
+    Bridge,
+}


### PR DESCRIPTION
### Motivation

- Reduce the crate-root surface area by moving server lifecycle, mode, and config out of `lib.rs` so the facade only answers “what is the public API”.
- Improve Single-Responsibility boundaries so server configuration and lifecycle are owned by a `server` domain rather than the crate root.

### Description

- Added `crates/perl-dap/src/server` with `mod.rs`, `config.rs`, `mode.rs`, and `lifecycle.rs` and moved `DapConfig`, `DapMode`, and `DapServer` into those files.
- Updated the crate root to publish the `server` module and kept compatibility by re-exporting `DapConfig`, `DapMode`, and `DapServer` from `lib.rs` as before.
- Kept all existing behavior unchanged; `DapServer::new`, `run`, and `run_socket` were moved into `server::lifecycle` with the same signatures and semantics.

### Testing

- Ran `cargo check -p perl-dap --all-targets --locked` which completed successfully.
- A full test suite was not executed in this change; no behavioral tests were modified and the public API was preserved via re-exports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f450d0bb1083338bd1542330813a26)