### PR TITLE
feat(semantic): make package graph scorecard concrete (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,6 +3881,7 @@ dependencies = [
  "perl-lsp-ux-tests",
  "perl-parser",
  "perl-parser-pest",
+ "perl-semantic-analyzer",
  "perl-semantic-facts",
  "perl-tdd-support",
  "perl-workspace",

--- a/docs/project/status/semantic_scorecard.json
+++ b/docs/project/status/semantic_scorecard.json
@@ -55,8 +55,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 109,
-        "high_confidence_facts": 109,
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 0
       }
@@ -83,8 +83,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 109,
-        "high_confidence_facts": 109,
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 0
       }
@@ -111,8 +111,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 109,
-        "high_confidence_facts": 109,
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 0
       }
@@ -139,8 +139,36 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 109,
-        "high_confidence_facts": 109,
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
+        "heuristic_facts": 1,
+        "dynamic_boundary_facts": 0
+      }
+    },
+    "inheritance_edges": {
+      "status": "available",
+      "total_facts": 1,
+      "fixture_coverage": {
+        "covered_fixture_count": 12,
+        "total_fixture_count": 12,
+        "covered_fixture_families": [
+          "AUTOLOAD dynamic boundary",
+          "dynamic require boundary",
+          "empty import suppression",
+          "eval STRING dynamic boundary",
+          "export tag expansion",
+          "generated accessor",
+          "imported function visibility",
+          "inherited method",
+          "qualified vs bare references",
+          "role method",
+          "same bare sub in two packages",
+          "typeglob alias"
+        ]
+      },
+      "confidence_breakdown": {
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 0
       }
@@ -167,8 +195,36 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 109,
-        "high_confidence_facts": 109,
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
+        "heuristic_facts": 1,
+        "dynamic_boundary_facts": 0
+      }
+    },
+    "package_graph_edges": {
+      "status": "available",
+      "total_facts": 2,
+      "fixture_coverage": {
+        "covered_fixture_count": 12,
+        "total_fixture_count": 12,
+        "covered_fixture_families": [
+          "AUTOLOAD dynamic boundary",
+          "dynamic require boundary",
+          "empty import suppression",
+          "eval STRING dynamic boundary",
+          "export tag expansion",
+          "generated accessor",
+          "imported function visibility",
+          "inherited method",
+          "qualified vs bare references",
+          "role method",
+          "same bare sub in two packages",
+          "typeglob alias"
+        ]
+      },
+      "confidence_breakdown": {
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 0
       }
@@ -195,8 +251,36 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 109,
-        "high_confidence_facts": 109,
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
+        "heuristic_facts": 1,
+        "dynamic_boundary_facts": 0
+      }
+    },
+    "role_composition_edges": {
+      "status": "available",
+      "total_facts": 1,
+      "fixture_coverage": {
+        "covered_fixture_count": 12,
+        "total_fixture_count": 12,
+        "covered_fixture_families": [
+          "AUTOLOAD dynamic boundary",
+          "dynamic require boundary",
+          "empty import suppression",
+          "eval STRING dynamic boundary",
+          "export tag expansion",
+          "generated accessor",
+          "imported function visibility",
+          "inherited method",
+          "qualified vs bare references",
+          "role method",
+          "same bare sub in two packages",
+          "typeglob alias"
+        ]
+      },
+      "confidence_breakdown": {
+        "exact_facts": 111,
+        "high_confidence_facts": 111,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 0
       }
@@ -214,6 +298,12 @@
       "value": "0",
       "threshold": "0",
       "evidence": "semantic shadow compare release-readiness receipts"
+    },
+    "package_graph": {
+      "status": "pass",
+      "value": "2",
+      "threshold": "> 0",
+      "evidence": "package graph fixture edges"
     },
     "reference_shadow_regressions": {
       "status": "pass",
@@ -235,7 +325,7 @@
     },
     "semantic_fact_counts_nonzero": {
       "status": "pass",
-      "value": "56",
+      "value": "58",
       "threshold": "> 0",
       "evidence": "semantic fixture indexing"
     },
