### PR TITLE
ci: guard Homebrew tap install command drift (#0000)

### DIFF
--- a/Formula/perllsp.rb
+++ b/Formula/perllsp.rb
@@ -1,35 +1,34 @@
 class Perllsp < Formula
   desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/EffortlessMetrics/perl-lsp"
-  version "__RELEASE_VERSION__"
   license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v__RELEASE_VERSION__/perllsp-__RELEASE_VERSION__-aarch64-apple-darwin.tar.gz"
       sha256 "__SHA256_MACOS_AARCH64__"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v__RELEASE_VERSION__/perllsp-__RELEASE_VERSION__-x86_64-apple-darwin.tar.gz"
       sha256 "__SHA256_MACOS_X86_64__"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v__RELEASE_VERSION__/perllsp-__RELEASE_VERSION__-aarch64-unknown-linux-gnu.tar.gz"
       sha256 "__SHA256_LINUX_AARCH64__"
     else
-      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v#{version}/perllsp-#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/EffortlessMetrics/perl-lsp/releases/download/v__RELEASE_VERSION__/perllsp-__RELEASE_VERSION__-x86_64-unknown-linux-gnu.tar.gz"
       sha256 "__SHA256_LINUX_X86_64__"
     end
   end
 
   def install
     extracted_dir = Dir.glob("perllsp-#{version}-*").find { |path| File.directory?(path) }
-    raise "expected release archive directory perllsp-#{version}-<target>" unless extracted_dir
+    package_dir = extracted_dir || "."
 
-    bin.install "#{extracted_dir}/perllsp"
-    bin.install "#{extracted_dir}/perl-dap"
+    bin.install "#{package_dir}/perllsp"
+    bin.install "#{package_dir}/perl-dap"
   end
 
   test do

--- a/docs/articles/research/ALPHA_READINESS_ARCHAEOLOGY.md
+++ b/docs/articles/research/ALPHA_READINESS_ARCHAEOLOGY.md
@@ -104,8 +104,8 @@ That aligns with the roadmap: parser robustness and corpus ratchets are the
 hardening sprint, and `90%+` CPAN clean parse rate is the release target.
 
 Version truth is also a blocker until it is updated. PR `#2035` explicitly
-describes the version bump as a release blocker because `perl-lsp --version`
-was still reporting `0.11.0`.
+describes the version bump as a release blocker because the server version
+command was still reporting `0.11.0`.
 
 So the blocker set is not broad:
 

--- a/docs/articles/research/INSTALL_SURFACE_ARCHAEOLOGY.md
+++ b/docs/articles/research/INSTALL_SURFACE_ARCHAEOLOGY.md
@@ -45,8 +45,8 @@ already treats install verification as part of the product surface:
 The user-facing docs mirror that. [`docs/how-to/INSTALLATION.md`](/home/steven/code/Rust/perl-lsp/tree-sitter-perl-rs/docs/how-to/INSTALLATION.md)
 explicitly tells users to run:
 
-- `perl-lsp --health`
-- `perl-lsp --info`
+- `perllsp --health`
+- `perllsp --info`
 
 and documents the expected behavior:
 

--- a/scripts/check_release_history.sh
+++ b/scripts/check_release_history.sh
@@ -148,6 +148,28 @@ else
     fi
 fi
 
+# ── Check 4: Active install docs must not advertise retired Homebrew commands ─
+
+for forbidden_homebrew_pattern in \
+    'brew install perl''-lsp' \
+    'brew tap effortlesssteven''/tap' \
+    'brew tap tree-sitter-perl''/tap'
+do
+    forbidden_output="$(
+        git grep -n -F "$forbidden_homebrew_pattern" -- \
+            ':!**/target/**' \
+            ':!docs/reference/archive/**' \
+            ':!docs/issues/**' \
+            ':!scripts/check_release_history.sh' \
+            || true
+    )"
+    if [[ -n "$forbidden_output" ]]; then
+        while IFS= read -r line; do
+            error "Forbidden retired Homebrew command in active docs: ${line}"
+        done <<< "$forbidden_output"
+    fi
+done
+
 # ── Exit ──────────────────────────────────────────────────────────────────────
 
 if [[ "$DRIFT_FOUND" -eq 1 ]]; then

