### PR TITLE
test(vscode): smoke published extension package (#0000)

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -237,6 +237,43 @@ jobs:
           echo "::error::Release ${RELEASE_TAG} was not available in time for VSIX attachment."
           exit 1
 
+  published-extension-smoke:
+    name: Published Extension Smoke
+    needs:
+      - prepare-vsix
+      - publish-vscode-marketplace
+    if: ${{ needs.prepare-vsix.outputs.is_prerelease != 'true' && needs.publish-vscode-marketplace.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: vscode-extension
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PERL_LSP_PUBLISHED_EXTENSION_SOURCE: marketplace
+      PERL_LSP_PUBLISHED_EXTENSION_VERSION: ${{ needs.prepare-vsix.outputs.version }}
+      PERL_LSP_PUBLISHED_BINARY_VERSION: ${{ needs.prepare-vsix.outputs.version }}
+      PERL_LSP_REQUIRE_STRUCTURED_COMMANDS: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: vscode-extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Smoke published Marketplace extension
+        run: xvfb-run -a npm run test:published
+
   publish-summary:
     name: Publish Extension Summary
     needs:
@@ -244,6 +281,7 @@ jobs:
       - publish-vscode-marketplace
       - publish-open-vsx
       - github-release-asset
+      - published-extension-smoke
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -259,6 +297,7 @@ jobs:
             echo "- VS Code Marketplace job: ${{ needs.publish-vscode-marketplace.result }}"
             echo "- Open VSX job: ${{ needs.publish-open-vsx.result }}"
             echo "- GitHub release asset job: ${{ needs.github-release-asset.result }}"
+            echo "- Published extension smoke job: ${{ needs.published-extension-smoke.result }}"
             if [ "${{ needs.prepare-vsix.outputs.is_prerelease }}" = "true" ]; then
               echo "- Marketplace prerelease policy: skipped; publish Marketplace only for non-prerelease SemVer versions."
             fi

--- a/.github/workflows/vscode-published-extension-smoke.yml
+++ b/.github/workflows/vscode-published-extension-smoke.yml
@@ -1,0 +1,67 @@
+name: VS Code Published Extension Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Published extension version to smoke, for example 0.13.2. Empty installs latest.'
+        required: false
+        type: string
+      source:
+        description: 'Published package source.'
+        required: false
+        default: marketplace
+        type: choice
+        options:
+          - marketplace
+          - open-vsx
+  schedule:
+    - cron: '0 14 * * 1'
+
+concurrency:
+  group: vscode-published-extension-smoke-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.source || 'marketplace' }}-${{ github.event_name == 'workflow_dispatch' && inputs.version || 'latest' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  published-extension-smoke:
+    name: Published extension smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    defaults:
+      run:
+        working-directory: vscode-extension
+
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PERL_LSP_PUBLISHED_EXTENSION_SOURCE: ${{ github.event_name == 'workflow_dispatch' && inputs.source || 'marketplace' }}
+      PERL_LSP_PUBLISHED_EXTENSION_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: vscode-extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run published extension smoke
+        if: runner.os != 'Linux'
+        run: npm run test:published
+
+      - name: Run published extension smoke under Xvfb
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npm run test:published

--- a/vscode-extension/jest.config.js
+++ b/vscode-extension/jest.config.js
@@ -4,7 +4,10 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/src/test'],
   testMatch: ['**/*.test.ts'],
-  testPathIgnorePatterns: ['<rootDir>/src/test/integration/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/src/test/integration/',
+    '<rootDir>/src/test/published/',
+  ],
   moduleNameMapper: {
     '^vscode$': '<rootDir>/src/test/__mocks__/vscode.ts',
   },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1067,6 +1067,7 @@
     "test": "jest --verbose",
     "test:ci": "jest --ci --coverage",
     "test:integration": "npm run compile && tsc -p ./tsconfig.integration.json && node ./out/test/integration/runTest.js",
+    "test:published": "tsc -p ./tsconfig.published-smoke.json && node ./out/test/published/runPublishedSmoke.js",
     "bundle-lsp": "node ./scripts/bundle-lsp.js",
     "package": "npx @vscode/vsce package",
     "publish": "npx @vscode/vsce publish",

--- a/vscode-extension/src/test/published/harness/extension.js
+++ b/vscode-extension/src/test/published/harness/extension.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function activate() {
+  return undefined;
+}
+
+function deactivate() {
+  return undefined;
+}
+
+module.exports = { activate, deactivate };

--- a/vscode-extension/src/test/published/harness/package.json
+++ b/vscode-extension/src/test/published/harness/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "perl-lsp-published-smoke-harness",
+  "displayName": "Perl LSP Published Smoke Harness",
+  "version": "0.0.0",
+  "publisher": "EffortlessMetrics",
+  "private": true,
+  "engines": {
+    "vscode": "^1.116.0"
+  },
+  "main": "./extension.js",
+  "activationEvents": []
+}

--- a/vscode-extension/src/test/published/managedBinaryPublishedSmoke.test.ts
+++ b/vscode-extension/src/test/published/managedBinaryPublishedSmoke.test.ts
@@ -1,0 +1,183 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+type CheckStatus = 'ok' | 'warning' | 'error';
+
+interface ReinstallCommandResult {
+  ok: boolean;
+  serverPath: string;
+  target: string;
+  version?: string;
+  checksumVerified?: boolean;
+  source: 'github-release' | 'internal-base-url' | 'existing';
+  error?: string;
+}
+
+interface HealthCheckCommandResult {
+  ok: boolean;
+  checks: Array<{
+    label: string;
+    status: CheckStatus;
+    detail: string;
+  }>;
+}
+
+async function withTimeout<T>(label: string, operation: PromiseLike<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([Promise.resolve(operation), timeoutPromise]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitForCommand(command: string, timeoutMs: number): Promise<void> {
+  await withTimeout(
+    `${command} registration`,
+    (async () => {
+      for (;;) {
+        const commands = await vscode.commands.getCommands(true);
+        if (commands.includes(command)) {
+          return;
+        }
+        await delay(100);
+      }
+    })(),
+    timeoutMs,
+  );
+}
+
+function versionParts(version: string): [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) {
+    return [0, 0, 0];
+  }
+
+  return [
+    Number.parseInt(match[1], 10),
+    Number.parseInt(match[2], 10),
+    Number.parseInt(match[3], 10),
+  ];
+}
+
+function versionAtLeast(actual: string, minimum: string): boolean {
+  const actualParts = versionParts(actual);
+  const minimumParts = versionParts(minimum);
+
+  for (let index = 0; index < actualParts.length; index += 1) {
+    if (actualParts[index] > minimumParts[index]) {
+      return true;
+    }
+    if (actualParts[index] < minimumParts[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function envFlag(name: string): boolean {
+  return ['1', 'true', 'yes'].includes((process.env[name] ?? '').toLowerCase());
+}
+
+function releaseTag(version: string): string {
+  return version.startsWith('v') ? version : `v${version}`;
+}
+
+suite('Published extension managed binary smoke', function () {
+  this.timeout(180_000);
+
+  test('Published extension installs and runs managed binary commands when supported', async function () {
+    this.timeout(180_000);
+
+    const extensionId = process.env.PERL_LSP_PUBLISHED_EXTENSION_ID ?? 'EffortlessMetrics.perl-lsp-rs';
+    const expectedVersion = process.env.PERL_LSP_PUBLISHED_EXTENSION_VERSION ?? '';
+    const requireStructuredCommands = envFlag('PERL_LSP_REQUIRE_STRUCTURED_COMMANDS');
+    const extension = vscode.extensions.getExtension(extensionId);
+
+    assert.ok(extension, `${extensionId} should be installed in the clean VS Code profile`);
+
+    const packageVersion = String(extension.packageJSON?.version ?? '');
+    assert.ok(packageVersion, 'published extension package should expose a version');
+    if (expectedVersion) {
+      assert.equal(packageVersion, expectedVersion);
+    }
+
+    const supportsStructuredCommands = versionAtLeast(packageVersion, '0.13.2');
+    if (!supportsStructuredCommands) {
+      assert.equal(
+        requireStructuredCommands,
+        false,
+        `published extension ${packageVersion} predates structured command results`,
+      );
+      return;
+    }
+
+    const config = vscode.workspace.getConfiguration('perl-lsp');
+    const binaryVersion = process.env.PERL_LSP_PUBLISHED_BINARY_VERSION || expectedVersion || packageVersion;
+    await config.update('autoDownload', false, vscode.ConfigurationTarget.Global);
+    await config.update('serverPath', '', vscode.ConfigurationTarget.Global);
+    await config.update('channel', 'tag', vscode.ConfigurationTarget.Global);
+    await config.update('versionTag', releaseTag(binaryVersion), vscode.ConfigurationTarget.Global);
+    await config.update('downloadBaseUrl', '', vscode.ConfigurationTarget.Global);
+    await config.update('updateCheckInterval', 0, vscode.ConfigurationTarget.Global);
+    await config.update('perlcritic.enabled', false, vscode.ConfigurationTarget.Global);
+
+    if (process.platform === 'linux') {
+      await config.update('linuxLibc', 'gnu', vscode.ConfigurationTarget.Global);
+    }
+
+    await withTimeout('published extension activation', extension.activate(), 45_000);
+    await waitForCommand('perl-lsp.reinstall', 15_000);
+    await waitForCommand('perl-lsp.runHealthCheck', 15_000);
+
+    await config.update('autoDownload', true, vscode.ConfigurationTarget.Global);
+
+    const reinstall = await withTimeout(
+      'published managed binary reinstall command',
+      vscode.commands.executeCommand<ReinstallCommandResult>('perl-lsp.reinstall'),
+      120_000,
+    );
+    assert.ok(reinstall, 'reinstall command should return a structured result');
+    assert.equal(reinstall.ok, true, JSON.stringify(reinstall, null, 2));
+    assert.ok(reinstall.serverPath, 'reinstall result should include the managed binary path');
+    assert.ok(fs.existsSync(reinstall.serverPath), `managed binary should exist: ${reinstall.serverPath}`);
+    assert.ok(reinstall.target, 'reinstall result should include the release target triple');
+    assert.equal(reinstall.checksumVerified, true, 'managed binary download should verify SHA256SUMS');
+
+    if (process.platform === 'linux') {
+      assert.match(reinstall.target, /-unknown-linux-gnu$/);
+    }
+
+    const health = await withTimeout(
+      'published managed binary health check command',
+      vscode.commands.executeCommand<HealthCheckCommandResult>(
+        'perl-lsp.runHealthCheck',
+        reinstall.serverPath,
+      ),
+      45_000,
+    );
+
+    assert.ok(health, 'health check command should return a structured result');
+    assert.equal(health.ok, true, JSON.stringify(health.checks, null, 2));
+    assert.ok(
+      health.checks.some(check => check.label === 'LSP binary' && check.status === 'ok'),
+      JSON.stringify(health.checks, null, 2),
+    );
+  });
+});

--- a/vscode-extension/src/test/published/runPublishedSmoke.ts
+++ b/vscode-extension/src/test/published/runPublishedSmoke.ts
@@ -1,0 +1,209 @@
+import * as fs from 'fs';
+import * as https from 'https';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import {
+  downloadAndUnzipVSCode,
+  resolveCliArgsFromVSCodeExecutablePath,
+  runTests,
+} from '@vscode/test-electron';
+
+const EXTENSION_ID = 'EffortlessMetrics.perl-lsp-rs';
+
+type ExtensionSource = 'marketplace' | 'open-vsx' | 'vsix';
+
+function envValue(name: string): string {
+  return process.env[name]?.trim() ?? '';
+}
+
+function publishedSource(): ExtensionSource {
+  const source = envValue('PERL_LSP_PUBLISHED_EXTENSION_SOURCE') || 'marketplace';
+  if (source === 'marketplace' || source === 'open-vsx' || source === 'vsix') {
+    return source;
+  }
+
+  throw new Error(`Unsupported PERL_LSP_PUBLISHED_EXTENSION_SOURCE=${source}`);
+}
+
+function validateExtensionId(extensionId: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9-]*\.[A-Za-z0-9][A-Za-z0-9-]*$/.test(extensionId)) {
+    throw new Error(`Extension id must be publisher.name, got ${extensionId}`);
+  }
+}
+
+function validatePublishedVersion(version: string): void {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Published extension version must be a SemVer package version, got ${version}`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function downloadFile(url: string, destination: string, redirects = 0): Promise<void> {
+  if (redirects > 5) {
+    return Promise.reject(new Error(`Too many redirects while downloading ${url}`));
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, response => {
+      const statusCode = response.statusCode ?? 0;
+      const location = response.headers.location;
+      if (statusCode >= 300 && statusCode < 400 && location) {
+        response.resume();
+        const redirectedUrl = new URL(location, url).toString();
+        downloadFile(redirectedUrl, destination, redirects + 1).then(resolve, reject);
+        return;
+      }
+
+      if (statusCode !== 200) {
+        response.resume();
+        reject(new Error(`GET ${url} failed with HTTP ${statusCode}`));
+        return;
+      }
+
+      const output = fs.createWriteStream(destination);
+      response.pipe(output);
+      output.on('finish', () => {
+        output.close();
+        resolve();
+      });
+      output.on('error', reject);
+    });
+
+    request.on('error', reject);
+    request.setTimeout(60_000, () => {
+      request.destroy(new Error(`Timed out downloading ${url}`));
+    });
+  });
+}
+
+async function resolveInstallTarget(source: ExtensionSource, tempDir: string): Promise<string> {
+  const version = envValue('PERL_LSP_PUBLISHED_EXTENSION_VERSION');
+  const extensionId = envValue('PERL_LSP_PUBLISHED_EXTENSION_ID') || EXTENSION_ID;
+  validateExtensionId(extensionId);
+
+  if (version) {
+    validatePublishedVersion(version);
+  }
+
+  if (source === 'marketplace') {
+    return version ? `${extensionId}@${version}` : extensionId;
+  }
+
+  if (source === 'vsix') {
+    const vsixPath = envValue('PERL_LSP_PUBLISHED_VSIX_PATH');
+    if (!vsixPath) {
+      throw new Error('PERL_LSP_PUBLISHED_VSIX_PATH is required when source is vsix');
+    }
+    return path.resolve(vsixPath);
+  }
+
+  if (!version) {
+    throw new Error('PERL_LSP_PUBLISHED_EXTENSION_VERSION is required when source is open-vsx');
+  }
+
+  const [namespace, extensionName] = extensionId.split('.');
+
+  const fileName = `${namespace}.${extensionName}-${version}.vsix`;
+  const url = `https://open-vsx.org/api/${namespace}/${extensionName}/${version}/file/${fileName}`;
+  const destination = path.join(tempDir, fileName);
+  await downloadFile(url, destination);
+  return destination;
+}
+
+async function installExtension(
+  vscodeExecutablePath: string,
+  installTarget: string,
+  userDataDir: string,
+  extensionsDir: string,
+): Promise<void> {
+  const [cliPath, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+  const args = [
+    ...cliArgs,
+    `--user-data-dir=${userDataDir}`,
+    `--extensions-dir=${extensionsDir}`,
+    '--install-extension',
+    installTarget,
+    '--force',
+  ];
+  const spawnTarget = process.platform === 'win32'
+    ? {
+        command: process.env.ComSpec || 'cmd.exe',
+        args: ['/d', '/s', '/c', cliPath, ...args],
+      }
+    : {
+        command: cliPath,
+        args,
+      };
+  let lastFailure = '';
+
+  for (let attempt = 1; attempt <= 12; attempt += 1) {
+    const result = spawnSync(spawnTarget.command, spawnTarget.args, {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+
+    if (result.status === 0) {
+      return;
+    }
+
+    lastFailure = [
+      `attempt ${attempt}`,
+      `exit ${result.status ?? 'unknown'}`,
+      result.error instanceof Error ? result.error.message : '',
+      result.stdout,
+      result.stderr,
+    ].filter(Boolean).join('\n');
+
+    if (attempt < 12) {
+      await sleep(20_000);
+    }
+  }
+
+  throw new Error(`Failed to install published extension ${installTarget}\n${lastFailure}`);
+}
+
+async function main(): Promise<void> {
+  const source = publishedSource();
+  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-published-smoke-workspace-'));
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-published-smoke-user-'));
+  const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-published-smoke-extensions-'));
+  const downloadDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-published-smoke-download-'));
+  const harnessExtensionPath = path.resolve(process.cwd(), 'src/test/published/harness');
+  const extensionTestsPath = path.resolve(__dirname, './suite');
+  const vscodeExecutablePath = await downloadAndUnzipVSCode();
+  const installTarget = await resolveInstallTarget(source, downloadDir);
+
+  fs.writeFileSync(path.join(workspacePath, 'smoke.pl'), "use strict;\nuse warnings;\nprint \"ok\\n\";\n");
+
+  await installExtension(vscodeExecutablePath, installTarget, userDataDir, extensionsDir);
+
+  await runTests({
+    vscodeExecutablePath,
+    extensionDevelopmentPath: harnessExtensionPath,
+    extensionTestsPath,
+    extensionTestsEnv: {
+      ...process.env,
+      PERL_LSP_EXTENSION_TEST_SKIP_STARTUP: '1',
+      PERL_LSP_PUBLISHED_EXTENSION_ID: envValue('PERL_LSP_PUBLISHED_EXTENSION_ID') || EXTENSION_ID,
+      PERL_LSP_PUBLISHED_EXTENSION_SOURCE: source,
+    },
+    launchArgs: [
+      workspacePath,
+      '--disable-workspace-trust',
+      `--user-data-dir=${userDataDir}`,
+      `--extensions-dir=${extensionsDir}`,
+    ],
+  });
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/vscode-extension/src/test/published/suite/index.ts
+++ b/vscode-extension/src/test/published/suite/index.ts
@@ -1,0 +1,32 @@
+import * as path from 'path';
+import Mocha from 'mocha';
+
+export async function run(): Promise<void> {
+  const mocha = new Mocha({
+    ui: 'tdd',
+    color: true,
+    timeout: 180_000,
+  });
+
+  const smokeTestPath = path.resolve(__dirname, '../managedBinaryPublishedSmoke.test.js');
+  mocha.addFile(smokeTestPath);
+  await mocha.loadFilesAsync();
+
+  if (mocha.suite.total() === 0) {
+    throw new Error(`No published-extension smoke tests loaded from ${smokeTestPath}`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const runner = mocha.run(failures => {
+      if (runner.total === 0) {
+        reject(new Error('No published-extension smoke tests matched.'));
+        return;
+      }
+      if (failures > 0) {
+        reject(new Error(`${failures} published-extension smoke test(s) failed.`));
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/vscode-extension/tsconfig.published-smoke.json
+++ b/vscode-extension/tsconfig.published-smoke.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vscode", "mocha"]
+  },
+  "include": ["src/test/published/**/*.ts"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
Problem: Source extension-host smoke proved the checkout, but not the package users install from Marketplace or Open VSX.
Fix: Add a published-extension smoke harness and workflow that installs the published package into a clean VS Code profile, with strict managed-binary command assertions for 0.13.2+ publishes and compatibility install checks for older published packages. Wire the Marketplace smoke into the extension publish workflow.
Verification: `npm run compile` passes; `npm run test:integration` passes; `npm test -- --runTestsByPath src/test/downloader.test.ts --runInBand` passes; `npm run test:published` passes for Marketplace latest and Open VSX 0.13.1; `bash scripts/check_release_history.sh` passes; `cargo xtask workflow-policy-lint --receipt target/receipts/workflow-policy.json` passes with unrelated existing warnings; `cargo xtask workflow-trigger-lint --policy .ci/policies/required-checks.toml --receipt target/receipts/workflow-trigger-lint.json --format json` passes; `git diff --check` passes.