### PR TITLE
chore(toolchain): bump MSRV pins to Rust 1.93.1 (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
           components: rustfmt, clippy
 
       - name: Install just
@@ -216,7 +216,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
           components: rustfmt, clippy
 
       - name: Install just
@@ -425,7 +425,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Install just
         uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1  # v2.75.22
@@ -523,7 +523,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Install just
         uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1  # v2.75.22
@@ -576,7 +576,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 [workspace.package]
 version = "0.13.1"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
 description = "Perl parser, LSP, and DAP ecosystem in Rust"
 license = "MIT OR Apache-2.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # clippy.toml
 # Keep pedantic on, but chill some noisy lints for a parser project.
 # warn-on-all-wildcard-imports = false
-msrv = "1.92"
+msrv = "1.93"
 
 # Common pedantic relaxations for parser projects
 allow-private-module-inception = true

--- a/docs/project/CI_LOCAL_VALIDATION.md
+++ b/docs/project/CI_LOCAL_VALIDATION.md
@@ -276,7 +276,7 @@ just ci-parser-features-check
 
 ### MSRV Validation
 
-Validate against Minimum Supported Rust Version (1.92.0):
+Validate against Minimum Supported Rust Version (1.93.1):
 
 ```bash
 # Fast merge gate on MSRV
@@ -286,7 +286,7 @@ just ci-gate-msrv
 just ci-full-msrv
 
 # Or manually
-RUSTUP_TOOLCHAIN=1.92.0 just ci-gate
+RUSTUP_TOOLCHAIN=1.93.1 just ci-gate
 ```
 
 ### Cost Estimation
@@ -426,7 +426,7 @@ flake.nix
 ### Reproducibility Guarantees
 
 1. **Rust Version Pinning**
-   - MSRV 1.92.0 is specified in `flake.nix`
+   - MSRV 1.93.1 is specified in `flake.nix`
    - Also enforced via `rust-toolchain.toml`
    - CI workflows use the same version
 
@@ -533,7 +533,7 @@ nix --experimental-features 'nix-command flakes' develop
 # Wrong (uses system Rust):
 just ci-gate
 
-# Correct (uses Nix Rust 1.92.0):
+# Correct (uses Nix Rust 1.93.1):
 nix develop -c just ci-gate
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,9 @@
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
 
-        # MSRV: Rust 1.92.0 - pinned for OpenAI Codex compatibility
+        # MSRV: Rust 1.93.1 - pinned for OpenAI Codex compatibility
         # This matches rust-toolchain.toml and CI workflows
-        rustVersion = "1.92.0";
+        rustVersion = "1.93.1";
         rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = [ "rust-src" "clippy" "rustfmt" ];
           targets = [ "wasm32-unknown-unknown" ];  # For WASM determinism checks

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Rust toolchain configuration for perl-lsp
-# MSRV: 1.92 (for OpenAI Codex compatibility)
+# MSRV: 1.93 (for OpenAI Codex compatibility)
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.1"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/xtask/src/tasks/check_toolchain.rs
+++ b/xtask/src/tasks/check_toolchain.rs
@@ -113,18 +113,18 @@ mod tests {
 
     #[test]
     fn parse_version_parts_handles_channel_prefixed_versions() {
-        assert_eq!(parse_version_parts("stable-1.92.0-x86_64-unknown-linux-gnu"), vec![1, 92, 0]);
+        assert_eq!(parse_version_parts("stable-1.93.1-x86_64-unknown-linux-gnu"), vec![1, 93, 1]);
     }
 
     #[test]
     fn parse_rustc_version_extracts_second_token() -> Result<()> {
-        let version = parse_rustc_version("rustc 1.92.0 (2aaa62b89 2025-10-28)\n")?;
-        assert_eq!(version, "1.92.0");
+        let version = parse_rustc_version("rustc 1.93.1 (2aaa62b89 2025-10-28)\n")?;
+        assert_eq!(version, "1.93.1");
         Ok(())
     }
 
     #[test]
     fn compare_versions_treats_missing_patch_as_zero() {
-        assert_eq!(compare_versions(&[1, 92], &[1, 92, 0]), std::cmp::Ordering::Equal);
+        assert_eq!(compare_versions(&[1, 92], &[1, 93, 1]), std::cmp::Ordering::Equal);
     }
 }


### PR DESCRIPTION
### Motivation

- Move the workspace MSRV and toolchain pins from Rust 1.92.x to `1.93.1` so the repo can use Rust 1.93 improvements while avoiding the 1.93.0 rustfmt/Clippy issues. 
- Align CI, Nix flake, and local validation docs with the new MSRV so all developer and CI surfaces are consistent. 
- Prepare the repository for a staged quality-wave upgrade (toolchain bump first, then rustc/Clippy lint waves and follow-ups).

### Description

- Updated the pinned toolchain and components in `rust-toolchain.toml` to `channel = "1.93.1"` and adjusted the MSRV comment to `1.93`.
- Bumped workspace `rust-version` in `Cargo.toml` to `"1.93"` and updated the `clippy.toml` `msrv` to `"1.93"`.
- Updated CI workflow toolchain entries in `.github/workflows/ci.yml` to use `toolchain: 1.93.1`.
- Updated the Nix flake `rustVersion` to `"1.93.1"` and aligned local validation docs in `docs/project/CI_LOCAL_VALIDATION.md` to reference `1.93.1`.
- Adjusted xtask toolchain checks in `xtask/src/tasks/check_toolchain.rs` to expect `1.93.1` in tests.

### Testing

- Ran `./scripts/cargo-safe xtask fmt` which completed successfully against the new `1.93.1` toolchain.
- Attempted `./scripts/cargo-safe test -p xtask --profile agent --locked`, but the local run was blocked by an environment storage guard (`DENY: /root/.cache/devplane/perl-lsp used=52% free=28G`) and could not finish; CI will run full gates with the updated toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f604cb676c8333afa41aef3e4158f6)