### PR TITLE
feat(parser): render accuracy denominator status (#0000)

### DIFF
--- a/.kiro/specs/parser-accuracy-observability/tasks.md
+++ b/.kiro/specs/parser-accuracy-observability/tasks.md
@@ -26,12 +26,12 @@ Build a layered parser accuracy scorecard that starts with denominator visibilit
     - Report fixture_count, fixture_family_count, scored_line_count, scored_symbol_count, fully_labeled_region_count, partial_labeled_region_count, unknown_region_count, negative_region_count, dynamic_boundary_case_count, unsupported_construct_case_count, real_project_file_count, generated_fixture_count, and hand_labeled_fixture_count
     - _Verify: targeted xtask tests and schema validation_
 
-- [ ] 3. Wire parser status visibility
-  - [ ] 3.1 Extend parser status rendering with accuracy artifact summary
+- [x] 3. Wire parser status visibility
+  - [x] 3.1 Extend parser status rendering with accuracy artifact summary
     - Show denominator rows and `insufficient_data` rows without pretending they are zero
     - Link to parser accuracy artifact location and spec
     - _Verify: `cargo test -p xtask update_status::parser --profile agent --locked`_
-  - [ ] 3.2 Preserve existing clean-parse status rows
+  - [x] 3.2 Preserve existing clean-parse status rows
     - Do not remove current clean parse, recovery, token health, or failure worklist rows
     - _Verify: existing parser status marker tests_
 

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -26,6 +26,15 @@
 | **Strict-clean subset** | insufficient_data | 10 pinned modules; run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
 
+## Parser Accuracy Observability
+
+| Layer | State | Notes | Source |
+| --- | --- | --- |
+<!-- BEGIN: PARSER_ACCURACY_SUMMARY -->
+| **Accuracy denominator** | insufficient_data | Generate with `cargo xtask metrics parser-accuracy --json`; missing artifact is not treated as zero | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
+| **Accuracy scorers** | insufficient_data | line/AST/symbol scoring rows wait for real denominators and validated artifact input | `.ci/schemas/parser-accuracy.schema.json` |
+<!-- END: PARSER_ACCURACY_SUMMARY -->
+
 ## Parser Performance Regimes
 
 | Regime | Value | Notes | Source |

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -21,7 +21,7 @@ mod failure;
 use failure::build_failure_worklist;
 
 #[cfg(test)]
-const PARSER_STATUS_MARKER_NAMES: [&str; 8] = [
+const PARSER_STATUS_MARKER_NAMES: [&str; 9] = [
     "PARSER_TRACKING_TABLE",
     "PARSER_PERFORMANCE_TABLE",
     "PARSER_METRICS_BULLETS",
@@ -29,6 +29,7 @@ const PARSER_STATUS_MARKER_NAMES: [&str; 8] = [
     "PARSER_NODEKIND_ROW",
     "PARSER_RELIABILITY_ROW",
     "PARSER_STRICT_CLEAN_ROW",
+    "PARSER_ACCURACY_SUMMARY",
     "PARSER_FAILURE_WORKLIST",
 ];
 
@@ -55,6 +56,7 @@ pub(super) struct ParserMetrics {
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
     pub performance_scorecard: Option<ParserPerformanceScorecard>,
+    pub parser_accuracy: Option<ParserAccuracyArtifactSummary>,
     pub token_metrics: TokenHealthMetrics,
 }
 
@@ -70,6 +72,48 @@ struct ParserPerfMetric {
     median_ns: u128,
     p95_ns: u128,
     mean_ns: u128,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ParserAccuracyArtifactSummary {
+    schema_version: u32,
+    subsystem: String,
+    generated_at: String,
+    commit: String,
+    cadence: String,
+    denominator: ParserAccuracyDenominator,
+    families: Vec<ParserAccuracyFamilySummary>,
+    metrics: Vec<ParserAccuracyMetricSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ParserAccuracyDenominator {
+    fixture_count: u64,
+    fixture_family_count: u64,
+    scored_line_count: u64,
+    scored_symbol_count: u64,
+    fully_labeled_region_count: u64,
+    partial_labeled_region_count: u64,
+    unknown_region_count: u64,
+    negative_region_count: u64,
+    dynamic_boundary_case_count: u64,
+    unsupported_construct_case_count: u64,
+    real_project_file_count: u64,
+    generated_fixture_count: u64,
+    hand_labeled_fixture_count: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ParserAccuracyFamilySummary {
+    family: String,
+    fixture_count: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+enum ParserAccuracyMetricSummary {
+    Measured { metric: String, value: f64, sample_count: u64 },
+    InsufficientData { metric: String, reason: String, sample_count: u64 },
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -88,6 +132,7 @@ pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
         common_corpus_receipt,
         common_corpus_pinned,
         performance_scorecard: read_parser_performance_scorecard(root),
+        parser_accuracy: read_parser_accuracy_artifact(root),
         token_metrics: super::token::collect_token_health_metrics(root),
     }
 }
@@ -112,6 +157,16 @@ fn read_parser_performance_scorecard(root: &Path) -> Option<ParserPerformanceSco
     let path = root.join("docs/project/status/parser_performance_scorecard.json");
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str(&raw).ok()
+}
+
+fn read_parser_accuracy_artifact(root: &Path) -> Option<ParserAccuracyArtifactSummary> {
+    let path = root.join("target/metrics/parser_accuracy.json");
+    let raw = fs::read_to_string(path).ok()?;
+    let artifact: ParserAccuracyArtifactSummary = serde_json::from_str(&raw).ok()?;
+    if artifact.schema_version != 1 || artifact.subsystem != "parser_accuracy" {
+        return None;
+    }
+    Some(artifact)
 }
 
 pub(super) fn count_corpus_sections(root: &Path) -> usize {
@@ -167,6 +222,91 @@ fn format_perf_metric_row(name: &str, metric: Option<&ParserPerfMetric>) -> Stri
             )
         },
     )
+}
+
+fn parser_accuracy_rows(artifact: Option<&ParserAccuracyArtifactSummary>) -> String {
+    const ARTIFACT_PATH: &str = "`target/metrics/parser_accuracy.json`";
+    const SPEC_PATH: &str = "`.kiro/specs/parser-accuracy-observability`";
+    const SCHEMA_PATH: &str = "`.ci/schemas/parser-accuracy.schema.json`";
+
+    let Some(artifact) = artifact else {
+        return format!(
+            "| **Accuracy denominator** | insufficient_data | Generate with `cargo xtask metrics parser-accuracy --json`; missing artifact is not treated as zero | {ARTIFACT_PATH}; {SPEC_PATH} |\n\
+             | **Accuracy scorers** | insufficient_data | line/AST/symbol scoring rows wait for real denominators and validated artifact input | {SCHEMA_PATH} |"
+        );
+    };
+
+    let d = &artifact.denominator;
+    let family_summary = parser_accuracy_family_summary(&artifact.families);
+    let metric_summary = parser_accuracy_metric_summary(&artifact.metrics);
+    format!(
+        "| **Accuracy denominator** | {} fixtures / {} families | {} scored lines, {} scored symbols, {} fully labeled, {} partial, {} unknown, {} negative, {} dynamic boundaries, {} unsupported, {} real-project, {} generated, {} hand-labeled; cadence `{}`, commit `{}`, generated `{}` | {ARTIFACT_PATH}; {SPEC_PATH} |\n\
+         | **Accuracy families** | {} | fixture family inventory from parser accuracy manifest | {ARTIFACT_PATH} |\n\
+         | **Accuracy scorers** | {} | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | {SCHEMA_PATH} |",
+        d.fixture_count,
+        d.fixture_family_count,
+        d.scored_line_count,
+        d.scored_symbol_count,
+        d.fully_labeled_region_count,
+        d.partial_labeled_region_count,
+        d.unknown_region_count,
+        d.negative_region_count,
+        d.dynamic_boundary_case_count,
+        d.unsupported_construct_case_count,
+        d.real_project_file_count,
+        d.generated_fixture_count,
+        d.hand_labeled_fixture_count,
+        artifact.cadence,
+        artifact.commit,
+        artifact.generated_at,
+        family_summary,
+        metric_summary,
+    )
+}
+
+fn parser_accuracy_family_summary(families: &[ParserAccuracyFamilySummary]) -> String {
+    if families.is_empty() {
+        return "insufficient_data".to_string();
+    }
+
+    let rendered = families
+        .iter()
+        .take(6)
+        .map(|family| format!("{} ({})", family.family, family.fixture_count))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let hidden = families.len().saturating_sub(6);
+    if hidden == 0 { rendered } else { format!("{rendered}, +{hidden} more") }
+}
+
+fn parser_accuracy_metric_summary(metrics: &[ParserAccuracyMetricSummary]) -> String {
+    let mut measured = Vec::new();
+    let mut insufficient = Vec::new();
+
+    for metric in metrics {
+        match metric {
+            ParserAccuracyMetricSummary::Measured { metric, value, sample_count } => {
+                measured.push(format!("{metric}={value:.1} (n={sample_count})"));
+            }
+            ParserAccuracyMetricSummary::InsufficientData { metric, reason, sample_count } => {
+                insufficient
+                    .push(format!("{metric}: insufficient_data ({reason}; n={sample_count})"));
+            }
+        }
+    }
+
+    if measured.is_empty() && insufficient.is_empty() {
+        return "insufficient_data".to_string();
+    }
+
+    let mut parts = Vec::new();
+    if !measured.is_empty() {
+        parts.push(format!("measured {}", measured.join(", ")));
+    }
+    if !insufficient.is_empty() {
+        parts.push(insufficient.join(", "));
+    }
+    parts.join("; ")
 }
 
 // ---------------------------------------------------------------------------
@@ -323,6 +463,8 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         |scorecard| format!("epoch {} (UTC seconds)", scorecard.generated_at_epoch_s),
     );
 
+    let parser_accuracy_summary = parser_accuracy_rows(metrics.parser_accuracy.as_ref());
+
     let token = &metrics.token_metrics;
     let token_table = format!(
         "| **TokenKind variants** | {} | enum size in `perl-token` | `crates/perl-token/src/lib.rs` |\n\
@@ -373,6 +515,7 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
     text = replace_parser_status_block(&text, "PARSER_NODEKIND_ROW", &nodekind_row)?;
     text = replace_parser_status_block(&text, "PARSER_RELIABILITY_ROW", &reliability_row)?;
     text = replace_parser_status_block(&text, "PARSER_STRICT_CLEAN_ROW", &strict_clean_row)?;
+    text = replace_parser_status_block(&text, "PARSER_ACCURACY_SUMMARY", &parser_accuracy_summary)?;
     text = replace_parser_status_block(&text, "PARSER_FAILURE_WORKLIST", &failure_worklist)?;
     Ok(text)
 }

--- a/xtask/src/tasks/update_status/parser/tests.rs
+++ b/xtask/src/tasks/update_status/parser/tests.rs
@@ -7,6 +7,7 @@ fn parser_status_template() -> &'static str {
          <!-- BEGIN: PARSER_NODEKIND_ROW -->\nold\n<!-- END: PARSER_NODEKIND_ROW -->\n\
          <!-- BEGIN: PARSER_RELIABILITY_ROW -->\nold\n<!-- END: PARSER_RELIABILITY_ROW -->\n\
          <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->\nold\n<!-- END: PARSER_STRICT_CLEAN_ROW -->\n\
+         <!-- BEGIN: PARSER_ACCURACY_SUMMARY -->\nold\n<!-- END: PARSER_ACCURACY_SUMMARY -->\n\
          <!-- BEGIN: PARSER_PERFORMANCE_TABLE -->\nold\n<!-- END: PARSER_PERFORMANCE_TABLE -->\n\
          <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n\
          <!-- BEGIN: TOKEN_HEALTH_TABLE -->\nold\n<!-- END: TOKEN_HEALTH_TABLE -->\n\
@@ -88,6 +89,7 @@ fn test_parser_nodekind_row_renders() -> Result<()> {
         common_corpus_receipt: None,
         common_corpus_pinned: 10,
         performance_scorecard: None,
+        parser_accuracy: None,
         token_metrics: token::token_metrics_fixture(),
     };
     let template = parser_status_template();
@@ -113,6 +115,7 @@ fn test_parser_strict_clean_row_no_receipt() -> Result<()> {
         common_corpus_receipt: None,
         common_corpus_pinned: 10,
         performance_scorecard: None,
+        parser_accuracy: None,
         token_metrics: token::token_metrics_fixture(),
     };
     let template = parser_status_template();
@@ -142,6 +145,7 @@ fn test_parser_failure_worklist_no_receipt_reports_insufficient_data() -> Result
         common_corpus_receipt: None,
         common_corpus_pinned: 10,
         performance_scorecard: None,
+        parser_accuracy: None,
         token_metrics: token::token_metrics_fixture(),
     };
     let result = generate_parser_status(&metrics, parser_status_template())?;
