### PR TITLE
feat(parser): score parser accuracy AST shape (#0000)

### DIFF
--- a/.kiro/specs/parser-accuracy-observability/tasks.md
+++ b/.kiro/specs/parser-accuracy-observability/tasks.md
@@ -43,10 +43,10 @@ Build a layered parser accuracy scorecard that starts with denominator visibilit
     - Emit TP/FP/FN, exact match rate, precision, recall, F1, error false positive rate, error false negative rate, dynamic boundary correct rate, and unsupported detection rate
     - _Verify: unit tests with at least one false positive and one false negative_
 
-- [ ] 5. Add AST structural scoring
-  - [ ] 5.1 Define AST gold fixture expectations
+- [x] 5. Add AST structural scoring
+  - [x] 5.1 Define AST gold fixture expectations
     - Track node kind, span, parent-child edge, and operator-precedence expectations
-  - [ ] 5.2 Implement AST scorer
+  - [x] 5.2 Implement AST scorer
     - Emit node-kind precision/recall/F1, span exact/near rates, parent-child edge accuracy, tree depth accuracy, operator precedence accuracy, delimiter pairing accuracy, unexpected error node count, and missing expected node count
     - _Verify: fixture with correct line tag but wrong parent-child edge fails AST score_
 

--- a/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
+++ b/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
@@ -29,6 +29,28 @@
             "sub_decl"
           ]
         }
+      ],
+      "ast_expectations": [
+        {
+          "id": "package_basic_package",
+          "kind": "Package",
+          "line": 1,
+          "span_text": "package Accuracy::Basic;",
+          "parent_kind": "Program",
+          "depth": 1,
+          "operator": null,
+          "parent_operator": null
+        },
+        {
+          "id": "package_basic_subroutine",
+          "kind": "Subroutine",
+          "line": 3,
+          "span_text": "sub answer { 42 }",
+          "parent_kind": "Program",
+          "depth": 1,
+          "operator": null,
+          "parent_operator": null
+        }
       ]
     },
     {
@@ -65,6 +87,110 @@
             "import",
             "dynamic_boundary"
           ]
+        }
+      ],
+      "ast_expectations": [
+        {
+          "id": "dynamic_require_package",
+          "kind": "Package",
+          "line": 1,
+          "span_text": "package Accuracy::DynamicRequire;",
+          "parent_kind": "Program",
+          "depth": 1,
+          "operator": null,
+          "parent_operator": null
+        },
+        {
+          "id": "dynamic_require_variable",
+          "kind": "VariableDeclaration",
+          "line": 3,
+          "span_text": "my $module = \"Accuracy::Plugin\"",
+          "parent_kind": "Program",
+          "depth": 1,
+          "operator": null,
+          "parent_operator": null
+        },
+        {
+          "id": "dynamic_require_call",
+          "kind": "FunctionCall",
+          "line": 4,
+          "span_text": "require $module",
+          "parent_kind": "ExpressionStatement",
+          "depth": 2,
+          "operator": null,
+          "parent_operator": null
+        }
+      ]
+    },
+    {
+      "id": "operator_precedence",
+      "family": "operators",
+      "label_mode": "full",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/operator_precedence.pl",
+      "scored_lines": 2,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 1,
+      "partial_labeled_regions": 0,
+      "unknown_regions": 0,
+      "negative_regions": 1,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        }
+      ],
+      "ast_expectations": [
+        {
+          "id": "operator_package",
+          "kind": "Package",
+          "line": 1,
+          "span_text": "package Accuracy::Operators;",
+          "parent_kind": "Program",
+          "depth": 1,
+          "operator": null,
+          "parent_operator": null
+        },
+        {
+          "id": "operator_variable",
+          "kind": "VariableDeclaration",
+          "line": 3,
+          "span_text": "my $value = 1 + 2 * 3",
+          "parent_kind": "Program",
+          "depth": 1,
+          "operator": null,
+          "parent_operator": null
+        },
+        {
+          "id": "operator_addition",
+          "kind": "Binary",
+          "line": 3,
+          "span_text": "1 + 2 * 3",
+          "parent_kind": "VariableDeclaration",
+          "depth": 2,
+          "operator": "+",
+          "parent_operator": null
+        },
+        {
+          "id": "operator_multiplication",
+          "kind": "Binary",
+          "line": 3,
+          "span_text": "2 * 3",
+          "parent_kind": "Binary",
+          "depth": 3,
+          "operator": "*",
+          "parent_operator": "+"
         }
       ]
     }

