### PR TITLE
refactor(perl-dap): extract server types from lib facade (#0000)

### DIFF
--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -406,6 +406,8 @@ pub mod dispatcher;
 pub mod inline_values;
 /// DAP protocol types following the JSON-RPC 2.0 message format.
 pub mod protocol;
+/// DAP server lifecycle and mode/configuration types.
+pub mod server;
 /// TCP-based attachment to running Perl debugger processes.
 pub mod tcp_attach;
 
@@ -424,6 +426,7 @@ pub use configuration::{
     create_launch_json_snippet,
 };
 pub use debug_adapter::{DapMessage, DebugAdapter};
+pub use server::{DapConfig, DapMode, DapServer};
 
 // Re-export Phase 2 public types
 pub use breakpoints::{BreakpointRecord, BreakpointStore};
@@ -450,92 +453,3 @@ pub use protocol::{
     VariablesResponseBody,
 };
 
-/// Debug adapter operating mode
-///
-/// Controls whether the DAP server uses its native `perl -d` adapter
-/// or proxies to Perl::LanguageServer's DAP implementation.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum DapMode {
-    /// Native adapter using `perl -d` directly
-    #[default]
-    Native,
-    /// Bridge adapter proxying to Perl::LanguageServer
-    Bridge,
-}
-
-/// DAP server configuration
-///
-/// Controls the operating mode, logging, and workspace context for the DAP server.
-pub struct DapConfig {
-    /// Logging level for DAP operations
-    pub log_level: String,
-    /// Operating mode (native or bridge)
-    pub mode: DapMode,
-    /// Workspace root directory
-    pub workspace_root: Option<std::path::PathBuf>,
-}
-
-/// DAP server
-///
-/// Supports two operating modes:
-/// - **Native** (default): Uses the built-in [`DebugAdapter`] with `perl -d`
-/// - **Bridge**: Proxies DAP messages to Perl::LanguageServer via [`BridgeAdapter`]
-pub struct DapServer {
-    /// Server configuration
-    pub config: DapConfig,
-    /// The underlying debug adapter (used in Native mode)
-    adapter: DebugAdapter,
-}
-
-impl DapServer {
-    /// Create a new DAP server instance
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - Server configuration including operating mode
-    ///
-    /// # Errors
-    ///
-    /// Currently always succeeds. Phase 2 will add validation and initialization errors.
-    pub fn new(config: DapConfig) -> anyhow::Result<Self> {
-        Ok(Self { config, adapter: DebugAdapter::new() })
-    }
-
-    /// Run the DAP server
-    ///
-    /// Dispatches to the appropriate transport based on the configured [`DapMode`]:
-    /// - [`DapMode::Native`]: Starts the stdio transport loop via `DebugAdapter::run`
-    /// - [`DapMode::Bridge`]: Spawns Perl::LanguageServer and proxies DAP messages
-    ///   via [`BridgeAdapter`] using a tokio async runtime
-    pub fn run(&mut self) -> anyhow::Result<()> {
-        match self.config.mode {
-            DapMode::Native => self.adapter.run().map_err(Into::into),
-            DapMode::Bridge => {
-                tracing::info!("Starting DAP server in bridge mode");
-                let rt = tokio::runtime::Runtime::new()?;
-                rt.block_on(async {
-                    let mut bridge = BridgeAdapter::new();
-                    bridge.spawn_pls_dap().await?;
-                    bridge.proxy_messages().await?;
-                    bridge.shutdown().await?;
-                    Ok(())
-                })
-            }
-        }
-    }
-
-    /// Run the DAP server over TCP socket transport.
-    ///
-    /// This binds to `127.0.0.1:<port>` and serves one DAP client session.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if bridge mode is selected, since socket transport
-    /// is only supported for native mode.
-    pub fn run_socket(&mut self, port: u16) -> anyhow::Result<()> {
-        if self.config.mode == DapMode::Bridge {
-            anyhow::bail!("Socket transport is not supported in bridge mode");
-        }
-        self.adapter.run_socket(port).map_err(Into::into)
-    }
-}

--- a/crates/perl-dap/src/server/config.rs
+++ b/crates/perl-dap/src/server/config.rs
@@ -1,0 +1,13 @@
+use crate::server::mode::DapMode;
+
+/// DAP server configuration
+///
+/// Controls the operating mode, logging, and workspace context for the DAP server.
+pub struct DapConfig {
+    /// Logging level for DAP operations
+    pub log_level: String,
+    /// Operating mode (native or bridge)
+    pub mode: DapMode,
+    /// Workspace root directory
+    pub workspace_root: Option<std::path::PathBuf>,
+}

