### PR TITLE
feat(diagnostics): dynamic-boundary suppression infrastructure (PR-A: producers + query + scope variant) (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
@@ -514,6 +514,15 @@ mod tests {
         fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
             SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     struct MethodCandidateStub {
@@ -575,6 +584,15 @@ mod tests {
 
         fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
             SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
+        }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
         }
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
@@ -9,6 +9,11 @@ use perl_parser_core::error::ParseError;
 use perl_pragma::PragmaTracker;
 use perl_semantic_analyzer::scope_analyzer::ScopeAnalyzer;
 use perl_semantic_analyzer::symbol::SymbolExtractor;
+use perl_semantic_facts::{
+    DefinitionCandidate, EntityFact, EntityId, FileId, OccurrenceFact, RenamePlan, SafeDeletePlan,
+    ScopeId, VisibleSymbol,
+};
+use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
 
 use super::dedup::deduplicate_diagnostics;
 use super::lints::common_mistakes::check_common_mistakes;
@@ -30,7 +35,69 @@ use super::lints::unreachable_code::check_unreachable_code;
 use super::lints::unused_imports::check_unused_imports;
 use super::lints::version_compat::check_version_compat;
 use super::parse_errors::{parse_error_code, parse_error_severity};
-use super::scope::scope_issues_to_diagnostics;
+use super::scope::scope_issues_to_diagnostics_with_semantics;
+
+// ── NullSemanticQueries ──
+
+/// A no-op [`SemanticQueries`] implementation used as a fallback when no
+/// workspace semantic data is available.
+///
+/// Returns empty/None for all queries. `dynamic_boundary_at` returns `None`,
+/// so `scope_issues_to_diagnostics_with_semantics` degrades to the same
+/// behavior as `scope_issues_to_diagnostics` when no semantic data is wired.
+struct NullSemanticQueries;
+
+impl SemanticQueries for NullSemanticQueries {
+    fn symbol_at(
+        &self,
+        _file_id: FileId,
+        _byte_offset: u32,
+    ) -> Option<(EntityFact, OccurrenceFact)> {
+        None
+    }
+
+    fn definitions(&self, _symbol: &str, _context: &QueryContext) -> Vec<DefinitionCandidate> {
+        Vec::new()
+    }
+
+    fn references(&self, _entity_id: EntityId) -> Vec<OccurrenceFact> {
+        Vec::new()
+    }
+
+    fn visible_symbols_at(
+        &self,
+        _file_id: FileId,
+        _byte_offset: u32,
+        _scope_id: Option<ScopeId>,
+    ) -> Vec<VisibleSymbol> {
+        Vec::new()
+    }
+
+    fn method_candidates(
+        &self,
+        _receiver_package: &str,
+        _method_name: &str,
+    ) -> Vec<DefinitionCandidate> {
+        Vec::new()
+    }
+
+    fn rename_plan(&self, entity_id: EntityId, new_name: &str) -> RenamePlan {
+        RenamePlan::new(entity_id, String::new(), new_name.to_string(), vec![], vec![], vec![])
+    }
+
+    fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
+        SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
+    }
+
+    fn dynamic_boundary_at(
+        &self,
+        _file_id: FileId,
+        _byte_offset: u32,
+        _symbol: Option<&str>,
+    ) -> Option<OccurrenceFact> {
+        None
+    }
+}
 
 // Re-export diagnostic types from local internal types module.
 #[allow(unused_imports)]
@@ -133,11 +200,20 @@ impl DiagnosticsProvider {
             });
         }
 
-        // Run scope analysis to detect undeclared/unused/shadowing issues
+        // Run scope analysis to detect undeclared/unused/shadowing issues.
+        // Uses the semantics-aware variant with NullSemanticQueries as the
+        // default (no suppression). Callers with workspace semantic data should
+        // use get_diagnostics_with_path_and_semantics instead.
         let pragma_map = PragmaTracker::build(ast);
         let scope_analyzer = ScopeAnalyzer::new();
         let scope_issues = scope_analyzer.analyze(ast, source, &pragma_map);
-        diagnostics.extend(scope_issues_to_diagnostics(scope_issues));
+        // FileId(0) is the null file ID — NullSemanticQueries returns None for
+        // all queries regardless, so the file_id value does not matter here.
+        diagnostics.extend(scope_issues_to_diagnostics_with_semantics(
+            scope_issues,
+            FileId(0),
+            &NullSemanticQueries,
+        ));
 
         // Detect heredoc anti-patterns
         let heredoc_diags = super::heredoc_antipatterns::detect_heredoc_antipatterns(source);

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
@@ -201,14 +201,17 @@ impl DiagnosticsProvider {
         }
 
         // Run scope analysis to detect undeclared/unused/shadowing issues.
-        // Uses the semantics-aware variant with NullSemanticQueries as the
-        // default (no suppression). Callers with workspace semantic data should
-        // use get_diagnostics_with_path_and_semantics instead.
+        //
+        // This default path passes `NullSemanticQueries`, which always returns
+        // `None`, so dynamic-boundary suppression does not trigger here — legacy
+        // behavior is preserved exactly. A follow-up PR (PR-B) will thread the
+        // real `WorkspaceSemanticQueries` from `LanguageServerCore` through to
+        // this call site, at which point suppression becomes live.
         let pragma_map = PragmaTracker::build(ast);
         let scope_analyzer = ScopeAnalyzer::new();
         let scope_issues = scope_analyzer.analyze(ast, source, &pragma_map);
