### PR TITLE
fix(install): clarify Linux binary selection (#7671)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -434,6 +434,11 @@ Every public release **must** update three surfaces. See [RELEASE_HISTORY.md](RE
   **Required** — `release-orchestration.yml` refuses to tag without this file,
   and `release.yml` uses its body (minus YAML frontmatter) as the GitHub
   Release body.
+- [ ] If the release ships Linux GNU and musl binaries, include a
+  `Which file should I download?` section or link to
+  `docs/how-to/INSTALLATION.md`. The GitHub asset list exposes raw target
+  triples; release notes must explain that most Linux users choose `gnu`, while
+  `musl` is mainly for Alpine Linux and musl-based containers.
 - [ ] Add a new row to `RELEASE_HISTORY.md` for vX.Y.Z (fill what you know; mark unknowns with `—`)
 - [ ] Ensure `CHANGELOG.md` has a `[X.Y.Z]` section with links to:
   - `docs/releases/vX.Y.Z.md`

--- a/book/src/architecture/lsp-implementation.md
+++ b/book/src/architecture/lsp-implementation.md
@@ -3853,7 +3853,7 @@ impl LspServer {
 **Usage Example**:
 ```bash
 # Test malformed frame recovery
-echo 'Content-Length: 50\r\n\r\n{"jsonrpc":"2.0","invalid_json":}' | perl-lsp --stdio
+echo 'Content-Length: 50\r\n\r\n{"jsonrpc":"2.0","invalid_json":}' | perllsp --stdio
 
 # Expected behavior:
 # - Server logs parsing error safely
@@ -4885,7 +4885,7 @@ VS Code ↔ perl-dap (Rust) ↔ Devel::TSPerlDAP (Perl shim) ↔ perl -d
 4. **Test with Protocol Examples**
    ```bash
    # Test specific LSP method
-   echo '{"jsonrpc":"2.0","id":1,"method":"workspace/symbol","params":{"query":"test"}}' | perl-lsp --stdio
+   echo '{"jsonrpc":"2.0","id":1,"method":"workspace/symbol","params":{"query":"test"}}' | perllsp --stdio
    ```
 
 ## Security Considerations in LSP Testing

--- a/book/src/ci/local-validation.md
+++ b/book/src/ci/local-validation.md
@@ -266,10 +266,10 @@ This runs the **full CI pipeline** (~10-20 minutes) including:
 
 ```bash
 # 1. Build release binary
-cargo build -p perl-lsp-rs --release
+cargo build -p perllsp --release
 
 # 2. Test LSP server health
-./target/release/perl-lsp --version
+./target/release/perllsp --version
 
 # 3. Editor integration (choose your editor)
 # - VS Code: Open a Perl file, verify:

--- a/book/src/developer/commands-reference.md
+++ b/book/src/developer/commands-reference.md
@@ -10,18 +10,17 @@
 curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
 
 # Homebrew (macOS)
-brew tap tree-sitter-perl/tap
-brew install perl-lsp
+brew install effortlessmetrics/tap/perllsp
 
 # Build from source
-cargo build -p perl-lsp-rs --release
+cargo build -p perllsp --release
 
 # Install globally
-cargo install --path crates/perl-lsp
+cargo install --path crates/perllsp
 
 # Run the LSP server
-perl-lsp --stdio  # For editor integration
-perl-lsp --stdio --log  # With debug logging
+perllsp --stdio  # For editor integration
+perllsp --stdio --log  # With debug logging
 ```
 
 ### DAP Server (Debug Adapter)
@@ -41,7 +40,7 @@ perl-dap --stdio  # Standard DAP transport
 ### Published Crates
 ```bash
 # Install from crates.io
-cargo install perl-lsp-rs                     # LSP server
+cargo install perllsp                     # LSP server
 cargo add perl-parser                      # As library dependency
 cargo add perl-corpus --dev                # For testing
 
@@ -320,16 +319,16 @@ cargo test -p perl-lsp-rs --test lsp_comprehensive_e2e_test test_e2e_document_fo
 cargo test -p perl-lsp-rs --test lsp_perltidy_test test_formatting_provider_capability
 
 # Test LSP server manually
-echo -e 'Content-Length: 58\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | perl-lsp --stdio
+echo -e 'Content-Length: 58\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | perllsp --stdio
 
 # Run with incremental parsing enabled
-PERL_LSP_INCREMENTAL=1 perl-lsp --stdio
+PERL_LSP_INCREMENTAL=1 perllsp --stdio
 
 # Test incremental parsing with LSP protocol
-PERL_LSP_INCREMENTAL=1 perl-lsp --stdio < test_requests.jsonrpc
+PERL_LSP_INCREMENTAL=1 perllsp --stdio < test_requests.jsonrpc
 
 # Run with a test file
-perl-lsp --stdio < test_requests.jsonrpc
+perllsp --stdio < test_requests.jsonrpc
 ```
 
 ### LSP Testing Environment Variables (*Diataxis: Reference* - Configuration options)
@@ -381,7 +380,7 @@ LSP_TEST_FALLBACKS=1 cargo check --workspace # Fast build verification
 ```bash
 # Enable incremental parsing
 export PERL_LSP_INCREMENTAL=1
-perl-lsp --stdio
+perllsp --stdio
 
 # Performance benefits:
 # - <1ms LSP updates with 70-99% node reuse efficiency

--- a/book/src/developer/contributing.md
+++ b/book/src/developer/contributing.md
@@ -22,7 +22,7 @@ Thank you for your interest in contributing to Perl LSP! This guide will help yo
 
 3. **Build the Project**
    ```bash
-   cargo build -p perl-lsp-rs --release     # LSP server
+   cargo build -p perllsp --release     # LSP server
    cargo build -p perl-parser --release  # Parser library
    cargo test --workspace --lib          # Run all tests
    ```

--- a/book/src/getting-started/configuration.md
+++ b/book/src/getting-started/configuration.md
@@ -639,7 +639,7 @@ Timeout for continue operations (5 minutes).
 Enable incremental text synchronization (requires `incremental` feature).
 
 ```bash
-PERL_LSP_INCREMENTAL=1 perl-lsp --stdio
+PERL_LSP_INCREMENTAL=1 perllsp --stdio
 ```
 
 ### `RUST_LOG`
@@ -647,8 +647,8 @@ PERL_LSP_INCREMENTAL=1 perl-lsp --stdio
 Enable debug logging for troubleshooting.
 
 ```bash
-RUST_LOG=perl_lsp=debug perl-lsp --stdio
-RUST_LOG=perl_parser=trace perl-lsp --stdio
+RUST_LOG=perl_lsp=debug perllsp --stdio
+RUST_LOG=perl_parser=trace perllsp --stdio
 ```
 
 ### `RUST_TEST_THREADS`
@@ -748,7 +748,7 @@ RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs
 You can verify configuration is being applied by enabling trace logging:
 
 ```bash
-RUST_LOG=perl_parser::lsp::state=debug perl-lsp --stdio
+RUST_LOG=perl_parser::lsp::state=debug perllsp --stdio
 ```
 
 ---

--- a/book/src/getting-started/editor-setup.md
+++ b/book/src/getting-started/editor-setup.md
@@ -20,12 +20,12 @@ This guide provides copy/paste ready configurations for setting up the Perl LSP 
 
 ```bash
 # Option 1: Install from crates.io (recommended)
-cargo install perl-lsp-rs
+cargo install perllsp
 
 # Option 2: Install from source
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install --path crates/perl-lsp
+cargo install --path crates/perllsp
 
 # Option 3: Download pre-built binary
 # See https://github.com/EffortlessMetrics/perl-lsp/releases
@@ -35,13 +35,13 @@ cargo install --path crates/perl-lsp
 
 ```bash
 # Check binary is in PATH
-which perl-lsp
+which perllsp
 
 # Check version
-perl-lsp --version
+perllsp --version
 
 # Quick health check
-perl-lsp --health
+perllsp --health
 ```
 
 ---
@@ -122,7 +122,7 @@ local configs = require('lspconfig.configs')
 if not configs.perl_lsp then
   configs.perl_lsp = {
     default_config = {
-      cmd = { 'perl-lsp', '--stdio' },
+      cmd = { 'perllsp', '--stdio' },
       filetypes = { 'perl' },
       root_dir = lspconfig.util.root_pattern(
         'Makefile.PL',
@@ -197,7 +197,7 @@ local configs = require('lspconfig.configs')
 if not configs.perl_lsp then
   configs.perl_lsp = {
     default_config = {
-      cmd = { 'perl-lsp', '--stdio' },
+      cmd = { 'perllsp', '--stdio' },
       filetypes = { 'perl' },
       root_dir = lspconfig.util.root_pattern('.git'),
       single_file_support = true,
@@ -236,7 +236,7 @@ Add to your Emacs configuration:
   ;; Register perl-lsp
   (lsp-register-client
    (make-lsp-client
-    :new-connection (lsp-stdio-connection '("perl-lsp" "--stdio"))
+    :new-connection (lsp-stdio-connection '("perllsp" "--stdio"))
     :major-modes '(cperl-mode perl-mode)
     :priority -1
     :server-id 'perl-lsp
@@ -274,7 +274,7 @@ Add to your Emacs configuration:
          (perl-mode . eglot-ensure))
   :config
   (add-to-list 'eglot-server-programs
-               '((cperl-mode perl-mode) . ("perl-lsp" "--stdio")))
+               '((cperl-mode perl-mode) . ("perllsp" "--stdio")))
 
   ;; Optional: Configure initialization options
   (setq-default eglot-workspace-configuration
@@ -316,7 +316,7 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 
 [language-server.perl-lsp.config.perl]
@@ -376,19 +376,19 @@ limits.referencesCap = 500
 
 1. **Verify binary location**:
    ```bash
-   which perl-lsp
+   which perllsp
    # Should output path like: /home/user/.cargo/bin/perl-lsp
    ```
 
 2. **Check binary works**:
    ```bash
-   perl-lsp --version
-   perl-lsp --health
+   perllsp --version
+   perllsp --health
    ```
 
 3. **Test JSON-RPC communication**:
    ```bash
-   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perl-lsp --stdio
+   echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
    ```
 
 ### No Diagnostics
@@ -402,7 +402,7 @@ limits.referencesCap = 500
 
 3. **Enable debug logging**:
    ```bash
-   RUST_LOG=perl_lsp=debug perl-lsp --stdio
+   RUST_LOG=perl_lsp=debug perllsp --stdio
    ```
 
 ### Slow Performance
@@ -468,7 +468,7 @@ limits.referencesCap = 500
 
 2. Run with logging enabled:
    ```bash
-   perl-lsp --stdio --log 2>perl-lsp.log
+   perllsp --stdio --log 2>perl-lsp.log
    ```
 
 3. Report issues with reproduction steps on [GitHub](https://github.com/EffortlessMetrics/perl-lsp/issues)
@@ -492,13 +492,13 @@ Options:
 
 Examples:
   # Run in stdio mode (for editors)
-  perl-lsp --stdio
+  perllsp --stdio
 
   # Run with logging enabled
-  perl-lsp --stdio --log
+  perllsp --stdio --log
 
   # Run with debug output
-  RUST_LOG=perl_lsp=debug perl-lsp --stdio
+  RUST_LOG=perl_lsp=debug perllsp --stdio
 ```
 
 ---

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -14,7 +14,7 @@ Choose one method:
 ### Option 1: Install from crates.io (Recommended)
 
 ```bash
-cargo install perl-lsp-rs
+cargo install perllsp
 ```
 
 ### Option 2: Install Script (Linux/macOS)
@@ -30,17 +30,17 @@ curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/i
 ```bash
 git clone https://github.com/EffortlessMetrics/perl-lsp.git
 cd perl-lsp
-cargo install --path crates/perl-lsp
+cargo install --path crates/perllsp
 ```
 
 ## Verify Installation
 
 ```bash
 # Check binary is available
-perl-lsp --version
+perllsp --version
 
 # Quick health check
-perl-lsp --health
+perllsp --health
 # Should output: ok 0.10.0
 ```
 
@@ -66,7 +66,7 @@ local configs = require('lspconfig.configs')
 if not configs.perl_lsp then
   configs.perl_lsp = {
     default_config = {
-      cmd = { 'perl-lsp', '--stdio' },
+      cmd = { 'perllsp', '--stdio' },
       filetypes = { 'perl' },
       root_dir = lspconfig.util.root_pattern('.git'),
       single_file_support = true,
@@ -81,7 +81,7 @@ lspconfig.perl_lsp.setup({})
 
 ```elisp
 (add-to-list 'eglot-server-programs
-             '((cperl-mode perl-mode) . ("perl-lsp" "--stdio")))
+             '((cperl-mode perl-mode) . ("perllsp" "--stdio")))
 ```
 
 Then run `M-x eglot` in a Perl buffer.
@@ -96,7 +96,7 @@ name = "perl"
 language-servers = ["perl-lsp"]
 
 [language-server.perl-lsp]
-command = "perl-lsp"
+command = "perllsp"
 args = ["--stdio"]
 ```
 
@@ -192,7 +192,7 @@ See [CONFIG.md](../reference/CONFIG.md) for all configuration options.
 
 ```bash
 # Test if the binary works
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perl-lsp --stdio
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
 ```
 
 ### No Diagnostics Appearing

--- a/book/src/lsp/implementation-guide.md
+++ b/book/src/lsp/implementation-guide.md
@@ -3853,7 +3853,7 @@ impl LspServer {
 **Usage Example**:
 ```bash
 # Test malformed frame recovery
-echo 'Content-Length: 50\r\n\r\n{"jsonrpc":"2.0","invalid_json":}' | perl-lsp --stdio
+echo 'Content-Length: 50\r\n\r\n{"jsonrpc":"2.0","invalid_json":}' | perllsp --stdio
 
 # Expected behavior:
 # - Server logs parsing error safely
@@ -4885,7 +4885,7 @@ VS Code ↔ perl-dap (Rust) ↔ Devel::TSPerlDAP (Perl shim) ↔ perl -d
 4. **Test with Protocol Examples**
    ```bash
    # Test specific LSP method
-   echo '{"jsonrpc":"2.0","id":1,"method":"workspace/symbol","params":{"query":"test"}}' | perl-lsp --stdio
+   echo '{"jsonrpc":"2.0","id":1,"method":"workspace/symbol","params":{"query":"test"}}' | perllsp --stdio
    ```
 
 ## Security Considerations in LSP Testing

--- a/book/src/reference/milestones.md
+++ b/book/src/reference/milestones.md
@@ -54,7 +54,7 @@
 - `nix develop -c just ci-gate` green on MSRV
 - `bash scripts/ignored-test-count.sh` shows BUG=0, MANUAL≤1
 - README / CURRENT_STATUS / ROADMAP agree (no unbacked claims)
-- `cargo install --path crates/perl-lsp` works cleanly
+- `cargo install --path crates/perllsp` works cleanly
 - Capability snapshot remains stable
 - Release notes match advertised capabilities
 

--- a/book/src/reference/upgrading.md
+++ b/book/src/reference/upgrading.md
@@ -87,12 +87,12 @@ let ast = parser.parse(source)?;
 **After (v0.9.x):**
 ```json
 // Setting removed - use standard installation methods
-// Install via: cargo install perl-lsp-rs
+// Install via: cargo install perllsp
 ```
 
 **Action Required:**
 - Remove `downloadBaseUrl` from VS Code settings
-- Use standard installation: `cargo install perl-lsp-rs`
+- Use standard installation: `cargo install perllsp`
 - Internal archive hosting no longer supported
 
 ### 4. UTF-16 Position Encoding
@@ -187,7 +187,7 @@ my $total = calculate_total($price, $quantity, $discount);
 
 ```bash
 # Start LSP server on TCP port
-perl-lsp --tcp 9257
+perllsp --tcp 9257
 
 # Connect from LSP client
 {

--- a/book/src/resources/ga-runbook.md
+++ b/book/src/resources/ga-runbook.md
@@ -30,7 +30,7 @@ sed -i "s/^version = \".*\"/version = \"$VERSION\"/" crates/tree-sitter-perl-rs/
 cargo update
 
 # Verify builds
-cargo build -p perl-parser --bin perl-lsp --release
+cargo build -p perl-parser --bin perllsp --release
 ```
 
 ### 2. Create & Push Tag (2 min)
@@ -104,43 +104,43 @@ git init
 mkdir Formula
 ```
 
-Create `Formula/perl-lsp.rb`:
+Create `Formula/perllsp.rb`:
 
 ```ruby
-class PerlLsp < Formula
-  desc "Perl language server with 100% edge case coverage"
+class Perllsp < Formula
+  desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/EffortlessMetrics/perl-lsp"
   version "0.8.3"
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perllsp-0.8.3-aarch64-apple-darwin.tar.gz"
       sha256 "ACTUAL_SHA256_FROM_RELEASE"
     end
     on_intel do
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perllsp-0.8.3-x86_64-apple-darwin.tar.gz"
       sha256 "ACTUAL_SHA256_FROM_RELEASE"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-aarch64-unknown-linux-musl.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perllsp-0.8.3-aarch64-unknown-linux-musl.tar.gz"
       sha256 "ACTUAL_SHA256_FROM_RELEASE"
     end
     on_intel do
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perl-lsp-v0.8.3-x86_64-unknown-linux-musl.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v0.8.3/perllsp-0.8.3-x86_64-unknown-linux-musl.tar.gz"
       sha256 "ACTUAL_SHA256_FROM_RELEASE"
     end
   end
 
   def install
-    bin.install "perl-lsp"
+    bin.install "perllsp"
   end
 
   test do
-    assert_match "perl-lsp", shell_output("#{bin}/perl-lsp --version")
+    assert_match "perllsp", shell_output("#{bin}/perllsp --version")
   end
 end
 ```
@@ -148,8 +148,8 @@ end
 Push the tap:
 
 ```bash
-git add Formula/perl-lsp.rb
-git commit -m "Add perl-lsp v0.8.3"
+git add Formula/perllsp.rb
+git commit -m "Add perllsp v0.8.3"
 git remote add origin https://github.com/EffortlessMetrics/homebrew-tap.git
 git push -u origin main
 ```
@@ -157,9 +157,8 @@ git push -u origin main
 Test the formula:
 
 ```bash
-brew tap effortlesssteven/tap
-brew install perl-lsp
-perl-lsp --version
+brew install effortlessmetrics/tap/perllsp
+perllsp --version
 ```
 
 ### 7. VS Code Extension (if ready)
@@ -193,8 +192,7 @@ irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.
 
 #### Homebrew
 ```bash
-brew tap effortlesssteven/tap
-brew install perl-lsp
+brew install effortlessmetrics/tap/perllsp
 ```
 
 ### Manual Download
@@ -233,8 +231,7 @@ curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/i
 irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.ps1 | iex
 
 # Homebrew
-brew tap effortlesssteven/tap
-brew install perl-lsp
+brew install effortlessmetrics/tap/perllsp
 ```
 
 ### 📊 Performance

--- a/book/src/user-guides/lsp-features.md
+++ b/book/src/user-guides/lsp-features.md
@@ -508,7 +508,7 @@ Using nvim-lspconfig:
 
 ```lua
 require('lspconfig').perl_lsp.setup{
-  cmd = {'perl-lsp', '--stdio'},
+  cmd = {'perllsp', '--stdio'},
   settings = {
     perl = {
       lsp = {
@@ -534,7 +534,7 @@ With lsp-mode or eglot:
 
 ;; eglot
 (add-to-list 'eglot-server-programs
-             '((perl-mode cperl-mode) . ("perl-lsp" "--stdio")))
+             '((perl-mode cperl-mode) . ("perllsp" "--stdio")))
 ```
 
 ### Sublime Text
@@ -589,10 +589,10 @@ With lsp-mode or eglot:
 **LSP not starting:**
 ```bash
 # Check if perl-lsp is in PATH
-which perl-lsp
+which perllsp
 
 # Test standalone
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | perl-lsp --stdio
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | perllsp --stdio
 ```
 
 **Slow performance:**
@@ -602,7 +602,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | perl-lsp --s
 - Check for recursive includes
 
 **Missing features:**
-- Ensure latest version: `perl-lsp --version`
+- Ensure latest version: `perllsp --version`
 - Check editor LSP client capabilities
 - Verify configuration is loaded
 
@@ -612,10 +612,10 @@ Enable debug logging for troubleshooting:
 
 ```bash
 # Command line
-perl-lsp --stdio --log-level=debug --log-file=perl-lsp.log
+perllsp --stdio --log-level=debug --log-file=perl-lsp.log
 
 # Environment variable
-RUST_LOG=debug perl-lsp --stdio
+RUST_LOG=debug perllsp --stdio
 ```
 
 ## Contributing

--- a/book/src/user-guides/troubleshooting.md
+++ b/book/src/user-guides/troubleshooting.md
@@ -6,13 +6,13 @@ Common issues and their solutions when using perl-lsp.
 
 ```bash
 # Check installation
-which perl-lsp && perl-lsp --version
+which perllsp && perllsp --version
 
 # Health check
-perl-lsp --health
+perllsp --health
 
 # Test JSON-RPC communication
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perl-lsp --stdio
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}' | perllsp --stdio
 ```
 
 ## Build Issues
@@ -32,12 +32,12 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}
 2. Clean and rebuild:
    ```bash
    cargo clean
-   cargo build -p perl-lsp-rs --release
+   cargo build -p perllsp --release
    ```
 
 3. If using Nix:
    ```bash
-   nix develop -c cargo build -p perl-lsp-rs --release
+   nix develop -c cargo build -p perllsp --release
    ```
 
 ### Missing Dependencies
@@ -47,7 +47,7 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}
 **Solution**: perl-lsp is pure Rust and should not require system dependencies. If you see C compiler or libclang errors, you may be building optional crates. Use:
 
 ```bash
-cargo build -p perl-lsp-rs --release
+cargo build -p perllsp --release
 ```
 
 Not `cargo build --workspace` which includes optional native crates.
@@ -96,7 +96,7 @@ chmod +x ~/.cargo/bin/perl-lsp
 
 1. Run with debug logging:
    ```bash
-   RUST_LOG=perl_lsp=debug perl-lsp --stdio 2>debug.log
+   RUST_LOG=perl_lsp=debug perllsp --stdio 2>debug.log
    ```
 
 2. Check for conflicting processes:
@@ -106,7 +106,7 @@ chmod +x ~/.cargo/bin/perl-lsp
 
 3. Verify the binary is not corrupted:
    ```bash
-   cargo install --path crates/perl-lsp --force
+   cargo install --path crates/perllsp --force
    ```
 
 ### High Memory Usage
@@ -298,7 +298,7 @@ chmod +x ~/.cargo/bin/perl-lsp
    EOF
 
    # Test parsing
-   perl-lsp --parse test.pl
+   perllsp --parse test.pl
    ```
 
 3. File an issue at: https://github.com/EffortlessMetrics/perl-lsp/issues
@@ -406,7 +406,7 @@ For detailed editor configuration and troubleshooting:
 
 2. Verify the command works in shell:
    ```bash
-   perl-lsp --stdio
+   perllsp --stdio
    ```
 
 3. Try lsp-mode as an alternative:
@@ -423,11 +423,11 @@ For detailed editor configuration and troubleshooting:
 
 2. Enable debug logging and include logs in bug reports:
    ```bash
-   RUST_LOG=perl_lsp=debug,perl_parser=debug perl-lsp --stdio 2>debug.log
+   RUST_LOG=perl_lsp=debug,perl_parser=debug perllsp --stdio 2>debug.log
    ```
 
 3. Include:
-   - perl-lsp version (`perl-lsp --version`)
+   - perl-lsp version (`perllsp --version`)
    - Rust version (`rustc --version`)
    - OS and editor
    - Minimal code reproduction

--- a/book/src/user-guides/workspace-navigation.md
+++ b/book/src/user-guides/workspace-navigation.md
@@ -218,10 +218,10 @@ my $result = calculate_complex_value($a, $b, $c, $d, $e);  # Complex parameter l
 ### Enable Enhanced Workspace Features
 ```bash
 # LSP server automatically uses enhanced workspace indexing
-perl-lsp --stdio
+perllsp --stdio
 
 # For development and debugging:
-PERL_LSP_DEBUG=1 perl-lsp --stdio --log
+PERL_LSP_DEBUG=1 perllsp --stdio --log
 ```
 
 ### Testing Enhanced Features

--- a/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
@@ -588,9 +588,9 @@ pub fn help_text() -> String {
     let mut out = String::with_capacity(1024);
     out.push_str("Perl Language Server\n");
     out.push('\n');
-    out.push_str("Usage: perl-lsp [options]\n");
-    out.push_str("       perl-lsp --check <file.pl> [file2.pm ...]\n");
-    out.push_str("       perl-lsp --check-project [dir]\n");
+    out.push_str("Usage: perllsp [options]\n");
+    out.push_str("       perllsp --check <file.pl> [file2.pm ...]\n");
+    out.push_str("       perllsp --check-project [dir]\n");
     out.push('\n');
     out.push_str("Server options:\n");
     out.push_str("  --stdio, --mcp       Use stdio for communication (default)\n");
@@ -615,15 +615,15 @@ pub fn help_text() -> String {
     out.push_str("  --help               Show this help message\n");
     out.push('\n');
     out.push_str("Examples:\n");
-    out.push_str("  perl-lsp --stdio                        # stdio mode (default)\n");
-    out.push_str("  perl-lsp --mcp                          # stdio mode alias for MCP clients\n");
-    out.push_str("  perl-lsp --stdio --log                   # with logging\n");
-    out.push_str("  perl-lsp --socket --port 9257            # TCP socket mode\n");
-    out.push_str("  perl-lsp --stdio --feature-profile=prod  # production profile\n");
-    out.push_str("  perl-lsp --check lib/MyModule.pm         # syntax check\n");
-    out.push_str("  perl-lsp --check-project lib/             # project scan\n");
-    out.push_str("  perl-lsp --info                          # server information\n");
-    out.push_str("  perl-lsp --completion bash >> ~/.bashrc   # install completions\n");
+    out.push_str("  perllsp --stdio                        # stdio mode (default)\n");
+    out.push_str("  perllsp --mcp                          # stdio mode alias for MCP clients\n");
+    out.push_str("  perllsp --stdio --log                   # with logging\n");
+    out.push_str("  perllsp --socket --port 9257            # TCP socket mode\n");
+    out.push_str("  perllsp --stdio --feature-profile=prod  # production profile\n");
+    out.push_str("  perllsp --check lib/MyModule.pm         # syntax check\n");
+    out.push_str("  perllsp --check-project lib/             # project scan\n");
+    out.push_str("  perllsp --info                          # server information\n");
+    out.push_str("  perllsp --completion bash >> ~/.bashrc   # install completions\n");
     out.push('\n');
     out.push_str("Environment:\n");
     out.push_str("  PERL_LSP_LOG=1       Enable logging (alternative to --log)\n");
@@ -840,8 +840,8 @@ pub fn port_in_use_message(port: u16) -> String {
         "Port {port} is already in use. Another instance of perl-lsp may be running.\n\
          Try a different port:\n\
          \n\
-         \x20 perl-lsp --socket --port {alt1}\n\
-         \x20 perl-lsp --socket --port {alt2}\n\
+         \x20 perllsp --socket --port {alt1}\n\
+         \x20 perllsp --socket --port {alt2}\n\
          \n\
          Or stop the existing process using port {port}."
     )
@@ -920,7 +920,7 @@ mod tests {
         let help = super::help_text();
         assert!(help.contains("--mcp"), "help_text is missing --mcp: {help}");
         assert!(
-            help.contains("perl-lsp --mcp"),
+            help.contains("perllsp --mcp"),
             "help_text examples are missing a --mcp invocation: {help}"
         );
 

--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -24,13 +24,8 @@ or use `lsp-mode`.
 
 Install `perllsp` using the project installation guide or README.
 
-Do not use:
-
-```bash
-cargo install perl-lsp
-```
-
-That crates.io package name belongs to a different project. Use:
+Do not install the unrelated crates.io package named `perl-lsp`; that package
+name belongs to a different project. Use:
 
 ```bash
 cargo install perllsp

--- a/docs/explanation/LSP_DOCUMENTATION.md
+++ b/docs/explanation/LSP_DOCUMENTATION.md
@@ -119,8 +119,7 @@ irm https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.
 
 ### Homebrew (macOS/Linux)
 ```bash
-brew tap effortlesssteven/tap
-brew install perl-lsp
+brew install effortlessmetrics/tap/perllsp
 ```
 
 ### Build from Source

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -19,11 +19,12 @@ shared automation.
 Use one of the public install paths that matches how you work:
 
 - VS Code: install the `EffortlessMetrics.perl-lsp-rs` extension and let it download the matching `perllsp` binary.
-- macOS or Linux: install via Homebrew (see below).
+- macOS or Linux: install via the EffortlessMetrics Homebrew tap (see below).
 - Other editors: download a prebuilt binary from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases) and put it on your `PATH`.
 - Local testing or pre-release validation: install from this repo with `cargo install --path crates/perllsp`.
 
-Do not use `cargo install perl-lsp` on crates.io. That package name is owned by another project, so the supported Cargo package is `perllsp`.
+Do not install the unrelated crates.io package named `perl-lsp`. That package
+name is owned by another project, so the supported Cargo package is `perllsp`.
 
 Verify the install before wiring it into an editor:
 
@@ -33,12 +34,20 @@ perllsp --health
 perllsp --info
 ```
 
-## Homebrew (macOS and Linux)
+## Homebrew via the EffortlessMetrics tap
 
-Install the current public-alpha release with one command:
+`perllsp` is distributed through the owned EffortlessMetrics Homebrew tap, not
+Homebrew/core. Install the current public-alpha release with one command:
 
 ```bash
 brew install effortlessmetrics/tap/perllsp
+```
+
+Equivalent two-step form:
+
+```bash
+brew tap effortlessmetrics/tap
+brew install perllsp
 ```
 
 This covers macOS Intel, macOS Apple Silicon, Linux x86_64, and Linux aarch64 via Linuxbrew. The formula is automatically bumped on each public-alpha release.
@@ -73,10 +82,15 @@ cargo install perllsp
 GitHub Releases provides public-alpha downloadable archives for the supported platforms.
 Check the latest release page before copying a version number.
 
-| Platform | Asset suffix |
+Most Linux users should choose the `gnu` archive. Use `musl` mainly for Alpine
+Linux or musl-based containers. You do not need both GNU and musl archives.
+
+| Your system | Asset suffix |
 | --- | --- |
-| Linux x86_64 | `x86_64-unknown-linux-gnu` |
-| Linux aarch64 | `aarch64-unknown-linux-gnu` |
+| Linux x64 / AMD64, most distributions | `x86_64-unknown-linux-gnu` |
+| Linux ARM64, most distributions | `aarch64-unknown-linux-gnu` |
+| Linux x64 / AMD64, Alpine or musl containers | `x86_64-unknown-linux-musl` |
+| Linux ARM64, Alpine or musl containers | `aarch64-unknown-linux-musl` |
 | macOS Intel | `x86_64-apple-darwin` |
 | macOS Apple Silicon | `aarch64-apple-darwin` |
 | Windows x86_64 | `x86_64-pc-windows-msvc` |

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -46,9 +46,8 @@ code --install-extension EffortlessMetrics.perl-lsp-rs
 # Best-effort install script (Linux/macOS)
 curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
 
-# Homebrew (macOS)
-brew tap tree-sitter-perl/tap
-brew install perl-lsp
+# Homebrew via the EffortlessMetrics tap (macOS/Linux)
+brew install effortlessmetrics/tap/perllsp
 
 # Build from source
 cargo build -p perllsp --release

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -671,6 +671,7 @@ options or client-specific configuration mechanisms.
 | `perl-lsp.serverPath` | `string` | `""` | Absolute path to the `perllsp` binary. Empty = auto-download. |
 | `perl-lsp.autoDownload` | `boolean` | `true` | Download the binary automatically if not found locally. |
 | `perl-lsp.downloadBaseUrl` | `string` | `""` | Override the GitHub releases base URL for internal mirrors. |
+| `perl-lsp.linuxLibc` | `"auto"\|"gnu"\|"glibc"\|"musl"` | `"auto"` | Linux libc release asset selection for managed downloads. Most Linux distributions use `gnu`/`glibc`; use `musl` mainly for Alpine Linux and musl-based containers. |
 | `perl-lsp.channel` | `"latest"\|"stable"\|"tag"` | `"latest"` | Release channel to track. |
 | `perl-lsp.versionTag` | `string` | `""` | Specific release tag (e.g., `v0.8.3`) when `channel` is `"tag"`. |
 

--- a/docs/reference/FAQ.md
+++ b/docs/reference/FAQ.md
@@ -6,6 +6,7 @@
 
 - **VS Code (recommended)**: install the [Perl LSP extension](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs) — it downloads the server binary automatically.
 - **Pre-built binary**: download from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
+- **Homebrew tap**: `brew install effortlessmetrics/tap/perllsp`.
 - **Installer script (Linux/macOS, best-effort)**:
   `curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash`
 - **From source**:
@@ -17,11 +18,32 @@ No. perl-lsp is a self-contained Rust binary. It parses Perl using a native recu
 
 ### Does the installer also install perl-dap?
 
-No. The installer installs `perl-lsp`. Build or install `perl-dap` separately when you need debugging support:
+Yes, when the release archive includes `perl-dap`. The installer always installs
+`perllsp` and installs the companion `perl-dap` binary when it is present in the
+downloaded archive. Build or install `perl-dap` separately only when you are
+working from source or using an older archive that did not include it:
 
 ```bash
 cargo install --path crates/perl-dap
 ```
+
+### What is the difference between GNU and musl release files?
+
+Most Linux users should choose `gnu`, which means the normal glibc Linux build.
+Use it for Ubuntu, Debian, Raspberry Pi OS, Fedora, RHEL, Arch, Amazon Linux,
+WSL, and most other Linux systems.
+
+Use `musl` mainly for Alpine Linux or musl-based containers. You do not need
+both GNU and musl archives.
+
+For common cases:
+
+| System | Download suffix |
+|---|---|
+| WSL2 x86_64 GNU/Linux | `x86_64-unknown-linux-gnu` |
+| Raspberry Pi OS / Debian aarch64 | `aarch64-unknown-linux-gnu` |
+| Alpine Linux x86_64 | `x86_64-unknown-linux-musl` |
+| Alpine Linux aarch64 | `aarch64-unknown-linux-musl` |
 
 ### Which platforms are supported?
 

--- a/docs/releases/v0.12.4.md
+++ b/docs/releases/v0.12.4.md
@@ -64,6 +64,21 @@ polish, hover improvements, completion ranking, and CI hygiene.
 - **Binary**: download from [GitHub Release assets](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4). Verify with `SHA256SUMS`.
 - **Source**: `cargo install perllsp` (once crates.io publish completes).
 
+## Which file should I download?
+
+Most Linux users should choose `gnu`. Use `musl` mainly for Alpine Linux or
+musl-based containers. You do not need both GNU and musl archives.
+
+| Your system | Download suffix |
+|---|---|
+| Linux x64 / AMD64, most distributions | `x86_64-unknown-linux-gnu` |
+| Linux ARM64, most distributions | `aarch64-unknown-linux-gnu` |
+| Linux x64 / AMD64, Alpine or musl containers | `x86_64-unknown-linux-musl` |
+| Linux ARM64, Alpine or musl containers | `aarch64-unknown-linux-musl` |
+| macOS Intel | `x86_64-apple-darwin` |
+| macOS Apple Silicon | `aarch64-apple-darwin` |
+| Windows x64 | `x86_64-pc-windows-msvc` |
+
 ## Links
 
 - [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4)

--- a/docs/releases/v0.13.1.md
+++ b/docs/releases/v0.13.1.md
@@ -37,12 +37,28 @@ package-manager correctness after the `v0.13.0` public alpha.
 - **VS Code**: install or update the
   [Perl Language Server](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
   extension. The managed `perllsp` binary is part of the public-alpha line.
-- **Package managers**: install Homebrew with
-  `brew install effortlessmetrics/tap/perllsp`; Windows package-manager
+- **Homebrew tap**: install with `brew install effortlessmetrics/tap/perllsp`.
+  This uses the owned EffortlessMetrics tap, not Homebrew/core.
+- **Package managers**: Windows package-manager
   manifests describe public-alpha artifacts. Verify with `perllsp --version`
   after updating.
 - **Source/Binary**: download release assets or use `cargo install perllsp`
   only for the published public-alpha line.
+
+## Which file should I download?
+
+Most Linux users should choose `gnu`. Use `musl` mainly for Alpine Linux or
+musl-based containers. You do not need both GNU and musl archives.
+
+| Your system | Download suffix |
+|---|---|
+| Linux x64 / AMD64, most distributions | `x86_64-unknown-linux-gnu` |
+| Linux ARM64, most distributions | `aarch64-unknown-linux-gnu` |
+| Linux x64 / AMD64, Alpine or musl containers | `x86_64-unknown-linux-musl` |
+| Linux ARM64, Alpine or musl containers | `aarch64-unknown-linux-musl` |
+| macOS Intel | `x86_64-apple-darwin` |
+| macOS Apple Silicon | `aarch64-apple-darwin` |
+| Windows x64 | `x86_64-pc-windows-msvc` |
 
 ## Links
 

--- a/install.sh
+++ b/install.sh
@@ -1,287 +1,45 @@
-#!/bin/bash
-# Perl LSP installer for Linux and macOS
-# Usage: curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
+#!/usr/bin/env bash
+# Compatibility wrapper for the canonical Linux/macOS installer.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/install.sh | bash
+#   bash install.sh 0.13.1 "$HOME/.local/bin"
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" 2>/dev/null && pwd || pwd)"
+CANONICAL_INSTALLER="$SCRIPT_DIR/scripts/install.sh"
+CANONICAL_INSTALLER_URL="https://raw.githubusercontent.com/EffortlessMetrics/perl-lsp/master/scripts/install.sh"
 
-# Default values
-VERSION="${1:-latest}"
-if [ "${2:-}" != "" ]; then
-    INSTALL_DIR="$2"
-elif [ -n "${TERMUX_VERSION:-}" ] || [ -d "/data/data/com.termux/files/usr/bin" ]; then
-    INSTALL_DIR="/data/data/com.termux/files/usr/bin"
-else
-    INSTALL_DIR="$HOME/.local/bin"
+ARGS=("$@")
+
+if [ "${1:-}" != "" ] && [[ "${1:-}" != -* ]]; then
+    if [ -z "${VERSION:-}" ]; then
+        export VERSION="$1"
+    fi
+    shift
+
+    if [ "${1:-}" != "" ] && [[ "${1:-}" != -* ]]; then
+        if [ -z "${INSTALL_DIR:-}" ]; then
+            export INSTALL_DIR="$1"
+        fi
+        shift
+    fi
+
+    ARGS=("$@")
 fi
-REPO="EffortlessMetrics/perl-lsp"
-NAME="perllsp"
 
-# Functions
-write_info() {
-    echo -e "${BLUE}→${NC} $1"
-}
+if [ -f "$CANONICAL_INSTALLER" ]; then
+    exec "$CANONICAL_INSTALLER" "${ARGS[@]}"
+fi
 
-write_success() {
-    echo -e "${GREEN}✓${NC} $1"
-}
-
-write_warn() {
-    echo -e "${YELLOW}⚠${NC} $1"
-}
-
-write_error() {
-    echo -e "${RED}Error:${NC} $1"
+if ! command -v curl >/dev/null 2>&1; then
+    echo "Error: curl is required to fetch the canonical installer" >&2
     exit 1
-}
+fi
 
-# Detect OS and architecture
-detect_system() {
-    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-    ARCH=$(uname -m)
-    IS_TERMUX=0
-
-    if [ -n "${TERMUX_VERSION:-}" ] || [ -d "/data/data/com.termux/files/usr/bin" ]; then
-        IS_TERMUX=1
-    fi
-    
-    case $OS in
-        linux)
-            OS="linux"
-            ;;
-        darwin)
-            OS="darwin"
-            ;;
-        *)
-            write_error "Unsupported OS: $OS"
-            ;;
-    esac
-    
-    case $ARCH in
-        x86_64|amd64|x64)
-            ARCH="x86_64"
-            ;;
-        aarch64|arm64)
-            ARCH="aarch64"
-            ;;
-        armv7l|armv7|armv6l|armhf)
-            write_error "Detected 32-bit ARM architecture ($ARCH). Prebuilt releases are currently available for ARM64 only.
-
-Try one of:
-  1) Install from source on this device:
-     cargo install perllsp --locked --target armv7-unknown-linux-gnueabihf
-  2) Use an ARM64 (aarch64) OS/device to install prebuilt binaries."
-            ;;
-        *)
-            write_error "Unsupported architecture: $ARCH"
-            ;;
-    esac
-    
-    TARGET="$ARCH-unknown-$OS-gnu"
-    if [ "$OS" = "linux" ] && [ "$IS_TERMUX" = "1" ]; then
-        TARGET="$ARCH-unknown-linux-musl"
-    elif [ "$OS" = "darwin" ]; then
-        TARGET="$ARCH-apple-darwin"
-    fi
-    
-    write_info "Detected system: $OS ($ARCH) - $TARGET"
-    if [ "$IS_TERMUX" = "1" ]; then
-        write_info "Termux environment detected; defaulting install path to $INSTALL_DIR"
-    fi
-}
-
-# Get version information
-get_version() {
-    if [ "$VERSION" = "latest" ]; then
-        write_info "Fetching latest release..."
-        RELEASE_API="https://api.github.com/repos/$REPO/releases/latest"
-        
-        if ! command -v curl >/dev/null 2>&1; then
-            write_error "curl is required but not installed"
-        fi
-        
-        if ! RELEASE_INFO=$(curl -s "$RELEASE_API"); then
-            write_error "Failed to fetch release information"
-        fi
-        
-        TAG=$(echo "$RELEASE_INFO" | grep '"tag_name":' | sed -E 's/.*"tag_name": ?"([^"]+)".*/\1/')
-        if [ -z "$TAG" ]; then
-            write_error "Could not determine latest version"
-        fi
-        
-        write_info "Latest version: $TAG"
-    else
-        TAG="v$VERSION"
-        if [[ "$VERSION" == v* ]]; then
-            TAG="$VERSION"
-        fi
-    fi
-}
-
-# Download and install binary
-install_binary() {
-    VERSION_NUM="${TAG#v}"
-    ASSET="$NAME-$VERSION_NUM-$TARGET.tar.gz"
-    URL="https://github.com/$REPO/releases/download/$TAG/$ASSET"
-    
-    write_info "Downloading $NAME $TAG for $TARGET"
-    
-    # Create temporary directory
-    TEMP_DIR=$(mktemp -d)
-    trap 'rm -rf "$TEMP_DIR"' EXIT
-    
-    # Download archive
-    ARCHIVE_PATH="$TEMP_DIR/$ASSET"
-    if ! curl -fsSL "$URL" -o "$ARCHIVE_PATH"; then
-        write_error "Failed to download from $URL"
-    fi
-    
-    # Download and verify checksum
-    CHECKSUM_URL="https://github.com/$REPO/releases/download/$TAG/SHA256SUMS"
-    CHECKSUM_PATH="$TEMP_DIR/SHA256SUMS"
-    
-    if curl -fsSL "$CHECKSUM_URL" -o "$CHECKSUM_PATH" 2>/dev/null; then
-        EXPECTED_HASH=$(grep "$ASSET" "$CHECKSUM_PATH" | awk '{print $1}')
-
-        if [ -z "$EXPECTED_HASH" ]; then
-            write_warn "No checksum entry found for $ASSET; skipping verification"
-        else
-            if command -v sha256sum >/dev/null 2>&1; then
-                ACTUAL_HASH=$(sha256sum "$ARCHIVE_PATH" | awk '{print $1}')
-            elif command -v shasum >/dev/null 2>&1; then
-                ACTUAL_HASH=$(shasum -a 256 "$ARCHIVE_PATH" | awk '{print $1}')
-            else
-                write_warn "No sha256 tool available (sha256sum/shasum); skipping checksum verification"
-                ACTUAL_HASH=""
-            fi
-
-            if [ -n "$ACTUAL_HASH" ] && [ "$EXPECTED_HASH" = "$ACTUAL_HASH" ]; then
-                write_success "Checksum verified"
-            elif [ -n "$ACTUAL_HASH" ]; then
-                write_error "Checksum mismatch - expected: $EXPECTED_HASH, got: $ACTUAL_HASH"
-            fi
-        fi
-    else
-        write_warn "Could not download or verify checksums"
-    fi
-    
-    # Extract archive
-    write_info "Extracting archive"
-    cd "$TEMP_DIR"
-    tar xzf "$ARCHIVE_PATH"
-    
-    # Find the binary
-    EXTRACTED_DIR="$NAME-$VERSION_NUM-$TARGET"
-    if [ ! -d "$EXTRACTED_DIR" ]; then
-        write_error "Extracted directory not found: $EXTRACTED_DIR"
-    fi
-    
-    BINARY_PATH="$EXTRACTED_DIR/$NAME"
-    if [ ! -f "$BINARY_PATH" ]; then
-        write_error "Binary not found at $BINARY_PATH"
-    fi
-    
-    # Create install directory
-    mkdir -p "$INSTALL_DIR"
-    
-    # Install binary
-    DEST_PATH="$INSTALL_DIR/$NAME"
-    write_info "Installing $NAME to $DEST_PATH"
-    
-    # Remove old binary if exists
-    if [ -f "$DEST_PATH" ]; then
-        rm -f "$DEST_PATH"
-    fi
-    
-    # Copy binary and make executable
-    cp "$BINARY_PATH" "$DEST_PATH"
-    chmod +x "$DEST_PATH"
-    
-    write_success "Installed $NAME to $DEST_PATH"
-    
-    # Install perl-dap if present in the archive
-    DAP_BINARY_PATH="$EXTRACTED_DIR/perl-dap"
-    if [ -f "$DAP_BINARY_PATH" ]; then
-        DAP_DEST_PATH="$INSTALL_DIR/perl-dap"
-        write_info "Installing perl-dap to $DAP_DEST_PATH"
-        if [ -f "$DAP_DEST_PATH" ]; then
-            rm -f "$DAP_DEST_PATH"
-        fi
-        cp "$DAP_BINARY_PATH" "$DAP_DEST_PATH"
-        chmod +x "$DAP_DEST_PATH"
-        write_success "Installed perl-dap to $DAP_DEST_PATH"
-    fi
-}
-
-# Verify installation
-verify_installation() {
-    if [ ! -f "$DEST_PATH" ]; then
-        write_error "Installation failed - binary not found at $DEST_PATH"
-    fi
-    
-    write_info "Verifying installation..."
-    if VERSION_OUTPUT=$("$DEST_PATH" --version 2>&1); then
-        write_success "Installation verified: $VERSION_OUTPUT"
-    else
-        write_warn "Could not verify installation"
-    fi
-}
-
-# Check PATH
-check_path() {
-    if echo ":$PATH:" | grep -q ":$INSTALL_DIR:"; then
-        write_success "$INSTALL_DIR is already in your PATH"
-    else
-        write_warn "$INSTALL_DIR is not in your PATH"
-        echo
-        echo "To add it to your PATH permanently, run:"
-        echo
-        if [ -n "${BASH_VERSION:-}" ]; then
-            echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.bashrc"
-            echo "  source ~/.bashrc"
-        elif [ -n "${ZSH_VERSION:-}" ]; then
-            echo "  echo 'export PATH=\"\$PATH:$INSTALL_DIR\"' >> ~/.zshrc"
-            echo "  source ~/.zshrc"
-        else
-            echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
-        fi
-        echo
-        echo "Or add it temporarily for this session:"
-        echo
-        echo "  export PATH=\"\$PATH:$INSTALL_DIR\""
-        echo
-    fi
-}
-
-# Main installation flow
-main() {
-    echo
-    echo "Perl Language Server Installer v1.0.0"
-    echo "====================================="
-    echo
-    
-    detect_system
-    get_version
-    install_binary
-    verify_installation
-    check_path
-    
-    echo
-    echo "Installation complete! 🎉"
-    echo
-    echo "To get started with Perl LSP:"
-    echo "  • VS Code: Install the Perl LSP extension from the marketplace"
-    echo "  • Other editors: Configure to use '$DEST_PATH --stdio'"
-    echo
-    echo "For more information: https://github.com/$REPO"
-    echo
-}
-
-# Run main function
-main "$@"
+TMP_INSTALLER="$(mktemp)"
+trap 'rm -f "$TMP_INSTALLER"' EXIT
+curl -fsSL "$CANONICAL_INSTALLER_URL" -o "$TMP_INSTALLER"
+exec bash "$TMP_INSTALLER" "${ARGS[@]}"

--- a/scripts/check_release_history.sh
+++ b/scripts/check_release_history.sh
@@ -137,6 +137,15 @@ else
     if ! grep -q "## \[${NEWEST_TAG}\]" CHANGELOG.md 2>/dev/null; then
         error "Newest tag v${NEWEST_TAG} not found in CHANGELOG.md"
     fi
+
+    newest_notes_file="docs/releases/v${NEWEST_TAG}.md"
+    if [[ -f "$newest_notes_file" ]] && grep -Eq 'unknown-linux-(gnu|musl)' "$newest_notes_file"; then
+        if ! grep -q 'Which file should I download?' "$newest_notes_file" &&
+           ! grep -q 'docs/how-to/INSTALLATION.md' "$newest_notes_file" &&
+           ! grep -q 'INSTALLATION.md' "$newest_notes_file"; then
+            error "Newest release notes with Linux GNU/musl assets must explain which file to download: ${newest_notes_file}"
+        fi
+    fi
 fi
 
 # ── Exit ──────────────────────────────────────────────────────────────────────

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,10 @@
 #
 # Or with options via environment variables:
 #   VERSION=v0.12.0 INSTALL_DIR=/usr/local/bin bash scripts/install.sh
-#   PREFER_GNU=1 bash scripts/install.sh   # prefer glibc over musl on Linux
+#   PERL_LSP_LINUX_LIBC=gnu bash scripts/install.sh
+#   PERL_LSP_LINUX_LIBC=musl bash scripts/install.sh
 #   BUILD_FROM_SOURCE=1 bash scripts/install.sh   # force cargo build/install
+#   bash scripts/install.sh --print-target
 #
 # Supported platforms:
 #   Linux x86_64 (musl/gnu), Linux aarch64 (musl/gnu), macOS x86_64, macOS aarch64
@@ -17,8 +19,10 @@ REPO="EffortlessMetrics/perl-lsp"
 BIN_NAME="perllsp"
 DAP_BIN_NAME="perl-dap"
 VERSION="${VERSION:-latest}"
+PERL_LSP_LINUX_LIBC="${PERL_LSP_LINUX_LIBC:-auto}"
 PREFER_GNU="${PREFER_GNU:-0}"
 BUILD_FROM_SOURCE="${BUILD_FROM_SOURCE:-0}"
+PRINT_TARGET=0
 
 # Determine install directory: user-local by default, system-wide if explicitly set
 if [ -z "${INSTALL_DIR:-}" ]; then
@@ -49,6 +53,95 @@ need_cmd() {
     fi
 }
 
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --print-target)
+            PRINT_TARGET=1
+            shift
+            ;;
+        -h|--help)
+            cat <<'USAGE'
+Usage: scripts/install.sh [--print-target]
+
+Environment:
+  VERSION=<latest|vX.Y.Z|X.Y.Z>        Release to install.
+  INSTALL_DIR=/path/to/bin             Install destination.
+  PERL_LSP_LINUX_LIBC=auto|gnu|glibc|musl
+                                      Linux libc target. Default: auto.
+  BUILD_FROM_SOURCE=1                  Build with cargo instead of downloading.
+
+Most Linux distributions use gnu/glibc. Use musl mainly for Alpine Linux and
+musl-based containers. --print-target prints the selected release target and
+exits without downloading.
+USAGE
+            exit 0
+            ;;
+        *)
+            err "unknown argument: $1"
+            ;;
+    esac
+done
+
+is_musl_system() {
+    if command -v ldd >/dev/null 2>&1; then
+        local _ldd
+        _ldd="$(ldd --version 2>&1 || true)"
+        if printf '%s\n' "$_ldd" | grep -qi musl; then
+            return 0
+        fi
+        if printf '%s\n' "$_ldd" | grep -Eqi 'glibc|gnu libc'; then
+            return 1
+        fi
+    fi
+
+    if command -v getconf >/dev/null 2>&1 && getconf GNU_LIBC_VERSION >/dev/null 2>&1; then
+        return 1
+    fi
+
+    if [ -f /etc/alpine-release ]; then
+        return 0
+    fi
+
+    if compgen -G "/lib/ld-musl-*.so.1" >/dev/null 2>&1 ||
+       compgen -G "/usr/lib/ld-musl-*.so.1" >/dev/null 2>&1 ||
+       compgen -G "/lib/libc.musl-*.so.1" >/dev/null 2>&1 ||
+       compgen -G "/usr/lib/libc.musl-*.so.1" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    return 1
+}
+
+resolve_linux_libc() {
+    local _choice
+    _choice="$(printf '%s' "$PERL_LSP_LINUX_LIBC" | tr '[:upper:]' '[:lower:]')"
+
+    # Backwards-compatible escape hatch from older docs/scripts. The new public
+    # spelling is PERL_LSP_LINUX_LIBC=gnu.
+    if [ "$_choice" = "auto" ] && [ "$PREFER_GNU" = "1" ]; then
+        _choice="gnu"
+    fi
+
+    case "$_choice" in
+        auto)
+            if is_musl_system; then
+                printf '%s\n' "musl"
+            else
+                printf '%s\n' "gnu"
+            fi
+            ;;
+        gnu|glibc)
+            printf '%s\n' "gnu"
+            ;;
+        musl)
+            printf '%s\n' "musl"
+            ;;
+        *)
+            err "invalid PERL_LSP_LINUX_LIBC=${PERL_LSP_LINUX_LIBC}; expected auto, gnu, glibc, or musl"
+            ;;
+    esac
+}
+
 # ── Platform detection ─────────────────────────────────────────────────────────
 
 detect_platform() {
@@ -67,14 +160,13 @@ detect_platform() {
     case "$_os" in
         Linux)
             _os="linux"
-            # Termux uses Android's bionic libc. Prefer static musl binaries there.
-            # For other Linux environments, prefer musl unless caller overrides.
             if [ "$_termux" = "1" ]; then
-                _libc="musl"
-            elif [ "$PREFER_GNU" = "1" ]; then
-                _libc="gnu"
+                # Termux uses Android's bionic libc. The release artifacts are
+                # Linux glibc/musl binaries, not Android/bionic binaries.
+                INSTALL_MODE="source"
+                SOURCE_TARGET=""
             else
-                _libc="musl"
+                _libc="$(resolve_linux_libc)"
             fi
             ;;
         Darwin)
@@ -96,7 +188,9 @@ detect_platform() {
         armv8l|armv7l|armv7*|armhf)
             if [ "$_os" = "linux" ]; then
                 _arch="armv7"
-                SOURCE_TARGET="armv7-unknown-linux-gnueabihf"
+                if [ "$_termux" != "1" ]; then
+                    SOURCE_TARGET="armv7-unknown-linux-gnueabihf"
+                fi
                 INSTALL_MODE="source"
             else
                 err "unsupported architecture: $_arch"
@@ -105,7 +199,9 @@ detect_platform() {
         armv6l|armv6*|arm)
             if [ "$_os" = "linux" ]; then
                 _arch="armv6"
-                SOURCE_TARGET="arm-unknown-linux-gnueabihf"
+                if [ "$_termux" != "1" ]; then
+                    SOURCE_TARGET="arm-unknown-linux-gnueabihf"
+                fi
                 INSTALL_MODE="source"
             else
                 err "unsupported architecture: $_arch"
@@ -124,16 +220,20 @@ detect_platform() {
         else
             TARGET="${_arch}-apple-darwin"
         fi
-        info "platform: $_os $_arch (target: $TARGET)"
-        if [ "$_termux" = "1" ]; then
-            info "termux environment detected; using musl release artifacts for compatibility"
+        if [ "$PRINT_TARGET" != "1" ]; then
+            info "platform: $_os $_arch (target: $TARGET)"
         fi
     else
         TARGET="${SOURCE_TARGET:-}"
-        if [ -n "$TARGET" ]; then
-            info "platform: $_os $_arch (source build target: $TARGET)"
-        else
-            info "platform: $_os $_arch (source build mode)"
+        if [ "$PRINT_TARGET" != "1" ]; then
+            if [ -n "$TARGET" ]; then
+                info "platform: $_os $_arch (source build target: $TARGET)"
+            else
+                info "platform: $_os $_arch (source build mode)"
+            fi
+            if [ "$_termux" = "1" ]; then
+                info "termux environment detected; no Android/bionic release asset is available, using source build mode"
+            fi
         fi
     fi
 }
@@ -242,14 +342,19 @@ The release archive may have an unexpected layout."
 
 build_from_source() {
     need_cmd cargo
-    need_cmd rustup
 
-    local _cargo_target
-    _cargo_target="${TARGET:-$(rustc -vV | awk -F': ' '/host:/ {print $2}')}"
+    local _target_arg=()
 
-    info "building from source for target: $_cargo_target"
-    rustup target add "$_cargo_target"
-    cargo install perllsp --locked --target "$_cargo_target" --root "$TMPDIR/install-root"
+    if [ -n "${TARGET:-}" ]; then
+        need_cmd rustup
+        info "building from source for target: $TARGET"
+        rustup target add "$TARGET"
+        _target_arg=(--target "$TARGET")
+    else
+        info "building from source for host target"
+    fi
+
+    cargo install perllsp --locked "${_target_arg[@]}" --root "$TMPDIR/install-root"
 
     EXTRACT_DIR="${TMPDIR}/install-root/bin"
 }
@@ -324,15 +429,29 @@ check_path() {
 # ── Main ───────────────────────────────────────────────────────────────────────
 
 main() {
-    say ""
-    say "Perl LSP installer"
-    say "=================="
-    say ""
+    if [ "$PRINT_TARGET" != "1" ]; then
+        say ""
+        say "Perl LSP installer"
+        say "=================="
+        say ""
+    fi
+
+    detect_platform
+
+    if [ "$PRINT_TARGET" = "1" ]; then
+        if [ "$INSTALL_MODE" = "release" ]; then
+            say "$TARGET"
+        elif [ -n "${TARGET:-}" ]; then
+            say "source:$TARGET"
+        else
+            say "source"
+        fi
+        exit 0
+    fi
 
     need_cmd curl
     need_cmd tar
 
-    detect_platform
     resolve_version
     TMPDIR="$(mktemp -d)"
     # shellcheck disable=SC2064

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -99,6 +99,11 @@ The extension automatically downloads the correct `perllsp` binary for your plat
 | **macOS** | Intel (x64), Apple Silicon (ARM64) |
 | **Linux** | x64, ARM64 (glibc and musl) |
 
+On Linux, `auto` selects the GNU/glibc archive for mainstream distributions and
+the musl archive for Alpine Linux or musl-based containers. Set
+`perl-lsp.linuxLibc` to `gnu`, `glibc`, or `musl` only when you need to override
+that detection.
+
 ### Enterprise / offline / air-gapped deployments
 
 The extension downloads the Perl LSP server binary on first activation. If your environment blocks internet access during extension install or uses a strict proxy, see [`INTERNAL_DEPLOYMENT.md`](./INTERNAL_DEPLOYMENT.md) for:
@@ -112,7 +117,7 @@ The extension downloads the Perl LSP server binary on first activation. If your 
 If you prefer to manage the binary yourself:
 
 ```bash
-# Homebrew (macOS/Linux)
+# Homebrew via the EffortlessMetrics tap (macOS/Linux)
 brew install effortlessmetrics/tap/perllsp
 
 # One-liner (Linux/macOS)
@@ -134,6 +139,7 @@ All settings are under the `perl-lsp.*` namespace. Open settings with `Ctrl+,` a
 | `perl-lsp.serverPath` | `""` | Absolute path to a `perllsp` binary (overrides auto-download) |
 | `perl-lsp.channel` | `"latest"` | Release channel. Use `latest` for the current public-alpha line or `tag` for a pinned public-alpha release |
 | `perl-lsp.versionTag` | `""` | Specific release tag (e.g. `v0.12.1`) when channel is `tag` |
+| `perl-lsp.linuxLibc` | `"auto"` | Linux libc release asset selection: `auto`, `gnu`, `glibc`, or `musl` |
 | `perl-lsp.enableDiagnostics` | `true` | Enable real-time syntax diagnostics |
 | `perl-lsp.enableSemanticTokens` | `true` | Enable semantic syntax highlighting |
 | `perl-lsp.enableFormatting` | `true` | Enable document formatting (requires `perltidy`) |

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -448,6 +448,26 @@
             "description": "Internal base URL hosting perllsp archives and SHA256SUMS, bypassing GitHub releases. Leave empty to use GitHub releases.",
             "markdownDescription": "Internal base URL hosting perllsp archives and SHA256SUMS, bypassing GitHub releases. Example: `https://internal.example.com/perllsp/`. Leave empty to use GitHub releases."
           },
