### PR TITLE
fix(vscode): resolve non-v release assets (#0000)

### DIFF
--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -23,6 +23,38 @@ interface Release {
     assets: ReleaseAsset[];
 }
 
+export function buildBinaryAssetCandidateNames(versionOrTag: string, target: string, ext: string): string[] {
+    const normalizedVersion = versionOrTag.replace(/^v/, '');
+    const tagVersion = `v${normalizedVersion}`;
+    const candidates = [
+        `perllsp-${normalizedVersion}-${target}${ext}`,
+        `perllsp-${versionOrTag}-${target}${ext}`,
+        `perllsp-${tagVersion}-${target}${ext}`,
+        `perllsp-${target}${ext}`,
+        `perl-lsp-${normalizedVersion}-${target}${ext}`,
+        `perl-lsp-${versionOrTag}-${target}${ext}`,
+        `perl-lsp-${tagVersion}-${target}${ext}`,
+        `perl-lsp-${target}${ext}`,
+    ];
+
+    return [...new Set(candidates)];
+}
+
+export function findReleaseAssetName(
+    assets: ReadonlyArray<{ name: string }>,
+    versionOrTag: string,
+    target: string,
+    ext: string
+): string | undefined {
+    for (const name of buildBinaryAssetCandidateNames(versionOrTag, target, ext)) {
+        if (assets.some(asset => asset.name === name)) {
+            return name;
+        }
+    }
+
+    return undefined;
+}
+
 /**
  * Parse the local version string from `perllsp --version` stdout.
  *
@@ -200,26 +232,8 @@ export class BinaryDownloader {
             
             // Try multiple naming patterns for our release format
             const ext = process.platform === 'win32' ? '.zip' : '.tar.gz';
-            const possibleNames = [
-                `perllsp-${release.tag_name}-${target}${ext}`,
-                `perllsp-v${release.tag_name.replace('v', '')}-${target}${ext}`,
-                `perllsp-${target}${ext}`,
-                `perl-lsp-${release.tag_name}-${target}${ext}`,
-                `perl-lsp-v${release.tag_name.replace('v', '')}-${target}${ext}`,
-                `perl-lsp-${target}${ext}`
-            ];
-            
-            let assetName: string | undefined;
-            let asset: ReleaseAsset | undefined;
-            
-            // Find the first matching asset
-            for (const name of possibleNames) {
-                asset = release.assets.find(a => a.name === name);
-                if (asset) {
-                    assetName = name;
-                    break;
-                }
-            }
+            const assetName = findReleaseAssetName(release.assets, release.tag_name, target, ext);
+            const asset = assetName ? release.assets.find(a => a.name === assetName) : undefined;
             
             if (!asset || !assetName) {
                 const availableAssets = release.assets.map(a => a.name).join(', ');
@@ -434,13 +448,8 @@ export class BinaryDownloader {
         
         // Try multiple naming patterns that might be used internally
         const possibleFilenames = [
-            `perllsp-${version}-${target}${ext}`,
-            `perllsp-v${version.replace('v', '')}-${target}${ext}`,
-            `perllsp-${target}${ext}`,
+            ...buildBinaryAssetCandidateNames(version, target, ext),
             `perllsp${ext}`,
-            `perl-lsp-${version}-${target}${ext}`,
-            `perl-lsp-v${version.replace('v', '')}-${target}${ext}`,
-            `perl-lsp-${target}${ext}`,
             `perl-lsp${ext}`
         ];
         

--- a/vscode-extension/src/test/__mocks__/vscode.ts
+++ b/vscode-extension/src/test/__mocks__/vscode.ts
@@ -6,6 +6,8 @@
  * @vscode/test-electron instead of this mock.
  */
 
+import { jest } from '@jest/globals';
+
 export const Uri = {
   parse: (value: string) => ({ toString: () => value, fsPath: value }),
   file: (path: string) => ({ toString: () => `file://${path}`, fsPath: path }),

--- a/vscode-extension/src/test/downloader.test.ts
+++ b/vscode-extension/src/test/downloader.test.ts
@@ -9,7 +9,14 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { BinaryDownloader, parseLocalVersion, compareVersions } from '../downloader';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import {
+  BinaryDownloader,
+  buildBinaryAssetCandidateNames,
+  compareVersions,
+  findReleaseAssetName,
+  parseLocalVersion,
+} from '../downloader';
 
 // ---------------------------------------------------------------------------
 // Helpers: build a minimal mock ExtensionContext
@@ -358,6 +365,46 @@ describe('asset name validation', () => {
     for (const name of maliciousNames) {
       expect(pattern.test(name) && !name.includes('..')).toBe(false);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release asset candidate selection
+// ---------------------------------------------------------------------------
+describe('release asset candidate selection', () => {
+  test('finds non-v Windows asset for v-prefixed release tag', () => {
+    const assetName = 'perllsp-0.13.1-x86_64-pc-windows-msvc.zip';
+    const found = findReleaseAssetName(
+      [{ name: assetName }, { name: 'SHA256SUMS' }],
+      'v0.13.1',
+      'x86_64-pc-windows-msvc',
+      '.zip'
+    );
+
+    expect(found).toBe(assetName);
+  });
+
+  test('finds non-v Linux asset for v-prefixed release tag', () => {
+    const assetName = 'perllsp-0.13.1-x86_64-unknown-linux-gnu.tar.gz';
+    const found = findReleaseAssetName(
+      [{ name: assetName }, { name: 'SHA256SUMS' }],
+      'v0.13.1',
+      'x86_64-unknown-linux-gnu',
+      '.tar.gz'
+    );
+
+    expect(found).toBe(assetName);
+  });
+
+  test('prefers release workflow non-v asset before v-prefixed alias', () => {
+    const candidates = buildBinaryAssetCandidateNames(
+      'v0.13.1',
+      'x86_64-pc-windows-msvc',
+      '.zip'
+    );
+
+    expect(candidates[0]).toBe('perllsp-0.13.1-x86_64-pc-windows-msvc.zip');
+    expect(candidates).toContain('perllsp-v0.13.1-x86_64-pc-windows-msvc.zip');
   });
 });
 


### PR DESCRIPTION
Problem: the VS Code extension only matched v-prefixed release asset names, while release.yml emits perllsp-0.13.1-<target> assets.
Fix: centralize binary asset candidate generation so v-prefixed tags also match non-v release assets, and use the same normalization for internal release URLs.
Verification: patched v0.13.1 GitHub Release with v-prefixed alias assets plus SHA256SUMS entries; `npm test -- --runTestsByPath src/test/downloader.test.ts --runInBand` passes; `npm run compile` passes; `npm run verify:marketplace` passes.