--- a/crates/perl-corpus/fixtures/parser_accuracy/operator_precedence.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/operator_precedence.pl
@@ -1,0 +1,5 @@
+package Accuracy::Operators;
+
+my $value = 1 + 2 * 3;
+
+1;

--- a/xtask/src/tasks/metrics/parser_accuracy.rs
+++ b/xtask/src/tasks/metrics/parser_accuracy.rs
@@ -43,6 +43,8 @@ struct FixtureMetadata {
     generated: bool,
     #[serde(default)]
     line_expectations: Vec<LineExpectation>,
+    #[serde(default)]
+    ast_expectations: Vec<AstExpectation>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -58,6 +60,29 @@ enum LabelMode {
 struct LineExpectation {
     line: u64,
     expected_tags: BTreeSet<LineTag>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct AstExpectation {
+    id: String,
+    kind: String,
+    line: u64,
+    span_text: String,
+    parent_kind: Option<String>,
+    depth: Option<u64>,
+    operator: Option<String>,
+    parent_operator: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AstPrediction {
+    kind: String,
+    line: u64,
+    span_text: String,
+    parent_kind: Option<String>,
+    depth: u64,
+    operator: Option<String>,
+    parent_operator: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -255,6 +280,27 @@ struct LineScore {
     correct_unsupported_construct_count: u64,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct AstScore {
+    expected_node_count: u64,
+    predicted_node_count: u64,
+    node_kind_true_positive_count: u64,
+    node_kind_false_positive_count: u64,
+    node_kind_false_negative_count: u64,
+    span_exact_count: u64,
+    span_near_count: u64,
+    parent_child_expected_count: u64,
+    parent_child_correct_count: u64,
+    tree_depth_expected_count: u64,
+    tree_depth_correct_count: u64,
+    operator_precedence_expected_count: u64,
+    operator_precedence_correct_count: u64,
+    delimiter_pairing_expected_count: u64,
+    delimiter_pairing_correct_count: u64,
+    unexpected_error_node_count: u64,
+    missing_expected_node_count: u64,
+}
+
 /// Run `cargo xtask metrics parser-accuracy`.
 pub fn run(
     json: bool,
@@ -324,6 +370,7 @@ fn build_artifact(
     let families = summarize_families(manifest);
     let fixture_count = denominator.fixture_count as f64;
     let line_score = score_manifest_line_tags(root, manifest)?;
+    let ast_score = score_manifest_ast(root, manifest)?;
     let mut metrics = vec![MetricRow::Measured {
         metric: "denominator_fixture_count".to_string(),
         value: fixture_count,
@@ -333,10 +380,8 @@ fn build_artifact(
         cadence,
     }];
     metrics.extend(line_metrics(&line_score, cadence));
-    metrics.extend([
-        insufficient("ast_node_kind_f1", "AST structural gold scorer is not wired yet"),
-        insufficient("symbol_decl_f1", "symbol gold scorer is not wired yet"),
-    ]);
+    metrics.extend(ast_metrics(&ast_score, cadence));
+    metrics.extend([insufficient("symbol_decl_f1", "symbol gold scorer is not wired yet")]);
 
     Ok(ParserAccuracyArtifact {
         schema_version: 1,
@@ -652,6 +697,272 @@ fn line_metrics(score: &LineScore, cadence: Cadence) -> Vec<MetricRow> {
     rows
 }
 
+fn score_manifest_ast(root: &Path, manifest: &ParserAccuracyManifest) -> Result<AstScore> {
+    let mut score = AstScore::default();
+    for fixture in &manifest.fixtures {
+        if fixture.ast_expectations.is_empty() {
+            continue;
+        }
+        let source_path = root.join(&fixture.source_path);
+        let source = fs::read_to_string(&source_path).with_context(|| {
+            format!("reading parser accuracy fixture source {}", source_path.display())
+        })?;
+        let expected_lines = fixture
+            .ast_expectations
+            .iter()
+            .map(|expectation| expectation.line)
+            .collect::<BTreeSet<_>>();
+        let predictions = extract_ast_predictions(&source)
+            .into_iter()
+            .filter(|prediction| expected_lines.contains(&prediction.line))
+            .collect::<Vec<_>>();
+        score_ast_expectations(&fixture.ast_expectations, &predictions, &mut score);
+    }
+    Ok(score)
+}
+
+fn extract_ast_predictions(source: &str) -> Vec<AstPrediction> {
+    let mut parser = Parser::new(source);
+    let output = parser.parse_with_recovery();
+    let line_starts = line_starts(source);
+    let mut predictions = Vec::new();
+    collect_ast_predictions(&output.ast, source, &line_starts, None, None, 0, &mut predictions);
+    predictions
+}
+
+fn collect_ast_predictions(
+    node: &Node,
+    source: &str,
+    line_starts: &[usize],
+    parent_kind: Option<&str>,
+    parent_operator: Option<&str>,
+    depth: u64,
+    predictions: &mut Vec<AstPrediction>,
+) {
+    let operator = node_operator(node);
+    if is_ast_scored_node(node) {
+        predictions.push(AstPrediction {
+            kind: node.kind.kind_name().to_string(),
+            line: line_for_offset(line_starts, node.location.start),
+            span_text: source
+                .get(node.location.start..node.location.end)
+                .unwrap_or_default()
+                .to_string(),
+            parent_kind: parent_kind.map(ToString::to_string),
+            depth,
+            operator: operator.map(ToString::to_string),
+            parent_operator: parent_operator.map(ToString::to_string),
+        });
+    }
+
+    let kind = node.kind.kind_name();
+    node.for_each_child(|child| {
+        collect_ast_predictions(
+            child,
+            source,
+            line_starts,
+            Some(kind),
+            operator,
+            depth + 1,
+            predictions,
+        );
+    });
+}
+
+fn is_ast_scored_node(node: &Node) -> bool {
+    matches!(
+        node.kind,
+        NodeKind::Package { .. }
+            | NodeKind::Subroutine { .. }
+            | NodeKind::Method { .. }
+            | NodeKind::VariableDeclaration { .. }
+            | NodeKind::VariableListDeclaration { .. }
+            | NodeKind::FunctionCall { .. }
+            | NodeKind::MethodCall { .. }
+            | NodeKind::Regex { .. }
+            | NodeKind::Match { .. }
+            | NodeKind::Substitution { .. }
+            | NodeKind::Transliteration { .. }
+            | NodeKind::Heredoc { .. }
+            | NodeKind::Format { .. }
+            | NodeKind::Binary { .. }
+            | NodeKind::Error { .. }
+            | NodeKind::UnknownRest
+    )
+}
+
+fn node_operator(node: &Node) -> Option<&str> {
+    match &node.kind {
+        NodeKind::Binary { op, .. } => Some(op.as_str()),
+        _ => None,
+    }
+}
+
+fn score_ast_expectations(
+    expectations: &[AstExpectation],
+    predictions: &[AstPrediction],
+    score: &mut AstScore,
+) {
+    score.expected_node_count += expectations.len() as u64;
+    score.predicted_node_count += predictions.len() as u64;
+    score.unexpected_error_node_count +=
+        predictions.iter().filter(|prediction| prediction.kind == "Error").count() as u64;
+
+    let mut matched = BTreeSet::new();
+    for expectation in expectations {
+        let prediction_index = predictions.iter().enumerate().find_map(|(index, prediction)| {
+            if matched.contains(&index) {
+                return None;
+            }
+            if prediction.kind == expectation.kind && prediction.line == expectation.line {
+                Some(index)
+            } else {
+                None
+            }
+        });
+
+        let Some(prediction_index) = prediction_index else {
+            score.node_kind_false_negative_count += 1;
+            score.missing_expected_node_count += 1;
+            continue;
+        };
+
+        matched.insert(prediction_index);
+        let prediction = &predictions[prediction_index];
+        score.node_kind_true_positive_count += 1;
+        if prediction.span_text == expectation.span_text {
+            score.span_exact_count += 1;
+        }
+        if prediction.line == expectation.line {
+            score.span_near_count += 1;
+        }
+        if let Some(parent_kind) = &expectation.parent_kind {
+            score.parent_child_expected_count += 1;
+            if prediction.parent_kind.as_ref() == Some(parent_kind) {
+                score.parent_child_correct_count += 1;
+            }
+        }
+        if let Some(depth) = expectation.depth {
+            score.tree_depth_expected_count += 1;
+            if prediction.depth == depth {
+                score.tree_depth_correct_count += 1;
+            }
+        }
+        if let Some(operator) = &expectation.operator {
+            score.operator_precedence_expected_count += 1;
+            if prediction.operator.as_ref() == Some(operator)
+                && prediction.parent_operator.as_ref() == expectation.parent_operator.as_ref()
+            {
+                score.operator_precedence_correct_count += 1;
+            }
+        }
+    }
+
+    score.node_kind_false_positive_count += predictions
+        .iter()
+        .enumerate()
+        .filter(|(index, prediction)| !matched.contains(index) && prediction.kind != "Error")
+        .count() as u64;
+}
+
+fn ast_metrics(score: &AstScore, cadence: Cadence) -> Vec<MetricRow> {
+    if score.expected_node_count == 0 {
+        return vec![insufficient("ast_node_kind_f1", "AST gold labels are not available")];
+    }
+
+    let precision_denominator =
+        score.node_kind_true_positive_count + score.node_kind_false_positive_count;
+    let recall_denominator =
+        score.node_kind_true_positive_count + score.node_kind_false_negative_count;
+    let precision = ratio(score.node_kind_true_positive_count, precision_denominator);
+    let recall = ratio(score.node_kind_true_positive_count, recall_denominator);
+    let f1 = match (precision, recall) {
+        (Some(precision), Some(recall)) if precision + recall > 0.0 => {
+            Some(2.0 * precision * recall / (precision + recall))
+        }
+        _ => None,
+    };
+
+    vec![
+        optional_measured_rate(
+            "ast_node_kind_precision",
+            precision,
+            precision_denominator,
+            "no predicted AST nodes were available",
+            cadence,
+        ),
+        optional_measured_rate(
+            "ast_node_kind_recall",
+            recall,
+            recall_denominator,
+            "no expected AST nodes were available",
+            cadence,
+        ),
+        optional_measured_rate(
+            "ast_node_kind_f1",
+            f1,
+            recall_denominator,
+            "AST precision or recall denominator is unavailable",
+            cadence,
+        ),
+        measured_rate(
+            "ast_node_span_exact_rate",
+            score.span_exact_count,
+            score.expected_node_count,
+            cadence,
+        ),
+        measured_rate(
+            "ast_node_span_near_rate",
+            score.span_near_count,
+            score.expected_node_count,
+            cadence,
+        ),
+        optional_measured_rate(
+            "ast_parent_child_edge_accuracy",
+            ratio(score.parent_child_correct_count, score.parent_child_expected_count),
+            score.parent_child_expected_count,
+            "no expected AST parent-child edges are available",
+            cadence,
+        ),
+        optional_measured_rate(
+            "ast_tree_depth_accuracy",
+            ratio(score.tree_depth_correct_count, score.tree_depth_expected_count),
+            score.tree_depth_expected_count,
+            "no expected AST tree-depth labels are available",
+            cadence,
+        ),
+        optional_measured_rate(
+            "ast_operator_precedence_accuracy",
+            ratio(
+                score.operator_precedence_correct_count,
+                score.operator_precedence_expected_count,
+            ),
+            score.operator_precedence_expected_count,
+            "no expected AST operator-precedence labels are available",
+            cadence,
+        ),
+        optional_measured_rate(
+            "ast_delimiter_pairing_accuracy",
+            ratio(score.delimiter_pairing_correct_count, score.delimiter_pairing_expected_count),
+            score.delimiter_pairing_expected_count,
+            "no expected AST delimiter-pairing labels are available",
+            cadence,
+        ),
+        measured_count(
+            "ast_unexpected_error_node_count",
+            score.unexpected_error_node_count,
+            score.expected_node_count,
+            cadence,
+        ),
+        measured_count(
+            "ast_missing_expected_node_count",
+            score.missing_expected_node_count,
+            score.expected_node_count,
+            cadence,
+        ),
+    ]
+}
+
 fn measured_count(metric: &str, value: u64, sample_count: u64, cadence: Cadence) -> MetricRow {
     MetricRow::Measured {
         metric: metric.to_string(),
@@ -831,6 +1142,28 @@ mod tests {
                         LineExpectation { line: 1, expected_tags: tags(&[LineTag::PackageDecl]) },
                         LineExpectation { line: 3, expected_tags: tags(&[LineTag::SubDecl]) },
                     ],
+                    ast_expectations: vec![
+                        AstExpectation {
+                            id: "package_basic_package".to_string(),
+                            kind: "Package".to_string(),
+                            line: 1,
+                            span_text: "package Accuracy::Basic;".to_string(),
+                            parent_kind: Some("Program".to_string()),
+                            depth: Some(1),
+                            operator: None,
+                            parent_operator: None,
+                        },
+                        AstExpectation {
+                            id: "package_basic_subroutine".to_string(),
+                            kind: "Subroutine".to_string(),
+                            line: 3,
+                            span_text: "sub answer { 42 }".to_string(),
+                            parent_kind: Some("Program".to_string()),
+                            depth: Some(1),
+                            operator: None,
+                            parent_operator: None,
+                        },
+                    ],
                 },
                 FixtureMetadata {
                     id: "dynamic_require_boundary".to_string(),
@@ -853,6 +1186,38 @@ mod tests {
                         LineExpectation {
                             line: 4,
                             expected_tags: tags(&[LineTag::Import, LineTag::DynamicBoundary]),
+                        },
+                    ],
+                    ast_expectations: vec![
+                        AstExpectation {
+                            id: "dynamic_require_package".to_string(),
+                            kind: "Package".to_string(),
+                            line: 1,
+                            span_text: "package Accuracy::DynamicRequire;".to_string(),
+                            parent_kind: Some("Program".to_string()),
+                            depth: Some(1),
+                            operator: None,
+                            parent_operator: None,
+                        },
+                        AstExpectation {
+                            id: "dynamic_require_variable".to_string(),
+                            kind: "VariableDeclaration".to_string(),
+                            line: 3,
+                            span_text: "my $module = \"Accuracy::Plugin\"".to_string(),
+                            parent_kind: Some("Program".to_string()),
+                            depth: Some(1),
+                            operator: None,
+                            parent_operator: None,
+                        },
+                        AstExpectation {
+                            id: "dynamic_require_call".to_string(),
+                            kind: "FunctionCall".to_string(),
+                            line: 4,
+                            span_text: "require $module".to_string(),
+                            parent_kind: Some("ExpressionStatement".to_string()),
+                            depth: Some(2),
+                            operator: None,
+                            parent_operator: None,
                         },
                     ],
                 },
@@ -937,8 +1302,82 @@ mod tests {
     }
 
     #[test]
-    fn artifact_uses_measured_line_scores_and_insufficient_data_for_unwired_scorers() -> Result<()>
-    {
+    fn ast_scorer_counts_wrong_parent_child_edge() {
+        let expectations = vec![AstExpectation {
+            id: "sub_wrong_parent".to_string(),
+            kind: "Subroutine".to_string(),
+            line: 1,
+            span_text: "sub answer { 42 }".to_string(),
+            parent_kind: Some("Block".to_string()),
+            depth: Some(1),
+            operator: None,
+            parent_operator: None,
+        }];
+        let predictions = vec![AstPrediction {
+            kind: "Subroutine".to_string(),
+            line: 1,
+            span_text: "sub answer { 42 }".to_string(),
+            parent_kind: Some("Program".to_string()),
+            depth: 1,
+            operator: None,
+            parent_operator: None,
+        }];
+        let mut score = AstScore::default();
+
+        score_ast_expectations(&expectations, &predictions, &mut score);
+
+        assert_eq!(score.node_kind_true_positive_count, 1);
+        assert_eq!(score.parent_child_expected_count, 1);
+        assert_eq!(score.parent_child_correct_count, 0);
+    }
+
+    #[test]
+    fn ast_metrics_emit_measured_scores_and_insufficient_missing_denominators() {
+        let mut score = AstScore::default();
+        score_ast_expectations(
+            &[AstExpectation {
+                id: "binary_precedence".to_string(),
+                kind: "Binary".to_string(),
+                line: 1,
+                span_text: "2 * 3".to_string(),
+                parent_kind: Some("Binary".to_string()),
+                depth: Some(3),
+                operator: Some("*".to_string()),
+                parent_operator: Some("+".to_string()),
+            }],
+            &[AstPrediction {
+                kind: "Binary".to_string(),
+                line: 1,
+                span_text: "2 * 3".to_string(),
+                parent_kind: Some("Binary".to_string()),
+                depth: 3,
+                operator: Some("*".to_string()),
+                parent_operator: Some("+".to_string()),
+            }],
+            &mut score,
+        );
+
+        let metrics = ast_metrics(&score, Cadence::Pr);
+
+        assert!(metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::Measured { metric, value, sample_count: 1, .. }
+                    if metric == "ast_operator_precedence_accuracy"
+                        && (*value - 1.0).abs() < f64::EPSILON
+            )
+        }));
+        assert!(metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::InsufficientData { metric, sample_count: 0, .. }
+                    if metric == "ast_delimiter_pairing_accuracy"
+            )
+        }));
+    }
+
+    #[test]
+    fn artifact_uses_measured_line_and_ast_scores_with_symbol_insufficient_data() -> Result<()> {
         let tmp = tempfile::tempdir()?;
         write_fixture_sources(tmp.path())?;
         let artifact = build_artifact(tmp.path(), &fixture_manifest(), Cadence::Pr)?;
@@ -954,8 +1393,16 @@ mod tests {
         assert!(artifact.metrics.iter().any(|metric| {
             matches!(
                 metric,
-                MetricRow::InsufficientData { metric, sample_count: 0, .. }
+                MetricRow::Measured { metric, sample_count, .. }
                     if metric == "ast_node_kind_f1"
+                        && *sample_count > 0
+            )
+        }));
+        assert!(artifact.metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::InsufficientData { metric, sample_count: 0, .. }
+                    if metric == "symbol_decl_f1"
             )
         }));
         Ok(())

--- a/xtask/tests/fixtures/parser-accuracy/example-artifact.json
+++ b/xtask/tests/fixtures/parser-accuracy/example-artifact.json
@@ -5,32 +5,21 @@
   "commit": "example",
   "cadence": "pr",
   "denominator": {
-    "fixture_count": 2,
-    "fixture_family_count": 2,
-    "scored_line_count": 5,
-    "scored_symbol_count": 2,
-    "fully_labeled_region_count": 1,
+    "fixture_count": 3,
+    "fixture_family_count": 3,
+    "scored_line_count": 7,
+    "scored_symbol_count": 4,
+    "fully_labeled_region_count": 2,
     "partial_labeled_region_count": 1,
     "unknown_region_count": 1,
-    "negative_region_count": 1,
+    "negative_region_count": 2,
     "dynamic_boundary_case_count": 1,
     "unsupported_construct_case_count": 0,
     "real_project_file_count": 0,
     "generated_fixture_count": 0,
-    "hand_labeled_fixture_count": 2
+    "hand_labeled_fixture_count": 3
   },
   "families": [
-    {
-      "family": "packages",
-      "fixture_count": 1,
-      "label_modes": [
-        "full"
-      ],
-      "scored_line_count": 2,
-      "scored_symbol_count": 1,
-      "dynamic_boundary_case_count": 0,
-      "unsupported_construct_case_count": 0
-    },
     {
       "family": "dynamic_require",
       "fixture_count": 1,
@@ -41,123 +30,235 @@
       "scored_symbol_count": 1,
       "dynamic_boundary_case_count": 1,
       "unsupported_construct_case_count": 0
+    },
+    {
+      "family": "operators",
+      "fixture_count": 1,
+      "label_modes": [
+        "full"
+      ],
+      "scored_line_count": 2,
+      "scored_symbol_count": 2,
+      "dynamic_boundary_case_count": 0,
+      "unsupported_construct_case_count": 0
+    },
+    {
+      "family": "packages",
+      "fixture_count": 1,
+      "label_modes": [
+        "full"
+      ],
+      "scored_line_count": 2,
+      "scored_symbol_count": 1,
+      "dynamic_boundary_case_count": 0,
+      "unsupported_construct_case_count": 0
     }
   ],
   "metrics": [
     {
+      "state": "measured",
       "metric": "denominator_fixture_count",
-      "state": "measured",
-      "value": 2,
-      "sample_count": 2,
+      "value": 3.0,
+      "sample_count": 3,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
-      "metric": "line_construct_f1",
       "state": "measured",
-      "value": 1,
-      "sample_count": 6,
-      "direction": "neutral",
-      "confidence": "high",
-      "cadence": "pr"
-    },
-    {
       "metric": "line_construct_true_positive_count",
-      "state": "measured",
-      "value": 6,
-      "sample_count": 5,
+      "value": 8.0,
+      "sample_count": 7,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
+      "state": "measured",
       "metric": "line_construct_false_positive_count",
-      "state": "measured",
-      "value": 0,
-      "sample_count": 5,
+      "value": 0.0,
+      "sample_count": 7,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
+      "state": "measured",
       "metric": "line_construct_false_negative_count",
-      "state": "measured",
-      "value": 0,
-      "sample_count": 5,
+      "value": 0.0,
+      "sample_count": 7,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
+      "state": "measured",
       "metric": "line_construct_exact_match_rate",
-      "state": "measured",
-      "value": 1,
-      "sample_count": 5,
+      "value": 1.0,
+      "sample_count": 7,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
+      "state": "measured",
       "metric": "line_construct_precision",
-      "state": "measured",
-      "value": 1,
-      "sample_count": 6,
+      "value": 1.0,
+      "sample_count": 8,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
+      "state": "measured",
       "metric": "line_construct_recall",
-      "state": "measured",
-      "value": 1,
-      "sample_count": 6,
+      "value": 1.0,
+      "sample_count": 8,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
+      "state": "measured",
+      "metric": "line_construct_f1",
+      "value": 1.0,
+      "sample_count": 8,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
       "metric": "line_error_false_positive_rate",
-      "state": "measured",
-      "value": 0,
-      "sample_count": 5,
+      "value": 0.0,
+      "sample_count": 7,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
-      "metric": "line_error_false_negative_rate",
       "state": "insufficient_data",
+      "metric": "line_error_false_negative_rate",
       "reason": "no expected parse-error line labels are available",
       "sample_count": 0,
       "confidence": "low"
     },
     {
-      "metric": "line_dynamic_boundary_correct_rate",
       "state": "measured",
-      "value": 1,
+      "metric": "line_dynamic_boundary_correct_rate",
+      "value": 1.0,
       "sample_count": 1,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
-      "metric": "line_unsupported_detection_rate",
       "state": "insufficient_data",
+      "metric": "line_unsupported_detection_rate",
       "reason": "no expected unsupported-construct line labels are available",
       "sample_count": 0,
       "confidence": "low"
     },
     {
+      "state": "measured",
+      "metric": "ast_node_kind_precision",
+      "value": 1.0,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "ast_node_kind_recall",
+      "value": 1.0,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
       "metric": "ast_node_kind_f1",
+      "value": 1.0,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "ast_node_span_exact_rate",
+      "value": 0.4444444444444444,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "ast_node_span_near_rate",
+      "value": 1.0,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "ast_parent_child_edge_accuracy",
+      "value": 1.0,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "ast_tree_depth_accuracy",
+      "value": 1.0,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "ast_operator_precedence_accuracy",
+      "value": 1.0,
+      "sample_count": 2,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
       "state": "insufficient_data",
-      "reason": "AST structural gold scorer is not wired yet",
+      "metric": "ast_delimiter_pairing_accuracy",
+      "reason": "no expected AST delimiter-pairing labels are available",
       "sample_count": 0,
       "confidence": "low"
     },
     {
-      "metric": "symbol_decl_f1",
+      "state": "measured",
+      "metric": "ast_unexpected_error_node_count",
+      "value": 0.0,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "ast_missing_expected_node_count",
+      "value": 0.0,
+      "sample_count": 9,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
       "state": "insufficient_data",
+      "metric": "symbol_decl_f1",
       "reason": "symbol gold scorer is not wired yet",
       "sample_count": 0,
       "confidence": "low"
@@ -179,7 +280,7 @@
     "runtime_ms": 1,
     "timeout_count": 0,
     "flake_count": 0,
-    "artifact_size_bytes": 2048,
+    "artifact_size_bytes": 4096,
     "ci_runner_failure_count": 0,
     "orphan_process_count": 0,
     "cache_hit_rate": null

--- a/xtask/tests/parser_accuracy_schema.rs
+++ b/xtask/tests/parser_accuracy_schema.rs
@@ -146,7 +146,7 @@ fn validate_metric_rows(artifact: &Value) -> TestResult {
 
     let mut saw_measured = false;
     let mut saw_measured_line = false;
-    let mut saw_insufficient_ast = false;
+    let mut saw_measured_ast = false;
     let mut saw_insufficient_symbol = false;
 
     for metric in metrics {
@@ -165,11 +165,13 @@ fn validate_metric_rows(artifact: &Value) -> TestResult {
                 if metric["metric"].as_str() == Some("line_construct_f1") {
                     saw_measured_line = true;
                 }
+                if metric["metric"].as_str() == Some("ast_node_kind_f1") {
+                    saw_measured_ast = true;
+                }
             }
             "insufficient_data" => {
                 assert!(metric.get("reason").and_then(Value::as_str).is_some());
                 match metric["metric"].as_str() {
-                    Some("ast_node_kind_f1") => saw_insufficient_ast = true,
                     Some("symbol_decl_f1") => saw_insufficient_symbol = true,
                     _ => {}
                 }
@@ -180,7 +182,7 @@ fn validate_metric_rows(artifact: &Value) -> TestResult {
 
     assert!(saw_measured, "example should include at least one measured denominator row");
     assert!(saw_measured_line, "example should include measured line F1 row");
-    assert!(saw_insufficient_ast, "example should include AST insufficient-data row");
+    assert!(saw_measured_ast, "example should include measured AST F1 row");
     assert!(saw_insufficient_symbol, "example should include symbol insufficient-data row");
     Ok(())
 }


### PR DESCRIPTION
Problem: Parser accuracy line scoring was measured, but AST shape accuracy was still an insufficient-data placeholder.
Fix: Add AST gold expectations, parser-AST prediction extraction with node kind/span/parent/depth/operator metadata, measured AST node-kind/span/edge/depth/operator rows, and Task 5 completion in the Kiro spec.
Verification: `cargo test -p xtask --profile agent --locked parser_accuracy -- --nocapture`; `cargo test -p xtask --profile agent --locked update_status::parser -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics parser-accuracy --json`; `cargo check -p xtask --all-targets --profile agent --locked`; `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`.
Note: The first AST span exact rate is intentionally measured below 1.0; the scorecard is surfacing current span mismatch instead of hiding it.