### PR TITLE
refactor(perl-lexer): extract cursor utilities into lexer module (#0000)

### DIFF
--- a/crates/perl-lexer/src/lexer/cursor.rs
+++ b/crates/perl-lexer/src/lexer/cursor.rs
@@ -1,0 +1,113 @@
+use crate::PerlLexer;
+
+impl<'a> PerlLexer<'a> {
+    /// Normalize file start by skipping BOM if present
+    pub(crate) fn normalize_file_start(&mut self) {
+        // Skip UTF-8 BOM (EF BB BF) if at file start
+        if self.position == 0 && self.matches_bytes(&[0xEF, 0xBB, 0xBF]) {
+            self.position = 3;
+            self.line_start_offset = 3;
+        }
+    }
+
+    /// Helper to check if remaining bytes on a line are only spaces/tabs
+    #[inline]
+    pub(crate) fn trailing_ws_only(bytes: &[u8], mut p: usize) -> bool {
+        while p < bytes.len() && bytes[p] != b'\n' && bytes[p] != b'\r' {
+            match bytes[p] {
+                b' ' | b'\t' => p += 1,
+                _ => return false,
+            }
+        }
+        true
+    }
+
+    /// Consume a newline sequence (CRLF or LF) and update state
+    #[inline]
+    pub(crate) fn consume_newline(&mut self) {
+        if self.position >= self.input.len() {
+            return;
+        }
+        match self.input_bytes[self.position] {
+            b'\r' => {
+                self.position += 1;
+                if self.position < self.input.len() && self.input_bytes[self.position] == b'\n' {
+                    self.position += 1;
+                }
+            }
+            b'\n' => self.advance(),
+            _ => return,
+        }
+        self.after_newline = true;
+        self.line_start_offset = self.position;
+    }
+
+    /// Find the end of the current line, returning both raw end and visible end (without trailing CR)
+    #[inline]
+    pub(crate) fn find_line_end(bytes: &[u8], start: usize) -> (usize, usize) {
+        let mut end = start;
+        while end < bytes.len() && bytes[end] != b'\n' && bytes[end] != b'\r' {
+            end += 1;
+        }
+        let visible_end = end;
+        (end, visible_end)
+    }
+
+    #[allow(clippy::inline_always)]
+    #[inline(always)]
+    pub(crate) fn byte_at(bytes: &[u8], index: usize) -> u8 {
+        debug_assert!(index < bytes.len());
+        match bytes.get(index) {
+            Some(&byte) => byte,
+            None => 0,
+        }
+    }
+
+    #[allow(clippy::inline_always)]
+    #[inline(always)]
+    pub(crate) fn current_char(&self) -> Option<char> {
+        if self.position < self.input_bytes.len() {
+            let byte = Self::byte_at(self.input_bytes, self.position);
+            if byte < 128 {
+                Some(byte as char)
+            } else {
+                self.input.get(self.position..).and_then(|s| s.chars().next())
+            }
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn peek_char(&self, offset: usize) -> Option<char> {
+        if offset > self.config.max_lookahead {
+            return None;
+        }
+
+        let pos = self.position.checked_add(offset)?;
+        if pos < self.input_bytes.len() {
+            let byte = Self::byte_at(self.input_bytes, pos);
+            if byte < 128 {
+                Some(byte as char)
+            } else {
+                self.input.get(self.position..).and_then(|s| s.chars().nth(offset))
+            }
+        } else {
+            None
+        }
+    }
+
+    #[allow(clippy::inline_always)]
+    #[inline(always)]
+    pub(crate) fn advance(&mut self) {
+        if self.position < self.input_bytes.len() {
+            let byte = Self::byte_at(self.input_bytes, self.position);
+            if byte < 128 {
+                self.position += 1;
+            } else if let Some(ch) = self.input.get(self.position..).and_then(|s| s.chars().next())
+            {
+                self.position += ch.len_utf8();
+            }
+        }
+    }
+}

--- a/crates/perl-lexer/src/lexer/mod.rs
+++ b/crates/perl-lexer/src/lexer/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod cursor;
+pub(crate) mod state;

--- a/crates/perl-lexer/src/lexer/state.rs
+++ b/crates/perl-lexer/src/lexer/state.rs
@@ -1,0 +1,110 @@
+#![allow(dead_code)] // Scaffold for staged lexer state migration.
+
+use perl_position_tracking::Position;
+
+use crate::{heredoc::HeredocSpec, mode::LexerMode, quote_handler::QuoteOperatorInfo, LexerConfig};
+
+#[derive(Clone, Debug)]
+pub(crate) struct SourceView<'a> {
+    pub(crate) input: &'a str,
+    pub(crate) input_bytes: &'a [u8],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CursorState {
+    pub(crate) position: usize,
+    pub(crate) current_pos: Position,
+    pub(crate) line_start_offset: usize,
+    pub(crate) after_newline: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LexicalContext {
+    pub(crate) delimiter_stack: Vec<char>,
+    pub(crate) in_prototype: bool,
+    pub(crate) prototype_depth: usize,
+    pub(crate) after_sub: bool,
+    pub(crate) after_arrow: bool,
+    pub(crate) hash_brace_depth: usize,
+    pub(crate) after_var_subscript: bool,
+    pub(crate) paren_depth: usize,
+}
+
+#[derive(Clone)]
+pub(crate) struct HeredocState {
+    pub(crate) pending_heredocs: Vec<HeredocSpec>,
+    pub(crate) emit_heredoc_body_tokens: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct QuoteState {
+    pub(crate) current_quote_op: Option<QuoteOperatorInfo>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct EofState {
+    pub(crate) eof_emitted: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BudgetState {
+    pub(crate) start_time: std::time::Instant,
+}
+
+#[derive(Clone)]
+pub(crate) struct LexerState<'a> {
+    pub(crate) source: SourceView<'a>,
+    pub(crate) cursor: CursorState,
+    pub(crate) mode: LexerMode,
+    pub(crate) config: LexerConfig,
+    pub(crate) context: LexicalContext,
+    pub(crate) heredocs: HeredocState,
+    pub(crate) quotes: QuoteState,
+    pub(crate) eof: EofState,
+    pub(crate) budget: BudgetState,
+}
+
+impl<'a> LexerState<'a> {
+    pub(crate) fn with_config(input: &'a str, config: LexerConfig) -> Self {
+        Self {
+            source: SourceView {
+                input,
+                input_bytes: input.as_bytes(),
+            },
+            cursor: CursorState {
+                position: 0,
+                current_pos: Position::start(),
+                line_start_offset: 0,
+                after_newline: true,
+            },
+            mode: LexerMode::ExpectTerm,
+            config,
+            context: LexicalContext {
+                delimiter_stack: Vec::new(),
+                in_prototype: false,
+                prototype_depth: 0,
+                after_sub: false,
+                after_arrow: false,
+                hash_brace_depth: 0,
+                after_var_subscript: false,
+                paren_depth: 0,
+            },
+            heredocs: HeredocState {
+                pending_heredocs: Vec::new(),
+                emit_heredoc_body_tokens: false,
+            },
+            quotes: QuoteState {
+                current_quote_op: None,
+            },
+            eof: EofState { eof_emitted: false },
+            budget: BudgetState {
+                start_time: std::time::Instant::now(),
+            },
+        }
+    }
+
+    pub(crate) fn with_body_tokens(mut self) -> Self {
+        self.heredocs.emit_heredoc_body_tokens = true;
+        self
+    }
+}

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -148,6 +148,7 @@ pub mod keywords;
 pub mod limits;
 pub mod mode;
 mod quote_handler;
+mod lexer;
 pub mod token;
 pub mod tokenizer;
 mod unicode;
@@ -276,61 +277,9 @@ impl<'a> PerlLexer<'a> {
         lexer
     }
 
-    /// Normalize file start by skipping BOM if present
-    fn normalize_file_start(&mut self) {
-        // Skip UTF-8 BOM (EF BB BF) if at file start
-        if self.position == 0 && self.matches_bytes(&[0xEF, 0xBB, 0xBF]) {
-            self.position = 3;
-            self.line_start_offset = 3;
-        }
-    }
-
     /// Set the lexer mode (for resetting state at statement boundaries)
     pub fn set_mode(&mut self, mode: LexerMode) {
         self.mode = mode;
-    }
-
-    /// Helper to check if remaining bytes on a line are only spaces/tabs
-    #[inline]
-    fn trailing_ws_only(bytes: &[u8], mut p: usize) -> bool {
-        while p < bytes.len() && bytes[p] != b'\n' && bytes[p] != b'\r' {
-            match bytes[p] {
-                b' ' | b'\t' => p += 1,
-                _ => return false,
-            }
-        }
-        true
-    }
-
-    /// Consume a newline sequence (CRLF or LF) and update state
-    #[inline]
-    fn consume_newline(&mut self) {
-        if self.position >= self.input.len() {
-            return;
-        }
-        match self.input_bytes[self.position] {
-            b'\r' => {
-                self.position += 1;
-                if self.position < self.input.len() && self.input_bytes[self.position] == b'\n' {
-                    self.position += 1;
-                }
-            }
-            b'\n' => self.advance(),
-            _ => return, // not at a newline
-        }
-        self.after_newline = true;
-        self.line_start_offset = self.position;
-    }
-
-    /// Find the end of the current line, returning both raw end and visible end (without trailing CR)
-    #[inline]
-    fn find_line_end(bytes: &[u8], start: usize) -> (usize, usize) {
-        let mut end = start;
-        while end < bytes.len() && bytes[end] != b'\n' && bytes[end] != b'\r' {
-            end += 1;
-        }
-        let visible_end = end;
-        (end, visible_end)
     }
 
     #[inline]
@@ -772,71 +721,6 @@ impl<'a> PerlLexer<'a> {
     /// line containing only `.` (the Perl format terminator).
     pub fn enter_format_mode(&mut self) {
         self.mode = LexerMode::InFormatBody;
-    }
-
-    // Internal helper methods
-
-    #[allow(clippy::inline_always)] // Performance critical in lexer hot path
-    #[inline(always)]
-    fn byte_at(bytes: &[u8], index: usize) -> u8 {
-        debug_assert!(index < bytes.len());
-        match bytes.get(index) {
-            Some(&byte) => byte,
-            None => 0,
-        }
-    }
-
-    #[allow(clippy::inline_always)] // Performance critical in lexer hot path
-    #[inline(always)]
-    fn current_char(&self) -> Option<char> {
-        if self.position < self.input_bytes.len() {
-            // For ASCII, direct access is safe
-            let byte = Self::byte_at(self.input_bytes, self.position);
-            if byte < 128 {
-                Some(byte as char)
-            } else {
-                // For non-ASCII, fall back to proper UTF-8 parsing
-                self.input.get(self.position..).and_then(|s| s.chars().next())
-            }
-        } else {
-            None
-        }
-    }
-
-    #[inline(always)]
-    fn peek_char(&self, offset: usize) -> Option<char> {
-        if offset > self.config.max_lookahead {
-            return None;
-        }
-
-        let pos = self.position.checked_add(offset)?;
-        if pos < self.input_bytes.len() {
-            // For ASCII, direct access is safe
-            let byte = Self::byte_at(self.input_bytes, pos);
-            if byte < 128 {
-                Some(byte as char)
-            } else {
-                // For non-ASCII, use chars iterator
-                self.input.get(self.position..).and_then(|s| s.chars().nth(offset))
-            }
-        } else {
-            None
-        }
-    }
-
-    #[allow(clippy::inline_always)] // Performance critical in lexer hot path
-    #[inline(always)]
-    fn advance(&mut self) {
-        if self.position < self.input_bytes.len() {
-            let byte = Self::byte_at(self.input_bytes, self.position);
-            if byte < 128 {
-                // ASCII fast path
-                self.position += 1;
-            } else if let Some(ch) = self.input.get(self.position..).and_then(|s| s.chars().next())
-            {
-                self.position += ch.len_utf8();
-            }
-        }
     }
 
     /// General-purpose balanced-segment consumer (no quote-boundary recovery).


### PR DESCRIPTION
### Motivation

- Reduce `lib.rs` size and separate mechanical cursor/byte movement from higher-level lexing logic to prepare for SRP-driven state grouping and checkpoint consolidation.
- Introduce an internal `lexer/` namespace as a safe migration surface while preserving the crate's public API and behaviour.

### Description

- Added an internal `lexer` module and submodules at `crates/perl-lexer/src/lexer/{mod.rs,cursor.rs,state.rs}` and wired `mod lexer;` into `src/lib.rs` to host implementation details.  
- Moved low-level cursor/line helpers out of `lib.rs` into `lexer/cursor.rs` as `impl<'a> PerlLexer<'a>` methods: `normalize_file_start`, `trailing_ws_only`, `consume_newline`, `find_line_end`, `byte_at`, `current_char`, `peek_char`, and `advance` to preserve hot-path performance and call sites.  
- Added staged state scaffolding in `lexer/state.rs` with grouped structs `SourceView`, `CursorState`, `LexicalContext`, `HeredocState`, `QuoteState`, `EofState`, `BudgetState`, and `LexerState` to enable future migration of `PerlLexer` fields without changing the public `LexerCheckpoint`/API surface.  
- Kept public behaviour stable (re-export shape unchanged) and restored `set_mode` on `PerlLexer` to preserve downstream integration points.

### Testing

- Ran `cargo check -p perl-lexer --lib --locked`, which completed successfully.  
- Ran the crate tests scoped to unicode and related suites with `cargo test -p perl-lexer unicode --locked`, which passed (all executed tests succeeded).  
- Note: an attempt to run the repository-wide `./scripts/cargo-safe check -p perl-lexer --all-targets --profile agent --locked` was blocked by the environment storage policy and was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45201ca54833391ae9db1ad74fc35)