### PR TITLE
ci(release): close v0.13.1 channel truth gaps (#0000)

### DIFF
--- a/.github/workflows/brew-bump.yml
+++ b/.github/workflows/brew-bump.yml
@@ -26,6 +26,7 @@ permissions:
 
 env:
   FORMULA_NAME: perllsp
+  GH_REPO: ${{ github.repository }}
   HOMEBREW_TAP_NAME: effortlessmetrics/tap
   HOMEBREW_TAP_REPOSITORY: EffortlessMetrics/homebrew-tap
 

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -208,6 +208,7 @@ jobs:
     permissions:
       contents: write
     env:
+      GH_REPO: ${{ github.repository }}
       GITHUB_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ needs.prepare-vsix.outputs.release_tag }}
       VSIX_FILE: ${{ needs.prepare-vsix.outputs.vsix_file }}

--- a/Formula/perllsp.rb
+++ b/Formula/perllsp.rb
@@ -1,10 +1,8 @@
 class Perllsp < Formula
   desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/EffortlessMetrics/perl-lsp"
-  # PLACEHOLDER-GUARD: __RELEASE_VERSION__ must be replaced in CI before merge.
   version "__RELEASE_VERSION__"
-  # PLACEHOLDER-GUARD: all sha256 values must be replaced in CI before merge.
-  license "MIT"
+  license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
     if Hardware::CPU.arm?

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ These are behavioral and corpus-backed signals, not feature inventory counts. Pr
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
-| Release track | `v0.13.0-alpha` release prep |
-| Published crate surface | 34 crates after the v0.13 collapse |
+| Release track | `v0.13.1` public-alpha patch |
+| Published crate surface | 32 crates in `[workspace.metadata.publish.allow]` |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |
 | Project parser corpus | 100.0% clean (`95/95`) |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -169,7 +169,7 @@ gh workflow run release-orchestration.yml \
 3. Click **Run workflow**.
 4. Fill in the fields:
    - **Release version**: `0.12.1` (no `v` prefix)
-   - **Mark as prerelease**: unchecked for stable releases
+   - **Mark as prerelease**: check only when GitHub should display the release as a prerelease
    - **Skip crates.io publishing**: leave unchecked
    - **Skip VSCode extension publishing**: leave unchecked
    - **Skip Docker image publishing**: leave unchecked
@@ -275,7 +275,7 @@ docker pull ghcr.io/effortlessmetrics/perl-lsp:0.12.1
 
 ### 6. Homebrew auto-bump
 
-The `brew-bump.yml` workflow triggers automatically on `release.published`. It downloads all four platform archives (`perllsp-${VERSION}-{x86_64,aarch64}-{apple-darwin,unknown-linux-gnu}.tar.gz`), computes SHA256 checksums, updates `Formula/perl-lsp.rb`, and creates a bump PR.
+The `brew-bump.yml` workflow triggers automatically on `release.published`. It downloads all four platform archives (`perllsp-${VERSION}-{x86_64,aarch64}-{apple-darwin,unknown-linux-gnu}.tar.gz`), validates them against `SHA256SUMS`, updates `Formula/perllsp.rb` in `EffortlessMetrics/homebrew-tap`, and creates a bump PR.
 
 To verify the workflow ran:
 
@@ -284,7 +284,7 @@ To verify the workflow ran:
 gh run list --workflow brew-bump.yml --limit 5
 
 # Check the bump PR was created
-gh pr list --search "perl-lsp" --state open
+gh pr list --search "perllsp" --state open
 ```
 
 If the workflow did not trigger automatically, run it manually:
@@ -296,7 +296,7 @@ gh workflow run brew-bump.yml --field tag=v0.12.1
 To test that the formula works locally (requires macOS or Linuxbrew):
 
 ```bash
