### PR TITLE
feat(parser): add parser accuracy safety ratchet (#0000)

### DIFF
--- a/.ci/metrics/baselines/parser_accuracy.json
+++ b/.ci/metrics/baselines/parser_accuracy.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "measured_at": "2026-05-03T00:00:00Z",
+  "subsystem": "parser_accuracy",
+  "commit": "bootstrap",
+  "floor_metrics": {
+    "dynamic_false_precision_count": 0,
+    "fast_path_wrong_result_count": 0
+  },
+  "improvement_metrics": {
+    "line_construct_precision": 0.8181818181818182,
+    "line_construct_recall": 0.8181818181818182,
+    "line_construct_f1": 0.8181818181818182,
+    "ast_node_kind_precision": 1.0,
+    "ast_node_kind_recall": 1.0,
+    "ast_node_kind_f1": 1.0,
+    "symbol_decl_precision": 1.0,
+    "symbol_decl_recall": 0.8571428571428571,
+    "symbol_decl_f1": 0.9230769230769231,
+    "symbol_ref_precision": 1.0,
+    "symbol_ref_recall": 1.0,
+    "symbol_ref_f1": 1.0,
+    "symbol_edge_precision": 1.0,
+    "symbol_edge_recall": 1.0,
+    "symbol_edge_f1": 1.0
+  },
+  "tolerance_pct": 0.0
+}

--- a/.kiro/specs/parser-accuracy-observability/tasks.md
+++ b/.kiro/specs/parser-accuracy-observability/tasks.md
@@ -117,23 +117,23 @@ Build a layered parser accuracy scorecard that starts with denominator visibilit
   - [x] 13.3 Require explanation for weakening changes
     - Removing expected symbols, widening spans, lowering thresholds, changing dynamic expectations, or removing fixture families requires PR text
 
-- [ ] 14. Add ratchet candidates after stable measurements
-  - [ ] 14.1 Start with safety floors only
+- [x] 14. Add ratchet candidates after stable measurements
+  - [x] 14.1 Start with safety floors only
     - `dynamic_false_precision_count == 0`
     - `fast_path_wrong_result_count == 0`
-  - [ ] 14.2 Defer precision/recall floors until sample counts stabilize
+  - [x] 14.2 Defer precision/recall floors until sample counts stabilize
     - No floor raise from a single run
     - Require current/previous/delta/floor/threshold/direction/sample_count/confidence for all floor candidates
 
-- [ ] 15. Final verification checkpoint
-  - [ ] 15.1 Parser accuracy command
+- [x] 15. Final verification checkpoint
+  - [x] 15.1 Parser accuracy command
     - `cargo xtask metrics parser-accuracy --json`
     - Artifact validates against schema
     - No generated `target/` artifacts committed
-  - [ ] 15.2 Parser status
+  - [x] 15.2 Parser status
     - `cargo xtask update-status --only parser --check`
     - Parser status shows measured denominator rows and insufficient-data rows honestly
-  - [ ] 15.3 Focused tests
+  - [x] 15.3 Focused tests
     - `cargo test -p xtask parser_accuracy`
     - `cargo test -p xtask update_status::parser --profile agent --locked`
     - `cargo check -p xtask --all-targets --profile agent --locked`

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -23,7 +23,7 @@
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 24 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |
 <!-- END: PARSER_RELIABILITY_ROW -->
 <!-- BEGIN: PARSER_STRICT_CLEAN_ROW -->
-| **Strict-clean subset** | 10/10 (100%) | 10 pinned modules, zero-error gate | `.ci/common-corpus-manifest.txt` |
+| **Strict-clean subset** | insufficient_data | 10 pinned modules; run `just common-corpus-check` to generate receipt | `.ci/common-corpus-manifest.txt` |
 <!-- END: PARSER_STRICT_CLEAN_ROW -->
 
 ## Parser Accuracy Observability
@@ -31,8 +31,9 @@
 | Layer | State | Notes | Source |
 | --- | --- | --- |
 <!-- BEGIN: PARSER_ACCURACY_SUMMARY -->