+          "perl-lsp.linuxLibc": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "gnu",
+              "glibc",
+              "musl"
+            ],
+            "enumDescriptions": [
+              "Detect Linux libc automatically.",
+              "Use the GNU/glibc Linux release asset.",
+              "Alias for gnu.",
+              "Use the musl Linux release asset."
+            ],
+            "default": "auto",
+            "scope": "machine",
+            "order": 34,
+            "description": "Linux libc release asset selection. Keep auto unless you need to force GNU/glibc or musl.",
+            "markdownDescription": "Linux libc release asset selection for managed `perllsp` downloads. Keep `auto` unless you need to force `gnu`/`glibc` or `musl`."
+          },
           "perl-lsp.updateCheckInterval": {
             "type": "number",
             "default": 24,

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -239,6 +239,12 @@ export class BinaryDownloader {
                 const availableAssets = release.assets.map(a => a.name).join(', ');
                 this.outputChannel.appendLine(`Target platform: ${target}`);
                 this.outputChannel.appendLine(`Available assets: ${availableAssets}`);
+                if (target.includes('unknown-linux-')) {
+                    this.outputChannel.appendLine(
+                        'Linux binary selection: most distributions use gnu/glibc; Alpine Linux and musl containers use musl. ' +
+                        'Override with perl-lsp.linuxLibc if auto-detection chose the wrong target.'
+                    );
+                }
                 throw new Error(`No binary found for platform: ${target}. Available assets: ${availableAssets}`);
             }
 
@@ -612,7 +618,8 @@ export class BinaryDownloader {
                 };
                 return androidArchMap[arch] ?? `${arch}-linux-android`;
             }