@@ -153,6 +157,169 @@ fn test_parser_failure_worklist_no_receipt_reports_insufficient_data() -> Result
         result.contains("| insufficient_data |"),
         "failure worklist missing-receipt count must be insufficient_data"
     );
+    Ok(())
+}
+
+#[test]
+fn test_parser_accuracy_missing_artifact_reports_insufficient_data() -> Result<()> {
+    let metrics = ParserMetrics {
+        syntax_sections: 611,
+        system_receipt: None,
+        cpan_receipt: None,
+        project_corpus: None,
+        common_corpus_receipt: None,
+        common_corpus_pinned: 10,
+        performance_scorecard: None,
+        parser_accuracy: None,
+        token_metrics: token::token_metrics_fixture(),
+    };
+    let result = generate_parser_status(&metrics, parser_status_template())?;
+    assert!(
+        result.contains("| **Accuracy denominator** | insufficient_data |"),
+        "missing parser accuracy artifact must report insufficient_data"
+    );
+    assert!(
+        result.contains("cargo xtask metrics parser-accuracy --json"),
+        "missing parser accuracy artifact row should include the generation command"
+    );
+    assert!(
+        result.contains(".kiro/specs/parser-accuracy-observability"),
+        "parser accuracy status should link the authoritative spec"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_parser_accuracy_artifact_renders_denominator_and_insufficient_rows() -> Result<()> {
+    let metrics = ParserMetrics {
+        syntax_sections: 611,
+        system_receipt: None,
+        cpan_receipt: None,
+        project_corpus: None,
+        common_corpus_receipt: None,
+        common_corpus_pinned: 10,
+        performance_scorecard: None,
+        parser_accuracy: Some(ParserAccuracyArtifactSummary {
+            schema_version: 1,
+            subsystem: "parser_accuracy".to_string(),
+            generated_at: "2026-05-02T15:00:00Z".to_string(),
+            commit: "abc123".to_string(),
+            cadence: "pr".to_string(),
+            denominator: ParserAccuracyDenominator {
+                fixture_count: 2,
+                fixture_family_count: 2,
+                scored_line_count: 3,
+                scored_symbol_count: 2,
+                fully_labeled_region_count: 1,
+                partial_labeled_region_count: 1,
+                unknown_region_count: 1,
+                negative_region_count: 1,
+                dynamic_boundary_case_count: 1,
+                unsupported_construct_case_count: 0,
+                real_project_file_count: 0,
+                generated_fixture_count: 0,
+                hand_labeled_fixture_count: 2,
+            },
+            families: vec![
+                ParserAccuracyFamilySummary {
+                    family: "dynamic_require".to_string(),
+                    fixture_count: 1,
+                },
+                ParserAccuracyFamilySummary { family: "packages".to_string(), fixture_count: 1 },
+            ],
+            metrics: vec![
+                ParserAccuracyMetricSummary::Measured {
+                    metric: "denominator_fixture_count".to_string(),
+                    value: 2.0,
+                    sample_count: 2,
+                },
+                ParserAccuracyMetricSummary::InsufficientData {
+                    metric: "line_construct_f1".to_string(),
+                    reason: "line-level gold scorer is not wired yet".to_string(),
+                    sample_count: 0,
+                },
+            ],
+        }),
+        token_metrics: token::token_metrics_fixture(),
+    };
+    let result = generate_parser_status(&metrics, parser_status_template())?;
+    assert!(
+        result.contains("| **Accuracy denominator** | 2 fixtures / 2 families |"),
+        "parser accuracy denominator row should render fixture and family counts"
+    );
+    assert!(
+        result.contains("3 scored lines, 2 scored symbols"),
+        "parser accuracy denominator row should render labeled denominator counts"
+    );
+    assert!(
+        result.contains("dynamic_require (1), packages (1)"),
+        "parser accuracy family row should render family inventory"
+    );
+    assert!(
+        result.contains("line_construct_f1: insufficient_data"),
+        "unwired accuracy scorer rows must remain insufficient_data"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_read_parser_accuracy_artifact_loads_target_metrics() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let metrics_dir = tmp.path().join("target").join("metrics");
+    std::fs::create_dir_all(&metrics_dir)?;
+    std::fs::write(
+        metrics_dir.join("parser_accuracy.json"),
+        r#"{
+  "schema_version": 1,
+  "subsystem": "parser_accuracy",
+  "generated_at": "2026-05-02T15:00:00Z",
+  "commit": "abc123",
+  "cadence": "pr",
+  "denominator": {
+    "fixture_count": 2,
+    "fixture_family_count": 2,
+    "scored_line_count": 3,
+    "scored_symbol_count": 2,
+    "fully_labeled_region_count": 1,
+    "partial_labeled_region_count": 1,
+    "unknown_region_count": 1,
+    "negative_region_count": 1,
+    "dynamic_boundary_case_count": 1,
+    "unsupported_construct_case_count": 0,
+    "real_project_file_count": 0,
+    "generated_fixture_count": 0,
+    "hand_labeled_fixture_count": 2
+  },
+  "families": [
+    {
+      "family": "packages",
+      "fixture_count": 1,
+      "label_modes": ["full"],
+      "scored_line_count": 2,
+      "scored_symbol_count": 1,
+      "dynamic_boundary_case_count": 0,
+      "unsupported_construct_case_count": 0
+    }
+  ],
+  "metrics": [
+    {
+      "state": "insufficient_data",
+      "metric": "line_construct_f1",
+      "reason": "line-level gold scorer is not wired yet",
+      "sample_count": 0,
+      "confidence": "low"
+    }
+  ],
+  "failure_packets": [],
+  "gold_drift": {},
+  "metric_runtime": {}
+}"#,
+    )?;
+
+    let artifact = read_parser_accuracy_artifact(tmp.path())
+        .ok_or_else(|| color_eyre::eyre::eyre!("valid parser accuracy artifact should load"))?;
+    assert_eq!(artifact.denominator.fixture_count, 2);
+    assert_eq!(artifact.metrics.len(), 1);
     Ok(())
 }
 
@@ -192,6 +359,7 @@ fn test_parser_performance_table_renders_with_scorecard() -> Result<()> {
         common_corpus_receipt: None,
         common_corpus_pinned: 10,
         performance_scorecard: Some(scorecard),
+        parser_accuracy: None,
         token_metrics: token::token_metrics_fixture(),
     };
 
@@ -467,6 +635,7 @@ fn test_parser_strict_clean_row_with_receipt() -> Result<()> {
         common_corpus_receipt: Some(receipt),
         common_corpus_pinned: 10,
         performance_scorecard: None,
+        parser_accuracy: None,
         token_metrics: token::token_metrics_fixture(),
     };
     let template = parser_status_template();
@@ -493,6 +662,7 @@ fn token_health_table_renders_correctly_from_fixture() -> Result<()> {
         common_corpus_receipt: None,
         common_corpus_pinned: 0,
         performance_scorecard: None,
+        parser_accuracy: None,
         token_metrics: token::token_metrics_fixture(),
     };
     let template = parser_status_template();


### PR DESCRIPTION
Problem: Parser accuracy denominator artifacts existed, but parser status had no visibility into them and could blur missing accuracy rows with unmeasured status.
Fix: Render a parser accuracy section from `target/metrics/parser_accuracy.json` when present, keep missing artifacts as `insufficient_data`, preserve existing clean-parse rows, and mark `.kiro` Task 3 complete.
Verification: `cargo test -p xtask --profile agent --locked update_status::parser`; `cargo check -p xtask --all-targets --profile agent --locked`; `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics parser-accuracy --json`; `cargo xtask fmt --check`; `git diff --check`.