-| **Accuracy denominator** | insufficient_data | Generate with `cargo xtask metrics parser-accuracy --json`; missing artifact is not treated as zero | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
-| **Accuracy scorers** | insufficient_data | line/AST/symbol scoring rows wait for real denominators and validated artifact input | `.ci/schemas/parser-accuracy.schema.json` |
+| **Accuracy denominator** | 9 fixtures / 9 families | 29 scored lines, 17 scored symbols, 2 fully labeled, 6 partial, 5 unknown, 5 negative, 2 dynamic boundaries, 2 unsupported, 0 real-project, 0 generated, 9 hand-labeled; cadence `pr` | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
+| **Accuracy families** | dynamic_require (1), generated_accessor (1), incremental (1), negative_symbol_regions (1), operators (1), packages (1), +3 more | fixture family inventory from parser accuracy manifest | `target/metrics/parser_accuracy.json` |
+| **Accuracy scorers** | selected line_construct_f1=0.8 (n=11), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=0.9 (n=7), symbol_ref_f1=1.0 (n=2), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 119 additional measured rows; 52 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
 <!-- END: PARSER_ACCURACY_SUMMARY -->
 
 ## Parser Performance Regimes

--- a/xtask/src/tasks/metrics/parser_accuracy.rs
+++ b/xtask/src/tasks/metrics/parser_accuracy.rs
@@ -25,10 +25,31 @@ use perl_semantic_facts::{AnchorId, EntityId};
 use perl_workspace::workspace::workspace_index::{FileFactShard, WorkspaceIndex};
 use serde::{Deserialize, Serialize};
 
+use crate::tasks::metrics::ratchet::MetricReceipt;
 use crate::utils::project_root;
 
 const DEFAULT_MANIFEST: &str = "crates/perl-corpus/fixtures/parser_accuracy/manifest.json";
 const DEFAULT_OUTPUT: &str = "target/metrics/parser_accuracy.json";
