### PR TITLE
ci(tokmd): gate advisory review workflow (#0000)

### DIFF
--- a/.github/workflows/tokmd.yml
+++ b/.github/workflows/tokmd.yml
@@ -3,12 +3,12 @@ name: tokmd PR Review
 on:
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
 
 permissions:
   contents: read
@@ -17,6 +17,7 @@ permissions:
 jobs:
   review:
     name: tokmd Review Cockpit
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci:tokmd')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 


### PR DESCRIPTION
Problem: tokmd PR Review ran on every pull request and failed the workflow spend audit.\nFix: require the ci:tokmd label for pull_request runs while preserving manual workflow_dispatch, and trigger on labeled events so maintainers can opt in.\nVerification: \cargo xtask ci-audit-workflows\; \cargo xtask workflow-trigger-lint\; \git diff --check\.