### PR TITLE
ci: handle CRLF release checksums in brew bump (#0000)

### DIFF
--- a/.github/workflows/brew-bump.yml
+++ b/.github/workflows/brew-bump.yml
@@ -218,7 +218,15 @@ jobs:
               exit 1
             fi
 
-            checksum="$(awk -v file="${asset}" '$2 == file { print $1 }' "${ASSET_DIR}/SHA256SUMS")"
+            checksum="$(
+              awk -v file="${asset}" '{
+                name = $2
+                sub(/\r$/, "", name)
+                if (name == file) {
+                  print $1
+                }
+              }' "${ASSET_DIR}/SHA256SUMS"
+            )"
             if [[ -z "${checksum}" ]]; then
               echo "::error::SHA256SUMS is missing checksum for ${asset}"
               exit 1


### PR DESCRIPTION
Problem: Homebrew bump checksum lookup can miss release assets when SHA256SUMS uses CRLF line endings.
Fix: Normalize a trailing carriage return from the checksum filename field before comparing asset names.
Verification: git diff --check passes locally.