+const DEFAULT_RATCHET_RECEIPT: &str = "target/receipts/metrics/parser_accuracy.json";
+const SAFETY_FLOOR_METRICS: &[(&str, f64)] =
+    &[("dynamic_false_precision_count", 0.0), ("fast_path_wrong_result_count", 0.0)];
+const DEFERRED_PRECISION_RECALL_CANDIDATES: &[&str] = &[
+    "line_construct_precision",
+    "line_construct_recall",
+    "line_construct_f1",
+    "ast_node_kind_precision",
+    "ast_node_kind_recall",
+    "ast_node_kind_f1",
+    "symbol_decl_precision",
+    "symbol_decl_recall",
+    "symbol_decl_f1",
+    "symbol_ref_precision",
+    "symbol_ref_recall",
+    "symbol_ref_f1",
+    "symbol_edge_precision",
+    "symbol_edge_recall",
+    "symbol_edge_f1",
+];
 
 #[derive(Debug, Clone, Deserialize)]
 struct ParserAccuracyManifest {
@@ -386,10 +407,22 @@ enum MetricRow {
     Measured {
         metric: String,
         value: f64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        previous: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        delta: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        floor: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        threshold: Option<f64>,
         sample_count: u64,
         direction: Direction,
         confidence: Confidence,
         cadence: Cadence,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        macro_value: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        micro_value: Option<f64>,
     },
     InsufficientData {
         metric: String,
@@ -402,6 +435,9 @@ enum MetricRow {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum Direction {
+    Up,
+    Down,
+    Flat,
     Neutral,
 }
 
@@ -740,6 +776,7 @@ pub fn run(
 
     if json {
         write_artifact(&output_path, &artifact)?;
+        write_ratchet_receipt(&root, &artifact)?;
         println!("parser accuracy artifact written: {}", output_path.display());
     } else {
         print_summary(&artifact);
@@ -788,14 +825,12 @@ fn build_artifact(
     let scale_cost_score = score_manifest_scale_cost(root, manifest)?;
     let determinism_score = score_manifest_determinism(root, manifest)?;
     let gold_drift = audit_gold_drift(root, manifest)?;
-    let mut metrics = vec![MetricRow::Measured {
-        metric: "denominator_fixture_count".to_string(),
-        value: fixture_count,
-        sample_count: denominator.fixture_count,
-        direction: Direction::Neutral,
-        confidence: Confidence::High,
+    let mut metrics = vec![measured_value(
+        "denominator_fixture_count",
+        fixture_count,
+        denominator.fixture_count,
         cadence,
-    }];
+    )];
     metrics.extend(line_metrics(&line_score, cadence));
     metrics.extend(ast_metrics(&ast_score, cadence));
     metrics.extend(symbol_metrics(&symbol_score, cadence));
@@ -811,6 +846,7 @@ fn build_artifact(
     metrics.extend(cache_reuse_metrics(&incremental_score, cadence));
     metrics.extend(determinism_metrics(&determinism_score, cadence));
     metrics.extend(gold_drift_metrics(&gold_drift, denominator.fixture_count, cadence));
+    apply_safety_floor_metadata(&mut metrics);
 
     Ok(ParserAccuracyArtifact {
         schema_version: 1,
@@ -3511,14 +3547,7 @@ fn gold_drift_metrics(drift: &GoldDrift, fixture_count: u64, cadence: Cadence) -
 fn sync_runtime_metric_rows(artifact: &mut ParserAccuracyArtifact, cadence: Cadence) {
     let runtime = &artifact.metric_runtime;
     artifact.metrics.extend([
-        MetricRow::Measured {
-            metric: "metric_runtime_ms".to_string(),
-            value: runtime.runtime_ms,
-            sample_count: 1,
-            direction: Direction::Neutral,
-            confidence: Confidence::High,
-            cadence,
-        },
+        measured_value("metric_runtime_ms", runtime.runtime_ms, 1, cadence),
         measured_count("metric_timeout_count", runtime.timeout_count, 1, cadence),
         measured_count("metric_flake_count", runtime.flake_count, 1, cadence),
         measured_count("metric_artifact_size_bytes", runtime.artifact_size_bytes, 1, cadence),
@@ -3611,14 +3640,7 @@ fn symbol_f1_metric(
 }
 
 fn measured_count(metric: &str, value: u64, sample_count: u64, cadence: Cadence) -> MetricRow {
-    MetricRow::Measured {
-        metric: metric.to_string(),
-        value: value as f64,
-        sample_count,
-        direction: Direction::Neutral,
-        confidence: Confidence::High,
-        cadence,
-    }
+    measured_value(metric, value as f64, sample_count, cadence)
 }
 
 fn optional_measured_count(
@@ -3642,27 +3664,30 @@ fn optional_measured_value(
     cadence: Cadence,
 ) -> MetricRow {
     match value {
-        Some(value) if sample_count > 0 => MetricRow::Measured {
-            metric: metric.to_string(),
-            value,
-            sample_count,
-            direction: Direction::Neutral,
-            confidence: Confidence::High,
-            cadence,
-        },
+        Some(value) if sample_count > 0 => measured_value(metric, value, sample_count, cadence),
         _ => insufficient(metric, insufficient_reason),
     }
 }
 
 fn measured_rate(metric: &str, numerator: u64, denominator: u64, cadence: Cadence) -> MetricRow {
     let value = ratio(numerator, denominator).unwrap_or(0.0);
+    measured_value(metric, value, denominator, cadence)
+}
+
+fn measured_value(metric: &str, value: f64, sample_count: u64, cadence: Cadence) -> MetricRow {
     MetricRow::Measured {
         metric: metric.to_string(),
         value,
-        sample_count: denominator,
+        previous: None,
+        delta: None,
+        floor: None,
+        threshold: None,
+        sample_count,
         direction: Direction::Neutral,
         confidence: Confidence::High,
         cadence,
+        macro_value: None,
+        micro_value: None,
     }
 }
 
@@ -3674,14 +3699,7 @@ fn optional_measured_rate(
     cadence: Cadence,
 ) -> MetricRow {
     match value {
-        Some(value) if sample_count > 0 => MetricRow::Measured {
-            metric: metric.to_string(),
-            value,
-            sample_count,
-            direction: Direction::Neutral,
-            confidence: Confidence::High,
-            cadence,
-        },
+        Some(value) if sample_count > 0 => measured_value(metric, value, sample_count, cadence),
         _ => insufficient(metric, insufficient_reason),
     }
 }
@@ -3777,6 +3795,70 @@ fn write_artifact(path: &Path, artifact: &ParserAccuracyArtifact) -> Result<()> 
     let json = render_artifact(artifact)?;
     fs::write(path, json).with_context(|| format!("writing {}", path.display()))?;
     Ok(())
+}
+
+fn write_ratchet_receipt(root: &Path, artifact: &ParserAccuracyArtifact) -> Result<()> {
+    let path = root.join(DEFAULT_RATCHET_RECEIPT);
+    let parent =
+        path.parent().ok_or_else(|| eyre!("parser accuracy ratchet receipt path has no parent"))?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!("creating parser accuracy ratchet receipt dir {}", parent.display())
+    })?;
+    let receipt = ratchet_receipt_for_artifact(artifact);
+    let json = serde_json::to_string_pretty(&receipt)
+        .context("serializing parser accuracy ratchet receipt")?;
+    fs::write(&path, format!("{json}\n")).with_context(|| format!("writing {}", path.display()))?;
+    println!("parser accuracy ratchet receipt written: {}", path.display());
+    Ok(())
+}
+
+fn ratchet_receipt_for_artifact(artifact: &ParserAccuracyArtifact) -> MetricReceipt {
+    let floor_metrics = SAFETY_FLOOR_METRICS
+        .iter()
+        .map(|(metric, _floor)| ((*metric).to_string(), measured_metric_value(artifact, metric)))
+        .collect();
+    let improvement_metrics = DEFERRED_PRECISION_RECALL_CANDIDATES
+        .iter()
+        .map(|metric| ((*metric).to_string(), measured_metric_value(artifact, metric)))
+        .collect();
+
+    MetricReceipt {
+        subsystem: artifact.subsystem.to_string(),
+        generated_at: artifact.generated_at.clone(),
+        commit: artifact.commit.clone(),
+        floor_metrics,
+        improvement_metrics,
+    }
+}
+
+fn measured_metric_value(artifact: &ParserAccuracyArtifact, name: &str) -> Option<f64> {
+    artifact.metrics.iter().find_map(|row| match row {
+        MetricRow::Measured { metric, value, .. } if metric == name => Some(*value),
+        _ => None,
+    })
+}
+
+fn apply_safety_floor_metadata(metrics: &mut [MetricRow]) {
+    for row in metrics {
+        let MetricRow::Measured {
+            metric, value, previous, delta, floor, threshold, direction, ..
+        } = row
+        else {
+            continue;
+        };
+
+        let Some((_, floor_value)) =
+            SAFETY_FLOOR_METRICS.iter().find(|(candidate, _)| candidate == metric)
+        else {
+            continue;
+        };
+
+        *previous = Some(*floor_value);
+        *delta = Some(*value - *floor_value);
+        *floor = Some(*floor_value);
+        *threshold = Some(*floor_value);
+        *direction = Direction::Down;
+    }
 }
 
 fn render_artifact(artifact: &ParserAccuracyArtifact) -> Result<String> {
@@ -4347,6 +4429,82 @@ mod tests {
                         && (*value - 2.0).abs() < f64::EPSILON
             )
         }));
+    }
+
+    #[test]
+    fn safety_floor_metadata_marks_only_zero_false_precision_candidates() {
+        let mut metrics = vec![
+            measured_count("dynamic_false_precision_count", 0, 1, Cadence::Pr),
+            measured_count("fast_path_wrong_result_count", 0, 1, Cadence::Pr),
+            measured_count("line_construct_f1", 1, 1, Cadence::Pr),
+        ];
+
+        apply_safety_floor_metadata(&mut metrics);
+
+        for name in ["dynamic_false_precision_count", "fast_path_wrong_result_count"] {
+            assert!(metrics.iter().any(|metric| {
+                matches!(
+                    metric,
+                    MetricRow::Measured {
+                        metric,
+                        value,
+                        previous: Some(0.0),
+                        delta: Some(0.0),
+                        floor: Some(0.0),
+                        threshold: Some(0.0),
+                        direction: Direction::Down,
+                        sample_count: 1,
+                        ..
+                    } if metric == name && (*value - 0.0).abs() < f64::EPSILON
+                )
+            }));
+        }
+        assert!(metrics.iter().any(|metric| {
+            matches!(
+                metric,
+                MetricRow::Measured {
+                    metric,
+                    floor: None,
+                    threshold: None,
+                    direction: Direction::Neutral,
+                    ..
+                } if metric == "line_construct_f1"
+            )
+        }));
+    }
+
+    #[test]
+    fn ratchet_receipt_keeps_precision_recall_metrics_out_of_floor_map() {
+        let artifact = ParserAccuracyArtifact {
+            schema_version: 1,
+            subsystem: "parser_accuracy",
+            generated_at: "2026-05-03T00:00:00Z".to_string(),
+            commit: "test".to_string(),
+            cadence: Cadence::Pr,
+            denominator: Denominator::default(),
+            families: Vec::new(),
+            metrics: vec![
+                measured_count("dynamic_false_precision_count", 0, 1, Cadence::Pr),
+                measured_count("fast_path_wrong_result_count", 0, 1, Cadence::Pr),
+                measured_value("line_construct_f1", 0.875, 8, Cadence::Pr),
+                measured_value("symbol_decl_precision", 0.9, 10, Cadence::Pr),
+            ],
+            failure_packets: Vec::new(),
+            gold_drift: GoldDrift::default(),
+            metric_runtime: MetricRuntime::default(),
+        };
+
+        let receipt = ratchet_receipt_for_artifact(&artifact);
+
+        assert_eq!(receipt.floor_metrics.len(), 2);
+        assert_eq!(receipt.floor_metrics.get("dynamic_false_precision_count"), Some(&Some(0.0)));
+        assert_eq!(receipt.floor_metrics.get("fast_path_wrong_result_count"), Some(&Some(0.0)));
+        assert!(
+            !receipt.floor_metrics.contains_key("line_construct_f1"),
+            "precision/recall rows must stay out of hard floors until sample counts stabilize"
+        );
+        assert_eq!(receipt.improvement_metrics.get("line_construct_f1"), Some(&Some(0.875)));
+        assert_eq!(receipt.improvement_metrics.get("symbol_decl_precision"), Some(&Some(0.9)));
     }
 
     #[test]

--- a/xtask/src/tasks/metrics/ratchet.rs
+++ b/xtask/src/tasks/metrics/ratchet.rs
@@ -182,12 +182,15 @@ pub fn run_ratchet_check(
 
     // Load current metrics from receipt file, falling back to the baseline
     // values themselves when no receipt exists yet (bootstrapping).
-    let current_metrics: BTreeMap<String, Option<f64>> = if receipt_path.exists() {
+    let (current_floor_metrics, current_improvement_metrics): (
+        BTreeMap<String, Option<f64>>,
+        BTreeMap<String, Option<f64>>,
+    ) = if receipt_path.exists() {
         let raw = std::fs::read_to_string(&receipt_path)
             .with_context(|| format!("Failed to read receipt: {}", receipt_path.display()))?;
         let receipt: MetricReceipt = serde_json::from_str(&raw)
             .with_context(|| format!("Failed to parse receipt: {}", receipt_path.display()))?;
-        receipt.floor_metrics
+        (receipt.floor_metrics, receipt.improvement_metrics)
     } else {
         // No receipt yet — fall back to baseline values (idempotent, always
         // passes, confirms infrastructure is wired).
@@ -195,10 +198,10 @@ pub fn run_ratchet_check(
             "note: no receipt at {} — using baseline values as current (bootstrap mode)",
             receipt_path.display()
         );
-        baseline.floor_metrics.clone()
+        (baseline.floor_metrics.clone(), BTreeMap::new())
     };
 
-    let violations = check_floor_metrics(&baseline, &current_metrics);
+    let violations = check_floor_metrics(&baseline, &current_floor_metrics);
 
     if violations.is_empty() {
         println!("ratchet-check [{subsystem}]: all floor metrics passed");
@@ -250,7 +253,12 @@ pub fn run_ratchet_check(
 
         let commit = std::env::var("GITHUB_SHA").unwrap_or_else(|_| "unknown".to_string());
         let timestamp = Utc::now().to_rfc3339();
-        record_run(&mut state, &commit, &timestamp, &current_metrics);
+        let record_metrics = if current_improvement_metrics.is_empty() {
+            &current_floor_metrics
+        } else {
+            &current_improvement_metrics
+        };
+        record_run(&mut state, &commit, &timestamp, record_metrics);
 
         let json = serde_json::to_string_pretty(&state)
             .context("Failed to serialize stable-wins state")?;
@@ -503,6 +511,64 @@ mod tests {
             "regression_pct should be ~1.0 (100%), got {}",
             violations[0].regression_pct
         );
+    }
+
+    #[test]
+    fn test_ratchet_record_prefers_improvement_metrics_from_receipt() -> Result<()> {
+        use crate::tasks::metrics::stable_wins::StableWinsState;
+
+        let dir = tempfile::tempdir()?;
+        let baseline_dir = dir.path().join(".ci/metrics/baselines");
+        let receipt_dir = dir.path().join("target/receipts/metrics");
+        std::fs::create_dir_all(&baseline_dir)?;
+        std::fs::create_dir_all(&receipt_dir)?;
+
+        std::fs::write(
+            baseline_dir.join("test.json"),
+            r#"{
+  "schema_version": 1,
+  "measured_at": "2026-05-03T00:00:00Z",
+  "subsystem": "test",
+  "commit": "baseline",
+  "floor_metrics": {
+    "dynamic_false_precision_count": 0
+  },
+  "improvement_metrics": {
+    "line_construct_f1": 0.8
+  },
+  "tolerance_pct": 0.0
+}"#,
+        )?;
+        std::fs::write(
+            receipt_dir.join("test.json"),
+            r#"{
+  "subsystem": "test",
+  "generated_at": "2026-05-03T00:00:00Z",
+  "commit": "current",
+  "floor_metrics": {
+    "dynamic_false_precision_count": 0
+  },
+  "improvement_metrics": {
+    "line_construct_f1": 0.9
+  }
+}"#,
+        )?;
+
+        run_ratchet_check(dir.path(), "test", None, true)?;
+
+        let state_path = dir.path().join("target/metrics/stable_wins/test.json");
+        let raw = std::fs::read_to_string(&state_path)?;
+        let state: StableWinsState = serde_json::from_str(&raw)?;
+        assert!(
+            state.recent_runs.contains_key("line_construct_f1"),
+            "recorded stable-wins state should track improvement candidates"
+        );
+        assert!(
+            !state.recent_runs.contains_key("dynamic_false_precision_count"),
+            "floor metrics should not crowd out receipt improvement candidates"
+        );
+
+        Ok(())
     }
 
     // -------------------------------------------------------------------------

--- a/xtask/src/tasks/update_status/parser/accuracy.rs
+++ b/xtask/src/tasks/update_status/parser/accuracy.rs
@@ -13,8 +13,6 @@ use serde::Deserialize;
 pub(super) struct ParserAccuracyArtifactSummary {
     pub(super) schema_version: u32,
     pub(super) subsystem: String,
-    pub(super) generated_at: String,
-    pub(super) commit: String,
     pub(super) cadence: String,
     pub(super) denominator: ParserAccuracyDenominator,
     pub(super) families: Vec<ParserAccuracyFamilySummary>,
@@ -51,6 +49,15 @@ pub(super) enum ParserAccuracyMetricSummary {
     InsufficientData { metric: String, reason: String, sample_count: u64 },
 }
 
+impl ParserAccuracyMetricSummary {
+    fn name(&self) -> &str {
+        match self {
+            ParserAccuracyMetricSummary::Measured { metric, .. }
+            | ParserAccuracyMetricSummary::InsufficientData { metric, .. } => metric,
+        }
+    }
+}
+
 pub(super) fn read_parser_accuracy_artifact(root: &Path) -> Option<ParserAccuracyArtifactSummary> {
     let path = root.join("target/metrics/parser_accuracy.json");
     let raw = fs::read_to_string(path).ok()?;
@@ -77,7 +84,7 @@ pub(super) fn parser_accuracy_rows(artifact: Option<&ParserAccuracyArtifactSumma
     let family_summary = parser_accuracy_family_summary(&artifact.families);
     let metric_summary = parser_accuracy_metric_summary(&artifact.metrics);
     format!(
-        "| **Accuracy denominator** | {} fixtures / {} families | {} scored lines, {} scored symbols, {} fully labeled, {} partial, {} unknown, {} negative, {} dynamic boundaries, {} unsupported, {} real-project, {} generated, {} hand-labeled; cadence `{}`, commit `{}`, generated `{}` | {ARTIFACT_PATH}; {SPEC_PATH} |\n\
+        "| **Accuracy denominator** | {} fixtures / {} families | {} scored lines, {} scored symbols, {} fully labeled, {} partial, {} unknown, {} negative, {} dynamic boundaries, {} unsupported, {} real-project, {} generated, {} hand-labeled; cadence `{}` | {ARTIFACT_PATH}; {SPEC_PATH} |\n\
          | **Accuracy families** | {} | fixture family inventory from parser accuracy manifest | {ARTIFACT_PATH} |\n\
          | **Accuracy scorers** | {} | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | {SCHEMA_PATH} |",
         d.fixture_count,
@@ -94,8 +101,6 @@ pub(super) fn parser_accuracy_rows(artifact: Option<&ParserAccuracyArtifactSumma
         d.generated_fixture_count,
         d.hand_labeled_fixture_count,
         artifact.cadence,
-        artifact.commit,
-        artifact.generated_at,
         family_summary,
         metric_summary,
     )
@@ -117,31 +122,48 @@ fn parser_accuracy_family_summary(families: &[ParserAccuracyFamilySummary]) -> S
 }
 
 fn parser_accuracy_metric_summary(metrics: &[ParserAccuracyMetricSummary]) -> String {
-    let mut measured = Vec::new();
-    let mut insufficient = Vec::new();
+    const SUMMARY_METRICS: &[&str] = &[
+        "line_construct_f1",
+        "ast_node_kind_f1",
+        "symbol_decl_f1",
+        "symbol_ref_f1",
+        "dynamic_false_precision_count",
+        "fast_path_wrong_result_count",
+    ];
 
-    for metric in metrics {
-        match metric {
-            ParserAccuracyMetricSummary::Measured { metric, value, sample_count } => {
-                measured.push(format!("{metric}={value:.1} (n={sample_count})"));
-            }
-            ParserAccuracyMetricSummary::InsufficientData { metric, reason, sample_count } => {
-                insufficient
-                    .push(format!("{metric}: insufficient_data ({reason}; n={sample_count})"));
-            }
-        }
-    }
-
-    if measured.is_empty() && insufficient.is_empty() {
+    if metrics.is_empty() {
         return "insufficient_data".to_string();
     }
 
     let mut parts = Vec::new();
-    if !measured.is_empty() {
-        parts.push(format!("measured {}", measured.join(", ")));
+    let selected = SUMMARY_METRICS
+        .iter()
+        .filter_map(|name| metrics.iter().find(|metric| metric.name() == *name))
+        .map(|metric| match metric {
+            ParserAccuracyMetricSummary::Measured { metric, value, sample_count } => {
+                format!("{metric}={value:.1} (n={sample_count})")
+            }
+            ParserAccuracyMetricSummary::InsufficientData { metric, reason, sample_count } => {
+                format!("{metric}: insufficient_data ({reason}; n={sample_count})")
+            }
+        })
+        .collect::<Vec<_>>();
+    if !selected.is_empty() {
+        parts.push(format!("selected {}", selected.join(", ")));
     }
-    if !insufficient.is_empty() {
-        parts.push(insufficient.join(", "));
+
+    let measured_count = metrics
+        .iter()
+        .filter(|metric| matches!(metric, ParserAccuracyMetricSummary::Measured { .. }))
+        .count();
+    let insufficient_count = metrics.len().saturating_sub(measured_count);
+    let summarized_count = selected.len();
+    let additional_measured = measured_count.saturating_sub(summarized_count);
+    if additional_measured > 0 {
+        parts.push(format!("{additional_measured} additional measured rows"));
+    }
+    if insufficient_count > 0 {
+        parts.push(format!("{insufficient_count} insufficient_data rows preserved"));
     }
     parts.join("; ")
 }

--- a/xtask/src/tasks/update_status/parser/tests.rs
+++ b/xtask/src/tasks/update_status/parser/tests.rs
@@ -219,8 +219,6 @@ fn test_parser_accuracy_artifact_renders_denominator_and_metric_rows() -> Result
         parser_accuracy: Some(ParserAccuracyArtifactSummary {
             schema_version: 1,
             subsystem: "parser_accuracy".to_string(),
-            generated_at: "2026-05-02T15:00:00Z".to_string(),
-            commit: "abc123".to_string(),
             cadence: "pr".to_string(),
             denominator: ParserAccuracyDenominator {
                 fixture_count: 2,


### PR DESCRIPTION
Problem: Parser accuracy had measured safety rows, but no committed safety-floor baseline or ratchet-compatible receipt path for enforcing them.
Fix: Add parser_accuracy safety floors for dynamic false precision and fast-path wrong results, emit a ratchet receipt from parser-accuracy JSON runs, record improvement candidates for stable-wins, and render parser accuracy status without volatile timestamp/runtime churn.
Verification: `cargo xtask metrics parser-accuracy --json`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy --current target/receipts/metrics/parser_accuracy.json`; `cargo xtask update-status --only parser --check`; `cargo test -p xtask --profile agent --locked -j 1 parser_accuracy -- --nocapture`; `cargo test -p xtask --profile agent --locked -j 1 ratchet -- --nocapture`; `cargo test -p xtask update_status::parser --profile agent --locked -j 1 -- --nocapture`; `cargo check -p xtask --all-targets --profile agent --locked -j 1`; `cargo clippy -p xtask --profile agent --locked -j 1 -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`.