-brew install --build-from-source Formula/perl-lsp.rb
+brew install --build-from-source Formula/perllsp.rb
 perllsp --health
 ```
 

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -14,6 +14,7 @@ Tag commit timestamps may differ from release dates.
 
 | Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
 |---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
+| [0.13.1] | `v0.13.1` | [yes][gh-0.13.1] (prerelease) | 2026-05-01 | `6ef20484` | [v0.13.0...v0.13.1] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.1 (32 crates) | [perl-lsp-rs][vsce] | [v0.13.1][n-0.13.1] |
 | [0.12.4] | `v0.12.4` | [yes][gh-0.12.4] | 2026-04-12 | `5ebb37aa` | [v0.12.3...v0.12.4] | 9 (7 binaries, SHA256SUMS, SBOM) | deferred | [perl-lsp-rs][vsce] | [v0.12.4][n-0.12.4] |
 | [0.12.3] | `v0.12.3` | [yes][gh-0.12.3] | 2026-04-09 | `a86af221` | [v0.12.2...v0.12.3] | 10 (+ VSIX) | deferred | [perl-lsp-rs][vsce] | [v0.12.3][n-0.12.3] |
 | [0.12.2] | `v0.12.2` | [yes][gh-0.12.2] | 2026-04-04 | `1c0620d8` | [v0.12.1...v0.12.2] | 9 | 0.12.2 (2026-04-08) | [perl-lsp-rs][vsce] | [v0.12.2][n-0.12.2] |
@@ -55,6 +56,7 @@ Tag commit timestamps may differ from release dates.
 ## Links
 
 <!-- Notes files -->
+[n-0.13.1]: docs/releases/v0.13.1.md
 [n-0.12.4]: docs/releases/v0.12.4.md
 [n-0.12.3]: docs/releases/v0.12.3.md
 [n-0.12.2]: docs/releases/v0.12.2.md
@@ -69,6 +71,7 @@ Tag commit timestamps may differ from release dates.
 [n-0.8.3]: docs/releases/v0.8.3.md
 
 <!-- Version links (to notes files) -->
+[0.13.1]: docs/releases/v0.13.1.md
 [0.12.4]: docs/releases/v0.12.4.md
 [0.12.3]: docs/releases/v0.12.3.md
 [0.12.2]: docs/releases/v0.12.2.md
@@ -83,6 +86,7 @@ Tag commit timestamps may differ from release dates.
 [0.8.3]: docs/releases/v0.8.3.md
 
 <!-- GitHub Releases -->
+[gh-0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.1
 [gh-0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4
 [gh-0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.3
 [gh-0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.2
@@ -93,6 +97,7 @@ Tag commit timestamps may differ from release dates.
 [gh-0.8.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3
 
 <!-- Compare ranges -->
+[v0.13.0...v0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0...v0.13.1
 [v0.12.3...v0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4
 [v0.12.2...v0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3
 [v0.12.1...v0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -22,11 +22,11 @@
 
 | Metric | Value | Source |
 | --- | --- | --- |
-| **Workspace version line** | `v0.12.4` | [`Cargo.toml`](../../Cargo.toml) |
-| **Latest GitHub/editor release** | `v0.12.4`, 2026-04-12 | GitHub Releases, VS Code Marketplace |
-| **crates.io line** | `v0.12.2`, 2026-04-08 | crates.io |
+| **Workspace version line** | `v0.13.1` | [`Cargo.toml`](../../Cargo.toml) |
+| **Current release train** | `v0.13.1` public-alpha patch | [docs/releases/v0.13.1.md](../releases/v0.13.1.md) |
+| **Published crate surface** | 32 crates | [`[workspace.metadata.publish.allow]`](../../Cargo.toml) |
 | **Release history** | [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) | Canonical cross-channel ledger |
-| **Active milestone** | `v0.13.0` public alpha announcement | [status/index.md](status/index.md) |
+| **Active milestone** | `v0.13.1` public-alpha channel verification | [status/index.md](status/index.md) |
 | **Merge gate** | `nix develop -c just ci-gate` | [protocols/verification.md](protocols/verification.md) |
 | **LSP Coverage** | See [status/lsp.md](status/lsp.md) | Generated per-merge |
 | **Test counts** | See [status/tests.md](status/tests.md) | Generated per-merge |

--- a/docs/project/GA_RUNBOOK.md
+++ b/docs/project/GA_RUNBOOK.md
@@ -104,43 +104,46 @@ git init
 mkdir Formula
 ```
 
