### PR TITLE
feat(parser): score parser recovery quality (#0000)

### DIFF
--- a/.kiro/specs/parser-accuracy-observability/tasks.md
+++ b/.kiro/specs/parser-accuracy-observability/tasks.md
@@ -67,10 +67,10 @@ Build a layered parser accuracy scorecard that starts with denominator visibilit
     - Prepare floor contract for `dynamic_false_precision_count == 0`
     - _Verify: dynamic fixture returns fallback/unavailable rather than false exact result_
 
-- [ ] 8. Add recovery quality scoring
-  - [ ] 8.1 Define malformed fixture labels
+- [x] 8. Add recovery quality scoring
+  - [x] 8.1 Define malformed fixture labels
     - Track first error line, expected error region, recovery boundary, and post-error symbols
-  - [ ] 8.2 Emit recovery containment rows
+  - [x] 8.2 Emit recovery containment rows
     - first_error_line_accuracy, error_region_precision/recall, spillover mean/p95/max, salvaged lines, salvaged symbols, post_error_symbol_recall, post_error_line_f1
     - _Verify: malformed heredoc fixture distinguishes local recovery from EOF spillover_
 

--- a/crates/perl-corpus/fixtures/parser_accuracy/malformed_heredoc_recovery.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/malformed_heredoc_recovery.pl
@@ -1,0 +1,10 @@
+package Accuracy::MalformedHeredocRecovery;
+
+my $text = <<'BROKEN';
+unterminated body
+
+sub after_recovery {
+    return 1;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
+++ b/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
@@ -399,6 +399,64 @@
           "span_text": "dynamic_name"
         }
       ]
