### PR TITLE
feat(parser): score parser accuracy line tags (#0000)

### DIFF
--- a/.kiro/specs/parser-accuracy-observability/tasks.md
+++ b/.kiro/specs/parser-accuracy-observability/tasks.md
@@ -35,10 +35,10 @@ Build a layered parser accuracy scorecard that starts with denominator visibilit
     - Do not remove current clean parse, recovery, token health, or failure worklist rows
     - _Verify: existing parser status marker tests_
 
-- [ ] 4. Add line-level construct scoring
-  - [ ] 4.1 Define line tag vocabulary
+- [x] 4. Add line-level construct scoring
+  - [x] 4.1 Define line tag vocabulary
     - Include package_decl, sub_decl, method_decl, variable_decl, import, export, function_call, method_call, regex, quote_like, heredoc_opener, heredoc_body, heredoc_terminator, pod, format_decl, given_when, do_while, until_loop, dynamic_boundary, parse_error, recovery_region, unsupported_construct
-  - [ ] 4.2 Implement line tag scorer
+  - [x] 4.2 Implement line tag scorer
     - Compare expected and actual tag sets
     - Emit TP/FP/FN, exact match rate, precision, recall, F1, error false positive rate, error false negative rate, dynamic boundary correct rate, and unsupported detection rate
     - _Verify: unit tests with at least one false positive and one false negative_

--- a/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
+++ b/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
@@ -15,14 +15,28 @@
       "dynamic_boundaries": 0,
       "unsupported_constructs": 0,
       "real_project_file": false,
-      "generated": false
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        }
+      ]
     },
     {
       "id": "dynamic_require_boundary",
       "family": "dynamic_require",
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/dynamic_require.pl",
-      "scored_lines": 1,
+      "scored_lines": 3,
       "scored_symbols": 1,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
@@ -31,7 +45,28 @@
       "dynamic_boundaries": 1,
       "unsupported_constructs": 0,
       "real_project_file": false,
-      "generated": false
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "import",
+            "dynamic_boundary"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/xtask/src/tasks/metrics/parser_accuracy.rs
+++ b/xtask/src/tasks/metrics/parser_accuracy.rs
@@ -1,8 +1,7 @@
 //! Parser accuracy scorecard contract and denominator inventory.
 //!
-//! The first implementation slice deliberately emits denominator rows and
-//! insufficient-data metric rows only. Accuracy scoring layers are added in
-//! later slices once their gold fixtures and extractors exist.
+//! The implementation starts with denominator rows and then adds accuracy
+//! scoring layers in small, schema-valid slices.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -12,6 +11,7 @@ use std::time::Instant;
 
 use chrono::Utc;
 use color_eyre::eyre::{Context, Result, bail, eyre};
+use perl_parser::{Node, NodeKind, Parser};
 use serde::{Deserialize, Serialize};
 
 use crate::utils::project_root;
@@ -41,6 +41,8 @@ struct FixtureMetadata {
     unsupported_constructs: u64,
     real_project_file: bool,
     generated: bool,
+    #[serde(default)]
+    line_expectations: Vec<LineExpectation>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -51,6 +53,64 @@ enum LabelMode {
     Unknown,
     Negative,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct LineExpectation {
+    line: u64,
+    expected_tags: BTreeSet<LineTag>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LineTag {
+    PackageDecl,
+    SubDecl,
+    MethodDecl,
+    VariableDecl,
+    Import,
+    Export,
+    FunctionCall,
+    MethodCall,
+    Regex,
+    QuoteLike,
+    HeredocOpener,
+    HeredocBody,
+    HeredocTerminator,
+    Pod,
+    FormatDecl,
+    GivenWhen,
+    DoWhile,
+    UntilLoop,
+    DynamicBoundary,
+    ParseError,
+    RecoveryRegion,
+    UnsupportedConstruct,
+}
+
+const LINE_TAG_VOCABULARY: &[LineTag] = &[
+    LineTag::PackageDecl,
+    LineTag::SubDecl,
+    LineTag::MethodDecl,
+    LineTag::VariableDecl,
+    LineTag::Import,
+    LineTag::Export,
+    LineTag::FunctionCall,
+    LineTag::MethodCall,
+    LineTag::Regex,
+    LineTag::QuoteLike,
+    LineTag::HeredocOpener,
+    LineTag::HeredocBody,
+    LineTag::HeredocTerminator,
+    LineTag::Pod,
+    LineTag::FormatDecl,
+    LineTag::GivenWhen,
+    LineTag::DoWhile,
+    LineTag::UntilLoop,
+    LineTag::DynamicBoundary,
+    LineTag::ParseError,
+    LineTag::RecoveryRegion,
+    LineTag::UnsupportedConstruct,
+];
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ParserAccuracyArtifact {
@@ -179,6 +239,22 @@ struct MetricRuntime {
     cache_hit_rate: Option<f64>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct LineScore {
+    line_count: u64,
+    true_positive_count: u64,
+    false_positive_count: u64,
+    false_negative_count: u64,
+    exact_match_count: u64,
+    expected_parse_error_count: u64,
+    false_parse_error_count: u64,
+    missed_parse_error_count: u64,
+    expected_dynamic_boundary_count: u64,
+    correct_dynamic_boundary_count: u64,
+    expected_unsupported_construct_count: u64,
+    correct_unsupported_construct_count: u64,
+}
+
 /// Run `cargo xtask metrics parser-accuracy`.
 pub fn run(
     json: bool,
@@ -247,19 +323,20 @@ fn build_artifact(
     let denominator = compute_denominator(manifest);
     let families = summarize_families(manifest);
     let fixture_count = denominator.fixture_count as f64;
-    let metrics = vec![
-        MetricRow::Measured {
-            metric: "denominator_fixture_count".to_string(),
-            value: fixture_count,
-            sample_count: denominator.fixture_count,
-            direction: Direction::Neutral,
-            confidence: Confidence::High,
-            cadence,
-        },
-        insufficient("line_construct_f1", "line-level gold scorer is not wired yet"),
+    let line_score = score_manifest_line_tags(root, manifest)?;
+    let mut metrics = vec![MetricRow::Measured {
+        metric: "denominator_fixture_count".to_string(),
+        value: fixture_count,
+        sample_count: denominator.fixture_count,
+        direction: Direction::Neutral,
+        confidence: Confidence::High,
+        cadence,
+    }];
+    metrics.extend(line_metrics(&line_score, cadence));
+    metrics.extend([
         insufficient("ast_node_kind_f1", "AST structural gold scorer is not wired yet"),
         insufficient("symbol_decl_f1", "symbol gold scorer is not wired yet"),
-    ];
+    ]);
 
     Ok(ParserAccuracyArtifact {
         schema_version: 1,
@@ -341,6 +418,287 @@ fn summarize_families(manifest: &ParserAccuracyManifest) -> Vec<FamilySummary> {
         .collect()
 }
 
+fn score_manifest_line_tags(root: &Path, manifest: &ParserAccuracyManifest) -> Result<LineScore> {
+    let mut score = LineScore::default();
+    for fixture in &manifest.fixtures {
+        if fixture.line_expectations.is_empty() {
+            continue;
+        }
+        let source_path = root.join(&fixture.source_path);
+        let source = fs::read_to_string(&source_path).with_context(|| {
+            format!("reading parser accuracy fixture source {}", source_path.display())
+        })?;
+        let actual_by_line = extract_line_tags(&source);
+        for expectation in &fixture.line_expectations {
+            let actual = actual_by_line.get(&expectation.line).cloned().unwrap_or_default();
+            score_line_tags(&expectation.expected_tags, &actual, &mut score);
+        }
+    }
+    Ok(score)
+}
+
+fn extract_line_tags(source: &str) -> BTreeMap<u64, BTreeSet<LineTag>> {
+    let mut parser = Parser::new(source);
+    let output = parser.parse_with_recovery();
+    let line_starts = line_starts(source);
+    let mut by_line = BTreeMap::new();
+    collect_node_line_tags(&output.ast, &line_starts, &mut by_line);
+    by_line
+}
+
+fn line_starts(source: &str) -> Vec<usize> {
+    let mut starts = vec![0];
+    for (index, byte) in source.bytes().enumerate() {
+        if byte == b'\n' && index + 1 < source.len() {
+            starts.push(index + 1);
+        }
+    }
+    starts
+}
+
+fn line_for_offset(line_starts: &[usize], offset: usize) -> u64 {
+    match line_starts.binary_search(&offset) {
+        Ok(index) => (index + 1) as u64,
+        Err(0) => 1,
+        Err(index) => index as u64,
+    }
+}
+
+fn collect_node_line_tags(
+    node: &Node,
+    line_starts: &[usize],
+    by_line: &mut BTreeMap<u64, BTreeSet<LineTag>>,
+) {
+    if let Some(tag) = line_tag_for_node(node) {
+        let line = line_for_offset(line_starts, node.location.start);
+        by_line.entry(line).or_default().insert(tag);
+    }
+    if let NodeKind::FunctionCall { name, args } = &node.kind
+        && name == "require"
+        && args.first().is_some_and(|arg| matches!(arg.kind, NodeKind::Variable { .. }))
+    {
+        let line = line_for_offset(line_starts, node.location.start);
+        by_line.entry(line).or_default().insert(LineTag::DynamicBoundary);
+    }
+    node.for_each_child(|child| collect_node_line_tags(child, line_starts, by_line));
+}
+
+fn line_tag_for_node(node: &Node) -> Option<LineTag> {
+    match &node.kind {
+        NodeKind::Package { .. } => Some(LineTag::PackageDecl),
+        NodeKind::Subroutine { .. } => Some(LineTag::SubDecl),
+        NodeKind::Method { .. } => Some(LineTag::MethodDecl),
+        NodeKind::VariableDeclaration { .. } | NodeKind::VariableListDeclaration { .. } => {
+            Some(LineTag::VariableDecl)
+        }
+        NodeKind::Use { .. } => Some(LineTag::Import),
+        NodeKind::FunctionCall { name, .. } if name == "require" => Some(LineTag::Import),
+        NodeKind::FunctionCall { .. } => Some(LineTag::FunctionCall),
+        NodeKind::MethodCall { .. } => Some(LineTag::MethodCall),
+        NodeKind::Regex { .. }
+        | NodeKind::Match { .. }
+        | NodeKind::Substitution { .. }
+        | NodeKind::Transliteration { .. } => Some(LineTag::Regex),
+        NodeKind::Heredoc { .. } => Some(LineTag::HeredocOpener),
+        NodeKind::Format { .. } => Some(LineTag::FormatDecl),
+        NodeKind::Given { .. } | NodeKind::When { .. } | NodeKind::Default { .. } => {
+            Some(LineTag::GivenWhen)
+        }
+        NodeKind::Do { .. } => Some(LineTag::DoWhile),
+        NodeKind::Error { .. } => Some(LineTag::ParseError),
+        NodeKind::UnknownRest => Some(LineTag::UnsupportedConstruct),
+        _ => None,
+    }
+}
+
+fn score_line_tags(
+    expected: &BTreeSet<LineTag>,
+    actual: &BTreeSet<LineTag>,
+    score: &mut LineScore,
+) {
+    score.line_count += 1;
+    let true_positives = expected.intersection(actual).count() as u64;
+    let false_positives = actual.difference(expected).count() as u64;
+    let false_negatives = expected.difference(actual).count() as u64;
+    score.true_positive_count += true_positives;
+    score.false_positive_count += false_positives;
+    score.false_negative_count += false_negatives;
+    if expected == actual {
+        score.exact_match_count += 1;
+    }
+
+    let expected_parse_error = expected.contains(&LineTag::ParseError);
+    let actual_parse_error = actual.contains(&LineTag::ParseError);
+    if expected_parse_error {
+        score.expected_parse_error_count += 1;
+    }
+    if actual_parse_error && !expected_parse_error {
+        score.false_parse_error_count += 1;
+    }
+    if expected_parse_error && !actual_parse_error {
+        score.missed_parse_error_count += 1;
+    }
+
+    if expected.contains(&LineTag::DynamicBoundary) {
+        score.expected_dynamic_boundary_count += 1;
+        if actual.contains(&LineTag::DynamicBoundary) {
+            score.correct_dynamic_boundary_count += 1;
+        }
+    }
+
+    if expected.contains(&LineTag::UnsupportedConstruct) {
+        score.expected_unsupported_construct_count += 1;
+        if actual.contains(&LineTag::UnsupportedConstruct) {
+            score.correct_unsupported_construct_count += 1;
+        }
+    }
+}
+
+fn line_metrics(score: &LineScore, cadence: Cadence) -> Vec<MetricRow> {
+    if score.line_count == 0 {
+        return vec![insufficient("line_construct_f1", "line-level gold labels are not available")];
+    }
+
+    let precision_denominator = score.true_positive_count + score.false_positive_count;
+    let recall_denominator = score.true_positive_count + score.false_negative_count;
+    let precision = ratio(score.true_positive_count, precision_denominator);
+    let recall = ratio(score.true_positive_count, recall_denominator);
+    let f1 = match (precision, recall) {
+        (Some(precision), Some(recall)) if precision + recall > 0.0 => {
+            Some(2.0 * precision * recall / (precision + recall))
+        }
+        _ => None,
+    };
+
+    let mut rows = vec![
+        measured_count(
+            "line_construct_true_positive_count",
+            score.true_positive_count,
+            score.line_count,
+            cadence,
+        ),
+        measured_count(
+            "line_construct_false_positive_count",
+            score.false_positive_count,
+            score.line_count,
+            cadence,
+        ),
+        measured_count(
+            "line_construct_false_negative_count",
+            score.false_negative_count,
+            score.line_count,
+            cadence,
+        ),
+        measured_rate(
+            "line_construct_exact_match_rate",
+            score.exact_match_count,
+            score.line_count,
+            cadence,
+        ),
+    ];
+
+    rows.push(optional_measured_rate(
+        "line_construct_precision",
+        precision,
+        precision_denominator,
+        "no predicted line tags were available",
+        cadence,
+    ));
+    rows.push(optional_measured_rate(
+        "line_construct_recall",
+        recall,
+        recall_denominator,
+        "no expected line tags were available",
+        cadence,
+    ));
+    rows.push(optional_measured_rate(
+        "line_construct_f1",
+        f1,
+        recall_denominator,
+        "line precision or recall denominator is unavailable",
+        cadence,
+    ));
+    rows.push(measured_rate(
+        "line_error_false_positive_rate",
+        score.false_parse_error_count,
+        score.line_count,
+        cadence,
+    ));
+    rows.push(optional_measured_rate(
+        "line_error_false_negative_rate",
+        ratio(score.missed_parse_error_count, score.expected_parse_error_count),
+        score.expected_parse_error_count,
+        "no expected parse-error line labels are available",
+        cadence,
+    ));
+    rows.push(optional_measured_rate(
+        "line_dynamic_boundary_correct_rate",
+        ratio(score.correct_dynamic_boundary_count, score.expected_dynamic_boundary_count),
+        score.expected_dynamic_boundary_count,
+        "no expected dynamic-boundary line labels are available",
+        cadence,
+    ));
+    rows.push(optional_measured_rate(
+        "line_unsupported_detection_rate",
+        ratio(
+            score.correct_unsupported_construct_count,
+            score.expected_unsupported_construct_count,
+        ),
+        score.expected_unsupported_construct_count,
+        "no expected unsupported-construct line labels are available",
+        cadence,
+    ));
+
+    rows
+}
+
+fn measured_count(metric: &str, value: u64, sample_count: u64, cadence: Cadence) -> MetricRow {
+    MetricRow::Measured {
+        metric: metric.to_string(),
+        value: value as f64,
+        sample_count,
+        direction: Direction::Neutral,
+        confidence: Confidence::High,
+        cadence,
+    }
+}
+
+fn measured_rate(metric: &str, numerator: u64, denominator: u64, cadence: Cadence) -> MetricRow {
+    let value = ratio(numerator, denominator).unwrap_or(0.0);
+    MetricRow::Measured {
+        metric: metric.to_string(),
+        value,
+        sample_count: denominator,
+        direction: Direction::Neutral,
+        confidence: Confidence::High,
+        cadence,
+    }
+}
+
+fn optional_measured_rate(
+    metric: &str,
+    value: Option<f64>,
+    sample_count: u64,
+    insufficient_reason: &str,
+    cadence: Cadence,
+) -> MetricRow {
+    match value {
+        Some(value) if sample_count > 0 => MetricRow::Measured {
+            metric: metric.to_string(),
+            value,
+            sample_count,
+            direction: Direction::Neutral,
+            confidence: Confidence::High,
+            cadence,
+        },
+        _ => insufficient(metric, insufficient_reason),
+    }
+}
+
+fn ratio(numerator: u64, denominator: u64) -> Option<f64> {
+    if denominator == 0 { None } else { Some(numerator as f64 / denominator as f64) }
+}
+
 fn insufficient(metric: &str, reason: &str) -> MetricRow {
     MetricRow::InsufficientData {
         metric: metric.to_string(),
@@ -351,6 +709,9 @@ fn insufficient(metric: &str, reason: &str) -> MetricRow {
 }
 
 fn validate_artifact_contract(artifact: &ParserAccuracyArtifact) -> Result<()> {
+    if LINE_TAG_VOCABULARY.is_empty() {
+        bail!("parser accuracy line tag vocabulary must not be empty");
+    }
     if artifact.schema_version != 1 {
         bail!("parser accuracy artifact schema_version must be 1");
     }
@@ -431,6 +792,22 @@ fn git_commit(root: &Path) -> String {
 mod tests {
     use super::*;
 
+    fn tags(values: &[LineTag]) -> BTreeSet<LineTag> {
+        values.iter().copied().collect()
+    }
+
+    fn write_fixture_sources(root: &Path) -> Result<()> {
+        fs::write(
+            root.join("package_basic.pl"),
+            "package Accuracy::Basic;\n\nsub answer { 42 }\n",
+        )?;
+        fs::write(
+            root.join("dynamic_require.pl"),
+            "package Accuracy::DynamicRequire;\n\nmy $module = \"Accuracy::Plugin\";\nrequire $module;\n",
+        )?;
+        Ok(())
+    }
+
     fn fixture_manifest() -> ParserAccuracyManifest {
         ParserAccuracyManifest {
             schema_version: 1,
@@ -450,13 +827,17 @@ mod tests {
                     unsupported_constructs: 0,
                     real_project_file: false,
                     generated: false,
+                    line_expectations: vec![
+                        LineExpectation { line: 1, expected_tags: tags(&[LineTag::PackageDecl]) },
+                        LineExpectation { line: 3, expected_tags: tags(&[LineTag::SubDecl]) },
+                    ],
                 },
                 FixtureMetadata {
                     id: "dynamic_require_boundary".to_string(),
                     family: "dynamic_require".to_string(),
                     label_mode: LabelMode::Partial,
                     source_path: "dynamic_require.pl".to_string(),
-                    scored_lines: 1,
+                    scored_lines: 3,
                     scored_symbols: 1,
                     fully_labeled_regions: 0,
                     partial_labeled_regions: 1,
@@ -466,6 +847,14 @@ mod tests {
                     unsupported_constructs: 0,
                     real_project_file: false,
                     generated: false,
+                    line_expectations: vec![
+                        LineExpectation { line: 1, expected_tags: tags(&[LineTag::PackageDecl]) },
+                        LineExpectation { line: 3, expected_tags: tags(&[LineTag::VariableDecl]) },
+                        LineExpectation {
+                            line: 4,
+                            expected_tags: tags(&[LineTag::Import, LineTag::DynamicBoundary]),
+                        },
+                    ],
                 },
             ],
         }
@@ -476,7 +865,7 @@ mod tests {
         let denominator = compute_denominator(&fixture_manifest());
         assert_eq!(denominator.fixture_count, 2);
         assert_eq!(denominator.fixture_family_count, 2);
-        assert_eq!(denominator.scored_line_count, 3);
+        assert_eq!(denominator.scored_line_count, 5);
         assert_eq!(denominator.scored_symbol_count, 2);
         assert_eq!(denominator.unknown_region_count, 1);
         assert_eq!(denominator.negative_region_count, 1);
@@ -499,15 +888,74 @@ mod tests {
     }
 
     #[test]
-    fn artifact_uses_insufficient_data_for_unwired_scorers() -> Result<()> {
-        let root = Path::new(".");
-        let artifact = build_artifact(root, &fixture_manifest(), Cadence::Pr)?;
+    fn line_tag_vocabulary_includes_required_contract() {
+        assert_eq!(LINE_TAG_VOCABULARY.len(), 22);
+        assert!(LINE_TAG_VOCABULARY.contains(&LineTag::PackageDecl));
+        assert!(LINE_TAG_VOCABULARY.contains(&LineTag::DynamicBoundary));
+        assert!(LINE_TAG_VOCABULARY.contains(&LineTag::UnsupportedConstruct));
+    }
+
+    #[test]
+    fn line_scorer_counts_false_positive_and_false_negative() {
+        let expected = tags(&[LineTag::PackageDecl, LineTag::SubDecl]);
+        let actual = tags(&[LineTag::PackageDecl, LineTag::MethodCall]);
+        let mut score = LineScore::default();
+
+        score_line_tags(&expected, &actual, &mut score);
+
+        assert_eq!(score.true_positive_count, 1);
+        assert_eq!(score.false_positive_count, 1);
+        assert_eq!(score.false_negative_count, 1);
+        assert_eq!(score.exact_match_count, 0);
+    }
+
+    #[test]
+    fn line_metrics_emit_measured_scores_and_insufficient_missing_denominators() {
+        let mut score = LineScore::default();
+        score_line_tags(
+            &tags(&[LineTag::Import, LineTag::DynamicBoundary]),
+            &tags(&[LineTag::Import, LineTag::DynamicBoundary]),
+            &mut score,
+        );
+
+        let metrics = line_metrics(&score, Cadence::Pr);
+
+        assert!(metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::Measured { metric, value, sample_count: 2, .. }
+                    if metric == "line_construct_f1" && (*value - 1.0).abs() < f64::EPSILON
+            )
+        }));
+        assert!(metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::InsufficientData { metric, sample_count: 0, .. }
+                    if metric == "line_unsupported_detection_rate"
+            )
+        }));
+    }
+
+    #[test]
+    fn artifact_uses_measured_line_scores_and_insufficient_data_for_unwired_scorers() -> Result<()>
+    {
+        let tmp = tempfile::tempdir()?;
+        write_fixture_sources(tmp.path())?;
+        let artifact = build_artifact(tmp.path(), &fixture_manifest(), Cadence::Pr)?;
         validate_artifact_contract(&artifact)?;
         assert!(artifact.metrics.iter().any(|metric| {
             matches!(
                 metric,
-                MetricRow::InsufficientData { metric, sample_count: 0, .. }
+                MetricRow::Measured { metric, sample_count, .. }
                     if metric == "line_construct_f1"
+                        && *sample_count > 0
+            )
+        }));
+        assert!(artifact.metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::InsufficientData { metric, sample_count: 0, .. }
+                    if metric == "ast_node_kind_f1"
             )
         }));
         Ok(())

--- a/xtask/src/tasks/update_status/parser/tests.rs
+++ b/xtask/src/tasks/update_status/parser/tests.rs
@@ -190,7 +190,7 @@ fn test_parser_accuracy_missing_artifact_reports_insufficient_data() -> Result<(
 }
 
 #[test]
-fn test_parser_accuracy_artifact_renders_denominator_and_insufficient_rows() -> Result<()> {
+fn test_parser_accuracy_artifact_renders_denominator_and_metric_rows() -> Result<()> {
     let metrics = ParserMetrics {
         syntax_sections: 611,
         system_receipt: None,
@@ -233,10 +233,10 @@ fn test_parser_accuracy_artifact_renders_denominator_and_insufficient_rows() -> 
                     value: 2.0,
                     sample_count: 2,
                 },
-                ParserAccuracyMetricSummary::InsufficientData {
+                ParserAccuracyMetricSummary::Measured {
                     metric: "line_construct_f1".to_string(),
-                    reason: "line-level gold scorer is not wired yet".to_string(),
-                    sample_count: 0,
+                    value: 1.0,
+                    sample_count: 6,
                 },
             ],
         }),
@@ -256,8 +256,8 @@ fn test_parser_accuracy_artifact_renders_denominator_and_insufficient_rows() -> 
         "parser accuracy family row should render family inventory"
     );
     assert!(
-        result.contains("line_construct_f1: insufficient_data"),
-        "unwired accuracy scorer rows must remain insufficient_data"
+        result.contains("line_construct_f1=1.0"),
+        "measured accuracy scorer rows should render their values"
     );
     Ok(())
 }

--- a/xtask/tests/fixtures/parser-accuracy/example-artifact.json
+++ b/xtask/tests/fixtures/parser-accuracy/example-artifact.json
@@ -7,7 +7,7 @@
   "denominator": {
     "fixture_count": 2,
     "fixture_family_count": 2,
-    "scored_line_count": 3,
+    "scored_line_count": 5,
     "scored_symbol_count": 2,
     "fully_labeled_region_count": 1,
     "partial_labeled_region_count": 1,
@@ -37,7 +37,7 @@
       "label_modes": [
         "partial"
       ],
-      "scored_line_count": 1,
+      "scored_line_count": 3,
       "scored_symbol_count": 1,
       "dynamic_boundary_case_count": 1,
       "unsupported_construct_case_count": 0
@@ -55,8 +55,96 @@
     },
     {
       "metric": "line_construct_f1",
+      "state": "measured",
+      "value": 1,
+      "sample_count": 6,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_construct_true_positive_count",
+      "state": "measured",
+      "value": 6,
+      "sample_count": 5,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_construct_false_positive_count",
+      "state": "measured",
+      "value": 0,
+      "sample_count": 5,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_construct_false_negative_count",
+      "state": "measured",
+      "value": 0,
+      "sample_count": 5,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_construct_exact_match_rate",
+      "state": "measured",
+      "value": 1,
+      "sample_count": 5,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_construct_precision",
+      "state": "measured",
+      "value": 1,
+      "sample_count": 6,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_construct_recall",
+      "state": "measured",
+      "value": 1,
+      "sample_count": 6,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_error_false_positive_rate",
+      "state": "measured",
+      "value": 0,
+      "sample_count": 5,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_error_false_negative_rate",
       "state": "insufficient_data",
-      "reason": "line-level gold scorer is not wired yet",
+      "reason": "no expected parse-error line labels are available",
+      "sample_count": 0,
+      "confidence": "low"
+    },
+    {
+      "metric": "line_dynamic_boundary_correct_rate",
+      "state": "measured",
+      "value": 1,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "metric": "line_unsupported_detection_rate",
+      "state": "insufficient_data",
+      "reason": "no expected unsupported-construct line labels are available",
       "sample_count": 0,
       "confidence": "low"
     },

--- a/xtask/tests/parser_accuracy_schema.rs
+++ b/xtask/tests/parser_accuracy_schema.rs
@@ -145,7 +145,7 @@ fn validate_metric_rows(artifact: &Value) -> TestResult {
     assert!(!metrics.is_empty(), "example artifact should include metric rows");
 
     let mut saw_measured = false;
-    let mut saw_insufficient_line = false;
+    let mut saw_measured_line = false;
     let mut saw_insufficient_ast = false;
     let mut saw_insufficient_symbol = false;
 
@@ -162,11 +162,13 @@ fn validate_metric_rows(artifact: &Value) -> TestResult {
                 assert!(metric.get("value").and_then(Value::as_f64).is_some());
                 assert!(metric.get("direction").and_then(Value::as_str).is_some());
                 assert!(metric.get("confidence").and_then(Value::as_str).is_some());
+                if metric["metric"].as_str() == Some("line_construct_f1") {
+                    saw_measured_line = true;
+                }
             }
             "insufficient_data" => {
                 assert!(metric.get("reason").and_then(Value::as_str).is_some());
                 match metric["metric"].as_str() {
-                    Some("line_construct_f1") => saw_insufficient_line = true,
                     Some("ast_node_kind_f1") => saw_insufficient_ast = true,
                     Some("symbol_decl_f1") => saw_insufficient_symbol = true,
                     _ => {}
@@ -177,7 +179,7 @@ fn validate_metric_rows(artifact: &Value) -> TestResult {
     }
 
     assert!(saw_measured, "example should include at least one measured denominator row");
-    assert!(saw_insufficient_line, "example should include line insufficient-data row");
+    assert!(saw_measured_line, "example should include measured line F1 row");
     assert!(saw_insufficient_ast, "example should include AST insufficient-data row");
     assert!(saw_insufficient_symbol, "example should include symbol insufficient-data row");
     Ok(())


### PR DESCRIPTION
Problem: Parser accuracy now has denominator visibility, but line-level construct accuracy was still an insufficient-data placeholder.
Fix: Add a line tag vocabulary, gold-backed manifest expectations, parser-AST line tag extraction, TP/FP/FN scoring, measured line precision/recall/F1 rows, and Task 4 completion in the Kiro spec.
Verification: `cargo test -p xtask --profile agent --locked parser_accuracy -- --nocapture`; `cargo test -p xtask --profile agent --locked update_status::parser -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics parser-accuracy --json`; `cargo check -p xtask --all-targets --profile agent --locked`; `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`.