--- a/crates/perl-dap/src/server/lifecycle.rs
+++ b/crates/perl-dap/src/server/lifecycle.rs
@@ -1,0 +1,67 @@
+use crate::{BridgeAdapter, DebugAdapter};
+use crate::server::{config::DapConfig, mode::DapMode};
+
+/// DAP server
+///
+/// Supports two operating modes:
+/// - **Native** (default): Uses the built-in [`DebugAdapter`] with `perl -d`
+/// - **Bridge**: Proxies DAP messages to Perl::LanguageServer via [`BridgeAdapter`]
+pub struct DapServer {
+    /// Server configuration
+    pub config: DapConfig,
+    /// The underlying debug adapter (used in Native mode)
+    adapter: DebugAdapter,
+}
+
+impl DapServer {
+    /// Create a new DAP server instance
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - Server configuration including operating mode
+    ///
+    /// # Errors
+    ///
+    /// Currently always succeeds. Phase 2 will add validation and initialization errors.
+    pub fn new(config: DapConfig) -> anyhow::Result<Self> {
+        Ok(Self { config, adapter: DebugAdapter::new() })
+    }
+
+    /// Run the DAP server
+    ///
+    /// Dispatches to the appropriate transport based on the configured [`DapMode`]:
+    /// - [`DapMode::Native`]: Starts the stdio transport loop via `DebugAdapter::run`
+    /// - [`DapMode::Bridge`]: Spawns Perl::LanguageServer and proxies DAP messages
+    ///   via [`BridgeAdapter`] using a tokio async runtime
+    pub fn run(&mut self) -> anyhow::Result<()> {
+        match self.config.mode {
+            DapMode::Native => self.adapter.run().map_err(Into::into),
+            DapMode::Bridge => {
+                tracing::info!("Starting DAP server in bridge mode");
+                let rt = tokio::runtime::Runtime::new()?;
+                rt.block_on(async {
+                    let mut bridge = BridgeAdapter::new();
+                    bridge.spawn_pls_dap().await?;
+                    bridge.proxy_messages().await?;
+                    bridge.shutdown().await?;
+                    Ok(())
+                })
+            }
+        }
+    }
+
+    /// Run the DAP server over TCP socket transport.
+    ///
+    /// This binds to `127.0.0.1:<port>` and serves one DAP client session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if bridge mode is selected, since socket transport
+    /// is only supported for native mode.
+    pub fn run_socket(&mut self, port: u16) -> anyhow::Result<()> {
+        if self.config.mode == DapMode::Bridge {
+            anyhow::bail!("Socket transport is not supported in bridge mode");
+        }
+        self.adapter.run_socket(port).map_err(Into::into)
+    }
+}

--- a/crates/perl-dap/src/server/mod.rs
+++ b/crates/perl-dap/src/server/mod.rs
@@ -1,0 +1,7 @@
+pub mod config;
+pub mod lifecycle;
+pub mod mode;
+
+pub use config::DapConfig;
+pub use lifecycle::DapServer;
+pub use mode::DapMode;

--- a/crates/perl-dap/src/server/mode.rs
+++ b/crates/perl-dap/src/server/mode.rs
@@ -1,0 +1,12 @@
+/// Debug adapter operating mode
+///
+/// Controls whether the DAP server uses its native `perl -d` adapter
+/// or proxies to Perl::LanguageServer's DAP implementation.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum DapMode {
+    /// Native adapter using `perl -d` directly
+    #[default]
+    Native,
+    /// Bridge adapter proxying to Perl::LanguageServer
+    Bridge,
+}


### PR DESCRIPTION
### Motivation

- Reduce the public-root responsibility of `lib.rs` by moving server lifecycle, mode, and configuration into a dedicated `server` domain so the crate root becomes a facade that answers "what is the public API" rather than "how the server runs".

### Description

- Added a `server` module with `mode.rs`, `config.rs`, `lifecycle.rs`, and `mod.rs` and moved `DapMode` into `server::mode`, `DapConfig` into `server::config`, and `DapServer` into `server::lifecycle` while preserving behavior.
- Updated `crates/perl-dap/src/lib.rs` to declare `pub mod server;` and re-export `server::{DapConfig, DapMode, DapServer}` so the public surface is unchanged for consumers.
- Kept existing compatibility re-exports (e.g. `BridgeAdapter`, `DebugAdapter`, protocol types) intact; no behavioral changes to adapter or transport logic were made.

### Testing

- Attempted `./scripts/cargo-safe test -p perl-dap --profile agent --locked`, but the helper was blocked by the environment storage policy (`DENY: /root/.cache/devplane/perl-lsp`), so the full safe script run was not executed.
- Ran `cargo test -p perl-dap --tests --no-fail-fast`; compilation of the workspace and the `perl-dap` crate succeeded and tests began executing, but the test run did not complete within the session window so results are inconclusive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f450d0bb1083338bd1542330813a26)