+    },
+    {
+      "id": "malformed_heredoc_recovery",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/malformed_heredoc_recovery.pl",
+      "scored_lines": 3,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "parse_error"
+          ]
+        },
+        {
+          "line": 6,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        }
+      ],
+      "recovery_expectations": [
+        {
+          "id": "malformed_heredoc_distinguishes_eof_spillover",
+          "first_error_line": 3,
+          "error_region": {
+            "start": 3,
+            "end": 4
+          },
+          "recovery_line": 6,
+          "post_error_line_expectations": [
+            {
+              "line": 6,
+              "expected_tags": [
+                "sub_decl"
+              ]
+            }
+          ],
+          "post_error_symbol_spans": [
+            "after_recovery"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/xtask/src/tasks/metrics/parser_accuracy.rs
+++ b/xtask/src/tasks/metrics/parser_accuracy.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use chrono::Utc;
 use color_eyre::eyre::{Context, Result, bail, eyre};
-use perl_parser::{Node, NodeKind, Parser};
+use perl_parser::{Node, NodeKind, ParseError, Parser};
 use perl_semantic_facts::{AnchorId, EntityId};
 use perl_workspace::workspace::workspace_index::{FileFactShard, WorkspaceIndex};
 use serde::{Deserialize, Serialize};
@@ -51,6 +51,8 @@ struct FixtureMetadata {
     symbol_expectations: SymbolExpectations,
     #[serde(default)]
     symbol_safety_regions: Vec<SymbolSafetyRegion>,
+    #[serde(default)]
+    recovery_expectations: Vec<RecoveryExpectation>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -149,6 +151,24 @@ enum SymbolSafetyRegionKind {
     Pod,
     String,
     Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct RecoveryExpectation {
+    id: String,
+    first_error_line: u64,
+    error_region: LineRange,
+    recovery_line: u64,
+    #[serde(default)]
+    post_error_line_expectations: Vec<LineExpectation>,
+    #[serde(default)]
+    post_error_symbol_spans: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+struct LineRange {
+    start: u64,
+    end: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -457,6 +477,19 @@ struct KindScore {
     false_negative_count: u64,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RecoveryScore {
+    expectation_count: u64,
+    first_error_line_correct_count: u64,
+    error_region_true_positive_count: u64,
+    error_region_false_positive_count: u64,
+    error_region_false_negative_count: u64,
+    spillover_lines: Vec<u64>,
+    post_error_line_score: LineScore,
+    post_error_symbol_expected_count: u64,
+    post_error_symbol_found_count: u64,
+}
+
 /// Run `cargo xtask metrics parser-accuracy`.
 pub fn run(
     json: bool,
@@ -528,6 +561,7 @@ fn build_artifact(
     let line_score = score_manifest_line_tags(root, manifest)?;
     let ast_score = score_manifest_ast(root, manifest)?;
     let symbol_score = score_manifest_symbols(root, manifest)?;
+    let recovery_score = score_manifest_recovery(root, manifest)?;
     let mut metrics = vec![MetricRow::Measured {
         metric: "denominator_fixture_count".to_string(),
         value: fixture_count,
@@ -540,6 +574,7 @@ fn build_artifact(
     metrics.extend(ast_metrics(&ast_score, cadence));
     metrics.extend(symbol_metrics(&symbol_score, cadence));
     metrics.extend(safety_metrics(&line_score, &symbol_score, cadence));
+    metrics.extend(recovery_metrics(&recovery_score, cadence));
 
     Ok(ParserAccuracyArtifact {
         schema_version: 1,
@@ -853,6 +888,128 @@ fn line_metrics(score: &LineScore, cadence: Cadence) -> Vec<MetricRow> {
     ));
 
     rows
+}
+
+fn score_manifest_recovery(
+    root: &Path,
+    manifest: &ParserAccuracyManifest,
+) -> Result<RecoveryScore> {
+    let mut score = RecoveryScore::default();
+    for fixture in &manifest.fixtures {
+        if fixture.recovery_expectations.is_empty() {
+            continue;
+        }
+        let source_path = root.join(&fixture.source_path);
+        let source = fs::read_to_string(&source_path).with_context(|| {
+            format!("reading parser accuracy recovery fixture source {}", source_path.display())
+        })?;
+        let prediction = extract_recovery_prediction(&source_path, &source);
+        for expectation in &fixture.recovery_expectations {
+            score_recovery_expectation(expectation, &prediction, &mut score);
+        }
+    }
+    Ok(score)
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RecoveryPrediction {
+    first_error_line: Option<u64>,
+    error_region_lines: BTreeSet<u64>,
+    actual_by_line: BTreeMap<u64, BTreeSet<LineTag>>,
+    symbol_spans: BTreeSet<SymbolSpanLocation>,
+}
+
+fn extract_recovery_prediction(source_path: &Path, source: &str) -> RecoveryPrediction {
+    let mut parser = Parser::new(source);
+    let output = parser.parse_with_recovery();
+    let line_starts = line_starts(source);
+    let mut error_lines = BTreeSet::new();
+    for diagnostic in &output.diagnostics {
+        if let Some(location) = parse_error_location(diagnostic) {
+            error_lines.insert(line_for_offset(&line_starts, location));
+        }
+    }
+    collect_error_node_lines(&output.ast, &line_starts, &mut error_lines);
+
+    let mut actual_by_line = BTreeMap::new();
+    collect_node_line_tags(&output.ast, &line_starts, &mut actual_by_line);
+    let symbol_spans = extract_symbol_predictions(source_path, source)
+        .map(|predictions| predictions.safety_spans)
+        .unwrap_or_default();
+
+    RecoveryPrediction {
+        first_error_line: error_lines.first().copied(),
+        error_region_lines: error_lines,
+        actual_by_line,
+        symbol_spans,
+    }
+}
+
+fn parse_error_location(error: &ParseError) -> Option<usize> {
+    match error {
+        ParseError::UnexpectedToken { location, .. }
+        | ParseError::SyntaxError { location, .. }
+        | ParseError::Recovered { location, .. } => Some(*location),
+        _ => None,
+    }
+}
+
+fn collect_error_node_lines(node: &Node, line_starts: &[usize], lines: &mut BTreeSet<u64>) {
+    if matches!(node.kind, NodeKind::Error { .. }) {
+        lines.insert(line_for_offset(line_starts, node.location.start));
+    }
+    node.for_each_child(|child| collect_error_node_lines(child, line_starts, lines));
+}
+
+fn score_recovery_expectation(
+    expectation: &RecoveryExpectation,
+    prediction: &RecoveryPrediction,
+    score: &mut RecoveryScore,
+) {
+    score.expectation_count += 1;
+    if prediction.first_error_line == Some(expectation.first_error_line) {
+        score.first_error_line_correct_count += 1;
+    }
+
+    let expected_region = line_range_set(expectation.error_region);
+    score.error_region_true_positive_count +=
+        expected_region.intersection(&prediction.error_region_lines).count() as u64;
+    score.error_region_false_positive_count +=
+        prediction.error_region_lines.difference(&expected_region).count() as u64;
+    score.error_region_false_negative_count +=
+        expected_region.difference(&prediction.error_region_lines).count() as u64;
+
+    let actual_end = prediction
+        .error_region_lines
+        .iter()
+        .next_back()
+        .copied()
+        .unwrap_or(expectation.error_region.end);
+    score.spillover_lines.push(actual_end.saturating_sub(expectation.error_region.end));
+
+    for line_expectation in &expectation.post_error_line_expectations {
+        let actual =
+            prediction.actual_by_line.get(&line_expectation.line).cloned().unwrap_or_default();
+        score_line_tags(&line_expectation.expected_tags, &actual, &mut score.post_error_line_score);
+    }
+
+    for span in &expectation.post_error_symbol_spans {
+        score.post_error_symbol_expected_count += 1;
+        if prediction
+            .symbol_spans
+            .iter()
+            .any(|actual| actual.line >= expectation.recovery_line && actual.span_text == *span)
+        {
+            score.post_error_symbol_found_count += 1;
+        }
+    }
+}
+
+fn line_range_set(range: LineRange) -> BTreeSet<u64> {
+    if range.end < range.start {
+        return BTreeSet::new();
+    }
+    (range.start..=range.end).collect()
 }
 
 fn score_manifest_ast(root: &Path, manifest: &ParserAccuracyManifest) -> Result<AstScore> {
@@ -1674,6 +1831,100 @@ fn safety_metrics(
     ]
 }
 
+fn recovery_metrics(score: &RecoveryScore, cadence: Cadence) -> Vec<MetricRow> {
+    if score.expectation_count == 0 {
+        return vec![insufficient(
+            "recovery_first_error_line_accuracy",
+            "recovery gold labels are not available",
+        )];
+    }
+
+    let region_precision_denominator =
+        score.error_region_true_positive_count + score.error_region_false_positive_count;
+    let region_recall_denominator =
+        score.error_region_true_positive_count + score.error_region_false_negative_count;
+    let post_line_precision_denominator = score.post_error_line_score.true_positive_count
+        + score.post_error_line_score.false_positive_count;
+    let post_line_recall_denominator = score.post_error_line_score.true_positive_count
+        + score.post_error_line_score.false_negative_count;
+
+    vec![
+        measured_rate(
+            "recovery_first_error_line_accuracy",
+            score.first_error_line_correct_count,
+            score.expectation_count,
+            cadence,
+        ),
+        optional_measured_rate(
+            "recovery_error_region_precision",
+            ratio(score.error_region_true_positive_count, region_precision_denominator),
+            region_precision_denominator,
+            "no predicted recovery error-region lines are available",
+            cadence,
+        ),
+        optional_measured_rate(
+            "recovery_error_region_recall",
+            ratio(score.error_region_true_positive_count, region_recall_denominator),
+            region_recall_denominator,
+            "no expected recovery error-region lines are available",
+            cadence,
+        ),
+        optional_measured_value(
+            "recovery_spillover_mean_lines",
+            mean_u64(&score.spillover_lines),
+            score.spillover_lines.len() as u64,
+            "no recovery spillover samples are available",
+            cadence,
+        ),
+        optional_measured_value(
+            "recovery_spillover_p95_lines",
+            p95_u64(&score.spillover_lines),
+            score.spillover_lines.len() as u64,
+            "no recovery spillover samples are available",
+            cadence,
+        ),
+        optional_measured_value(
+            "recovery_spillover_max_lines",
+            score.spillover_lines.iter().copied().max().map(|value| value as f64),
+            score.spillover_lines.len() as u64,
+            "no recovery spillover samples are available",
+            cadence,
+        ),
+        optional_measured_count(
+            "recovery_salvaged_lines_after_error",
+            score.post_error_line_score.exact_match_count,
+            score.post_error_line_score.line_count,
+            "no post-error line labels are available",
+            cadence,
+        ),
+        optional_measured_count(
+            "recovery_salvaged_symbols_after_error",
+            score.post_error_symbol_found_count,
+            score.post_error_symbol_expected_count,
+            "no post-error symbol labels are available",
+            cadence,
+        ),
+        optional_measured_rate(
+            "recovery_post_error_symbol_recall",
+            ratio(score.post_error_symbol_found_count, score.post_error_symbol_expected_count),
+            score.post_error_symbol_expected_count,
+            "no post-error symbol labels are available",
+            cadence,
+        ),
+        optional_measured_rate(
+            "recovery_post_error_line_f1",
+            f1_from_counts(
+                score.post_error_line_score.true_positive_count,
+                score.post_error_line_score.false_positive_count,
+                score.post_error_line_score.false_negative_count,
+            ),
+            post_line_recall_denominator.max(post_line_precision_denominator),
+            "post-error line precision or recall denominator is unavailable",
+            cadence,
+        ),
+    ]
+}
+
 #[derive(Debug, Clone, Copy)]
 enum SymbolMetricSource {
     Entity,
@@ -1769,6 +2020,26 @@ fn optional_measured_count(
     measured_count(metric, value, sample_count, cadence)
 }
 
+fn optional_measured_value(
+    metric: &str,
+    value: Option<f64>,
+    sample_count: u64,
+    insufficient_reason: &str,
+    cadence: Cadence,
+) -> MetricRow {
+    match value {
+        Some(value) if sample_count > 0 => MetricRow::Measured {
+            metric: metric.to_string(),
+            value,
+            sample_count,
+            direction: Direction::Neutral,
+            confidence: Confidence::High,
+            cadence,
+        },
+        _ => insufficient(metric, insufficient_reason),
+    }
+}
+
 fn measured_rate(metric: &str, numerator: u64, denominator: u64, cadence: Cadence) -> MetricRow {
     let value = ratio(numerator, denominator).unwrap_or(0.0);
     MetricRow::Measured {
@@ -1803,6 +2074,29 @@ fn optional_measured_rate(
 
 fn ratio(numerator: u64, denominator: u64) -> Option<f64> {
     if denominator == 0 { None } else { Some(numerator as f64 / denominator as f64) }
+}
+
+fn f1_from_counts(true_positive: u64, false_positive: u64, false_negative: u64) -> Option<f64> {
+    let denominator = (2 * true_positive) + false_positive + false_negative;
+    ratio(2 * true_positive, denominator)
+}
+
+fn mean_u64(values: &[u64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    Some(values.iter().sum::<u64>() as f64 / values.len() as f64)
+}
+
+fn p95_u64(values: &[u64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let rank = ((sorted.len() as f64) * 0.95).ceil() as usize;
+    let index = rank.saturating_sub(1).min(sorted.len() - 1);
+    Some(sorted[index] as f64)
 }
 
 fn insufficient(metric: &str, reason: &str) -> MetricRow {
@@ -1993,6 +2287,7 @@ mod tests {
                         }],
                     },
                     symbol_safety_regions: vec![],
+                    recovery_expectations: vec![],
                 },
                 FixtureMetadata {
                     id: "dynamic_require_boundary".to_string(),
@@ -2051,6 +2346,7 @@ mod tests {
                     ],
                     symbol_expectations: SymbolExpectations::default(),
                     symbol_safety_regions: vec![],
+                    recovery_expectations: vec![],
                 },
             ],
         }
@@ -2413,6 +2709,76 @@ mod tests {
                 MetricRow::Measured { metric, value, sample_count: 3, .. }
                     if metric == "false_symbol_count"
                         && (*value - 2.0).abs() < f64::EPSILON
+            )
+        }));
+    }
+
+    #[test]
+    fn recovery_scorer_counts_local_spillover_and_salvaged_symbols() {
+        let expectation = RecoveryExpectation {
+            id: "recover_before_sub".to_string(),
+            first_error_line: 3,
+            error_region: LineRange { start: 3, end: 3 },
+            recovery_line: 5,
+            post_error_line_expectations: vec![LineExpectation {
+                line: 5,
+                expected_tags: tags(&[LineTag::SubDecl]),
+            }],
+            post_error_symbol_spans: vec!["after_recovery".to_string()],
+        };
+        let prediction = RecoveryPrediction {
+            first_error_line: Some(3),
+            error_region_lines: [3].into_iter().collect(),
+            actual_by_line: [(5, tags(&[LineTag::SubDecl]))].into_iter().collect(),
+            symbol_spans: [SymbolSpanLocation { line: 5, span_text: "after_recovery".to_string() }]
+                .into_iter()
+                .collect(),
+        };
+        let mut score = RecoveryScore::default();
+
+        score_recovery_expectation(&expectation, &prediction, &mut score);
+
+        assert_eq!(score.first_error_line_correct_count, 1);
+        assert_eq!(score.error_region_true_positive_count, 1);
+        assert_eq!(score.spillover_lines, vec![0]);
+        assert_eq!(score.post_error_line_score.exact_match_count, 1);
+        assert_eq!(score.post_error_symbol_found_count, 1);
+    }
+
+    #[test]
+    fn recovery_metrics_emit_measured_containment_rows() {
+        let score = RecoveryScore {
+            expectation_count: 1,
+            first_error_line_correct_count: 1,
+            error_region_true_positive_count: 1,
+            spillover_lines: vec![0, 2],
+            post_error_line_score: LineScore {
+                line_count: 1,
+                true_positive_count: 1,
+                exact_match_count: 1,
+                ..LineScore::default()
+            },
+            post_error_symbol_expected_count: 1,
+            post_error_symbol_found_count: 1,
+            ..RecoveryScore::default()
+        };
+
+        let metrics = recovery_metrics(&score, Cadence::Pr);
+
+        assert!(metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::Measured { metric, value, sample_count: 2, .. }
+                    if metric == "recovery_spillover_p95_lines"
+                        && (*value - 2.0).abs() < f64::EPSILON
+            )
+        }));
+        assert!(metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::Measured { metric, value, sample_count: 1, .. }
+                    if metric == "recovery_post_error_symbol_recall"
+                        && (*value - 1.0).abs() < f64::EPSILON
             )
         }));
     }

--- a/xtask/tests/fixtures/parser-accuracy/example-artifact.json
+++ b/xtask/tests/fixtures/parser-accuracy/example-artifact.json
@@ -5,19 +5,19 @@
   "commit": "example",
   "cadence": "pr",
   "denominator": {
-    "fixture_count": 6,
-    "fixture_family_count": 6,
-    "scored_line_count": 20,
-    "scored_symbol_count": 16,
+    "fixture_count": 7,
+    "fixture_family_count": 7,
+    "scored_line_count": 23,
+    "scored_symbol_count": 17,
     "fully_labeled_region_count": 2,
-    "partial_labeled_region_count": 3,
-    "unknown_region_count": 4,
+    "partial_labeled_region_count": 4,
+    "unknown_region_count": 5,
     "negative_region_count": 5,
     "dynamic_boundary_case_count": 2,
     "unsupported_construct_case_count": 2,
     "real_project_file_count": 0,
     "generated_fixture_count": 0,
-    "hand_labeled_fixture_count": 6
+    "hand_labeled_fixture_count": 7
   },
   "families": [
     {
@@ -76,6 +76,17 @@
       "unsupported_construct_case_count": 0
     },
     {
+      "family": "recovery",
+      "fixture_count": 1,
+      "label_modes": [
+        "partial"
+      ],
+      "scored_line_count": 3,
+      "scored_symbol_count": 1,
+      "dynamic_boundary_case_count": 0,
+      "unsupported_construct_case_count": 0
+    },
+    {
       "family": "typeglob_alias",
       "fixture_count": 1,
       "label_modes": [
@@ -91,8 +102,8 @@
     {
       "state": "measured",
       "metric": "denominator_fixture_count",
-      "value": 6.0,
-      "sample_count": 6,
+      "value": 7.0,
+      "sample_count": 7,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -100,8 +111,8 @@
     {
       "state": "measured",
       "metric": "line_construct_true_positive_count",
-      "value": 8.0,
-      "sample_count": 7,
+      "value": 9.0,
+      "sample_count": 10,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -109,8 +120,8 @@
     {
       "state": "measured",
       "metric": "line_construct_false_positive_count",
-      "value": 0.0,
-      "sample_count": 7,
+      "value": 2.0,
+      "sample_count": 10,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -118,8 +129,8 @@
     {
       "state": "measured",
       "metric": "line_construct_false_negative_count",
-      "value": 0.0,
-      "sample_count": 7,
+      "value": 2.0,
+      "sample_count": 10,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -127,8 +138,8 @@
     {
       "state": "measured",
       "metric": "line_construct_exact_match_rate",
-      "value": 1.0,
-      "sample_count": 7,
+      "value": 0.8,
+      "sample_count": 10,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -136,8 +147,8 @@
     {
       "state": "measured",
       "metric": "line_construct_precision",
-      "value": 1.0,
-      "sample_count": 8,
+      "value": 0.8181818181818182,
+      "sample_count": 11,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -145,8 +156,8 @@
     {
       "state": "measured",
       "metric": "line_construct_recall",
-      "value": 1.0,
-      "sample_count": 8,
+      "value": 0.8181818181818182,
+      "sample_count": 11,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -154,8 +165,8 @@
     {
       "state": "measured",
       "metric": "line_construct_f1",
-      "value": 1.0,
-      "sample_count": 8,
+      "value": 0.8181818181818182,
+      "sample_count": 11,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -164,17 +175,19 @@
       "state": "measured",
       "metric": "line_error_false_positive_rate",
       "value": 0.0,
-      "sample_count": 7,
+      "sample_count": 10,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
     },
     {
-      "state": "insufficient_data",
+      "state": "measured",
       "metric": "line_error_false_negative_rate",
-      "reason": "no expected parse-error line labels are available",
-      "sample_count": 0,
-      "confidence": "low"
+      "value": 1.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
     },
     {
       "state": "measured",
@@ -511,7 +524,7 @@
       "state": "measured",
       "metric": "false_parse_error_count",
       "value": 0.0,
-      "sample_count": 7,
+      "sample_count": 10,
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
@@ -578,6 +591,96 @@
       "direction": "neutral",
       "confidence": "high",
       "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_first_error_line_accuracy",
+      "value": 0.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_error_region_precision",
+      "value": 0.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_error_region_recall",
+      "value": 0.0,
+      "sample_count": 2,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_spillover_mean_lines",
+      "value": 6.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_spillover_p95_lines",
+      "value": 6.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_spillover_max_lines",
+      "value": 6.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_salvaged_lines_after_error",
+      "value": 0.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_salvaged_symbols_after_error",
+      "value": 0.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_post_error_symbol_recall",
+      "value": 0.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
+    },
+    {
+      "state": "measured",
+      "metric": "recovery_post_error_line_f1",
+      "value": 0.0,
+      "sample_count": 1,
+      "direction": "neutral",
+      "confidence": "high",
+      "cadence": "pr"
     }
   ],
   "failure_packets": [],
@@ -593,10 +696,10 @@
     "dynamic_expectation_change_count": 0
   },
   "metric_runtime": {
-    "runtime_ms": 33.2847,
+    "runtime_ms": 29.534100000000002,
     "timeout_count": 0,
     "flake_count": 0,
-    "artifact_size_bytes": 14925,
+    "artifact_size_bytes": 17409,
     "ci_runner_failure_count": 0,
     "orphan_process_count": 0,
     "cache_hit_rate": null


### PR DESCRIPTION
Problem: Parser accuracy can report clean ingestion and symbol safety, but recovery quality is still not measured.
Fix: Add malformed heredoc recovery labels, parse-diagnostic/error-region scoring, spillover metrics, post-error line F1, and post-error symbol salvage rows.
Verification: `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics parser-accuracy --json`; `cargo test -p xtask --profile agent --locked -j 1 parser_accuracy -- --nocapture`; `cargo test -p xtask --profile agent --locked -j 1 update_status::parser -- --nocapture`; `cargo check -p xtask --all-targets --profile agent --locked -j 1`; `cargo clippy -p xtask --profile agent --locked -j 1 -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`.