### PR TITLE
feat(refactor): make safe delete plan scorecard concrete (#0000)

### DIFF
--- a/crates/perl-workspace-index/src/semantic/queries.rs
+++ b/crates/perl-workspace-index/src/semantic/queries.rs
@@ -573,28 +573,63 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
         // ── Check for remaining references (Req 17.2) ──
         // If the symbol has references in the workspace, block deletion.
         let ref_edges = self.reference_index.get_by_entity(entity_id);
-        if !ref_edges.is_empty() {
+        let dynamic_ref_count =
+            ref_edges.iter().filter(|edge| edge.kind == OccurrenceKind::DynamicBoundary).count();
+        let concrete_ref_count = ref_edges.len().saturating_sub(dynamic_ref_count);
+        if dynamic_ref_count > 0 {
+            blockers.push(PlanBlocker::new(
+                PlanBlockerReason::DynamicBoundary,
+                None,
+                format!(
+                    "Symbol '{}' crosses {} dynamic boundary reference(s).",
+                    bare, dynamic_ref_count
+                ),
+            ));
+        }
+        if concrete_ref_count > 0 {
             blockers.push(PlanBlocker::new(
                 PlanBlockerReason::ReferencesExist,
                 None,
                 format!(
                     "Symbol '{}' still has {} reference(s) in the workspace.",
-                    bare,
-                    ref_edges.len()
+                    bare, concrete_ref_count
                 ),
             ));
         }
 
         // Also check occurrences in fact shards for non-definition references
         // that may not be in the reference index.
+        let shard_dynamic_count: usize = self
+            .fact_shards
+            .values()
+            .flat_map(|s| s.occurrences.iter())
+            .filter(|occ| {
+                occ.entity_id == Some(entity_id) && occ.kind == OccurrenceKind::DynamicBoundary
+            })
+            .count();
         let shard_ref_count: usize = self
             .fact_shards
             .values()
             .flat_map(|s| s.occurrences.iter())
             .filter(|occ| {
-                occ.entity_id == Some(entity_id) && occ.kind != OccurrenceKind::Definition
+                occ.entity_id == Some(entity_id)
+                    && !matches!(
+                        occ.kind,
+                        OccurrenceKind::Definition | OccurrenceKind::DynamicBoundary
+                    )
             })
             .count();
+
+        if ref_edges.is_empty() && shard_dynamic_count > 0 {
+            blockers.push(PlanBlocker::new(
+                PlanBlockerReason::DynamicBoundary,
+                None,
+                format!(
+                    "Symbol '{}' crosses {} dynamic boundary occurrence(s) in fact shards.",
+                    bare, shard_dynamic_count
+                ),
+            ));
+        }
 
         if ref_edges.is_empty() && shard_ref_count > 0 {
             blockers.push(PlanBlocker::new(
@@ -2203,6 +2238,85 @@ mod tests {
             !ref_blockers.is_empty(),
             "should have ReferencesExist blocker from shard occurrences"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn safe_delete_plan_blocks_on_dynamic_boundary() -> Result<(), Box<dyn std::error::Error>> {
+        let file_id = FileId(1);
+        let entity_id = EntityId(100);
+        let anchor_def = AnchorId(10);
+        let anchor_dyn = AnchorId(20);
+
+        let shard = make_shard(
+            "file:///lib/DynamicDelete.pm",
+            file_id,
+            vec![
+                AnchorFact {
+                    id: anchor_def,
+                    file_id,
+                    span_start_byte: 0,
+                    span_end_byte: 10,
+                    scope_id: None,
+                    provenance: Provenance::ExactAst,
+                    confidence: Confidence::High,
+                },
+                AnchorFact {
+                    id: anchor_dyn,
+                    file_id,
+                    span_start_byte: 20,
+                    span_end_byte: 30,
+                    scope_id: None,
+                    provenance: Provenance::DynamicBoundary,
+                    confidence: Confidence::Low,
+                },
+            ],
+            vec![EntityFact {
+                id: entity_id,
+                kind: EntityKind::Subroutine,
+                canonical_name: "DynamicDelete::dispatch".to_string(),
+                anchor_id: Some(anchor_def),
+                scope_id: None,
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            }],
+            vec![
+                OccurrenceFact {
+                    id: OccurrenceId(200),
+                    kind: OccurrenceKind::Definition,
+                    entity_id: Some(entity_id),
+                    anchor_id: anchor_def,
+                    scope_id: None,
+                    provenance: Provenance::ExactAst,
+                    confidence: Confidence::High,
+                },
+                OccurrenceFact {
+                    id: OccurrenceId(201),
+                    kind: OccurrenceKind::DynamicBoundary,
+                    entity_id: Some(entity_id),
+                    anchor_id: anchor_dyn,
+                    scope_id: None,
+                    provenance: Provenance::DynamicBoundary,
+                    confidence: Confidence::Low,
+                },
+            ],
+            vec![],
+        );
+
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        let plan = queries.safe_delete_plan(entity_id);
+        let dynamic_blockers: Vec<_> = plan
+            .blockers
+            .iter()
+            .filter(|b| b.reason == PlanBlockerReason::DynamicBoundary)
+            .collect();
+        assert!(!dynamic_blockers.is_empty(), "should have DynamicBoundary blocker");
         Ok(())
     }
 

--- a/docs/project/status/semantic_scorecard.json
+++ b/docs/project/status/semantic_scorecard.json
@@ -333,7 +333,13 @@
       "status": "pass",
       "value": "100%",
       "threshold": "100%",
-      "evidence": "safe-delete blocker fixtures"
+      "evidence": "safe-delete plan query fixtures"
+    },
+    "safe_delete_plan": {
+      "status": "pass",
+      "value": "100%",
+      "threshold": "100%",
+      "evidence": "safe-delete plan query fixtures"
     },
     "semantic_fact_counts_nonzero": {
       "status": "pass",
@@ -354,11 +360,6 @@
       "evidence": "workspace scorecard fixtures"
     }
   },
-  "unavailable_rows": {
-    "safe_delete_plan": {
-      "status": "unavailable",
-      "reason": "planned for future scorecard waves"
-    }
-  },
+  "unavailable_rows": {},
   "notes": "0.13.2 semantic proof rail: scorecard rows are deterministic and fixture-backed; semantic expansion remains conservative for unavailable rows."
 }

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -29,7 +29,8 @@ Fixtures loaded: `12`
 | reference_shadow_regressions | pass | 0 | 0 | semantic shadow compare release-readiness receipts |
 | rename_plan | pass | 100% | 100% | rename plan query fixtures |
 | rename_unsafe_edit_count | pass | 0 | 0 | rename plan query fixtures |
-| safe_delete_blocker_fixture_pass_rate | pass | 100% | 100% | safe-delete blocker fixtures |
+| safe_delete_blocker_fixture_pass_rate | pass | 100% | 100% | safe-delete plan query fixtures |
+| safe_delete_plan | pass | 100% | 100% | safe-delete plan query fixtures |
 | semantic_fact_counts_nonzero | pass | 58 | > 0 | semantic fixture indexing |
 | undefined_symbol_false_positive_fixture_rate | pass | 0% | 0% | diagnostics fixture receipts |
 | visible_symbols_fixture_pass_rate | pass | 100% | 100% | workspace scorecard fixtures |
@@ -38,7 +39,6 @@ Fixtures loaded: `12`
 
 | Row | Status | Reason |
 |---|---|---|
-| safe_delete_plan | unavailable | planned for future scorecard waves |
 
 ## Fixture IDs
 

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -5,6 +5,7 @@ use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EdgeKind, EntityFact, EntityId, EntityKind, ExportSet,
     FileId, ImportKind, ImportSpec, ImportSymbols, OccurrenceFact, OccurrenceId, OccurrenceKind,
     PackageEdge, PackageEdgeKind, PlanBlockerReason, PlannedEditCategory, Provenance, RenamePlan,
+    SafeDeletePlan,
 };
 use perl_workspace::semantic::imports::ImportExportIndex;
 use perl_workspace::semantic::package_graph::PackageGraphIndex;
@@ -33,7 +34,7 @@ const AVAILABLE_ROWS: &[&str] = &[
     "role_composition_edges",
 ];
 
-const UNAVAILABLE_ROWS: &[&str] = &["safe_delete_plan"];
+const UNAVAILABLE_ROWS: &[&str] = &[];
 
 #[derive(Debug, Deserialize)]
 struct SemanticManifest {
@@ -120,6 +121,10 @@ struct FactMeasurement {
     rename_plan_planned_edits: usize,
     rename_plan_blockers: usize,
     rename_plan_unsafe_edits: usize,
+    safe_delete_plan_fixture_passes: usize,
+    safe_delete_plan_fixture_total: usize,
+    safe_delete_safe_candidates: usize,
+    safe_delete_plan_blockers: usize,
     exact_facts: usize,
     high_confidence_facts: usize,
     heuristic_facts: usize,
@@ -302,6 +307,12 @@ fn measure_fixtures(manifest_path: &Path, manifest: &SemanticManifest) -> Result
     measurement.rename_plan_planned_edits = rename_plan.planned_edits;
     measurement.rename_plan_blockers = rename_plan.blockers;
     measurement.rename_plan_unsafe_edits = rename_plan.unsafe_edits;
+
+    let safe_delete_plan = measure_safe_delete_plan_fixtures();
+    measurement.safe_delete_plan_fixture_passes = safe_delete_plan.passes;
+    measurement.safe_delete_plan_fixture_total = safe_delete_plan.total;
+    measurement.safe_delete_safe_candidates = safe_delete_plan.safe_candidates;
+    measurement.safe_delete_plan_blockers = safe_delete_plan.blockers;
 
     Ok(measurement)
 }
@@ -778,6 +789,266 @@ fn count_unsafe_rename_edits(plan: &RenamePlan) -> usize {
         .count()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SafeDeletePlanMeasurement {
+    passes: usize,
+    total: usize,
+    safe_candidates: usize,
+    blockers: usize,
+}
+
+fn measure_safe_delete_plan_fixtures() -> SafeDeletePlanMeasurement {
+    let fixtures = [
+        safe_delete_plan_unused_local_fixture(),
+        safe_delete_plan_referenced_local_fixture(),
+        safe_delete_plan_exported_symbol_fixture(),
+        safe_delete_plan_imported_symbol_fixture(),
+        safe_delete_plan_generated_member_fixture(),
+        safe_delete_plan_dynamic_boundary_fixture(),
+    ];
+    let total = fixtures.len();
+
+    let mut passes = 0;
+    let mut safe_candidates = 0;
+    let mut blockers = 0;
+    for (plan, passed) in fixtures {
+        if plan.blockers.is_empty() {
+            safe_candidates += 1;
+        }
+        blockers += plan.blockers.len();
+        if passed {
+            passes += 1;
+        }
+    }
+
+    SafeDeletePlanMeasurement { passes, total, safe_candidates, blockers }
+}
+
+fn safe_delete_plan_unused_local_fixture() -> (SafeDeletePlan, bool) {
+    let entity_id = EntityId(51_000);
+    let shard = rename_plan_fact_shard(
+        "file:///semantic/safe_delete_unused_local.pm",
+        FileId(51_001),
+        entity_id,
+        "Unused::local_only",
+        EntityKind::Subroutine,
+        &[RenameOccurrenceSpec {
+            anchor_id: AnchorId(51_100),
+            occurrence_id: OccurrenceId(51_200),
+            kind: OccurrenceKind::Definition,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        }],
+        Provenance::ExactAst,
+        Confidence::High,
+    );
+
+    let plan = run_safe_delete_plan_fixture(vec![shard], ImportExportIndex::new(), entity_id);
+    let passed = plan.blockers.is_empty() && !plan.warnings.is_empty();
+    (plan, passed)
+}
+
+fn safe_delete_plan_referenced_local_fixture() -> (SafeDeletePlan, bool) {
+    let entity_id = EntityId(52_000);
+    let shard = rename_plan_fact_shard(
+        "file:///semantic/safe_delete_referenced_local.pm",
+        FileId(52_001),
+        entity_id,
+        "Used::local_only",
+        EntityKind::Subroutine,
+        &[
+            RenameOccurrenceSpec {
+                anchor_id: AnchorId(52_100),
+                occurrence_id: OccurrenceId(52_200),
+                kind: OccurrenceKind::Definition,
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            },
+            RenameOccurrenceSpec {
+                anchor_id: AnchorId(52_101),
+                occurrence_id: OccurrenceId(52_201),
+                kind: OccurrenceKind::Call,
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            },
+        ],
+        Provenance::ExactAst,
+        Confidence::High,
+    );
+
+    let plan = run_safe_delete_plan_fixture(vec![shard], ImportExportIndex::new(), entity_id);
+    let passed = safe_delete_plan_has_blocker(&plan, PlanBlockerReason::ReferencesExist);
+    (plan, passed)
+}
+
+fn safe_delete_plan_exported_symbol_fixture() -> (SafeDeletePlan, bool) {
+    let entity_id = EntityId(53_000);
+    let shard = rename_plan_fact_shard(
+        "file:///semantic/safe_delete_exported_symbol.pm",
+        FileId(53_001),
+        entity_id,
+        "Exported::helper",
+        EntityKind::Subroutine,
+        &[RenameOccurrenceSpec {
+            anchor_id: AnchorId(53_100),
+            occurrence_id: OccurrenceId(53_200),
+            kind: OccurrenceKind::Definition,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        }],
+        Provenance::ExactAst,
+        Confidence::High,
+    );
+
+    let mut import_export_index = ImportExportIndex::new();
+    import_export_index.add_module_exports(
+        "file:///semantic/safe_delete_exported_symbol.pm",
+        "Exported",
+        ExportSet {
+            default_exports: vec!["helper".to_string()],
+            optional_exports: Vec::new(),
+            tags: Vec::new(),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+            module_name: Some("Exported".to_string()),
+            anchor_id: None,
+        },
+    );
+
+    let plan = run_safe_delete_plan_fixture(vec![shard], import_export_index, entity_id);
+    let passed = safe_delete_plan_has_blocker(&plan, PlanBlockerReason::ExportedSymbol);
+    (plan, passed)
+}
+
+fn safe_delete_plan_imported_symbol_fixture() -> (SafeDeletePlan, bool) {
+    let provider_file = FileId(54_001);
+    let importer_file = FileId(54_002);
+    let entity_id = EntityId(54_000);
+    let shard = rename_plan_fact_shard(
+        "file:///semantic/safe_delete_provider.pm",
+        provider_file,
+        entity_id,
+        "Provider::util",
+        EntityKind::Subroutine,
+        &[RenameOccurrenceSpec {
+            anchor_id: AnchorId(54_100),
+            occurrence_id: OccurrenceId(54_200),
+            kind: OccurrenceKind::Definition,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        }],
+        Provenance::ExactAst,
+        Confidence::High,
+    );
+    let importer_shard =
+        empty_fact_shard("file:///semantic/safe_delete_consumer.pm", importer_file);
+
+    let mut import_export_index = ImportExportIndex::new();
+    import_export_index.add_module_exports(
+        "file:///semantic/safe_delete_provider.pm",
+        "Provider",
+        ExportSet {
+            default_exports: Vec::new(),
+            optional_exports: vec!["util".to_string()],
+            tags: Vec::new(),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+            module_name: Some("Provider".to_string()),
+            anchor_id: None,
+        },
+    );
+    import_export_index.add_file_imports(
+        "file:///semantic/safe_delete_consumer.pm",
+        importer_file,
+        vec![ImportSpec {
+            module: "Provider".to_string(),
+            kind: ImportKind::UseExplicitList,
+            symbols: ImportSymbols::Explicit(vec!["util".to_string()]),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+            file_id: Some(importer_file),
+            anchor_id: None,
+            scope_id: None,
+        }],
+    );
+
+    let plan =
+        run_safe_delete_plan_fixture(vec![shard, importer_shard], import_export_index, entity_id);
+    let passed = safe_delete_plan_has_blocker(&plan, PlanBlockerReason::ImportedSymbol);
+    (plan, passed)
+}
+
+fn safe_delete_plan_generated_member_fixture() -> (SafeDeletePlan, bool) {
+    let entity_id = EntityId(55_000);
+    let shard = rename_plan_fact_shard(
+        "file:///semantic/safe_delete_generated_member.pm",
+        FileId(55_001),
+        entity_id,
+        "Person::name",
+        EntityKind::GeneratedMember,
+        &[],
+        Provenance::FrameworkSynthesis,
+        Confidence::Medium,
+    );
+
+    let plan = run_safe_delete_plan_fixture(vec![shard], ImportExportIndex::new(), entity_id);
+    let passed = safe_delete_plan_has_blocker(&plan, PlanBlockerReason::GeneratedMember);
+    (plan, passed)
+}
+
+fn safe_delete_plan_dynamic_boundary_fixture() -> (SafeDeletePlan, bool) {
+    let entity_id = EntityId(56_000);
+    let shard = rename_plan_fact_shard(
+        "file:///semantic/safe_delete_dynamic_boundary.pm",
+        FileId(56_001),
+        entity_id,
+        "Dynamic::dispatch",
+        EntityKind::Subroutine,
+        &[
+            RenameOccurrenceSpec {
+                anchor_id: AnchorId(56_100),
+                occurrence_id: OccurrenceId(56_200),
+                kind: OccurrenceKind::Definition,
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            },
+            RenameOccurrenceSpec {
+                anchor_id: AnchorId(56_101),
+                occurrence_id: OccurrenceId(56_201),
+                kind: OccurrenceKind::DynamicBoundary,
+                provenance: Provenance::DynamicBoundary,
+                confidence: Confidence::Low,
+            },
+        ],
+        Provenance::ExactAst,
+        Confidence::High,
+    );
+
+    let plan = run_safe_delete_plan_fixture(vec![shard], ImportExportIndex::new(), entity_id);
+    let passed = safe_delete_plan_has_blocker(&plan, PlanBlockerReason::DynamicBoundary);
+    (plan, passed)
+}
+
+fn run_safe_delete_plan_fixture(
+    shards: Vec<FileFactShard>,
+    import_export_index: ImportExportIndex,
+    entity_id: EntityId,
+) -> SafeDeletePlan {
+    let mut fact_shards = std::collections::HashMap::new();
+    for shard in shards {
+        fact_shards.insert(shard.source_uri.clone(), shard);
+    }
+
+    let reference_index = ReferenceIndex::new();
+    let queries =
+        WorkspaceSemanticQueries::new(&reference_index, &import_export_index, &fact_shards);
+    queries.safe_delete_plan(entity_id)
+}
+
+fn safe_delete_plan_has_blocker(plan: &SafeDeletePlan, reason: PlanBlockerReason) -> bool {
+    plan.blockers.iter().any(|blocker| blocker.reason == reason)
+}
+
 fn measure_package_graph_edges(
     source: &str,
     path: &Path,
@@ -885,6 +1156,15 @@ fn build_readiness_rows(
         format!(
             "{}%",
             measurement.rename_plan_fixture_passes * 100 / measurement.rename_plan_fixture_total
+        )
+    };
+    let safe_delete_plan_rate = if measurement.safe_delete_plan_fixture_total == 0 {
+        "0%".to_string()
+    } else {
+        format!(
+            "{}%",
+            measurement.safe_delete_plan_fixture_passes * 100
+                / measurement.safe_delete_plan_fixture_total
         )
     };
 
@@ -1000,10 +1280,36 @@ fn build_readiness_rows(
         (
             "safe_delete_blocker_fixture_pass_rate".to_string(),
             ReadinessRow {
-                status: "pass",
-                value: fixture_rate.to_string(),
+                status: if measurement.safe_delete_plan_fixture_passes
+                    == measurement.safe_delete_plan_fixture_total
+                    && measurement.safe_delete_plan_fixture_total > 0
+                    && measurement.safe_delete_plan_blockers > 0
+                {
+                    "pass"
+                } else {
+                    "fail"
+                },
+                value: safe_delete_plan_rate.clone(),
                 threshold: "100%",
-                evidence: "safe-delete blocker fixtures",
+                evidence: "safe-delete plan query fixtures",
+            },
+        ),
+        (
+            "safe_delete_plan".to_string(),
+            ReadinessRow {
+                status: if measurement.safe_delete_plan_fixture_passes
+                    == measurement.safe_delete_plan_fixture_total
+                    && measurement.safe_delete_plan_fixture_total > 0
+                    && measurement.safe_delete_safe_candidates > 0
+                    && measurement.safe_delete_plan_blockers > 0
+                {
+                    "pass"
+                } else {
+                    "fail"
+                },
+                value: safe_delete_plan_rate,
+                threshold: "100%",
+                evidence: "safe-delete plan query fixtures",
             },
         ),
     ])
@@ -1262,7 +1568,40 @@ sub local { 1 }
         assert_eq!(unsafe_edits.status, "pass");
         assert_eq!(unsafe_edits.value, "0");
         assert!(!artifact.unavailable_rows.contains_key("rename_plan"));
-        assert!(artifact.unavailable_rows.contains_key("safe_delete_plan"));
+        assert!(!artifact.unavailable_rows.contains_key("safe_delete_plan"));
+        Ok(())
+    }
+
+    #[test]
+    fn safe_delete_plan_rows_are_measured_from_queries() -> Result<()> {
+        let measurement = measure_safe_delete_plan_fixtures();
+        assert_eq!(measurement.total, 6);
+        assert_eq!(measurement.passes, 6);
+        assert_eq!(measurement.safe_candidates, 1);
+        assert!(measurement.blockers >= 5, "blocked safe-delete fixtures should produce blockers");
+
+        let tmp = tempfile::tempdir()?;
+        let manifest_path = write_fixture_set(
+            tmp.path(),
+            r#"{"fixture_family_version":1,"fixtures":[{"id":"safe_delete_fixture","family":"safe delete","path":"safe_delete.pl"}]}"#,
+            &[("safe_delete.pl", "package SafeDeleteFixture; sub unused_local { 1 }\n")],
+        )?;
+        let artifact = build_artifact(&manifest_path, load_manifest(&manifest_path)?)?;
+
+        let safe_delete_plan = artifact
+            .readiness_rows
+            .get("safe_delete_plan")
+            .ok_or_else(|| color_eyre::eyre::eyre!("missing safe_delete_plan readiness row"))?;
+        assert_eq!(safe_delete_plan.status, "pass");
+        assert_eq!(safe_delete_plan.value, "100%");
+
+        let blocker_rate =
+            artifact.readiness_rows.get("safe_delete_blocker_fixture_pass_rate").ok_or_else(
+                || color_eyre::eyre::eyre!("missing safe_delete_blocker_fixture_pass_rate row"),
+            )?;
+        assert_eq!(blocker_rate.status, "pass");
+        assert_eq!(blocker_rate.value, "100%");
+        assert!(artifact.unavailable_rows.is_empty());
         Ok(())
     }
 


### PR DESCRIPTION
Problem: The semantic scorecard still marked `safe_delete_plan` unavailable, and dynamic safe-delete blockers were reported only as generic remaining references.
Fix: Classify dynamic-boundary safe-delete blockers explicitly, measure deterministic safe-delete plan fixtures through `WorkspaceSemanticQueries::safe_delete_plan`, and remove the final unavailable semantic row.
Verification: `cargo test -p perl-workspace --profile agent --locked safe_delete_plan`, `cargo test -p xtask --profile agent --locked semantic`, `cargo check -p perl-workspace --all-targets --profile agent --locked`, `cargo check -p xtask --all-targets --profile agent --locked`, `cargo clippy -p perl-workspace --profile agent --locked -- -D warnings -A missing_docs`, `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`, `cargo xtask semantic-scorecard --check`, `cargo xtask semantic-shadow-compare --check`, `cargo xtask fmt --check`, `git diff --check`, and `./scripts/storage-doctor` pass.