### PR TITLE
fix(semantic): reconcile shadow proof readiness rows (#0000)

### DIFF
--- a/docs/project/RC2_SEMANTIC_SCORECARD.md
+++ b/docs/project/RC2_SEMANTIC_SCORECARD.md
@@ -1,6 +1,7 @@
-# RC2 Semantic Scorecard
+# 0.13.2 Semantic Scorecard
 
-The RC2 semantic proof rail is split into two deterministic xtask surfaces:
+The semantic spine landed as the baseline for the 0.13.2 expansion train. Its
+proof rail is split into two deterministic xtask surfaces:
 
 ```bash
 cargo xtask semantic-scorecard
@@ -14,16 +15,18 @@ cargo xtask semantic-shadow-compare --check
 - `docs/project/status/semantic_scorecard.json`
 - `docs/project/status/semantic_scorecard.md`
 
-`semantic-shadow-compare` writes deterministic old-path/new-path receipt shapes for provider cutover proof:
+`semantic-shadow-compare` writes deterministic old-path/new-path receipt shapes
+for semantic provider proof:
 
 - `docs/project/status/semantic_shadow_compare.json`
 - `docs/project/status/semantic_shadow_compare.md`
 
 `--check` recomputes the same payloads and fails when the committed artifacts are stale.
 
-## Blocking Rows
+## Release-Readiness Rows
 
-The scorecard tracks the RC2 release-readiness rows reviewers need for provider migration:
+The scorecard tracks release-readiness rows reviewers need for semantic UX and
+provider behavior:
 
 - `semantic_fact_counts_nonzero`
 - `visible_symbols_fixture_pass_rate`
@@ -35,6 +38,11 @@ The scorecard tracks the RC2 release-readiness rows reviewers need for provider 
 - `safe_delete_blocker_fixture_pass_rate`
 
 Provider cutover should stay conservative: dynamic, unavailable, or ambiguous cases must keep returning fallback, unavailable, warning, or blocker results rather than false precision.
+
+Shadow compare includes both release-readiness receipts and schema fixture
+receipts. Release-readiness rows count only provider-gating receipts; schema
+fixture receipts exist to keep `same`, `improved`, `regression`, `ambiguous`,
+and `unavailable` output shapes deterministic.
 
 ## Slow Analyzer Fuzz
 

--- a/docs/project/status/semantic_scorecard.json
+++ b/docs/project/status/semantic_scorecard.json
@@ -213,13 +213,13 @@
       "status": "pass",
       "value": "0",
       "threshold": "0",
-      "evidence": "semantic shadow compare receipts"
+      "evidence": "semantic shadow compare release-readiness receipts"
     },
     "reference_shadow_regressions": {
       "status": "pass",
       "value": "0",
       "threshold": "0",
-      "evidence": "semantic shadow compare receipts"
+      "evidence": "semantic shadow compare release-readiness receipts"
     },
     "rename_unsafe_edit_count": {
       "status": "pass",
@@ -266,5 +266,5 @@
       "reason": "planned for future scorecard waves"
     }
   },
-  "notes": "RC2 proof rail: scorecard rows are deterministic and fixture-backed; provider cutover remains conservative for unavailable rows."
+  "notes": "0.13.2 semantic proof rail: scorecard rows are deterministic and fixture-backed; semantic expansion remains conservative for unavailable rows."
 }

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -20,8 +20,8 @@ Fixtures loaded: `12`
 | Row | Status | Value | Threshold | Evidence |
 |---|---|---:|---:|---|
 | completion_import_fixture_pass_rate | pass | 100% | 100% | import/export visibility fixtures |
-| definition_shadow_regressions | pass | 0 | 0 | semantic shadow compare receipts |
-| reference_shadow_regressions | pass | 0 | 0 | semantic shadow compare receipts |
+| definition_shadow_regressions | pass | 0 | 0 | semantic shadow compare release-readiness receipts |
+| reference_shadow_regressions | pass | 0 | 0 | semantic shadow compare release-readiness receipts |
 | rename_unsafe_edit_count | pass | 0 | 0 | rename blocker fixtures |
 | safe_delete_blocker_fixture_pass_rate | pass | 100% | 100% | safe-delete blocker fixtures |
 | semantic_fact_counts_nonzero | pass | 56 | > 0 | semantic fixture indexing |
@@ -51,4 +51,4 @@ Fixtures loaded: `12`
 - `same_bare_sub_two_packages`
 - `typeglob_alias`
 
-RC2 proof rail: scorecard rows are deterministic and fixture-backed; provider cutover remains conservative for unavailable rows.
+0.13.2 semantic proof rail: scorecard rows are deterministic and fixture-backed; semantic expansion remains conservative for unavailable rows.

--- a/docs/project/status/semantic_shadow_compare.json
+++ b/docs/project/status/semantic_shadow_compare.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "measured_at": "deterministic-fixture-baseline",
   "subsystem": "semantic_shadow_compare",
   "receipts": [
@@ -133,5 +133,19 @@
     "same": 1,
     "unavailable": 1
   },
-  "notes": "Deterministic RC2 shadow-compare receipt shape for semantic provider cutover proof."
+  "release_readiness_verdict_counts": {
+    "ambiguous": 0,
+    "improved": 1,
+    "regression": 0,
+    "same": 1,
+    "unavailable": 0
+  },
+  "schema_fixture_verdict_counts": {
+    "ambiguous": 1,
+    "improved": 0,
+    "regression": 1,
+    "same": 0,
+    "unavailable": 1
+  },
+  "notes": "0.13.2 semantic shadow proof: release-readiness counts include provider-gating receipts only; schema fixture receipts exercise non-gating verdict shapes."
 }

--- a/docs/project/status/semantic_shadow_compare.md
+++ b/docs/project/status/semantic_shadow_compare.md
@@ -14,14 +14,34 @@ Receipts: `5`
 | same | 1 |
 | unavailable | 1 |
 
+## Release-Readiness Verdict Counts
+
+| Verdict | Count |
+|---|---:|
+| ambiguous | 0 |
+| improved | 1 |
+| regression | 0 |
+| same | 1 |
+| unavailable | 0 |
+
+## Schema Fixture Verdict Counts
+
+| Verdict | Count |
+|---|---:|
+| ambiguous | 1 |
+| improved | 0 |
+| regression | 1 |
+| same | 0 |
+| unavailable | 1 |
+
 ## Receipts
 
-| Query | Symbol | Verdict | Old count | New count |
-|---|---|---|---:|---:|
-| FindDefinition | `Foo::bar` | same | 1 | 1 |
-| FindReferences | `Foo::bar` | improved | 1 | 2 |
-| CountUsages | `Foo::bar` | regression | 4 | 3 |
-| VisibleSymbols | `Foo::bar` | ambiguous | 2 | 2 |
-| Hover | `Foo::bar` | unavailable | 0 | 1 |
+| Scope | Query | Symbol | Verdict | Old count | New count |
+|---|---|---|---|---:|---:|
+| release-readiness | FindDefinition | `Foo::bar` | same | 1 | 1 |
+| release-readiness | FindReferences | `Foo::bar` | improved | 1 | 2 |
+| schema-fixture | CountUsages | `Foo::bar` | regression | 4 | 3 |
+| schema-fixture | VisibleSymbols | `Foo::bar` | ambiguous | 2 | 2 |
+| schema-fixture | Hover | `Foo::bar` | unavailable | 0 | 1 |
 
-Deterministic RC2 shadow-compare receipt shape for semantic provider cutover proof.
+0.13.2 semantic shadow proof: release-readiness counts include provider-gating receipts only; schema fixture receipts exercise non-gating verdict shapes.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1087,7 +1087,7 @@ enum Commands {
         ratchet_check: bool,
     },
 
-    /// Publish/check RC2 semantic scorecard artifacts from deterministic fixtures.
+    /// Publish/check 0.13.2 semantic scorecard artifacts from deterministic fixtures.
     SemanticScorecard {
         /// Optional path to semantic fixture manifest JSON.
         #[arg(long)]

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -205,7 +205,7 @@ fn build_artifact(manifest_path: &Path, manifest: SemanticManifest) -> Result<Ar
         fact_rows,
         readiness_rows,
         unavailable_rows,
-        notes: "RC2 proof rail: scorecard rows are deterministic and fixture-backed; provider cutover remains conservative for unavailable rows.",
+        notes: "0.13.2 semantic proof rail: scorecard rows are deterministic and fixture-backed; semantic expansion remains conservative for unavailable rows.",
     })
 }
 
@@ -355,7 +355,7 @@ fn build_readiness_rows(
                 status: "pass",
                 value: "0".to_string(),
                 threshold: "0",
-                evidence: "semantic shadow compare receipts",
+                evidence: "semantic shadow compare release-readiness receipts",
             },
         ),
         (
@@ -364,7 +364,7 @@ fn build_readiness_rows(
                 status: "pass",
                 value: "0".to_string(),
                 threshold: "0",
-                evidence: "semantic shadow compare receipts",
+                evidence: "semantic shadow compare release-readiness receipts",
             },
         ),
         (
@@ -474,7 +474,7 @@ fn render_status_markdown(artifact: &Artifact) -> String {
         text.push_str(&format!("- `{id}`\n"));
     }
 
-    text.push_str("\n");
+    text.push('\n');
     text.push_str(artifact.notes);
     text.push('\n');
     text

--- a/xtask/src/tasks/semantic_shadow_compare.rs
+++ b/xtask/src/tasks/semantic_shadow_compare.rs
@@ -19,6 +19,8 @@ struct Artifact {
     subsystem: &'static str,
     receipts: Vec<SemanticShadowCompareReceipt>,
     verdict_counts: BTreeMap<String, usize>,
+    release_readiness_verdict_counts: BTreeMap<String, usize>,
+    schema_fixture_verdict_counts: BTreeMap<String, usize>,
     notes: &'static str,
 }
 
@@ -83,26 +85,51 @@ fn build_artifact() -> Artifact {
         ),
     ];
 
-    let mut verdict_counts = BTreeMap::from([
+    let verdict_counts = count_verdicts(&receipts);
+    let release_readiness_verdict_counts =
+        count_verdicts(receipts.iter().filter(|receipt| is_release_readiness_receipt(receipt)));
+    let schema_fixture_verdict_counts =
+        count_verdicts(receipts.iter().filter(|receipt| !is_release_readiness_receipt(receipt)));
+
+    Artifact {
+        schema_version: 2,
+        measured_at: "deterministic-fixture-baseline",
+        subsystem: "semantic_shadow_compare",
+        receipts,
+        verdict_counts,
+        release_readiness_verdict_counts,
+        schema_fixture_verdict_counts,
+        notes: "0.13.2 semantic shadow proof: release-readiness counts include provider-gating receipts only; schema fixture receipts exercise non-gating verdict shapes.",
+    }
+}
+
+fn count_verdicts<'a>(
+    receipts: impl IntoIterator<Item = &'a SemanticShadowCompareReceipt>,
+) -> BTreeMap<String, usize> {
+    let mut verdict_counts = empty_verdict_counts();
+    for receipt in receipts {
+        let key = verdict_key(receipt.verdict).to_string();
+        *verdict_counts.entry(key).or_default() += 1;
+    }
+    verdict_counts
+}
+
+fn empty_verdict_counts() -> BTreeMap<String, usize> {
+    BTreeMap::from([
         ("same".to_string(), 0),
         ("improved".to_string(), 0),
         ("regression".to_string(), 0),
         ("ambiguous".to_string(), 0),
         ("unavailable".to_string(), 0),
-    ]);
-    for receipt in &receipts {
-        let key = verdict_key(receipt.verdict).to_string();
-        *verdict_counts.entry(key).or_default() += 1;
-    }
+    ])
+}
 
-    Artifact {
-        schema_version: 1,
-        measured_at: "deterministic-fixture-baseline",
-        subsystem: "semantic_shadow_compare",
-        receipts,
-        verdict_counts,
-        notes: "Deterministic RC2 shadow-compare receipt shape for semantic provider cutover proof.",
-    }
+fn is_release_readiness_receipt(receipt: &SemanticShadowCompareReceipt) -> bool {
+    matches!(receipt.query, ShadowQueryName::FindDefinition | ShadowQueryName::FindReferences)
+}
+
+fn receipt_scope(receipt: &SemanticShadowCompareReceipt) -> &'static str {
+    if is_release_readiness_receipt(receipt) { "release-readiness" } else { "schema-fixture" }
 }
 
 fn receipt_from_identities(
@@ -184,12 +211,25 @@ fn render_status_markdown(artifact: &Artifact) -> String {
         text.push_str(&format!("| {verdict} | {count} |\n"));
     }
 
+    text.push_str("\n## Release-Readiness Verdict Counts\n\n");
+    text.push_str("| Verdict | Count |\n|---|---:|\n");
+    for (verdict, count) in &artifact.release_readiness_verdict_counts {
+        text.push_str(&format!("| {verdict} | {count} |\n"));
+    }
+
+    text.push_str("\n## Schema Fixture Verdict Counts\n\n");
+    text.push_str("| Verdict | Count |\n|---|---:|\n");
+    for (verdict, count) in &artifact.schema_fixture_verdict_counts {
+        text.push_str(&format!("| {verdict} | {count} |\n"));
+    }
+
     text.push_str("\n## Receipts\n\n");
-    text.push_str("| Query | Symbol | Verdict | Old count | New count |\n");
-    text.push_str("|---|---|---|---:|---:|\n");
+    text.push_str("| Scope | Query | Symbol | Verdict | Old count | New count |\n");
+    text.push_str("|---|---|---|---|---:|---:|\n");
     for receipt in &artifact.receipts {
         text.push_str(&format!(
-            "| {:?} | `{}` | {} | {} | {} |\n",
+            "| {} | {:?} | `{}` | {} | {} | {} |\n",
+            receipt_scope(receipt),
             receipt.query,
             receipt.input.symbol,
             verdict_key(receipt.verdict),
@@ -198,7 +238,7 @@ fn render_status_markdown(artifact: &Artifact) -> String {
         ));
     }
 
-    text.push_str("\n");
+    text.push('\n');
     text.push_str(artifact.notes);
     text.push('\n');
     text
@@ -211,11 +251,19 @@ mod tests {
     #[test]
     fn artifact_includes_required_verdict_rows() {
         let artifact = build_artifact();
+        assert_eq!(artifact.schema_version, 2);
         assert_eq!(artifact.verdict_counts.get("same"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("improved"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("regression"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("ambiguous"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("unavailable"), Some(&1));
+        assert_eq!(artifact.release_readiness_verdict_counts.get("same"), Some(&1));
+        assert_eq!(artifact.release_readiness_verdict_counts.get("improved"), Some(&1));
+        assert_eq!(artifact.release_readiness_verdict_counts.get("regression"), Some(&0));
+        assert_eq!(artifact.release_readiness_verdict_counts.get("unavailable"), Some(&0));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("regression"), Some(&1));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("ambiguous"), Some(&1));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("unavailable"), Some(&1));
     }
 
     #[test]
@@ -224,6 +272,15 @@ mod tests {
         let second = serialize_json(&build_artifact())?;
         assert_eq!(first, second);
         Ok(())
+    }
+
+    #[test]
+    fn status_markdown_separates_release_readiness_from_schema_fixtures() {
+        let markdown = render_status_markdown(&build_artifact());
+        assert!(markdown.contains("## Release-Readiness Verdict Counts"));
+        assert!(markdown.contains("## Schema Fixture Verdict Counts"));
+        assert!(markdown.contains("| release-readiness | FindDefinition"));
+        assert!(markdown.contains("| schema-fixture | CountUsages"));
     }
 
     #[test]


### PR DESCRIPTION
Problem: 0.13.2 semantic proof artifacts mixed release-readiness receipts with schema fixture receipts, so the scorecard could report zero shadow regressions while shadow compare displayed a CountUsages regression.
Fix: split shadow-compare verdict counts into release-readiness and schema-fixture buckets, regenerate the artifacts, and update the scorecard evidence wording to point at release-readiness receipts.
Verification: `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo test -p xtask --profile agent --locked semantic`; `cargo check -p xtask --all-targets --profile agent --locked`; `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`.