### PR TITLE
fix(parser): accept `=>` in `tie` builtin within expression context (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -687,10 +687,28 @@ impl<'a> Parser<'a> {
                             } else {
                                 Box::new(self.parse_assignment()?)
                             };
-                            self.expect(TokenKind::Comma)?;
+                            // Accept comma or fat arrow between variable and
+                            // package — Perl treats `=>` as a synonym for `,`.
+                            match self.peek_kind() {
+                                Some(TokenKind::Comma | TokenKind::FatArrow) => {
+                                    self.consume_token()?;
+                                }
+                                _ => {
+                                    return Err(ParseError::unexpected(
+                                        TokenKind::Comma.display_name(),
+                                        self.peek_kind()
+                                            .map(|k| k.display_name())
+                                            .unwrap_or("end of input"),
+                                        self.current_position(),
+                                    ));
+                                }
+                            }
                             let package = Box::new(self.parse_assignment()?);
                             let mut args = vec![];
-                            while self.peek_kind() == Some(TokenKind::Comma) {
+                            while matches!(
+                                self.peek_kind(),
+                                Some(TokenKind::Comma | TokenKind::FatArrow)
+                            ) {
                                 self.consume_token()?;
                                 args.push(self.parse_assignment()?);
                             }

--- a/crates/perl-parser-core/tests/fix_tie_fat_arrow_in_paren.rs
+++ b/crates/perl-parser-core/tests/fix_tie_fat_arrow_in_paren.rs
@@ -1,0 +1,46 @@
+// Regression coverage for the `tie EXPR` builtin used inside an expression
+// context (parentheses) with `=>` as the separator instead of `,`.
+//
+// Perl treats `=>` as a synonym for `,`, so all of these forms are valid:
+//   tie %h, 'X', $arg;
+//   tie %h => 'X', $arg;
+//   my $rc = (tie %h => 'X', $arg);
+//
+// Before the fix, the expression-context `tie` parser only accepted a comma
+// between the variable and the package name, which caused parses of the
+// real-world idiom `(tie %cache => $module, @opts)` (Memoize/Expire.pm) to
+// drive the parser into an unbounded recovery loop and OOM.
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_tie_fat_arrow_in_parens() {
+    assert_clean_parse(r#"(tie %h => $m, $n);"#);
+}
+
+#[test]
+fn test_tie_fat_arrow_inside_my_assignment() {
+    // From Memoize/Expire.pm:32 — was OOMing the parser.
+    assert_clean_parse(r#"my $rc = (tie %cache => $module, @opts);"#);
+}
+
+#[test]
+fn test_tie_fat_arrow_single_pair_in_parens() {
+    assert_clean_parse(r#"(tie %h => $m);"#);
+}
+
+#[test]
+fn test_tie_fat_arrow_with_my_in_parens() {
+    assert_clean_parse(r#"(tie my %h => 'Pkg', $arg);"#);
+}
+
+#[test]
+fn test_tie_comma_in_parens_still_works() {
+    assert_clean_parse(r#"my $rc = (tie %h, $m, @opts);"#);
+}
+
+#[test]
+fn test_tie_mixed_comma_and_fat_arrow_in_parens() {
+    assert_clean_parse(r#"(tie %h => 'Pkg', LIFETIME => 60, NUM_USES => 10);"#);
+}


### PR DESCRIPTION
## Summary

Fix a parser hang/OOM on the real-world `(tie %hash => $module, ...)` idiom from `Memoize/Expire.pm`.

The `tie` handler in `crates/perl-parser-core/src/engine/parser/expressions/primary.rs` (used in expression context, e.g. inside parentheses) only accepted a comma between the variable and the package, while the statement-level handler in `statements.rs` already accepted both `,` and `=>` (Perl treats `=>` as a synonym for `,`). When the wrong-token path in `expect()` consumed the `=>` and bubbled an error up, statement-level recovery sent the parser into an unbounded loop and OOM-killed the process on input as small as a single line.

The fix mirrors the statement-context logic in the primary-context handler so both sites accept `,` or `=>` between the variable and the package, and as the trailing-args separator.

## Reproducer

```perl
my $rc = (tie %cache => $module, @opts);  # from Memoize/Expire.pm:32
```

Before: parser OOMs / hangs (SIGKILL).
After: parses cleanly to a `(tie ...)` AST node.

## Test plan

- [x] New regression file `tests/fix_tie_fat_arrow_in_paren.rs` covering:
  - `(tie %h => $m, $n);`
  - `my $rc = (tie %cache => $module, @opts);` (Memoize/Expire.pm shape)
  - `(tie %h => $m);`
  - `(tie my %h => 'Pkg', $arg);`
  - `(tie %h, $m, @opts);` (comma form — no behaviour change)
  - mixed `,` and `=>` in trailing args
- [x] All 6 new tests pass; pre-existing `tie`-related tests still pass
- [x] `cargo clippy -p perl-parser-core --lib` clean
- [x] `cargo fmt --check` clean
- [x] Manually verified `Memoize/Expire.pm` now parses without OOM via `perl-parse`

The remaining failures in the parser-core test suite (e.g. `extra_closing_paren_does_not_cascade`, `test_double_comma_in_function_args`, several `subst_e_*` tests, `test_double_invocant_separator_is_rejected`) all reproduce on master without this change and are out of scope for this PR — they appear to be a separate class of unbounded-recovery bugs on malformed input.

https://claude.ai/code/session_01UbaRhRKJNUghC7kkjCUMVT

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbaRhRKJNUghC7kkjCUMVT)_