### PR TITLE
feat(parser): define accuracy scorecard schema (#0000)

### DIFF
--- a/.ci/schemas/parser-accuracy.schema.json
+++ b/.ci/schemas/parser-accuracy.schema.json
@@ -1,0 +1,448 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/schemas/parser-accuracy.schema.json",
+  "title": "perl-lsp parser accuracy scorecard",
+  "description": "Layered parser accuracy scorecard covering denominator visibility, measured accuracy rows, insufficient-data rows, and metric runtime trust signals.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "subsystem",
+    "generated_at",
+    "commit",
+    "cadence",
+    "denominator",
+    "families",
+    "metrics",
+    "failure_packets",
+    "gold_drift",
+    "metric_runtime"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "subsystem": {
+      "type": "string",
+      "const": "parser_accuracy"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "commit": {
+      "type": "string",
+      "minLength": 1
+    },
+    "cadence": {
+      "type": "string",
+      "enum": [
+        "pr",
+        "merge_gate",
+        "nightly",
+        "release"
+      ]
+    },
+    "denominator": {
+      "$ref": "#/$defs/denominator"
+    },
+    "families": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/family"
+      }
+    },
+    "metrics": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/metricRow"
+      }
+    },
+    "failure_packets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/failurePacket"
+      }
+    },
+    "gold_drift": {
+      "$ref": "#/$defs/goldDrift"
+    },
+    "metric_runtime": {
+      "$ref": "#/$defs/metricRuntime"
+    }
+  },
+  "$defs": {
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nonNegativeNumber": {
+      "type": "number",
+      "minimum": 0
+    },
+    "denominator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fixture_count",
+        "fixture_family_count",
+        "scored_line_count",
+        "scored_symbol_count",
+        "fully_labeled_region_count",
+        "partial_labeled_region_count",
+        "unknown_region_count",
+        "negative_region_count",
+        "dynamic_boundary_case_count",
+        "unsupported_construct_case_count",
+        "real_project_file_count",
+        "generated_fixture_count",
+        "hand_labeled_fixture_count"
+      ],
+      "properties": {
+        "fixture_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "fixture_family_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "scored_line_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "scored_symbol_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "fully_labeled_region_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "partial_labeled_region_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "unknown_region_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "negative_region_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "dynamic_boundary_case_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "unsupported_construct_case_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "real_project_file_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "generated_fixture_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "hand_labeled_fixture_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        }
+      }
+    },
+    "family": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "family",
+        "fixture_count",
+        "label_modes",
+        "scored_line_count",
+        "scored_symbol_count",
+        "dynamic_boundary_case_count",
+        "unsupported_construct_case_count"
+      ],
+      "properties": {
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fixture_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "label_modes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "full",
+              "partial",
+              "unknown",
+              "negative"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "scored_line_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "scored_symbol_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "dynamic_boundary_case_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "unsupported_construct_case_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        }
+      }
+    },
+    "metricRow": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/measuredMetric"
+        },
+        {
+          "$ref": "#/$defs/insufficientDataMetric"
+        }
+      ]
+    },
+    "measuredMetric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "metric",
+        "state",
+        "value",
+        "sample_count",
+        "direction",
+        "confidence"
+      ],
+      "properties": {
+        "metric": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "type": "string",
+          "const": "measured"
+        },
+        "value": {
+          "type": "number"
+        },
+        "previous": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "delta": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "floor": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "threshold": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "up",
+            "down",
+            "flat",
+            "neutral"
+          ]
+        },
+        "sample_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        },
+        "cadence": {
+          "type": "string",
+          "enum": [
+            "pr",
+            "merge_gate",
+            "nightly",
+            "release"
+          ]
+        },
+        "macro_value": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "micro_value": {
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      }
+    },
+    "insufficientDataMetric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "metric",
+        "state",
+        "reason",
+        "sample_count"
+      ],
+      "properties": {
+        "metric": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "type": "string",
+          "const": "insufficient_data"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sample_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        }
+      }
+    },
+    "confidence": {
+      "type": "string",
+      "enum": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "failurePacket": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "failure_kind",
+        "likely_layer",
+        "fixture_id"
+      ],
+      "properties": {
+        "failure_kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "likely_layer": {
+          "type": "string",
+          "enum": [
+            "lexer",
+            "parser",
+            "recovery",
+            "ast_projection",
+            "semantic_fact_extraction",
+            "workspace_index",
+            "provider_query",
+            "gold_schema",
+            "metric_infrastructure",
+            "unknown"
+          ]
+        },
+        "fixture_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "line": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "details": {
+          "type": "string"
+        }
+      }
+    },
+    "goldDrift": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_error_count",
+        "span_error_count",
+        "duplicate_symbol_id_count",
+        "missing_resolves_to_target_count",
+        "changed_line_count",
+        "changed_symbol_count",
+        "removed_expectation_count",
+        "added_expectation_count",
+        "dynamic_expectation_change_count"
+      ],
+      "properties": {
+        "schema_error_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "span_error_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "duplicate_symbol_id_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "missing_resolves_to_target_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "changed_line_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "changed_symbol_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "removed_expectation_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "added_expectation_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "dynamic_expectation_change_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        }
+      }
+    },
+    "metricRuntime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runtime_ms",
+        "timeout_count",
+        "flake_count",
+        "artifact_size_bytes"
+      ],
+      "properties": {
+        "runtime_ms": {
+          "$ref": "#/$defs/nonNegativeNumber"
+        },
+        "timeout_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "flake_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "artifact_size_bytes": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "ci_runner_failure_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "orphan_process_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "cache_hit_rate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    }
+  }
+}