-            const libc = this.detectMusl() ? 'musl' : 'gnu';
+            const libc = this.getLinuxLibcTarget();
+            this.outputChannel.appendLine(`Linux binary target libc: ${libc}`);
             return `${archPrefix}-unknown-linux-${libc}`;
         } else if (platform === 'win32') {
             return arch === 'arm64' ? 'aarch64-pc-windows-msvc' : 'x86_64-pc-windows-msvc';
@@ -636,6 +643,28 @@ export class BinaryDownloader {
         return `${rustArch}-${rustPlatform}`;
     }
 
+    private getLinuxLibcTarget(): 'gnu' | 'musl' {
+        const config = vscode.workspace.getConfiguration('perl-lsp');
+        const rawValue = config.get<string>('linuxLibc', 'auto');
+        const value = rawValue.trim().toLowerCase();
+
+        if (value === 'gnu' || value === 'glibc') {
+            return 'gnu';
+        }
+
+        if (value === 'musl') {
+            return 'musl';
+        }
+
+        if (value !== 'auto') {
+            this.outputChannel.appendLine(
+                `Unknown perl-lsp.linuxLibc value "${rawValue}", falling back to auto`
+            );
+        }
+
+        return this.detectMusl() ? 'musl' : 'gnu';
+    }
+
     private isAndroidEnvironment(): boolean {
         if (process.platform !== 'linux') {
             return false;
@@ -650,7 +679,27 @@ export class BinaryDownloader {
     }
     
     private detectMusl(): boolean {
-        // Check for Alpine or musl
+        const ldd = child_process.spawnSync('ldd', ['--version'], {
+            encoding: 'utf8',
+            timeout: 1000
+        });
+        const lddOutput = `${ldd.stdout ?? ''}${ldd.stderr ?? ''}`.toLowerCase();
+        if (lddOutput.includes('musl')) {
+            return true;
+        }
+        if (lddOutput.includes('glibc') || lddOutput.includes('gnu libc')) {
+            return false;
+        }
+
+        const getconf = child_process.spawnSync('getconf', ['GNU_LIBC_VERSION'], {
+            encoding: 'utf8',
+            timeout: 1000
+        });
+        if (getconf.status === 0) {
+            return false;
+        }
+
+        // Check for Alpine or musl when active-libc probes are unavailable.
         if (fs.existsSync('/etc/alpine-release')) {
             return true;
         }

--- a/vscode-extension/src/startupDiagnosis.ts
+++ b/vscode-extension/src/startupDiagnosis.ts
@@ -37,7 +37,7 @@ export function classifyStartupError(output: string): StartupErrorDiagnosis {
         return {
             kind: StartupErrorKind.GlibcMismatch,
             hint: `glibc version mismatch: binary requires ${version} but your system has an older version. This typically happens on Alpine/musl or older Linux distros.`,
-            remediation: 'Install from source with: cargo install perl-lsp-rs\nOr set perl-lsp.serverPath to a locally-built binary.',
+            remediation: 'Install from source with: cargo install perllsp\nOr set perl-lsp.serverPath to a locally-built binary.',
         };
     }
 
@@ -50,7 +50,7 @@ export function classifyStartupError(output: string): StartupErrorDiagnosis {
         return {
             kind: StartupErrorKind.MissingSharedLibrary,
             hint: `Missing shared library: ${lib}. The pre-built binary depends on system libraries not present on your machine.`,
-            remediation: `Install the missing library (e.g. apt install ${lib.replace(/\.so.*/, '')} or equivalent), or install from source: cargo install perl-lsp-rs`,
+            remediation: `Install the missing library (e.g. apt install ${lib.replace(/\.so.*/, '')} or equivalent), or install from source: cargo install perllsp`,
         };
     }
 
@@ -59,7 +59,7 @@ export function classifyStartupError(output: string): StartupErrorDiagnosis {
         return {
             kind: StartupErrorKind.ExecFormatError,
             hint: 'Architecture mismatch: the pre-built binary is for a different CPU architecture than your system.',
-            remediation: 'Reinstall the extension to get a binary for your architecture, or build from source: cargo install perl-lsp-rs',
+            remediation: 'Reinstall the extension to get a binary for your architecture, or build from source: cargo install perllsp',
         };
     }
 
@@ -82,7 +82,7 @@ export function classifyStartupError(output: string): StartupErrorDiagnosis {
         return {
             kind: StartupErrorKind.WindowsBinaryError,
             hint: 'Windows could not load the LSP binary. The binary may be corrupt, for a different Windows architecture (x86 vs x64), or missing a required DLL.',
-            remediation: 'Reinstall the extension to get a matching binary, or build from source: cargo install perl-lsp-rs',
+            remediation: 'Reinstall the extension to get a matching binary, or build from source: cargo install perllsp',
         };
     }
 

--- a/vscode-extension/src/test/downloader.test.ts
+++ b/vscode-extension/src/test/downloader.test.ts
@@ -58,10 +58,22 @@ describe('BinaryDownloader.getPlatformTarget', () => {
     process.env.ANDROID_ROOT = androidRootBackup;
     process.env.ANDROID_DATA = androidDataBackup;
     process.env.TERMUX_VERSION = termuxVersionBackup;
+    jest.restoreAllMocks();
   });
 
   function getPlatformTarget(dl: any): string {
     return dl.getPlatformTarget();
+  }
+
+  function mockConfig(overrides: Record<string, unknown>): void {
+    const vscode = require('vscode');
+    vscode.workspace.getConfiguration.mockImplementationOnce(() => ({
+      get: jest.fn((key: string, defaultValue?: unknown) => {
+        if (key in overrides) { return overrides[key]; }
+        return defaultValue;
+      }),
+      update: jest.fn(),
+    }));
   }
 
   test('returns a non-empty target triple', () => {
@@ -89,6 +101,39 @@ describe('BinaryDownloader.getPlatformTarget', () => {
     jest.spyOn(downloader as any, 'isTermuxEnvironment').mockReturnValue(true);
     const target = getPlatformTarget(downloader);
     expect(target).toMatch(/-linux-android$/);
+  });
+
+  test('linuxLibc=glibc selects GNU Linux release target', () => {
+    if (process.platform !== 'linux') {
+      return;
+    }
+
+    mockConfig({ linuxLibc: 'glibc' });
+    jest.spyOn(downloader as any, 'detectMusl').mockReturnValue(true);
+
+    expect(getPlatformTarget(downloader)).toMatch(/-unknown-linux-gnu$/);
+  });
+
+  test('linuxLibc=musl selects musl Linux release target', () => {
+    if (process.platform !== 'linux') {
+      return;
+    }
+
+    mockConfig({ linuxLibc: 'musl' });
+    jest.spyOn(downloader as any, 'detectMusl').mockReturnValue(false);
+
+    expect(getPlatformTarget(downloader)).toMatch(/-unknown-linux-musl$/);
+  });
+
+  test('linuxLibc=auto follows musl detection', () => {
+    if (process.platform !== 'linux') {
+      return;
+    }
+
+    mockConfig({ linuxLibc: 'auto' });
+    jest.spyOn(downloader as any, 'detectMusl').mockReturnValue(true);
+
+    expect(getPlatformTarget(downloader)).toMatch(/-unknown-linux-musl$/);
   });
 });
 


### PR DESCRIPTION
Problem: Linux users could not tell whether to download GNU or musl assets, and installer/downloader libc selection used inconsistent defaults.
Fix: Canonicalized installer libc selection, added VS Code `perl-lsp.linuxLibc`, documented GNU/musl and EffortlessMetrics tap wording, and added a release-note guard.
Verification: `bash -n install.sh scripts/install.sh scripts/check_release_history.sh`; installer `--print-target` checks for auto/gnu/glibc/musl/bad input; `npm run compile`; `npm test -- --runTestsByPath src/test/downloader.test.ts --runInBand`; `bash scripts/check_release_history.sh`; `cargo xtask release-notes --tag v0.13.1 --output /tmp/v0.13.1-body.md`; `cargo xtask release-notes --tag v0.12.4 --output /tmp/v0.12.4-body.md`; `MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-lsp-rs-core --lib --profile agent --locked runtime::launcher`.

Note: full `perl-lsp-rs-core` package tests currently fail on master at `g1b_collapse_infrastructure::test_crate_perl_lsp_navigation_deleted` because `crates/perl-lsp-navigation` exists in `origin/master`; this PR does not touch that crate.