### PR TITLE
feat(diagnostics): suppress dynamic import boundary warnings (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/tests/dynamic_boundary_diagnostics_tests.rs
+++ b/crates/perl-lsp-rs-core/tests/dynamic_boundary_diagnostics_tests.rs
@@ -1,0 +1,76 @@
+//! Diagnostics integration tests for dynamic import boundaries.
+
+use std::sync::Arc;
+
+use perl_diagnostics::codes::DiagnosticCode;
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticsProvider};
+use perl_parser::Parser;
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn unquoted_bareword_diagnostics(source: &str) -> Vec<Diagnostic> {
+    diagnostics_for(source)
+        .into_iter()
+        .filter(|diag| diag.code.as_deref() == Some(DiagnosticCode::UnquotedBareword.as_str()))
+        .collect()
+}
+
+#[test]
+fn dynamic_require_import_suppresses_unquoted_bareword_diagnostic()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+use strict 'subs';
+my $module = 'Dynamic::Loader';
+require $module;
+$module->import(qw(dynamic_func));
+print dynamic_func;
+"#;
+
+    let diags = unquoted_bareword_diagnostics(source);
+
+    assert!(
+        diags.is_empty(),
+        "dynamic require/import boundary should suppress exact PL109 for imported bareword: {diags:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn runtime_import_symbol_list_keeps_unquoted_bareword_diagnostic()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+use strict 'subs';
+my $module = 'Dynamic::Loader';
+my @names = ('dynamic_func');
+require $module;
+$module->import(@names);
+print dynamic_func;
+"#;
+
+    let diags = unquoted_bareword_diagnostics(source);
+
+    assert_eq!(
+        diags.len(),
+        1,
+        "runtime-computed import lists should not claim exact imported barewords: {diags:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn ordinary_missing_bareword_still_warns() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+use strict 'subs';
+print still_missing;
+"#;
+
+    let diags = unquoted_bareword_diagnostics(source);
+
+    assert_eq!(diags.len(), 1, "normal strict-subs bareword should still emit PL109");
+    Ok(())
+}

--- a/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/scope_analyzer.rs
@@ -1919,6 +1919,20 @@ fn collect_imported_barewords(ast: &Node) -> HashSet<String> {
         }
     }
 
+    fn require_variable_name(node: &Node) -> Option<String> {
+        let NodeKind::FunctionCall { name, args } = &node.kind else {
+            return None;
+        };
+        if name != "require" {
+            return None;
+        }
+        let first = args.first()?;
+        let NodeKind::Variable { sigil, name } = &first.kind else {
+            return None;
+        };
+        (sigil == "$" && !name.contains("::")).then(|| name.clone())
+    }
+
     fn maybe_record_manual_imports(
         node: &Node,
         required_modules: &HashSet<String>,
@@ -1964,6 +1978,52 @@ fn collect_imported_barewords(ast: &Node) -> HashSet<String> {
         }
     }
 
+    fn maybe_record_dynamic_manual_imports(
+        node: &Node,
+        dynamic_require_vars: &HashSet<String>,
+        imported: &mut HashSet<String>,
+    ) {
+        let NodeKind::MethodCall { object, method, args } = &node.kind else {
+            return;
+        };
+        if method != "import" {
+            return;
+        }
+        let NodeKind::Variable { sigil, name } = &object.kind else {
+            return;
+        };
+        if sigil != "$" || !dynamic_require_vars.contains(name) {
+            return;
+        }
+
+        for arg in args {
+            match &arg.kind {
+                NodeKind::String { value, .. } => push_symbol(imported, "", value),
+                NodeKind::Identifier { name } => {
+                    if name.starts_with("qw") {
+                        let content = name
+                            .trim_start_matches("qw")
+                            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+                            .trim_end_matches(|c: char| ")]}/|!>".contains(c));
+                        for token in content.split_whitespace() {
+                            push_symbol(imported, "", token);
+                        }
+                    } else {
+                        push_symbol(imported, "", name);
+                    }
+                }
+                NodeKind::ArrayLiteral { elements } => {
+                    for el in elements {
+                        if let NodeKind::String { value, .. } = &el.kind {
+                            push_symbol(imported, "", value);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Unwrap an `ExpressionStatement` node to its inner expression, or return
     /// the node itself if it is not an expression statement.
     fn inner_node(stmt: &Node) -> &Node {
@@ -1998,9 +2058,15 @@ fn collect_imported_barewords(ast: &Node) -> HashSet<String> {
                     .iter()
                     .filter_map(|stmt| require_module_name(inner_node(stmt)))
                     .collect();
-                if !required_modules.is_empty() {
+                let dynamic_require_vars: HashSet<String> = statements
+                    .iter()
+                    .filter_map(|stmt| require_variable_name(inner_node(stmt)))
+                    .collect();
+                if !required_modules.is_empty() || !dynamic_require_vars.is_empty() {
                     for stmt in statements {
-                        maybe_record_manual_imports(inner_node(stmt), &required_modules, imported);
+                        let inner = inner_node(stmt);
+                        maybe_record_manual_imports(inner, &required_modules, imported);
+                        maybe_record_dynamic_manual_imports(inner, &dynamic_require_vars, imported);
                     }
                 }
             }

--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -4067,6 +4067,54 @@ print exported_func;
 }
 
 #[test]
+fn dynamic_require_with_matching_variable_import_suppresses_strict_subs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+my $module = 'Dynamic::Loader';
+require $module;
+$module->import(qw(dynamic_func other_func));
+print dynamic_func;
+print other_func;
+"#;
+    let issues = scope_issues_strict(code);
+
+    for symbol in &["dynamic_func", "other_func"] {
+        assert!(
+            !issues.iter().any(|issue| {
+                matches!(issue.kind, IssueKind::UnquotedBareword) && &issue.variable_name == symbol
+            }),
+            "matching dynamic require/import pair should suppress exact strict 'subs' for {}",
+            symbol
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn dynamic_import_symbol_list_does_not_suppress_unrelated_bareword()
+-> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+my $module = 'Dynamic::Loader';
+my @names = ('dynamic_func');
+require $module;
+$module->import(@names);
+print dynamic_func;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "dynamic_func"
+        }),
+        "runtime-computed import lists must not claim exact imported barewords"
+    );
+    Ok(())
+}
+
+#[test]
 fn multiple_imports_from_same_required_module() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';


### PR DESCRIPTION
Problem: Dynamic require/import boundaries could still produce exact strict-subs diagnostics for explicitly imported barewords.\nFix: Treat matching \equire ; ->import(...)\ pairs as dynamic import boundaries for literal import names while preserving diagnostics for runtime-computed import lists and normal missing barewords.\nVerification: \cargo test -p perl-lsp-rs-core --profile agent --locked diagnostics -- --nocapture\; \cargo test -p perl-semantic-analyzer --profile agent --locked dynamic -- --nocapture\; \cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked\; \cargo check -p perl-lsp-rs-core --all-targets --profile agent --locked\; \cargo clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs\; \cargo clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs\; \cargo xtask semantic-scorecard --check\; \cargo xtask semantic-shadow-compare --check\; \cargo xtask fmt --check\; \git diff --check\.