@@ -253,10 +343,6 @@
     }
   },
   "unavailable_rows": {
-    "package_graph": {
-      "status": "unavailable",
-      "reason": "planned for future scorecard waves"
-    },
     "rename_plan": {
       "status": "unavailable",
       "reason": "planned for future scorecard waves"

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -8,12 +8,15 @@ Fixtures loaded: `12`
 
 | Row | Status | Facts | Coverage | Exact | High | Heuristic | Dynamic boundary |
 |---|---|---:|---:|---:|---:|---:|---:|
-| declaration_facts | available | 31 | 12/12 | 109 | 109 | 1 | 0 |
-| definition_candidates | available | 31 | 12/12 | 109 | 109 | 1 | 0 |
-| export_facts | available | 3 | 12/12 | 109 | 109 | 1 | 0 |
-| import_specs | available | 7 | 12/12 | 109 | 109 | 1 | 0 |
-| occurrence_facts | available | 14 | 12/12 | 109 | 109 | 1 | 0 |
-| reference_edges | available | 1 | 12/12 | 109 | 109 | 1 | 0 |
+| declaration_facts | available | 31 | 12/12 | 111 | 111 | 1 | 0 |
+| definition_candidates | available | 31 | 12/12 | 111 | 111 | 1 | 0 |
+| export_facts | available | 3 | 12/12 | 111 | 111 | 1 | 0 |
+| import_specs | available | 7 | 12/12 | 111 | 111 | 1 | 0 |
+| inheritance_edges | available | 1 | 12/12 | 111 | 111 | 1 | 0 |
+| occurrence_facts | available | 14 | 12/12 | 111 | 111 | 1 | 0 |
+| package_graph_edges | available | 2 | 12/12 | 111 | 111 | 1 | 0 |
+| reference_edges | available | 1 | 12/12 | 111 | 111 | 1 | 0 |
+| role_composition_edges | available | 1 | 12/12 | 111 | 111 | 1 | 0 |
 
 ## Readiness Rows
 
@@ -21,10 +24,11 @@ Fixtures loaded: `12`
 |---|---|---:|---:|---|
 | completion_import_fixture_pass_rate | pass | 100% | 100% | import/export visibility fixtures |
 | definition_shadow_regressions | pass | 0 | 0 | semantic shadow compare release-readiness receipts |
+| package_graph | pass | 2 | > 0 | package graph fixture edges |
 | reference_shadow_regressions | pass | 0 | 0 | semantic shadow compare release-readiness receipts |
 | rename_unsafe_edit_count | pass | 0 | 0 | rename blocker fixtures |
 | safe_delete_blocker_fixture_pass_rate | pass | 100% | 100% | safe-delete blocker fixtures |
-| semantic_fact_counts_nonzero | pass | 56 | > 0 | semantic fixture indexing |
+| semantic_fact_counts_nonzero | pass | 58 | > 0 | semantic fixture indexing |
 | undefined_symbol_false_positive_fixture_rate | pass | 0% | 0% | diagnostics fixture receipts |
 | visible_symbols_fixture_pass_rate | pass | 100% | 100% | workspace scorecard fixtures |
 
@@ -32,7 +36,6 @@ Fixtures loaded: `12`
 
 | Row | Status | Reason |
 |---|---|---|
-| package_graph | unavailable | planned for future scorecard waves |
 | rename_plan | unavailable | planned for future scorecard waves |
 | safe_delete_plan | unavailable | planned for future scorecard waves |
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -24,6 +24,7 @@ serde_json.workspace = true
 anyhow.workspace = true
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 perl-lsp-rs-core = { workspace = true }
+perl-semantic-analyzer = { workspace = true }
 perl-semantic-facts = { workspace = true }
 perl-workspace = { workspace = true }
 perl-ci-hygiene = { workspace = true }

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1,6 +1,7 @@
 use crate::utils::project_root;
 use color_eyre::eyre::{Context, Result, bail};
-use perl_semantic_facts::{Confidence, EdgeKind, OccurrenceKind, Provenance};
+use perl_semantic_analyzer::{Parser, semantic::SemanticModel};
+use perl_semantic_facts::{Confidence, EdgeKind, OccurrenceKind, PackageEdgeKind, Provenance};
 use perl_workspace::workspace::workspace_index::WorkspaceIndex;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -19,9 +20,12 @@ const AVAILABLE_ROWS: &[&str] = &[
     "export_facts",
     "definition_candidates",
     "reference_edges",
+    "package_graph_edges",
+    "inheritance_edges",
+    "role_composition_edges",
 ];
 
-const UNAVAILABLE_ROWS: &[&str] = &["package_graph", "rename_plan", "safe_delete_plan"];
+const UNAVAILABLE_ROWS: &[&str] = &["rename_plan", "safe_delete_plan"];
 
 #[derive(Debug, Deserialize)]
 struct SemanticManifest {
@@ -97,6 +101,9 @@ struct FactMeasurement {
     export_facts: usize,
     definition_candidates: usize,
     reference_edges: usize,
+    package_graph_edges: usize,
+    inheritance_edges: usize,
+    role_composition_edges: usize,
     exact_facts: usize,
     high_confidence_facts: usize,
     heuristic_facts: usize,
@@ -217,6 +224,9 @@ fn row_total(measurement: &FactMeasurement, row: &str) -> usize {
         "export_facts" => measurement.export_facts,
         "definition_candidates" => measurement.definition_candidates,
         "reference_edges" => measurement.reference_edges,
+        "package_graph_edges" => measurement.package_graph_edges,
+        "inheritance_edges" => measurement.inheritance_edges,
+        "role_composition_edges" => measurement.role_composition_edges,
         _ => 0,
     }
 }
@@ -244,6 +254,7 @@ fn measure_fixtures(manifest_path: &Path, manifest: &SemanticManifest) -> Result
             shard.edges.iter().filter(|edge| edge.kind == EdgeKind::References).count();
         measurement.import_specs += count_import_like_sites(&source);
         measurement.export_facts += count_export_like_sites(&source);
+        measure_package_graph_edges(&source, &path, &mut measurement)?;
 
         for anchor in &shard.anchors {
             record_proof_shape(anchor.provenance, anchor.confidence, None, &mut measurement);
@@ -265,6 +276,35 @@ fn measure_fixtures(manifest_path: &Path, manifest: &SemanticManifest) -> Result
     }
 
     Ok(measurement)
+}
+
+fn measure_package_graph_edges(
+    source: &str,
+    path: &Path,
+    measurement: &mut FactMeasurement,
+) -> Result<()> {
+    let mut parser = Parser::new(source);
+    let ast = parser.parse().map_err(|err| {
+        color_eyre::eyre::eyre!(
+            "parsing package graph scorecard fixture {}: {}",
+            path.display(),
+            err
+        )
+    })?;
+    let model = SemanticModel::build(&ast, source);
+
+    for edge in model.package_edges() {
+        measurement.package_graph_edges += 1;
+        match edge.kind {
+            PackageEdgeKind::Inherits => measurement.inheritance_edges += 1,
+            PackageEdgeKind::ComposesRole => measurement.role_composition_edges += 1,
+            PackageEdgeKind::DependsOn => {}
+            _ => {}
+        }
+        record_proof_shape(edge.provenance, edge.confidence, None, measurement);
+    }
+
+    Ok(())
 }
 
 fn fixture_source_path(manifest_path: &Path, fixture: &FixtureCase) -> Result<PathBuf> {
@@ -327,10 +367,20 @@ fn build_readiness_rows(
         + measurement.occurrence_facts
         + measurement.import_specs
         + measurement.export_facts
-        + measurement.reference_edges;
+        + measurement.reference_edges
+        + measurement.package_graph_edges;
     let fixture_rate = if fixture_count == 0 { "0%" } else { "100%" };
 
     BTreeMap::from([
+        (
+            "package_graph".to_string(),
+            ReadinessRow {
+                status: if measurement.package_graph_edges > 0 { "pass" } else { "fail" },
+                value: measurement.package_graph_edges.to_string(),
+                threshold: "> 0",
+                evidence: "package graph fixture edges",
+            },
+        ),
         (
             "semantic_fact_counts_nonzero".to_string(),
             ReadinessRow {
@@ -566,6 +616,57 @@ mod tests {
         assert!(value.get("readiness_rows").is_some(), "readiness_rows should exist");
         assert!(value.get("unavailable_rows").is_some(), "unavailable_rows should exist");
         assert!(value.get("fixture_families").is_some(), "fixture_families should exist");
+        Ok(())
+    }
+
+    #[test]
+    fn package_graph_rows_are_measured_from_semantic_model() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let manifest_path = write_fixture_set(
+            tmp.path(),
+            r#"{"fixture_family_version":1,"fixtures":[{"id":"graph_fixture","family":"package graph","path":"graph.pl"}]}"#,
+            &[(
+                "graph.pl",
+                r#"
+package Parent;
+sub inherited { 1 }
+
+package Role;
+sub role_method { 1 }
+
+package Child;
+use parent 'Parent';
+with 'Role';
+sub local { 1 }
+"#,
+            )],
+        )?;
+
+        let artifact = build_artifact(&manifest_path, load_manifest(&manifest_path)?)?;
+        let package_graph_edges = artifact
+            .fact_rows
+            .get("package_graph_edges")
+            .ok_or_else(|| color_eyre::eyre::eyre!("missing package_graph_edges row"))?;
+        let inheritance_edges = artifact
+            .fact_rows
+            .get("inheritance_edges")
+            .ok_or_else(|| color_eyre::eyre::eyre!("missing inheritance_edges row"))?;
+        let role_edges = artifact
+            .fact_rows
+            .get("role_composition_edges")
+            .ok_or_else(|| color_eyre::eyre::eyre!("missing role_composition_edges row"))?;
+
+        assert_eq!(package_graph_edges.total_facts, 2);
+        assert_eq!(inheritance_edges.total_facts, 1);
+        assert_eq!(role_edges.total_facts, 1);
+
+        let package_graph = artifact
+            .readiness_rows
+            .get("package_graph")
+            .ok_or_else(|| color_eyre::eyre::eyre!("missing package graph readiness row"))?;
+        assert_eq!(package_graph.status, "pass");
+        assert_eq!(package_graph.value, "2");
+        assert!(!artifact.unavailable_rows.contains_key("package_graph"));
         Ok(())
     }
 


### PR DESCRIPTION
Problem: `package_graph` still appeared as unavailable in the semantic scorecard even though package graph edges are now exposed through `SemanticModel`.
Fix: Measure package graph edges from scorecard fixtures, add inheritance/role edge rows, move `package_graph` to a concrete readiness row, and refresh generated artifacts.
Verification: `cargo test -p xtask --profile agent --locked semantic` passes; `cargo xtask semantic-scorecard --check` passes; `cargo xtask semantic-shadow-compare --check` passes; `cargo check -p xtask --all-targets --profile agent --locked` passes; `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo xtask fmt --check` passes.