### PR TITLE
ci: avoid label metadata in brew bump (#0000)

### DIFF
--- a/.github/workflows/brew-bump.yml
+++ b/.github/workflows/brew-bump.yml
@@ -307,7 +307,6 @@ jobs:
           add-paths: |
             Formula/perllsp.rb
             Formula/perl-lsp.rb
-          labels: automated-pr
           signoff: false
           delete-branch: true
 


### PR DESCRIPTION
Problem: The Homebrew tap bump workflow requested PR label writes even though the tap token only needs repository and pull-request access.
Fix: Remove the automated label request from create-pull-request.
Verification: git diff --check passes locally.