### PR TITLE
refactor(perl-dap): extract server lifecycle from lib facade (#0000)

### DIFF
--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -406,6 +406,8 @@ pub mod dispatcher;
 pub mod inline_values;
 /// DAP protocol types following the JSON-RPC 2.0 message format.
 pub mod protocol;
+/// DAP server lifecycle and runtime mode configuration.
+pub mod server;
 /// TCP-based attachment to running Perl debugger processes.
 pub mod tcp_attach;
 
@@ -424,6 +426,7 @@ pub use configuration::{
     create_launch_json_snippet,
 };
 pub use debug_adapter::{DapMessage, DebugAdapter};
+pub use server::{DapConfig, DapMode, DapServer};
 
 // Re-export Phase 2 public types
 pub use breakpoints::{BreakpointRecord, BreakpointStore};
@@ -450,92 +453,4 @@ pub use protocol::{
     VariablesResponseBody,
 };
 
-/// Debug adapter operating mode
-///
-/// Controls whether the DAP server uses its native `perl -d` adapter
-/// or proxies to Perl::LanguageServer's DAP implementation.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum DapMode {
-    /// Native adapter using `perl -d` directly
-    #[default]
-    Native,
-    /// Bridge adapter proxying to Perl::LanguageServer
-    Bridge,
-}
 
-/// DAP server configuration
-///
-/// Controls the operating mode, logging, and workspace context for the DAP server.
-pub struct DapConfig {
-    /// Logging level for DAP operations
-    pub log_level: String,
-    /// Operating mode (native or bridge)
-    pub mode: DapMode,
-    /// Workspace root directory
-    pub workspace_root: Option<std::path::PathBuf>,
-}
-
-/// DAP server
-///
-/// Supports two operating modes:
-/// - **Native** (default): Uses the built-in [`DebugAdapter`] with `perl -d`
-/// - **Bridge**: Proxies DAP messages to Perl::LanguageServer via [`BridgeAdapter`]
-pub struct DapServer {
-    /// Server configuration
-    pub config: DapConfig,
-    /// The underlying debug adapter (used in Native mode)
-    adapter: DebugAdapter,
-}
-
-impl DapServer {
-    /// Create a new DAP server instance
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - Server configuration including operating mode
-    ///
-    /// # Errors
-    ///
-    /// Currently always succeeds. Phase 2 will add validation and initialization errors.
-    pub fn new(config: DapConfig) -> anyhow::Result<Self> {
-        Ok(Self { config, adapter: DebugAdapter::new() })
-    }
-
-    /// Run the DAP server
-    ///
-    /// Dispatches to the appropriate transport based on the configured [`DapMode`]:
-    /// - [`DapMode::Native`]: Starts the stdio transport loop via `DebugAdapter::run`
-    /// - [`DapMode::Bridge`]: Spawns Perl::LanguageServer and proxies DAP messages
-    ///   via [`BridgeAdapter`] using a tokio async runtime
-    pub fn run(&mut self) -> anyhow::Result<()> {
-        match self.config.mode {
-            DapMode::Native => self.adapter.run().map_err(Into::into),
-            DapMode::Bridge => {
-                tracing::info!("Starting DAP server in bridge mode");
-                let rt = tokio::runtime::Runtime::new()?;
-                rt.block_on(async {
-                    let mut bridge = BridgeAdapter::new();
-                    bridge.spawn_pls_dap().await?;
-                    bridge.proxy_messages().await?;
-                    bridge.shutdown().await?;
-                    Ok(())
-                })
-            }
-        }
-    }
-
-    /// Run the DAP server over TCP socket transport.
-    ///
-    /// This binds to `127.0.0.1:<port>` and serves one DAP client session.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if bridge mode is selected, since socket transport
-    /// is only supported for native mode.
-    pub fn run_socket(&mut self, port: u16) -> anyhow::Result<()> {
-        if self.config.mode == DapMode::Bridge {
-            anyhow::bail!("Socket transport is not supported in bridge mode");
-        }
-        self.adapter.run_socket(port).map_err(Into::into)
-    }
-}

--- a/crates/perl-dap/src/server/config.rs
+++ b/crates/perl-dap/src/server/config.rs
@@ -1,0 +1,13 @@
+use crate::server::mode::DapMode;
+
+/// DAP server configuration
+///
+/// Controls the operating mode, logging, and workspace context for the DAP server.
+pub struct DapConfig {
+    /// Logging level for DAP operations
+    pub log_level: String,
+    /// Operating mode (native or bridge)
+    pub mode: DapMode,
+    /// Workspace root directory
+    pub workspace_root: Option<std::path::PathBuf>,
+}

