### PR TITLE
ci: fix gate ambiguity — draft status, stale title noise, shard timing (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,18 @@ jobs:
           mkdir -p target/receipts/shards
           for gate in ${{ matrix.gates }}; do
             printf '::group::gate %s\n' "$gate"
+            gate_start_ms=$(date +%s%3N)
+            set +e
             cargo xtask gates --gate "$gate" --receipt --receipt-path "target/receipts/shards/${gate}.json"
+            gate_exit=$?
+            set -e
+            gate_end_ms=$(date +%s%3N)
+            gate_dur_ms=$((gate_end_ms - gate_start_ms))
+            printf '::notice::gate %s finished in %dms (exit %d)\n' "$gate" "$gate_dur_ms" "$gate_exit"
             printf '::endgroup::\n'
+            if [ "$gate_exit" -ne 0 ]; then
+              exit "$gate_exit"
+            fi
           done
 
       - name: Upload gate receipt
@@ -333,7 +343,7 @@ jobs:
       - ux-tests
       - windows-guardrails
       - merge-gate-shards
-    if: always() && needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
+    if: always()
     permissions:
       statuses: write
     steps:
@@ -341,53 +351,94 @@ jobs:
         shell: bash
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
+          RUN_CI: ${{ needs.draft-pr-check.outputs.run_ci }}
+          IS_LATEST: ${{ needs.preflight-latest-check.outputs.is_latest }}
         run: |
           python3 - <<'PY'
           import json
           import os
+          import sys
           from pathlib import Path
 
           needs = json.loads(os.environ["NEEDS_JSON"])
-          lines = ["### CI Gate aggregate", ""]
-          lines.append("| Dependency | Result |")
-          lines.append("| --- | --- |")
-          failed = []
-          for name, value in sorted(needs.items()):
-              result = value.get("result", "")
-              lines.append(f"| {name} | {result} |")
-              if result != "success":
-                  failed.append(name)
-
-          if failed:
-              lines.extend(["", f"Blocking dependency failure(s): {', '.join(failed)}"])
-          else:
-              lines.extend(["", "All merge-gate dependencies passed."])
-
+          run_ci = os.environ.get("RUN_CI", "").lower() == "true"
+          is_latest = os.environ.get("IS_LATEST", "").lower() == "true"
           summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          github_env = os.environ.get("GITHUB_ENV", "/dev/null")
+
+          lines = ["### CI Gate aggregate", ""]
+
+          if not run_ci:
+              # Draft PR: CI is intentionally skipped until the PR is marked ready.
+              ci_state = "pending"
+              ci_description = "FULL_CI_NOT_RUN_DRAFT: mark ready for review to trigger CI"
+              lines.extend([
+                  "> **Draft PR** — Full CI is intentionally skipped.",
+                  "> Mark the PR ready for review to trigger all CI gates.",
+                  "",
+                  "| Dependency | Result |",
+                  "| --- | --- |",
+              ])
+              for name, value in sorted(needs.items()):
+                  lines.append(f"| {name} | {value.get('result', '')} |")
+              lines.extend(["", "Status: `FULL_CI_NOT_RUN_DRAFT`"])
+          elif not is_latest:
+              # Superseded SHA: a newer push is in flight and will run full CI.
+              ci_state = "success"
+              ci_description = "STALE_CONTEXT_SKIPPED: superseded SHA, newer commit runs CI"
+              lines.extend([
+                  "> **Superseded SHA** — A newer commit exists on this branch.",
+                  "> CI skipped to save cost; the newer commit will run full CI.",
+                  "",
+                  "Status: `STALE_CONTEXT_SKIPPED`",
+              ])
+          else:
+              # Full CI ran: aggregate dependency results.
+              # draft-pr-check and preflight-latest-check are control-flow jobs that
+              # are always success when full CI reaches this point.
+              control_flow = {"draft-pr-check", "preflight-latest-check"}
+              lines.extend([
+                  "| Dependency | Result |",
+                  "| --- | --- |",
+              ])
+              failed = []
+              for name, value in sorted(needs.items()):
+                  result = value.get("result", "")
+                  lines.append(f"| {name} | {result} |")
+                  if name not in control_flow and result != "success":
+                      failed.append(name)
+
+              if failed:
+                  ci_state = "failure"
+                  ci_description = f"Failed: {', '.join(failed[:3])}"
+                  if len(failed) > 3:
+                      ci_description += f" (+{len(failed) - 3} more)"
+                  lines.extend(["", f"❌ Blocking failure(s): {', '.join(failed)}"])
+              else:
+                  ci_state = "success"
+                  ci_description = "All merge-gate dependencies passed"
+                  lines.extend(["", "✅ All merge-gate dependencies passed."])
+
           if summary_path:
               Path(summary_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-          if failed:
-              raise SystemExit(1)
+          with open(github_env, "a") as f:
+              f.write(f"CI_MERGE_GATE_STATE={ci_state}\n")
+              f.write(f"CI_MERGE_GATE_DESCRIPTION={ci_description[:140]}\n")
+
+          if ci_state == "failure":
+              sys.exit(1)
           PY
 
       - name: Set PR status (check)
         if: always()
         uses: actions/github-script@v9
-        env:
-          NEEDS_JSON: ${{ toJson(needs) }}
         with:
           script: |
-            const needs = JSON.parse(process.env.NEEDS_JSON || '{}');
-            const failed = Object.entries(needs)
-              .filter(([name, value]) => value.result !== 'success')
-              .map(([name]) => name);
-            const status = failed.length === 0 ? 'success' : 'failure';
-            const description = failed.length === 0
-              ? 'All merge-gate dependencies passed'
-              : `Failed dependency: ${failed.join(', ')}`;
+            const state = process.env.CI_MERGE_GATE_STATE || 'failure';
+            const description = process.env.CI_MERGE_GATE_DESCRIPTION || 'Unknown CI gate state';
 
-            console.log(`Setting PR status to: ${status}`);
+            console.log(`Setting ci/merge-gate status to: ${state}`);
             console.log(`Description: ${description}`);
 
             try {
@@ -395,14 +446,14 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 sha: context.sha,
-                state: status,
+                state,
                 context: 'ci/merge-gate',
                 description,
                 target_url: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
               });
             } catch (error) {
               if (error.status === 403) {
-                core.warning(`Could not create ci/merge-gate commit status from this workflow context: ${error.message}`);
+                core.warning(`Could not create ci/merge-gate commit status: ${error.message}`);
               } else {
                 throw error;
               }

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   pull-requests: write
   checks: write
+  statuses: write
 
 jobs:
   validate-title:
@@ -38,14 +39,37 @@ jobs:
             }
 
             const BOT_MARKER = '<!-- pr-title-check-bot -->';