-Create `Formula/perl-lsp.rb`:
+Create `Formula/perllsp.rb`:
 
 ```ruby
-class PerlLsp < Formula
-  desc "Perl language server with 100% edge case coverage"
+class Perllsp < Formula
+  desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/EffortlessMetrics/perl-lsp"
-  version "0.8.3"
-  license "MIT"
+  version "0.13.1"
+  license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
-    on_arm do
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-aarch64-apple-darwin.tar.gz"
+    if Hardware::CPU.arm?
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-aarch64-apple-darwin.tar.gz"
       sha256 "ACTUAL_SHA256_FROM_RELEASE"
-    end
-    on_intel do
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-x86_64-apple-darwin.tar.gz"
+    else
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-x86_64-apple-darwin.tar.gz"
       sha256 "ACTUAL_SHA256_FROM_RELEASE"
     end
   end
 
   on_linux do
-    on_arm do
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-aarch64-unknown-linux-musl.tar.gz"
+    if Hardware::CPU.arm?
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "ACTUAL_SHA256_FROM_RELEASE"
-    end
-    on_intel do
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-x86_64-unknown-linux-musl.tar.gz"
+    else
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-x86_64-unknown-linux-gnu.tar.gz"
       sha256 "ACTUAL_SHA256_FROM_RELEASE"
     end
   end
 
   def install
-    bin.install "perllsp"
+    extracted_dir = Dir.glob("perllsp-#{version}-*").find { |path| File.directory?(path) }
+    raise "expected release archive directory perllsp-#{version}-<target>" unless extracted_dir
+
+    bin.install "#{extracted_dir}/perllsp"
+    bin.install "#{extracted_dir}/perl-dap"
   end
 
   test do
-    assert_match "perllsp", shell_output("#{bin}/perllsp --version")
+    assert_match version.to_s, shell_output("#{bin}/perllsp --version")
+    assert_match version.to_s, shell_output("#{bin}/perl-dap --version")
   end
 end
 ```
@@ -148,8 +151,8 @@ end
 Push the tap:
 
 ```bash
-git add Formula/perl-lsp.rb
-git commit -m "Add perl-lsp v0.8.3"
+git add Formula/perllsp.rb
+git commit -m "Add perllsp v0.13.1"
 git remote add origin https://github.com/EffortlessMetrics/homebrew-tap.git
 git push -u origin main
 ```
@@ -157,8 +160,7 @@ git push -u origin main
 Test the formula:
 
 ```bash
-brew tap effortlesssteven/tap
-brew install perl-lsp
+brew install effortlessmetrics/tap/perllsp
 perllsp --version
 ```
 
@@ -193,8 +195,7 @@ irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.
 
 #### Homebrew
 ```bash
-brew tap effortlesssteven/tap
-brew install perl-lsp
+brew install effortlessmetrics/tap/perllsp
 ```
 
 ### Manual Download
@@ -233,8 +234,7 @@ curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/i
 irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.ps1 | iex
 
 # Homebrew