--- a/.kiro/specs/parser-accuracy-observability/tasks.md
+++ b/.kiro/specs/parser-accuracy-observability/tasks.md
@@ -6,13 +6,13 @@ Build a layered parser accuracy scorecard that starts with denominator visibilit
 
 ## Tasks
 
-- [ ] 1. Define the scorecard contract
-  - [ ] 1.1 Add `.ci/schemas/parser-accuracy.schema.json`
+- [x] 1. Define the scorecard contract
+  - [x] 1.1 Add `.ci/schemas/parser-accuracy.schema.json`
     - Include top-level fields: `schema_version`, `subsystem`, `generated_at`, `commit`, `cadence`, `denominator`, `families`, `metrics`, `failure_packets`, `gold_drift`, and `metric_runtime`
     - Require each metric row to be either `measured` or `insufficient_data`
     - Require measured rows to include value, sample_count, direction, and confidence
     - _Verify: schema validation test in xtask or a dedicated fixture test_
-  - [ ] 1.2 Add a tiny example fixture artifact
+  - [x] 1.2 Add a tiny example fixture artifact
     - Create a committed example under a test fixture path, not under `target/`
     - Include denominator rows and `insufficient_data` line/AST/symbol rows
     - _Verify: JSON parses and validates_

--- a/xtask/tests/fixtures/parser-accuracy/example-artifact.json
+++ b/xtask/tests/fixtures/parser-accuracy/example-artifact.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": 1,
+  "subsystem": "parser_accuracy",
+  "generated_at": "2026-05-02T00:00:00Z",
+  "commit": "example",
+  "cadence": "pr",
+  "denominator": {
+    "fixture_count": 2,
+    "fixture_family_count": 2,
+    "scored_line_count": 3,
+    "scored_symbol_count": 2,
+    "fully_labeled_region_count": 1,
+    "partial_labeled_region_count": 1,
+    "unknown_region_count": 1,
+    "negative_region_count": 1,
+    "dynamic_boundary_case_count": 1,
+    "unsupported_construct_case_count": 0,
+    "real_project_file_count": 0,
+    "generated_fixture_count": 0,
+    "hand_labeled_fixture_count": 2
+  },
+  "families": [
+    {
+      "family": "packages",
+      "fixture_count": 1,
+      "label_modes": [
+        "full"
+      ],
+      "scored_line_count": 2,
+      "scored_symbol_count": 1,
+      "dynamic_boundary_case_count": 0,
+      "unsupported_construct_case_count": 0
+    },
+    {
+      "family": "dynamic_require",
+      "fixture_count": 1,
+      "label_modes": [
+        "partial"
+      ],
+      "scored_line_count": 1,
+      "scored_symbol_count": 1,
+      "dynamic_boundary_case_count": 1,
+      "unsupported_construct_case_count": 0
+    }
+  ],
+  "metrics": [
+    {
+      "metric": "denominator_fixture_count",
+      "state": "measured",
+      "value": 2,
+      "sample_count": 2,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_construct_f1",
+      "state": "insufficient_data",
+      "reason": "line-level gold scorer is not wired yet",
+      "sample_count": 0,
+      "confidence": "low"
+    },
+    {
+      "metric": "ast_node_kind_f1",
+      "state": "insufficient_data",
+      "reason": "AST structural gold scorer is not wired yet",
+      "sample_count": 0,
+      "confidence": "low"
+    },
+    {
+      "metric": "symbol_decl_f1",
+      "state": "insufficient_data",
+      "reason": "symbol gold scorer is not wired yet",
+      "sample_count": 0,
+      "confidence": "low"
+    }
+  ],
+  "failure_packets": [],
+  "gold_drift": {
+    "schema_error_count": 0,
+    "span_error_count": 0,
+    "duplicate_symbol_id_count": 0,
+    "missing_resolves_to_target_count": 0,
+    "changed_line_count": 0,
+    "changed_symbol_count": 0,
+    "removed_expectation_count": 0,
+    "added_expectation_count": 0,
+    "dynamic_expectation_change_count": 0
+  },
+  "metric_runtime": {
+    "runtime_ms": 1,
+    "timeout_count": 0,
+    "flake_count": 0,
+    "artifact_size_bytes": 2048,
+    "ci_runner_failure_count": 0,
+    "orphan_process_count": 0,
+    "cache_hit_rate": null
+  }
+}