+            const prHeadSha = pr.head.sha;
+            const statusContext = 'ci/pr-title';
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+
+            // Post a commit status so stale failures for the same SHA are always
+            // overwritten when the title is subsequently fixed (without a new push).
+            async function postTitleStatus(state, description) {
+              try {
+                await github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: prHeadSha,
+                  state,
+                  context: statusContext,
+                  description: description.slice(0, 140),
+                  target_url: runUrl,
+                });
+              } catch (err) {
+                core.warning(`Could not post ci/pr-title commit status: ${err.message}`);
+              }
+            }
 
             if (!/\B#\d+\b/.test(title)) {
               core.setFailed(
                 `PR title must reference an issue (e.g. "feat: add thing (#42)"). Got: "${title}"`
               );
 
+              await postTitleStatus('failure', 'PR title missing issue reference (#NNN)');
+
               const commentBody = [
-                '## \u26a0\ufe0f PR Title Check Failed',
+                '## ⚠️ PR Title Check Failed',
                 '',
                 BOT_MARKER,
                 '',
@@ -108,4 +132,7 @@ jobs:
               }
             }
 
+            // Post success status — overwrites any stale failure from a prior title edit
+            // on this same SHA (e.g. title fixed without a new commit push).
+            await postTitleStatus('success', 'PR title passes validation');
             core.info('PR title passes validation.');


### PR DESCRIPTION
## Summary

- **`merge-gate` always runs** (`if: always()`) and posts `ci/merge-gate` for every SHA, including draft PRs. Draft PRs get `state=pending` with description `FULL_CI_NOT_RUN_DRAFT` — the status context is never absent or ambiguous. Stale SHAs get `state=success` with `STALE_CONTEXT_SKIPPED`. The aggregation skips the two control-flow jobs (`draft-pr-check`, `preflight-latest-check`) when checking for failures.
- **`pr-title-check` posts an explicit `ci/pr-title` commit status** on every run (pass and fail). Commit statuses for the same context are overwritten by newer results, so fixing a PR title without a new push correctly clears the stale failure on that SHA.
- **Per-gate wall-clock timing** added to the shard runner via `date +%s%3N` before/after each `xtask` call. Duration is emitted as a `::notice::` annotation, making slowest-gate diagnostics visible in the Actions log without parsing receipt JSON.

## What was broken

From the transcript analysis: draft PRs showed no `ci/merge-gate` status at all (the job was completely skipped), so the merge UI was ambiguous about whether CI had run. After marking ready, slow pending gates and a stale `validate-title` failure created false confidence. Per-gate timing was only recoverable from receipt JSON after the fact.

## Test plan

- [ ] Open a draft PR → confirm `ci/merge-gate` shows `pending` / `FULL_CI_NOT_RUN_DRAFT`
- [ ] Mark it ready → confirm `ci/merge-gate` updates to aggregate result of all gates
- [ ] Fix a PR title without pushing a new commit → confirm `ci/pr-title` overwrites the old failure on the same SHA
- [ ] Check Actions log for a shard run → confirm `::notice::` timing lines appear per gate
- [ ] Confirm stale-SHA case: push two commits rapidly → older SHA should show `STALE_CONTEXT_SKIPPED`

## Follow-up (P1, not in this PR)

Per the diagnosis: split `CI Gate (lsp)` into `lsp-smoke-required` + `lsp-full-regression` (path-triggered), split `UX Regression Tests` into smoke/full tiers, and convert Windows `sandbox-fail-closed` to fixture-driven policy tests.

https://claude.ai/code/session_01TTyyhcJgXteXTSWTNtYNXn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTyyhcJgXteXTSWTNtYNXn)_