-        // FileId(0) is the null file ID — NullSemanticQueries returns None for
-        // all queries regardless, so the file_id value does not matter here.
+        // FileId(0) is a placeholder — NullSemanticQueries returns None for all
+        // queries regardless, so the file_id value does not matter here.
         diagnostics.extend(scope_issues_to_diagnostics_with_semantics(
             scope_issues,
             FileId(0),

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
@@ -393,6 +393,15 @@ mod tests {
         fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
             SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_candidate(

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs
@@ -139,6 +139,29 @@ mod tests {
             };
             SafeDeletePlan::new(entity_id, String::new(), blockers, vec![])
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            // Stub: stubs that report rename/safe-delete blocked as DynamicBoundary
+            // also report dynamic boundary coverage at any position.
+            if self.rename_blocked || self.safe_delete_blocked {
+                Some(OccurrenceFact {
+                    id: perl_semantic_facts::OccurrenceId(9999),
+                    kind: perl_semantic_facts::OccurrenceKind::DynamicBoundary,
+                    entity_id: None,
+                    anchor_id: AnchorId(9999),
+                    scope_id: None,
+                    provenance: perl_semantic_facts::Provenance::DynamicBoundary,
+                    confidence: perl_semantic_facts::Confidence::Low,
+                })
+            } else {
+                None
+            }
+        }
     }
 
     // ── Helpers ──
@@ -474,6 +497,147 @@ mod tests {
             diagnostics_undefined_symbol_cutover(true, &stub, "test_sym", FileId(1), None, 0, true);
 
         assert_eq!(outcome.receipt.schema_version, 1, "receipt schema version should be 1");
+        Ok(())
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Fixture suite 5: new missing-case patterns (Q5 provenance upgrade)
+    // ════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn dynamic_import_via_variable_suppressed() -> Result<(), Box<dyn std::error::Error>> {
+        // Pattern: `require $module; $module->import(qw(foo))`
+        // 'foo' is plausibly imported — suppress the undefined-symbol diagnostic.
+        let stub = DynamicBoundaryStub::empty_in_dynamic_scope();
+        let outcome = assert_dynamic_scope_suppresses(&stub, "foo")?;
+        assert_receipt_explains_dynamic(&outcome)?;
+        Ok(())
+    }
+
+    #[test]
+    fn static_class_dynamic_args_import_suppressed() -> Result<(), Box<dyn std::error::Error>> {
+        // Pattern: `Foo->import(@names)` — static class, dynamic arg list.
+        // The imported symbols are not statically known — suppress.
+        let stub = DynamicBoundaryStub::empty_in_dynamic_scope();
+        let outcome = assert_dynamic_scope_suppresses(&stub, "bar")?;
+        assert_receipt_explains_dynamic(&outcome)?;
+        Ok(())
+    }
+
+    #[test]
+    fn symbolic_deref_variable_suppressed() -> Result<(), Box<dyn std::error::Error>> {
+        // Pattern: `${$name} = 1`
+        // Variable created via symbolic dereference — suppress the diagnostic.
+        let stub = DynamicBoundaryStub::empty_in_dynamic_scope();
+        let outcome = assert_dynamic_scope_suppresses(&stub, "dynamic_var")?;
+        assert_receipt_explains_dynamic(&outcome)?;
+        Ok(())
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Control fixture: normal static missing symbol MUST still fire
+    // ════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn normal_static_missing_symbol_still_fires() -> Result<(), Box<dyn std::error::Error>> {
+        // Control fixture: no dynamic boundary, no semantic candidates.
+        // A genuinely missing symbol MUST produce Warn, not Suppress.
+        // The stub has no candidates and is NOT in a dynamic scope.
+        struct StaticNoDynamicStub;
+
+        impl SemanticQueries for StaticNoDynamicStub {
+            fn symbol_at(&self, _: FileId, _: u32) -> Option<(EntityFact, OccurrenceFact)> {
+                None
+            }
+            fn definitions(&self, _: &str, _: &QueryContext) -> Vec<DefinitionCandidate> {
+                Vec::new() // no candidates → symbol is undefined
+            }
+            fn references(&self, _: EntityId) -> Vec<OccurrenceFact> {
+                Vec::new()
+            }
+            fn visible_symbols_at(
+                &self,
+                _: FileId,
+                _: u32,
+                _: Option<ScopeId>,
+            ) -> Vec<VisibleSymbol> {
+                Vec::new()
+            }
+            fn method_candidates(&self, _: &str, _: &str) -> Vec<DefinitionCandidate> {
+                Vec::new()
+            }
+            fn rename_plan(&self, id: EntityId, n: &str) -> RenamePlan {
+                RenamePlan::new(id, String::new(), n.to_string(), vec![], vec![], vec![])
+            }
+            fn safe_delete_plan(&self, id: EntityId) -> SafeDeletePlan {
+                SafeDeletePlan::new(id, String::new(), vec![], vec![])
+            }
+            fn dynamic_boundary_at(
+                &self,
+                _: FileId,
+                _: u32,
+                _: Option<&str>,
+            ) -> Option<OccurrenceFact> {
+                None // no dynamic boundary anywhere
+            }
+        }
+
+        let stub = StaticNoDynamicStub;
+        let outcome = diagnostics_undefined_symbol_cutover(
+            true,
+            &stub,
+            "truly_undefined_sub",
+            FileId(1),
+            None,
+            0,
+            false, // NOT in dynamic scope
+        );
+
+        assert_eq!(
+            outcome.action,
+            DiagnosticAction::Warn,
+            "static missing symbol with no candidates must produce Warn (control fixture: normal_static_missing_symbol.pl)"
+        );
+        assert_eq!(
+            outcome.classification,
+            DiagnosticClassification::Exact,
+            "no candidates → Exact classification → Warn"
+        );
+        Ok(())
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // dynamic_boundary_at integration: the stub reports coverage
+    // ════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn dynamic_boundary_stub_returns_coverage_when_blocked()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // When the stub is in dynamic scope (rename/safe-delete blocked),
+        // dynamic_boundary_at returns Some — confirming the stub contract.
+        let stub = DynamicBoundaryStub::dynamic_scope();
+        let result = stub.dynamic_boundary_at(FileId(1), 0, Some("any_sym"));
+        assert!(result.is_some(), "dynamic_scope stub should report coverage at any position");
+        let occ = result.ok_or("expected OccurrenceFact")?;
+        assert_eq!(occ.kind, perl_semantic_facts::OccurrenceKind::DynamicBoundary);
+        assert_eq!(occ.provenance, perl_semantic_facts::Provenance::DynamicBoundary);
+        assert_eq!(occ.confidence, perl_semantic_facts::Confidence::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_boundary_stub_returns_none_when_not_blocked()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // When the stub has no dynamic scope, dynamic_boundary_at returns None.
+        let stub = DynamicBoundaryStub {
+            definitions_result: vec![],
+            rename_blocked: false,
+            rename_block_reason: None,
+            safe_delete_blocked: false,
+            safe_delete_block_reason: None,
+        };
+        let result = stub.dynamic_boundary_at(FileId(1), 0, Some("any_sym"));
+        assert!(result.is_none(), "non-dynamic stub should return None from dynamic_boundary_at");
         Ok(())
     }
 }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
@@ -19,9 +19,10 @@ use perl_diagnostics::codes::DiagnosticSeverity;
 ///
 /// # Backward compatibility
 ///
-/// Preserved for callers that do not have semantic query data. Internally,
-/// [`scope_issues_to_diagnostics_with_semantics`] is used with
-/// `NullSemanticQueries`, which is functionally equivalent to this function.
+/// Preserved for callers that do not have semantic query data. This path
+/// preserves the original conversion logic directly — no semantic suppression
+/// is applied. Callers with workspace semantic data should call
+/// [`scope_issues_to_diagnostics_with_semantics`] instead.
 #[allow(dead_code)] // Preserved for API backward compatibility
 pub fn scope_issues_to_diagnostics(issues: Vec<ScopeIssue>) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
@@ -5,6 +5,8 @@
 
 use perl_diagnostics::codes::DiagnosticCode;
 use perl_semantic_analyzer::scope_analyzer::{IssueKind, ScopeIssue};
+use perl_semantic_facts::FileId;
+use perl_workspace::semantic::queries::SemanticQueries;
 
 use super::internal_types::{Diagnostic, DiagnosticTag, RelatedInformation};
 use perl_diagnostics::codes::DiagnosticSeverity;
@@ -14,6 +16,13 @@ use perl_diagnostics::codes::DiagnosticSeverity;
 /// This function processes scope analyzer issues and converts them into
 /// appropriate diagnostics with severity levels, codes, and helpful related
 /// information based on the issue type.
+///
+/// # Backward compatibility
+///
+/// Preserved for callers that do not have semantic query data. Internally,
+/// [`scope_issues_to_diagnostics_with_semantics`] is used with
+/// `NullSemanticQueries`, which is functionally equivalent to this function.
+#[allow(dead_code)] // Preserved for API backward compatibility
 pub fn scope_issues_to_diagnostics(issues: Vec<ScopeIssue>) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
@@ -44,90 +53,7 @@ pub fn scope_issues_to_diagnostics(issues: Vec<ScopeIssue>) -> Vec<Diagnostic> {
             IssueKind::CaptureVarWithoutRegexMatch => DiagnosticCode::CaptureVarWithoutRegexMatch,
         };
 
-        // Build helpful related information based on issue type
-        let related_info = match issue.kind {
-            IssueKind::UndeclaredVariable => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Declare the variable with 'my', 'our', 'local', or 'state'".to_string(),
-                },
-                RelatedInformation {
-                    location: issue.range,
-                    message: "ℹ️ Under 'use strict', all variables must be declared before use. Use 'my' for lexical scope or 'our' for package variables.".to_string(),
-                }
-            ],
-            IssueKind::UnusedVariable => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Remove the unused variable or prefix with '_' to indicate it's intentionally unused".to_string(),
-                }
-            ],
-            IssueKind::UnusedParameter => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Remove the unused parameter or prefix with '_' (e.g., $_unused) to indicate it's intentionally unused".to_string(),
-                }
-            ],
-            IssueKind::VariableShadowing => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Rename this variable or use the outer scope variable instead".to_string(),
-                },
-                RelatedInformation {
-                    location: issue.range,
-                    message: "ℹ️ Variable shadowing can make code harder to understand and may hide bugs.".to_string(),
-                }
-            ],
-            IssueKind::VariableRedeclaration => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Remove the duplicate 'my' declaration - just assign to the existing variable".to_string(),
-                }
-            ],
-            IssueKind::DuplicateParameter => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Remove the duplicate parameter or use a different name".to_string(),
-                }
-            ],
-            IssueKind::ParameterShadowsGlobal => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Rename the parameter to avoid shadowing the global variable".to_string(),
-                }
-            ],
-            IssueKind::UninitializedVariable => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Initialize the variable when declaring it: my $var = value;".to_string(),
-                },
-                RelatedInformation {
-                    location: issue.range,
-                    message: "ℹ️ Using uninitialized variables may cause warnings and unexpected behavior.".to_string(),
-                }
-            ],
-            IssueKind::UnquotedBareword => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Quote the bareword as a string: 'word' or \"word\"".to_string(),
-                },
-                RelatedInformation {
-                    location: issue.range,
-                    message: "ℹ️ Under 'use strict', barewords are not allowed unless they're subroutine calls or hash keys.".to_string(),
-                }
-            ],
-            IssueKind::CaptureVarWithoutRegexMatch => vec![
-                RelatedInformation {
-                    location: issue.range,
-                    message: "💡 Perform a regex match before using this capture variable: if ($str =~ /(...)/){ ... }".to_string(),
-                },
-                RelatedInformation {
-                    location: issue.range,
-                    message: "ℹ️ Capture variables ($1, $2, etc.) hold the last successful match and may be undef if no match has occurred.".to_string(),
-                }
-            ],
-        };
-
+        let related_info = build_scope_related_info(&issue);
         let suggestion = build_scope_suggestion(&issue);
 
         diagnostics.push(Diagnostic {
@@ -146,6 +72,208 @@ pub fn scope_issues_to_diagnostics(issues: Vec<ScopeIssue>) -> Vec<Diagnostic> {
     }
 
     diagnostics
+}
+
+/// Convert scope analyzer issues to diagnostics with dynamic-boundary suppression.
+///
+/// Extends [`scope_issues_to_diagnostics`] by consulting `semantic_queries`
+/// for each `UndeclaredVariable` issue. If the issue's position is covered by
+/// dynamic-boundary evidence (e.g., `require $var`, string `eval`, typeglob
+/// assignment, or AUTOLOAD scope), the diagnostic is **suppressed** for that
+/// specific variable.
+///
+/// # Suppression policy (Q3 architectural decision)
+///
+/// - High-confidence normal missing symbol → diagnostic still fires.
+/// - Dynamic boundary covering THE specific variable → suppress that exact
+///   undefined diagnostic.
+/// - Ambiguous but not dynamic → emit the diagnostic (conservative default).
+/// - Unavailable semantic path (no shard for file) → fall back to emitting
+///   the diagnostic (no false suppression).
+///
+/// Importantly, a dynamic construct anywhere in the file does **not** suppress
+/// unrelated diagnostics: `require $module; print $undeclared_static_var;`
+/// still fires for `$undeclared_static_var` because `dynamic_boundary_at`
+/// checks the *specific position* of each issue.
+///
+/// # Backward compatibility
+///
+/// The original [`scope_issues_to_diagnostics`] is preserved unchanged.
+/// Callers that cannot provide `FileId` or semantic queries should continue
+/// using the original function.
+///
+/// # Requirements
+///
+/// - **Req 7.4**: Suppress undefined-symbol diagnostics for references within
+///   dynamic boundary scopes.
+pub fn scope_issues_to_diagnostics_with_semantics<Q: SemanticQueries>(
+    issues: Vec<ScopeIssue>,
+    file_id: FileId,
+    semantic_queries: &Q,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for issue in issues {
+        // For UndeclaredVariable issues, check whether the specific variable
+        // position is covered by dynamic-boundary evidence.
+        if issue.kind == IssueKind::UndeclaredVariable {
+            let byte_offset = issue.range.0 as u32;
+            // Strip the sigil from the variable name to get the bare symbol.
+            let bare_symbol = issue.variable_name.trim_start_matches(['$', '@', '%', '&', '*']);
+            // Use the full variable name (with sigil) as a fallback too.
+            let symbol_to_check =
+                if bare_symbol.is_empty() { issue.variable_name.as_str() } else { bare_symbol };
+
+            // Query for dynamic boundary at the specific position for this symbol.
+            let is_covered = semantic_queries
+                .dynamic_boundary_at(file_id, byte_offset, Some(symbol_to_check))
+                .is_some();
+
+            if is_covered {
+                // The specific variable at this position is covered by a
+                // dynamic boundary — suppress the undefined-symbol diagnostic.
+                tracing::debug!(
+                    variable = %issue.variable_name,
+                    byte_offset,
+                    "suppressed UndeclaredVariable diagnostic: covered by dynamic boundary"
+                );
+                continue;
+            }
+        }
+
+        // All other issue kinds — and UndeclaredVariable issues not covered by
+        // a dynamic boundary — are emitted as diagnostics.
+        let severity = match issue.kind {
+            IssueKind::UndeclaredVariable
+            | IssueKind::VariableRedeclaration
+            | IssueKind::DuplicateParameter
+            | IssueKind::UnquotedBareword => DiagnosticSeverity::Error,
+            IssueKind::VariableShadowing
+            | IssueKind::UnusedVariable
+            | IssueKind::ParameterShadowsGlobal
+            | IssueKind::UnusedParameter
+            | IssueKind::UninitializedVariable => DiagnosticSeverity::Warning,
+            IssueKind::CaptureVarWithoutRegexMatch => DiagnosticSeverity::Information,
+        };
+
+        let code = match issue.kind {
+            IssueKind::UndeclaredVariable => DiagnosticCode::UndefinedVariable,
+            IssueKind::UnusedVariable => DiagnosticCode::UnusedVariable,
+            IssueKind::VariableShadowing => DiagnosticCode::VariableShadowing,
+            IssueKind::VariableRedeclaration => DiagnosticCode::VariableRedeclaration,
+            IssueKind::DuplicateParameter => DiagnosticCode::DuplicateParameter,
+            IssueKind::ParameterShadowsGlobal => DiagnosticCode::ParameterShadowsGlobal,
+            IssueKind::UnusedParameter => DiagnosticCode::UnusedParameter,
+            IssueKind::UnquotedBareword => DiagnosticCode::UnquotedBareword,
+            IssueKind::UninitializedVariable => DiagnosticCode::UninitializedVariable,
+            IssueKind::CaptureVarWithoutRegexMatch => DiagnosticCode::CaptureVarWithoutRegexMatch,
+        };
+
+        let related_info = build_scope_related_info(&issue);
+        let suggestion = build_scope_suggestion(&issue);
+
+        diagnostics.push(Diagnostic {
+            range: issue.range,
+            severity,
+            code: Some(code.as_str().to_string()),
+            message: build_enhanced_scope_message(&issue),
+            related_information: related_info,
+            tags: if matches!(issue.kind, IssueKind::UnusedVariable | IssueKind::UnusedParameter) {
+                vec![DiagnosticTag::Unnecessary]
+            } else {
+                Vec::new()
+            },
+            suggestion,
+        });
+    }
+
+    diagnostics
+}
+
+/// Build related information for a scope issue (extracted for reuse).
+fn build_scope_related_info(issue: &ScopeIssue) -> Vec<RelatedInformation> {
+    match issue.kind {
+        IssueKind::UndeclaredVariable => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Declare the variable with 'my', 'our', 'local', or 'state'".to_string(),
+            },
+            RelatedInformation {
+                location: issue.range,
+                message: "ℹ️ Under 'use strict', all variables must be declared before use. Use 'my' for lexical scope or 'our' for package variables.".to_string(),
+            }
+        ],
+        IssueKind::UnusedVariable => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Remove the unused variable or prefix with '_' to indicate it's intentionally unused".to_string(),
+            }
+        ],
+        IssueKind::UnusedParameter => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Remove the unused parameter or prefix with '_' (e.g., $_unused) to indicate it's intentionally unused".to_string(),
+            }
+        ],
+        IssueKind::VariableShadowing => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Rename this variable or use the outer scope variable instead".to_string(),
+            },
+            RelatedInformation {
+                location: issue.range,
+                message: "ℹ️ Variable shadowing can make code harder to understand and may hide bugs.".to_string(),
+            }
+        ],
+        IssueKind::VariableRedeclaration => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Remove the duplicate 'my' declaration - just assign to the existing variable".to_string(),
+            }
+        ],
+        IssueKind::DuplicateParameter => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Remove the duplicate parameter or use a different name".to_string(),
+            }
+        ],
+        IssueKind::ParameterShadowsGlobal => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Rename the parameter to avoid shadowing the global variable".to_string(),
+            }
+        ],
+        IssueKind::UninitializedVariable => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Initialize the variable when declaring it: my $var = value;".to_string(),
+            },
+            RelatedInformation {
+                location: issue.range,
+                message: "ℹ️ Using uninitialized variables may cause warnings and unexpected behavior.".to_string(),
+            }
+        ],
+        IssueKind::UnquotedBareword => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Quote the bareword as a string: 'word' or \"word\"".to_string(),
+            },
+            RelatedInformation {
+                location: issue.range,
+                message: "ℹ️ Under 'use strict', barewords are not allowed unless they're subroutine calls or hash keys.".to_string(),
+            }
+        ],
+        IssueKind::CaptureVarWithoutRegexMatch => vec![
+            RelatedInformation {
+                location: issue.range,
+                message: "💡 Perform a regex match before using this capture variable: if ($str =~ /(...)/){ ... }".to_string(),
+            },
+            RelatedInformation {
+                location: issue.range,
+                message: "ℹ️ Capture variables ($1, $2, etc.) hold the last successful match and may be undef if no match has occurred.".to_string(),
+            }
+        ],
+    }
 }
 
 /// Build an enhanced, more helpful message for a scope issue.
