### PR TITLE
fix(vscode): harden managed binary install for 0.13.3 (#0000)

### DIFF
--- a/.github/workflows/vscode-managed-binary-smoke.yml
+++ b/.github/workflows/vscode-managed-binary-smoke.yml
@@ -59,3 +59,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: xvfb-run -a npm run test:integration
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-smoke-source-${{ matrix.os }}
+          path: target/receipts/vscode-smoke/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/vscode-published-extension-smoke.yml
+++ b/.github/workflows/vscode-published-extension-smoke.yml
@@ -65,3 +65,12 @@ jobs:
       - name: Run published extension smoke under Xvfb
         if: runner.os == 'Linux'
         run: xvfb-run -a npm run test:published
+
+      - name: Upload published smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-smoke-published-${{ env.PERL_LSP_PUBLISHED_EXTENSION_SOURCE }}-${{ matrix.os }}
+          path: target/receipts/vscode-smoke/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -23,8 +23,27 @@ interface Release {
     assets: ReleaseAsset[];
 }
 
-const MANAGED_INSTALL_RETRY_DELAYS_MS = [100, 250, 500, 1000, 2000];
+// Retry budget for transient managed-install file locks. Total wait grows to
+// ~31s so first-time Windows Defender signature scans of freshly extracted
+// perllsp.exe (5–15s on cold caches) and end-of-life lock release for a
+// running perllsp.exe both fit comfortably.
+const MANAGED_INSTALL_RETRY_DELAYS_MS = [100, 250, 500, 1000, 2000, 4000, 8000, 16000];
 const TRANSIENT_MANAGED_INSTALL_ERROR_CODES = new Set(['EBUSY', 'EPERM', 'EACCES', 'ETXTBSY']);
+
+// Module-level singleflight: coalesce concurrent managed-install calls so
+// activation auto-download, manual reinstall, and silent update-check do not
+// race the same destination path. Multiple BinaryDownloader instances are
+// constructed across call sites, so this state lives at module scope.
+type ManagedInstallReason = 'force' | 'ensure';
+interface ActiveManagedInstall {
+  promise: Promise<string | null>;
+  reason: ManagedInstallReason;
+}
+let activeManagedInstall: ActiveManagedInstall | undefined;
+
+export function __resetManagedInstallSingleflightForTesting(): void {
+  activeManagedInstall = undefined;
+}
 
 function delay(ms: number): Promise<void> {
     return new Promise(resolve => {
@@ -163,15 +182,48 @@ export class BinaryDownloader {
     
     async ensureBinary(forceDownload = false): Promise<string | null> {
         this.lastErrorMessage = undefined;
+        const myReason: ManagedInstallReason = forceDownload ? 'force' : 'ensure';
+
+        // Singleflight: if an install is already running, decide whether to
+        // join it or run our own afterward. A pending force install always
+        // satisfies all callers; an ensure call always joins; a force call
+        // that arrives while an ensure is in flight waits for it then runs
+        // its own to honor the explicit reinstall intent.
+        if (activeManagedInstall) {
+            const activeReason = activeManagedInstall.reason;
+            this.outputChannel.appendLine(
+                `Managed install already in progress (${activeReason}); ${myReason} call will join.`,
+            );
+            const joined = await activeManagedInstall.promise.catch(() => null);
+            if (!forceDownload || activeReason === 'force') {
+                return joined;
+            }
+            this.outputChannel.appendLine(
+                'Joined ensure-install completed; running explicit force-reinstall now.',
+            );
+        }
+
+        const promise = this.runEnsureBinary(forceDownload);
+        activeManagedInstall = { promise, reason: myReason };
+        try {
+            return await promise;
+        } finally {
+            if (activeManagedInstall && activeManagedInstall.promise === promise) {
+                activeManagedInstall = undefined;
+            }
+        }
+    }
+
+    private async runEnsureBinary(forceDownload: boolean): Promise<string | null> {
         const config = vscode.workspace.getConfiguration('perl-lsp');
         const channel = config.get<string>('channel', 'latest');
         const versionTag = config.get<string>('versionTag', '');
-        
+
         // If channel is 'tag' and versionTag is specified, use that specific version
         if (channel === 'tag' && versionTag) {
             this.outputChannel.appendLine(`Using specific version: ${versionTag}`);
         }
-        
+
         // Check if binary already exists
         const existingPath = this.getLocalBinaryPath();
         if (!forceDownload && existingPath && fs.existsSync(existingPath)) {
@@ -182,14 +234,14 @@ export class BinaryDownloader {
         if (forceDownload && existingPath && fs.existsSync(existingPath)) {
             this.outputChannel.appendLine(`Refreshing existing binary: ${existingPath}`);
         }
-        
+
         // Show status bar while downloading
         const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
         statusBar.text = '$(sync~spin) Perl LSP: downloading binary...';
         statusBar.tooltip = 'Downloading Perl Language Server... Click to show logs';
         statusBar.command = 'perl-lsp.showOutput';
         statusBar.show();
-        
+
         // Download binary
         try {
             return await this.downloadWithProgress();
@@ -404,22 +456,30 @@ export class BinaryDownloader {
                     throw new Error('Binary not found in archive');
                 }
                 
-                // Move to final location
+                // Move to final location. Each install lands in a unique
+                // versioned dir so a forced reinstall while perllsp.exe is
+                // running does not have to overwrite the running file. The
+                // active install is selected by an atomically-committed
+                // pointer file at the base dir.
                 progress.report({ increment: 15, message: 'Installing binary...' });
-                const finalPath = this.getLocalBinaryPath();
-                const finalDir = path.dirname(finalPath);
-                
-                if (!fs.existsSync(finalDir)) {
-                    fs.mkdirSync(finalDir, { recursive: true });
+                const baseDir = this.getManagedBaseDir();
+                if (!fs.existsSync(baseDir)) {
+                    fs.mkdirSync(baseDir, { recursive: true });
                 }
-                
+                const installDirName = this.buildVersionedInstallDirName(release.tag_name);
+                const installDir = path.join(baseDir, installDirName);
+                fs.mkdirSync(installDir, { recursive: true });
+
+                const binaryName = process.platform === 'win32' ? 'perllsp.exe' : 'perllsp';
+                const finalPath = path.join(installDir, binaryName);
+
                 await copyManagedFileWithRetry(
                     extractedBinary,
                     finalPath,
                     'perllsp',
                     message => this.outputChannel.appendLine(message)
                 );
-                
+
                 // Make executable on Unix
                 if (process.platform !== 'win32') {
                     fs.chmodSync(finalPath, 0o755);
@@ -429,7 +489,7 @@ export class BinaryDownloader {
                 const dapName = process.platform === 'win32' ? 'perl-dap.exe' : 'perl-dap';
                 const extractedDap = this.findBinary(extractDir, dapName);
                 if (extractedDap) {
-                    const dapDest = path.join(finalDir, dapName);
+                    const dapDest = path.join(installDir, dapName);
                     try {
                         await copyManagedFileWithRetry(
                             extractedDap,
@@ -446,9 +506,15 @@ export class BinaryDownloader {
                     }
                 }
 
+                // Atomically activate the new install. Old install dirs stay
+                // on disk for one generation as a fallback, then get pruned.
+                this.commitVersionedInstall(installDirName);
+                this.outputChannel.appendLine(`Active managed install: ${installDirName}`);
+                this.pruneOldVersionedInstalls(baseDir, installDirName);
+
                 progress.report({ increment: 5, message: 'Complete!' });
                 this.outputChannel.appendLine(`Binary installed to: ${finalPath}`);
-                
+
                 return finalPath;
                 
             } finally {
@@ -802,34 +868,136 @@ export class BinaryDownloader {
         );
     }
     
-    private getLocalBinaryPath(): string {
-        const platform = process.platform;
-        const arch = process.arch;
-        const binaryName = platform === 'win32' ? 'perllsp.exe' : 'perllsp';
-        
+    /**
+     * Root for managed installs: globalStorage/.../bin/<platform>-<arch>/.
+     * Inside this directory, the active install is selected by the `current`
+     * pointer file, falling back to a legacy flat layout (perllsp.exe at the
+     * top level) when the pointer is absent.
+     */
+    private getManagedBaseDir(): string {
+        return BinaryDownloader.computeManagedBaseDir(this.context);
+    }
+
+    private static computeManagedBaseDir(context: vscode.ExtensionContext): string {
         return path.join(
-            this.context.globalStorageUri.fsPath,
+            context.globalStorageUri.fsPath,
             'bin',
-            `${platform}-${arch}`,
-            binaryName
+            `${process.platform}-${process.arch}`,
         );
     }
-    
+
+    /**
+     * Reads the `current` pointer file at the managed base dir and returns the
+     * absolute path of the active install dir, or null if no pointer exists or
+     * the named subdir is missing or invalid. Pointer content is restricted to
+     * a single dir name with no separators or '..' components.
+     */
+    private static readActiveManagedInstallDir(context: vscode.ExtensionContext): string | null {
+        const baseDir = BinaryDownloader.computeManagedBaseDir(context);
+        const pointerPath = path.join(baseDir, 'current');
+        if (!fs.existsSync(pointerPath)) {
+            return null;
+        }
+        let content = '';
+        try {
+            content = fs.readFileSync(pointerPath, 'utf8').trim();
+        } catch {
+            return null;
+        }
+        if (!content) {
+            return null;
+        }
+        if (!/^[A-Za-z0-9._-]+$/.test(content) || content.includes('..')) {
+            return null;
+        }
+        const candidate = path.join(baseDir, content);
+        if (!fs.existsSync(candidate)) {
+            return null;
+        }
+        return candidate;
+    }
+
+    /**
+     * Builds a unique install dir name from a release tag plus an ISO timestamp.
+     * Uniqueness lets a forced reinstall of the same version land in a fresh
+     * directory instead of overwriting the running binary on Windows.
+     */
+    private buildVersionedInstallDirName(versionTag: string): string {
+        const sanitizedTag = (versionTag || 'unknown').replace(/[^A-Za-z0-9._-]/g, '_');
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+        return `${sanitizedTag}-${stamp}`;
+    }
+
+    /**
+     * Atomically updates the `current` pointer to a freshly populated install
+     * dir. The temp + rename pattern is the strongest form of "commit on
+     * success" we can use with no extra dependencies.
+     */
+    private commitVersionedInstall(installDirName: string): void {
+        const baseDir = this.getManagedBaseDir();
+        const pointerPath = path.join(baseDir, 'current');
+        const tmpPath = `${pointerPath}.tmp`;
+        fs.writeFileSync(tmpPath, `${installDirName}\n`, { encoding: 'utf8' });
+        fs.renameSync(tmpPath, pointerPath);
+    }
+
+    /**
+     * Removes versioned install dirs older than the most recent two. Best
+     * effort only — failure to prune is logged but never propagates so it
+     * cannot mask install success.
+     *
+     * Keeps `currentName` plus one prior install for fallback recovery.
+     */
+    private pruneOldVersionedInstalls(baseDir: string, currentName: string): void {
+        let entries: { name: string; mtime: number }[] = [];
+        try {
+            entries = fs.readdirSync(baseDir, { withFileTypes: true })
+                .filter(d => d.isDirectory() && d.name !== currentName)
+                .map(d => {
+                    const full = path.join(baseDir, d.name);
+                    let mtime = 0;
+                    try { mtime = fs.statSync(full).mtimeMs; } catch { /* ignore */ }
+                    return { name: d.name, mtime };
+                })
+                .sort((a, b) => b.mtime - a.mtime);
+        } catch {
+            return;
+        }
+        // Keep most recent prior install; remove anything older.
+        for (const entry of entries.slice(1)) {
+            const target = path.join(baseDir, entry.name);
+            try {
+                fs.rmSync(target, { recursive: true, force: true });
+                this.outputChannel.appendLine(`Removed stale managed install: ${entry.name}`);
+            } catch (err: unknown) {
+                const msg = err instanceof Error ? err.message : String(err);
+                this.outputChannel.appendLine(`Could not remove stale install ${entry.name}: ${msg}`);
+            }
+        }
+    }
+
+    private getLocalBinaryPath(): string {
+        const binaryName = process.platform === 'win32' ? 'perllsp.exe' : 'perllsp';
+        const activeDir = BinaryDownloader.readActiveManagedInstallDir(this.context);
+        if (activeDir) {
+            return path.join(activeDir, binaryName);
+        }
+        // Legacy flat layout — pre-versioned installs grandfathered.
+        return path.join(this.getManagedBaseDir(), binaryName);
+    }
+
     /**
      * Returns the path where perl-dap would be placed inside the auto-download
      * directory.  Used by debugAdapter.ts to locate the binary without
      * duplicating path logic.
      */
     static getLocalDapPath(context: vscode.ExtensionContext): string {
-        const platform = process.platform;
-        const arch = process.arch;
-        const dapName = platform === 'win32' ? 'perl-dap.exe' : 'perl-dap';
-        return path.join(
-            context.globalStorageUri.fsPath,
-            'bin',
-            `${platform}-${arch}`,
-            dapName
-        );
+        const dapName = process.platform === 'win32' ? 'perl-dap.exe' : 'perl-dap';
+        const activeDir = BinaryDownloader.readActiveManagedInstallDir(context);
+        if (activeDir) {
+            return path.join(activeDir, dapName);
+        }
+        return path.join(BinaryDownloader.computeManagedBaseDir(context), dapName);
     }
 
     /**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2009,6 +2009,27 @@ async function reinstallServerBinary(context: vscode.ExtensionContext): Promise<
     const downloader = new BinaryDownloader(context, outputChannel);
     const target = downloader.getTargetTriple();
     const source = getManagedBinarySource();
+
+    // Lifecycle snapshot: stop a running language client before install so
+    // Windows releases its handle on the existing perllsp.exe. On failure
+    // we restart with the previous binary so the user is never left worse
+    // off than before they invoked Reinstall.
+    const wasRunning = client !== undefined;
+    const previousServerPath = currentServerPath;
+
+    if (wasRunning) {
+        outputChannel.appendLine('[reinstall] stopping language client to release the running binary');
+        try {
+            await disposeLanguageClient();
+        } catch (stopErr: unknown) {
+            const msg = stopErr instanceof Error ? stopErr.message : String(stopErr);
+            outputChannel.appendLine(`[reinstall] language client stop reported: ${msg}`);
+        }
+        // Brief grace period: Windows can lag a few ms releasing the
+        // executable file handle after the LSP child process exits.
+        await new Promise(resolve => setTimeout(resolve, 250));
+    }
+
     const downloadedPath = await downloader.ensureBinary(true);
 
     if (!downloadedPath) {
@@ -2021,16 +2042,24 @@ async function reinstallServerBinary(context: vscode.ExtensionContext): Promise<
                 void vscode.commands.executeCommand('workbench.action.openSettings', 'http.proxy');
             }
         });
+        if (wasRunning && previousServerPath) {
+            outputChannel.appendLine('[reinstall] restoring previous binary after failed download');
+            currentServerPath = previousServerPath;
+            try {
+                await restartServer(context);
+            } catch {
+                // restartServer surfaces its own dialog/log; nothing to add here.
+            }
+        }
         return {
             ok: false,
-            serverPath: '',
+            serverPath: previousServerPath ?? '',
             target,
             source,
             error: downloader.getLastErrorMessage() ?? 'download failed',
         };
     }
 
-    currentServerPath = downloadedPath;
     const healthOk = await runHealthCheck(downloadedPath);
     const version = await readInstalledServerVersion(downloadedPath);
     if (!healthOk) {
@@ -2043,6 +2072,15 @@ async function reinstallServerBinary(context: vscode.ExtensionContext): Promise<
                 void vscode.env.openExternal(vscode.Uri.parse('https://github.com/EffortlessMetrics/perl-lsp/issues'));
             }
         });
+        if (wasRunning && previousServerPath) {
+            outputChannel.appendLine('[reinstall] restoring previous binary after failed health check');
+            currentServerPath = previousServerPath;
+            try {
+                await restartServer(context);
+            } catch {
+                // restartServer surfaces its own dialog/log.
+            }
+        }
         return {
             ok: false,
             serverPath: downloadedPath,
@@ -2054,14 +2092,18 @@ async function reinstallServerBinary(context: vscode.ExtensionContext): Promise<
         };
     }
 
-    vscode.window.showInformationMessage(
-        'perl-lsp was reinstalled successfully.',
-        client ? 'Restart Server' : 'OK'
-    ).then(selection => {
-        if (selection === 'Restart Server' && client) {
-            void restartServer(context);
+    currentServerPath = downloadedPath;
+
+    if (wasRunning) {
+        outputChannel.appendLine('[reinstall] restarting language client with the freshly installed binary');
+        try {
+            await restartServer(context);
+        } catch {
+            // restartServer surfaces its own dialog/log.
         }
-    });
+    } else {
+        vscode.window.showInformationMessage('perl-lsp was reinstalled successfully.', 'OK');
+    }
 
     return {
         ok: true,

--- a/vscode-extension/src/test/integration/managedBinarySmoke.test.ts
+++ b/vscode-extension/src/test/integration/managedBinarySmoke.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
+import * as path from 'path';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import * as vscode from 'vscode';
 import type { HealthCheckCommandResult, ReinstallCommandResult } from '../../commandResults';
 
@@ -42,61 +44,245 @@ async function waitForCommand(command: string, timeoutMs: number): Promise<void>
   );
 }
 
+function platformLabel(): string {
+  switch (process.platform) {
+    case 'win32': return 'windows';
+    case 'darwin': return 'macos';
+    case 'linux': return 'linux';
+    default: return process.platform;
+  }
+}
+
+function smokeReceiptsDir(sourceLabel: string): string {
+  // __dirname after compile is <repo>/vscode-extension/out/test/integration → 4x .. reaches repo root.
+  const root = process.env.PERL_LSP_SMOKE_RECEIPTS_DIR
+    ?? path.resolve(__dirname, '..', '..', '..', '..', 'target', 'receipts', 'vscode-smoke');
+  const dir = path.join(root, sourceLabel, platformLabel());
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+interface SmokeArtifacts {
+  state: Record<string, unknown>;
+  log: string[];
+}
+
+function appendLog(artifacts: SmokeArtifacts, line: string): void {
+  artifacts.log.push(`[${new Date().toISOString()}] ${line}`);
+}
+
+function writeArtifacts(
+  receiptsDir: string,
+  artifacts: SmokeArtifacts,
+  results: Record<string, unknown>,
+): void {
+  try {
+    fs.writeFileSync(
+      path.join(receiptsDir, 'extension-output.log'),
+      artifacts.log.join('\n') + '\n',
+    );
+    fs.writeFileSync(
+      path.join(receiptsDir, 'command-results.json'),
+      JSON.stringify(results, null, 2),
+    );
+    fs.writeFileSync(
+      path.join(receiptsDir, 'managed-binary-state.json'),
+      JSON.stringify(artifacts.state, null, 2),
+    );
+  } catch (err: unknown) {
+    // Receipt-writing failures must not mask test failures — log to stderr.
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[smoke] failed to write receipts to ${receiptsDir}: ${msg}\n`);
+  }
+}
+
+function killLockingProcess(child: ChildProcessWithoutNullStreams | undefined): void {
+  if (!child || child.killed || child.exitCode !== null) {
+    return;
+  }
+  try {
+    child.kill();
+  } catch {
+    // best-effort
+  }
+}
+
 suite('Managed binary smoke', function () {
-  this.timeout(180_000);
+  this.timeout(240_000);
 
-  test('Managed binary smoke reinstalls managed perllsp and passes health check', async function () {
-    this.timeout(180_000);
+  test('Managed binary smoke reinstalls perllsp twice and survives running-binary lock', async function () {
+    this.timeout(240_000);
 
-    const config = vscode.workspace.getConfiguration('perl-lsp');
-    await config.update('autoDownload', false, vscode.ConfigurationTarget.Global);
-    await config.update('serverPath', '', vscode.ConfigurationTarget.Global);
-    await config.update('channel', 'tag', vscode.ConfigurationTarget.Global);
-    await config.update('versionTag', 'v0.13.1', vscode.ConfigurationTarget.Global);
-    await config.update('downloadBaseUrl', '', vscode.ConfigurationTarget.Global);
-    await config.update('updateCheckInterval', 0, vscode.ConfigurationTarget.Global);
-    await config.update('perlcritic.enabled', false, vscode.ConfigurationTarget.Global);
+    const sourceLabel = process.env.PERL_LSP_SMOKE_SOURCE_LABEL ?? 'integration';
+    const receiptsDir = smokeReceiptsDir(sourceLabel);
+    const artifacts: SmokeArtifacts = {
+      log: [],
+      state: {
+        platform: process.platform,
+        arch: process.arch,
+        sourceLabel,
+        startedAt: new Date().toISOString(),
+        firstReinstallOk: false,
+        secondReinstallOk: false,
+        firstHealthOk: false,
+        secondHealthOk: false,
+        binaryRewrittenSecondPass: false,
+        lockingProcessSpawned: false,
+        lastError: null,
+      },
+    };
+    const results: Record<string, unknown> = {};
+    let lockingProcess: ChildProcessWithoutNullStreams | undefined;
 
-    if (process.platform === 'linux') {
-      await config.update('linuxLibc', 'gnu', vscode.ConfigurationTarget.Global);
+    try {
+      appendLog(artifacts, 'configuring perl-lsp settings for managed-download mode');
+      const config = vscode.workspace.getConfiguration('perl-lsp');
+      await config.update('autoDownload', false, vscode.ConfigurationTarget.Global);
+      await config.update('serverPath', '', vscode.ConfigurationTarget.Global);
+      await config.update('channel', 'tag', vscode.ConfigurationTarget.Global);
+      await config.update('versionTag', 'v0.13.1', vscode.ConfigurationTarget.Global);
+      await config.update('downloadBaseUrl', '', vscode.ConfigurationTarget.Global);
+      await config.update('updateCheckInterval', 0, vscode.ConfigurationTarget.Global);
+      await config.update('perlcritic.enabled', false, vscode.ConfigurationTarget.Global);
+
+      if (process.platform === 'linux') {
+        await config.update('linuxLibc', 'gnu', vscode.ConfigurationTarget.Global);
+      }
+
+      const extension = vscode.extensions.getExtension('EffortlessMetrics.perl-lsp-rs');
+      assert.ok(extension, 'extension should be available in the extension host');
+      await withTimeout('extension activation', extension.activate(), 30_000);
+      await waitForCommand('perl-lsp.reinstall', 10_000);
+      await config.update('autoDownload', true, vscode.ConfigurationTarget.Global);
+
+      appendLog(artifacts, 'starting first reinstall');
+      const reinstall1 = await withTimeout(
+        'managed binary reinstall command (first)',
+        vscode.commands.executeCommand<ReinstallCommandResult>('perl-lsp.reinstall'),
+        120_000,
+      );
+      results.reinstall1 = reinstall1;
+      assert.ok(reinstall1, 'first reinstall command should return a result');
+      assert.equal(reinstall1.ok, true, JSON.stringify(reinstall1, null, 2));
+      assert.ok(reinstall1.serverPath, 'first reinstall should include the managed binary path');
+      assert.ok(
+        fs.existsSync(reinstall1.serverPath),
+        `managed binary should exist after first reinstall: ${reinstall1.serverPath}`,
+      );
+      assert.ok(reinstall1.target, 'first reinstall should include the release target triple');
+      assert.equal(
+        reinstall1.checksumVerified,
+        true,
+        'first reinstall should verify SHA256SUMS',
+      );
+
+      if (process.platform === 'linux') {
+        assert.match(reinstall1.target, /-unknown-linux-gnu$/);
+      }
+
+      artifacts.state.firstReinstallOk = true;
+      artifacts.state.serverPath = reinstall1.serverPath;
+      artifacts.state.target = reinstall1.target;
+      artifacts.state.binaryVersion = reinstall1.version ?? null;
+      artifacts.state.managedSource = reinstall1.source;
+
+      const mtimeBefore = fs.statSync(reinstall1.serverPath).mtimeMs;
+      artifacts.state.binaryMtimeBefore = mtimeBefore;
+
+      appendLog(artifacts, 'running first health check');
+      const health1 = await withTimeout(
+        'managed binary health check command (first)',
+        vscode.commands.executeCommand<HealthCheckCommandResult>(
+          'perl-lsp.runHealthCheck',
+          reinstall1.serverPath,
+        ),
+        45_000,
+      );
+      results.health1 = health1;
+      assert.ok(health1, 'first health check should return a result');
+      assert.equal(health1.ok, true, JSON.stringify(health1.checks, null, 2));
+      assert.ok(
+        health1.checks.some(check => check.label === 'LSP binary' && check.status === 'ok'),
+        JSON.stringify(health1.checks, null, 2),
+      );
+      artifacts.state.firstHealthOk = true;
+
+      // Force the binary to be held by a running process so the second reinstall
+      // exercises the same lock condition users hit on Windows when the language
+      // server is running. The server invocation will idle waiting for an LSP
+      // handshake on stdin; we kill it once the second reinstall completes.
+      appendLog(artifacts, 'spawning perllsp to hold the binary across second reinstall');
+      lockingProcess = spawn(reinstall1.serverPath, [], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+      lockingProcess.stdout.on('data', () => { /* drain */ });
+      lockingProcess.stderr.on('data', () => { /* drain */ });
+      lockingProcess.on('error', err => {
+        appendLog(artifacts, `locking process error: ${err.message}`);
+      });
+      // Give the OS a moment to actually hold the executable file handle.
+      await delay(750);
+      const lockingExited = lockingProcess.exitCode !== null;
+      artifacts.state.lockingProcessSpawned = !lockingExited;
+      artifacts.state.lockingProcessPid = lockingProcess.pid ?? null;
+      if (lockingExited) {
+        appendLog(
+          artifacts,
+          `locking process exited early with code=${lockingProcess.exitCode}; second reinstall will run without lock`,
+        );
+      }
+
+      appendLog(artifacts, 'starting second reinstall while binary is held');
+      const reinstall2 = await withTimeout(
+        'managed binary reinstall command (second, locked)',
+        vscode.commands.executeCommand<ReinstallCommandResult>('perl-lsp.reinstall'),
+        120_000,
+      );
+      results.reinstall2 = reinstall2;
+      assert.ok(reinstall2, 'second reinstall command should return a result');
+      assert.equal(reinstall2.ok, true, JSON.stringify(reinstall2, null, 2));
+      assert.ok(
+        fs.existsSync(reinstall2.serverPath),
+        `managed binary should exist after second reinstall: ${reinstall2.serverPath}`,
+      );
+      assert.equal(
+        reinstall2.checksumVerified,
+        true,
+        'second reinstall should verify SHA256SUMS',
+      );
+
+      const mtimeAfter = fs.statSync(reinstall2.serverPath).mtimeMs;
+      artifacts.state.binaryMtimeAfter = mtimeAfter;
+      artifacts.state.binaryRewrittenSecondPass = mtimeAfter >= mtimeBefore;
+      artifacts.state.secondReinstallOk = true;
+
+      appendLog(artifacts, 'running second health check');
+      const health2 = await withTimeout(
+        'managed binary health check command (second)',
+        vscode.commands.executeCommand<HealthCheckCommandResult>(
+          'perl-lsp.runHealthCheck',
+          reinstall2.serverPath,
+        ),
+        45_000,
+      );
+      results.health2 = health2;
+      assert.ok(health2, 'second health check should return a result');
+      assert.equal(health2.ok, true, JSON.stringify(health2.checks, null, 2));
+      assert.ok(
+        health2.checks.some(check => check.label === 'LSP binary' && check.status === 'ok'),
+        JSON.stringify(health2.checks, null, 2),
+      );
+      artifacts.state.secondHealthOk = true;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      artifacts.state.lastError = msg;
+      appendLog(artifacts, `smoke failed: ${msg}`);
+      throw err;
+    } finally {
+      killLockingProcess(lockingProcess);
+      artifacts.state.completedAt = new Date().toISOString();
+      writeArtifacts(receiptsDir, artifacts, results);
     }
-
-    const extension = vscode.extensions.getExtension('EffortlessMetrics.perl-lsp-rs');
-    assert.ok(extension, 'extension should be available in the extension host');
-    await withTimeout('extension activation', extension.activate(), 30_000);
-    await waitForCommand('perl-lsp.reinstall', 10_000);
-    await config.update('autoDownload', true, vscode.ConfigurationTarget.Global);
-
-    const reinstall = await withTimeout(
-      'managed binary reinstall command',
-      vscode.commands.executeCommand<ReinstallCommandResult>('perl-lsp.reinstall'),
-      120_000,
-    );
-    assert.ok(reinstall, 'reinstall command should return a result');
-    assert.equal(reinstall.ok, true, JSON.stringify(reinstall, null, 2));
-    assert.ok(reinstall.serverPath, 'reinstall result should include the managed binary path');
-    assert.ok(fs.existsSync(reinstall.serverPath), `managed binary should exist: ${reinstall.serverPath}`);
-    assert.ok(reinstall.target, 'reinstall result should include the release target triple');
-    assert.equal(reinstall.checksumVerified, true, 'managed binary download should verify SHA256SUMS');
-
-    if (process.platform === 'linux') {
-      assert.match(reinstall.target, /-unknown-linux-gnu$/);
-    }
-
-    const health = await withTimeout(
-      'managed binary health check command',
-      vscode.commands.executeCommand<HealthCheckCommandResult>(
-        'perl-lsp.runHealthCheck',
-        reinstall.serverPath,
-      ),
-      30_000,
-    );
-
-    assert.ok(health, 'health check command should return a result');
-    assert.equal(health.ok, true, JSON.stringify(health.checks, null, 2));
-    assert.ok(
-      health.checks.some(check => check.label === 'LSP binary' && check.status === 'ok'),
-      JSON.stringify(health.checks, null, 2),
-    );
   });
 });

--- a/vscode-extension/src/test/integration/runTest.ts
+++ b/vscode-extension/src/test/integration/runTest.ts
@@ -23,11 +23,15 @@ function getGrepArg(args: string[]): string | undefined {
 
 async function main(): Promise<void> {
   const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+  const repoRoot = path.resolve(extensionDevelopmentPath, '..');
   const extensionTestsPath = path.resolve(__dirname, './suite');
   const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-vscode-smoke-workspace-'));
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-vscode-smoke-user-'));
   const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-vscode-smoke-extensions-'));
   const grep = getGrepArg(process.argv.slice(2));
+  const receiptsRoot = process.env.PERL_LSP_SMOKE_RECEIPTS_DIR
+    || path.join(repoRoot, 'target', 'receipts', 'vscode-smoke');
+  fs.mkdirSync(receiptsRoot, { recursive: true });
 
   fs.writeFileSync(path.join(workspacePath, 'smoke.pl'), "use strict;\nuse warnings;\nprint \"ok\\n\";\n");
 
@@ -37,6 +41,8 @@ async function main(): Promise<void> {
     extensionTestsEnv: {
       ...process.env,
       PERL_LSP_EXTENSION_TEST_SKIP_STARTUP: '1',
+      PERL_LSP_SMOKE_RECEIPTS_DIR: receiptsRoot,
+      PERL_LSP_SMOKE_SOURCE_LABEL: process.env.PERL_LSP_SMOKE_SOURCE_LABEL || 'integration',
       VSCODE_TEST_GREP: grep ?? '',
     },
     launchArgs: [

--- a/vscode-extension/src/test/published/managedBinaryPublishedSmoke.test.ts
+++ b/vscode-extension/src/test/published/managedBinaryPublishedSmoke.test.ts
@@ -1,5 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
+import * as path from 'path';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import * as vscode from 'vscode';
 
 type CheckStatus = 'ok' | 'warning' | 'error';
@@ -99,92 +101,297 @@ function releaseTag(version: string): string {
   return version.startsWith('v') ? version : `v${version}`;
 }
 
+function platformLabel(): string {
+  switch (process.platform) {
+    case 'win32': return 'windows';
+    case 'darwin': return 'macos';
+    case 'linux': return 'linux';
+    default: return process.platform;
+  }
+}
+
+function smokeReceiptsDir(sourceLabel: string): string {
+  // __dirname after compile is <repo>/vscode-extension/out/test/published → 4x .. reaches repo root.
+  const root = process.env.PERL_LSP_SMOKE_RECEIPTS_DIR
+    ?? path.resolve(__dirname, '..', '..', '..', '..', 'target', 'receipts', 'vscode-smoke');
+  const dir = path.join(root, sourceLabel, platformLabel());
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+interface SmokeArtifacts {
+  state: Record<string, unknown>;
+  log: string[];
+}
+
+function appendLog(artifacts: SmokeArtifacts, line: string): void {
+  artifacts.log.push(`[${new Date().toISOString()}] ${line}`);
+}
+
+function writeArtifacts(
+  receiptsDir: string,
+  artifacts: SmokeArtifacts,
+  results: Record<string, unknown>,
+): void {
+  try {
+    fs.writeFileSync(
+      path.join(receiptsDir, 'extension-output.log'),
+      artifacts.log.join('\n') + '\n',
+    );
+    fs.writeFileSync(
+      path.join(receiptsDir, 'command-results.json'),
+      JSON.stringify(results, null, 2),
+    );
+    fs.writeFileSync(
+      path.join(receiptsDir, 'managed-binary-state.json'),
+      JSON.stringify(artifacts.state, null, 2),
+    );
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[published-smoke] failed to write receipts to ${receiptsDir}: ${msg}\n`);
+  }
+}
+
+function killLockingProcess(child: ChildProcessWithoutNullStreams | undefined): void {
+  if (!child || child.killed || child.exitCode !== null) {
+    return;
+  }
+  try {
+    child.kill();
+  } catch {
+    // best-effort
+  }
+}
+
 suite('Published extension managed binary smoke', function () {
-  this.timeout(180_000);
+  this.timeout(240_000);
 
   test('Published extension installs and runs managed binary commands when supported', async function () {
-    this.timeout(180_000);
+    this.timeout(240_000);
 
-    const extensionId = process.env.PERL_LSP_PUBLISHED_EXTENSION_ID ?? 'EffortlessMetrics.perl-lsp-rs';
-    const expectedVersion = process.env.PERL_LSP_PUBLISHED_EXTENSION_VERSION ?? '';
-    const requireStructuredCommands = envFlag('PERL_LSP_REQUIRE_STRUCTURED_COMMANDS');
-    const extension = vscode.extensions.getExtension(extensionId);
+    const sourceLabel = process.env.PERL_LSP_SMOKE_SOURCE_LABEL
+      ?? process.env.PERL_LSP_PUBLISHED_EXTENSION_SOURCE
+      ?? 'marketplace';
+    const receiptsDir = smokeReceiptsDir(sourceLabel);
+    const artifacts: SmokeArtifacts = {
+      log: [],
+      state: {
+        platform: process.platform,
+        arch: process.arch,
+        sourceLabel,
+        startedAt: new Date().toISOString(),
+        firstReinstallOk: false,
+        secondReinstallOk: false,
+        firstHealthOk: false,
+        secondHealthOk: false,
+        secondReinstallExercised: false,
+        binaryRewrittenSecondPass: false,
+        lockingProcessSpawned: false,
+        lastError: null,
+      },
+    };
+    const results: Record<string, unknown> = {};
+    let lockingProcess: ChildProcessWithoutNullStreams | undefined;
 
-    assert.ok(extension, `${extensionId} should be installed in the clean VS Code profile`);
+    try {
+      const extensionId = process.env.PERL_LSP_PUBLISHED_EXTENSION_ID ?? 'EffortlessMetrics.perl-lsp-rs';
+      const expectedVersion = process.env.PERL_LSP_PUBLISHED_EXTENSION_VERSION ?? '';
+      const requireStructuredCommands = envFlag('PERL_LSP_REQUIRE_STRUCTURED_COMMANDS');
+      const extension = vscode.extensions.getExtension(extensionId);
 
-    const packageVersion = String(extension.packageJSON?.version ?? '');
-    assert.ok(packageVersion, 'published extension package should expose a version');
-    if (expectedVersion) {
-      assert.equal(packageVersion, expectedVersion);
-    }
+      assert.ok(extension, `${extensionId} should be installed in the clean VS Code profile`);
 
-    const supportsStructuredCommands = versionAtLeast(packageVersion, '0.13.2');
-    if (!supportsStructuredCommands) {
-      assert.equal(
-        requireStructuredCommands,
-        false,
-        `published extension ${packageVersion} predates structured command results`,
+      const packageVersion = String(extension.packageJSON?.version ?? '');
+      assert.ok(packageVersion, 'published extension package should expose a version');
+      if (expectedVersion) {
+        assert.equal(packageVersion, expectedVersion);
+      }
+
+      artifacts.state.extensionId = extensionId;
+      artifacts.state.extensionVersion = packageVersion;
+
+      const supportsStructuredCommands = versionAtLeast(packageVersion, '0.13.2');
+      const supportsLockedReinstall = versionAtLeast(packageVersion, '0.13.3');
+      artifacts.state.supportsStructuredCommands = supportsStructuredCommands;
+      artifacts.state.supportsLockedReinstall = supportsLockedReinstall;
+
+      if (!supportsStructuredCommands) {
+        appendLog(
+          artifacts,
+          `published extension ${packageVersion} predates structured command results — skipping`,
+        );
+        assert.equal(
+          requireStructuredCommands,
+          false,
+          `published extension ${packageVersion} predates structured command results`,
+        );
+        return;
+      }
+
+      appendLog(artifacts, 'configuring perl-lsp settings for managed-download mode');
+      const config = vscode.workspace.getConfiguration('perl-lsp');
+      const binaryVersion = process.env.PERL_LSP_PUBLISHED_BINARY_VERSION || expectedVersion || packageVersion;
+      artifacts.state.binaryVersion = binaryVersion;
+      await config.update('autoDownload', false, vscode.ConfigurationTarget.Global);
+      await config.update('serverPath', '', vscode.ConfigurationTarget.Global);
+      await config.update('channel', 'tag', vscode.ConfigurationTarget.Global);
+      await config.update('versionTag', releaseTag(binaryVersion), vscode.ConfigurationTarget.Global);
+      await config.update('downloadBaseUrl', '', vscode.ConfigurationTarget.Global);
+      await config.update('updateCheckInterval', 0, vscode.ConfigurationTarget.Global);
+      await config.update('perlcritic.enabled', false, vscode.ConfigurationTarget.Global);
+
+      if (process.platform === 'linux') {
+        await config.update('linuxLibc', 'gnu', vscode.ConfigurationTarget.Global);
+      }
+
+      let activationFailure: unknown;
+      void Promise.resolve(extension.activate()).catch((error: unknown) => {
+        activationFailure = error;
+      });
+
+      await waitForCommand('perl-lsp.reinstall', 15_000);
+      await waitForCommand('perl-lsp.runHealthCheck', 15_000);
+      if (activationFailure) {
+        throw activationFailure;
+      }
+
+      await config.update('autoDownload', true, vscode.ConfigurationTarget.Global);
+
+      appendLog(artifacts, 'starting first reinstall');
+      const reinstall1 = await withTimeout(
+        'published managed binary reinstall command (first)',
+        vscode.commands.executeCommand<ReinstallCommandResult>('perl-lsp.reinstall'),
+        120_000,
       );
-      return;
+      results.reinstall1 = reinstall1;
+      assert.ok(reinstall1, 'first reinstall command should return a structured result');
+      assert.equal(reinstall1.ok, true, JSON.stringify(reinstall1, null, 2));
+      assert.ok(reinstall1.serverPath, 'first reinstall result should include the managed binary path');
+      assert.ok(
+        fs.existsSync(reinstall1.serverPath),
+        `managed binary should exist after first reinstall: ${reinstall1.serverPath}`,
+      );
+      assert.ok(reinstall1.target, 'first reinstall result should include the release target triple');
+      assert.equal(
+        reinstall1.checksumVerified,
+        true,
+        'first reinstall should verify SHA256SUMS',
+      );
+
+      if (process.platform === 'linux') {
+        assert.match(reinstall1.target, /-unknown-linux-gnu$/);
+      }
+
+      artifacts.state.firstReinstallOk = true;
+      artifacts.state.serverPath = reinstall1.serverPath;
+      artifacts.state.target = reinstall1.target;
+      artifacts.state.installedVersion = reinstall1.version ?? null;
+      artifacts.state.managedSource = reinstall1.source;
+
+      const mtimeBefore = fs.statSync(reinstall1.serverPath).mtimeMs;
+      artifacts.state.binaryMtimeBefore = mtimeBefore;
+
+      appendLog(artifacts, 'running first health check');
+      const health1 = await withTimeout(
+        'published managed binary health check command (first)',
+        vscode.commands.executeCommand<HealthCheckCommandResult>(
+          'perl-lsp.runHealthCheck',
+          reinstall1.serverPath,
+        ),
+        45_000,
+      );
+      results.health1 = health1;
+      assert.ok(health1, 'first health check should return a structured result');
+      assert.equal(health1.ok, true, JSON.stringify(health1.checks, null, 2));
+      assert.ok(
+        health1.checks.some(check => check.label === 'LSP binary' && check.status === 'ok'),
+        JSON.stringify(health1.checks, null, 2),
+      );
+      artifacts.state.firstHealthOk = true;
+
+      if (!supportsLockedReinstall) {
+        appendLog(
+          artifacts,
+          `published extension ${packageVersion} predates locked-reinstall guarantee — single-pass smoke complete`,
+        );
+        return;
+      }
+
+      // 0.13.3+ guarantees: a second reinstall must succeed even when perllsp
+      // is held by a running process. Spawn the binary so the OS holds the
+      // executable file handle, then run reinstall a second time.
+      appendLog(artifacts, 'spawning perllsp to hold the binary across second reinstall');
+      lockingProcess = spawn(reinstall1.serverPath, [], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+      lockingProcess.stdout.on('data', () => { /* drain */ });
+      lockingProcess.stderr.on('data', () => { /* drain */ });
+      lockingProcess.on('error', err => {
+        appendLog(artifacts, `locking process error: ${err.message}`);
+      });
+      await delay(750);
+      const lockingExited = lockingProcess.exitCode !== null;
+      artifacts.state.lockingProcessSpawned = !lockingExited;
+      artifacts.state.lockingProcessPid = lockingProcess.pid ?? null;
+      if (lockingExited) {
+        appendLog(
+          artifacts,
+          `locking process exited early with code=${lockingProcess.exitCode}; second reinstall will run without lock`,
+        );
+      }
+
+      appendLog(artifacts, 'starting second reinstall while binary is held');
+      artifacts.state.secondReinstallExercised = true;
+      const reinstall2 = await withTimeout(
+        'published managed binary reinstall command (second, locked)',
+        vscode.commands.executeCommand<ReinstallCommandResult>('perl-lsp.reinstall'),
+        120_000,
+      );
+      results.reinstall2 = reinstall2;
+      assert.ok(reinstall2, 'second reinstall command should return a structured result');
+      assert.equal(reinstall2.ok, true, JSON.stringify(reinstall2, null, 2));
+      assert.ok(
+        fs.existsSync(reinstall2.serverPath),
+        `managed binary should exist after second reinstall: ${reinstall2.serverPath}`,
+      );
+      assert.equal(
+        reinstall2.checksumVerified,
+        true,
+        'second reinstall should verify SHA256SUMS',
+      );
+
+      const mtimeAfter = fs.statSync(reinstall2.serverPath).mtimeMs;
+      artifacts.state.binaryMtimeAfter = mtimeAfter;
+      artifacts.state.binaryRewrittenSecondPass = mtimeAfter >= mtimeBefore;
+      artifacts.state.secondReinstallOk = true;
+
+      appendLog(artifacts, 'running second health check');
+      const health2 = await withTimeout(
+        'published managed binary health check command (second)',
+        vscode.commands.executeCommand<HealthCheckCommandResult>(
+          'perl-lsp.runHealthCheck',
+          reinstall2.serverPath,
+        ),
+        45_000,
+      );
+      results.health2 = health2;
+      assert.ok(health2, 'second health check should return a structured result');
+      assert.equal(health2.ok, true, JSON.stringify(health2.checks, null, 2));
+      assert.ok(
+        health2.checks.some(check => check.label === 'LSP binary' && check.status === 'ok'),
+        JSON.stringify(health2.checks, null, 2),
+      );
+      artifacts.state.secondHealthOk = true;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      artifacts.state.lastError = msg;
+      appendLog(artifacts, `smoke failed: ${msg}`);
+      throw err;
+    } finally {
+      killLockingProcess(lockingProcess);
+      artifacts.state.completedAt = new Date().toISOString();
+      writeArtifacts(receiptsDir, artifacts, results);
     }
-
-    const config = vscode.workspace.getConfiguration('perl-lsp');
-    const binaryVersion = process.env.PERL_LSP_PUBLISHED_BINARY_VERSION || expectedVersion || packageVersion;
-    await config.update('autoDownload', false, vscode.ConfigurationTarget.Global);
-    await config.update('serverPath', '', vscode.ConfigurationTarget.Global);
-    await config.update('channel', 'tag', vscode.ConfigurationTarget.Global);
-    await config.update('versionTag', releaseTag(binaryVersion), vscode.ConfigurationTarget.Global);
-    await config.update('downloadBaseUrl', '', vscode.ConfigurationTarget.Global);
-    await config.update('updateCheckInterval', 0, vscode.ConfigurationTarget.Global);
-    await config.update('perlcritic.enabled', false, vscode.ConfigurationTarget.Global);
-
-    if (process.platform === 'linux') {
-      await config.update('linuxLibc', 'gnu', vscode.ConfigurationTarget.Global);
-    }
-
-    let activationFailure: unknown;
-    void Promise.resolve(extension.activate()).catch((error: unknown) => {
-      activationFailure = error;
-    });
-
-    await waitForCommand('perl-lsp.reinstall', 15_000);
-    await waitForCommand('perl-lsp.runHealthCheck', 15_000);
-    if (activationFailure) {
-      throw activationFailure;
-    }
-
-    await config.update('autoDownload', true, vscode.ConfigurationTarget.Global);
-
-    const reinstall = await withTimeout(
-      'published managed binary reinstall command',
-      vscode.commands.executeCommand<ReinstallCommandResult>('perl-lsp.reinstall'),
-      120_000,
-    );
-    assert.ok(reinstall, 'reinstall command should return a structured result');
-    assert.equal(reinstall.ok, true, JSON.stringify(reinstall, null, 2));
-    assert.ok(reinstall.serverPath, 'reinstall result should include the managed binary path');
-    assert.ok(fs.existsSync(reinstall.serverPath), `managed binary should exist: ${reinstall.serverPath}`);
-    assert.ok(reinstall.target, 'reinstall result should include the release target triple');
-    assert.equal(reinstall.checksumVerified, true, 'managed binary download should verify SHA256SUMS');
-
-    if (process.platform === 'linux') {
-      assert.match(reinstall.target, /-unknown-linux-gnu$/);
-    }
-
-    const health = await withTimeout(
-      'published managed binary health check command',
-      vscode.commands.executeCommand<HealthCheckCommandResult>(
-        'perl-lsp.runHealthCheck',
-        reinstall.serverPath,
-      ),
-      45_000,
-    );
-
-    assert.ok(health, 'health check command should return a structured result');
-    assert.equal(health.ok, true, JSON.stringify(health.checks, null, 2));
-    assert.ok(
-      health.checks.some(check => check.label === 'LSP binary' && check.status === 'ok'),
-      JSON.stringify(health.checks, null, 2),
-    );
   });
 });

--- a/vscode-extension/src/test/published/runPublishedSmoke.ts
+++ b/vscode-extension/src/test/published/runPublishedSmoke.ts
@@ -197,8 +197,12 @@ async function main(): Promise<void> {
   const downloadDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-published-smoke-download-'));
   const harnessExtensionPath = path.resolve(process.cwd(), 'src/test/published/harness');
   const extensionTestsPath = path.resolve(__dirname, './suite');
+  const repoRoot = path.resolve(__dirname, '../../../..');
   const vscodeExecutablePath = await downloadAndUnzipVSCode();
   const installTarget = await resolveInstallTarget(source, downloadDir);
+  const receiptsRoot = process.env.PERL_LSP_SMOKE_RECEIPTS_DIR
+    || path.join(repoRoot, 'target', 'receipts', 'vscode-smoke');
+  fs.mkdirSync(receiptsRoot, { recursive: true });
 
   fs.writeFileSync(path.join(workspacePath, 'smoke.pl'), "use strict;\nuse warnings;\nprint \"ok\\n\";\n");
 
@@ -213,6 +217,8 @@ async function main(): Promise<void> {
       PERL_LSP_EXTENSION_TEST_SKIP_STARTUP: '1',
       PERL_LSP_PUBLISHED_EXTENSION_ID: envValue('PERL_LSP_PUBLISHED_EXTENSION_ID') || EXTENSION_ID,
       PERL_LSP_PUBLISHED_EXTENSION_SOURCE: source,
+      PERL_LSP_SMOKE_RECEIPTS_DIR: receiptsRoot,
+      PERL_LSP_SMOKE_SOURCE_LABEL: process.env.PERL_LSP_SMOKE_SOURCE_LABEL || source,
     },
     launchArgs: [
       workspacePath,


### PR DESCRIPTION
## Summary

- Real-world Windows reinstalls hit two failure modes #7862's retry-only fix cannot cover: source-side EBUSY from Defender holding a freshly extracted perllsp.exe, and destination-side EBUSY from a running perllsp.exe being overwritten in place.
- This PR ships the four 0.13.3 install-reliability fixes together so the user-visible failure (\"Failed to obtain a Perl LSP binary\" / EBUSY on reinstall) actually goes away.
- Strengthened source + published smokes prove both paths and write artifacts under target/receipts/vscode-smoke/ on every run.

## Changes

**Downloader** (\`vscode-extension/src/downloader.ts\`)
- Retry budget for transient EBUSY/EPERM/EACCES/ETXTBSY copies extended from ~4s to ~31s. Covers Defender first-time signature scans on a fresh release artifact.
- Versioned managed install dirs. Each install lands in \`globalStorage/.../bin/<platform>-<arch>/<tag>-<iso-stamp>/\`. The active install is selected by an atomically-committed \`current\` pointer file. A forced reinstall while perllsp.exe is held lands in a fresh sibling dir instead of trying to overwrite the running file. Legacy flat-layout installs are grandfathered until the next reinstall.
- Singleflight install at module scope: activation auto-download, manual Reinstall, and the silent update check coalesce so two installs cannot race the same destination.
- Best-effort prune of stale versioned dirs (keeps current + one prior for fallback).

**Extension** (\`vscode-extension/src/extension.ts\`)
- \`Perl: Reinstall Server Binary\` is now lifecycle-safe: capture wasRunning, stop client + wait for OS handle release, install, restart with fresh binary on success, fall back to the previous binary on failure so users never end up worse off than before clicking Reinstall.

**Smokes** (\`src/test/integration/managedBinarySmoke.test.ts\`, \`src/test/published/managedBinaryPublishedSmoke.test.ts\`)
- Both suites now reinstall twice. The second pass spawns perllsp directly via child_process so the OS holds the executable file handle during the install — the canonical user-facing failure shape.
- Assert both reinstalls return ok + checksumVerified and both health checks pass.
- Write receipts on both pass and fail under \`target/receipts/vscode-smoke/<source>/<os>/\` (extension-output.log, command-results.json, managed-binary-state.json).
- Published smoke gates the second-reinstall requirement on packageVersion >= 0.13.3 so the existing 0.13.2 published smoke continues to pass.

**Workflows** (\`.github/workflows/vscode-{managed-binary,published-extension}-smoke.yml\`)
- Upload \`target/receipts/vscode-smoke/**\` on every run (always()).

## Local verification (Windows 11 + Defender)

- \`npm test -- --runTestsByPath src/test/downloader.test.ts\`: 85/85 green
- \`npm run test:integration\`: 2 consecutive passes, both reinstalls land in distinct versioned dirs while an externally-spawned perllsp.exe holds the first.

Receipt fragment:
\`\`\`
reinstall1.serverPath: ...\bin\win32-x64\v0.13.1-2026-05-03T06-47-43-545Z\perllsp.exe
reinstall2.serverPath: ...\bin\win32-x64\v0.13.1-2026-05-03T06-47-45-506Z\perllsp.exe
firstReinstallOk: true, firstHealthOk: true
secondReinstallOk: true, secondHealthOk: true
lockingProcessSpawned: true
\`\`\`

## Test plan

- [ ] CI: VS Code Managed Binary Smoke green on windows-latest, ubuntu-latest, macos-latest.
- [ ] CI: smoke artifacts uploaded as \`vscode-smoke-source-<os>\`.
- [ ] CI: jest unit tests still green (downloader.test.ts especially).
- [ ] After merge: prepare v0.13.3 release-prep PR.
- [ ] After publish: dispatch \`vscode-published-extension-smoke.yml\` for both \`marketplace\` and \`open-vsx\` at version=0.13.3 — windows + macos + ubuntu must all pass.
- [ ] After publish: manual Windows VS Code stable + Insiders smoke (Reinstall x2, Health x2, no EBUSY/EPERM/EACCES).

This PR is the foundation for the 0.13.3 install-smoothness release. Release-prep and full-train dispatch land in subsequent PRs.