### PR TITLE
feat(perl-symbol): project method call sites (#0000)

### DIFF
--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -60,6 +60,12 @@ pub fn symbol_refs_to_semantic_facts(
         let occurrence_kind = match symbol_ref.kind {
             SymbolRefKind::Variable(_) => OccurrenceKind::Read,
             SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+            SymbolRefKind::MethodCall => OccurrenceKind::MethodCall,
+            SymbolRefKind::StaticMethodCall => OccurrenceKind::StaticMethodCall,
+        };
+        let confidence = match symbol_ref.kind {
+            SymbolRefKind::MethodCall => Confidence::Medium,
+            _ => Confidence::High,
         };
         let entity_id = entity_ids_by_qualified_name.get(&symbol_ref.qualified_name).copied();
         let occurrence_id = OccurrenceId(stable_id(
@@ -75,7 +81,7 @@ pub fn symbol_refs_to_semantic_facts(
             anchor_id,
             scope_id: None,
             provenance: Provenance::ExactAst,
-            confidence: Confidence::High,
+            confidence,
         });
 
         if let Some(to_entity_id) = entity_id {
@@ -513,17 +519,42 @@ mod tests {
                 full_span: (21, 23),
                 anchor_span: None,
             },
+            SymbolRef {
+                kind: SymbolRefKind::StaticMethodCall,
+                name: "new".to_string(),
+                qualified_name: "Foo::new".to_string(),
+                sigil: None,
+                package_qualifier: Some("Foo".to_string()),
+                full_span: (24, 32),
+                anchor_span: None,
+            },
+            SymbolRef {
+                kind: SymbolRefKind::MethodCall,
+                name: "save".to_string(),
+                qualified_name: "save".to_string(),
+                sigil: None,
+                package_qualifier: None,
+                full_span: (33, 45),
+                anchor_span: None,
+            },
         ];
         let mut entity_map = BTreeMap::new();
         entity_map.insert("Foo::run".to_string(), EntityId(42));
+        entity_map.insert("Foo::new".to_string(), EntityId(43));
 
         let facts = symbol_refs_to_semantic_facts(&refs, FileId(7), &entity_map);
-        assert_eq!(facts.anchors.len(), 2);
-        assert_eq!(facts.occurrences.len(), 2);
-        assert_eq!(facts.reference_edges.len(), 1);
+        assert_eq!(facts.anchors.len(), 4);
+        assert_eq!(facts.occurrences.len(), 4);
+        assert_eq!(facts.reference_edges.len(), 2);
         assert_eq!(facts.occurrences[0].kind, OccurrenceKind::Call);
         assert_eq!(facts.occurrences[1].kind, OccurrenceKind::Read);
+        assert_eq!(facts.occurrences[2].kind, OccurrenceKind::StaticMethodCall);
+        assert_eq!(facts.occurrences[3].kind, OccurrenceKind::MethodCall);
         assert_eq!(facts.occurrences[0].entity_id, Some(EntityId(42)));
         assert_eq!(facts.occurrences[1].entity_id, None);
+        assert_eq!(facts.occurrences[2].entity_id, Some(EntityId(43)));
+        assert_eq!(facts.occurrences[3].entity_id, None);
+        assert_eq!(facts.occurrences[2].confidence, Confidence::High);
+        assert_eq!(facts.occurrences[3].confidence, Confidence::Medium);
     }
 }

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -3,6 +3,7 @@
 //! This phase intentionally targets a narrow, high-confidence subset:
 //! - variable references (`$x`, `@items`, `%opts`, `$#array`)
 //! - subroutine call references (`foo(...)` / bareword calls via `NodeKind::FunctionCall`)
+//! - method call references (`$obj->method(...)`, `Pkg->method(...)`)
 //! - package-qualified forms where the AST encodes them directly
 //!   (`$Pkg::var`, `Pkg::func(...)`)
 //!
@@ -11,8 +12,6 @@
 //! The following reference types are **not** emitted in this phase:
 //! - `&foo` / `\&foo` code-reference variables (sigil `&`) — `VarKind` has no `CodeRef` variant
 //! - `*foo` typeglob variables (sigil `*`) — reserved for a future phase
-//! - Method calls (`$obj->method(...)`, `NodeKind::MethodCall`) — method name is not a
-//!   `Node`, so extraction requires a dedicated `MethodCallRef` kind (future phase)
 //! - Indirect-object calls (`new Class @args`, `NodeKind::IndirectCall`) — same reason
 //! - Subroutine signature parameter bindings (`MandatoryParameter`, `SlurpyParameter`,
 //!   `NamedParameter`) — these are declaration sites, not reference sites.  Optional
@@ -28,6 +27,10 @@ pub enum SymbolRefKind {
     Variable(VarKind),
     /// Subroutine invocation (`foo(...)`).
     SubroutineCall,
+    /// Instance method invocation (`$obj->method(...)`, `$self->method(...)`).
+    MethodCall,
+    /// Static/package method invocation (`Package->method(...)`).
+    StaticMethodCall,
 }
 
 /// A projected view of a symbol reference/use site in Perl source.
@@ -123,10 +126,43 @@ fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
             }
         }
 
