### PR TITLE
fix(completion): filter method shadow legacy summary (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
@@ -137,8 +137,10 @@ pub fn method_completion_shadow<Q: SemanticQueries>(
     receiver_package: &str,
     method_prefix: &str,
 ) -> MethodCompletionShadowResult {
-    let old_summary = legacy_symbols_to_summary(&legacy_methods);
-    let probed_methods = method_probe_names(&legacy_methods, &probe_methods, method_prefix);
+    let legacy_methods_for_prefix = method_names_for_prefix(&legacy_methods, method_prefix);
+    let old_summary = legacy_symbols_to_summary(&legacy_methods_for_prefix);
+    let probed_methods =
+        method_probe_names(&legacy_methods_for_prefix, &probe_methods, method_prefix);
 
     let mut semantic_candidates = Vec::new();
     for method_name in &probed_methods {
@@ -418,6 +420,17 @@ fn method_probe_names(
     let mut names: Vec<String> = legacy_methods
         .iter()
         .chain(probe_methods.iter())
+        .filter(|name| method_prefix.is_empty() || name.starts_with(method_prefix))
+        .cloned()
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn method_names_for_prefix(methods: &[String], method_prefix: &str) -> Vec<String> {
+    let mut names: Vec<String> = methods
+        .iter()
         .filter(|name| method_prefix.is_empty() || name.starts_with(method_prefix))
         .cloned()
         .collect();
@@ -798,6 +811,8 @@ mod tests {
         );
 
         assert_eq!(result.probed_methods, vec!["name".to_string(), "notify".to_string()]);
+        assert_eq!(result.receipt.old_result.identities, vec!["name".to_string()]);
+        assert_eq!(result.receipt.old_result.match_count, 1);
         Ok(())
     }
 


### PR DESCRIPTION
Problem: Method completion shadow receipts summarized all legacy labels even when the semantic probe set was filtered by the active method prefix, which could report false regressions for methods not visible for that completion request.\nFix: Summarize the legacy path from the same prefix-filtered, deduplicated method set used for semantic probes, and assert the receipt identities in the prefix/dedupe regression test.\nVerification: \cargo test -p perl-lsp-rs-core --profile agent --locked completion_shadow\; \cargo check -p perl-lsp-rs-core --all-targets --profile agent --locked\; \cargo clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs\; \cargo xtask semantic-shadow-compare --check\; \cargo xtask fmt --check\; \git diff --check\.