### PR TITLE
feat(perl-symbol): classify coderef and typeglob sites (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
@@ -206,9 +206,12 @@ fn classify_hover_result(
 ) -> HoverCutoverResult {
     match entity_occ {
         Some((ref entity, ref occurrence)) => {
-            // Dynamic boundary: provenance is DynamicBoundary or occurrence kind is DynamicBoundary
+            // Dynamic boundary: provenance is DynamicBoundary or occurrence kind marks one.
             if entity.provenance == Provenance::DynamicBoundary
-                || occurrence.kind == OccurrenceKind::DynamicBoundary
+                || matches!(
+                    occurrence.kind,
+                    OccurrenceKind::DynamicBoundary | OccurrenceKind::TypeglobReference
+                )
             {
                 let explanation = build_dynamic_boundary_explanation(entity, occurrence, symbol);
                 return HoverCutoverResult::DynamicBoundary(explanation);
@@ -435,6 +438,8 @@ fn occurrence_kind_label(kind: OccurrenceKind) -> &'static str {
         OccurrenceKind::Call => "call",
         OccurrenceKind::MethodCall => "method call",
         OccurrenceKind::StaticMethodCall => "static method call",
+        OccurrenceKind::CoderefReference => "coderef reference",
+        OccurrenceKind::TypeglobReference => "typeglob reference",
         OccurrenceKind::Import => "import",
         OccurrenceKind::Export => "export",
         OccurrenceKind::Inheritance => "inheritance",
@@ -1294,6 +1299,8 @@ mod tests {
             OccurrenceKind::Call,
             OccurrenceKind::MethodCall,
             OccurrenceKind::StaticMethodCall,
+            OccurrenceKind::CoderefReference,
+            OccurrenceKind::TypeglobReference,
             OccurrenceKind::Import,
             OccurrenceKind::Export,
             OccurrenceKind::Inheritance,

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -52,6 +52,8 @@ pub enum OccurrenceKind {
     Call,
     MethodCall,
     StaticMethodCall,
+    CoderefReference,
+    TypeglobReference,
     Import,
     Export,
     Inheritance,

--- a/crates/perl-semantic-facts/tests/prop_json_roundtrip.rs
+++ b/crates/perl-semantic-facts/tests/prop_json_roundtrip.rs
@@ -60,6 +60,8 @@ fn arb_occurrence_kind() -> impl Strategy<Value = OccurrenceKind> {
         Just(OccurrenceKind::Call),
         Just(OccurrenceKind::MethodCall),
         Just(OccurrenceKind::StaticMethodCall),
+        Just(OccurrenceKind::CoderefReference),
+        Just(OccurrenceKind::TypeglobReference),
         Just(OccurrenceKind::Import),
         Just(OccurrenceKind::Export),
         Just(OccurrenceKind::Inheritance),

--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -40,6 +40,9 @@ pub fn symbol_refs_to_semantic_facts(
     let mut reference_edges = Vec::new();
 
     for symbol_ref in refs {
+        let occurrence_kind = occurrence_kind(&symbol_ref.kind);
+        let provenance = occurrence_provenance(&symbol_ref.kind);
+        let confidence = occurrence_confidence(&symbol_ref.kind);
         let anchor_span = symbol_ref.anchor_span.unwrap_or(symbol_ref.full_span);
         let anchor_id = AnchorId(stable_id(
             "ref-anchor",
@@ -53,20 +56,10 @@ pub fn symbol_refs_to_semantic_facts(
             span_start_byte: anchor_span.0 as u32,
             span_end_byte: anchor_span.1 as u32,
             scope_id: None,
-            provenance: Provenance::ExactAst,
-            confidence: Confidence::High,
+            provenance,
+            confidence,
         });
 
-        let occurrence_kind = match symbol_ref.kind {
-            SymbolRefKind::Variable(_) => OccurrenceKind::Read,
-            SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
-            SymbolRefKind::MethodCall => OccurrenceKind::MethodCall,
-            SymbolRefKind::StaticMethodCall => OccurrenceKind::StaticMethodCall,
-        };
-        let confidence = match symbol_ref.kind {
-            SymbolRefKind::MethodCall => Confidence::Medium,
-            _ => Confidence::High,
-        };
         let entity_id = entity_ids_by_qualified_name.get(&symbol_ref.qualified_name).copied();
         let occurrence_id = OccurrenceId(stable_id(
             "occurrence",
@@ -80,7 +73,7 @@ pub fn symbol_refs_to_semantic_facts(
             entity_id,
             anchor_id,
             scope_id: None,
-            provenance: Provenance::ExactAst,
+            provenance,
             confidence,
         });
 
@@ -105,6 +98,32 @@ pub fn symbol_refs_to_semantic_facts(
     }
 
     SymbolRefSemanticFacts { anchors, occurrences, reference_edges }
+}
+
+fn occurrence_kind(kind: &SymbolRefKind) -> OccurrenceKind {
+    match kind {
+        SymbolRefKind::Variable(_) => OccurrenceKind::Read,
+        SymbolRefKind::SubroutineCall => OccurrenceKind::Call,
+        SymbolRefKind::MethodCall => OccurrenceKind::MethodCall,
+        SymbolRefKind::StaticMethodCall => OccurrenceKind::StaticMethodCall,
+        SymbolRefKind::CoderefReference => OccurrenceKind::CoderefReference,
+        SymbolRefKind::TypeglobReference => OccurrenceKind::TypeglobReference,
+    }
+}
+
+fn occurrence_provenance(kind: &SymbolRefKind) -> Provenance {
+    match kind {
+        SymbolRefKind::TypeglobReference => Provenance::DynamicBoundary,
+        _ => Provenance::ExactAst,
+    }
+}
+
+fn occurrence_confidence(kind: &SymbolRefKind) -> Confidence {
+    match kind {
+        SymbolRefKind::MethodCall => Confidence::Medium,
+        SymbolRefKind::TypeglobReference => Confidence::Low,
+        _ => Confidence::High,
+    }
 }
 
 pub fn symbol_decls_to_semantic_facts(
@@ -537,24 +556,50 @@ mod tests {
                 full_span: (33, 45),
                 anchor_span: None,
             },
+            SymbolRef {
+                kind: SymbolRefKind::CoderefReference,
+                name: "callback".to_string(),
+                qualified_name: "Foo::callback".to_string(),
+                sigil: Some("&".to_string()),
+                package_qualifier: Some("Foo".to_string()),
+                full_span: (46, 59),
+                anchor_span: Some((47, 59)),
+            },
+            SymbolRef {
+                kind: SymbolRefKind::TypeglobReference,
+                name: "alias".to_string(),
+                qualified_name: "alias".to_string(),
+                sigil: Some("*".to_string()),
+                package_qualifier: None,
+                full_span: (60, 66),
+                anchor_span: None,
+            },
         ];
         let mut entity_map = BTreeMap::new();
         entity_map.insert("Foo::run".to_string(), EntityId(42));
         entity_map.insert("Foo::new".to_string(), EntityId(43));
+        entity_map.insert("Foo::callback".to_string(), EntityId(44));
 
         let facts = symbol_refs_to_semantic_facts(&refs, FileId(7), &entity_map);
-        assert_eq!(facts.anchors.len(), 4);
-        assert_eq!(facts.occurrences.len(), 4);
-        assert_eq!(facts.reference_edges.len(), 2);
+        assert_eq!(facts.anchors.len(), 6);
+        assert_eq!(facts.occurrences.len(), 6);
+        assert_eq!(facts.reference_edges.len(), 3);
         assert_eq!(facts.occurrences[0].kind, OccurrenceKind::Call);
         assert_eq!(facts.occurrences[1].kind, OccurrenceKind::Read);
         assert_eq!(facts.occurrences[2].kind, OccurrenceKind::StaticMethodCall);
         assert_eq!(facts.occurrences[3].kind, OccurrenceKind::MethodCall);
+        assert_eq!(facts.occurrences[4].kind, OccurrenceKind::CoderefReference);
+        assert_eq!(facts.occurrences[5].kind, OccurrenceKind::TypeglobReference);
         assert_eq!(facts.occurrences[0].entity_id, Some(EntityId(42)));
         assert_eq!(facts.occurrences[1].entity_id, None);
         assert_eq!(facts.occurrences[2].entity_id, Some(EntityId(43)));
         assert_eq!(facts.occurrences[3].entity_id, None);
+        assert_eq!(facts.occurrences[4].entity_id, Some(EntityId(44)));
+        assert_eq!(facts.occurrences[5].entity_id, None);
         assert_eq!(facts.occurrences[2].confidence, Confidence::High);
         assert_eq!(facts.occurrences[3].confidence, Confidence::Medium);
+        assert_eq!(facts.occurrences[4].confidence, Confidence::High);
+        assert_eq!(facts.occurrences[5].confidence, Confidence::Low);
+        assert_eq!(facts.occurrences[5].provenance, Provenance::DynamicBoundary);
     }
 }

--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -4,14 +4,13 @@
 //! - variable references (`$x`, `@items`, `%opts`, `$#array`)
 //! - subroutine call references (`foo(...)` / bareword calls via `NodeKind::FunctionCall`)
 //! - method call references (`$obj->method(...)`, `Pkg->method(...)`)
+//! - coderef and typeglob boundary references (`&foo`, `\&foo`, `*alias`)
 //! - package-qualified forms where the AST encodes them directly
 //!   (`$Pkg::var`, `Pkg::func(...)`)
 //!
 //! # Phase-1 Intentional Exclusions
 //!
 //! The following reference types are **not** emitted in this phase:
-//! - `&foo` / `\&foo` code-reference variables (sigil `&`) — `VarKind` has no `CodeRef` variant
-//! - `*foo` typeglob variables (sigil `*`) — reserved for a future phase
 //! - Indirect-object calls (`new Class @args`, `NodeKind::IndirectCall`) — same reason
 //! - Subroutine signature parameter bindings (`MandatoryParameter`, `SlurpyParameter`,
 //!   `NamedParameter`) — these are declaration sites, not reference sites.  Optional
@@ -31,6 +30,10 @@ pub enum SymbolRefKind {
     MethodCall,
     /// Static/package method invocation (`Package->method(...)`).
     StaticMethodCall,
+    /// Coderef-oriented reference (`&foo`, `\&foo`, `goto &foo`).
+    CoderefReference,
+    /// Typeglob reference or alias boundary (`*foo`, `*alias = ...`).
+    TypeglobReference,
 }
 
 /// A projected view of a symbol reference/use site in Perl source.
@@ -85,18 +88,20 @@ fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
         }
 
         NodeKind::Variable { sigil, name } => {
-            if let Some(var_kind) = var_kind_from_sigil(sigil) {
-                let (package_qualifier, bare_name, qualified_name) = split_qualified_name(name);
-                out.push(SymbolRef {
-                    kind: SymbolRefKind::Variable(var_kind),
-                    name: bare_name,
-                    qualified_name,
-                    sigil: Some(sigil.clone()),
-                    package_qualifier,
-                    full_span: (node.location.start, node.location.end),
-                    anchor_span: Some((node.location.start, node.location.end)),
-                });
-            }
+            push_variable_like_ref(node, sigil, name, out);
+        }
+
+        NodeKind::Typeglob { name } => {
+            let (package_qualifier, bare_name, qualified_name) = split_qualified_name(name);
+            out.push(SymbolRef {
+                kind: SymbolRefKind::TypeglobReference,
+                name: bare_name,
+                qualified_name,
+                sigil: Some("*".to_string()),
+                package_qualifier,
+                full_span: (node.location.start, node.location.end),
+                anchor_span: Some((node.location.start, node.location.end)),
+            });
         }
 
         NodeKind::FunctionCall { name, args } => {
@@ -165,6 +170,29 @@ fn static_method_target(object: &Node, method: &str) -> Option<(String, String)>
     Some((name.clone(), format!("{name}::{method}")))
 }
 
+fn push_variable_like_ref(node: &Node, sigil: &str, name: &str, out: &mut Vec<SymbolRef>) {
+    let kind = match sigil {
+        "&" => SymbolRefKind::CoderefReference,
+        "*" => SymbolRefKind::TypeglobReference,
+        _ => {
+            let Some(var_kind) = var_kind_from_sigil(sigil) else {
+                return;
+            };
+            SymbolRefKind::Variable(var_kind)
+        }
+    };
+    let (package_qualifier, bare_name, qualified_name) = split_qualified_name(name);
+    out.push(SymbolRef {
+        kind,
+        name: bare_name,
+        qualified_name,
+        sigil: Some(sigil.to_string()),
+        package_qualifier,
+        full_span: (node.location.start, node.location.end),
+        anchor_span: Some((node.location.start, node.location.end)),
+    });
+}
+
 /// Split a potentially package-qualified name into `(qualifier, bare, full)`.
 ///
 /// Returns `(Some("Pkg::Sub"), "baz", "Pkg::Sub::baz")` for `"Pkg::Sub::baz"`.
@@ -188,7 +216,6 @@ fn var_kind_from_sigil(sigil: &str) -> Option<VarKind> {
         "$#" => Some(VarKind::Scalar),
         "@" => Some(VarKind::Array),
         "%" => Some(VarKind::Hash),
-        // `&` (code reference) and `*` (typeglob) are phase-1 exclusions.
         _ => None,
     }
 }

--- a/crates/perl-symbol/tests/edge_cases_and_regressions.rs
+++ b/crates/perl-symbol/tests/edge_cases_and_regressions.rs
@@ -65,6 +65,8 @@ fn api_regression_every_documented_name_is_reachable_at_crate_root() -> Result<(
     let _rk = SymbolRefKind::SubroutineCall;
     let _method = SymbolRefKind::MethodCall;
     let _static_method = SymbolRefKind::StaticMethodCall;
+    let _coderef = SymbolRefKind::CoderefReference;
+    let _typeglob = SymbolRefKind::TypeglobReference;
 
     Ok(())
 }

--- a/crates/perl-symbol/tests/facade_api_completeness.rs
+++ b/crates/perl-symbol/tests/facade_api_completeness.rs
@@ -88,6 +88,8 @@ fn surface_ref_accessible() {
     let _kind = SymbolRefKind::SubroutineCall;
     let _method = SymbolRefKind::MethodCall;
     let _static_method = SymbolRefKind::StaticMethodCall;
+    let _coderef = SymbolRefKind::CoderefReference;
+    let _typeglob = SymbolRefKind::TypeglobReference;
     let _fn: fn(&perl_ast::Node) -> Vec<SymbolRef> = extract_symbol_refs;
 }
 

--- a/crates/perl-symbol/tests/prop_adapter_determinism.rs
+++ b/crates/perl-symbol/tests/prop_adapter_determinism.rs
@@ -113,6 +113,8 @@ fn arb_symbol_ref_kind() -> impl Strategy<Value = SymbolRefKind> {
         Just(SymbolRefKind::SubroutineCall),
         Just(SymbolRefKind::MethodCall),
         Just(SymbolRefKind::StaticMethodCall),
+        Just(SymbolRefKind::CoderefReference),
+        Just(SymbolRefKind::TypeglobReference),
     ]
 }
 
@@ -126,6 +128,8 @@ fn arb_symbol_ref() -> impl Strategy<Value = SymbolRef> {
             Just("$".to_string()),
             Just("@".to_string()),
             Just("%".to_string()),
+            Just("&".to_string()),
+            Just("*".to_string()),
         ]),
         prop::option::of(arb_qualified_name()),
         arb_spans(),

--- a/crates/perl-symbol/tests/prop_anchor_referential_integrity.rs
+++ b/crates/perl-symbol/tests/prop_anchor_referential_integrity.rs
@@ -114,6 +114,8 @@ fn arb_symbol_ref_kind() -> impl Strategy<Value = SymbolRefKind> {
         Just(SymbolRefKind::SubroutineCall),
         Just(SymbolRefKind::MethodCall),
         Just(SymbolRefKind::StaticMethodCall),
+        Just(SymbolRefKind::CoderefReference),
+        Just(SymbolRefKind::TypeglobReference),
     ]
 }
 
@@ -127,6 +129,8 @@ fn arb_symbol_ref() -> impl Strategy<Value = SymbolRef> {
             Just("$".to_string()),
             Just("@".to_string()),
             Just("%".to_string()),
+            Just("&".to_string()),
+            Just("*".to_string()),
         ]),
         prop::option::of(arb_qualified_name()),
         arb_spans(),

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -120,9 +120,7 @@ fn array_last_index_sigil_is_treated_as_scalar_reference() -> Result<()> {
 }
 
 #[test]
-fn code_ref_and_typeglob_sigils_are_excluded_in_phase1() -> Result<()> {
-    // `&` (code ref) and `*` (typeglob) are phase-1 exclusions documented in the
-    // module; they must not produce SymbolRef entries.
+fn coderef_and_typeglob_sigils_are_classified() -> Result<()> {
     let code_ref = Node::new(
         NodeKind::Variable { sigil: "&".to_string(), name: "handler".to_string() },
         loc(0, 8),
@@ -134,11 +132,13 @@ fn code_ref_and_typeglob_sigils_are_excluded_in_phase1() -> Result<()> {
     let program = Node::new(NodeKind::Program { statements: vec![code_ref, typeglob] }, loc(0, 14));
 
     let refs = extract_symbol_refs(&program);
-    assert!(
-        refs.is_empty(),
-        "phase-1 should not emit refs for & or * sigil variables, got: {:?}",
-        refs
-    );
+    assert_eq!(refs.len(), 2);
+    assert_eq!(refs[0].kind, SymbolRefKind::CoderefReference);
+    assert_eq!(refs[0].name, "handler");
+    assert_eq!(refs[0].sigil.as_deref(), Some("&"));
+    assert_eq!(refs[1].kind, SymbolRefKind::TypeglobReference);
+    assert_eq!(refs[1].name, "slot");
+    assert_eq!(refs[1].sigil.as_deref(), Some("*"));
     Ok(())
 }
 
@@ -353,9 +353,9 @@ fn variable_reads_and_writes_collapse_to_variable_refs() -> Result<()> {
 }
 
 #[test]
-fn coderef_syntax_forms_are_intentionally_not_emitted_in_phase1() -> Result<()> {
+fn coderef_syntax_forms_are_classified_conservatively() -> Result<()> {
     // Covers `&foo`, `\\&foo`, and `goto &foo` style sigil usage: all are represented
-    // as `Variable` nodes with sigil `&` and intentionally excluded in phase-1.
+    // as `Variable` nodes with sigil `&` and classify as coderef references.
     let amp = Node::new(
         NodeKind::Variable { sigil: "&".to_string(), name: "foo".to_string() },
         loc(0, 4),
@@ -368,24 +368,53 @@ fn coderef_syntax_forms_are_intentionally_not_emitted_in_phase1() -> Result<()> 
         NodeKind::Variable { sigil: "&".to_string(), name: "foo".to_string() },
         loc(11, 19),
     );
+    let goto = Node::new(NodeKind::Goto { target: Box::new(goto_amp) }, loc(11, 19));
     let program =
-        Node::new(NodeKind::Program { statements: vec![amp, backslash_amp, goto_amp] }, loc(0, 19));
+        Node::new(NodeKind::Program { statements: vec![amp, backslash_amp, goto] }, loc(0, 19));
 
     let refs = extract_symbol_refs(&program);
-    assert!(refs.is_empty(), "phase-1 SymbolRef extraction does not model coderef boundary edges");
+    assert_eq!(refs.len(), 3);
+    assert!(refs.iter().all(|r| r.kind == SymbolRefKind::CoderefReference));
+    assert!(refs.iter().all(|r| r.name == "foo"));
     Ok(())
 }
 
 #[test]
-fn typeglob_alias_boundary_is_not_typed_in_phase1() -> Result<()> {
-    let typeglob = Node::new(
-        NodeKind::Variable { sigil: "*".to_string(), name: "foo".to_string() },
-        loc(0, 4),
-    );
+fn typeglob_alias_boundary_is_classified() -> Result<()> {
+    let typeglob = Node::new(NodeKind::Typeglob { name: "foo".to_string() }, loc(0, 4));
     let program = Node::new(NodeKind::Program { statements: vec![typeglob] }, loc(0, 4));
 
     let refs = extract_symbol_refs(&program);
-    assert!(refs.is_empty(), "typeglob aliases are a future typed-edge boundary");
+    assert_eq!(refs.len(), 1);
+    assert_eq!(refs[0].kind, SymbolRefKind::TypeglobReference);
+    assert_eq!(refs[0].name, "foo");
+    assert_eq!(refs[0].sigil.as_deref(), Some("*"));
+    Ok(())
+}
+
+#[test]
+fn typeglob_assignment_keeps_rhs_coderef_reference() -> Result<()> {
+    let lhs = Node::new(NodeKind::Typeglob { name: "alias".to_string() }, loc(0, 6));
+    let rhs_target = Node::new(
+        NodeKind::Variable { sigil: "&".to_string(), name: "target".to_string() },
+        loc(10, 17),
+    );
+    let rhs = Node::new(
+        NodeKind::Unary { op: "\\".to_string(), operand: Box::new(rhs_target) },
+        loc(9, 17),
+    );
+    let assign = Node::new(
+        NodeKind::Assignment { lhs: Box::new(lhs), rhs: Box::new(rhs), op: "=".to_string() },
+        loc(0, 17),
+    );
+    let program = Node::new(NodeKind::Program { statements: vec![assign] }, loc(0, 17));
+
+    let refs = extract_symbol_refs(&program);
+    assert_eq!(refs.len(), 2);
+    assert_eq!(refs[0].kind, SymbolRefKind::TypeglobReference);
+    assert_eq!(refs[0].name, "alias");
+    assert_eq!(refs[1].kind, SymbolRefKind::CoderefReference);
+    assert_eq!(refs[1].name, "target");
     Ok(())
 }
 

--- a/crates/perl-workspace-index/src/semantic/queries.rs
+++ b/crates/perl-workspace-index/src/semantic/queries.rs
@@ -429,7 +429,7 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
                 let category = classify_occurrence(occ.kind);
 
                 // Dynamic boundary references → add blocker (Req 16.2).
-                if occ.kind == OccurrenceKind::DynamicBoundary {
+                if is_dynamic_boundary_occurrence(occ.kind) {
                     blockers.push(PlanBlocker::new(
                         PlanBlockerReason::DynamicBoundary,
                         Some(occ.anchor_id),
@@ -467,7 +467,7 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
         // ── Collect reference occurrences from the reference index ──
         let ref_edges = self.reference_index.get_by_entity(entity_id);
         for edge in ref_edges {
-            if edge.kind == OccurrenceKind::DynamicBoundary {
+            if is_dynamic_boundary_occurrence(edge.kind) {
                 blockers.push(PlanBlocker::new(
                     PlanBlockerReason::DynamicBoundary,
                     Some(edge.anchor_id),
@@ -574,7 +574,7 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
         // If the symbol has references in the workspace, block deletion.
         let ref_edges = self.reference_index.get_by_entity(entity_id);
         let dynamic_ref_count =
-            ref_edges.iter().filter(|edge| edge.kind == OccurrenceKind::DynamicBoundary).count();
+            ref_edges.iter().filter(|edge| is_dynamic_boundary_occurrence(edge.kind)).count();
         let concrete_ref_count = ref_edges.len().saturating_sub(dynamic_ref_count);
         if dynamic_ref_count > 0 {
             blockers.push(PlanBlocker::new(
@@ -604,7 +604,7 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
             .values()
             .flat_map(|s| s.occurrences.iter())
             .filter(|occ| {
-                occ.entity_id == Some(entity_id) && occ.kind == OccurrenceKind::DynamicBoundary
+                occ.entity_id == Some(entity_id) && is_dynamic_boundary_occurrence(occ.kind)
             })
             .count();
         let shard_ref_count: usize = self
@@ -613,10 +613,8 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
             .flat_map(|s| s.occurrences.iter())
             .filter(|occ| {
                 occ.entity_id == Some(entity_id)
-                    && !matches!(
-                        occ.kind,
-                        OccurrenceKind::Definition | OccurrenceKind::DynamicBoundary
-                    )
+                    && !matches!(occ.kind, OccurrenceKind::Definition)
+                    && !is_dynamic_boundary_occurrence(occ.kind)
             })
             .count();
 
@@ -882,13 +880,18 @@ fn classify_occurrence(kind: OccurrenceKind) -> Option<PlannedEditCategory> {
         | OccurrenceKind::Call
         | OccurrenceKind::MethodCall
         | OccurrenceKind::StaticMethodCall
+        | OccurrenceKind::CoderefReference
         | OccurrenceKind::GeneratedUse => Some(PlannedEditCategory::Reference),
         // Inheritance and role-composition are structural edges, not rename
         // targets — warn rather than silently omitting.
         OccurrenceKind::Inheritance | OccurrenceKind::RoleComposition => None,
-        // DynamicBoundary is handled as a blocker before this function is called.
-        OccurrenceKind::DynamicBoundary => None,
+        // Dynamic-boundary classes are handled as blockers before this function is called.
+        OccurrenceKind::DynamicBoundary | OccurrenceKind::TypeglobReference => None,
     }
+}
+
+fn is_dynamic_boundary_occurrence(kind: OccurrenceKind) -> bool {
+    matches!(kind, OccurrenceKind::DynamicBoundary | OccurrenceKind::TypeglobReference)
 }
 
 #[cfg(test)]
@@ -3187,8 +3190,8 @@ mod tests {
 
         /// An occurrence kind that the rename plan can classify into a
         /// `PlannedEditCategory`.  We exclude `DynamicBoundary`,
-        /// `Inheritance`, and `RoleComposition` because those are handled
-        /// as blockers/warnings rather than edits.
+        /// `TypeglobReference`, `Inheritance`, and `RoleComposition` because
+        /// those are handled as blockers/warnings rather than edits.
         #[derive(Debug, Clone, Copy)]
         struct ClassifiableOccurrence {
             kind: OccurrenceKind,
@@ -3233,6 +3236,10 @@ mod tests {
                 }),
                 Just(ClassifiableOccurrence {
                     kind: OccurrenceKind::StaticMethodCall,
+                    expected_category: PlannedEditCategory::Reference,
+                }),
+                Just(ClassifiableOccurrence {
+                    kind: OccurrenceKind::CoderefReference,
                     expected_category: PlannedEditCategory::Reference,
                 }),
                 Just(ClassifiableOccurrence {

--- a/docs/project/status/semantic_scorecard.json
+++ b/docs/project/status/semantic_scorecard.json
@@ -58,7 +58,7 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     },
     "definition_candidates": {
@@ -86,7 +86,7 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     },
     "export_facts": {
@@ -114,7 +114,7 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     },
     "import_specs": {
@@ -142,7 +142,7 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     },
     "inheritance_edges": {
@@ -170,12 +170,12 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     },
     "occurrence_facts": {
       "status": "available",
-      "total_facts": 14,
+      "total_facts": 15,
       "fixture_coverage": {
         "covered_fixture_count": 12,
         "total_fixture_count": 12,
@@ -198,7 +198,7 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     },
     "package_graph_edges": {
@@ -226,7 +226,7 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     },
     "reference_edges": {
@@ -254,7 +254,7 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     },
     "role_composition_edges": {
@@ -282,7 +282,7 @@
         "exact_facts": 111,
         "high_confidence_facts": 111,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 0
+        "dynamic_boundary_facts": 2
       }
     }
   },
@@ -343,7 +343,7 @@
     },
     "semantic_fact_counts_nonzero": {
       "status": "pass",
-      "value": "58",
+      "value": "59",
       "threshold": "> 0",
       "evidence": "semantic fixture indexing"
     },

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -8,15 +8,15 @@ Fixtures loaded: `12`
 
 | Row | Status | Facts | Coverage | Exact | High | Heuristic | Dynamic boundary |
 |---|---|---:|---:|---:|---:|---:|---:|
-| declaration_facts | available | 31 | 12/12 | 111 | 111 | 1 | 0 |
-| definition_candidates | available | 31 | 12/12 | 111 | 111 | 1 | 0 |
-| export_facts | available | 3 | 12/12 | 111 | 111 | 1 | 0 |
-| import_specs | available | 7 | 12/12 | 111 | 111 | 1 | 0 |
-| inheritance_edges | available | 1 | 12/12 | 111 | 111 | 1 | 0 |
-| occurrence_facts | available | 14 | 12/12 | 111 | 111 | 1 | 0 |
-| package_graph_edges | available | 2 | 12/12 | 111 | 111 | 1 | 0 |
-| reference_edges | available | 1 | 12/12 | 111 | 111 | 1 | 0 |
-| role_composition_edges | available | 1 | 12/12 | 111 | 111 | 1 | 0 |
+| declaration_facts | available | 31 | 12/12 | 111 | 111 | 1 | 2 |
+| definition_candidates | available | 31 | 12/12 | 111 | 111 | 1 | 2 |
+| export_facts | available | 3 | 12/12 | 111 | 111 | 1 | 2 |
+| import_specs | available | 7 | 12/12 | 111 | 111 | 1 | 2 |
+| inheritance_edges | available | 1 | 12/12 | 111 | 111 | 1 | 2 |
+| occurrence_facts | available | 15 | 12/12 | 111 | 111 | 1 | 2 |
+| package_graph_edges | available | 2 | 12/12 | 111 | 111 | 1 | 2 |
+| reference_edges | available | 1 | 12/12 | 111 | 111 | 1 | 2 |
+| role_composition_edges | available | 1 | 12/12 | 111 | 111 | 1 | 2 |
 
 ## Readiness Rows
 
@@ -31,7 +31,7 @@ Fixtures loaded: `12`
 | rename_unsafe_edit_count | pass | 0 | 0 | rename plan query fixtures |
 | safe_delete_blocker_fixture_pass_rate | pass | 100% | 100% | safe-delete plan query fixtures |
 | safe_delete_plan | pass | 100% | 100% | safe-delete plan query fixtures |
-| semantic_fact_counts_nonzero | pass | 58 | > 0 | semantic fixture indexing |
+| semantic_fact_counts_nonzero | pass | 59 | > 0 | semantic fixture indexing |
 | undefined_symbol_false_positive_fixture_rate | pass | 0% | 0% | diagnostics fixture receipts |
 | visible_symbols_fixture_pass_rate | pass | 100% | 100% | workspace scorecard fixtures |
 


### PR DESCRIPTION
Problem: Coderef and typeglob sites were still invisible to typed semantic references, so rename/safe-delete could not distinguish concrete coderef references from dynamic alias boundaries.
Fix: Add CoderefReference and TypeglobReference occurrence kinds, project `&foo`/`\&foo`/`goto &foo` and `*alias` sites through perl-symbol, and treat typeglob references as dynamic-boundary blockers in semantic queries.
Verification: `cargo test -p perl-semantic-facts --profile agent --locked`; `cargo test -p perl-symbol --profile agent --locked`; `cargo test -p perl-workspace --profile agent --locked rename_plan_occurrence_classification -- --nocapture`; `cargo test -p perl-lsp-rs-core --profile agent --locked occurrence_kind_labels_cover_all_variants -- --nocapture`; `cargo check -p perl-semantic-facts --all-targets --profile agent --locked`; `cargo check -p perl-symbol --all-targets --profile agent --locked`; `cargo check -p perl-workspace --all-targets --profile agent --locked`; `cargo check -p perl-lsp-rs-core --all-targets --profile agent --locked`; `cargo clippy -p perl-semantic-facts --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-symbol --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-workspace --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`