### PR TITLE
chore(toolchain): bump MSRV pins to Rust 1.93.1 (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
           components: rustfmt, clippy
 
       - name: Install just
@@ -234,7 +234,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
           components: rustfmt, clippy
 
       - name: Install just
@@ -461,7 +461,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Install just
         uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1  # v2.75.22
@@ -585,7 +585,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Install just
         uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1  # v2.75.22
@@ -638,7 +638,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 [workspace.package]
 version = "0.13.3"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
 description = "Perl parser, LSP, and DAP ecosystem in Rust"
 license = "MIT OR Apache-2.0"

--- a/book/src/ci/local-validation.md
+++ b/book/src/ci/local-validation.md
@@ -46,7 +46,7 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 nix develop
 
 # You now have:
-# - Rust 1.92.0 (MSRV) with wasm32-unknown-unknown target
+# - Rust 1.93.1 (MSRV) with wasm32-unknown-unknown target
 # - cargo, rustfmt, clippy
 # - just (command runner)
 # - cargo-nextest (fast test runner)
@@ -68,9 +68,9 @@ cargo install just
 # Install cargo-nextest (optional but recommended)
 cargo install cargo-nextest
 
-# Ensure MSRV compliance (Rust 1.92)
-rustup install 1.92.0
-rustup override set 1.92.0
+# Ensure MSRV compliance (Rust 1.93)
+rustup install 1.93.1
+rustup override set 1.93.1
 ```
 
 ---
@@ -81,7 +81,7 @@ rustup override set 1.92.0
 
 Nix provides **reproducible builds** - the exact same tools and versions on every machine:
 
-1. **Pinned toolchain**: Rust 1.92.0 (MSRV) is locked via `flake.lock`
+1. **Pinned toolchain**: Rust 1.93.1 (MSRV) is locked via `flake.lock`
 2. **All CI tools included**: just, cargo-nextest, cargo-audit, gh, etc.
 3. **Cross-platform**: Works on Linux, macOS, and WSL
 4. **No system pollution**: Tools don't affect your global environment
@@ -555,7 +555,7 @@ just ci-parser-features-check
 
 ### MSRV Validation
 
-Validate against Minimum Supported Rust Version (1.92.0):
+Validate against Minimum Supported Rust Version (1.93.1):
 
 ```bash
 # Fast merge gate on MSRV
@@ -565,7 +565,7 @@ just ci-gate-msrv
 just ci-full-msrv
 
 # Or manually
-RUSTUP_TOOLCHAIN=1.92.0 just ci-gate
+RUSTUP_TOOLCHAIN=1.93.1 just ci-gate
 ```
 
 ### Cost Estimation
@@ -740,7 +740,7 @@ flake.nix
 ### Reproducibility Guarantees
 
 1. **Rust Version Pinning**
-   - MSRV 1.92.0 is specified in `flake.nix`
+   - MSRV 1.93.1 is specified in `flake.nix`
    - Also enforced via `rust-toolchain.toml`
    - CI workflows use the same version
 
@@ -927,7 +927,7 @@ nix --experimental-features 'nix-command flakes' develop
 # Wrong (uses system Rust):
 just ci-gate
 
-# Correct (uses Nix Rust 1.92.0):
+# Correct (uses Nix Rust 1.93.1):
 nix develop -c just ci-gate
 ```
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # clippy.toml
 # Keep pedantic on, but chill some noisy lints for a parser project.
 # warn-on-all-wildcard-imports = false
-msrv = "1.92"
+msrv = "1.93"
 
 # Common pedantic relaxations for parser projects
 allow-private-module-inception = true

--- a/crates/perl-test-generators/src/lib.rs
+++ b/crates/perl-test-generators/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate provides reusable [`proptest::Strategy`] implementations for
 //! generating Perl variables, module paths, code snippets, and Unicode
 //! strings suitable for fuzzing parsers and LSP components.
+
+// The crate-level doctest demonstrates `proptest!` syntax, which uses `#[test]`.
+#![allow(clippy::test_attr_in_doctest)]
 //!
 //! # Example
 //!

--- a/docs/project/CI_LOCAL_VALIDATION.md
+++ b/docs/project/CI_LOCAL_VALIDATION.md
@@ -276,7 +276,7 @@ just ci-parser-features-check
 
 ### MSRV Validation
 
-Validate against Minimum Supported Rust Version (1.92.0):
+Validate against Minimum Supported Rust Version (1.93.1):
 
 ```bash
 # Fast merge gate on MSRV
@@ -286,7 +286,7 @@ just ci-gate-msrv
 just ci-full-msrv
 
 # Or manually
-RUSTUP_TOOLCHAIN=1.92.0 just ci-gate
+RUSTUP_TOOLCHAIN=1.93.1 just ci-gate
 ```
 
 ### Cost Estimation
@@ -426,7 +426,7 @@ flake.nix
 ### Reproducibility Guarantees
 
 1. **Rust Version Pinning**
-   - MSRV 1.92.0 is specified in `flake.nix`
+   - MSRV 1.93.1 is specified in `flake.nix`
    - Also enforced via `rust-toolchain.toml`
    - CI workflows use the same version
 
@@ -533,7 +533,7 @@ nix --experimental-features 'nix-command flakes' develop
 # Wrong (uses system Rust):
 just ci-gate
 
-# Correct (uses Nix Rust 1.92.0):
+# Correct (uses Nix Rust 1.93.1):
 nix develop -c just ci-gate
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,9 @@
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
 
-        # MSRV: Rust 1.92.0 - pinned for OpenAI Codex compatibility
+        # MSRV: Rust 1.93.1 - pinned for OpenAI Codex compatibility
         # This matches rust-toolchain.toml and CI workflows
-        rustVersion = "1.92.0";
+        rustVersion = "1.93.1";
         rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = [ "rust-src" "clippy" "rustfmt" ];
           targets = [ "wasm32-unknown-unknown" ];  # For WASM determinism checks

--- a/justfile
+++ b/justfile
@@ -875,8 +875,8 @@ _check-tools-nextest:
 # CI Validation Commands (Issue #211)
 # ============================================================================
 
-# MSRV: Rust 1.92 (for OpenAI Codex compatibility)
-# The rust-toolchain.toml pins to 1.92.0, so standard commands use MSRV by default.
+# MSRV: Rust 1.93 (for OpenAI Codex compatibility)
+# The rust-toolchain.toml pins to 1.93.1, so standard commands use MSRV by default.
 # Use these recipes to explicitly verify MSRV compliance:
 
 # Phase 0: publish receipts to review/receipts/YYYY-MM-DD/
@@ -899,10 +899,10 @@ ci-measure:
 # UX Regression Tests (first-5-minutes user experience)
 # ============================================================================
 
-# Fast merge gate on MSRV (~2-5 min) - proves 1.92 compatibility
+# Fast merge gate on MSRV (~2-5 min) - proves 1.93 compatibility
 ci-gate-msrv:
-    @echo "🚪 Running fast merge gate on MSRV (Rust 1.92)..."
-    @RUSTUP_TOOLCHAIN=1.92.0 just ci-gate
+    @echo "🚪 Running fast merge gate on MSRV (Rust 1.93)..."
+    @RUSTUP_TOOLCHAIN=1.93.1 just ci-gate
 
 # Low-memory merge gate - for constrained environments (WSL, CI runners, low-RAM)
 # Forces single-threaded builds/tests to prevent OOM crashes
@@ -927,10 +927,10 @@ ci-gate-low-mem:
         just ci-features-invariants'
     @echo "✅ Low-memory merge gate passed!"
 
-# Full CI on MSRV (~10-20 min) - proves 1.92 compatibility for releases
+# Full CI on MSRV (~10-20 min) - proves 1.93 compatibility for releases
 ci-full-msrv:
-    @echo "🚀 Running full CI on MSRV (Rust 1.92)..."
-    @RUSTUP_TOOLCHAIN=1.92.0 just ci-full
+    @echo "🚀 Running full CI on MSRV (Rust 1.93)..."
+    @RUSTUP_TOOLCHAIN=1.93.1 just ci-full
 
 # Check for nested Cargo.lock files (footgun prevention)
 ci-check-no-nested-lock:

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,5 +1,5 @@
 schema = 1
-msrv = "1.92"
+msrv = "1.93"
 
 [policy]
 panic_free_tests = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Rust toolchain configuration for perl-lsp
-# MSRV: 1.92 (for OpenAI Codex compatibility)
+# MSRV: 1.93 (for OpenAI Codex compatibility)
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.1"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/xtask/src/tasks/check_toolchain.rs
+++ b/xtask/src/tasks/check_toolchain.rs
@@ -113,13 +113,13 @@ mod tests {
 
     #[test]
     fn parse_version_parts_handles_channel_prefixed_versions() {
-        assert_eq!(parse_version_parts("stable-1.92.0-x86_64-unknown-linux-gnu"), vec![1, 92, 0]);
+        assert_eq!(parse_version_parts("stable-1.93.1-x86_64-unknown-linux-gnu"), vec![1, 93, 1]);
     }
 
     #[test]
     fn parse_rustc_version_extracts_second_token() -> Result<()> {
-        let version = parse_rustc_version("rustc 1.92.0 (2aaa62b89 2025-10-28)\n")?;
-        assert_eq!(version, "1.92.0");
+        let version = parse_rustc_version("rustc 1.93.1 (2aaa62b89 2025-10-28)\n")?;
+        assert_eq!(version, "1.93.1");
         Ok(())
     }
 


### PR DESCRIPTION
Problem: The workspace MSRV/toolchain pins need to move from Rust 1.92 to Rust 1.93.1 consistently across CI, local tooling, docs, and policy receipts.
Fix: Align rust-toolchain, workspace rust-version, Clippy MSRV, Nix, CI pins, local validation docs, just recipes, toolchain tests, and the Clippy policy ledger; add a scoped allow for the new 1.93 doctest lint in the proptest generator docs.
Verification: `cargo xtask check-toolchain`, `cargo xtask check-lint-policy`, `cargo test -p xtask --profile agent --locked check_toolchain`, `cargo test -p xtask --profile agent --locked check_lint_policy`, `cargo clippy -p perl-test-generators --lib --locked -- -D warnings -A missing_docs`, `cargo xtask gates --gate clippy_full --receipt --receipt-path C:\Users\steven\AppData\Local\Temp\clippy-full-7832.json`, `cargo check -p xtask --all-targets --profile agent --locked`, `cargo xtask fmt --check`, `cargo xtask metrics parser-accuracy --check`, `cargo xtask metrics ratchet-check parser_accuracy`, and `git diff --check` pass.