### PR TITLE
test(semantic): add real-workspace baseline (#0000)

### DIFF
--- a/crates/perl-symbol/src/surface/ref.rs
+++ b/crates/perl-symbol/src/surface/ref.rs
@@ -45,8 +45,8 @@ pub struct SymbolRef {
     pub name: String,
     /// Package-qualified name when syntactically explicit, else bare `name`.
     pub qualified_name: String,
-    /// Variable sigil (`$`, `@`, `%`) for variable refs.  `&` and `*` sigils are
-    /// not emitted in phase-1 (see module-level exclusion list).
+    /// Variable sigil (`$`, `@`, `%`) for variable refs, or boundary sigils
+    /// (`&`, `*`) for coderef/typeglob refs.
     pub sigil: Option<String>,
     /// Explicit package qualifier from syntax (for example `Some("Pkg")` for
     /// `Pkg::func` or `$Pkg::var`).
@@ -85,6 +85,18 @@ fn walk(node: &Node, out: &mut Vec<SymbolRef>) {
         NodeKind::OptionalParameter { default_value, .. } => {
             // The default expression may reference other variables.
             walk(default_value, out);
+        }
+
+        NodeKind::Goto { target } => {
+            if !push_coderef_target(target, (node.location.start, node.location.end), out) {
+                walk(target, out);
+            }
+        }
+
+        NodeKind::Unary { op, operand } if op == "\\" => {
+            if !push_coderef_target(operand, (node.location.start, node.location.end), out) {
+                walk(operand, out);
+            }
         }
 
         NodeKind::Variable { sigil, name } => {
@@ -191,6 +203,33 @@ fn push_variable_like_ref(node: &Node, sigil: &str, name: &str, out: &mut Vec<Sy
         full_span: (node.location.start, node.location.end),
         anchor_span: Some((node.location.start, node.location.end)),
     });
+}
+
+fn push_coderef_target(node: &Node, full_span: (usize, usize), out: &mut Vec<SymbolRef>) -> bool {
+    let Some(name) = coderef_target_name(node) else {
+        return false;
+    };
+    let (package_qualifier, bare_name, qualified_name) = split_qualified_name(name);
+    out.push(SymbolRef {
+        kind: SymbolRefKind::CoderefReference,
+        name: bare_name,
+        qualified_name,
+        sigil: Some("&".to_string()),
+        package_qualifier,
+        full_span,
+        anchor_span: Some((node.location.start, node.location.end)),
+    });
+    true
+}
+
+fn coderef_target_name(node: &Node) -> Option<&str> {
+    match &node.kind {
+        NodeKind::Variable { sigil, name } if sigil == "&" => Some(name),
+        // The parser lowers source forms like `\&foo` and `goto &foo` into a
+        // zero-argument FunctionCall target after consuming the ampersand.
+        NodeKind::FunctionCall { name, args } if args.is_empty() => Some(name),
+        _ => None,
+    }
 }
 
 /// Split a potentially package-qualified name into `(qualifier, bare, full)`.

--- a/crates/perl-symbol/tests/surface_refs.rs
+++ b/crates/perl-symbol/tests/surface_refs.rs
@@ -354,23 +354,24 @@ fn variable_reads_and_writes_collapse_to_variable_refs() -> Result<()> {
 
 #[test]
 fn coderef_syntax_forms_are_classified_conservatively() -> Result<()> {
-    // Covers `&foo`, `\\&foo`, and `goto &foo` style sigil usage: all are represented
-    // as `Variable` nodes with sigil `&` and classify as coderef references.
+    // Covers direct `&foo` plus parser-shaped `\\&foo` and `goto &foo` targets.
+    // The parser consumes the ampersand in the latter forms and leaves a zero-arg
+    // FunctionCall target, which must still classify as a coderef reference.
     let amp = Node::new(
         NodeKind::Variable { sigil: "&".to_string(), name: "foo".to_string() },
         loc(0, 4),
     );
+    let backslash_amp_target =
+        Node::new(NodeKind::FunctionCall { name: "foo".to_string(), args: vec![] }, loc(7, 10));
     let backslash_amp = Node::new(
-        NodeKind::Variable { sigil: "&".to_string(), name: "foo".to_string() },
+        NodeKind::Unary { op: "\\".to_string(), operand: Box::new(backslash_amp_target) },
         loc(5, 10),
     );
-    let goto_amp = Node::new(
-        NodeKind::Variable { sigil: "&".to_string(), name: "foo".to_string() },
-        loc(11, 19),
-    );
-    let goto = Node::new(NodeKind::Goto { target: Box::new(goto_amp) }, loc(11, 19));
+    let goto_amp =
+        Node::new(NodeKind::FunctionCall { name: "foo".to_string(), args: vec![] }, loc(17, 20));
+    let goto = Node::new(NodeKind::Goto { target: Box::new(goto_amp) }, loc(11, 20));
     let program =
-        Node::new(NodeKind::Program { statements: vec![amp, backslash_amp, goto] }, loc(0, 19));
+        Node::new(NodeKind::Program { statements: vec![amp, backslash_amp, goto] }, loc(0, 20));
 
     let refs = extract_symbol_refs(&program);
     assert_eq!(refs.len(), 3);
@@ -395,10 +396,8 @@ fn typeglob_alias_boundary_is_classified() -> Result<()> {
 #[test]
 fn typeglob_assignment_keeps_rhs_coderef_reference() -> Result<()> {
     let lhs = Node::new(NodeKind::Typeglob { name: "alias".to_string() }, loc(0, 6));
-    let rhs_target = Node::new(
-        NodeKind::Variable { sigil: "&".to_string(), name: "target".to_string() },
-        loc(10, 17),
-    );
+    let rhs_target =
+        Node::new(NodeKind::FunctionCall { name: "target".to_string(), args: vec![] }, loc(11, 17));
     let rhs = Node::new(
         NodeKind::Unary { op: "\\".to_string(), operand: Box::new(rhs_target) },
         loc(9, 17),

--- a/crates/perl-workspace-index/tests/fixtures/semantic_real_workspace/cpan_style/lib/RealBaseline/App.pm
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_real_workspace/cpan_style/lib/RealBaseline/App.pm
@@ -1,0 +1,23 @@
+package RealBaseline::App;
+use strict;
+use warnings;
+use parent 'RealBaseline::Base';
+use RealBaseline::Util qw(helper alias);
+
+sub new {
+    my ($class, %args) = @_;
+    return bless \%args, $class;
+}
+
+sub run {
+    my ($self) = @_;
+    helper($self->name);
+    alias($self->shared);
+    return $self->shared;
+}
+
+sub name {
+    return $_[0]->{name};
+}
+
+1;

--- a/crates/perl-workspace-index/tests/fixtures/semantic_real_workspace/cpan_style/lib/RealBaseline/Base.pm
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_real_workspace/cpan_style/lib/RealBaseline/Base.pm
@@ -1,0 +1,13 @@
+package RealBaseline::Base;
+use strict;
+use warnings;
+
+sub shared {
+    return 'shared';
+}
+
+sub reset {
+    return 1;
+}
+
+1;

--- a/crates/perl-workspace-index/tests/fixtures/semantic_real_workspace/cpan_style/lib/RealBaseline/Util.pm
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_real_workspace/cpan_style/lib/RealBaseline/Util.pm
@@ -1,0 +1,18 @@
+package RealBaseline::Util;
+use strict;
+use warnings;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(helper alias);
+
+sub helper {
+    return shift;
+}
+
+*alias = \&helper;
+
+sub bounce {
+    goto &helper;
+}
+
+1;

--- a/crates/perl-workspace-index/tests/fixtures/semantic_real_workspace/cpan_style/script/real-baseline.pl
+++ b/crates/perl-workspace-index/tests/fixtures/semantic_real_workspace/cpan_style/script/real-baseline.pl
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+use lib 'lib';
+use RealBaseline::App;
+
+my $app = RealBaseline::App->new(name => 'demo');
+$app->run;

--- a/crates/perl-workspace-index/tests/semantic_real_workspace_baseline.rs
+++ b/crates/perl-workspace-index/tests/semantic_real_workspace_baseline.rs
@@ -1,0 +1,136 @@
+use perl_semantic_facts::{OccurrenceKind, Provenance};
+use perl_workspace::workspace::workspace_index::{FileFactShard, WorkspaceIndex};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Debug, Default)]
+struct BaselineTotals {
+    files: usize,
+    entities: usize,
+    occurrences: usize,
+    edges: usize,
+    dynamic_boundary_occurrences: usize,
+}
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("semantic_real_workspace")
+        .join("cpan_style")
+}
+
+fn perl_files(root: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<_> = WalkDir::new(root)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| entry.file_type().is_file())
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "pm" || ext == "pl"))
+        .map(|entry| entry.into_path())
+        .collect();
+    files.sort();
+    files
+}
+
+fn index_fixture_workspace(root: &Path) -> Result<(WorkspaceIndex, Vec<FileFactShard>)> {
+    let index = WorkspaceIndex::new();
+    let mut shards = Vec::new();
+
+    for path in perl_files(root) {
+        let source = std::fs::read_to_string(&path)?;
+        let uri = url::Url::from_file_path(&path)
+            .map_err(|()| format!("fixture path cannot become file URI: {}", path.display()))?;
+
+        index.index_file(uri.clone(), source)?;
+        let shard = index.file_fact_shard(uri.as_str()).ok_or_else(|| {
+            format!("missing fact shard for real-workspace fixture {}", path.display())
+        })?;
+        shards.push(shard);
+    }
+
+    Ok((index, shards))
+}
+
+fn measure(shards: &[FileFactShard]) -> BaselineTotals {
+    BaselineTotals {
+        files: shards.len(),
+        entities: shards.iter().map(|shard| shard.entities.len()).sum(),
+        occurrences: shards.iter().map(|shard| shard.occurrences.len()).sum(),
+        edges: shards.iter().map(|shard| shard.edges.len()).sum(),
+        dynamic_boundary_occurrences: shards
+            .iter()
+            .flat_map(|shard| shard.occurrences.iter())
+            .filter(|occ| {
+                occ.provenance == Provenance::DynamicBoundary
+                    || matches!(
+                        occ.kind,
+                        OccurrenceKind::DynamicBoundary | OccurrenceKind::TypeglobReference
+                    )
+            })
+            .count(),
+    }
+}
+
+fn occurrence_kinds(shards: &[FileFactShard]) -> BTreeSet<OccurrenceKind> {
+    shards.iter().flat_map(|shard| shard.occurrences.iter().map(|occ| occ.kind)).collect()
+}
+
+fn entity_names(shards: &[FileFactShard]) -> BTreeSet<String> {
+    shards
+        .iter()
+        .flat_map(|shard| shard.entities.iter().map(|entity| entity.canonical_name.clone()))
+        .collect()
+}
+
+#[test]
+fn real_workspace_baseline_indexes_cpan_style_project() -> Result<()> {
+    let root = fixture_root();
+    let (index, shards) = index_fixture_workspace(&root)?;
+    let totals = measure(&shards);
+
+    assert_eq!(totals.files, 4, "baseline fixture should stay small and deterministic");
+    assert_eq!(index.fact_shard_count(), totals.files);
+    assert!(index.symbol_count() >= 8, "expected package/subroutine symbols in baseline");
+    assert!(totals.entities >= 8, "expected package and subroutine facts: {totals:?}");
+    assert!(totals.occurrences >= 8, "expected cross-file reference facts: {totals:?}");
+    assert!(totals.edges >= 8, "expected definition/reference edge facts: {totals:?}");
+
+    let names = entity_names(&shards);
+    for expected in [
+        "RealBaseline::App",
+        "RealBaseline::App::run",
+        "RealBaseline::Base::shared",
+        "RealBaseline::Util::helper",
+    ] {
+        assert!(names.contains(expected), "missing expected semantic entity {expected}");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn real_workspace_baseline_covers_method_coderef_and_typeglob_shapes() -> Result<()> {
+    let root = fixture_root();
+    let (_index, shards) = index_fixture_workspace(&root)?;
+    let totals = measure(&shards);
+    let kinds = occurrence_kinds(&shards);
+
+    for expected in [
+        OccurrenceKind::Call,
+        OccurrenceKind::MethodCall,
+        OccurrenceKind::StaticMethodCall,
+        OccurrenceKind::CoderefReference,
+        OccurrenceKind::TypeglobReference,
+    ] {
+        assert!(kinds.contains(&expected), "missing expected occurrence kind {expected:?}");
+    }
+    assert!(
+        totals.dynamic_boundary_occurrences >= 1,
+        "typeglob alias should register a dynamic-boundary occurrence: {totals:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Problem: Semantic proof was still dominated by focused fixtures, so parser-to-workspace behavior on a small multi-file Perl project was not guarded.
Fix: Add a CPAN-style real-workspace fixture and baseline tests over indexed fact shards, including method calls, static calls, coderef references, and typeglob dynamic boundaries. The producer also recognizes parser-shaped `\&foo` / `goto &foo` coderef targets so the baseline reflects real parser output.
Verification: `cargo test -p perl-symbol --profile agent --locked` passes; `cargo test -p perl-workspace --profile agent --locked` passes; `cargo check -p perl-symbol --all-targets --profile agent --locked` passes; `cargo check -p perl-workspace --all-targets --profile agent --locked` passes; direct `cargo clippy -p perl-symbol --profile agent --locked -- -D warnings -A missing_docs` passes; direct `cargo clippy -p perl-workspace --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo xtask semantic-scorecard --check` passes; `cargo xtask semantic-shadow-compare --check` passes; `cargo xtask fmt --check` passes; `git diff --check` passes. Note: `./scripts/cargo-safe clippy -p perl-symbol ...` timed out locally without diagnostics; the equivalent direct Cargo clippy completed cleanly.