-brew tap effortlesssteven/tap
-brew install perl-lsp
+brew install effortlessmetrics/tap/perllsp
 ```
 
 ### 📊 Performance

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -9,12 +9,12 @@
 ## Current Framing
 
 - Workspace version line: `v0.13.1`
-- Latest published GitHub/editor release: `v0.12.4` (GitHub Releases and VS Code Marketplace, shipped 2026-04-12)
-- crates.io published line: `v0.12.2` (registry line, published 2026-04-08)
-- Active work: finish the `v0.13.0` public alpha announcement pass (demo assets, distribution-truth cleanup, post-release docs/automation cleanup) while keeping the shipped `v0.12.4` line stable across GitHub Releases and the editor marketplaces
+- Current release train: `v0.13.1` public-alpha patch, dispatched 2026-05-01 for channel publication and verification
+- Published crate surface target: 32 crates from `[workspace.metadata.publish.allow]`
+- Active work: monitor the `v0.13.1` downstream publish workflows, close package-manager receipts, and keep release language public-alpha rather than stable/GA
 - Canonical local receipt: `nix develop -c just ci-gate`
 
-Publication discipline: public release truth is intentionally split right now. GitHub Releases and the editor marketplaces are on `v0.12.4`; crates.io remains on `v0.12.2` until the registry window reopens. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the full cross-channel ledger. Milestone sections below can describe the intended `0.12.x` breakdown, but they must not blur that channel split.
+Publication discipline: `v0.13.1` uses a normal SemVer package version for release channels while the human-facing product posture remains public alpha. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the cross-channel ledger, and do not mark the release complete until every intended channel is green or explicitly deferred.
 
 ## How To Read This File
 
@@ -90,16 +90,16 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - End-to-end LSP feature development guide (#3027, PR #3115)
 - GIF recording guide and asset structure (#2336, PR #3130)
 
-## Active: Quality Cleanup (post-v0.12.3 / pre-v0.13.0)
+## Active: Public-Alpha Channel Verification (v0.13.1)
 
-- Debug println removal from library code (in progress)
-- Unused dependency removal across 6 crates (in progress)
-- Banned unwrap()/expect() replacement in production code (in progress)
-- Clippy zero-warning enforcement (done, PR #3138)
+- GitHub Release, crates.io, Docker, VS Code Marketplace, Open VSX, and Homebrew tap receipts are tracked separately
+- The owned Homebrew path is `brew install effortlessmetrics/tap/perllsp`
+- Public install language must say public alpha, not stable/GA
+- Follow-on quality cleanup resumes after the release-channel receipts are closed
 
 ## Now / Next / Later
 
-### Now (post-v0.12.3 / pre-v0.13.0)
+### Now (v0.13.1 public-alpha patch)
 
 - CI/control-plane Wave 2 substrate already landed and should not be re-implemented in parallel follow-up PRs:
   - Per-gate timeout regression coverage in gate receipts (#7525)
@@ -116,7 +116,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
   6. Merge-train planner/receipt protocol with stop conditions
   7. Tokmd advisory stabilization (explicitly non-required while calibrating signal)
 - Wave guardrails: no bulk stale-closure automation, no full merge bot scope, no global pre-push hooks, no broad CI architecture rewrite in this pass.
-- `v0.12.3` shipped to GitHub Releases, VS Code Marketplace, and Open VSX on 2026-04-09; crates.io remains on `v0.12.2`
+- `v0.13.1` has been dispatched as the public-alpha patch release; verify each downstream publish channel before declaring the train complete
 - Pre-announcement license badge fix (PR #3193): canonical SPDX text in all 126 LICENSE files
 - Pre-announcement Docker arm64 timeout fix (#3188 → PR #3191, merged)
 - Per-release dependency triage: 7 dependabot PRs merged 2026-04-07 (#3178–#3184)
@@ -129,12 +129,12 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Semantic substrate migration status now tracks Wave 2 reality (facts vocabulary, SymbolDecl adapter, FileFactShard write-through, and DefinitionCandidate multimap landed; SymbolRef adapter and typed-reference global index still staged; ExportInfo -> ExportSet landed) in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md); provider cutover remains explicitly deferred until Wave 3 foundations (`ImportSpec` + `visible_symbols_at`) are proven
 - CI/control-plane next-wave execution sequencing is tracked in [CI_WAVE_EXECUTION_PLAN.md](CI_WAVE_EXECUTION_PLAN.md), with #7404 (`update-status --write` streaming) as the top urgency lane.
 
-### Next (v0.13.0 — public alpha announcement)
+### Next (post v0.13.1)
 
 - The 0.12.x line has built confidence across parser, diagnostics, refactoring, and distribution
-- Quality cleanup PRs land, version bump to 0.13.0
-- Seamless install story verified across all distribution channels
-- Announcement blog post / release notes
+- Resume parser, corpus, semantic, and DAP hardening after the release-channel receipts close
+- Keep the install story verified across all distribution channels
+- Keep public-alpha release notes concise and tied to concrete channel receipts
 
 ## Milestone Ladder
 
@@ -169,7 +169,7 @@ Follow-on diagnostics and semantics scope retained on the prep track, not yet a 
 ### v0.12.5–v0.12.8
 
 Parser confidence, performance, distribution, and announcement-polish scopes retained on the prep track.
-Treat these as internal milestone slices until the next public GitHub release beyond `v0.12.3` is actually cut.
+Treat these as historical prep slices superseded by the `v0.13.x` public-alpha line.
 
 ### v0.13.0
 
@@ -207,9 +207,9 @@ For live capability posture, run `just status-check` or read [CURRENT_STATUS.md]
 | Topic | Source |
 | --- | --- |
 | Workspace version line | [`../../Cargo.toml`](../../Cargo.toml) |
-| Latest published release | GitHub Releases (`v0.12.3`) + crates.io API (`0.12.2` when channel split matters) |
+| Latest published release | [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) records the cross-channel ledger; verify live channel state before citing completion |
 | Capability catalog | [`../../features.toml`](../../features.toml) |
 | Evidence-backed metrics | [CURRENT_STATUS.md](CURRENT_STATUS.md) |
 | Top-level summary docs | [../../ROADMAP.md](../../ROADMAP.md), [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) |
 
-<!-- Last Updated: 2026-04-09 -->
+<!-- Last Updated: 2026-05-01 -->

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -5,7 +5,7 @@
 
 ## What's True Right Now
 
-- **Release posture**: GitHub Releases plus the editor channels (VS Code Marketplace and Open VSX) are live on `v0.12.3` as of 2026-04-09, the workspace version line is `v0.12.3`, crates.io intentionally remains on `v0.12.2`, and the active milestone is the `v0.13.0` public alpha announcement
+- **Release posture**: `v0.13.1` is the current public-alpha patch train. The workspace version line is `v0.13.1`, the published crate surface is 32 crates, and the release is being verified across GitHub Releases, crates.io, Docker, VS Code Marketplace, Open VSX, and the owned `effortlessmetrics/tap/perllsp` Homebrew path.
 - **Status discipline**: this file is for narrative, subsystem files are for evidence, and `just status-update` plus `just status-check` are the anti-drift workflow
 - **LSP server**: `features.toml` is the canonical capability catalog; 58 user-visible features at 100% coverage (116/116 including plumbing protocol methods and DAP handlers — corrected in PR #4107 after the DAP catalog undercount audit) — computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `cargo xtask ignored-tests` is the tracked-test-debt source
@@ -29,19 +29,19 @@
 
 ## What's Next
 
-**Now (active milestone: v0.13.0 public alpha announcement)**
-- Close out `#3302` demo-asset recording — the main remaining human-owned blocker before the `v0.13.0` public alpha announcement
-- Keep the public release split explicit: GitHub Releases, VS Code Marketplace, and Open VSX are on `v0.12.3`, while crates.io remains on `v0.12.2` until the registry window reopens
+**Now (active milestone: v0.13.1 public-alpha channel verification)**
+- Monitor the `v0.13.1` downstream release workflows and keep each channel status explicit until it is green or deliberately deferred
+- Keep public-alpha wording consistent: package versions use normal SemVer, but the product posture is not stable/GA
 - Keep the three parser verification lanes explicit and green: `just corpus-sweep-check`, `just cpan-corpus-check`, and `just parser-audit`, with `just common-corpus-check` covering the pinned strict-clean subset
-- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line, the `perl-lsp-rs` extension package, and the delayed crates.io surface
-- Resume parser, corpus, and semantic hardening while the `v0.13.0` announcement pass stays open
+- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line, the `perl-lsp-rs` extension package, and the 32-crate published surface
+- Follow up any post-merge status regeneration gaps before declaring the release ledger closed
 
-**Next (v0.13.0 public alpha)**
+**Next (post v0.13.1 public alpha)**
 - Keep all three parser corpus lanes current: Ubuntu system Perl, the cached CPAN top 1000 install, and the repo-owned corpus audit
 - Fold internal torture and edge-case suites into routine verification receipts
-- Publish benchmark and release-readiness receipts for the alpha burndown
+- Resume parser, corpus, semantic, and DAP hardening after the release-channel receipts are closed
 
-**Later (post v0.13.0)**
+**Later**
 - DAP preview hardening (deeper live variables/evaluate, shim packaging, cross-editor native receipts)
 - Full LSP 3.18 compliance
 - Broader distribution packaging
@@ -68,5 +68,5 @@ See [ROADMAP.md](../ROADMAP.md) for milestone details.
 
 ---
 
-*Last Updated: 2026-04-09 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
+*Last Updated: 2026-05-01 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
 *Canonical docs: [ROADMAP.md](../ROADMAP.md), [../../features.toml](../../features.toml)*

--- a/docs/project/status/release.md
+++ b/docs/project/status/release.md
@@ -5,17 +5,31 @@
 
 ## Current Release Call
 
-**Latest GitHub/editor release**: `v0.12.3` (2026-04-09)
-**crates.io line**: `v0.12.2` (2026-04-07)
-**Release target**: `v0.13.0` public alpha announcement
-**Ship readiness**: `v0.12.3` is live on GitHub Releases, VS Code Marketplace, and Open VSX; the remaining launch work is announcement-path cleanup, with `#3302` demo assets still the main human-owned blocker before the `v0.13.0` public alpha announcement
+**Current release train**: `v0.13.1` public-alpha patch (dispatched 2026-05-01)
+**Workspace version line**: `v0.13.1`
+**Published crate surface**: 32 crates
+**Release target**: channel verification across GitHub Releases, crates.io, Docker, VS Code Marketplace, Open VSX, and the owned Homebrew tap
+**Ship readiness**: release orchestration validated the default-branch tip, created `v0.13.1`, and dispatched downstream publish workflows. Do not declare all channels complete until post-publish verification is done.
 
 ## Active Blockers
 
