### PR TITLE
refactor(xtask): extract accuracy types into parser/accuracy.rs — fix LOC-cap test (#7642)

### DIFF
--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -13,25 +13,13 @@ use serde::Deserialize;
 use super::replace_block;
 use super::token::TokenHealthMetrics;
 
-#[cfg(test)]
-use super::token;
-
+mod accuracy;
 mod failure;
 
+use accuracy::{
+    ParserAccuracyArtifactSummary, parser_accuracy_rows, read_parser_accuracy_artifact,
+};
 use failure::build_failure_worklist;
-
-#[cfg(test)]
-const PARSER_STATUS_MARKER_NAMES: [&str; 9] = [
-    "PARSER_TRACKING_TABLE",
-    "PARSER_PERFORMANCE_TABLE",
-    "PARSER_METRICS_BULLETS",
-    "TOKEN_HEALTH_TABLE",
-    "PARSER_NODEKIND_ROW",
-    "PARSER_RELIABILITY_ROW",
-    "PARSER_STRICT_CLEAN_ROW",
-    "PARSER_ACCURACY_SUMMARY",
-    "PARSER_FAILURE_WORKLIST",
-];
 
 fn parser_marker_bounds(marker_name: &str) -> (String, String) {
     (format!("<!-- BEGIN: {marker_name} -->"), format!("<!-- END: {marker_name} -->"))
@@ -56,7 +44,7 @@ pub(super) struct ParserMetrics {
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
     pub performance_scorecard: Option<ParserPerformanceScorecard>,
-    pub parser_accuracy: Option<ParserAccuracyArtifactSummary>,
+    parser_accuracy: Option<ParserAccuracyArtifactSummary>,
     pub token_metrics: TokenHealthMetrics,
 }
 
@@ -72,48 +60,6 @@ struct ParserPerfMetric {
     median_ns: u128,
     p95_ns: u128,
     mean_ns: u128,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub(super) struct ParserAccuracyArtifactSummary {
-    schema_version: u32,
-    subsystem: String,
-    generated_at: String,
-    commit: String,
-    cadence: String,
-    denominator: ParserAccuracyDenominator,
-    families: Vec<ParserAccuracyFamilySummary>,
-    metrics: Vec<ParserAccuracyMetricSummary>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct ParserAccuracyDenominator {
-    fixture_count: u64,
-    fixture_family_count: u64,
-    scored_line_count: u64,
-    scored_symbol_count: u64,
-    fully_labeled_region_count: u64,
-    partial_labeled_region_count: u64,
-    unknown_region_count: u64,
-    negative_region_count: u64,
-    dynamic_boundary_case_count: u64,
-    unsupported_construct_case_count: u64,
-    real_project_file_count: u64,
-    generated_fixture_count: u64,
-    hand_labeled_fixture_count: u64,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct ParserAccuracyFamilySummary {
-    family: String,
-    fixture_count: u64,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "state", rename_all = "snake_case")]
-enum ParserAccuracyMetricSummary {
-    Measured { metric: String, value: f64, sample_count: u64 },
-    InsufficientData { metric: String, reason: String, sample_count: u64 },
 }
 
 pub(super) fn collect_parser_metrics(root: &Path) -> ParserMetrics {
@@ -157,16 +103,6 @@ fn read_parser_performance_scorecard(root: &Path) -> Option<ParserPerformanceSco
     let path = root.join("docs/project/status/parser_performance_scorecard.json");
     let raw = fs::read_to_string(path).ok()?;
     serde_json::from_str(&raw).ok()
-}
-
-fn read_parser_accuracy_artifact(root: &Path) -> Option<ParserAccuracyArtifactSummary> {
-    let path = root.join("target/metrics/parser_accuracy.json");
-    let raw = fs::read_to_string(path).ok()?;
-    let artifact: ParserAccuracyArtifactSummary = serde_json::from_str(&raw).ok()?;
-    if artifact.schema_version != 1 || artifact.subsystem != "parser_accuracy" {
-        return None;
-    }
-    Some(artifact)
 }
 
 pub(super) fn count_corpus_sections(root: &Path) -> usize {
@@ -222,91 +158,6 @@ fn format_perf_metric_row(name: &str, metric: Option<&ParserPerfMetric>) -> Stri
             )
         },
     )
-}
-
-fn parser_accuracy_rows(artifact: Option<&ParserAccuracyArtifactSummary>) -> String {
-    const ARTIFACT_PATH: &str = "`target/metrics/parser_accuracy.json`";
-    const SPEC_PATH: &str = "`.kiro/specs/parser-accuracy-observability`";
-    const SCHEMA_PATH: &str = "`.ci/schemas/parser-accuracy.schema.json`";
-
-    let Some(artifact) = artifact else {
-        return format!(
-            "| **Accuracy denominator** | insufficient_data | Generate with `cargo xtask metrics parser-accuracy --json`; missing artifact is not treated as zero | {ARTIFACT_PATH}; {SPEC_PATH} |\n\
-             | **Accuracy scorers** | insufficient_data | line/AST/symbol scoring rows wait for real denominators and validated artifact input | {SCHEMA_PATH} |"
-        );
-    };
-
-    let d = &artifact.denominator;
-    let family_summary = parser_accuracy_family_summary(&artifact.families);
-    let metric_summary = parser_accuracy_metric_summary(&artifact.metrics);
-    format!(
-        "| **Accuracy denominator** | {} fixtures / {} families | {} scored lines, {} scored symbols, {} fully labeled, {} partial, {} unknown, {} negative, {} dynamic boundaries, {} unsupported, {} real-project, {} generated, {} hand-labeled; cadence `{}`, commit `{}`, generated `{}` | {ARTIFACT_PATH}; {SPEC_PATH} |\n\
-         | **Accuracy families** | {} | fixture family inventory from parser accuracy manifest | {ARTIFACT_PATH} |\n\
-         | **Accuracy scorers** | {} | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | {SCHEMA_PATH} |",
-        d.fixture_count,
-        d.fixture_family_count,
-        d.scored_line_count,
-        d.scored_symbol_count,
-        d.fully_labeled_region_count,
-        d.partial_labeled_region_count,
-        d.unknown_region_count,
-        d.negative_region_count,
-        d.dynamic_boundary_case_count,
-        d.unsupported_construct_case_count,
-        d.real_project_file_count,
-        d.generated_fixture_count,
-        d.hand_labeled_fixture_count,
-        artifact.cadence,
-        artifact.commit,
-        artifact.generated_at,
-        family_summary,
-        metric_summary,
-    )
-}
-
-fn parser_accuracy_family_summary(families: &[ParserAccuracyFamilySummary]) -> String {
-    if families.is_empty() {
-        return "insufficient_data".to_string();
-    }
-
-    let rendered = families
-        .iter()
-        .take(6)
-        .map(|family| format!("{} ({})", family.family, family.fixture_count))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let hidden = families.len().saturating_sub(6);
-    if hidden == 0 { rendered } else { format!("{rendered}, +{hidden} more") }
-}
-
-fn parser_accuracy_metric_summary(metrics: &[ParserAccuracyMetricSummary]) -> String {
-    let mut measured = Vec::new();
-    let mut insufficient = Vec::new();
-
-    for metric in metrics {
-        match metric {
-            ParserAccuracyMetricSummary::Measured { metric, value, sample_count } => {
-                measured.push(format!("{metric}={value:.1} (n={sample_count})"));
-            }
-            ParserAccuracyMetricSummary::InsufficientData { metric, reason, sample_count } => {
-                insufficient
-                    .push(format!("{metric}: insufficient_data ({reason}; n={sample_count})"));
-            }
-        }
-    }
-
-    if measured.is_empty() && insufficient.is_empty() {
-        return "insufficient_data".to_string();
-    }
-
-    let mut parts = Vec::new();
-    if !measured.is_empty() {
-        parts.push(format!("measured {}", measured.join(", ")));
-    }
-    if !insufficient.is_empty() {
-        parts.push(insufficient.join(", "));
-    }
-    parts.join("; ")
 }
 
 // ---------------------------------------------------------------------------

--- a/xtask/src/tasks/update_status/parser/accuracy.rs
+++ b/xtask/src/tasks/update_status/parser/accuracy.rs
@@ -1,0 +1,147 @@
+//! Parser accuracy artifact types and status-row formatting.
+//!
+//! Holds the serde-deserializable structs for the JSON artifact produced by
+//! `cargo xtask metrics parser-accuracy --json` plus the helper functions that
+//! render those structs into status-doc rows.
+
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ParserAccuracyArtifactSummary {
+    pub(super) schema_version: u32,
+    pub(super) subsystem: String,
+    pub(super) generated_at: String,
+    pub(super) commit: String,
+    pub(super) cadence: String,
+    pub(super) denominator: ParserAccuracyDenominator,
+    pub(super) families: Vec<ParserAccuracyFamilySummary>,
+    pub(super) metrics: Vec<ParserAccuracyMetricSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ParserAccuracyDenominator {
+    pub(super) fixture_count: u64,
+    pub(super) fixture_family_count: u64,
+    pub(super) scored_line_count: u64,
+    pub(super) scored_symbol_count: u64,
+    pub(super) fully_labeled_region_count: u64,
+    pub(super) partial_labeled_region_count: u64,
+    pub(super) unknown_region_count: u64,
+    pub(super) negative_region_count: u64,
+    pub(super) dynamic_boundary_case_count: u64,
+    pub(super) unsupported_construct_case_count: u64,
+    pub(super) real_project_file_count: u64,
+    pub(super) generated_fixture_count: u64,
+    pub(super) hand_labeled_fixture_count: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ParserAccuracyFamilySummary {
+    pub(super) family: String,
+    pub(super) fixture_count: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(super) enum ParserAccuracyMetricSummary {
+    Measured { metric: String, value: f64, sample_count: u64 },
+    InsufficientData { metric: String, reason: String, sample_count: u64 },
+}
+
+pub(super) fn read_parser_accuracy_artifact(root: &Path) -> Option<ParserAccuracyArtifactSummary> {
+    let path = root.join("target/metrics/parser_accuracy.json");
+    let raw = fs::read_to_string(path).ok()?;
+    let artifact: ParserAccuracyArtifactSummary = serde_json::from_str(&raw).ok()?;
+    if artifact.schema_version != 1 || artifact.subsystem != "parser_accuracy" {
+        return None;
+    }
+    Some(artifact)
+}
+
+pub(super) fn parser_accuracy_rows(artifact: Option<&ParserAccuracyArtifactSummary>) -> String {
+    const ARTIFACT_PATH: &str = "`target/metrics/parser_accuracy.json`";
+    const SPEC_PATH: &str = "`.kiro/specs/parser-accuracy-observability`";
+    const SCHEMA_PATH: &str = "`.ci/schemas/parser-accuracy.schema.json`";
+
+    let Some(artifact) = artifact else {
+        return format!(
+            "| **Accuracy denominator** | insufficient_data | Generate with `cargo xtask metrics parser-accuracy --json`; missing artifact is not treated as zero | {ARTIFACT_PATH}; {SPEC_PATH} |\n\
+             | **Accuracy scorers** | insufficient_data | line/AST/symbol scoring rows wait for real denominators and validated artifact input | {SCHEMA_PATH} |"
+        );
+    };
+
+    let d = &artifact.denominator;
+    let family_summary = parser_accuracy_family_summary(&artifact.families);
+    let metric_summary = parser_accuracy_metric_summary(&artifact.metrics);
+    format!(
+        "| **Accuracy denominator** | {} fixtures / {} families | {} scored lines, {} scored symbols, {} fully labeled, {} partial, {} unknown, {} negative, {} dynamic boundaries, {} unsupported, {} real-project, {} generated, {} hand-labeled; cadence `{}`, commit `{}`, generated `{}` | {ARTIFACT_PATH}; {SPEC_PATH} |\n\
+         | **Accuracy families** | {} | fixture family inventory from parser accuracy manifest | {ARTIFACT_PATH} |\n\
+         | **Accuracy scorers** | {} | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | {SCHEMA_PATH} |",
+        d.fixture_count,
+        d.fixture_family_count,
+        d.scored_line_count,
+        d.scored_symbol_count,
+        d.fully_labeled_region_count,
+        d.partial_labeled_region_count,
+        d.unknown_region_count,
+        d.negative_region_count,
+        d.dynamic_boundary_case_count,
+        d.unsupported_construct_case_count,
+        d.real_project_file_count,
+        d.generated_fixture_count,
+        d.hand_labeled_fixture_count,
+        artifact.cadence,
+        artifact.commit,
+        artifact.generated_at,
+        family_summary,
+        metric_summary,
+    )
+}
+
+fn parser_accuracy_family_summary(families: &[ParserAccuracyFamilySummary]) -> String {
+    if families.is_empty() {
+        return "insufficient_data".to_string();
+    }
+
+    let rendered = families
+        .iter()
+        .take(6)
+        .map(|family| format!("{} ({})", family.family, family.fixture_count))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let hidden = families.len().saturating_sub(6);
+    if hidden == 0 { rendered } else { format!("{rendered}, +{hidden} more") }
+}
+
+fn parser_accuracy_metric_summary(metrics: &[ParserAccuracyMetricSummary]) -> String {
+    let mut measured = Vec::new();
+    let mut insufficient = Vec::new();
+
+    for metric in metrics {
+        match metric {
+            ParserAccuracyMetricSummary::Measured { metric, value, sample_count } => {
+                measured.push(format!("{metric}={value:.1} (n={sample_count})"));
+            }
+            ParserAccuracyMetricSummary::InsufficientData { metric, reason, sample_count } => {
+                insufficient
+                    .push(format!("{metric}: insufficient_data ({reason}; n={sample_count})"));
+            }
+        }
+    }
+
+    if measured.is_empty() && insufficient.is_empty() {
+        return "insufficient_data".to_string();
+    }
+
+    let mut parts = Vec::new();
+    if !measured.is_empty() {
+        parts.push(format!("measured {}", measured.join(", ")));
+    }
+    if !insufficient.is_empty() {
+        parts.push(insufficient.join(", "));
+    }
+    parts.join("; ")
+}

--- a/xtask/src/tasks/update_status/parser/tests.rs
+++ b/xtask/src/tasks/update_status/parser/tests.rs
@@ -1,6 +1,23 @@
+use super::super::token;
+use super::accuracy::{
+    ParserAccuracyArtifactSummary, ParserAccuracyDenominator, ParserAccuracyFamilySummary,
+    ParserAccuracyMetricSummary,
+};
 use super::failure::{FailureCluster, build_failure_worklist, classify_failure_bucket};
 use super::*;
 use color_eyre::eyre::Result;
+
+const PARSER_STATUS_MARKER_NAMES: [&str; 9] = [
+    "PARSER_TRACKING_TABLE",
+    "PARSER_PERFORMANCE_TABLE",
+    "PARSER_METRICS_BULLETS",
+    "TOKEN_HEALTH_TABLE",
+    "PARSER_NODEKIND_ROW",
+    "PARSER_RELIABILITY_ROW",
+    "PARSER_STRICT_CLEAN_ROW",
+    "PARSER_ACCURACY_SUMMARY",
+    "PARSER_FAILURE_WORKLIST",
+];
 
 fn parser_status_template() -> &'static str {
     "h\n<!-- BEGIN: PARSER_TRACKING_TABLE -->\nold\n<!-- END: PARSER_TRACKING_TABLE -->\n\


### PR DESCRIPTION
## Summary

Fixes the silently-failing `test_update_status_is_split_into_subsystem_modules` test in `xtask/src/tasks/update_status/mod.rs` (issue #7642).

**The bug:** `xtask/src/tasks/update_status/parser.rs` had grown to **524 lines**, 124 lines over the 400-line anti-regression gate enforced by the in-tree test. Because xtask unit tests are excluded from `cargo test --workspace --lib` (xtask has no library target), the failure was silently accumulating on master since at least PR #7599 added the heartbeat.

**The fix:** Extract all parser-accuracy concerns out of `parser.rs` into a new sibling submodule `parser/accuracy.rs`, following the same pattern already established by `parser/failure.rs`.

## Changes

### New file: `xtask/src/tasks/update_status/parser/accuracy.rs` (+140 lines)

Extracted from `parser.rs`:
- `ParserAccuracyArtifactSummary`, `ParserAccuracyDenominator`, `ParserAccuracyFamilySummary`, `ParserAccuracyMetricSummary` — the serde-deserializable structs for the JSON artifact produced by `cargo xtask metrics parser-accuracy --json`
- `read_parser_accuracy_artifact` — reads `target/metrics/parser_accuracy.json` and validates schema version + subsystem tag
- `parser_accuracy_rows`, `parser_accuracy_family_summary`, `parser_accuracy_metric_summary` — status-doc row formatters that render the artifact into markdown table rows

All items are `pub(super)` (visible to `parser.rs` and its submodules only — `update_status/mod.rs` never touches these types directly).

### Modified: `xtask/src/tasks/update_status/parser.rs` (-154 lines → 375 LOC)

- Adds `mod accuracy;` and `use accuracy::{...}` to reference the new submodule
- Removes the extracted types, functions, and the `#[cfg(test)]` constant `PARSER_STATUS_MARKER_NAMES` (moved to `parser/tests.rs`)
- Makes `ParserMetrics::parser_accuracy` field private (no `pub`) — it's only accessed within `parser.rs` itself by `collect_parser_metrics` and `generate_parser_status`; `mod.rs` never touches the field directly. This eliminates a `private_interfaces` warning that the visibility gap would otherwise produce.

### Modified: `xtask/src/tasks/update_status/parser/tests.rs` (+17 lines)

- Adds explicit imports for the accuracy sub-types (`ParserAccuracyArtifactSummary`, `ParserAccuracyDenominator`, `ParserAccuracyFamilySummary`, `ParserAccuracyMetricSummary`) and the `token` module — both previously reached via `use super::*` but no longer in scope after the extraction
- Defines `PARSER_STATUS_MARKER_NAMES` locally (was a `#[cfg(test)]` constant in `parser.rs` used exclusively in this test file)

## Verification

All five modules now pass the 400-line gate:

| Module | Before | After |
|--------|--------|-------|
| `mod.rs` | 389 ✓ | 389 ✓ |
| `lsp.rs` | 241 ✓ | 241 ✓ |
| `tests.rs` | 157 ✓ | 157 ✓ |
| `parser.rs` | **524 ✗** | **375 ✓** |
| `quality.rs` | 293 ✓ | 293 ✓ |

```
test tasks::update_status::mod_tests::test_update_status_is_split_into_subsystem_modules ... ok
```

All `update_status::parser::tests::*` tests pass (20 tests, 0 failures).

`cargo clippy -p xtask -- -D warnings` passes clean. `cargo xtask fmt` applied (no drift).

## No behaviour change

This is a pure structural refactor — no logic moved, no signatures changed, no production crate touched. The accuracy module's JSON deserialization, validation, and row-rendering behaviour is identical; only the file boundary changed.

## Related

- Closes #7642
- The two pre-existing failures in the full test run (`test_count_dap_tests`, `token_kind_variants_matches_actual_enum`) are environment-specific resource-limit issues (SIGKILL) unrelated to this PR.

https://claude.ai/code/session_01AxqSC2nX4YjD9UwbhQhFB2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxqSC2nX4YjD9UwbhQhFB2)_