+        NodeKind::MethodCall { object, method, args } => {
+            let (package_qualifier, qualified_name, kind) = static_method_target(object, method)
+                .map(|(package, qualified)| {
+                    (Some(package), qualified, SymbolRefKind::StaticMethodCall)
+                })
+                .unwrap_or_else(|| (None, method.clone(), SymbolRefKind::MethodCall));
+
+            out.push(SymbolRef {
+                kind,
+                name: method.clone(),
+                qualified_name,
+                sigil: None,
+                package_qualifier,
+                full_span: (node.location.start, node.location.end),
+                anchor_span: None,
+            });
+
+            walk(object, out);
+            for arg in args {
+                walk(arg, out);
+            }
+        }
+
         _ => {
             node.for_each_child(|child| walk(child, out));
         }
     }
+}
+
+fn static_method_target(object: &Node, method: &str) -> Option<(String, String)> {
+    let NodeKind::Identifier { name } = &object.kind else {
+        return None;
+    };
+    if name.is_empty() || method.is_empty() {
+        return None;
+    }
+    Some((name.clone(), format!("{name}::{method}")))
 }
 
 /// Split a potentially package-qualified name into `(qualifier, bare, full)`.

--- a/crates/perl-symbol/tests/edge_cases_and_regressions.rs
+++ b/crates/perl-symbol/tests/edge_cases_and_regressions.rs
@@ -63,6 +63,8 @@ fn api_regression_every_documented_name_is_reachable_at_crate_root() -> Result<(
     let _sr_size = std::mem::size_of::<SymbolRef>();
     let _f8: fn(&Node) -> Vec<SymbolRef> = extract_symbol_refs;
     let _rk = SymbolRefKind::SubroutineCall;
+    let _method = SymbolRefKind::MethodCall;
+    let _static_method = SymbolRefKind::StaticMethodCall;
 
     Ok(())
 }