-- `#3302` demo GIFs remain the main human-owned blocker before the `v0.13.0` public alpha announcement
-- Public install guidance must keep the channel split explicit while crates.io remains on `v0.12.2`
+- No known code release blocker after `#7676`, `#7781`, `#7782`, and `#7791`
+- Remaining work is operational: monitor downstream channel workflows, run post-publish verification, and record final channel receipts
 
-## 0.12.3 Ship Receipts (2026-04-09)
+## 0.13.1 Release Receipts (2026-05-01)
+
+- Release-channel hardening landed in `#7676`: Marketplace-safe version handling, independent Open VSX publishing, explicit token/channel status, and CI timeout classification
+- Homebrew tap targeting landed in `#7781`: owned `EffortlessMetrics/homebrew-tap`, `Formula/perllsp.rb`, `class Perllsp`, strict release asset validation, and `brew install effortlessmetrics/tap/perllsp`
+- Release naming/docs landed in `#7782`: `docs/releases/v0.13.1.md`, concise changelog entry, and public-alpha wording
+- Version bump landed in `#7791`: workspace and package surfaces moved to `0.13.1`; release checks reported 32 published crates
+- Release orchestration run `25209777861` created tag `v0.13.1` at `6ef20484` and dispatched GitHub Release, crates.io, extension, and Docker workflows
+- crates.io publish run `25209810591` completed and verified all 32 crates at `0.13.1`
+- GitHub Release run `25209810124` published `v0.13.1` binaries, `SHA256SUMS`, and SBOM; the VSIX was attached after the release object existed
+- VS Code Marketplace and Open VSX publish jobs completed independently; the failed attach job exposed a missing `GH_REPO` environment setting and is patched in the follow-up release-hygiene PR
+- Homebrew manual bump run `25210359468` reached the owned-tap path but exposed the same missing `GH_REPO` setting for release asset downloads outside the source checkout; the follow-up release-hygiene PR patches that before rerunning the tap bump
+- Homebrew patched-branch run `25210881000` validated the `v0.13.1` release asset layout and checksums, then stopped because `HOMEBREW_TAP_TOKEN` is not configured; `EffortlessMetrics/homebrew-tap` was bootstrapped and `EffortlessMetrics/homebrew-tap#1` merged the `perllsp 0.13.1` formula
+
+## Historical 0.12.3 Ship Receipts (2026-04-09)
 
 - GitHub release `v0.12.3` published 2026-04-09 against `cc801735`
 - `Release` workflow completed successfully and attached the cross-platform `perllsp` archives plus `SHA256SUMS`
@@ -60,4 +74,4 @@ Native + Bridge preview. Harden preview flows is active work.
 
 ---
 
-*Last Updated: 2026-04-09*
+*Last Updated: 2026-05-01*

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -252,11 +252,11 @@ enum Commands {
         repo: String,
 
         /// Artifact prefix for release filenames.
-        #[arg(long, default_value = "perl-lsp")]
+        #[arg(long, default_value = "perllsp")]
         prefix: String,
 
         /// Output path for generated Homebrew formula.
-        #[arg(long, default_value = "homebrew/perl-lsp.rb")]
+        #[arg(long, default_value = "Formula/perllsp.rb")]
         output: PathBuf,
     },
 