--- a/xtask/tests/parser_accuracy_schema.rs
+++ b/xtask/tests/parser_accuracy_schema.rs
@@ -1,0 +1,206 @@
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Result, eyre};
+use serde_json::Value;
+
+type TestResult = Result<()>;
+
+const TOP_LEVEL_REQUIRED: &[&str] = &[
+    "schema_version",
+    "subsystem",
+    "generated_at",
+    "commit",
+    "cadence",
+    "denominator",
+    "families",
+    "metrics",
+    "failure_packets",
+    "gold_drift",
+    "metric_runtime",
+];
+
+const DENOMINATOR_REQUIRED: &[&str] = &[
+    "fixture_count",
+    "fixture_family_count",
+    "scored_line_count",
+    "scored_symbol_count",
+    "fully_labeled_region_count",
+    "partial_labeled_region_count",
+    "unknown_region_count",
+    "negative_region_count",
+    "dynamic_boundary_case_count",
+    "unsupported_construct_case_count",
+    "real_project_file_count",
+    "generated_fixture_count",
+    "hand_labeled_fixture_count",
+];
+
+#[test]
+fn parser_accuracy_schema_declares_required_contract() -> TestResult {
+    let schema = read_json(&repo_root()?.join(".ci/schemas/parser-accuracy.schema.json"))?;
+    assert_eq!(schema["$schema"], "https://json-schema.org/draft/2020-12/schema");
+    assert_eq!(schema["properties"]["subsystem"]["const"], "parser_accuracy");
+
+    let required = string_array(&schema["required"], "top-level required fields")?;
+    for field in TOP_LEVEL_REQUIRED {
+        assert!(
+            required.iter().any(|item| item == field),
+            "schema is missing required top-level field {field}"
+        );
+    }
+
+    let metric_row = &schema["$defs"]["metricRow"];
+    let one_of = metric_row["oneOf"].as_array().ok_or_else(|| {
+        eyre!("metricRow must define measured and insufficient-data alternatives")
+    })?;
+    assert_eq!(one_of.len(), 2, "metricRow must have exactly two states");
+
+    Ok(())
+}
+
+#[test]
+fn parser_accuracy_example_artifact_matches_schema_contract() -> TestResult {
+    let root = repo_root()?;
+    let artifact =
+        read_json(&root.join("xtask/tests/fixtures/parser-accuracy/example-artifact.json"))?;
+
+    for field in TOP_LEVEL_REQUIRED {
+        assert!(artifact.get(*field).is_some(), "example artifact is missing {field}");
+    }
+    assert_eq!(artifact["schema_version"], 1);
+    assert_eq!(artifact["subsystem"], "parser_accuracy");
+    assert!(
+        ["pr", "merge_gate", "nightly", "release"].contains(
+            &artifact["cadence"]
+                .as_str()
+                .ok_or_else(|| eyre!("cadence must be a string in example artifact"))?,
+        ),
+        "cadence must match the schema enum"
+    );
+
+    validate_denominator(&artifact["denominator"])?;
+    validate_families(&artifact)?;
+    validate_metric_rows(&artifact)?;
+    validate_gold_drift(&artifact["gold_drift"])?;
+    validate_metric_runtime(&artifact["metric_runtime"])?;
+
+    Ok(())
+}
+
+fn repo_root() -> Result<PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let root = manifest_dir
+        .parent()
+        .ok_or_else(|| eyre!("xtask manifest should have a workspace parent"))?;
+    Ok(root.to_path_buf())
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let raw = std::fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&raw)?)
+}
+
+fn string_array(value: &Value, label: &str) -> Result<Vec<String>> {
+    let items = value.as_array().ok_or_else(|| eyre!("{label} must be an array"))?;
+    let mut output = Vec::with_capacity(items.len());
+    for item in items {
+        let text = item.as_str().ok_or_else(|| eyre!("{label} must contain strings"))?;
+        output.push(text.to_string());
+    }
+    Ok(output)
+}
+
+fn validate_denominator(value: &Value) -> TestResult {
+    let object = value.as_object().ok_or_else(|| eyre!("denominator must be an object"))?;
+    for field in DENOMINATOR_REQUIRED {
+        object
+            .get(*field)
+            .and_then(Value::as_u64)
+            .ok_or_else(|| eyre!("denominator field {field} must be a non-negative integer"))?;
+    }
+    Ok(())
+}
+
+fn validate_families(artifact: &Value) -> TestResult {
+    let families =
+        artifact["families"].as_array().ok_or_else(|| eyre!("families must be an array"))?;
+    assert!(!families.is_empty(), "example artifact should include at least one family");
+    for family in families {
+        assert!(
+            family["family"].as_str().is_some_and(|value| !value.is_empty()),
+            "family rows require a non-empty family name"
+        );
+        assert!(family["fixture_count"].as_u64().is_some(), "family rows require fixture_count");
+        let label_modes = family["label_modes"]
+            .as_array()
+            .ok_or_else(|| eyre!("label_modes must be an array"))?;
+        assert!(!label_modes.is_empty(), "family rows require label_modes");
+    }
+    Ok(())
+}
+
+fn validate_metric_rows(artifact: &Value) -> TestResult {
+    let metrics =
+        artifact["metrics"].as_array().ok_or_else(|| eyre!("metrics must be an array"))?;
+    assert!(!metrics.is_empty(), "example artifact should include metric rows");
+
+    let mut saw_measured = false;
+    let mut saw_insufficient_line = false;
+    let mut saw_insufficient_ast = false;
+    let mut saw_insufficient_symbol = false;
+
+    for metric in metrics {
+        let state =
+            metric["state"].as_str().ok_or_else(|| eyre!("metric state must be a string"))?;
+        let sample_count = metric["sample_count"]
+            .as_u64()
+            .ok_or_else(|| eyre!("metric sample_count must be a non-negative integer"))?;
+        match state {
+            "measured" => {
+                saw_measured = true;
+                assert!(sample_count > 0, "measured rows require a positive sample_count");
+                assert!(metric.get("value").and_then(Value::as_f64).is_some());
+                assert!(metric.get("direction").and_then(Value::as_str).is_some());
+                assert!(metric.get("confidence").and_then(Value::as_str).is_some());
+            }
+            "insufficient_data" => {
+                assert!(metric.get("reason").and_then(Value::as_str).is_some());
+                match metric["metric"].as_str() {
+                    Some("line_construct_f1") => saw_insufficient_line = true,
+                    Some("ast_node_kind_f1") => saw_insufficient_ast = true,
+                    Some("symbol_decl_f1") => saw_insufficient_symbol = true,
+                    _ => {}
+                }
+            }
+            other => return Err(eyre!("unexpected metric state {other}")),
+        }
+    }
+
+    assert!(saw_measured, "example should include at least one measured denominator row");
+    assert!(saw_insufficient_line, "example should include line insufficient-data row");
+    assert!(saw_insufficient_ast, "example should include AST insufficient-data row");
+    assert!(saw_insufficient_symbol, "example should include symbol insufficient-data row");
+    Ok(())
+}
+
+fn validate_gold_drift(value: &Value) -> TestResult {
+    let object = value.as_object().ok_or_else(|| eyre!("gold_drift must be an object"))?;
+    for (key, count) in object {
+        assert!(count.as_u64().is_some(), "gold_drift field {key} must be a non-negative integer");
+    }
+    Ok(())
+}
+
+fn validate_metric_runtime(value: &Value) -> TestResult {
+    assert!(
+        value["runtime_ms"].as_f64().is_some_and(|runtime| runtime >= 0.0),
+        "metric_runtime.runtime_ms must be non-negative"
+    );
+    for field in ["timeout_count", "flake_count", "artifact_size_bytes"] {
+        assert!(
+            value[field].as_u64().is_some(),
+            "metric_runtime.{field} must be a non-negative integer"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Problem: Parser accuracy observability had a merged spec, but no committed artifact schema or example contract to validate against.
Fix: Add `.ci/schemas/parser-accuracy.schema.json`, a tiny parser-accuracy example artifact fixture, structural xtask schema-contract tests, and mark Task 1 complete in the Kiro spec.
Verification: `cargo test -p xtask parser_accuracy --profile agent --locked`, `cargo check -p xtask --all-targets --profile agent --locked`, `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`, `cargo xtask fmt --check`, and `git diff --check` pass.
