### PR TITLE
feat(semantic-analyzer): classify dynamic import arguments (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
@@ -123,12 +123,13 @@ impl ImportExtractor {
                 //
                 // Use the require statement's anchor for the spec.
                 let anchor_id = Self::anchor_from_node(require_node);
+                let confidence = Self::confidence_for_symbols(&symbols);
                 out.push(ImportSpec {
                     module: module_name,
                     kind: ImportKind::RequireThenImport,
                     symbols,
                     provenance: Provenance::ExactAst,
-                    confidence: Confidence::High,
+                    confidence,
                     file_id: Some(file_id),
                     anchor_id: Some(anchor_id),
                     scope_id: None,
@@ -250,9 +251,14 @@ impl ImportExtractor {
 
         let mut names: Vec<String> = Vec::new();
         let mut tags: Vec<String> = Vec::new();
+        let mut has_dynamic_arg = false;
 
         for arg in args {
-            Self::collect_import_arg_symbols(arg, &mut names, &mut tags);
+            has_dynamic_arg |= Self::collect_import_arg_symbols(arg, &mut names, &mut tags);
+        }
+
+        if has_dynamic_arg {
+            return ImportSymbols::Dynamic;
         }
 
         if names.is_empty() && tags.is_empty() {
@@ -272,7 +278,14 @@ impl ImportExtractor {
 
     /// Collect symbol names and tags from a single argument node of an
     /// `import(...)` call.
-    fn collect_import_arg_symbols(arg: &Node, names: &mut Vec<String>, tags: &mut Vec<String>) {
+    ///
+    /// Returns `true` when the argument is dynamic or unsupported and should
+    /// prevent the import site from claiming exact symbol names.
+    fn collect_import_arg_symbols(
+        arg: &Node,
+        names: &mut Vec<String>,
+        tags: &mut Vec<String>,
+    ) -> bool {
         match &arg.kind {
             NodeKind::String { value, .. } => {
                 let bare = value.trim_matches('\'').trim_matches('"');
@@ -281,6 +294,7 @@ impl ImportExtractor {
                 } else if !bare.is_empty() {
                     names.push(bare.to_string());
                 }
+                false
             }
             NodeKind::Identifier { name } => {
                 // Handle qw(...) stored as raw identifier string.
@@ -297,15 +311,27 @@ impl ImportExtractor {
                 } else if !name.is_empty() {
                     names.push(name.clone());
                 }
+                false
+            }
+            NodeKind::Variable { .. } => {
+                // `Foo->import(@names)` / `Foo->import($name)` is dynamic:
+                // do not guess exact imported symbols.
+                true
             }
             NodeKind::ArrayLiteral { elements } => {
                 // qw(...) in expression context → ArrayLiteral of String nodes
+                let mut has_dynamic_arg = false;
                 for el in elements {
-                    Self::collect_import_arg_symbols(el, names, tags);
+                    has_dynamic_arg |= Self::collect_import_arg_symbols(el, names, tags);
                 }
+                has_dynamic_arg
             }
-            _ => {}
+            _ => true,
         }
+    }
+
+    fn confidence_for_symbols(symbols: &ImportSymbols) -> Confidence {
+        if matches!(symbols, ImportSymbols::Dynamic) { Confidence::Low } else { Confidence::High }
     }
 
     // ── Classification ──────────────────────────────────────────────────
@@ -934,6 +960,47 @@ Some::Module->import();
 
         assert_eq!(spec.kind, ImportKind::RequireThenImport);
         assert_eq!(spec.symbols, ImportSymbols::Default);
+        Ok(())
+    }
+
+    #[test]
+    fn test_require_then_import_quoted_strings() -> Result<(), String> {
+        let code = r#"
+require Foo::Bar;
+Foo::Bar->import('alpha', 'beta');
+"#;
+        let specs = parse_and_extract(code);
+        let spec = specs
+            .iter()
+            .find(|s| s.module == "Foo::Bar")
+            .ok_or("expected ImportSpec for Foo::Bar")?;
+
+        assert_eq!(spec.kind, ImportKind::RequireThenImport);
+        if let ImportSymbols::Explicit(names) = &spec.symbols {
+            assert!(names.contains(&"alpha".to_string()), "missing 'alpha' in {names:?}");
+            assert!(names.contains(&"beta".to_string()), "missing 'beta' in {names:?}");
+        } else {
+            return Err(format!("expected Explicit, got {:?}", spec.symbols));
+        }
+        assert_eq!(spec.confidence, Confidence::High);
+        Ok(())
+    }
+
+    #[test]
+    fn test_require_then_import_dynamic_symbol_list() -> Result<(), String> {
+        let code = r#"
+require Foo::Bar;
+Foo::Bar->import(@names);
+"#;
+        let specs = parse_and_extract(code);
+        let spec = specs
+            .iter()
+            .find(|s| s.module == "Foo::Bar")
+            .ok_or("expected ImportSpec for Foo::Bar")?;
+
+        assert_eq!(spec.kind, ImportKind::RequireThenImport);
+        assert_eq!(spec.symbols, ImportSymbols::Dynamic);
+        assert_eq!(spec.confidence, Confidence::Low);
         Ok(())
     }
 

--- a/crates/perl-workspace-index/src/semantic/visibility.rs
+++ b/crates/perl-workspace-index/src/semantic/visibility.rs
@@ -754,6 +754,31 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn require_then_import_dynamic_symbols_do_not_invent_visibility()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let file_id = FileId(1);
+        let shard = empty_shard(file_id);
+        let mut index = ImportExportIndex::new();
+
+        let import = ImportSpec {
+            module: "Bar".to_string(),
+            kind: ImportKind::RequireThenImport,
+            symbols: ImportSymbols::Dynamic,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::Low,
+            file_id: Some(file_id),
+            anchor_id: Some(AnchorId(104)),
+            scope_id: None,
+        };
+        index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
+
+        let symbols = visible_symbols_at(file_id, 0, None, &shard, &index);
+
+        assert!(symbols.is_empty(), "dynamic import list should not invent exact symbols");
+        Ok(())
+    }
+
     // ── No imports, no exports ──
 
     #[test]


### PR DESCRIPTION
Problem: `require Foo; Foo->import(@names)` was treated like a default import because dynamic import arguments produced no extracted names.
Fix: classify variable or unsupported `import(...)` arguments as `ImportSymbols::Dynamic`, lower that import site's confidence, and keep workspace visibility from inventing exact symbols for dynamic require/import flows.
Verification: `cargo test -p perl-semantic-analyzer --profile agent --locked import_extractor -- --nocapture`; `cargo test -p perl-workspace --profile agent --locked require_then_import_dynamic_symbols_do_not_invent_visibility -- --nocapture`; `cargo test -p perl-workspace --profile agent --locked visible -- --nocapture`; `cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked`; `cargo check -p perl-workspace --all-targets --profile agent --locked`; `cargo clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-workspace --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask semantic-scorecard --check`; `cargo xtask fmt --check`.