--- a/xtask/src/tasks/inject_sha_assets.rs
+++ b/xtask/src/tasks/inject_sha_assets.rs
@@ -104,11 +104,11 @@ fn build_brew_formula(config: &InjectShaAssetsConfig, assets: &AssetShaMap<'_>) 
     let lin_x64_filename = artifact_filename(&config.prefix, &config.version, LIN_X64);
 
     format!(
-        r##"class PerlLsp < Formula
-  desc "Perl language server"
+        r##"class Perllsp < Formula
+  desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/{owner}/{repo}"
   version "{version}"
-  license "MIT"
+  license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
     on_arm do
@@ -133,11 +133,16 @@ fn build_brew_formula(config: &InjectShaAssetsConfig, assets: &AssetShaMap<'_>) 
   end
 
   def install
-    bin.install "perllsp"
+    extracted_dir = Dir.glob("perllsp-#{{version}}-*").find {{ |path| File.directory?(path) }}
+    raise "expected release archive directory perllsp-#{{version}}-<target>" unless extracted_dir
+
+    bin.install "#{{extracted_dir}}/perllsp"
+    bin.install "#{{extracted_dir}}/perl-dap"
   end
 
   test do
-    assert_match "perllsp", shell_output("#{{bin}}/perllsp --version")
+    assert_match version.to_s, shell_output("#{{bin}}/perllsp --version")
+    assert_match version.to_s, shell_output("#{{bin}}/perl-dap --version")
   end
 end
 "##,

--- a/xtask/src/tasks/update_homebrew.rs
+++ b/xtask/src/tasks/update_homebrew.rs
@@ -67,12 +67,11 @@ pub fn run(config: UpdateHomebrewConfig) -> Result<()> {
     println!();
     println!("Next steps:");
     println!("1. Review the formula: cat {}", output.display());
-    println!("2. Copy to your homebrew-tap repository");
-    println!("3. Commit and push the updated formula");
+    println!("2. Copy to EffortlessMetrics/homebrew-tap");
+    println!("3. Commit and push Formula/perllsp.rb");
     println!();
     println!("Users can then install with:");
-    println!("  brew tap effortlesssteven/tap");
-    println!("  brew install perl-lsp");
+    println!("  brew install effortlessmetrics/tap/perllsp");
 
     Ok(())
 }
@@ -157,11 +156,11 @@ fn build_brew_formula(
     let linux_x64_filename = artifact_filename(&config.prefix, version, LIN_X64);
 
     format!(
-        r##"class PerlLsp < Formula
-  desc "Fast, reliable Perl language server with 100% syntax coverage"
+        r##"class Perllsp < Formula
+  desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/{owner}/{repo}"
   version "{version}"
-  license "MIT"
+  license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
     if Hardware::CPU.arm?
@@ -184,14 +183,11 @@ fn build_brew_formula(
   end
 
   def install
-    # Find the extracted directory (should be perllsp-v*).
-    extracted_dir = Dir.glob("perllsp-v*").first
-    if extracted_dir && File.directory?(extracted_dir)
-      bin.install "#{{extracted_dir}}/perllsp"
-    else
-      # Fallback: binary might be in the root
-      bin.install "perllsp"
-    end
+    extracted_dir = Dir.glob("perllsp-#{{version}}-*").find {{ |path| File.directory?(path) }}
+    raise "expected release archive directory perllsp-#{{version}}-<target>" unless extracted_dir
+
+    bin.install "#{{extracted_dir}}/perllsp"
+    bin.install "#{{extracted_dir}}/perl-dap"
   end
 
   def caveats
@@ -215,13 +211,8 @@ fn build_brew_formula(
   end
 
   test do
-    # Test that the binary runs and responds to version request
-    assert_match(/perllsp|Perl LSP/, shell_output("#{{bin}}/perllsp --version"))
-
-    # Test LSP initialization
-    input = '{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{}}}}'
-    output = pipe_output("#{{bin}}/perllsp --stdio", input, 0)
-    assert_match(/Content-Length/, output)
+    assert_match version.to_s, shell_output("#{{bin}}/perllsp --version")
+    assert_match version.to_s, shell_output("#{{bin}}/perl-dap --version")
   end
 end
 "##,


### PR DESCRIPTION
Problem: v0.13.1 exposed post-tag release-truth drift and gh CLI repo-context gaps in Homebrew/VSIX asset publishing.
Fix: align docs/ledger/Homebrew formula naming, update Homebrew formula generators for the perllsp tap flow, and set GH_REPO for release asset lookups outside checkout directories.
Verification: `git diff --check` passes; `bash scripts/check_release_history.sh` passes; `cargo-safe xtask update-homebrew --version v0.13.1 --output /tmp/perllsp-generated-formula-0.13.1.rb` generated the expected perllsp formula from live release checksums; release archive layout confirmed includes `perllsp` and `perl-dap`. Patched Homebrew workflow run `25210881000` validated assets/checksums and is now blocked only on missing `HOMEBREW_TAP_TOKEN`; the owned tap was bootstrapped and https://github.com/EffortlessMetrics/homebrew-tap/pull/1 merged the v0.13.1 formula. `cargo-safe test -p xtask` runs but has existing unrelated failures in status/worktree/swarm tests.