### PR TITLE
test(vscode): smoke published Open VSX package (#0000)

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -237,8 +237,8 @@ jobs:
           echo "::error::Release ${RELEASE_TAG} was not available in time for VSIX attachment."
           exit 1
 
-  published-extension-smoke:
-    name: Published Extension Smoke
+  published-marketplace-smoke:
+    name: Published Marketplace Smoke
     needs:
       - prepare-vsix
       - publish-vscode-marketplace
@@ -274,6 +274,43 @@ jobs:
       - name: Smoke published Marketplace extension
         run: xvfb-run -a npm run test:published
 
+  published-open-vsx-smoke:
+    name: Published Open VSX Smoke
+    needs:
+      - prepare-vsix
+      - publish-open-vsx
+    if: ${{ needs.publish-open-vsx.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: vscode-extension
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PERL_LSP_PUBLISHED_EXTENSION_SOURCE: open-vsx
+      PERL_LSP_PUBLISHED_EXTENSION_VERSION: ${{ needs.prepare-vsix.outputs.version }}
+      PERL_LSP_PUBLISHED_BINARY_VERSION: ${{ needs.prepare-vsix.outputs.version }}
+      PERL_LSP_REQUIRE_STRUCTURED_COMMANDS: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: vscode-extension/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Smoke published Open VSX extension
+        run: xvfb-run -a npm run test:published
+
   publish-summary:
     name: Publish Extension Summary
     needs:
@@ -281,7 +318,8 @@ jobs:
       - publish-vscode-marketplace
       - publish-open-vsx
       - github-release-asset
-      - published-extension-smoke
+      - published-marketplace-smoke
+      - published-open-vsx-smoke
     if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -297,7 +335,8 @@ jobs:
             echo "- VS Code Marketplace job: ${{ needs.publish-vscode-marketplace.result }}"
             echo "- Open VSX job: ${{ needs.publish-open-vsx.result }}"
             echo "- GitHub release asset job: ${{ needs.github-release-asset.result }}"
-            echo "- Published extension smoke job: ${{ needs.published-extension-smoke.result }}"
+            echo "- Published Marketplace smoke job: ${{ needs.published-marketplace-smoke.result }}"
+            echo "- Published Open VSX smoke job: ${{ needs.published-open-vsx-smoke.result }}"
             if [ "${{ needs.prepare-vsix.outputs.is_prerelease }}" = "true" ]; then
               echo "- Marketplace prerelease policy: skipped; publish Marketplace only for non-prerelease SemVer versions."
             fi

--- a/vscode-extension/src/test/published/runPublishedSmoke.ts
+++ b/vscode-extension/src/test/published/runPublishedSmoke.ts
@@ -82,6 +82,27 @@ function downloadFile(url: string, destination: string, redirects = 0): Promise<
   });
 }
 
+async function downloadFileWithRetry(url: string, destination: string): Promise<void> {
+  let lastFailure = '';
+
+  for (let attempt = 1; attempt <= 12; attempt += 1) {
+    try {
+      await downloadFile(url, destination);
+      return;
+    } catch (error: unknown) {
+      lastFailure = error instanceof Error ? error.message : String(error);
+      if (fs.existsSync(destination)) {
+        fs.rmSync(destination, { force: true });
+      }
+      if (attempt < 12) {
+        await sleep(20_000);
+      }
+    }
+  }
+
+  throw new Error(`Failed to download published extension from ${url}\n${lastFailure}`);
+}
+
 async function resolveInstallTarget(source: ExtensionSource, tempDir: string): Promise<string> {
   const version = envValue('PERL_LSP_PUBLISHED_EXTENSION_VERSION');
   const extensionId = envValue('PERL_LSP_PUBLISHED_EXTENSION_ID') || EXTENSION_ID;
@@ -112,7 +133,7 @@ async function resolveInstallTarget(source: ExtensionSource, tempDir: string): P
   const fileName = `${namespace}.${extensionName}-${version}.vsix`;
   const url = `https://open-vsx.org/api/${namespace}/${extensionName}/${version}/file/${fileName}`;
   const destination = path.join(tempDir, fileName);
-  await downloadFile(url, destination);
+  await downloadFileWithRetry(url, destination);
   return destination;
 }
 


### PR DESCRIPTION
Problem: Open VSX publish success was only covered by manual/scheduled published-extension smoke, while Marketplace had an automatic post-publish smoke.
Fix: Add an Open VSX post-publish smoke job and retry Open VSX VSIX downloads for registry propagation.
Verification: `npx tsc -p ./tsconfig.published-smoke.json`, `npm run test:published` for Marketplace/Open VSX 0.13.1, workflow lints, install-surface/release-history checks, and installer target-selection script pass.