### PR TITLE
test(vscode): harden managed binary smoke path (#0000)

### DIFF
--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -23,6 +23,48 @@ interface Release {
     assets: ReleaseAsset[];
 }
 
+const MANAGED_INSTALL_RETRY_DELAYS_MS = [100, 250, 500, 1000, 2000];
+const TRANSIENT_MANAGED_INSTALL_ERROR_CODES = new Set(['EBUSY', 'EPERM', 'EACCES', 'ETXTBSY']);
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}
+
+export function isTransientManagedInstallError(error: unknown): boolean {
+    const code = typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code?: unknown }).code ?? '')
+        : '';
+    return TRANSIENT_MANAGED_INSTALL_ERROR_CODES.has(code);
+}
+
+export async function copyManagedFileWithRetry(
+    sourcePath: string,
+    destinationPath: string,
+    label: string,
+    log: (message: string) => void,
+    retryDelaysMs = MANAGED_INSTALL_RETRY_DELAYS_MS,
+    copyFile: (source: string, destination: string) => void = fs.copyFileSync
+): Promise<void> {
+    for (let attempt = 0; ; attempt += 1) {
+        try {
+            copyFile(sourcePath, destinationPath);
+            return;
+        } catch (error: unknown) {
+            const canRetry = attempt < retryDelaysMs.length && isTransientManagedInstallError(error);
+            if (!canRetry) {
+                throw error;
+            }
+
+            const message = error instanceof Error ? error.message : String(error);
+            const delayMs = retryDelaysMs[attempt];
+            log(`Retrying ${label} install after transient file lock (${message}); waiting ${delayMs}ms.`);
+            await delay(delayMs);
+        }
+    }
+}
+
 function githubApiHeaders(url: string): Record<string, string> {
     const headers: Record<string, string> = {
         'User-Agent': 'vscode-perl-lsp',
@@ -371,7 +413,12 @@ export class BinaryDownloader {
                     fs.mkdirSync(finalDir, { recursive: true });
                 }
                 
-                fs.copyFileSync(extractedBinary, finalPath);
+                await copyManagedFileWithRetry(
+                    extractedBinary,
+                    finalPath,
+                    'perllsp',
+                    message => this.outputChannel.appendLine(message)
+                );
                 
                 // Make executable on Unix
                 if (process.platform !== 'win32') {
@@ -384,7 +431,12 @@ export class BinaryDownloader {
                 if (extractedDap) {
                     const dapDest = path.join(finalDir, dapName);
                     try {
-                        fs.copyFileSync(extractedDap, dapDest);
+                        await copyManagedFileWithRetry(
+                            extractedDap,
+                            dapDest,
+                            'perl-dap',
+                            message => this.outputChannel.appendLine(message)
+                        );
                         if (process.platform !== 'win32') {
                             fs.chmodSync(dapDest, 0o755);
                         }
@@ -409,7 +461,7 @@ export class BinaryDownloader {
             }
         });
     }
-    
+
     private async getLatestRelease(): Promise<Release> {
         const config = vscode.workspace.getConfiguration('perl-lsp');
         const channel = config.get<string>('channel', 'latest');

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -42,6 +42,7 @@ let streamingController: StreamingCompletionController | undefined;
 let stateChangeDisposable: vscode.Disposable | undefined;
 const COEXISTENCE_GUIDE_URL =
     'https://github.com/EffortlessMetrics/perl-lsp/blob/master/vscode-extension/README.md#extension-coexistence';
+const MANAGED_BINARY_HEALTH_TIMEOUT_MS = 30_000;
 /**
  * Cached startup diagnosis from the last server failure.
  *
@@ -1362,23 +1363,36 @@ async function probeStartupFailure(serverPath: string): Promise<StartupErrorDiag
 /**
  * Run `perllsp --health` and return `true` if the binary responds with `ok`.
  *
- * Waits up to 5 seconds. Returns `false` on timeout, non-zero exit, or if
+ * Waits up to 30 seconds. Returns `false` on timeout, non-zero exit, or if
  * stdout does not start with `ok`.
  */
 async function runHealthCheck(serverPath: string): Promise<boolean> {
     return new Promise(resolve => {
-        execFile(serverPath, ['--health'], { timeout: 5000 }, (err: Error | null, stdout: string) => {
-            if (err) {
-                outputChannel.appendLine(`[health-check] Failed: ${err.message}`);
-                resolve(false);
-                return;
+        execFile(
+            serverPath,
+            ['--health'],
+            { timeout: MANAGED_BINARY_HEALTH_TIMEOUT_MS },
+            (err: Error | null, stdout: string, stderr: string) => {
+                if (err) {
+                    outputChannel.appendLine(`[health-check] Failed: ${err.message}`);
+                    const stderrText = stderr.trim();
+                    if (stderrText) {
+                        outputChannel.appendLine(`[health-check] stderr: ${stderrText}`);
+                    }
+                    const stdoutText = stdout.trim();
+                    if (stdoutText) {
+                        outputChannel.appendLine(`[health-check] stdout: ${stdoutText}`);
+                    }
+                    resolve(false);
+                    return;
+                }
+                const ok = stdout.trim().startsWith('ok');
+                if (!ok) {
+                    outputChannel.appendLine(`[health-check] Unexpected output: ${stdout.trim()}`);
+                }
+                resolve(ok);
             }
-            const ok = stdout.trim().startsWith('ok');
-            if (!ok) {
-                outputChannel.appendLine(`[health-check] Unexpected output: ${stdout.trim()}`);
-            }
-            resolve(ok);
-        });
+        );
     });
 }
 

--- a/vscode-extension/src/test/downloader.test.ts
+++ b/vscode-extension/src/test/downloader.test.ts
@@ -14,7 +14,9 @@ import {
   BinaryDownloader,
   buildBinaryAssetCandidateNames,
   compareVersions,
+  copyManagedFileWithRetry,
   findReleaseAssetName,
+  isTransientManagedInstallError,
   parseLocalVersion,
 } from '../downloader';
 
@@ -187,6 +189,50 @@ describe('BinaryDownloader.getLocalDapPath', () => {
     const lspPath: string = downloader.getLocalBinaryPath();
 
     expect(path.dirname(dapPath)).toBe(path.dirname(lspPath));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Managed binary installation
+// ---------------------------------------------------------------------------
+describe('BinaryDownloader managed file install', () => {
+  test('classifies transient file-lock errors as retryable', () => {
+    expect(isTransientManagedInstallError(Object.assign(new Error('locked'), { code: 'EBUSY' }))).toBe(true);
+    expect(isTransientManagedInstallError(Object.assign(new Error('denied'), { code: 'EPERM' }))).toBe(true);
+    expect(isTransientManagedInstallError(Object.assign(new Error('missing'), { code: 'ENOENT' }))).toBe(false);
+  });
+
+  test('retries transient file-lock errors while installing managed binaries', async () => {
+    const logs: string[] = [];
+    let attempts = 0;
+    const transientError = Object.assign(new Error('locked'), { code: 'EBUSY' });
+    const copyFile = jest.fn(() => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw transientError;
+      }
+    });
+
+    await copyManagedFileWithRetry('source', 'destination', 'perllsp', message => logs.push(message), [0], copyFile);
+
+    expect(attempts).toBe(2);
+    expect(copyFile).toHaveBeenCalledTimes(2);
+    expect(logs).toEqual([expect.stringContaining('Retrying perllsp install')]);
+  });
+
+  test('does not retry non-transient managed install errors', async () => {
+    const logs: string[] = [];
+    const missingError = Object.assign(new Error('missing'), { code: 'ENOENT' });
+    const copyFile = jest.fn(() => {
+      throw missingError;
+    });
+
+    await expect(
+      copyManagedFileWithRetry('source', 'destination', 'perllsp', message => logs.push(message), [0], copyFile),
+    ).rejects.toThrow('missing');
+
+    expect(copyFile).toHaveBeenCalledTimes(1);
+    expect(logs).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Problem: The published extension smoke still exposed platform-specific managed binary install failures on Windows and macOS.\nFix: Retry transient file-lock failures while copying managed binaries, and give the binary health probe a longer timeout with stdout/stderr logging.\nVerification: \
pm run compile\, \
pm test -- --runTestsByPath src/test/downloader.test.ts --runInBand\, and \
pm run test:integration\ pass.