### PR TITLE
chore(toolchain): bump MSRV and pins to Rust 1.93.1 (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
           components: rustfmt, clippy
 
       - name: Install just
@@ -216,7 +216,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
           components: rustfmt, clippy
 
       - name: Install just
@@ -425,7 +425,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Install just
         uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1  # v2.75.22
@@ -523,7 +523,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Install just
         uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1  # v2.75.22
@@ -576,7 +576,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.1
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 [workspace.package]
 version = "0.13.1"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
 description = "Perl parser, LSP, and DAP ecosystem in Rust"
 license = "MIT OR Apache-2.0"

--- a/book/src/ci/local-validation.md
+++ b/book/src/ci/local-validation.md
@@ -46,7 +46,7 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 nix develop
 
 # You now have:
-# - Rust 1.92.0 (MSRV) with wasm32-unknown-unknown target
+# - Rust 1.93.1 (MSRV) with wasm32-unknown-unknown target
 # - cargo, rustfmt, clippy
 # - just (command runner)
 # - cargo-nextest (fast test runner)
@@ -68,9 +68,9 @@ cargo install just
 # Install cargo-nextest (optional but recommended)
 cargo install cargo-nextest
 
-# Ensure MSRV compliance (Rust 1.92)
-rustup install 1.92.0
-rustup override set 1.92.0
+# Ensure MSRV compliance (Rust 1.93
+rustup install 1.93.1
+rustup override set 1.93.1
 ```
 
 ---
@@ -81,7 +81,7 @@ rustup override set 1.92.0
 
 Nix provides **reproducible builds** - the exact same tools and versions on every machine:
 
-1. **Pinned toolchain**: Rust 1.92.0 (MSRV) is locked via `flake.lock`
+1. **Pinned toolchain**: Rust 1.93.1 (MSRV) is locked via `flake.lock`
 2. **All CI tools included**: just, cargo-nextest, cargo-audit, gh, etc.
 3. **Cross-platform**: Works on Linux, macOS, and WSL
 4. **No system pollution**: Tools don't affect your global environment
@@ -555,7 +555,7 @@ just ci-parser-features-check
 
 ### MSRV Validation
 
-Validate against Minimum Supported Rust Version (1.92.0):
+Validate against Minimum Supported Rust Version (1.93.1):
 
 ```bash
 # Fast merge gate on MSRV
@@ -565,7 +565,7 @@ just ci-gate-msrv
 just ci-full-msrv
 
 # Or manually
-RUSTUP_TOOLCHAIN=1.92.0 just ci-gate
+RUSTUP_TOOLCHAIN=1.93.1 just ci-gate
 ```
 
 ### Cost Estimation
@@ -740,7 +740,7 @@ flake.nix
 ### Reproducibility Guarantees
 
 1. **Rust Version Pinning**
-   - MSRV 1.92.0 is specified in `flake.nix`
+   - MSRV 1.93.1 is specified in `flake.nix`
    - Also enforced via `rust-toolchain.toml`
    - CI workflows use the same version
 
@@ -927,7 +927,7 @@ nix --experimental-features 'nix-command flakes' develop
 # Wrong (uses system Rust):
 just ci-gate
 
-# Correct (uses Nix Rust 1.92.0):
+# Correct (uses Nix Rust 1.93.1):
 nix develop -c just ci-gate
 ```
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # clippy.toml
 # Keep pedantic on, but chill some noisy lints for a parser project.
 # warn-on-all-wildcard-imports = false
-msrv = "1.92"
+msrv = "1.93"
 
 # Common pedantic relaxations for parser projects
 allow-private-module-inception = true

--- a/docs/project/CI_LOCAL_VALIDATION.md
+++ b/docs/project/CI_LOCAL_VALIDATION.md
@@ -276,7 +276,7 @@ just ci-parser-features-check
 
 ### MSRV Validation
 
-Validate against Minimum Supported Rust Version (1.92.0):
+Validate against Minimum Supported Rust Version (1.93.1):
 
 ```bash
 # Fast merge gate on MSRV
@@ -286,7 +286,7 @@ just ci-gate-msrv
 just ci-full-msrv
 
 # Or manually
-RUSTUP_TOOLCHAIN=1.92.0 just ci-gate
+RUSTUP_TOOLCHAIN=1.93.1 just ci-gate
 ```
 
 ### Cost Estimation
@@ -426,7 +426,7 @@ flake.nix
 ### Reproducibility Guarantees
 
 1. **Rust Version Pinning**
-   - MSRV 1.92.0 is specified in `flake.nix`
+   - MSRV 1.93.1 is specified in `flake.nix`
    - Also enforced via `rust-toolchain.toml`
    - CI workflows use the same version
 
@@ -533,7 +533,7 @@ nix --experimental-features 'nix-command flakes' develop
 # Wrong (uses system Rust):
 just ci-gate
 
-# Correct (uses Nix Rust 1.92.0):
+# Correct (uses Nix Rust 1.93.1):
 nix develop -c just ci-gate
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,9 @@
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
 
-        # MSRV: Rust 1.92.0 - pinned for OpenAI Codex compatibility
+        # MSRV: Rust 1.93.1 - pinned for OpenAI Codex compatibility
         # This matches rust-toolchain.toml and CI workflows
-        rustVersion = "1.92.0";
+        rustVersion = "1.93.1";
         rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = [ "rust-src" "clippy" "rustfmt" ];
           targets = [ "wasm32-unknown-unknown" ];  # For WASM determinism checks

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Rust toolchain configuration for perl-lsp
-# MSRV: 1.92 (for OpenAI Codex compatibility)
+# MSRV: 1.93.1
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.1"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/xtask/src/tasks/check_toolchain.rs
+++ b/xtask/src/tasks/check_toolchain.rs
@@ -113,13 +113,13 @@ mod tests {
 
     #[test]
     fn parse_version_parts_handles_channel_prefixed_versions() {
-        assert_eq!(parse_version_parts("stable-1.92.0-x86_64-unknown-linux-gnu"), vec![1, 92, 0]);
+        assert_eq!(parse_version_parts("stable-1.93.1-x86_64-unknown-linux-gnu"), vec![1, 93, 1]);
     }
 
     #[test]
     fn parse_rustc_version_extracts_second_token() -> Result<()> {
-        let version = parse_rustc_version("rustc 1.92.0 (2aaa62b89 2025-10-28)\n")?;
-        assert_eq!(version, "1.92.0");
+        let version = parse_rustc_version("rustc 1.93.1 (abcdef012 2026-01-15)\n")?;
+        assert_eq!(version, "1.93.1");
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- Move the workspace MSRV and toolchain pins from Rust 1.92 → Rust 1.93.1 to take advantage of bugfixes (rustfmt ICE and Clippy false-positive fixes) and new lint/quality improvements in 1.93/1.93.1.
- This is a workspace-wide compatibility bump (not a code migration) so the pinned toolchain, CI, Nix, and MSRV metadata must stay in sync to avoid CI/validation mismatches.

### Description

- Updated `rust-toolchain.toml` to `channel = "1.93.1"` and adjusted the MSRV comment to `1.93.1`.
- Bumped workspace `rust-version` in `Cargo.toml` to `"1.93"` and updated `clippy.toml` `msrv` to `"1.93"`.
- Changed all GitHub Actions `toolchain:` entries from `1.92.0` to `1.93.1` and updated `flake.nix` `rustVersion` to `"1.93.1"` with matching comment.
- Updated `xtask/src/tasks/check_toolchain.rs` tests to expect `1.93.1` strings and refreshed local MSRV guidance in `book/src/ci/local-validation.md` and `docs/project/CI_LOCAL_VALIDATION.md`.

### Testing

- Attempted to run `./scripts/cargo-safe test -p xtask --profile agent --locked`, but it was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`).
- No other automated test or CI runs were executed locally in this environment; CI workflow files were updated so GitHub Actions will exercise the change on the next push/PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f604cb676c8333afa41aef3e4158f6)