--- a/crates/perl-symbol/tests/facade_api_completeness.rs
+++ b/crates/perl-symbol/tests/facade_api_completeness.rs
@@ -86,6 +86,8 @@ fn surface_decl_accessible() {
 #[test]
 fn surface_ref_accessible() {
     let _kind = SymbolRefKind::SubroutineCall;
+    let _method = SymbolRefKind::MethodCall;
+    let _static_method = SymbolRefKind::StaticMethodCall;
     let _fn: fn(&perl_ast::Node) -> Vec<SymbolRef> = extract_symbol_refs;
 }
 

--- a/crates/perl-symbol/tests/prop_adapter_determinism.rs
+++ b/crates/perl-symbol/tests/prop_adapter_determinism.rs
@@ -111,6 +111,8 @@ fn arb_symbol_ref_kind() -> impl Strategy<Value = SymbolRefKind> {
     prop_oneof![
         arb_var_kind().prop_map(SymbolRefKind::Variable),
         Just(SymbolRefKind::SubroutineCall),
+        Just(SymbolRefKind::MethodCall),
+        Just(SymbolRefKind::StaticMethodCall),
     ]
 }
 

--- a/crates/perl-symbol/tests/prop_anchor_referential_integrity.rs
+++ b/crates/perl-symbol/tests/prop_anchor_referential_integrity.rs
@@ -112,6 +112,8 @@ fn arb_symbol_ref_kind() -> impl Strategy<Value = SymbolRefKind> {
     prop_oneof![
         arb_var_kind().prop_map(SymbolRefKind::Variable),
         Just(SymbolRefKind::SubroutineCall),
+        Just(SymbolRefKind::MethodCall),
+        Just(SymbolRefKind::StaticMethodCall),
     ]
 }
 

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -209,6 +209,64 @@ fn function_call_args_are_walked_for_refs() -> Result<()> {
 }
 
 #[test]
+fn static_method_call_reference_is_projected() -> Result<()> {
+    let object = Node::new(NodeKind::Identifier { name: "My::Class".to_string() }, loc(0, 9));
+    let call = Node::new(
+        NodeKind::MethodCall {
+            object: Box::new(object),
+            method: "build".to_string(),
+            args: vec![],
+        },
+        loc(0, 16),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![call] }, loc(0, 16));
+
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].kind, SymbolRefKind::StaticMethodCall);
+    assert_eq!(refs[0].name, "build");
+    assert_eq!(refs[0].qualified_name, "My::Class::build");
+    assert_eq!(refs[0].package_qualifier.as_deref(), Some("My::Class"));
+    assert_eq!(refs[0].sigil, None);
+    Ok(())
+}
+
+#[test]
+fn instance_method_call_reference_is_projected_with_receiver_refs() -> Result<()> {
+    let object = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "self".to_string() },
+        loc(0, 5),
+    );
+    let arg = Node::new(
+        NodeKind::Variable { sigil: "$".to_string(), name: "value".to_string() },
+        loc(13, 19),
+    );
+    let call = Node::new(
+        NodeKind::MethodCall {
+            object: Box::new(object),
+            method: "save".to_string(),
+            args: vec![arg],
+        },
+        loc(0, 20),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![call] }, loc(0, 20));
+
+    let refs = extract_symbol_refs(&program);
+
+    assert_eq!(refs.len(), 3);
+    assert_eq!(refs[0].kind, SymbolRefKind::MethodCall);
+    assert_eq!(refs[0].name, "save");
+    assert_eq!(refs[0].qualified_name, "save");
+    assert_eq!(refs[0].anchor_span, None);
+    assert_eq!(refs[1].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[1].name, "self");
+    assert_eq!(refs[2].kind, SymbolRefKind::Variable(VarKind::Scalar));
+    assert_eq!(refs[2].name, "value");
+    Ok(())
+}
+
+#[test]
 fn parser_sentinel_names_are_not_emitted_as_refs() -> Result<()> {
     // The parser uses synthetic FunctionCall names for constructs that are not real
     // subroutine calls: "->()"/\&{}\" for coderef invocations, "field" for OOP


### PR DESCRIPTION
Problem: Method calls were still omitted from perl-symbol reference projection, leaving semantic ReferenceEdge consumers without typed method call occurrences.
Fix: Add MethodCall and StaticMethodCall SymbolRef kinds, project NodeKind::MethodCall into typed occurrences, and keep unresolved instance methods medium-confidence instead of inventing targets.
Verification: `cargo test -p perl-symbol --profile agent --locked`; `cargo check -p perl-symbol --all-targets --profile agent --locked`; `cargo clippy -p perl-symbol --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`