### PR TITLE
chore(release): prepare v0.13.3 (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.3] - 2026-05-03
+
+Release notes: [v0.13.3](docs/releases/v0.13.3.md)
+
+### Fixed
+
+- **VS Code managed binary install reliability** — Reinstall now installs
+  into a versioned subdirectory and atomically updates a `current` pointer,
+  so a forced reinstall while the previous `perllsp.exe` is held by a
+  running process lands in a fresh sibling directory instead of failing
+  with `EBUSY`.
+- **Lifecycle-safe `Perl: Reinstall Server Binary`** — The command stops a
+  running language client before installing, restarts with the newly
+  installed binary on success, and falls back to the previous binary on
+  download or health-check failure so a failed reinstall never leaves the
+  user worse off than before.
+- **Extended retry budget for transient managed-install file locks** —
+  Total retry wait grows from ~4s to ~31s, covering the upper end of
+  Windows Defender first-time signature scans on a fresh release artifact.
+- **Singleflight managed install** — Activation auto-download, manual
+  Reinstall, and the silent update check coalesce so two installs cannot
+  race the same destination path.
+
+### Changed
+
+- Strengthened source and published VS Code smokes to reinstall twice
+  across Windows, macOS, and Linux, with the binary held by a spawned
+  process during the second pass. Smokes upload artifacts under
+  `target/receipts/vscode-smoke/<source>/<os>/` on every run.
+- Prepared the `v0.13.3` public-alpha patch train with workspace, crate,
+  feature catalog, and VS Code extension version surfaces aligned.
+
 ## [0.13.2] - 2026-05-02
 
 Release notes: [v0.13.2](docs/releases/v0.13.2.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**Latest Release**: 0.13.2 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
+**Latest Release**: 0.13.3 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
 
 ## Orchestration Model
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,7 +1481,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1490,14 +1490,14 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "chrono",
  "clap",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "perl-corpus"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-workspace",
  "serde",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-test-must",
  "serde",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lexer"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "criterion",
  "memchr",
@@ -1607,11 +1607,11 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.13.2"
+version = "0.13.3"
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-subprocess-runtime",
  "perl-tdd-support",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs-core"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ux-tests"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-parser-core",
  "perl-tdd-support",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-bench"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-parser",
  "walkdir",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -1803,11 +1803,11 @@ dependencies = [
 
 [[package]]
 name = "perl-pod"
-version = "0.13.2"
+version = "0.13.3"
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "criterion",
  "perl-ast",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "proptest",
  "thiserror",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-facts"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "proptest",
  "serde",
@@ -1877,14 +1877,14 @@ dependencies = [
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "lsp-types",
  "perl-parser-core",
@@ -1911,18 +1911,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.13.2"
+version = "0.13.3"
 
 [[package]]
 name = "perl-token"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "criterion",
  "perl-lexer",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "perllsp"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -3173,7 +3173,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl-c"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-perl-rs"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "insta",
  "perl-ast",
@@ -3860,7 +3860,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -212,26 +212,26 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.13.2" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.13.3" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.13.2" }
-perl-regex = { path = "crates/perl-regex", version = "0.13.2" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.13.2" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.13.2" }
-perl-ast = { path = "crates/perl-ast", version = "0.13.2" }
+perl-token = { path = "crates/perl-token", version = "0.13.3" }
+perl-regex = { path = "crates/perl-regex", version = "0.13.3" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.13.3" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.13.3" }
+perl-ast = { path = "crates/perl-ast", version = "0.13.3" }
 # Wave D absorbed (internal modules in perl-parser/src/):
 #   perl-heredoc-anti-patterns → perl-parser::heredoc_anti_patterns
 # Wave D absorbed (internal modules in perl-parser-core/src/syntax/):
 #   perl-quote, perl-heredoc, perl-error, perl-edit
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.13.2" }
-perl-symbol = { path = "crates/perl-symbol", version = "0.13.2" }
-perl-module = { path = 'crates/perl-module', version = "0.13.2" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.13.3" }
+perl-symbol = { path = "crates/perl-symbol", version = "0.13.3" }
+perl-module = { path = 'crates/perl-module', version = "0.13.3" }
 # Wave D absorbed: perl-qualified-name → perl-parser::qualified_name
-perl-line-index = { path = "crates/perl-line-index", version = "0.13.2" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.13.3" }
 # Wave D absorbed: perl-source-file → perl-parser::source_file
 # Wave D absorbed: perl-text-line → perl-parser-core::text_line
 # (perl-content-length-framing absorbed into perl-lsp-rs-core::transport::framing — Wave Final PR B)
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.13.2" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.13.3" }
 # (perl-lsp-document-highlight absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-document-links absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-performance absorbed into perl-lsp-rs-core::tooling::performance — Wave G3 step 5)
@@ -239,30 +239,30 @@ perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "
 # Wave D absorbed: perl-ast-utils → perl-parser::ast_utils
 # (perl-lsp-input-validation absorbed into perl-lsp-rs-core::runtime::input_validation — Wave G2)
 # (perl-lsp-text-utils absorbed into perl-lsp-rs-core::runtime::text_utils — Wave G2)
-perl-uri = { path = "crates/perl-uri", version = "0.13.2" }
+perl-uri = { path = "crates/perl-uri", version = "0.13.3" }
 # Wave D absorbed: perl-percentile → perl-parser::percentile
 # (perl-lsp-import-management absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-critic-parser absorbed into perl-lsp-rs-core::critic_parser — Wave G3 step 7)
 # (perl-lsp-protocol absorbed into perl-lsp-rs-core::protocol — Wave G3 step 2)
 # Wave D absorbed: perl-path-normalize → perl-parser-core::path_normalize
 # Wave D absorbed: perl-path-security → perl-parser-core::path_security
-perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.13.2" }
-perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.13.2" }
-perl-pod = { path = "crates/perl-pod", version = "0.13.2" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.13.2" }
-perl-dap = { path = "crates/perl-dap", version = "0.13.2" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.13.2" }
+perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.13.3" }
+perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.13.3" }
+perl-pod = { path = "crates/perl-pod", version = "0.13.3" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.13.3" }
+perl-dap = { path = "crates/perl-dap", version = "0.13.3" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.13.3" }
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.13.2" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.13.3" }
 # (perl-lsp-transport absorbed into perl-lsp-rs-core::transport — Wave G3 step 4)
 # (perl-lsp-tooling absorbed into perl-lsp-rs-core::tooling — Wave G3 step 6)
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.13.2" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.13.3" }
 # (perl-lsp-on-type-formatting absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting-types absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting absorbed into perl-lsp-rs-core::providers::formatting — Wave G1b)
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.13.2" }
-perl-test-must = { path = "crates/perl-test-must", version = "0.13.2" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.13.3" }
+perl-test-must = { path = "crates/perl-test-must", version = "0.13.3" }
 # (perl-lsp-diagnostics absorbed into perl-lsp-rs-core::providers::diagnostics — Wave G1b)
 # (perl-lsp-semantic-tokens absorbed into perl-lsp-rs-core::providers::semantic_tokens — Wave G1b)
 # (perl-lsp-inlay-hints absorbed into perl-lsp-rs-core::providers — Wave G1a)
@@ -286,28 +286,28 @@ perl-test-must = { path = "crates/perl-test-must", version = "0.13.2" }
 # (perl-lsp-code-actions absorbed into perl-lsp-rs-core::providers::code_actions — Wave G1b)
 # (perl-lsp-folding absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-selection-range absorbed into perl-lsp-rs-core::providers — Wave G1a)
-perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.13.2" }
+perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.13.3" }
 # Tier 3: Two-level dependencies
-perl-workspace = { path = "crates/perl-workspace", version = "0.13.2" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.13.2" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.13.2" }
+perl-workspace = { path = "crates/perl-workspace", version = "0.13.3" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.13.3" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.13.3" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.13.2" }
-perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.13.2" }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.13.3" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.13.3" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.13.2" }
-perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.13.2" }
-perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.13.2" }
+perl-parser = { path = "crates/perl-parser", version = "0.13.3" }
+perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.13.3" }
+perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.13.3" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.13.2" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.13.3" }
 
 # External dependencies
-tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.13.2" }
-tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.13.2" }
+tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.13.3" }
+tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.13.3" }
 tree-sitter = "0.26.8"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-module"
-version = "0.13.2"
+version = "0.13.3"
 publish = true
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -8,7 +8,7 @@
 
 ## Current Framing
 
-- Workspace version line: `v0.13.2`
+- Workspace version line: `v0.13.3`
 - Current release train: `v0.13.2` public-alpha patch prep, with release dispatch intentionally pending
 - Published crate surface target: 31 crates from `[workspace.metadata.publish.allow]`
 - Active work: finish release-prep verification, keep install-surface receipts wired into the runbook, and keep release language public-alpha rather than stable/GA

--- a/docs/releases/v0.13.3.md
+++ b/docs/releases/v0.13.3.md
@@ -1,0 +1,81 @@
+---
+version: "0.13.3"
+tag: "v0.13.3"
+release_date_utc: "2026-05-03"
+previous_tag: "v0.13.2"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.2...v0.13.3"
+notes_status: canonical
+release_track: public-alpha
+release_kind: patch
+channels:
+  crates_io: pending
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: pending
+  docker: pending
+---
+
+# v0.13.3
+
+## Summary
+
+Public-alpha patch release focused on VS Code managed binary install
+reliability. Reinstall is now safe to run while the language server is
+running on Windows, and first-time installs survive Windows Defender
+signature scanning of freshly extracted release artifacts.
+
+## Highlights
+
+- **Versioned managed install dirs** — Each managed install now lands in
+  `globalStorage/.../bin/<platform>-<arch>/<tag>-<iso-stamp>/`. The active
+  install is selected by an atomically-committed `current` pointer file. A
+  forced reinstall while `perllsp.exe` is held by a running process now
+  installs to a fresh sibling directory instead of trying to overwrite the
+  running file.
+- **Lifecycle-safe `Perl: Reinstall Server Binary`** — The command stops a
+  running language client before installing, restarts with the freshly
+  installed binary on success, and falls back to the previous binary on
+  download or health-check failure so users never end up worse off than
+  before they invoked Reinstall.
+- **Extended retry budget for transient install locks** — Total retry wait
+  for `EBUSY`, `EPERM`, `EACCES`, and `ETXTBSY` copy errors now grows to
+  ~31 seconds, covering the upper end of Windows Defender first-time
+  signature scans on a fresh release artifact.
+- **Singleflight install lock** — Activation auto-download, manual
+  Reinstall, and the silent update check now coalesce so two installs
+  cannot race the same destination path.
+- **Stronger source and published extension smokes** — Both reinstall
+  twice across Windows, macOS, and Linux. The second pass holds the
+  binary via a spawned process before reinstalling, exercising the
+  exact lock condition users hit on Windows. Smoke artifacts upload
+  on every run under `target/receipts/vscode-smoke/<source>/<os>/`.
+
+## Install / upgrade
+
+- **VS Code**: install or update the
+  [Perl Language Server](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+  extension. The managed `perllsp` binary is part of the public-alpha line.
+- **Homebrew tap**: install with `brew install effortlessmetrics/tap/perllsp`.
+  This uses the owned EffortlessMetrics tap, not Homebrew/core.
+- **Source/Binary**: download release assets or use `cargo install perllsp`
+  for the published public-alpha line.
+
+## Which file should I download?
+
+Most Linux users should choose `gnu`. Use `musl` mainly for Alpine Linux or
+musl-based containers. You do not need both GNU and musl archives.
+
+| Your system | Download suffix |
+|---|---|
+| Linux x64 / AMD64, most distributions | `x86_64-unknown-linux-gnu` |
+| Linux ARM64, most distributions | `aarch64-unknown-linux-gnu` |
+| Linux x64 / AMD64, Alpine or musl containers | `x86_64-unknown-linux-musl` |
+| Linux ARM64, Alpine or musl containers | `aarch64-unknown-linux-musl` |
+| macOS Intel | `x86_64-apple-darwin` |
+| macOS Apple Silicon | `aarch64-apple-darwin` |
+| Windows x64 | `x86_64-pc-windows-msvc` |
+
+## Links
+
+- [Compare v0.13.2...v0.13.3](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.2...v0.13.3)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/features.toml
+++ b/features.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.13.2"
+version = "0.13.3"
 lsp_version = "3.18"
 compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 118/119 advertised
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.17",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
## Summary

- Public-alpha patch release focused on VS Code managed binary install reliability. Reinstall is safe to run while the language server is running on Windows; first-time installs survive Defender signature scanning of freshly extracted release artifacts.
- The shipped fixes are in #7870 \`fix(vscode): harden managed binary install for 0.13.3\`. This PR is the version-bump + release-notes sibling that lands once #7870 merges.
- Bumped 42 sites across 7 files via \`cargo xtask bump-version 0.13.3\`, plus Cargo.lock workspace pins and a CHANGELOG entry / release notes doc.

This PR is **draft and chained off #7870**. GitHub will retarget the base to master automatically once #7870 merges.

## Version surfaces touched

\`\`\`
Cargo.toml workspace + dependency pins -> 0.13.3
Cargo.lock workspace crates            -> 0.13.3
features.toml                          -> 0.13.3
vscode-extension/package.json + lock   -> 0.13.3
crates/perl-module/Cargo.toml          -> 0.13.3
CLAUDE.md latest-release line          -> 0.13.3
docs/project/ROADMAP.md                -> 0.13.3
CHANGELOG.md                           -> [0.13.3] entry
docs/releases/v0.13.3.md               -> created
\`\`\`

## Pre-release checks (local)

\`\`\`
cargo xtask check-version-sync     -> 42/42 sites agree on 0.13.3
cargo xtask install-surface-check  -> passed
bash scripts/check_release_history.sh -> passed
bash scripts/tests/test-install-target-selection.sh -> skipped (Windows host)
cargo xtask release-notes --tag v0.13.3 -> body contains chooser + gnu + musl + windows
git diff --check -> clean
\`\`\`

## Test plan

- [ ] Wait for #7870 to merge.
- [ ] Rebase this PR onto master (or let GitHub retarget the base).
- [ ] CI: validate-title + check-version-sync + Compile All Targets + PR Smoke green.
- [ ] After merge: dispatch \`release-orchestration.yml\` with version=0.13.3, no skips.
- [ ] After publish: dispatch \`vscode-published-extension-smoke.yml\` for both \`marketplace\` and \`open-vsx\` at version=0.13.3 — windows + macos + ubuntu must all pass.
- [ ] After publish: dispatch \`brew-bump.yml\` with tag=v0.13.3.
- [ ] Manual Windows VS Code stable + Insiders smoke (Reinstall x2, Health x2, no EBUSY/EPERM/EACCES).
- [ ] Capture release receipt under \`target/receipts/release-install-surface-v0.13.3.md\`.