### PR TITLE
docs(parser): specify accuracy observability stack (#0000)

### DIFF
--- a/.kiro/specs/parser-accuracy-observability/.config.kiro
+++ b/.kiro/specs/parser-accuracy-observability/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "b0a9c5e6-8df2-47c9-9d14-06dff3872f6d", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/parser-accuracy-observability/design.md
+++ b/.kiro/specs/parser-accuracy-observability/design.md
@@ -1,0 +1,334 @@
+# Design Document: Parser Accuracy Observability
+
+## Overview
+
+Parser Accuracy Observability layers gold scoring on top of the existing parser scorecard. The current scorecard answers whether perl-lsp can ingest real Perl without erroring and whether recovery is useful. This design adds the next question: when parsing succeeds, did it produce the right line tags, AST shape, symbols, spans, dynamic-boundary behavior, and editor-facing facts?
+
+The system is intentionally layered:
+
+1. Denominator inventory
+2. Clean parse and recovery
+3. Line-level construct accuracy
+4. AST structural accuracy
+5. Symbol and edge accuracy
+6. False-positive and false-precision tracking
+7. Span and coordinate correctness
+8. Incremental equivalence
+9. Confidence, unsupported constructs, and dynamic boundaries
+10. Provider impact
+11. Real-project partial labels
+12. Cost, scale, cache, determinism, failure attribution, gold drift, and metric runtime
+
+Do not collapse these into one health number. The scorecard must show separate rows with sample counts, confidence, and metric state.
+
+## Data Flow
+
+```
+gold fixtures / partial real-project labels
+  |
+  v
+parser accuracy scorer
+  |
+  +--> target/metrics/parser_accuracy.json
+  |
+  +--> target/receipts/parser-accuracy/*.json
+  |
+  v
+schema validation
+  |
+  v
+xtask update-status --only parser
+  |
+  v
+docs/project/status/parser.md
+```
+
+Committed contracts live in:
+
+```
+.ci/schemas/parser-accuracy.schema.json
+.ci/metrics/baselines/parser_accuracy.json
+docs/project/metrics/parser.md
+.kiro/specs/parser-accuracy-observability/
+```
+
+Generated artifacts live in:
+
+```
+target/metrics/parser_accuracy.json
+target/receipts/parser-accuracy/*.json
+```
+
+## Artifact Shape
+
+The JSON scorecard uses one top-level artifact:
+
+```jsonc
+{
+  "schema_version": 1,
+  "subsystem": "parser_accuracy",
+  "generated_at": "2026-05-02T00:00:00Z",
+  "commit": "<sha>",
+  "cadence": "pr|merge_gate|nightly|release",
+  "denominator": { "...": "..." },
+  "families": [],
+  "metrics": [],
+  "failure_packets": [],
+  "gold_drift": {},
+  "metric_runtime": {}
+}
+```
+
+Each metric row has:
+
+```jsonc
+{
+  "metric": "symbol_ref_f1",
+  "state": "measured",
+  "value": 0.837,
+  "previous": 0.821,
+  "delta": 0.016,
+  "floor": 0.75,
+  "threshold": 0.85,
+  "direction": "up",
+  "sample_count": 428,
+  "confidence": "medium",
+  "cadence": "merge_gate",
+  "macro_value": 0.801,
+  "micro_value": 0.837
+}
+```
+
+Insufficient data is represented as a metric state:
+
+```jsonc
+{
+  "metric": "provider_goto_definition_hit_rate",
+  "state": "insufficient_data",
+  "reason": "provider gold fixtures are not wired yet",
+  "sample_count": 0
+}
+```
+
+## Denominator Model
+
+The denominator block records what was scored before interpreting accuracy:
+
+```jsonc
+{
+  "fixture_count": 120,
+  "fixture_family_count": 28,
+  "scored_line_count": 8400,
+  "scored_symbol_count": 1250,
+  "fully_labeled_region_count": 640,
+  "partial_labeled_region_count": 210,
+  "unknown_region_count": 88,
+  "negative_region_count": 93,
+  "dynamic_boundary_case_count": 82,
+  "unsupported_construct_case_count": 37,
+  "real_project_file_count": 43,
+  "generated_fixture_count": 70,
+  "hand_labeled_fixture_count": 50
+}
+```
+
+Fixture families are explicit and stable. Required families include package declarations, subroutines, methods, lexical variables, globals, imports, exports, qualified references, bare references, typeglob aliases, AUTOLOAD, eval string, dynamic require, generated accessors, roles, inheritance, heredocs, regexes, quote-like operators, POD, format statements, Moose/Moo DSL, signatures/invocants, postderef, do-while/until, and given/when/default.
+
+## Scoring Layers
+
+### Clean Parse
+
+Clean parse stays as a top-level parser score, but it is not treated as accuracy by itself.
+
+Rows:
+
+- `clean_parse_file_rate`
+- `clean_parse_line_rate`
+- `parse_error_density_per_kloc`
+- `first_error_bucket`
+- `files_with_recovery`
+- `strict_clean_rate`
+- `partial_clean_rate`
+
+Failure clusters:
+
+- `quote_transliteration`
+- `heredoc_delimiter`
+- `declaration_package`
+- `recovery_only`
+- `encoding_multibyte`
+- `regex`
+- `operator_precedence`
+- `incremental_edit_application`
+
+### Line-Level Construct Accuracy
+
+Line scoring compares expected tag sets with observed tag sets:
+
+```text
+TP = expected intersect actual
+FP = actual - expected
+FN = expected - actual
+precision = TP / (TP + FP)
+recall = TP / (TP + FN)
+f1 = 2PR / (P + R)
+```
+
+Rows:
+
+- `line_exact_match_rate`
+- `line_construct_precision`
+- `line_construct_recall`
+- `line_construct_f1`
+- `line_error_false_positive_rate`
+- `line_error_false_negative_rate`
+- `line_dynamic_boundary_correct_rate`
+- `unsupported_line_detection_rate`
+
+### AST Structural Accuracy
+
+AST scoring validates node kinds, spans, and relationships.
+
+Rows:
+
+- `node_kind_precision`
+- `node_kind_recall`
+- `node_kind_f1`
+- `node_span_exact_rate`
+- `node_span_near_rate`
+- `parent_child_edge_accuracy`
+- `tree_depth_accuracy`
+- `operator_precedence_accuracy`
+- `delimiter_pairing_accuracy`
+- `unexpected_error_node_count`
+- `missing_expected_node_count`
+
+### Symbol and Edge Accuracy
+
+Symbol scoring consumes canonical facts when available.
+
+Rows:
+
+- `symbol_decl_precision`
+- `symbol_decl_recall`
+- `symbol_decl_f1`
+- `symbol_ref_precision`
+- `symbol_ref_recall`
+- `symbol_ref_f1`
+- `definition_edge_precision`
+- `definition_edge_recall`
+- `definition_edge_f1`
+- `reference_edge_precision`
+- `reference_edge_recall`
+- `reference_edge_f1`
+- `span_exact_rate`
+- `span_near_rate`
+- `semantic_match_rate`
+
+Breakdowns include package, subroutine, method, lexical variable, global variable, import, export, typeglob alias, generated accessor, role method, inherited method, and dynamic boundary.
+
+### False Positives and False Precision
+
+False positives are reported separately from misses. The hard safety floor is:
+
+```text
+dynamic_false_precision_count == 0
+fast_path_wrong_result_count == 0
+```
+
+Rows include false symbols, false declarations, false references, false imports, false exports, false parse errors, false exact resolutions, false dynamic resolutions, and symbols emitted in comments, POD, strings, or unknown regions.
+
+### Recovery Quality
+
+Recovery scoring measures containment and salvage:
+
+- `first_error_line_accuracy`
+- `error_region_precision`
+- `error_region_recall`
+- `recovery_spillover_mean`
+- `recovery_spillover_p95`
+- `recovery_spillover_max`
+- `salvaged_lines_after_error`
+- `salvaged_symbols_after_error`
+- `post_error_symbol_recall`
+- `post_error_line_f1`
+
+### Incremental Equivalence
+
+Incremental scoring compares:
+
+```text
+full_parse(final_source)
+==
+incremental_parse(base_source + edit_sequence)
+```
+
+Rows:
+
+- `incremental_full_parse_equivalence_rate`
+- `incremental_edit_apply_equivalence_rate`
+- `incremental_no_panic_rate`
+- `incremental_no_progress_count`
+- `incremental_timeout_count`
+- `incremental_full_reparse_fallback_rate`
+- `incremental_checkpoint_hit_rate`
+- `incremental_checkpoint_miss_rate`
+- `incremental_reparse_byte_ratio`
+- `incremental_reused_token_ratio`
+- `incremental_reused_node_ratio`
+- `incremental_changed_range_accuracy`
+
+The command that verifies these rows must enable the incremental feature.
+
+### Span and Coordinate Correctness
+
+Rows:
+
+- `byte_span_exact_rate`
+- `line_span_exact_rate`
+- `utf16_range_exact_rate`
+- `span_near_rate`
+- `span_invalid_count`
+- `span_out_of_bounds_count`
+- `span_inverted_count`
+- `span_non_char_boundary_count`
+- `crlf_position_error_count`
+- `unicode_position_error_count`
+- `tab_column_mismatch_count`
+
+### Cost, Scale, Cache, and Determinism
+
+Cost rows track phase timings, memory, and allocation shape. Scale rows track file size, token count, AST node count, symbol count, nesting, regex length, heredoc size, quote-like count, and dynamic boundary count. Cache rows explain whether speed comes from reuse. Determinism rows track hash stability and metamorphic invariants.
+
+Speed improvements must be interpreted with scale rows. A faster parser on tiny files only is not a general parser speed win.
+
+## Cadence
+
+| Cadence | Contents | Blocking |
+| --- | --- | --- |
+| PR fast | schema validation, denominator inventory, tiny line/AST/symbol fixture set, incremental smoke | yes |
+| Merge gate | sharded line/AST/symbol/incremental/cost fixture set | yes after stable |
+| Nightly | full gold corpus, real-project partial labels, macro/micro family breakdowns | report first, gate later |
+| Release | full parser accuracy dashboard with trend and baseline comparison | release decision input |
+
+## First Implementation Slice
+
+The first PR after this spec should be intentionally small:
+
+1. Add `.ci/schemas/parser-accuracy.schema.json`.
+2. Add a minimal fixture manifest with denominator fields and two or three fixture families.
+3. Add an xtask command that emits `target/metrics/parser_accuracy.json`.
+4. Emit only denominator rows and placeholder `insufficient_data` rows for line/AST/symbol metrics.
+5. Add schema validation tests.
+6. Render a small parser status note pointing to the generated artifact.
+
+Do not implement the entire metric list in the first PR.
+
+## Review Rules
+
+- No generated `target/metrics` or `target/receipts` artifacts are committed.
+- Missing data is `insufficient_data`, not zero.
+- Real-project unlabeled regions are not negative space.
+- Dynamic Perl is scored conservatively; false exact precision is a blocker.
+- Incremental rows are not accepted unless run with the incremental feature enabled.
+- Runtime and sample count must be present before any floor is ratcheted.

--- a/.kiro/specs/parser-accuracy-observability/requirements.md
+++ b/.kiro/specs/parser-accuracy-observability/requirements.md
@@ -1,0 +1,263 @@
+# Requirements Document
+
+## Introduction
+
+The Parser Accuracy Observability system extends the current parser scorecard from clean-parse and recovery-health tracking into layered accuracy measurement. The goal is to answer, with evidence, how well perl-lsp parses Perl and how accurate the derived editor-facing facts are.
+
+The current parser scorecard already tracks corpus cleanliness, error density, recovery worklists, node-kind coverage, and parse cost. That is necessary, but not sufficient. A parser can parse a file cleanly while attaching nodes incorrectly, missing symbols, inventing false references, widening spans, or making an incremental fast path return a different result from a full parse. This system adds the denominator, gold-scoring, structural accuracy, semantic accuracy, incremental equivalence, span correctness, and metric-trust layers needed to make parser progress measurable without conflating parser success with editor UX or release readiness.
+
+### Implementation Ordering Constraint
+
+Requirements MUST be implemented in small slices. The canonical order is:
+
+1. **Metric contract and schemas** - define parser accuracy artifact shape and fixture metadata contract.
+2. **Fixture denominator inventory** - report what is labeled before scoring accuracy.
+3. **Line-level construct scoring** - compare expected line tags with observed tags.
+4. **AST structural scoring** - compare node kinds, spans, and parent-child edges on gold fixtures.
+5. **Symbol and edge scoring** - score declarations, references, imports, exports, and resolution edges.
+6. **False-positive and dynamic-boundary scoring** - make invented precision visible.
+7. **Recovery and incremental equivalence scoring** - measure salvage and fast-path correctness.
+8. **Cost, scale, cache, determinism, and gold-drift rows** - prevent misleading speed or accuracy wins.
+9. **Status rendering and ratchets** - render measured rows and only ratchet floors after stable samples.
+
+Do not implement provider impact, real-project partial labels, release thresholds, or rolling trend windows before the first scorecard artifact exists and validates against schema.
+
+### Ownership
+
+- **Metric command owner:** `xtask` parser metrics tasks.
+- **Status owner:** `xtask/src/tasks/update_status/parser.rs`.
+- **Gold fixture owner:** parser and semantic fixture crates that already own source snippets.
+- **Runtime artifacts:** generated under `target/metrics/` or `target/receipts/`.
+- **Committed contracts and baselines:** `.ci/schemas/`, `.ci/metrics/baselines/`, and docs/spec files.
+
+## Glossary
+
+- **Parser_Accuracy_Scorecard:** A machine-readable JSON artifact containing parser denominator, clean parse, line, AST, symbol, span, incremental, cost, scale, cache, determinism, gold-drift, and metric-runtime rows.
+- **Fixture_Family:** A named Perl construct family such as `heredoc`, `typeglob_alias`, `generated_accessor`, `dynamic_require`, `quote_like`, or `signatures`.
+- **Gold_Fixture:** A fixture with explicit expected tags, nodes, symbols, spans, edges, or dynamic-boundary outcomes.
+- **Partial_Label:** A real-project or large fixture annotation that scores only known regions and does not treat unlabeled regions as negative space.
+- **Negative_Region:** A labeled region where the scorer expects no symbol, edge, diagnostic, parse error, or dynamic resolution.
+- **Line_Tag:** A construct tag assigned to a source line, such as `sub_decl`, `import`, `regex`, `pod`, `dynamic_boundary`, or `recovery_region`.
+- **False_Precision:** A confident parser or semantic result for a dynamic or unsupported Perl construct where the correct behavior is conservative fallback, unavailable, warning, or blocker.
+- **Recovery_Spillover:** Lines or regions after the first parse error that remain affected by recovery.
+- **Incremental_Equivalence:** Equality between full parsing of final source and incremental parsing after applying the same edit sequence.
+- **Metric_State:** A row state of `measured` or `insufficient_data`; insufficient data is not a parse result.
+
+## Requirements
+
+### Requirement 1: Denominator Visibility
+
+**User Story:** As a parser maintainer, I want accuracy reports to show the labeled input denominator, so that percentages cannot overstate confidence from tiny or narrow fixtures.
+
+#### Acceptance Criteria
+
+1. WHEN a parser accuracy scorecard is generated, THE scorecard SHALL report fixture count, fixture family count, scored line count, scored symbol count, fully labeled region count, partial labeled region count, unknown region count, negative region count, dynamic boundary case count, unsupported construct case count, real project file count, generated fixture count, and hand-labeled fixture count.
+2. THE scorecard SHALL break denominator counts down by fixture family.
+3. THE scorecard SHALL distinguish fully labeled gold fixtures from partial-label real-project fixtures.
+4. THE scorecard SHALL NOT treat unlabeled regions as false positives unless they are explicitly marked as negative regions.
+
+### Requirement 2: Fixture Family Coverage
+
+**User Story:** As a reviewer, I want parser scorecards to show which Perl construct families are represented, so that rare but important Perl features do not disappear behind micro averages.
+
+#### Acceptance Criteria
+
+1. THE fixture inventory SHALL support at least these families: packages, subroutines, methods, lexicals, globals, imports, exports, qualified references, bare references, same bare sub in multiple packages, typeglob aliases, AUTOLOAD, eval string, dynamic require, generated accessors, roles, inheritance, heredocs, regexes, quote-like operators, POD, format statements, Moose/Moo DSL, signatures/invocants, postderef, do-while/until, and given/when/default.
+2. THE scorecard SHALL report macro averages across fixture families separately from micro averages across all scored items.
+3. THE scorecard SHALL identify worst-performing fixture families by score and sample count.
+
+### Requirement 3: Clean Parse Metrics
+
+**User Story:** As a parser maintainer, I want clean-parse rates to remain visible but not be treated as the whole accuracy story.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report clean parse file rate, clean parse line rate, parse error density per KLOC, first error bucket, first error line, files with recovery, strict clean rate, and partial clean rate.
+2. THE scorecard SHALL report parser failure clusters including quote/transliteration, heredoc/delimiter, declaration/package, recovery-only, encoding/multibyte, regex, operator precedence, and incremental edit application.
+3. THE parser status renderer SHALL continue to show failure clusters in the parser status page.
+
+### Requirement 4: Line-Level Construct Accuracy
+
+**User Story:** As an editor feature maintainer, I want line-level construct scores, so that we know whether the parser understood source shape before provider behavior is measured.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL compare expected line tags with observed line tags.
+2. THE scorecard SHALL compute line exact match rate, line construct precision, line construct recall, line construct F1, line error false positive rate, line error false negative rate, line dynamic boundary correct rate, and unsupported line detection rate.
+3. THE scoring model SHALL compute true positives, false positives, and false negatives from set intersection and set difference between expected and observed tags.
+4. THE line tag vocabulary SHALL include package declarations, sub declarations, method declarations, variable declarations, imports, exports, function calls, method calls, regexes, quote-like operators, heredoc opener/body/terminator, POD, format declarations, given/when, do-while, until loops, dynamic boundaries, parse errors, recovery regions, and unsupported constructs.
+
+### Requirement 5: AST Structural Accuracy
+
+**User Story:** As a parser maintainer, I want structural AST scores, so that a clean parse cannot hide incorrect tree shape.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report node-kind precision, node-kind recall, node-kind F1, node span exact rate, node span near rate, parent-child edge accuracy, tree depth accuracy, operator precedence accuracy, delimiter pairing accuracy, recovery node count, unexpected error node count, and missing expected node count.
+2. THE scorecard SHALL break AST metrics down by declarations, control flow, expressions, operators, regex nodes, quote-like nodes, heredoc nodes, package/class/role nodes, variable declarations, function calls, and method calls.
+3. THE scorecard SHALL classify a line tag match with an incorrect parent-child edge as structurally wrong.
+
+### Requirement 6: Symbol and Edge Accuracy
+
+**User Story:** As a semantic feature maintainer, I want symbol and edge scores, so that we know whether parser output produces correct declarations, references, imports, exports, scopes, spans, and relationships.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report precision, recall, and F1 for symbol declarations, symbol references, definition edges, and reference edges.
+2. THE scorecard SHALL report import precision/recall, export precision/recall, canonical name accuracy, display name accuracy, symbol kind accuracy, scope accuracy, package accuracy, span exact rate, span near rate, and semantic match rate.
+3. THE scorecard SHALL break symbol rows down by package, subroutine, method, lexical variable, global variable, import, export, typeglob alias, generated accessor, role method, inherited method, and dynamic boundary.
+4. THE scorecard SHALL use canonical fact shard fields such as anchors, entities, occurrences, edges, byte spans, provenance, confidence, and hashes where available.
+
+### Requirement 7: False Positive and False Precision Tracking
+
+**User Story:** As a reviewer, I want invented symbols and false exact resolutions reported separately, so that missing a fact is not conflated with unsafe overconfidence.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report false symbol count, false declaration count, false reference count, false import count, false export count, false parse error count, false exact resolution count, false dynamic resolution count, symbols emitted in comments, symbols emitted in POD, symbols emitted in strings, and symbols emitted in unknown regions.
+2. THE scorecard SHALL report `dynamic_false_precision_count`.
+3. THE floor `dynamic_false_precision_count == 0` SHALL be eligible for ratchet enforcement after the first measured artifact is stable.
+4. Dynamic, unavailable, ambiguous, or unsupported cases SHALL score as conservative fallback when no exact static answer is justified.
+
+### Requirement 8: Recovery Quality and Salvage
+
+**User Story:** As a user of malformed or incomplete code, I want parser recovery to be contained, so that one syntax error does not poison the rest of the file.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report first error line accuracy, error region precision, error region recall, recovery spillover mean, recovery spillover p95, recovery spillover max, salvaged lines after error, salvaged symbols after error, post-error symbol recall, and post-error line F1.
+2. THE scorecard SHALL distinguish local recovery from recovery regions that extend to EOF.
+3. THE status page SHALL identify worst recovery fixture families when sample count is sufficient.
+
+### Requirement 9: Incremental Equivalence
+
+**User Story:** As a performance maintainer, I want incremental parsing measured against full parsing, so that fast paths cannot silently return wrong output.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL compare full parse of final source with incremental parse after applying the same edit sequence.
+2. THE scorecard SHALL report incremental full parse equivalence rate, incremental edit apply equivalence rate, incremental no panic rate, incremental no-progress count, incremental timeout count, incremental full reparse fallback rate, incremental checkpoint hit rate, incremental checkpoint miss rate, incremental reparse byte ratio, incremental reused token ratio, incremental reused node ratio, and incremental changed range accuracy.
+3. THE floor `fast_path_wrong_result_count == 0` SHALL be eligible for ratchet enforcement after the first measured artifact is stable.
+4. Incremental checks SHALL be run with the actual `incremental` feature enabled.
+
+### Requirement 10: Span and Coordinate Correctness
+
+**User Story:** As an LSP provider maintainer, I want span and range correctness measured directly, so that parsing accuracy carries through to editor positions.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report byte span exact rate, line span exact rate, UTF-16 range exact rate, span near rate, span invalid count, span out-of-bounds count, span inverted count, span non-char-boundary count, CRLF position error count, Unicode position error count, and tab column mismatch count.
+2. THE fixture inventory SHALL include UTF-8 multibyte, surrogate-pair-style code points, CRLF, mixed newline styles, tabs, BOM, empty spans, and cross-line spans.
+
+### Requirement 11: Confidence Calibration
+
+**User Story:** As a provider maintainer, I want confidence levels calibrated, so that high-confidence facts are trustworthy and heuristic facts do not drive unsafe actions.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report exact fact precision, high-confidence precision, medium-confidence precision, low-confidence precision, heuristic fact precision, dynamic boundary precision, and confidence calibration error.
+2. THE scorecard SHALL distinguish exact, high-confidence, heuristic, and dynamic-boundary provenance.
+3. Unsafe provider actions SHALL NOT be powered by low-confidence or dynamic-boundary facts without explicit blocker/warning behavior.
+
+### Requirement 12: Unsupported Construct Honesty
+
+**User Story:** As a product owner, I want unsupported Perl constructs visible, so that accuracy improves honestly without pretending dynamic Perl is static.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report unsupported construct detected count, unsupported construct missed count, unsupported construct family count, unsupported construct false exact count, and unsupported-but-salvaged count.
+2. Symbolic calls, dynamic requires, eval string, AUTOLOAD, and unsupported DSL constructs SHALL be eligible for conservative dynamic/unsupported labels.
+3. Unsupported constructs SHALL NOT disappear from denominator counts.
+
+### Requirement 13: Provider Impact
+
+**User Story:** As an editor UX maintainer, I want parser accuracy connected to provider outcomes, so that parser improvements are visible in editor behavior without merging scorecard ownership.
+
+#### Acceptance Criteria
+
+1. THE parser accuracy scorecard SHALL expose provider-impact rows for document symbol precision/recall, goto-definition hit rate, references precision/recall, hover symbol origin accuracy, completion visible symbol relevance, completion import visibility accuracy, rename safe edit accuracy, safe-delete blocker accuracy, diagnostic false positive rate, and diagnostic false negative rate.
+2. Provider impact rows MAY be `insufficient_data` until gold provider fixtures are wired.
+3. Provider impact rows SHALL reference editor-intelligence or UX scorecards rather than duplicating their ownership.
+
+### Requirement 14: Real-Project Partial Labels
+
+**User Story:** As a maintainer, I want real-project behavior measured separately from gold fixtures, so that weird real Perl informs progress without corrupting precision math.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report real project clean parse rate, real project error density, real project recovery spillover p95, real project symbol density, real project parse p95 ms, real project index p95 ms, and real project memory peak MB.
+2. Real-project scoring SHALL support partial labels for known package declarations, sub declarations, imports, exports, selected references, and selected dynamic boundaries.
+3. Unlabeled real-project regions SHALL NOT count as false positives unless marked as negative regions.
+
+### Requirement 15: Cost, Speed, and Scale Shape
+
+**User Story:** As a performance reviewer, I want phase cost and scale context, so that speed wins are not misleading or only true for tiny files.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report lex, parse, AST projection, recovery, semantic extraction, workspace insert, definition query, reference query, completion query, and incremental edit p50/p95 timings where applicable.
+2. THE scorecard SHALL report memory and allocation rows including peak RSS MB, allocated bytes, allocation count, tokens allocated, AST nodes allocated, semantic facts allocated, incremental state bytes, checkpoint bytes, and cache size bytes where available.
+3. THE scorecard SHALL report file bytes, line count, token count, AST node count, symbol count, import count, export count, sub count, package count, max nesting depth, max brace depth, max regex length, max heredoc body bytes, quote-like count, heredoc count, and dynamic boundary count.
+4. THE scorecard SHALL normalize cost with parse ms per KB, parse ms per 1k tokens, semantic ms per symbol, workspace index ms per file, correct symbols per ms, and correct lines per ms.
+
+### Requirement 16: Cache and Reuse Quality
+
+**User Story:** As an incremental parser maintainer, I want reuse quality measured, so that speed gains are attributable and correct.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report lexer checkpoint reuse rate, parser checkpoint reuse rate, semantic fact cache hit rate, workspace shard reuse rate, unchanged file skip rate, content hash hit rate, fast path attempt count, fast path success count, fast path fallback count, and fast path wrong result count.
+2. THE floor `fast_path_wrong_result_count == 0` SHALL be eligible for ratchet enforcement after the first stable measured artifact exists.
+
+### Requirement 17: Determinism and Invariants
+
+**User Story:** As a reviewer, I want parse output determinism measured, so that nondeterministic facts or hashes cannot silently destabilize providers.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report parse hash stability rate, token stream hash stability rate, AST hash stability rate, semantic fact hash stability rate, and diagnostic hash stability rate.
+2. THE scorecard SHALL report whitespace invariance rate, comment invariance rate, newline style invariance rate, incremental equivalence rate, and repeated parse determinism rate.
+3. Adding comments SHALL NOT change symbol facts except for spans when expected by fixture metadata.
+4. CRLF and LF variants SHALL preserve line tags unless fixture metadata explicitly permits a difference.
+
+### Requirement 18: Failure Attribution
+
+**User Story:** As a fix-forward agent, I want failed scorecard rows to identify the likely layer, so that regressions are actionable.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL emit failure packets with failure kind, likely layer, fixture ID, line, parser line tag presence, AST node presence, semantic fact presence, and provider result presence.
+2. Likely layers SHALL include lexer, parser, recovery, AST projection, semantic fact extraction, workspace index, provider query, gold/schema issue, and CI/metric infrastructure.
+3. The status page SHALL summarize top failure packets without requiring raw log inspection.
+
+### Requirement 19: Gold Quality and Drift
+
+**User Story:** As a reviewer, I want gold fixture changes audited, so that accuracy improvements cannot come from weakening expected truth.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report gold schema errors, gold span errors, gold duplicate symbol IDs, gold missing resolves-to targets, gold changed line count, gold changed symbol count, gold removed expectation count, gold added expectation count, and gold dynamic expectation changes.
+2. Removing expected symbols, widening expected spans, changing expected dynamic behavior, lowering thresholds, or removing fixture families SHALL require a human-readable explanation in the PR.
+3. Gold fixture validation SHALL run before score computation.
+
+### Requirement 20: Metric Runtime and Flakiness
+
+**User Story:** As a CI operator, I want the parser accuracy system itself measured, so that it remains trustworthy and cheap enough for its cadence tier.
+
+#### Acceptance Criteria
+
+1. THE scorecard SHALL report metric runtime ms, metric timeout count, metric flake count, metric artifact size bytes, metric CI runner failure count, metric orphan process count, and metric cache hit rate.
+2. PR-fast metrics SHALL be bounded and small.
+3. Merge-gate metrics SHALL be sharded when they exceed the fast lane budget.
+4. Nightly and release metrics MAY run the full corpus and real-project labels.
+
+### Requirement 21: Deltas, Floors, and Confidence
+
+**User Story:** As a maintainer, I want every metric row to show current, previous, delta, floor, threshold, direction, sample count, and confidence, so that movement is interpreted correctly.
+
+#### Acceptance Criteria
+
+1. Each metric row SHALL support current value, previous value, delta, floor, threshold, direction, sample count, and confidence.
+2. Missing or below-threshold sample counts SHALL report `insufficient_data`, not zero.
+3. Floors SHALL NOT be raised from a single lucky run.
+4. Macro and micro averages SHALL both be available for line, AST, symbol, and provider-impact scores.

--- a/.kiro/specs/parser-accuracy-observability/tasks.md
+++ b/.kiro/specs/parser-accuracy-observability/tasks.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Parser Accuracy Observability
+
+## Overview
+
+Build a layered parser accuracy scorecard that starts with denominator visibility and then adds line, AST, symbol, recovery, incremental, span, cost, and trust metrics in reviewable slices. This is not a request to implement every metric at once. Each task should produce a small, schema-valid artifact and focused tests.
+
+## Tasks
+
+- [ ] 1. Define the scorecard contract
+  - [ ] 1.1 Add `.ci/schemas/parser-accuracy.schema.json`
+    - Include top-level fields: `schema_version`, `subsystem`, `generated_at`, `commit`, `cadence`, `denominator`, `families`, `metrics`, `failure_packets`, `gold_drift`, and `metric_runtime`
+    - Require each metric row to be either `measured` or `insufficient_data`
+    - Require measured rows to include value, sample_count, direction, and confidence
+    - _Verify: schema validation test in xtask or a dedicated fixture test_
+  - [ ] 1.2 Add a tiny example fixture artifact
+    - Create a committed example under a test fixture path, not under `target/`
+    - Include denominator rows and `insufficient_data` line/AST/symbol rows
+    - _Verify: JSON parses and validates_
+
+- [ ] 2. Add denominator inventory
+  - [ ] 2.1 Define fixture metadata shape
+    - Track fixture ID, family, label mode, source path, scored lines, scored symbols, dynamic boundaries, unsupported constructs, negative regions, and generated-vs-hand-labeled source
+    - Keep unlabeled regions distinct from negative regions
+  - [ ] 2.2 Emit denominator-only scorecard
+    - Add an xtask command that writes `target/metrics/parser_accuracy.json`
+    - Report fixture_count, fixture_family_count, scored_line_count, scored_symbol_count, fully_labeled_region_count, partial_labeled_region_count, unknown_region_count, negative_region_count, dynamic_boundary_case_count, unsupported_construct_case_count, real_project_file_count, generated_fixture_count, and hand_labeled_fixture_count
+    - _Verify: targeted xtask tests and schema validation_
+
+- [ ] 3. Wire parser status visibility
+  - [ ] 3.1 Extend parser status rendering with accuracy artifact summary
+    - Show denominator rows and `insufficient_data` rows without pretending they are zero
+    - Link to parser accuracy artifact location and spec
+    - _Verify: `cargo test -p xtask update_status::parser --profile agent --locked`_
+  - [ ] 3.2 Preserve existing clean-parse status rows
+    - Do not remove current clean parse, recovery, token health, or failure worklist rows
+    - _Verify: existing parser status marker tests_
+
+- [ ] 4. Add line-level construct scoring
+  - [ ] 4.1 Define line tag vocabulary
+    - Include package_decl, sub_decl, method_decl, variable_decl, import, export, function_call, method_call, regex, quote_like, heredoc_opener, heredoc_body, heredoc_terminator, pod, format_decl, given_when, do_while, until_loop, dynamic_boundary, parse_error, recovery_region, unsupported_construct
+  - [ ] 4.2 Implement line tag scorer
+    - Compare expected and actual tag sets
+    - Emit TP/FP/FN, exact match rate, precision, recall, F1, error false positive rate, error false negative rate, dynamic boundary correct rate, and unsupported detection rate
+    - _Verify: unit tests with at least one false positive and one false negative_
+
+- [ ] 5. Add AST structural scoring
+  - [ ] 5.1 Define AST gold fixture expectations
+    - Track node kind, span, parent-child edge, and operator-precedence expectations
+  - [ ] 5.2 Implement AST scorer
+    - Emit node-kind precision/recall/F1, span exact/near rates, parent-child edge accuracy, tree depth accuracy, operator precedence accuracy, delimiter pairing accuracy, unexpected error node count, and missing expected node count
+    - _Verify: fixture with correct line tag but wrong parent-child edge fails AST score_
+
+- [ ] 6. Add symbol and edge scoring
+  - [ ] 6.1 Define symbol expectation shape
+    - Track declarations, references, imports, exports, scopes, packages, spans, definition edges, reference edges, provenance, and confidence
+  - [ ] 6.2 Consume canonical fact shards where available
+    - Use anchors, entities, occurrences, edges, real byte spans, provenance, confidence, and hashes
+  - [ ] 6.3 Emit symbol precision/recall/F1 rows by kind
+    - Include package, subroutine, method, lexical variable, global variable, import, export, typeglob alias, generated accessor, role method, inherited method, and dynamic boundary
+    - _Verify: at least one fixture each for generated accessor and typeglob alias_
+
+- [ ] 7. Add false-positive and dynamic-boundary gates
+  - [ ] 7.1 Emit false-positive counts
+    - false symbols, false declarations, false references, false imports, false exports, false parse errors, false exact resolutions, false dynamic resolutions, and symbols emitted in comments/POD/strings/unknown regions
+  - [ ] 7.2 Add false precision safety rows
+    - Emit `dynamic_false_precision_count`
+    - Prepare floor contract for `dynamic_false_precision_count == 0`
+    - _Verify: dynamic fixture returns fallback/unavailable rather than false exact result_
+
+- [ ] 8. Add recovery quality scoring
+  - [ ] 8.1 Define malformed fixture labels
+    - Track first error line, expected error region, recovery boundary, and post-error symbols
+  - [ ] 8.2 Emit recovery containment rows
+    - first_error_line_accuracy, error_region_precision/recall, spillover mean/p95/max, salvaged lines, salvaged symbols, post_error_symbol_recall, post_error_line_f1
+    - _Verify: malformed heredoc fixture distinguishes local recovery from EOF spillover_
+
+- [ ] 9. Add incremental equivalence scoring
+  - [ ] 9.1 Add full-vs-incremental comparison fixtures
+    - Compare full parse of final source with incremental parse after edit sequence
+    - Run with `--features incremental`
+  - [ ] 9.2 Emit incremental rows
+    - equivalence rate, edit apply equivalence, no panic, no-progress count, timeout count, fallback rate, checkpoint hit/miss, reparse byte ratio, reused token/node ratios, changed range accuracy
+    - _Verify: `cargo test -p perl-parser --features incremental --locked incremental`_
+
+- [ ] 10. Add span and coordinate scoring
+  - [ ] 10.1 Add span fixture families
+    - UTF-8 multibyte, emoji/surrogate-style code points, CRLF, mixed newline styles, tabs, BOM, empty spans, and cross-line spans
+  - [ ] 10.2 Emit span rows
+    - byte span exact, line span exact, UTF-16 range exact, span near, invalid/out-of-bounds/inverted/non-char-boundary counts, CRLF errors, Unicode errors, tab column mismatches
+
+- [ ] 11. Add confidence, unsupported construct, and provider-impact rows
+  - [ ] 11.1 Emit confidence calibration rows
+    - exact/high/medium/low/heuristic/dynamic precision and calibration error
+  - [ ] 11.2 Emit unsupported construct rows
+    - detected, missed, family count, false exact, and salvaged counts
+  - [ ] 11.3 Add provider-impact placeholders
+    - document symbols, goto definition, references, hover, completion, rename, safe delete, diagnostics
+    - Use `insufficient_data` until provider gold fixtures are wired
+
+- [ ] 12. Add cost, scale, cache, determinism, and metric-runtime rows
+  - [ ] 12.1 Emit scale shape
+    - bytes, lines, tokens, AST nodes, symbols, imports, exports, subs, packages, nesting, brace depth, regex length, heredoc bytes, quote-like count, dynamic boundary count
+  - [ ] 12.2 Emit cost rows
+    - lex/parse/AST projection/recovery/semantic/index/query timings and memory/allocation rows where available
+  - [ ] 12.3 Emit cache and reuse rows
+    - lexer/parser checkpoint reuse, semantic fact cache hit, workspace shard reuse, unchanged file skip, content hash hit, fast path attempts/success/fallback/wrong result
+  - [ ] 12.4 Emit determinism rows
+    - parse/token/AST/fact/diagnostic hash stability and whitespace/comment/newline/incremental/repeated-parse invariants
+  - [ ] 12.5 Emit metric runtime rows
+    - runtime ms, timeout count, flake count, artifact size, CI runner failures, orphan process count, cache hit rate
+
+- [ ] 13. Add gold drift audit
+  - [ ] 13.1 Validate gold fixtures before scoring
+    - schema errors, span errors, duplicate symbol IDs, missing resolves-to targets
+  - [ ] 13.2 Emit gold change counts
+    - changed lines, changed symbols, removed expectations, added expectations, dynamic expectation changes
+  - [ ] 13.3 Require explanation for weakening changes
+    - Removing expected symbols, widening spans, lowering thresholds, changing dynamic expectations, or removing fixture families requires PR text
+
+- [ ] 14. Add ratchet candidates after stable measurements
+  - [ ] 14.1 Start with safety floors only
+    - `dynamic_false_precision_count == 0`
+    - `fast_path_wrong_result_count == 0`
+  - [ ] 14.2 Defer precision/recall floors until sample counts stabilize
+    - No floor raise from a single run
+    - Require current/previous/delta/floor/threshold/direction/sample_count/confidence for all floor candidates
+
+- [ ] 15. Final verification checkpoint
+  - [ ] 15.1 Parser accuracy command
+    - `cargo xtask metrics parser-accuracy --json`
+    - Artifact validates against schema
+    - No generated `target/` artifacts committed
+  - [ ] 15.2 Parser status
+    - `cargo xtask update-status --only parser --check`
+    - Parser status shows measured denominator rows and insufficient-data rows honestly
+  - [ ] 15.3 Focused tests
+    - `cargo test -p xtask parser_accuracy`
+    - `cargo test -p xtask update_status::parser --profile agent --locked`
+    - `cargo check -p xtask --all-targets --profile agent --locked`

--- a/docs/project/metrics/parser.md
+++ b/docs/project/metrics/parser.md
@@ -10,6 +10,23 @@ The parser scorecard answers the question **"can we ingest real Perl without err
 
 It is one of the seven subsystem scorecards defined in [`README.md`](README.md) and the first one to graduate from *proposed* to *stood up, improvement-only* in the scorecard lifecycle.
 
+## Next Layer: Accuracy Observability
+
+The current scorecard is the parser ingestion and recovery floor. The next layer is the parser accuracy scorecard, captured in [`.kiro/specs/parser-accuracy-observability`](../../../.kiro/specs/parser-accuracy-observability). That spec extends the parser answer from "did it parse cleanly?" to:
+
+- What input denominator did we score?
+- Did we identify the right line-level constructs?
+- Did the AST have the right node kinds, spans, and parent-child edges?
+- Did semantic facts contain the right declarations, references, imports, exports, scopes, and definition/reference edges?
+- Did we falsely invent symbols or false exact resolutions?
+- Did recovery stay contained after bad syntax?
+- Did incremental parsing match full parsing?
+- Were byte, line, and UTF-16 ranges correct?
+- Did fast paths, cache reuse, and speed improvements preserve correctness?
+- Did gold fixtures change in a way that weakens the denominator?
+
+Those rows are intentionally separate from the clean-parse floor. A clean parse can still produce the wrong tree, the wrong span, or unsafe false precision for dynamic Perl. The accuracy layer must report `insufficient_data` until each row has a real denominator; it must not report missing measurements as zero or pass.
+
 ## 1. The four shape-questions, answered
 
 Every scorecard in this repo answers the same four questions, in the same order:


### PR DESCRIPTION
Problem: The parser scorecard tracks ingestion/recovery well, but the next parser accuracy layer was only described in discussion and not captured as reviewable repo guidance.
Fix: Add a `.kiro` requirements/design/tasks spec for parser accuracy observability and link it from the parser metrics page as the next scorecard layer.
Verification: `cargo xtask fmt --check` passes; `git diff --check` passes.