--- a/scripts/inject-sha-assets.sh
+++ b/scripts/inject-sha-assets.sh
@@ -68,8 +68,7 @@ BREW_FORMULA=$(cat <<RUBY
 class Perllsp < Formula
   desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/$OWNER/$REPO"
-  version "$VERSION"
-  license "MIT"
+  license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
     on_arm do
@@ -95,10 +94,10 @@ class Perllsp < Formula
 
   def install
     extracted_dir = Dir.glob("perllsp-#{version}-*").find { |path| File.directory?(path) }
-    raise "expected release archive directory perllsp-#{version}-<target>" unless extracted_dir
+    package_dir = extracted_dir || "."
 
-    bin.install "#{extracted_dir}/perllsp"
-    bin.install "#{extracted_dir}/perl-dap"
+    bin.install "#{package_dir}/perllsp"
+    bin.install "#{package_dir}/perl-dap"
   end
 
   test do

--- a/xtask/src/tasks/inject_sha_assets.rs
+++ b/xtask/src/tasks/inject_sha_assets.rs
@@ -26,8 +26,8 @@ pub struct InjectShaAssetsConfig {
 
 const MAC_ARM: &str = "aarch64-apple-darwin.tar.gz";
 const MAC_X64: &str = "x86_64-apple-darwin.tar.gz";
-const LIN_ARM: &str = "aarch64-unknown-linux-musl.tar.gz";
-const LIN_X64: &str = "x86_64-unknown-linux-musl.tar.gz";
+const LIN_ARM: &str = "aarch64-unknown-linux-gnu.tar.gz";
+const LIN_X64: &str = "x86_64-unknown-linux-gnu.tar.gz";
 const WIN_X64: &str = "x86_64-pc-windows-msvc.zip";
 const WIN_ARM: &str = "aarch64-pc-windows-msvc.zip";
 
@@ -107,7 +107,6 @@ fn build_brew_formula(config: &InjectShaAssetsConfig, assets: &AssetShaMap<'_>) 
         r##"class Perllsp < Formula
   desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/{owner}/{repo}"
-  version "{version}"
   license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
@@ -134,10 +133,10 @@ fn build_brew_formula(config: &InjectShaAssetsConfig, assets: &AssetShaMap<'_>) 
 
   def install
     extracted_dir = Dir.glob("perllsp-#{{version}}-*").find {{ |path| File.directory?(path) }}
-    raise "expected release archive directory perllsp-#{{version}}-<target>" unless extracted_dir
+    package_dir = extracted_dir || "."
 
-    bin.install "#{{extracted_dir}}/perllsp"
-    bin.install "#{{extracted_dir}}/perl-dap"
+    bin.install "#{{package_dir}}/perllsp"
+    bin.install "#{{package_dir}}/perl-dap"
   end
 
   test do
@@ -148,7 +147,6 @@ end
 "##,
         owner = config.owner,
         repo = config.repo,
-        version = config.version,
         base = base,
         mac_arm_filename = mac_arm_filename,
         mac_x64_filename = mac_x64_filename,

--- a/xtask/src/tasks/update_homebrew.rs
+++ b/xtask/src/tasks/update_homebrew.rs
@@ -159,7 +159,6 @@ fn build_brew_formula(
         r##"class Perllsp < Formula
   desc "Native Rust language server and debug adapter for Perl"
   homepage "https://github.com/{owner}/{repo}"
-  version "{version}"
   license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
@@ -184,10 +183,10 @@ fn build_brew_formula(
 
   def install
     extracted_dir = Dir.glob("perllsp-#{{version}}-*").find {{ |path| File.directory?(path) }}
-    raise "expected release archive directory perllsp-#{{version}}-<target>" unless extracted_dir
+    package_dir = extracted_dir || "."
 
-    bin.install "#{{extracted_dir}}/perllsp"
-    bin.install "#{{extracted_dir}}/perl-dap"
+    bin.install "#{{package_dir}}/perllsp"
+    bin.install "#{{package_dir}}/perl-dap"
   end
 
   def caveats
@@ -219,7 +218,6 @@ end
         owner = config.owner,
         repo = config.repo,
         base = base,
-        version = version,
         mac_arm_filename = mac_arm_filename,
         mac_x64_filename = mac_x64_filename,
         linux_arm_filename = linux_arm_filename,


### PR DESCRIPTION
Problem: Retired Homebrew commands and generator drift could bring back stale install instructions or overwrite the tap formula behavior.
Fix: Added an active-docs guard for retired Homebrew tap commands and aligned the source formula template plus generators with the owned tap formula.
Verification: `git diff --check`, `bash -n scripts/check_release_history.sh scripts/inject-sha-assets.sh`, `bash scripts/check_release_history.sh`, the requested docs sweeps, and `cargo check -p xtask --profile agent --locked` pass locally.
