### PR TITLE
test(semantic): guard dynamic import variable matching (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
+++ b/crates/perl-semantic-analyzer/tests/scope_and_symbol_tests.rs
@@ -4115,6 +4115,28 @@ print dynamic_func;
 }
 
 #[test]
+fn mismatched_dynamic_import_var_flags_bareword() -> Result<(), Box<dyn std::error::Error>> {
+    let code = r#"
+use strict 'subs';
+my $loader = 'Dynamic::Loader';
+my $module = 'Other::Loader';
+require $loader;
+$module->import(qw(dynamic_func));
+print dynamic_func;
+"#;
+    let issues = scope_issues_strict(code);
+
+    assert!(
+        issues.iter().any(|issue| {
+            matches!(issue.kind, IssueKind::UnquotedBareword)
+                && issue.variable_name == "dynamic_func"
+        }),
+        "dynamic variable imports must require the same variable before suppressing strict 'subs'"
+    );
+    Ok(())
+}
+
+#[test]
 fn multiple_imports_from_same_required_module() -> Result<(), Box<dyn std::error::Error>> {
     let code = r#"
 use strict 'subs';


### PR DESCRIPTION
Problem: #7836 suppresses literal imports behind dynamic require/import pairs, but lacked a negative regression for mismatched require/import variables.
Fix: Add a semantic analyzer test proving `$module->import(qw(...))` only suppresses strict bareword diagnostics when the same variable was required.
Verification: `cargo test -p perl-semantic-analyzer --profile agent --locked mismatched_dynamic_import_var_flags_bareword -- --nocapture`; `cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked`; `cargo clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`.