@@ -218,5 +346,287 @@ fn build_scope_suggestion(issue: &ScopeIssue) -> Option<String> {
             Some(format!("Quote as '{}' or use qw({}) for lists", name, name))
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_semantic_facts::{
+        AnchorId, Confidence, DefinitionCandidate, EntityFact, EntityId, FileId, OccurrenceFact,
+        OccurrenceId, OccurrenceKind, Provenance, RenamePlan, SafeDeletePlan, ScopeId,
+        VisibleSymbol,
+    };
+    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+
+    // ── Stub that simulates dynamic boundary coverage at any position ──
+
+    struct DynamicBoundaryStubQueries;
+
+    impl SemanticQueries for DynamicBoundaryStubQueries {
+        fn symbol_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+        ) -> Option<(EntityFact, OccurrenceFact)> {
+            None
+        }
+
+        fn definitions(&self, _symbol: &str, _context: &QueryContext) -> Vec<DefinitionCandidate> {
+            Vec::new()
+        }
+
+        fn references(&self, _entity_id: EntityId) -> Vec<OccurrenceFact> {
+            Vec::new()
+        }
+
+        fn visible_symbols_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _scope_id: Option<ScopeId>,
+        ) -> Vec<VisibleSymbol> {
+            Vec::new()
+        }
+
+        fn method_candidates(
+            &self,
+            _receiver_package: &str,
+            _method_name: &str,
+        ) -> Vec<DefinitionCandidate> {
+            Vec::new()
+        }
+
+        fn rename_plan(&self, entity_id: EntityId, new_name: &str) -> RenamePlan {
+            RenamePlan::new(entity_id, String::new(), new_name.to_string(), vec![], vec![], vec![])
+        }
+
+        fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
+            SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
+        }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            // Simulates full file dynamic coverage: any position is covered.
+            Some(OccurrenceFact {
+                id: OccurrenceId(8888),
+                kind: OccurrenceKind::DynamicBoundary,
+                entity_id: None,
+                anchor_id: AnchorId(8888),
+                scope_id: None,
+                provenance: Provenance::DynamicBoundary,
+                confidence: Confidence::Low,
+            })
+        }
+    }
+
+    /// No-op stub — no dynamic boundary coverage anywhere.
+    struct NullStubQueries;
+
+    impl SemanticQueries for NullStubQueries {
+        fn symbol_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+        ) -> Option<(EntityFact, OccurrenceFact)> {
+            None
+        }
+
+        fn definitions(&self, _symbol: &str, _context: &QueryContext) -> Vec<DefinitionCandidate> {
+            Vec::new()
+        }
+
+        fn references(&self, _entity_id: EntityId) -> Vec<OccurrenceFact> {
+            Vec::new()
+        }
+
+        fn visible_symbols_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _scope_id: Option<ScopeId>,
+        ) -> Vec<VisibleSymbol> {
+            Vec::new()
+        }
+
+        fn method_candidates(
+            &self,
+            _receiver_package: &str,
+            _method_name: &str,
+        ) -> Vec<DefinitionCandidate> {
+            Vec::new()
+        }
+
+        fn rename_plan(&self, entity_id: EntityId, new_name: &str) -> RenamePlan {
+            RenamePlan::new(entity_id, String::new(), new_name.to_string(), vec![], vec![], vec![])
+        }
+
+        fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
+            SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
+        }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
+    }
+
+    // ── Helper ──
+
+    fn undeclared_issue(name: &str, range: (usize, usize)) -> ScopeIssue {
+        ScopeIssue {
+            kind: IssueKind::UndeclaredVariable,
+            variable_name: name.to_string(),
+            line: 1,
+            range,
+            description: format!("Variable '{}' not declared", name),
+        }
+    }
+
+    fn unused_issue(name: &str, range: (usize, usize)) -> ScopeIssue {
+        ScopeIssue {
+            kind: IssueKind::UnusedVariable,
+            variable_name: name.to_string(),
+            line: 1,
+            range,
+            description: format!("Variable '{}' unused", name),
+        }
+    }
+
+    // ── Tests ──
+
+    #[test]
+    fn suppresses_undeclared_variable_when_covered_by_dynamic_boundary()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let issues = vec![undeclared_issue("$foo", (10, 14))];
+        let queries = DynamicBoundaryStubQueries;
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert!(
+            diagnostics.is_empty(),
+            "UndeclaredVariable covered by dynamic boundary should be suppressed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_suppress_undeclared_variable_when_not_covered()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let issues = vec![undeclared_issue("$foo", (10, 14))];
+        let queries = NullStubQueries;
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "UndeclaredVariable NOT covered by dynamic boundary should still fire"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_suppress_unused_variable_even_in_dynamic_scope()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Non-UndeclaredVariable issues are never suppressed by dynamic boundary.
+        let issues = vec![unused_issue("$bar", (20, 24))];
+        let queries = DynamicBoundaryStubQueries;
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "UnusedVariable should NOT be suppressed by dynamic boundary"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn suppresses_only_dynamic_not_static_variable_in_same_file()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // This tests the issue-local suppression contract (Q1):
+        // when NullStubQueries is used, nothing is suppressed even if a
+        // dynamic construct exists "nearby" in the file.
+        // DynamicBoundaryStubQueries suppresses ALL positions — to test
+        // selective suppression, we use a position-aware stub.
+        struct PositionAwareStub;
+        impl SemanticQueries for PositionAwareStub {
+            fn symbol_at(&self, _: FileId, _: u32) -> Option<(EntityFact, OccurrenceFact)> {
+                None
+            }
+            fn definitions(&self, _: &str, _: &QueryContext) -> Vec<DefinitionCandidate> {
+                Vec::new()
+            }
+            fn references(&self, _: EntityId) -> Vec<OccurrenceFact> {
+                Vec::new()
+            }
+            fn visible_symbols_at(
+                &self,
+                _: FileId,
+                _: u32,
+                _: Option<ScopeId>,
+            ) -> Vec<VisibleSymbol> {
+                Vec::new()
+            }
+            fn method_candidates(&self, _: &str, _: &str) -> Vec<DefinitionCandidate> {
+                Vec::new()
+            }
+            fn rename_plan(&self, id: EntityId, n: &str) -> RenamePlan {
+                RenamePlan::new(id, String::new(), n.to_string(), vec![], vec![], vec![])
+            }
+            fn safe_delete_plan(&self, id: EntityId) -> SafeDeletePlan {
+                SafeDeletePlan::new(id, String::new(), vec![], vec![])
+            }
+            fn dynamic_boundary_at(
+                &self,
+                _: FileId,
+                byte_offset: u32,
+                _: Option<&str>,
+            ) -> Option<OccurrenceFact> {
+                // Only cover positions 10..30.
+                if byte_offset >= 10 && byte_offset < 30 {
+                    Some(OccurrenceFact {
+                        id: OccurrenceId(7777),
+                        kind: OccurrenceKind::DynamicBoundary,
+                        entity_id: None,
+                        anchor_id: AnchorId(7777),
+                        scope_id: None,
+                        provenance: Provenance::DynamicBoundary,
+                        confidence: Confidence::Low,
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+
+        let dynamic_var = undeclared_issue("$dynamic_var", (15, 27)); // covered (15 < 30)
+        let static_var = undeclared_issue("$static_var", (50, 61)); // NOT covered (50 >= 30)
+        let issues = vec![dynamic_var, static_var];
+
+        let diagnostics =
+            scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &PositionAwareStub);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Only the static_var diagnostic should fire; dynamic_var should be suppressed"
+        );
+        assert!(
+            diagnostics[0].message.contains("static_var"),
+            "The remaining diagnostic should be for $static_var, got: {:?}",
+            diagnostics[0].message
+        );
+        Ok(())
     }
 }

--- a/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
@@ -308,6 +308,15 @@ mod tests {
         fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
             SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_candidate(name: &str, anchor_id: u64, entity_id: u64) -> DefinitionCandidate {

--- a/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
@@ -628,6 +628,15 @@ mod tests {
         fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
             SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     struct RankedDefinitionStub {
@@ -676,6 +685,15 @@ mod tests {
 
         fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
             SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
+        }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
         }
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
@@ -316,6 +316,15 @@ mod tests {
         fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
             SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_occurrence(

--- a/crates/perl-lsp-rs-core/src/providers/navigation/rename_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/rename_shadow.rs
@@ -298,6 +298,15 @@ mod tests {
         fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
             SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_edit(anchor_id: u64, category: PlannedEditCategory) -> PlannedEdit {

--- a/crates/perl-lsp-rs-core/src/providers/navigation/safe_delete_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/safe_delete_shadow.rs
@@ -273,6 +273,15 @@ mod tests {
         fn safe_delete_plan(&self, _entity_id: EntityId) -> SafeDeletePlan {
             self.safe_delete_plan_result.clone()
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_blocker(reason: PlanBlockerReason) -> PlanBlocker {

--- a/crates/perl-lsp-rs-core/src/providers/navigation/scorecard_gate_fixtures.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/scorecard_gate_fixtures.rs
@@ -158,6 +158,15 @@ mod tests {
         fn safe_delete_plan(&self, _entity_id: EntityId) -> SafeDeletePlan {
             self.safe_delete_plan_result.clone()
         }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     // ── Helpers ──

--- a/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
@@ -197,13 +197,19 @@ impl ImportExtractor {
     }
 
     /// Build an [`ImportSpec`] for `require $var` (dynamic require).
+    ///
+    /// Uses `Provenance::DynamicBoundary + Confidence::Low` because the module
+    /// identity is not statically known — only the pattern is known. This
+    /// provenance marks the import site for the diagnostics suppressor so that
+    /// symbols "plausibly imported" via dynamic require are not flagged as
+    /// undefined.
     fn make_dynamic_require(file_id: FileId, node: &Node) -> ImportSpec {
         let anchor_id = Self::anchor_from_node(node);
         ImportSpec {
             module: String::new(),
             kind: ImportKind::DynamicRequire,
             symbols: ImportSymbols::Dynamic,
-            provenance: Provenance::ExactAst,
+            provenance: Provenance::DynamicBoundary,
             confidence: Confidence::Low,
             file_id: Some(file_id),
             anchor_id: Some(anchor_id),
@@ -1016,7 +1022,9 @@ Foo::Bar->import(@names);
 
         assert_eq!(spec.module, "");
         assert_eq!(spec.symbols, ImportSymbols::Dynamic);
-        assert_eq!(spec.provenance, Provenance::ExactAst);
+        // DynamicRequire must use DynamicBoundary provenance (Q5 architectural decision):
+        // the module identity is not statically known, so we cannot claim ExactAst.
+        assert_eq!(spec.provenance, Provenance::DynamicBoundary);
         assert_eq!(spec.confidence, Confidence::Low);
         assert_eq!(spec.file_id, Some(FileId(1)));
         assert!(spec.anchor_id.is_some(), "anchor_id should be populated");

--- a/crates/perl-workspace/src/semantic/queries.rs
+++ b/crates/perl-workspace/src/semantic/queries.rs
@@ -124,6 +124,45 @@ pub trait SemanticQueries {
     /// remaining references, is exported, is imported by another file,
     /// or is a generated member without a generator-specific delete plan.
     fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan;
+
+    /// Return the covering dynamic-boundary occurrence at a given position.
+    ///
+    /// # Contract (Q1 — issue-local, not file-global)
+    ///
+    /// Returns `Some(OccurrenceFact)` **only** when ALL of the following hold:
+    ///
+    /// 1. The file at `file_id` has at least one occurrence with
+    ///    `kind = OccurrenceKind::DynamicBoundary` whose enclosing anchor's
+    ///    span contains `byte_offset`.
+    /// 2. If `symbol` is `Some`, the occurrence either has no associated
+    ///    entity (fully dynamic — any symbol is plausible) OR the entity's
+    ///    canonical/bare name matches `symbol`.
+    ///
+    /// # Why issue-local
+    ///
+    /// A file-global check `scope_is_dynamic(file, offset) -> bool` would
+    /// suppress *all* undefined-symbol diagnostics in a file that has *any*
+    /// dynamic construct, even for symbols that are statically provably missing.
+    /// This method is deliberately narrow: it returns evidence only when the
+    /// *specific position* is covered by dynamic-boundary evidence, and only
+    /// for the *specific symbol* being checked.
+    ///
+    /// # Returns
+    ///
+    /// `None` when the position is not covered by any dynamic-boundary
+    /// occurrence, or when the semantic data for `file_id` is unavailable.
+    /// Callers should fall back to the legacy diagnostic path when `None`.
+    ///
+    /// # Requirement
+    ///
+    /// - **Req 7.4**: Suppress undefined-symbol diagnostics for references
+    ///   within dynamic boundary scopes.
+    fn dynamic_boundary_at(
+        &self,
+        file_id: FileId,
+        byte_offset: u32,
+        symbol: Option<&str>,
+    ) -> Option<OccurrenceFact>;
 }
 
 // ── WorkspaceSemanticQueries ──
@@ -680,6 +719,52 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
         }
 
         SafeDeletePlan::new(entity_id, name, blockers, warnings)
+    }
+
+    fn dynamic_boundary_at(
+        &self,
+        file_id: FileId,
+        byte_offset: u32,
+        symbol: Option<&str>,
+    ) -> Option<OccurrenceFact> {
+        let shard = self.shard_for_file(file_id)?;
+
+        // Walk occurrences in the shard looking for DynamicBoundary occurrences
+        // whose enclosing anchor covers the query position.
+        for occurrence in &shard.occurrences {
+            if occurrence.kind != OccurrenceKind::DynamicBoundary {
+                continue;
+            }
+
+            // Find the anchor that owns this occurrence.
+            let anchor = shard.anchors.iter().find(|a| a.id == occurrence.anchor_id)?;
+
+            // Check whether the anchor's span covers the query byte offset.
+            if anchor.span_start_byte > byte_offset || byte_offset >= anchor.span_end_byte {
+                continue;
+            }
+
+            // Symbol filter: if a symbol name is requested, it must match the
+            // entity associated with this occurrence (when known). When the
+            // entity_id is None the boundary is fully dynamic (any symbol).
+            if let Some(sym) = symbol {
+                if let Some(entity_id) = occurrence.entity_id {
+                    // Resolve the entity to check name match.
+                    let entity_matches = shard.entities.iter().any(|e| {
+                        e.id == entity_id
+                            && (e.canonical_name == sym || bare_name(&e.canonical_name) == sym)
+                    });
+                    if !entity_matches {
+                        continue;
+                    }
+                }
+                // entity_id is None → fully dynamic, any symbol is plausible.
+            }
+
+            return Some(occurrence.clone());
+        }
+
+        None
     }
 }
 
@@ -3432,6 +3517,191 @@ mod tests {
                 }
             }
         }
+    }
+
+    // ── dynamic_boundary_at tests ──
+
+    /// Build a shard that contains a DynamicBoundary occurrence at a given span.
+    fn dynamic_boundary_shard(
+        file_id: FileId,
+        span_start: u32,
+        span_end: u32,
+        entity_id: Option<EntityId>,
+        entity_name: Option<&str>,
+    ) -> FileFactShard {
+        let anchor_id = AnchorId(5000);
+        let occurrence_id = OccurrenceId(5001);
+
+        let mut anchors = vec![AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: span_start,
+            span_end_byte: span_end,
+            scope_id: None,
+            provenance: Provenance::DynamicBoundary,
+            confidence: Confidence::Low,
+        }];
+
+        let mut entities = Vec::new();
+        if let (Some(eid), Some(name)) = (entity_id, entity_name) {
+            // Add a static anchor for the entity
+            let entity_anchor = AnchorId(5010);
+            anchors.push(AnchorFact {
+                id: entity_anchor,
+                file_id,
+                span_start_byte: 0,
+                span_end_byte: 5,
+                scope_id: None,
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            });
+            entities.push(EntityFact {
+                id: eid,
+                kind: EntityKind::Subroutine,
+                canonical_name: name.to_string(),
+                anchor_id: Some(entity_anchor),
+                scope_id: None,
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+            });
+        }
+
+        let occurrence = OccurrenceFact {
+            id: occurrence_id,
+            kind: OccurrenceKind::DynamicBoundary,
+            entity_id,
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::DynamicBoundary,
+            confidence: Confidence::Low,
+        };
+
+        make_shard("file:///test/dyn.pl", file_id, anchors, entities, vec![occurrence], vec![])
+    }
+
+    #[test]
+    fn dynamic_boundary_at_returns_some_when_covered() -> Result<(), Box<dyn std::error::Error>> {
+        let file_id = FileId(50);
+        let shard = dynamic_boundary_shard(file_id, 10, 30, None, None);
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // Offset 20 falls within the dynamic boundary span (10..30).
+        let result = queries.dynamic_boundary_at(file_id, 20, None);
+        assert!(result.is_some(), "should find dynamic boundary at offset 20");
+        let occ = result.ok_or("expected occurrence")?;
+        assert_eq!(occ.kind, OccurrenceKind::DynamicBoundary);
+        assert_eq!(occ.provenance, Provenance::DynamicBoundary);
+        assert_eq!(occ.confidence, Confidence::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_boundary_at_returns_none_when_not_covered() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let file_id = FileId(51);
+        let shard = dynamic_boundary_shard(file_id, 10, 30, None, None);
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // Offset 5 is before the span start (10).
+        let result = queries.dynamic_boundary_at(file_id, 5, None);
+        assert!(result.is_none(), "should NOT find dynamic boundary at offset 5");
+
+        // Offset 35 is after the span end (30).
+        let result2 = queries.dynamic_boundary_at(file_id, 35, None);
+        assert!(result2.is_none(), "should NOT find dynamic boundary at offset 35");
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_boundary_at_returns_none_for_unknown_file() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let file_id = FileId(52);
+        let shard = dynamic_boundary_shard(file_id, 10, 30, None, None);
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // FileId(999) is not in the shards.
+        let result = queries.dynamic_boundary_at(FileId(999), 20, None);
+        assert!(result.is_none(), "should return None for unknown file");
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_boundary_at_symbol_filter_passes_when_entity_matches()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let file_id = FileId(53);
+        let entity_id = EntityId(9000);
+        let shard = dynamic_boundary_shard(file_id, 10, 30, Some(entity_id), Some("Foo::bar"));
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // "bar" is the bare name of "Foo::bar" — should match.
+        let result = queries.dynamic_boundary_at(file_id, 20, Some("bar"));
+        assert!(result.is_some(), "should find dynamic boundary for symbol 'bar'");
+
+        // "Foo::bar" qualified name — should also match.
+        let result2 = queries.dynamic_boundary_at(file_id, 20, Some("Foo::bar"));
+        assert!(result2.is_some(), "should find dynamic boundary for qualified symbol 'Foo::bar'");
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_boundary_at_symbol_filter_blocks_when_entity_mismatches()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let file_id = FileId(54);
+        let entity_id = EntityId(9001);
+        let shard = dynamic_boundary_shard(file_id, 10, 30, Some(entity_id), Some("Foo::bar"));
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // "baz" does not match "bar" or "Foo::bar" — should NOT find.
+        let result = queries.dynamic_boundary_at(file_id, 20, Some("baz"));
+        assert!(result.is_none(), "should NOT find dynamic boundary for unrelated symbol 'baz'");
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_boundary_at_no_entity_id_accepts_any_symbol()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let file_id = FileId(55);
+        // No entity_id — fully dynamic, any symbol should match.
+        let shard = dynamic_boundary_shard(file_id, 10, 30, None, None);
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // Any symbol name should match when entity_id is None.
+        let result = queries.dynamic_boundary_at(file_id, 20, Some("any_symbol"));
+        assert!(result.is_some(), "fully-dynamic boundary should accept any symbol");
+
+        let result2 = queries.dynamic_boundary_at(file_id, 20, Some("foo"));
+        assert!(result2.is_some(), "fully-dynamic boundary should accept 'foo'");
+        Ok(())
     }
 }
 

--- a/crates/perl-workspace/src/semantic/queries.rs
+++ b/crates/perl-workspace/src/semantic/queries.rs
@@ -737,7 +737,12 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
             }
 
             // Find the anchor that owns this occurrence.
-            let anchor = shard.anchors.iter().find(|a| a.id == occurrence.anchor_id)?;
+            // Use `continue` rather than `?` so a missing anchor for one
+            // occurrence does not short-circuit the search for others.
+            let anchor = match shard.anchors.iter().find(|a| a.id == occurrence.anchor_id) {
+                Some(a) => a,
+                None => continue,
+            };
 
             // Check whether the anchor's span covers the query byte offset.
             if anchor.span_start_byte > byte_offset || byte_offset >= anchor.span_end_byte {

--- a/crates/perl-workspace/tests/fixtures/semantic_scorecard/dynamic_import_via_variable.pl
+++ b/crates/perl-workspace/tests/fixtures/semantic_scorecard/dynamic_import_via_variable.pl
@@ -1,0 +1,8 @@
+package DynamicImportViaVariable;
+
+# Pattern: $module->import(qw(foo))
+# The module variable holds the module name, then import is called dynamically.
+# 'foo' is "plausibly imported" — not exactly known. Suppress diagnostic.
+my $module = "Some::Module";
+require $module;
+$module->import(qw(foo));

--- a/crates/perl-workspace/tests/fixtures/semantic_scorecard/manifest.json
+++ b/crates/perl-workspace/tests/fixtures/semantic_scorecard/manifest.json
@@ -2,6 +2,7 @@
   "fixture_family_version": 1,
   "fixtures": [
     {"id": "autoload_dynamic_boundary", "family": "AUTOLOAD dynamic boundary", "path": "fixtures/autoload_dynamic_boundary.pl"},
+    {"id": "dynamic_import_via_variable", "family": "dynamic import via variable", "path": "fixtures/dynamic_import_via_variable.pl"},
     {"id": "dynamic_require_boundary", "family": "dynamic require boundary", "path": "fixtures/dynamic_require_boundary.pl"},
     {"id": "empty_import_suppression", "family": "empty import suppression", "path": "fixtures/empty_import_suppression.pl"},
     {"id": "eval_string_dynamic_boundary", "family": "eval STRING dynamic boundary", "path": "fixtures/eval_string_dynamic_boundary.pl"},
@@ -9,9 +10,12 @@
     {"id": "generated_accessor", "family": "generated accessor", "path": "fixtures/generated_accessor.pl"},
     {"id": "imported_function_visibility", "family": "imported function visibility", "path": "fixtures/imported_function_visibility.pl"},
     {"id": "inherited_method", "family": "inherited method", "path": "fixtures/inherited_method.pl"},
+    {"id": "normal_static_missing_symbol", "family": "normal static missing symbol", "path": "fixtures/normal_static_missing_symbol.pl"},
     {"id": "qualified_vs_bare_references", "family": "qualified vs bare references", "path": "fixtures/qualified_vs_bare_references.pl"},
     {"id": "role_method", "family": "role method", "path": "fixtures/role_method.pl"},
     {"id": "same_bare_sub_two_packages", "family": "same bare sub in two packages", "path": "fixtures/same_bare_sub_two_packages.pl"},
+    {"id": "static_class_dynamic_import", "family": "static class dynamic import", "path": "fixtures/static_class_dynamic_import.pl"},
+    {"id": "symbolic_deref_assign", "family": "symbolic dereference assign", "path": "fixtures/symbolic_deref_assign.pl"},
     {"id": "typeglob_alias", "family": "typeglob alias", "path": "fixtures/typeglob_alias.pl"}
   ]
 }

--- a/crates/perl-workspace/tests/fixtures/semantic_scorecard/normal_static_missing_symbol.pl
+++ b/crates/perl-workspace/tests/fixtures/semantic_scorecard/normal_static_missing_symbol.pl
@@ -1,0 +1,13 @@
+package NormalStaticMissingSymbol;
+
+use strict;
+use warnings;
+
+# Control fixture: no dynamic boundary at all.
+# 'truly_undefined_sub' is statically missing — diagnostic MUST fire.
+# This is a high-confidence normal missing symbol.
+sub defined_sub {
+    return 1;
+}
+
+my $result = defined_sub();

--- a/crates/perl-workspace/tests/fixtures/semantic_scorecard/normal_static_missing_symbol.pl
+++ b/crates/perl-workspace/tests/fixtures/semantic_scorecard/normal_static_missing_symbol.pl
@@ -4,10 +4,12 @@ use strict;
 use warnings;
 
 # Control fixture: no dynamic boundary at all.
-# 'truly_undefined_sub' is statically missing — diagnostic MUST fire.
-# This is a high-confidence normal missing symbol.
+# `truly_undefined_sub` is statically missing — diagnostic MUST fire.
+# This proves dynamic-boundary suppression does not become a broad
+# "shut up" switch for ordinary high-confidence missing-symbol errors.
 sub defined_sub {
     return 1;
 }
 
 my $result = defined_sub();
+truly_undefined_sub();

--- a/crates/perl-workspace/tests/fixtures/semantic_scorecard/static_class_dynamic_import.pl
+++ b/crates/perl-workspace/tests/fixtures/semantic_scorecard/static_class_dynamic_import.pl
@@ -1,0 +1,7 @@
+package StaticClassDynamicImport;
+
+# Pattern: Foo->import(@names)
+# Static class name but dynamic symbol list — symbols not exactly known.
+# 'bar' is plausibly imported but cannot be exactly verified.
+use POSIX ();
+POSIX->import(@POSIX::EXPORT_OK);

--- a/crates/perl-workspace/tests/fixtures/semantic_scorecard/symbolic_deref_assign.pl
+++ b/crates/perl-workspace/tests/fixtures/semantic_scorecard/symbolic_deref_assign.pl
@@ -1,0 +1,8 @@
+package SymbolicDerefAssign;
+
+# Pattern: ${$name} = 1
+# Variable created/accessed via symbolic dereference.
+# The variable exists dynamically — suppress undefined-symbol diagnostic.
+my $name = "dynamic_var";
+${$name} = 1;
+my $val = ${$name};

--- a/docs/project/status/semantic_scorecard.json
+++ b/docs/project/status/semantic_scorecard.json
@@ -3,9 +3,10 @@
   "measured_at": "deterministic-fixture-baseline",
   "subsystem": "semantic",
   "fixture_family_version": 1,
-  "fixture_count": 12,
+  "fixture_count": 16,
   "fixture_ids": [
     "autoload_dynamic_boundary",
+    "dynamic_import_via_variable",
     "dynamic_require_boundary",
     "empty_import_suppression",
     "eval_string_dynamic_boundary",
@@ -13,13 +14,17 @@
     "generated_accessor",
     "imported_function_visibility",
     "inherited_method",
+    "normal_static_missing_symbol",
     "qualified_vs_bare_references",
     "role_method",
     "same_bare_sub_two_packages",
+    "static_class_dynamic_import",
+    "symbolic_deref_assign",
     "typeglob_alias"
   ],
   "fixture_families": [
     "AUTOLOAD dynamic boundary",
+    "dynamic import via variable",
     "dynamic require boundary",
     "empty import suppression",
     "eval STRING dynamic boundary",
@@ -27,20 +32,24 @@
     "generated accessor",
     "imported function visibility",
     "inherited method",
+    "normal static missing symbol",
     "qualified vs bare references",
     "role method",
     "same bare sub in two packages",
+    "static class dynamic import",
+    "symbolic dereference assign",
     "typeglob alias"
   ],
   "fact_rows": {
     "declaration_facts": {
       "status": "available",
-      "total_facts": 31,
+      "total_facts": 40,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -48,27 +57,31 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
     },
     "definition_candidates": {
       "status": "available",
-      "total_facts": 31,
+      "total_facts": 40,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -76,15 +89,18 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -93,10 +109,11 @@
       "status": "available",
       "total_facts": 3,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -104,27 +121,31 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
     },
     "import_specs": {
       "status": "available",
-      "total_facts": 7,
+      "total_facts": 11,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -132,15 +153,18 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -149,10 +173,11 @@
       "status": "available",
       "total_facts": 1,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -160,27 +185,31 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
     },
     "occurrence_facts": {
       "status": "available",
-      "total_facts": 15,
+      "total_facts": 24,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -188,15 +217,18 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -205,10 +237,11 @@
       "status": "available",
       "total_facts": 2,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -216,15 +249,18 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -233,10 +269,11 @@
       "status": "available",
       "total_facts": 1,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -244,15 +281,18 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -261,10 +301,11 @@
       "status": "available",
       "total_facts": 1,
       "fixture_coverage": {
-        "covered_fixture_count": 12,
-        "total_fixture_count": 12,
+        "covered_fixture_count": 16,
+        "total_fixture_count": 16,
         "covered_fixture_families": [
           "AUTOLOAD dynamic boundary",
+          "dynamic import via variable",
           "dynamic require boundary",
           "empty import suppression",
           "eval STRING dynamic boundary",
@@ -272,15 +313,18 @@
           "generated accessor",
           "imported function visibility",
           "inherited method",
+          "normal static missing symbol",
           "qualified vs bare references",
           "role method",
           "same bare sub in two packages",
+          "static class dynamic import",
+          "symbolic dereference assign",
           "typeglob alias"
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 111,
-        "high_confidence_facts": 111,
+        "exact_facts": 152,
+        "high_confidence_facts": 150,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -343,7 +387,7 @@
     },
     "semantic_fact_counts_nonzero": {
       "status": "pass",
-      "value": "59",
+      "value": "81",
       "threshold": "> 0",
       "evidence": "semantic fixture indexing"
     },

--- a/docs/project/status/semantic_scorecard.json
+++ b/docs/project/status/semantic_scorecard.json
@@ -67,8 +67,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -99,8 +99,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -131,8 +131,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -163,8 +163,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -195,15 +195,15 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
     },
     "occurrence_facts": {
       "status": "available",
-      "total_facts": 24,
+      "total_facts": 25,
       "fixture_coverage": {
         "covered_fixture_count": 16,
         "total_fixture_count": 16,
@@ -227,8 +227,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -259,8 +259,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -291,8 +291,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -323,8 +323,8 @@
         ]
       },
       "confidence_breakdown": {
-        "exact_facts": 152,
-        "high_confidence_facts": 150,
+        "exact_facts": 154,
+        "high_confidence_facts": 152,
         "heuristic_facts": 1,
         "dynamic_boundary_facts": 2
       }
@@ -387,7 +387,7 @@
     },
     "semantic_fact_counts_nonzero": {
       "status": "pass",
-      "value": "81",
+      "value": "82",
       "threshold": "> 0",
       "evidence": "semantic fixture indexing"
     },

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -8,15 +8,15 @@ Fixtures loaded: `16`
 
 | Row | Status | Facts | Coverage | Exact | High | Heuristic | Dynamic boundary |
 |---|---|---:|---:|---:|---:|---:|---:|
-| declaration_facts | available | 40 | 16/16 | 152 | 150 | 1 | 2 |
-| definition_candidates | available | 40 | 16/16 | 152 | 150 | 1 | 2 |
-| export_facts | available | 3 | 16/16 | 152 | 150 | 1 | 2 |
-| import_specs | available | 11 | 16/16 | 152 | 150 | 1 | 2 |
-| inheritance_edges | available | 1 | 16/16 | 152 | 150 | 1 | 2 |
-| occurrence_facts | available | 24 | 16/16 | 152 | 150 | 1 | 2 |
-| package_graph_edges | available | 2 | 16/16 | 152 | 150 | 1 | 2 |
-| reference_edges | available | 1 | 16/16 | 152 | 150 | 1 | 2 |
-| role_composition_edges | available | 1 | 16/16 | 152 | 150 | 1 | 2 |
+| declaration_facts | available | 40 | 16/16 | 154 | 152 | 1 | 2 |
+| definition_candidates | available | 40 | 16/16 | 154 | 152 | 1 | 2 |
+| export_facts | available | 3 | 16/16 | 154 | 152 | 1 | 2 |
+| import_specs | available | 11 | 16/16 | 154 | 152 | 1 | 2 |
+| inheritance_edges | available | 1 | 16/16 | 154 | 152 | 1 | 2 |
+| occurrence_facts | available | 25 | 16/16 | 154 | 152 | 1 | 2 |
+| package_graph_edges | available | 2 | 16/16 | 154 | 152 | 1 | 2 |
+| reference_edges | available | 1 | 16/16 | 154 | 152 | 1 | 2 |
+| role_composition_edges | available | 1 | 16/16 | 154 | 152 | 1 | 2 |
 
 ## Readiness Rows
 
@@ -31,7 +31,7 @@ Fixtures loaded: `16`
 | rename_unsafe_edit_count | pass | 0 | 0 | rename plan query fixtures |
 | safe_delete_blocker_fixture_pass_rate | pass | 100% | 100% | safe-delete plan query fixtures |
 | safe_delete_plan | pass | 100% | 100% | safe-delete plan query fixtures |
-| semantic_fact_counts_nonzero | pass | 81 | > 0 | semantic fixture indexing |
+| semantic_fact_counts_nonzero | pass | 82 | > 0 | semantic fixture indexing |
 | undefined_symbol_false_positive_fixture_rate | pass | 0% | 0% | diagnostics fixture receipts |
 | visible_symbols_fixture_pass_rate | pass | 100% | 100% | workspace scorecard fixtures |
 

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -2,21 +2,21 @@
 
 Measured: `deterministic-fixture-baseline`  
 Fixture family version: `1`  
-Fixtures loaded: `12`
+Fixtures loaded: `16`
 
 ## Fact Coverage
 
 | Row | Status | Facts | Coverage | Exact | High | Heuristic | Dynamic boundary |
 |---|---|---:|---:|---:|---:|---:|---:|
-| declaration_facts | available | 31 | 12/12 | 111 | 111 | 1 | 2 |
-| definition_candidates | available | 31 | 12/12 | 111 | 111 | 1 | 2 |
-| export_facts | available | 3 | 12/12 | 111 | 111 | 1 | 2 |
-| import_specs | available | 7 | 12/12 | 111 | 111 | 1 | 2 |
-| inheritance_edges | available | 1 | 12/12 | 111 | 111 | 1 | 2 |
-| occurrence_facts | available | 15 | 12/12 | 111 | 111 | 1 | 2 |
-| package_graph_edges | available | 2 | 12/12 | 111 | 111 | 1 | 2 |
-| reference_edges | available | 1 | 12/12 | 111 | 111 | 1 | 2 |
-| role_composition_edges | available | 1 | 12/12 | 111 | 111 | 1 | 2 |
+| declaration_facts | available | 40 | 16/16 | 152 | 150 | 1 | 2 |
+| definition_candidates | available | 40 | 16/16 | 152 | 150 | 1 | 2 |
+| export_facts | available | 3 | 16/16 | 152 | 150 | 1 | 2 |
+| import_specs | available | 11 | 16/16 | 152 | 150 | 1 | 2 |
+| inheritance_edges | available | 1 | 16/16 | 152 | 150 | 1 | 2 |
+| occurrence_facts | available | 24 | 16/16 | 152 | 150 | 1 | 2 |
+| package_graph_edges | available | 2 | 16/16 | 152 | 150 | 1 | 2 |
+| reference_edges | available | 1 | 16/16 | 152 | 150 | 1 | 2 |
+| role_composition_edges | available | 1 | 16/16 | 152 | 150 | 1 | 2 |
 
 ## Readiness Rows
 
@@ -31,7 +31,7 @@ Fixtures loaded: `12`
 | rename_unsafe_edit_count | pass | 0 | 0 | rename plan query fixtures |
 | safe_delete_blocker_fixture_pass_rate | pass | 100% | 100% | safe-delete plan query fixtures |
 | safe_delete_plan | pass | 100% | 100% | safe-delete plan query fixtures |
-| semantic_fact_counts_nonzero | pass | 59 | > 0 | semantic fixture indexing |
+| semantic_fact_counts_nonzero | pass | 81 | > 0 | semantic fixture indexing |
 | undefined_symbol_false_positive_fixture_rate | pass | 0% | 0% | diagnostics fixture receipts |
 | visible_symbols_fixture_pass_rate | pass | 100% | 100% | workspace scorecard fixtures |
 
@@ -43,6 +43,7 @@ Fixtures loaded: `12`
 ## Fixture IDs
 
 - `autoload_dynamic_boundary`
+- `dynamic_import_via_variable`
 - `dynamic_require_boundary`
 - `empty_import_suppression`
 - `eval_string_dynamic_boundary`
@@ -50,9 +51,12 @@ Fixtures loaded: `12`
 - `generated_accessor`
 - `imported_function_visibility`
 - `inherited_method`
+- `normal_static_missing_symbol`
 - `qualified_vs_bare_references`
 - `role_method`
 - `same_bare_sub_two_packages`
+- `static_class_dynamic_import`
+- `symbolic_deref_assign`
 - `typeglob_alias`
 
 0.13.2 semantic proof rail: scorecard rows are deterministic and fixture-backed; semantic expansion remains conservative for unavailable rows.


### PR DESCRIPTION
## Status: PR-A of split A+B

This PR delivers the **infrastructure** for dynamic-boundary undefined-symbol diagnostic suppression, but does **not** wire it to live workspace semantic data. In production today, `DiagnosticsProvider` passes `&NullSemanticQueries` (a no-op stub) to the new semantics-aware path, so suppression never actually triggers for real LSP requests.

**What's wired:**
- Producer evidence (Commit 2) — provenance fix for `DynamicRequire` is real, affects any consumer of `ImportSpec`
- Query API (Commit 3) — `dynamic_boundary_at` is callable on real `WorkspaceSemanticQueries` instances
- Scope variant (Commit 4) — `scope_issues_to_diagnostics_with_semantics` works correctly when given real semantic data
- Tests (Commits 1, 2, 3, 4) — acceptance + unit tests cover suppression behavior against realistic inputs (with stubbed `SemanticQueries`)

**What's dormant (PR-B):**
- Threading `Arc<WorkspaceSemanticQueries>` from `LanguageServerCore` through `DiagnosticsProvider::get_diagnostics_with_path` to replace the `NullSemanticQueries` placeholder
- Estimated ~150 LOC across `crates/perl-lsp-rs/src/runtime/`, mostly mechanical

The split was an organic decision during implementation: completing the production wiring would have required touching 3-4 call sites in `perl-lsp-rs/runtime/`, broadening blast radius beyond a reviewable single PR. PR-B will land that cleanly on top of this infrastructure.

---

## Summary

- Add `dynamic_boundary_at(file_id, byte_offset, symbol)` to the `SemanticQueries` trait and implement in `WorkspaceSemanticQueries`, enabling issue-local (not file-global) dynamic boundary detection
- Add `scope_issues_to_diagnostics_with_semantics` — a semantic-aware variant that suppresses `UndeclaredVariable` diagnostics when the specific variable position is covered by dynamic-boundary evidence
- Add semantics-aware path to `DiagnosticsProvider::get_diagnostics_with_path` (currently using `NullSemanticQueries` placeholder; PR-B will thread real semantics)
- Upgrade `DynamicRequire` ImportSpec provenance from `ExactAst` to `DynamicBoundary` (Q5)

## Architectural Decisions (Q1-Q6, signed off)

**Q1 — Issue-local query (most critical):** `dynamic_boundary_at` is position-and-symbol specific. `require $module; print $undeclared_static_var;` still fires for `$undeclared_static_var` because the dynamic boundary evidence does not cover that specific byte offset. No file-global suppression.

**Q2 — AUTOLOAD scope:** Same-file/same-package only. Cross-file AUTOLOAD propagation is a follow-up.

**Q3 — Suppression policy:**
- High-confidence normal missing symbol → diagnostic still fires (control fixture: `normal_static_missing_symbol.pl` verifies this)
- Dynamic boundary covering THE specific issue → suppress that exact undefined diagnostic
- No semantic data available → `NullSemanticQueries` falls back to emitting diagnostics (conservative default)

**Q4 — Confidence variants:** No new variants added. `Confidence::{High, Medium, Low}` preserved.

**Q5 — DynamicRequire provenance:** `require $var` now uses `Provenance::DynamicBoundary + Confidence::Low` (was `ExactAst + Low`). The module identity is not statically known, so `ExactAst` was incorrect. Static `require Module` remains `ExactAst + High`.

**Q6 — Producer triple:** All new dynamic-boundary producers emit `kind: DynamicBoundary + provenance: DynamicBoundary + confidence: Low`. The existing property test in `prop_dynamic_boundary_invariants.rs` enforces this invariant.

## Preflight Classification Table

| Signal | Class | Evidence |
|--------|-------|---------|
| `require $var` provenance | Wrong → Fixed | `ExactAst` → `DynamicBoundary` in `import_extractor.rs` |
| `dynamic_boundary_at` query | New capability | Added to `SemanticQueries` trait + impl |
| Issue-local suppression | New behavior | Position-checked, not file-global |
| Control fixture fires | Invariant preserved | `normal_static_missing_symbol_still_fires` test |
| NullSemanticQueries fallback | **Dormant in production (PR-B)** | `get_diagnostics_with_path` unchanged API |
| Scorecard check | Deterministic | `cargo xtask semantic-scorecard --check` passes |
| Shadow compare check | Deterministic | `cargo xtask semantic-shadow-compare --check` passes |
| `--profile agent` | Available | Confirmed in `.cargo/config.toml` line 335 |

## Dynamic Evidence / Fixture Cases Added

This PR adds **fixture evidence** and **stub-driven seam tests**, not yet **live LSP suppression proof**. The breakdown:

**Fixture evidence added (4 new fixtures):**
- `dynamic_import_via_variable.pl` — `require $module; $module->import(qw(foo))` — exercises producer evidence shape
- `static_class_dynamic_import.pl` — `Foo->import(@names)` with dynamic arg list — exercises `ImportSymbols::Dynamic`
- `symbolic_deref_assign.pl` — `${$name} = 1` symbolic dereference — fact-shape evidence
- `normal_static_missing_symbol.pl` — **control fixture**: contains `truly_undefined_sub();` so a high-confidence missing symbol is present and diagnostic MUST fire (proves dynamic suppression doesn't become a broad shut-up switch)

**Stub/unit suppression seam tested (28 tests across 3 locations):**
- `dynamic_boundary_acceptance.rs`: 8 acceptance tests against a hand-rolled `DynamicBoundaryStub` implementing `SemanticQueries`, including `normal_static_missing_symbol_still_fires` (control)
- `queries.rs::tests`: 6 unit tests for `dynamic_boundary_at` (covered, not-covered, unknown-file, symbol-filter-match, symbol-filter-mismatch, entity-less=any-symbol)
- `scope.rs::tests`: 4 unit tests for `scope_issues_to_diagnostics_with_semantics` against stubbed queries

**Production suppression proof: deferred to PR-B.** The fixtures and stub tests are correctness contracts for the seam; PR-B will convert them into live E2E proof by threading real `WorkspaceSemanticQueries` through `DiagnosticsProvider`.

## Diagnostic Policy Summary

```
UndeclaredVariable at position P, symbol S:
  dynamic_boundary_at(file_id, P, S) = Some(_) → SUPPRESS
  dynamic_boundary_at(file_id, P, S) = None    → EMIT (no false suppression)

All other IssueKinds:
  Always EMIT (UnusedVariable, VariableShadowing, etc. never suppressed)
```

In production today, `dynamic_boundary_at` is queried on `&NullSemanticQueries` which always returns `None`, so the EMIT branch is always taken. PR-B replaces the stub with a real `&WorkspaceSemanticQueries` and the SUPPRESS branch becomes reachable.

## AUTOLOAD Scope Note

AUTOLOAD scope detection is **same-file/same-package only** in this PR. Cross-file AUTOLOAD propagation (e.g., `Foo->missing_method()` when `Foo::AUTOLOAD` is defined in a different file) requires cross-file entity graph traversal and is deferred to a follow-up issue.

## Control Fixture Confirmation

The test `normal_static_missing_symbol_still_fires` verifies that `diagnostics_undefined_symbol_cutover` produces `DiagnosticAction::Warn` (not `Suppress`) for a symbol with no candidates and no dynamic boundary. The control fixture `normal_static_missing_symbol.pl` calls `truly_undefined_sub();` — a static high-confidence missing symbol with no dynamic constructs anywhere in the file. The diagnostic MUST fire.

## Scorecard/Shadow Status

**Before:** fixture_count=12, dynamic_boundary_facts=2
**After:** fixture_count=16, dynamic_boundary_facts=2 (unchanged)

The `dynamic_boundary_facts` count is measured from `FileFactShard` occurrences. The `DynamicRequire` provenance change affects `ImportSpec` not directly `FileFactShard` occurrences in the legacy `WorkspaceIndex` path used by the scorecard. Both checks pass: `cargo xtask semantic-scorecard --check` and `cargo xtask semantic-shadow-compare --check`. Bumping the counter to reflect the new evidence is a candidate for PR-B or a separate scorecard PR.

## Verification Commands Run

```
cargo test -p perl-lsp-rs-core diagnostics    → 183 passed
cargo test -p perl-semantic-analyzer dynamic  → 13 passed
cargo test -p perl-workspace semantic         → 240 passed
cargo xtask semantic-scorecard --check        → PASSED
cargo xtask semantic-shadow-compare --check   → PASSED
cargo xtask fmt                               → clean
cargo clippy (perl-workspace, perl-lsp-rs-core, perl-semantic-analyzer) → no issues
cargo check --workspace --exclude tree-sitter-perl → 0 errors
```

**Pre-existing test failure (not caused by this PR):**
`test_dap_build_includes_rs_core_catalog` in `wave_final_absorption_tests.rs` — exists on `origin/master` before this PR.

## Files Changed (by commit)

**Commit 1** — Fixtures:
- `crates/perl-workspace/tests/fixtures/semantic_scorecard/dynamic_import_via_variable.pl` (new)
- `crates/perl-workspace/tests/fixtures/semantic_scorecard/normal_static_missing_symbol.pl` (new)
- `crates/perl-workspace/tests/fixtures/semantic_scorecard/static_class_dynamic_import.pl` (new)
- `crates/perl-workspace/tests/fixtures/semantic_scorecard/symbolic_deref_assign.pl` (new)
- `crates/perl-workspace/tests/fixtures/semantic_scorecard/manifest.json` (16 fixtures)

**Commit 2** — Provenance fix + acceptance tests:
- `crates/perl-semantic-analyzer/src/analysis/import_extractor.rs` (`DynamicRequire` → `DynamicBoundary`)
- `crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs` (8 new tests)

**Commit 3** — New query:
- `crates/perl-workspace/src/semantic/queries.rs` (`dynamic_boundary_at` trait + impl + 6 tests)

**Commit 4** — Scope variant + stub updates:
- `crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs` (new variant + 4 tests + helper extract)
- `crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs` (stub)
- `crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs` (2 stubs)
- `crates/perl-lsp-rs-core/src/providers/navigation/{definition,hover,references,rename,safe_delete}_shadow.rs` (stubs)
- `crates/perl-lsp-rs-core/src/providers/navigation/scorecard_gate_fixtures.rs` (stub)

**Commit 5** — Wire + scorecard:
- `crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs` (NullSemanticQueries + wire)
- `docs/project/status/semantic_scorecard.json` (16 fixtures)
- `docs/project/status/semantic_scorecard.md` (regenerated)

**Commit 6** — Bug fix (self-review catch):
- `crates/perl-workspace/src/semantic/queries.rs` (`?` → `match+continue` in anchor lookup loop)

**Commit 7** — Reviewability cleanup (post-review):
- `crates/perl-workspace/tests/fixtures/semantic_scorecard/normal_static_missing_symbol.pl` (added the `truly_undefined_sub();` call so the fixture matches its stated intent)
- `crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs` (replaced reference to nonexistent `get_diagnostics_with_path_and_semantics` with PR-B reference)
- `crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs` (corrected wrapper docstring; preserves old conversion path directly)
- `docs/project/status/semantic_scorecard.{json,md}` (regenerated for new fact count from added call)

## Intentional Non-Goals (this PR)

- No production wiring of real semantic data — that's PR-B
- No symbolic evaluation or type inference
- No Moose metamodel support
- No cross-file AUTOLOAD propagation (follow-up)
- No new crate (all changes in existing crates)
- No broad file-global suppression (`scope_is_dynamic(file) -> bool`)
- `dynamic_boundary_facts` scorecard row intentionally stays at 2 (legacy path limitation, candidate for PR-B)

## PR-B Scope (next)

`feat(diagnostics): wire WorkspaceSemanticQueries through DiagnosticsProvider`

Replace `&NullSemanticQueries` at `diagnostics.rs:215` with a real `&WorkspaceSemanticQueries` instance threaded from `LanguageServerCore`. ~150 LOC across `crates/perl-lsp-rs/src/runtime/`. After PR-B lands, every fixture in this PR becomes a live E2E proof of suppression, not just an isolated unit test.

PR-B preflight question (the one real architectural decision left): does current dynamic-boundary evidence cover the **later issue location** (e.g., the bareword `foo()` after `require $module; $module->import(qw(foo))`), or only the import expression span itself? If only the import span, PR-B needs either (a) a query that models dynamic-import scope/effect, or (b) producer evidence at the plausible use site.

## Test Plan

```bash
# Run targeted test suites
cargo test -p perl-lsp-rs-core diagnostics
cargo test -p perl-semantic-analyzer dynamic
cargo test -p perl-workspace semantic

# Verify scorecard determinism
cargo xtask semantic-scorecard --check
cargo xtask semantic-shadow-compare --check

# Verify workspace health
cargo check --workspace --exclude tree-sitter-perl
cargo clippy -p perl-workspace -p perl-lsp-rs-core -p perl-semantic-analyzer
```
