### PR TITLE
test(parser): expand parser accuracy denominator (#0000)

### DIFF
--- a/crates/perl-corpus/fixtures/parser_accuracy/autoload_boundary.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/autoload_boundary.pl
@@ -1,0 +1,13 @@
+package Accuracy::Autoload;
+
+our $AUTOLOAD;
+
+sub AUTOLOAD {
+    return $AUTOLOAD;
+}
+
+sub call_missing {
+    Accuracy::Autoload->missing();
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/control_do_until.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/control_do_until.pl
@@ -1,0 +1,11 @@
+package Accuracy::Control;
+
+sub loop_until {
+    my $count = 0;
+    do {
+        $count++;
+    } until $count > 2;
+    return $count;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/eval_string_boundary.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/eval_string_boundary.pl
@@ -1,0 +1,10 @@
+package Accuracy::EvalString;
+
+my $code = 'sub generated { 1 }';
+eval $code;
+
+sub after_eval {
+    return 1;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/export_tags.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/export_tags.pl
@@ -1,0 +1,15 @@
+package Accuracy::ExportTags;
+
+our %EXPORT_TAGS = (
+    all => [qw(foo bar)],
+);
+
+sub foo {
+    return 1;
+}
+
+sub bar {
+    return 2;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/format_decl.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/format_decl.pl
@@ -1,0 +1,12 @@
+package Accuracy::Format;
+
+format STDOUT =
+@<<<<
+$main::value
+.
+
+sub after_format {
+    return 1;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/heredoc_basic.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/heredoc_basic.pl
@@ -1,0 +1,11 @@
+package Accuracy::Heredoc;
+
+my $text = <<'END_TEXT';
+hello
+END_TEXT
+
+sub after {
+    return $text;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/imports_exports.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/imports_exports.pl
@@ -1,0 +1,12 @@
+package Accuracy::ImportsExports;
+
+use strict;
+use warnings;
+
+our @EXPORT_OK = qw(answer);
+
+sub answer {
+    return 42;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/inherited_method.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/inherited_method.pl
@@ -1,0 +1,15 @@
+package Accuracy::Parent;
+
+sub inherited {
+    return 1;
+}
+
+package Accuracy::Child;
+
+our @ISA = qw(Accuracy::Parent);
+
+sub call_parent {
+    return Accuracy::Child->inherited();
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
+++ b/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
@@ -598,6 +598,836 @@
           ]
         }
       ]
+    },
+    {
+      "id": "imports_exports",
+      "family": "imports_exports",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/imports_exports.pl",
+      "scored_lines": 5,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "import"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "import"
+          ]
+        },
+        {
+          "line": 6,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 8,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        }
+      ],
+      "symbol_expectations": {
+        "entities": [
+          {
+            "id": "imports_exports_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::ImportsExports",
+            "span_text": "Accuracy::ImportsExports",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "imports_exports_answer_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::ImportsExports::answer",
+            "span_text": "answer",
+            "package": "Accuracy::ImportsExports",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ]
+      }
+    },
+    {
+      "id": "qualified_refs",
+      "family": "qualified_references",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/qualified_refs.pl",
+      "scored_lines": 5,
+      "scored_symbols": 3,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 7,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 8,
+          "expected_tags": [
+            "function_call"
+          ]
+        },
+        {
+          "line": 9,
+          "expected_tags": [
+            "function_call"
+          ]
+        }
+      ],
+      "symbol_expectations": {
+        "entities": [
+          {
+            "id": "qualified_refs_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::Refs",
+            "span_text": "Accuracy::Refs",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "qualified_refs_target_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::Refs::target",
+            "span_text": "target",
+            "package": "Accuracy::Refs",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "qualified_refs_caller_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::Refs::caller",
+            "span_text": "caller",
+            "package": "Accuracy::Refs",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ]
+      }
+    },
+    {
+      "id": "same_bare_subs",
+      "family": "same_bare_subs",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/same_bare_subs.pl",
+      "scored_lines": 8,
+      "scored_symbols": 6,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 7,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 9,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 13,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 15,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 16,
+          "expected_tags": [
+            "function_call"
+          ]
+        },
+        {
+          "line": 17,
+          "expected_tags": [
+            "function_call"
+          ]
+        }
+      ],
+      "symbol_expectations": {
+        "entities": [
+          {
+            "id": "same_bare_subs_a_package",
+            "kind": "Package",
+            "canonical_name": "Accuracy::Same::A",
+            "span_text": "Accuracy::Same::A",
+            "package": "Accuracy::Same",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "same_bare_subs_a_run",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::Same::A::run",
+            "span_text": "run",
+            "package": "Accuracy::Same::A",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "same_bare_subs_b_package",
+            "kind": "Package",
+            "canonical_name": "Accuracy::Same::B",
+            "span_text": "Accuracy::Same::B",
+            "package": "Accuracy::Same",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "same_bare_subs_b_run",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::Same::B::run",
+            "span_text": "run",
+            "package": "Accuracy::Same::B",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "same_bare_subs_main_package",
+            "kind": "Package",
+            "canonical_name": "Accuracy::Same::Main",
+            "span_text": "Accuracy::Same::Main",
+            "package": "Accuracy::Same",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "same_bare_subs_call_both",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::Same::Main::call_both",
+            "span_text": "call_both",
+            "package": "Accuracy::Same::Main",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ]
+      }
+    },
+    {
+      "id": "heredoc_basic",
+      "family": "heredoc",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/heredoc_basic.pl",
+      "scored_lines": 3,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 7,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "regex_match",
+      "family": "regex",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/regex_match.pl",
+      "scored_lines": 4,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 5,
+          "expected_tags": [
+            "regex"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "method_call",
+      "family": "method_call",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/method_call.pl",
+      "scored_lines": 4,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 5,
+          "expected_tags": [
+            "method_call"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "autoload_boundary",
+      "family": "autoload",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/autoload_boundary.pl",
+      "scored_lines": 5,
+      "scored_symbols": 3,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 1,
+      "unsupported_constructs": 1,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 5,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 9,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 10,
+          "expected_tags": [
+            "method_call"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "eval_string_boundary",
+      "family": "eval_string",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/eval_string_boundary.pl",
+      "scored_lines": 5,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 1,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "function_call"
+          ]
+        },
+        {
+          "line": 6,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "control_do_until",
+      "family": "control_flow",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/control_do_until.pl",
+      "scored_lines": 4,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 5,
+          "expected_tags": [
+            "do_while"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "format_decl",
+      "family": "format",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/format_decl.pl",
+      "scored_lines": 3,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "format_decl"
+          ]
+        },
+        {
+          "line": 8,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "postderef_boundary",
+      "family": "postderef",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/postderef_boundary.pl",
+      "scored_lines": 3,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 1,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "signatures_basic",
+      "family": "signatures",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/signatures_basic.pl",
+      "scored_lines": 4,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 1,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "import"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "function_call"
+          ]
+        },
+        {
+          "line": 6,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "role_method",
+      "family": "role_method",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/role_method.pl",
+      "scored_lines": 5,
+      "scored_symbols": 4,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 7,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 9,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 10,
+          "expected_tags": [
+            "function_call"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "inherited_method",
+      "family": "inherited_method",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/inherited_method.pl",
+      "scored_lines": 6,
+      "scored_symbols": 4,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 7,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 9,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 11,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 12,
+          "expected_tags": [
+            "method_call"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "export_tags",
+      "family": "export_tags",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/export_tags.pl",
+      "scored_lines": 5,
+      "scored_symbols": 4,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        },
+        {
+          "line": 7,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 11,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "quote_like",
+      "family": "quote_like",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/quote_like.pl",
+      "scored_lines": 4,
+      "scored_symbols": 2,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        },
+        {
+          "line": 3,
+          "expected_tags": [
+            "sub_decl"
+          ]
+        },
+        {
+          "line": 4,
+          "expected_tags": [
+            "variable_decl"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/crates/perl-corpus/fixtures/parser_accuracy/method_call.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/method_call.pl
@@ -1,0 +1,8 @@
+package Accuracy::MethodCall;
+
+sub invoke {
+    my $object = shift;
+    $object->run("arg");
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/postderef_boundary.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/postderef_boundary.pl
@@ -1,0 +1,8 @@
+package Accuracy::Postderef;
+
+sub values {
+    my $array = [1, 2, 3];
+    return $array->@*;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/qualified_refs.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/qualified_refs.pl
@@ -1,0 +1,12 @@
+package Accuracy::Refs;
+
+sub target {
+    return 1;
+}
+
+sub caller {
+    target();
+    Accuracy::Refs::target();
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/quote_like.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/quote_like.pl
@@ -1,0 +1,8 @@
+package Accuracy::QuoteLike;
+
+sub quote {
+    my $message = q{hello};
+    return qq{$message};
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/regex_match.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/regex_match.pl
@@ -1,0 +1,8 @@
+package Accuracy::Regex;
+
+sub matches {
+    my $value = shift;
+    return $value =~ /foo\d+/;
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/role_method.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/role_method.pl
@@ -1,0 +1,13 @@
+package Accuracy::Role;
+
+sub provided {
+    return 1;
+}
+
+package Accuracy::RoleConsumer;
+
+sub local_method {
+    return provided();
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/same_bare_subs.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/same_bare_subs.pl
@@ -1,0 +1,20 @@
+package Accuracy::Same::A;
+
+sub run {
+    return "A";
+}
+
+package Accuracy::Same::B;
+
+sub run {
+    return "B";
+}
+
+package Accuracy::Same::Main;
+
+sub call_both {
+    Accuracy::Same::A::run();
+    Accuracy::Same::B::run();
+}
+
+1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/signatures_basic.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/signatures_basic.pl
@@ -1,0 +1,10 @@
+package Accuracy::Signatures;
+
+use feature 'signatures';
+no warnings 'experimental::signatures';
+
+sub add ($left, $right) {
+    return $left + $right;
+}
+
+1;

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -31,9 +31,9 @@
 | Layer | State | Notes | Source |
 | --- | --- | --- |
 <!-- BEGIN: PARSER_ACCURACY_SUMMARY -->
-| **Accuracy denominator** | 9 fixtures / 9 families | 29 scored lines, 17 scored symbols, 2 fully labeled, 6 partial, 5 unknown, 5 negative, 2 dynamic boundaries, 2 unsupported, 0 real-project, 0 generated, 9 hand-labeled; cadence `pr` | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
-| **Accuracy families** | dynamic_require (1), generated_accessor (1), incremental (1), negative_symbol_regions (1), operators (1), packages (1), +3 more | fixture family inventory from parser accuracy manifest | `target/metrics/parser_accuracy.json` |
-| **Accuracy scorers** | selected line_construct_f1=0.8 (n=11), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=0.9 (n=7), symbol_ref_f1=1.0 (n=2), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 119 additional measured rows; 52 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
+| **Accuracy denominator** | 25 fixtures / 25 families | 102 scored lines, 61 scored symbols, 2 fully labeled, 22 partial, 21 unknown, 5 negative, 4 dynamic boundaries, 5 unsupported, 0 real-project, 0 generated, 25 hand-labeled; cadence `pr` | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
+| **Accuracy families** | autoload (1), control_flow (1), dynamic_require (1), eval_string (1), export_tags (1), format (1), +19 more | fixture family inventory from parser accuracy manifest | `target/metrics/parser_accuracy.json` |
+| **Accuracy scorers** | selected line_construct_f1=0.9 (n=81), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=1.0 (n=18), symbol_ref_f1=1.0 (n=2), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 119 additional measured rows; 52 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
 <!-- END: PARSER_ACCURACY_SUMMARY -->
 
 ## Parser Performance Regimes


### PR DESCRIPTION
Problem: Parser accuracy observability had the rail wired but only a tiny fixture denominator.
Fix: Add 16 parser-accuracy gold fixtures across Perl construct families and refresh parser status; safety ratchet floors remain unchanged.
Verification: `cargo xtask metrics parser-accuracy --json`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy --current target/receipts/metrics/parser_accuracy.json`; `cargo xtask update-status --only parser --check`; `cargo test -p xtask --profile agent --locked -j 1 parser_accuracy -- --nocapture`; `cargo xtask fmt --check`; `git diff --check`.