### PR TITLE
ci: route Homebrew formula generation through xtask (#0000)

### DIFF
--- a/.github/workflows/brew-bump.yml
+++ b/.github/workflows/brew-bump.yml
@@ -185,9 +185,8 @@ jobs:
             sleep 30
           done
 
-      - name: Download Homebrew assets and checksums
+      - name: Verify Homebrew assets and checksums
         if: steps.release.outputs.should_bump == 'true'
-        id: checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag }}
@@ -233,7 +232,6 @@ jobs:
             fi
 
             printf '%s  %s\n' "${checksum}" "${asset_path}" | sha256sum --check --status
-            echo "${OUTPUT_NAMES[${target}]}=${checksum}" >> "${GITHUB_OUTPUT}"
             echo "${asset}: ${checksum}"
           done
 
@@ -257,31 +255,31 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
+      - name: Install Rust toolchain
+        if: steps.release.outputs.should_bump == 'true'
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
+        with:
+          toolchain: stable
+
       - name: Update tap formula
         if: steps.release.outputs.should_bump == 'true'
+        working-directory: source
         env:
-          VERSION: ${{ steps.release.outputs.version }}
-          SHA_MACOS_AARCH64: ${{ steps.checksums.outputs.macos_aarch64 }}
-          SHA_MACOS_X86_64: ${{ steps.checksums.outputs.macos_x86_64 }}
-          SHA_LINUX_AARCH64: ${{ steps.checksums.outputs.linux_aarch64 }}
-          SHA_LINUX_X86_64: ${{ steps.checksums.outputs.linux_x86_64 }}
+          TAG: ${{ steps.release.outputs.tag }}
+          FORMULA_OUTPUT: ${{ github.workspace }}/homebrew-tap/Formula/perllsp.rb
         run: |
           set -euo pipefail
 
-          mkdir -p homebrew-tap/Formula
-          cp source/Formula/perllsp.rb homebrew-tap/Formula/perllsp.rb
+          cargo xtask update-homebrew \
+            --version "${TAG}" \
+            --owner EffortlessMetrics \
+            --repo perl-lsp \
+            --prefix perllsp \
+            --output "${FORMULA_OUTPUT}"
 
-          sed -i \
-            -e "s/__RELEASE_VERSION__/${VERSION}/g" \
-            -e "s/__SHA256_MACOS_AARCH64__/${SHA_MACOS_AARCH64}/g" \
-            -e "s/__SHA256_MACOS_X86_64__/${SHA_MACOS_X86_64}/g" \
-            -e "s/__SHA256_LINUX_AARCH64__/${SHA_LINUX_AARCH64}/g" \
-            -e "s/__SHA256_LINUX_X86_64__/${SHA_LINUX_X86_64}/g" \
-            homebrew-tap/Formula/perllsp.rb
+          rm -f "${GITHUB_WORKSPACE}/homebrew-tap/Formula/perl-lsp.rb"
 
-          rm -f homebrew-tap/Formula/perl-lsp.rb
-
-          if grep -q "__RELEASE_VERSION__\|__SHA256_" homebrew-tap/Formula/perllsp.rb; then
+          if grep -q "__RELEASE_VERSION__\|__SHA256_" "${FORMULA_OUTPUT}"; then
             echo "::error::Formula still contains unreplaced placeholders after update."
             exit 1
           fi
@@ -301,7 +299,7 @@ jobs:
           title: "perllsp ${{ steps.release.outputs.version }}"
           body: |
             Problem: the owned Homebrew tap needs a perllsp formula bump for ${{ steps.release.outputs.tag }}.
-            Fix: update Formula/perllsp.rb with release.yml-aligned release assets and SHA256 checksums.
+            Fix: update Formula/perllsp.rb with the canonical xtask Homebrew formula generator.
             Verification: release assets were downloaded and checked against SHA256SUMS in the bump workflow.
           commit-message: "perllsp ${{ steps.release.outputs.version }}"
           add-paths: |

--- a/xtask/src/tasks/inject_sha_assets.rs
+++ b/xtask/src/tasks/inject_sha_assets.rs
@@ -262,6 +262,10 @@ mod tests {
             !formula.contains("unknown-linux-musl"),
             "Homebrew formula URLs must use GNU/glibc Linux assets"
         );
+        assert!(
+            !formula.contains("def caveats"),
+            "Homebrew formula should stay focused on install/test behavior"
+        );
     }
 
     #[test]

--- a/xtask/src/tasks/update_homebrew.rs
+++ b/xtask/src/tasks/update_homebrew.rs
@@ -189,26 +189,6 @@ fn build_brew_formula(
     bin.install "#{{package_dir}}/perl-dap"
   end
 
-  def caveats
-    <<~EOS
-      To use perl-lsp with your editor:
-
-      VS Code:
-        Install the "Perl Language Server" extension from the marketplace
-
-      Neovim (with lspconfig):
-        require('lspconfig').perl_lsp.setup{{
-          cmd = {{'#{{opt_bin}}/perllsp', '--stdio'}}
-        }}
-
-      Emacs (with lsp-mode):
-        (lsp-register-client
-         (make-lsp-client :new-connection (lsp-stdio-connection '#{{opt_bin}}/perllsp' "--stdio")
-                          :activation-fn (lsp-activate-on "perl")
-                          :server-id 'perl-lsp))
-    EOS
-  end
-
   test do
     assert_match version.to_s, shell_output("#{{bin}}/perllsp --version")
     assert_match version.to_s, shell_output("#{{bin}}/perl-dap --version")
@@ -234,6 +214,7 @@ fn artifact_filename(prefix: &str, version: &str, artifact: &str) -> String {
 }
 
 fn write_formula(path: &std::path::Path, content: &str) -> Result<()> {
+    let content = content.trim_end_matches('\n');
     if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create directory for {}", path.display()))?;
@@ -283,6 +264,10 @@ mod tests {
         assert!(
             !formula.contains("unknown-linux-musl"),
             "Homebrew formula URLs must use GNU/glibc Linux assets"
+        );
+        assert!(
+            !formula.contains("def caveats"),
+            "Homebrew formula should stay focused on install/test behavior"
         );
     }
 


### PR DESCRIPTION
Problem: Homebrew tap bumps still duplicated formula substitution in the workflow.
Fix: Route tap formula generation through the canonical xtask generator and keep the workflow asset/checksum validation as a preflight.
Verification: `cargo xtask update-homebrew --version v0.13.1 --output <temp>` matches the live tap formula; `cargo test -p xtask locks_owned_tap_shape --profile agent --locked` passes; `bash scripts/check_release_history.sh` passes; `cargo xtask workflow-trigger-lint` passes; `git diff --check` passes.