--- a/crates/perl-dap/src/server/lifecycle.rs
+++ b/crates/perl-dap/src/server/lifecycle.rs
@@ -1,0 +1,69 @@
+use crate::bridge_adapter::BridgeAdapter;
+use crate::debug_adapter::DebugAdapter;
+use crate::server::config::DapConfig;
+use crate::server::mode::DapMode;
+
+/// DAP server
+///
+/// Supports two operating modes:
+/// - **Native** (default): Uses the built-in [`DebugAdapter`] with `perl -d`
+/// - **Bridge**: Proxies DAP messages to Perl::LanguageServer via [`BridgeAdapter`]
+pub struct DapServer {
+    /// Server configuration
+    pub config: DapConfig,
+    /// The underlying debug adapter (used in Native mode)
+    adapter: DebugAdapter,
+}
+
+impl DapServer {
+    /// Create a new DAP server instance
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Server configuration including operating mode
+    ///
+    /// # Errors
+    ///
+    /// Currently always succeeds. Phase 2 will add validation and initialization errors.
+    pub fn new(config: DapConfig) -> anyhow::Result<Self> {
+        Ok(Self { config, adapter: DebugAdapter::new() })
+    }
+
+    /// Run the DAP server
+    ///
+    /// Dispatches to the appropriate transport based on the configured [`DapMode`]:
+    /// - [`DapMode::Native`]: Starts the stdio transport loop via `DebugAdapter::run`
+    /// - [`DapMode::Bridge`]: Spawns Perl::LanguageServer and proxies DAP messages
+    ///   via [`BridgeAdapter`] using a tokio async runtime
+    pub fn run(&mut self) -> anyhow::Result<()> {
+        match self.config.mode {
+            DapMode::Native => self.adapter.run().map_err(Into::into),
+            DapMode::Bridge => {
+                tracing::info!("Starting DAP server in bridge mode");
+                let rt = tokio::runtime::Runtime::new()?;
+                rt.block_on(async {
+                    let mut bridge = BridgeAdapter::new();
+                    bridge.spawn_pls_dap().await?;
+                    bridge.proxy_messages().await?;
+                    bridge.shutdown().await?;
+                    Ok(())
+                })
+            }
+        }
+    }
+
+    /// Run the DAP server over TCP socket transport.
+    ///
+    /// This binds to `127.0.0.1:<port>` and serves one DAP client session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if bridge mode is selected, since socket transport
+    /// is only supported for native mode.
+    pub fn run_socket(&mut self, port: u16) -> anyhow::Result<()> {
+        if self.config.mode == DapMode::Bridge {
+            anyhow::bail!("Socket transport is not supported in bridge mode");
+        }
+        self.adapter.run_socket(port).map_err(Into::into)
+    }
+}

--- a/crates/perl-dap/src/server/mod.rs
+++ b/crates/perl-dap/src/server/mod.rs
@@ -1,0 +1,7 @@
+pub mod config;
+pub mod lifecycle;
+pub mod mode;
+
+pub use config::DapConfig;
+pub use lifecycle::DapServer;
+pub use mode::DapMode;

--- a/crates/perl-dap/src/server/mode.rs
+++ b/crates/perl-dap/src/server/mode.rs
@@ -1,0 +1,12 @@
+/// Debug adapter operating mode
+///
+/// Controls whether the DAP server uses its native `perl -d` adapter
+/// or proxies to Perl::LanguageServer's DAP implementation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum DapMode {
+    /// Native adapter using `perl -d` directly
+    #[default]
+    Native,
+    /// Bridge adapter proxying to Perl::LanguageServer
+    Bridge,
+}


### PR DESCRIPTION
### Motivation

- `lib.rs` combined public facade and server lifecycle/configuration, exposing implementation details at crate root rather than a small public surface. 
- Separate ownership of server concerns so `lib.rs` can answer "what is the public crate surface?" without also answering "how the server runs".

### Description

- Added a new `server` module at `crates/perl-dap/src/server` and split server concerns into `mode.rs`, `config.rs`, and `lifecycle.rs` so `DapMode`, `DapConfig`, and `DapServer` are owned by `server`.
- Updated `crates/perl-dap/src/lib.rs` to declare `pub mod server;` and re-export `server::{DapConfig, DapMode, DapServer}` so the public API remains stable.
- Removed the inline `DapMode` / `DapConfig` / `DapServer` definitions from `lib.rs` to reduce implementation surface and keep behavior unchanged.
- Preserved existing protocol and compatibility-facing re-exports to avoid API drift in this refactor step.

### Testing

- Ran `./scripts/storage-doctor` to verify build/storage invariants and it succeeded.
- Ran `cargo test -p perl-dap --test wave_h_api_stability --locked` and all tests passed.
- Ran `cargo test -p perl-dap --test wave_h_external_consumer_integration --locked` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f450d0bb1083338bd1542330813a26)