### PR TITLE
feat(diagnostics): add dynamic callable evidence infrastructure for strict-bareword diagnostics (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
@@ -463,7 +463,9 @@ mod tests {
         EntityFact, EntityId, EntityKind, FileId, OccurrenceFact, Provenance, RenamePlan,
         SafeDeletePlan, ScopeId, VisibleSymbol, VisibleSymbolContext, VisibleSymbolSource,
     };
-    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+    use perl_workspace::semantic::queries::{
+        DynamicCallableEvidence, QueryContext, SemanticQueries,
+    };
     use perl_workspace::semantic_shadow_compare::ShadowCompareVerdict;
     use std::collections::BTreeMap;
 
@@ -529,7 +531,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }
@@ -609,7 +611,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
@@ -523,6 +523,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     struct MethodCandidateStub {
@@ -591,6 +600,15 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
         ) -> Option<OccurrenceFact> {
             None
         }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
@@ -13,7 +13,7 @@ use perl_semantic_facts::{
     DefinitionCandidate, EntityFact, EntityId, FileId, OccurrenceFact, RenamePlan, SafeDeletePlan,
     ScopeId, VisibleSymbol,
 };
-use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+use perl_workspace::semantic::queries::{DynamicCallableEvidence, QueryContext, SemanticQueries};
 
 use super::dedup::deduplicate_diagnostics;
 use super::lints::common_mistakes::check_common_mistakes;
@@ -103,7 +103,7 @@ impl SemanticQueries for NullSemanticQueries {
         _file_id: FileId,
         _byte_offset: u32,
         _symbol: &str,
-    ) -> Option<OccurrenceFact> {
+    ) -> Option<DynamicCallableEvidence> {
         None
     }
 }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
@@ -97,6 +97,15 @@ impl SemanticQueries for NullSemanticQueries {
     ) -> Option<OccurrenceFact> {
         None
     }
+
+    fn dynamic_callable_may_be_visible_at(
+        &self,
+        _file_id: FileId,
+        _byte_offset: u32,
+        _symbol: &str,
+    ) -> Option<OccurrenceFact> {
+        None
+    }
 }
 
 // Re-export diagnostic types from local internal types module.

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
@@ -343,7 +343,7 @@ mod tests {
         EntityFact, EntityId, EntityKind, FileId, OccurrenceFact, Provenance, RenamePlan,
         SafeDeletePlan, ScopeId, VisibleSymbol,
     };
-    use perl_workspace::semantic::queries::SemanticQueries;
+    use perl_workspace::semantic::queries::{DynamicCallableEvidence, SemanticQueries};
     use perl_workspace::semantic_shadow_compare::ShadowCompareVerdict;
 
     // ── Minimal SemanticQueries stub for testing ──
@@ -408,7 +408,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
@@ -402,6 +402,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_candidate(

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs
@@ -162,6 +162,29 @@ mod tests {
                 None
             }
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            // When the stub is in a dynamic scope, dynamic callables may also
+            // be visible (same condition as dynamic_boundary_at).
+            if self.rename_blocked || self.safe_delete_blocked {
+                Some(OccurrenceFact {
+                    id: perl_semantic_facts::OccurrenceId(9998),
+                    kind: perl_semantic_facts::OccurrenceKind::DynamicBoundary,
+                    entity_id: None,
+                    anchor_id: AnchorId(9998),
+                    scope_id: None,
+                    provenance: perl_semantic_facts::Provenance::DynamicBoundary,
+                    confidence: perl_semantic_facts::Confidence::Low,
+                })
+            } else {
+                None
+            }
+        }
     }
 
     // ── Helpers ──
@@ -579,6 +602,14 @@ mod tests {
                 _: Option<&str>,
             ) -> Option<OccurrenceFact> {
                 None // no dynamic boundary anywhere
+            }
+            fn dynamic_callable_may_be_visible_at(
+                &self,
+                _: FileId,
+                _: u32,
+                _: &str,
+            ) -> Option<OccurrenceFact> {
+                None // no dynamic callables either
             }
         }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs
@@ -30,7 +30,9 @@ mod tests {
         EntityFact, EntityId, EntityKind, FileId, OccurrenceFact, PlanBlocker, PlanBlockerReason,
         Provenance, RenamePlan, SafeDeletePlan, ScopeId, VisibleSymbol,
     };
-    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+    use perl_workspace::semantic::queries::{
+        DynamicCallableEvidence, QueryContext, SemanticQueries,
+    };
 
     // ── Configurable SemanticQueries stub ──
 
@@ -165,21 +167,17 @@ mod tests {
 
         fn dynamic_callable_may_be_visible_at(
             &self,
-            _file_id: FileId,
+            file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             // When the stub is in a dynamic scope, dynamic callables may also
             // be visible (same condition as dynamic_boundary_at).
             if self.rename_blocked || self.safe_delete_blocked {
-                Some(OccurrenceFact {
-                    id: perl_semantic_facts::OccurrenceId(9998),
-                    kind: perl_semantic_facts::OccurrenceKind::DynamicBoundary,
-                    entity_id: None,
-                    anchor_id: AnchorId(9998),
-                    scope_id: None,
-                    provenance: perl_semantic_facts::Provenance::DynamicBoundary,
-                    confidence: perl_semantic_facts::Confidence::Low,
+                Some(DynamicCallableEvidence::DynamicImport {
+                    file_id,
+                    anchor_id: Some(AnchorId(9998)),
+                    module: "DynamicBoundaryStub".to_string(),
                 })
             } else {
                 None
@@ -608,7 +606,7 @@ mod tests {
                 _: FileId,
                 _: u32,
                 _: &str,
-            ) -> Option<OccurrenceFact> {
+            ) -> Option<DynamicCallableEvidence> {
                 None // no dynamic callables either
             }
         }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/mod.rs
@@ -43,7 +43,7 @@ mod lints;
 /// Parse error to diagnostic conversion
 mod parse_errors;
 /// Scope analysis integration
-mod scope;
+pub mod scope;
 /// AST walker utilities
 mod walker;
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
@@ -410,7 +410,9 @@ mod tests {
         OccurrenceId, OccurrenceKind, Provenance, RenamePlan, SafeDeletePlan, ScopeId,
         VisibleSymbol,
     };
-    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+    use perl_workspace::semantic::queries::{
+        DynamicCallableEvidence, QueryContext, SemanticQueries,
+    };
 
     // ── Stub that simulates dynamic boundary coverage at any position ──
 
@@ -481,7 +483,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }
@@ -545,7 +547,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }
@@ -640,19 +642,15 @@ mod tests {
 
         fn dynamic_callable_may_be_visible_at(
             &self,
-            _file_id: FileId,
+            file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             // Simulates a file with a dynamic import: any bareword might be visible.
-            Some(OccurrenceFact {
-                id: OccurrenceId(6666),
-                kind: OccurrenceKind::DynamicBoundary,
-                entity_id: None,
-                anchor_id: AnchorId(6666),
-                scope_id: None,
-                provenance: Provenance::DynamicBoundary,
-                confidence: Confidence::Low,
+            Some(DynamicCallableEvidence::DynamicImport {
+                file_id,
+                anchor_id: Some(AnchorId(6666)),
+                module: "StubModule".to_string(),
             })
         }
     }
@@ -770,7 +768,7 @@ mod tests {
                 _: FileId,
                 _: u32,
                 _: &str,
-            ) -> Option<OccurrenceFact> {
+            ) -> Option<DynamicCallableEvidence> {
                 None
             }
         }
@@ -907,17 +905,19 @@ mod tests {
                 _: FileId,
                 _: u32,
                 symbol: &str,
-            ) -> Option<OccurrenceFact> {
+            ) -> Option<DynamicCallableEvidence> {
                 // Only suppress the named sub from the eval string.
                 if symbol == "generated_from_string" {
-                    Some(OccurrenceFact {
-                        id: OccurrenceId(5555),
-                        kind: OccurrenceKind::DynamicBoundary,
-                        entity_id: None,
-                        anchor_id: AnchorId(5555),
-                        scope_id: None,
-                        provenance: Provenance::DynamicBoundary,
-                        confidence: Confidence::Low,
+                    Some(DynamicCallableEvidence::EvalSub {
+                        occurrence: OccurrenceFact {
+                            id: OccurrenceId(5555),
+                            kind: OccurrenceKind::DynamicBoundary,
+                            entity_id: None,
+                            anchor_id: AnchorId(5555),
+                            scope_id: None,
+                            provenance: Provenance::DynamicBoundary,
+                            confidence: Confidence::Low,
+                        },
                     })
                 } else {
                     None

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
@@ -78,24 +78,35 @@ pub fn scope_issues_to_diagnostics(issues: Vec<ScopeIssue>) -> Vec<Diagnostic> {
 /// Convert scope analyzer issues to diagnostics with dynamic-boundary suppression.
 ///
 /// Extends [`scope_issues_to_diagnostics`] by consulting `semantic_queries`
-/// for each `UndeclaredVariable` issue. If the issue's position is covered by
-/// dynamic-boundary evidence (e.g., `require $var`, string `eval`, typeglob
-/// assignment, or AUTOLOAD scope), the diagnostic is **suppressed** for that
-/// specific variable.
+/// for `UndeclaredVariable` and `UnquotedBareword` issues.
 ///
-/// # Suppression policy (Q3 architectural decision)
+/// # Suppression policy
 ///
-/// - High-confidence normal missing symbol → diagnostic still fires.
-/// - Dynamic boundary covering THE specific variable → suppress that exact
-///   undefined diagnostic.
-/// - Ambiguous but not dynamic → emit the diagnostic (conservative default).
-/// - Unavailable semantic path (no shard for file) → fall back to emitting
-///   the diagnostic (no false suppression).
+/// ## `UndeclaredVariable` (position-scoped)
 ///
-/// Importantly, a dynamic construct anywhere in the file does **not** suppress
-/// unrelated diagnostics: `require $module; print $undeclared_static_var;`
-/// still fires for `$undeclared_static_var` because `dynamic_boundary_at`
-/// checks the *specific position* of each issue.
+/// Calls [`SemanticQueries::dynamic_boundary_at`] at the specific byte
+/// position of the issue. If the position is covered by dynamic-boundary
+/// evidence (e.g. `require $var` at that offset), the diagnostic is suppressed
+/// for that specific variable.
+///
+/// A dynamic construct **elsewhere** in the file does NOT suppress unrelated
+/// variables: `require $module; print $undeclared_static_var;` still fires for
+/// `$undeclared_static_var` because `dynamic_boundary_at` is position-scoped.
+///
+/// ## `UnquotedBareword` (file-wide dynamic callable)
+///
+/// Calls [`SemanticQueries::dynamic_callable_may_be_visible_at`] for the
+/// bareword name. Returns `Some` when:
+/// - The file has at least one `ImportSpec` with `ImportSymbols::Dynamic`
+///   (e.g. `Foo->import(@names)`) — any bareword in the file might be imported.
+/// - The file has a `DynamicBoundary` occurrence whose entity name matches the
+///   bareword (e.g. `eval "sub NAME { ... }"` — only `NAME` is suppressed).
+///
+/// Non-literal evals, non-Dynamic imports, and genuinely missing subs still fire.
+///
+/// ## All other issue kinds
+///
+/// Always emitted as diagnostics (no suppression).
 ///
 /// # Backward compatibility
 ///
@@ -107,6 +118,8 @@ pub fn scope_issues_to_diagnostics(issues: Vec<ScopeIssue>) -> Vec<Diagnostic> {
 ///
 /// - **Req 7.4**: Suppress undefined-symbol diagnostics for references within
 ///   dynamic boundary scopes.
+/// - **Req 7.5**: Suppress `UnquotedBareword` diagnostics for barewords
+///   plausibly provided by a dynamic import or string-eval sub declaration.
 pub fn scope_issues_to_diagnostics_with_semantics<Q: SemanticQueries>(
     issues: Vec<ScopeIssue>,
     file_id: FileId,
@@ -115,8 +128,12 @@ pub fn scope_issues_to_diagnostics_with_semantics<Q: SemanticQueries>(
     let mut diagnostics = Vec::new();
 
     for issue in issues {
-        // For UndeclaredVariable issues, check whether the specific variable
-        // position is covered by dynamic-boundary evidence.
+        // ── UndeclaredVariable suppression (position-scoped) ──
+        //
+        // Check whether the specific variable position is covered by a
+        // dynamic-boundary occurrence (e.g. `require $var` at that offset).
+        // This is deliberately narrow: only positions within the dynamic
+        // construct's span are suppressed.
         if issue.kind == IssueKind::UndeclaredVariable {
             let byte_offset = issue.range.0 as u32;
             // Strip the sigil from the variable name to get the bare symbol.
@@ -142,8 +159,43 @@ pub fn scope_issues_to_diagnostics_with_semantics<Q: SemanticQueries>(
             }
         }
 
-        // All other issue kinds — and UndeclaredVariable issues not covered by
-        // a dynamic boundary — are emitted as diagnostics.
+        // ── UnquotedBareword suppression (file-wide dynamic callable) ──
+        //
+        // Check whether a dynamic import or eval-sub evidence exists in the
+        // file that makes this bareword plausibly visible.
+        //
+        // Policy differences from UndeclaredVariable:
+        // - Coverage is file-wide when a Dynamic import exists (any bareword
+        //   in the file might come from an import with unknown symbol list).
+        // - Coverage is name-scoped when an eval-sub boundary exists (only
+        //   the sub named in the eval string is suppressed).
+        //
+        // This is intentionally conservative — non-literal evals, non-Dynamic
+        // imports, and barewords with genuinely no evidence are still flagged.
+        if issue.kind == IssueKind::UnquotedBareword {
+            let byte_offset = issue.range.0 as u32;
+            // Barewords have no sigil; use the name directly.
+            let symbol = issue.variable_name.as_str();
+
+            let is_callable_visible = semantic_queries
+                .dynamic_callable_may_be_visible_at(file_id, byte_offset, symbol)
+                .is_some();
+
+            if is_callable_visible {
+                tracing::debug!(
+                    bareword = %issue.variable_name,
+                    "suppressed UnquotedBareword diagnostic: dynamic callable evidence present"
+                );
+                continue;
+            }
+        }
+
+        // ── All other issue kinds ── (and unsuppressed UndeclaredVariable /
+        // UnquotedBareword) — always emit the diagnostic.
+        //
+        // This includes: VariableRedeclaration, DuplicateParameter,
+        // VariableShadowing, UnusedVariable, ParameterShadowsGlobal,
+        // UnusedParameter, UninitializedVariable, CaptureVarWithoutRegexMatch.
         let severity = match issue.kind {
             IssueKind::UndeclaredVariable
             | IssueKind::VariableRedeclaration

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
@@ -423,6 +423,15 @@ mod tests {
                 confidence: Confidence::Low,
             })
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     /// No-op stub — no dynamic boundary coverage anywhere.
@@ -478,6 +487,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     // ── Helper ──
@@ -499,6 +517,91 @@ mod tests {
             line: 1,
             range,
             description: format!("Variable '{}' unused", name),
+        }
+    }
+
+    fn bareword_issue(name: &str, range: (usize, usize)) -> ScopeIssue {
+        ScopeIssue {
+            kind: IssueKind::UnquotedBareword,
+            variable_name: name.to_string(),
+            line: 1,
+            range,
+            description: format!("Bareword '{}' not allowed under 'use strict'", name),
+        }
+    }
+
+    /// Stub that returns `Some` from `dynamic_callable_may_be_visible_at`
+    /// for any symbol (simulates a file with a dynamic import or eval sub).
+    struct DynamicCallableStubQueries;
+
+    impl SemanticQueries for DynamicCallableStubQueries {
+        fn symbol_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+        ) -> Option<(EntityFact, OccurrenceFact)> {
+            None
+        }
+
+        fn definitions(&self, _symbol: &str, _context: &QueryContext) -> Vec<DefinitionCandidate> {
+            Vec::new()
+        }
+
+        fn references(&self, _entity_id: EntityId) -> Vec<OccurrenceFact> {
+            Vec::new()
+        }
+
+        fn visible_symbols_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _scope_id: Option<ScopeId>,
+        ) -> Vec<VisibleSymbol> {
+            Vec::new()
+        }
+
+        fn method_candidates(
+            &self,
+            _receiver_package: &str,
+            _method_name: &str,
+        ) -> Vec<DefinitionCandidate> {
+            Vec::new()
+        }
+
+        fn rename_plan(&self, entity_id: EntityId, new_name: &str) -> RenamePlan {
+            RenamePlan::new(entity_id, String::new(), new_name.to_string(), vec![], vec![], vec![])
+        }
+
+        fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
+            SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
+        }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            // No variable boundary coverage (this stub is for callables only).
+            None
+        }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            // Simulates a file with a dynamic import: any bareword might be visible.
+            Some(OccurrenceFact {
+                id: OccurrenceId(6666),
+                kind: OccurrenceKind::DynamicBoundary,
+                entity_id: None,
+                anchor_id: AnchorId(6666),
+                scope_id: None,
+                provenance: Provenance::DynamicBoundary,
+                confidence: Confidence::Low,
+            })
         }
     }
 
@@ -609,6 +712,15 @@ mod tests {
                     None
                 }
             }
+
+            fn dynamic_callable_may_be_visible_at(
+                &self,
+                _: FileId,
+                _: u32,
+                _: &str,
+            ) -> Option<OccurrenceFact> {
+                None
+            }
         }
 
         let dynamic_var = undeclared_issue("$dynamic_var", (15, 27)); // covered (15 < 30)
@@ -627,6 +739,173 @@ mod tests {
             diagnostics[0].message.contains("static_var"),
             "The remaining diagnostic should be for $static_var, got: {:?}",
             diagnostics[0].message
+        );
+        Ok(())
+    }
+
+    // ── UnquotedBareword suppression tests (PR-B) ──
+    //
+    // Cases 2 and 3 from the spec:
+    //   2. `Foo->import(@names); bar()` — dynamic import, bareword should be suppressed
+    //   3. `eval "sub generated_from_string { 1 }"; generated_from_string()` — suppressed
+    //
+    // Controls:
+    //   4. `$undeclared_static_var` — UndeclaredVariable must still fire
+    //   5. `truly_undefined_sub()` — UnquotedBareword with no dynamic evidence must still fire
+    //   6. eval defines NAME but other bareword is unrelated — only NAME suppressed
+
+    #[test]
+    fn suppresses_unquoted_bareword_when_dynamic_callable_may_be_visible()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Case 2/3: dynamic import or eval-sub evidence → suppress UnquotedBareword.
+        // DynamicCallableStubQueries returns Some for dynamic_callable_may_be_visible_at.
+        let issues = vec![bareword_issue("bar", (20, 23))];
+        let queries = DynamicCallableStubQueries;
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert!(
+            diagnostics.is_empty(),
+            "UnquotedBareword covered by dynamic callable evidence should be suppressed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_suppress_unquoted_bareword_when_no_dynamic_evidence()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Case 5: no dynamic evidence → UnquotedBareword must still fire.
+        // NullStubQueries returns None for all queries.
+        let issues = vec![bareword_issue("truly_undefined_sub", (10, 29))];
+        let queries = NullStubQueries;
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "UnquotedBareword with no dynamic evidence must still fire"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn undeclared_variable_still_fires_when_only_callable_evidence_present()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Case 4: UndeclaredVariable is suppressed by dynamic_boundary_at (position-based),
+        // NOT by dynamic_callable_may_be_visible_at. When only callable evidence is
+        // present (DynamicCallableStubQueries returns None from dynamic_boundary_at),
+        // UndeclaredVariable must still fire.
+        let issues = vec![undeclared_issue("$undeclared_static_var", (10, 32))];
+        let queries = DynamicCallableStubQueries;
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "UndeclaredVariable must not be suppressed by callable evidence (wrong query)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn eval_sub_boundary_suppresses_named_sub_not_other_barewords()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Case 6: eval defines NAME → NAME suppressed, other bareword still fires.
+        // Use a stub that suppresses "generated_from_string" but not "truly_undefined_sub".
+        struct NamedEvalSubStub;
+        impl SemanticQueries for NamedEvalSubStub {
+            fn symbol_at(&self, _: FileId, _: u32) -> Option<(EntityFact, OccurrenceFact)> {
+                None
+            }
+            fn definitions(&self, _: &str, _: &QueryContext) -> Vec<DefinitionCandidate> {
+                Vec::new()
+            }
+            fn references(&self, _: EntityId) -> Vec<OccurrenceFact> {
+                Vec::new()
+            }
+            fn visible_symbols_at(
+                &self,
+                _: FileId,
+                _: u32,
+                _: Option<ScopeId>,
+            ) -> Vec<VisibleSymbol> {
+                Vec::new()
+            }
+            fn method_candidates(&self, _: &str, _: &str) -> Vec<DefinitionCandidate> {
+                Vec::new()
+            }
+            fn rename_plan(&self, id: EntityId, n: &str) -> RenamePlan {
+                RenamePlan::new(id, String::new(), n.to_string(), vec![], vec![], vec![])
+            }
+            fn safe_delete_plan(&self, id: EntityId) -> SafeDeletePlan {
+                SafeDeletePlan::new(id, String::new(), vec![], vec![])
+            }
+            fn dynamic_boundary_at(
+                &self,
+                _: FileId,
+                _: u32,
+                _: Option<&str>,
+            ) -> Option<OccurrenceFact> {
+                None
+            }
+            fn dynamic_callable_may_be_visible_at(
+                &self,
+                _: FileId,
+                _: u32,
+                symbol: &str,
+            ) -> Option<OccurrenceFact> {
+                // Only suppress the named sub from the eval string.
+                if symbol == "generated_from_string" {
+                    Some(OccurrenceFact {
+                        id: OccurrenceId(5555),
+                        kind: OccurrenceKind::DynamicBoundary,
+                        entity_id: None,
+                        anchor_id: AnchorId(5555),
+                        scope_id: None,
+                        provenance: Provenance::DynamicBoundary,
+                        confidence: Confidence::Low,
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+
+        let generated = bareword_issue("generated_from_string", (10, 31));
+        let unrelated = bareword_issue("truly_undefined_sub", (40, 59));
+        let issues = vec![generated, unrelated];
+
+        let diagnostics =
+            scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &NamedEvalSubStub);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "Only 'truly_undefined_sub' should fire; 'generated_from_string' should be suppressed"
+        );
+        assert!(
+            diagnostics[0].message.contains("truly_undefined_sub"),
+            "The remaining diagnostic should be for 'truly_undefined_sub', got: {:?}",
+            diagnostics[0].message
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn other_issue_kinds_never_suppressed_by_dynamic_callable_evidence()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Non-UndeclaredVariable, non-UnquotedBareword issues are never suppressed.
+        let issues = vec![unused_issue("$bar", (20, 24))];
+        let queries = DynamicCallableStubQueries;
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "UnusedVariable should NOT be suppressed by dynamic callable evidence"
         );
         Ok(())
     }

--- a/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
@@ -317,6 +317,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_candidate(name: &str, anchor_id: u64, entity_id: u64) -> DefinitionCandidate {

--- a/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
@@ -258,7 +258,7 @@ mod tests {
         EntityFact, EntityId, EntityKind, FileId, OccurrenceFact, Provenance, RenamePlan,
         SafeDeletePlan, ScopeId, VisibleSymbol,
     };
-    use perl_workspace::semantic::queries::SemanticQueries;
+    use perl_workspace::semantic::queries::{DynamicCallableEvidence, SemanticQueries};
     use perl_workspace::semantic_shadow_compare::ShadowCompareVerdict;
 
     // ── Minimal SemanticQueries stub for testing ──
@@ -323,7 +323,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }

--- a/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
@@ -577,7 +577,9 @@ mod tests {
         Provenance, RenamePlan, SafeDeletePlan, ScopeId, VisibleSymbol, VisibleSymbolContext,
         VisibleSymbolSource,
     };
-    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+    use perl_workspace::semantic::queries::{
+        DynamicCallableEvidence, QueryContext, SemanticQueries,
+    };
     use perl_workspace::semantic_shadow_compare::ShadowCompareVerdict;
 
     // ── Minimal SemanticQueries stub for testing ──
@@ -643,7 +645,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }
@@ -710,7 +712,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }

--- a/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
@@ -637,6 +637,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     struct RankedDefinitionStub {
@@ -692,6 +701,15 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
         ) -> Option<OccurrenceFact> {
             None
         }

--- a/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
@@ -266,7 +266,9 @@ mod tests {
         OccurrenceId, OccurrenceKind, Provenance, RenamePlan, SafeDeletePlan, ScopeId,
         VisibleSymbol,
     };
-    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+    use perl_workspace::semantic::queries::{
+        DynamicCallableEvidence, QueryContext, SemanticQueries,
+    };
     use perl_workspace::semantic_shadow_compare::ShadowCompareVerdict;
 
     // ── Minimal SemanticQueries stub for testing ──
@@ -331,7 +333,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }

--- a/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
@@ -325,6 +325,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_occurrence(

--- a/crates/perl-lsp-rs-core/src/providers/navigation/rename_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/rename_shadow.rs
@@ -307,6 +307,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_edit(anchor_id: u64, category: PlannedEditCategory) -> PlannedEdit {

--- a/crates/perl-lsp-rs-core/src/providers/navigation/rename_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/rename_shadow.rs
@@ -248,7 +248,9 @@ mod tests {
         PlanBlockerReason, PlannedEdit, PlannedEditCategory, RenamePlan, SafeDeletePlan, ScopeId,
         VisibleSymbol,
     };
-    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+    use perl_workspace::semantic::queries::{
+        DynamicCallableEvidence, QueryContext, SemanticQueries,
+    };
     use perl_workspace::semantic_shadow_compare::ShadowCompareVerdict;
 
     // ── Minimal SemanticQueries stub for testing ──
@@ -313,7 +315,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }

--- a/crates/perl-lsp-rs-core/src/providers/navigation/safe_delete_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/safe_delete_shadow.rs
@@ -223,7 +223,9 @@ mod tests {
         AnchorId, DefinitionCandidate, EntityFact, EntityId, FileId, OccurrenceFact, PlanBlocker,
         PlanBlockerReason, RenamePlan, SafeDeletePlan, ScopeId, VisibleSymbol,
     };
-    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+    use perl_workspace::semantic::queries::{
+        DynamicCallableEvidence, QueryContext, SemanticQueries,
+    };
     use perl_workspace::semantic_shadow_compare::ShadowCompareVerdict;
 
     // ── Minimal SemanticQueries stub for testing ──
@@ -288,7 +290,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }

--- a/crates/perl-lsp-rs-core/src/providers/navigation/safe_delete_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/safe_delete_shadow.rs
@@ -282,6 +282,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     fn make_blocker(reason: PlanBlockerReason) -> PlanBlocker {

--- a/crates/perl-lsp-rs-core/src/providers/navigation/scorecard_gate_fixtures.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/scorecard_gate_fixtures.rs
@@ -167,6 +167,15 @@ mod tests {
         ) -> Option<OccurrenceFact> {
             None
         }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
     }
 
     // ── Helpers ──

--- a/crates/perl-lsp-rs-core/src/providers/navigation/scorecard_gate_fixtures.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/scorecard_gate_fixtures.rs
@@ -25,7 +25,9 @@ mod tests {
         PlanBlockerReason, PlannedEdit, PlannedEditCategory, Provenance, RenamePlan,
         SafeDeletePlan, ScopeId, VisibleSymbol, VisibleSymbolSource,
     };
-    use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
+    use perl_workspace::semantic::queries::{
+        DynamicCallableEvidence, QueryContext, SemanticQueries,
+    };
     use perl_workspace::semantic::scorecard::{Scorecard, ScorecardMode};
     use perl_workspace::workspace_index::WorkspaceIndex;
 
@@ -173,7 +175,7 @@ mod tests {
             _file_id: FileId,
             _byte_offset: u32,
             _symbol: &str,
-        ) -> Option<OccurrenceFact> {
+        ) -> Option<DynamicCallableEvidence> {
             None
         }
     }

--- a/crates/perl-lsp-rs-core/tests/dynamic_callable_integration_tests.rs
+++ b/crates/perl-lsp-rs-core/tests/dynamic_callable_integration_tests.rs
@@ -1,0 +1,190 @@
+//! Real end-to-end integration tests for `dynamic_callable_may_be_visible_at`
+//! suppression of `UnquotedBareword` diagnostics.
+//!
+//! These tests use real `WorkspaceSemanticQueries` (not stubs) and exercise
+//! the full path:
+//!
+//!   source string
+//!   → real parser
+//!   → ImportExtractor (real import data)
+//!   → eval_sub_extractor (real eval-sub evidence)
+//!   → WorkspaceSemanticQueries
+//!   → scope_issues_to_diagnostics_with_semantics
+//!   → assert UnquotedBareword suppressed (or fired) per case
+//!
+//! # Test cases
+//!
+//! 1. `Foo->import(@names); bar();` → suppress (import precedes call)
+//! 2. `bar(); Foo->import(@names);` → still diagnose (import AFTER call, order-aware)
+//! 3. `eval "sub generated_from_string { 1 }"; generated_from_string();` → suppress
+//! 4. `eval "sub generated_from_string { 1 }"; truly_undefined_sub();` → diagnose
+//! 5. `truly_undefined_sub();` → diagnose (no dynamic evidence at all)
+
+use std::collections::HashMap;
+
+use perl_lsp_rs_core::providers::diagnostics::scope::scope_issues_to_diagnostics_with_semantics;
+use perl_semantic_analyzer::analysis::import_extractor::ImportExtractor;
+use perl_semantic_analyzer::scope_analyzer::{IssueKind, ScopeIssue};
+use perl_semantic_facts::FileId;
+use perl_workspace::semantic::eval_sub_extractor::extract_eval_sub_boundaries;
+use perl_workspace::semantic::imports::ImportExportIndex;
+use perl_workspace::semantic::queries::WorkspaceSemanticQueries;
+use perl_workspace::semantic::references::ReferenceIndex;
+use perl_workspace::workspace::workspace_index::{FileFactShard, WorkspaceIndex};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+// ── Helper ──
+
+/// Index `source` under `uri`, extract dynamic import and eval-sub evidence,
+/// and return everything needed to construct a `WorkspaceSemanticQueries`.
+fn build_real_queries(
+    source: &str,
+    uri: &str,
+) -> Result<(FileId, HashMap<String, FileFactShard>, ReferenceIndex, ImportExportIndex)> {
+    // Use WorkspaceIndex to index the file and populate fact shards.
+    let index = WorkspaceIndex::new();
+    let url = url::Url::parse(uri)?;
+    index
+        .index_file(url, source.to_string())
+        .map_err(|e| -> Box<dyn std::error::Error> { format!("index_file failed: {e}").into() })?;
+
+    let shard =
+        index.file_fact_shard(uri).ok_or_else(|| format!("fact shard missing for {uri}"))?;
+    let file_id = shard.file_id;
+
+    // Parse and extract import specs.
+    let ast = {
+        let mut parser = perl_parser::Parser::new(source);
+        parser.parse().map_err(|e| format!("parse error: {e:?}"))?
+    };
+    let import_specs = ImportExtractor::extract(&ast, file_id);
+    let mut ie_index = ImportExportIndex::new();
+    ie_index.add_file_imports(uri, file_id, import_specs);
+
+    // Extract eval-sub boundaries and merge into shard.
+    let eval_triples = extract_eval_sub_boundaries(&ast, file_id);
+    let mut full_shard = shard;
+    for (entity, anchor, occurrence) in eval_triples {
+        full_shard.entities.push(entity);
+        full_shard.anchors.push(anchor);
+        full_shard.occurrences.push(occurrence);
+    }
+
+    let mut shards = HashMap::new();
+    shards.insert(full_shard.source_uri.clone(), full_shard);
+
+    Ok((file_id, shards, ReferenceIndex::new(), ie_index))
+}
+
+fn bareword_issue(name: &str, range: (usize, usize)) -> ScopeIssue {
+    ScopeIssue {
+        kind: IssueKind::UnquotedBareword,
+        variable_name: name.to_string(),
+        line: 1,
+        range,
+        description: format!("Bareword '{name}' not allowed under 'use strict'"),
+    }
+}
+
+// ── Case 1: dynamic import before call → suppress ──
+
+#[test]
+fn dynamic_import_before_call_suppresses_bareword() -> Result<()> {
+    let source = "Foo->import(@names);\nbar();\n";
+    let (file_id, shards, ref_index, ie_index) =
+        build_real_queries(source, "file:///test/c1_before.pl")?;
+    let queries = WorkspaceSemanticQueries::new(&ref_index, &ie_index, &shards);
+
+    let bar_offset = source.find("bar").unwrap_or(21);
+    let issues = vec![bareword_issue("bar", (bar_offset, bar_offset + 3))];
+    let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, file_id, &queries);
+
+    assert!(
+        diagnostics.is_empty(),
+        "case 1: dynamic import before call should suppress UnquotedBareword, got: {diagnostics:?}"
+    );
+    Ok(())
+}
+
+// ── Case 2: dynamic import AFTER call → still diagnose (order-aware) ──
+
+#[test]
+fn dynamic_import_after_call_still_diagnoses_bareword() -> Result<()> {
+    let source = "bar();\nFoo->import(@names);\n";
+    let (file_id, shards, ref_index, ie_index) =
+        build_real_queries(source, "file:///test/c2_after.pl")?;
+    let queries = WorkspaceSemanticQueries::new(&ref_index, &ie_index, &shards);
+
+    // "bar" is at byte 0 — before the import at byte 7.
+    let issues = vec![bareword_issue("bar", (0, 3))];
+    let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, file_id, &queries);
+
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "case 2: dynamic import AFTER call must not suppress the bareword (order-aware), got: {diagnostics:?}"
+    );
+    Ok(())
+}
+
+// ── Case 3: eval-sub defines NAME → suppress that NAME ──
+
+#[test]
+fn eval_sub_suppresses_named_sub_at_call_site() -> Result<()> {
+    let source = r#"eval "sub generated_from_string { 1 }"; generated_from_string();"#;
+    let (file_id, shards, ref_index, ie_index) =
+        build_real_queries(source, "file:///test/c3_eval.pl")?;
+    let queries = WorkspaceSemanticQueries::new(&ref_index, &ie_index, &shards);
+
+    let call_offset = source.find("generated_from_string();").unwrap_or(40);
+    let issues = vec![bareword_issue("generated_from_string", (call_offset, call_offset + 21))];
+    let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, file_id, &queries);
+
+    assert!(
+        diagnostics.is_empty(),
+        "case 3: eval-sub named sub should suppress UnquotedBareword for that name, got: {diagnostics:?}"
+    );
+    Ok(())
+}
+
+// ── Case 4: eval defines NAME, but OTHER bareword is still diagnosed ──
+
+#[test]
+fn eval_sub_does_not_suppress_unrelated_bareword() -> Result<()> {
+    let source = r#"eval "sub generated_from_string { 1 }"; truly_undefined_sub();"#;
+    let (file_id, shards, ref_index, ie_index) =
+        build_real_queries(source, "file:///test/c4_unrelated.pl")?;
+    let queries = WorkspaceSemanticQueries::new(&ref_index, &ie_index, &shards);
+
+    let call_offset = source.find("truly_undefined_sub();").unwrap_or(40);
+    let issues = vec![bareword_issue("truly_undefined_sub", (call_offset, call_offset + 19))];
+    let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, file_id, &queries);
+
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "case 4: truly_undefined_sub has no evidence and must still fire, got: {diagnostics:?}"
+    );
+    Ok(())
+}
+
+// ── Case 5: no dynamic evidence → always diagnose ──
+
+#[test]
+fn no_dynamic_evidence_always_diagnoses() -> Result<()> {
+    let source = "truly_undefined_sub();\n";
+    let (file_id, shards, ref_index, ie_index) =
+        build_real_queries(source, "file:///test/c5_static.pl")?;
+    let queries = WorkspaceSemanticQueries::new(&ref_index, &ie_index, &shards);
+
+    let issues = vec![bareword_issue("truly_undefined_sub", (0, 19))];
+    let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, file_id, &queries);
+
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "case 5: no dynamic evidence must produce diagnostic, got: {diagnostics:?}"
+    );
+    Ok(())
+}

--- a/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
@@ -49,6 +49,20 @@ impl ImportExtractor {
             }
         }
 
+        // Detect standalone `ClassName->import(...)` method calls where
+        // `ClassName` is a static identifier (not a variable).
+        //
+        // These are NOT preceded by a `require` statement. The exported
+        // symbol list is often dynamic (e.g. `Foo->import(@names)`), so
+        // we emit `ImportSymbols::Dynamic` conservatively.
+        //
+        // This covers Case 3 in the PR-B spec: a static class name with
+        // dynamic arguments signals that some set of symbols is imported
+        // from `Foo`, but the exact names are not statically known.
+        if let Some(spec) = Self::try_classify_standalone_class_import(node, file_id) {
+            out.push(spec);
+        }
+
         // For statement-list containers (Program, Block, Package), scan
         // consecutive statements to detect `require Module; Module->import(...)`
         // pairs and standalone `require` statements.
@@ -67,6 +81,62 @@ impl ImportExtractor {
         for child in node.children() {
             Self::walk(child, file_id, out);
         }
+    }
+
+    /// Detect a standalone `ClassName->import(...)` call where `ClassName`
+    /// is a static identifier (not a variable).
+    ///
+    /// Returns `None` when:
+    /// - The node is not a `MethodCall`.
+    /// - The method name is not `"import"`.
+    /// - The object is a variable (those are covered by `walk_statements`).
+    /// - The argument list is entirely static (fully explicit symbols) — those
+    ///   are already captured by `walk_statements` when preceded by `require`.
+    ///
+    /// Returns an `ImportSpec` with `ImportSymbols::Dynamic` when the
+    /// argument list contains any dynamic argument (e.g. `@names`, `$names`).
+    /// Returns `None` when all arguments are static strings or `qw(...)` lists
+    /// (those produce `Explicit` specs through `walk_statements`).
+    fn try_classify_standalone_class_import(
+        node: &Node,
+        file_id: FileId,
+    ) -> Option<ImportSpec> {
+        let (object, method, args) = match &node.kind {
+            NodeKind::MethodCall { object, method, args } => (object, method, args),
+            _ => return None,
+        };
+
+        if method != "import" {
+            return None;
+        }
+
+        // Only static class names (Identifier nodes), not variables.
+        let class_name = match &object.kind {
+            NodeKind::Identifier { name } => name.as_str(),
+            _ => return None,
+        };
+
+        // Classify the argument list.
+        let symbols = Self::extract_import_call_symbols(args);
+
+        // Only emit evidence when the arguments are Dynamic (unknown at
+        // compile time). Explicit/tag lists are precise and do not need
+        // the conservative "any bareword might be imported" treatment.
+        if !matches!(symbols, ImportSymbols::Dynamic) {
+            return None;
+        }
+
+        let anchor_id = Self::anchor_from_node(node);
+        Some(ImportSpec {
+            module: class_name.to_string(),
+            kind: ImportKind::Use,
+            symbols,
+            provenance: Provenance::DynamicBoundary,
+            confidence: Confidence::Low,
+            file_id: Some(file_id),
+            anchor_id: Some(anchor_id),
+            scope_id: None,
+        })
     }
 
     /// Scan a list of sibling statements for `require` patterns.
@@ -1086,6 +1156,61 @@ require $dynamic;
 
         assert_eq!(spec.kind, ImportKind::Require);
         assert_eq!(spec.symbols, ImportSymbols::Default);
+        Ok(())
+    }
+
+    // ── standalone ClassName->import(@names) — Case 3 (PR-B) ────────────
+
+    #[test]
+    fn standalone_class_dynamic_import_produces_dynamic_spec() -> Result<(), String> {
+        // `Foo->import(@names)` — static class, dynamic arg list.
+        // Should produce one ImportSpec with ImportSymbols::Dynamic.
+        let specs = parse_and_extract(r#"Foo->import(@names);"#);
+        let spec = specs
+            .iter()
+            .find(|s| s.module == "Foo" && matches!(s.symbols, ImportSymbols::Dynamic))
+            .ok_or("expected Dynamic ImportSpec for Foo")?;
+
+        assert_eq!(spec.provenance, Provenance::DynamicBoundary);
+        assert_eq!(spec.confidence, Confidence::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn standalone_class_explicit_import_produces_no_dynamic_spec() -> Result<(), String> {
+        // `Foo->import('bar')` — static class, static arg list.
+        // Should NOT produce a Dynamic ImportSpec (explicit symbols only).
+        let specs = parse_and_extract(r#"Foo->import('bar');"#);
+        let dynamic_specs: Vec<_> = specs
+            .iter()
+            .filter(|s| matches!(s.symbols, ImportSymbols::Dynamic))
+            .collect();
+
+        assert!(
+            dynamic_specs.is_empty(),
+            "explicit import args must not produce a Dynamic spec"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn variable_class_import_does_not_produce_standalone_spec() -> Result<(), String> {
+        // `$var->import(@names)` — variable object, not a static class name.
+        // The standalone extractor should not match variable-object calls.
+        let specs = parse_and_extract(r#"$var->import(@names);"#);
+        // Variable-object calls are handled by require+import pair logic, not
+        // the standalone path. Without a require, this should produce no spec.
+        let standalone_dynamic: Vec<_> = specs
+            .iter()
+            .filter(|s| matches!(s.symbols, ImportSymbols::Dynamic) && s.module.is_empty())
+            .collect();
+
+        // The standalone extractor only handles Identifier objects, so this
+        // should produce nothing via the standalone path.
+        assert!(
+            standalone_dynamic.is_empty(),
+            "variable-class import without require must not produce standalone Dynamic spec"
+        );
         Ok(())
     }
 }

--- a/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
@@ -126,13 +126,16 @@ impl ImportExtractor {
         let anchor_id = Self::anchor_from_node(node);
         Some(ImportSpec {
             module: class_name.to_string(),
-            kind: ImportKind::Use,
+            // ManualImport distinguishes this from a `use Foo` statement —
+            // it is a `Class->import(...)` method call, not a `use` declaration.
+            kind: ImportKind::ManualImport,
             symbols,
             provenance: Provenance::DynamicBoundary,
             confidence: Confidence::Low,
             file_id: Some(file_id),
             anchor_id: Some(anchor_id),
             scope_id: None,
+            span_start_byte: Some(node.location.start as u32),
         })
     }
 
@@ -200,6 +203,7 @@ impl ImportExtractor {
                     file_id: Some(file_id),
                     anchor_id: Some(anchor_id),
                     scope_id: None,
+                    span_start_byte: Some(require_node.location.start as u32),
                 });
                 consumed.insert(i);
                 consumed.insert(i + 1);
@@ -218,6 +222,7 @@ impl ImportExtractor {
                     file_id: Some(file_id),
                     anchor_id: Some(anchor_id),
                     scope_id: None,
+                    span_start_byte: Some(require_node.location.start as u32),
                 });
                 consumed.insert(i);
             }
@@ -281,6 +286,7 @@ impl ImportExtractor {
             file_id: Some(file_id),
             anchor_id: Some(anchor_id),
             scope_id: None,
+            span_start_byte: Some(node.location.start as u32),
         }
     }
 
@@ -443,6 +449,7 @@ impl ImportExtractor {
             file_id: Some(file_id),
             anchor_id: Some(anchor_id),
             scope_id: None,
+            span_start_byte: Some(node.location.start as u32),
         })
     }
 
@@ -555,6 +562,7 @@ impl ImportExtractor {
                 file_id: Some(file_id),
                 anchor_id: Some(anchor_id),
                 scope_id: None,
+                span_start_byte: None, // position not needed for UseConstant
             };
         }
 
@@ -611,6 +619,7 @@ impl ImportExtractor {
             file_id: Some(file_id),
             anchor_id: Some(anchor_id),
             scope_id: None,
+            span_start_byte: None, // position not needed for UseConstant
         }
     }
 
@@ -1161,7 +1170,8 @@ require $dynamic;
     #[test]
     fn standalone_class_dynamic_import_produces_dynamic_spec() -> Result<(), String> {
         // `Foo->import(@names)` — static class, dynamic arg list.
-        // Should produce one ImportSpec with ImportSymbols::Dynamic.
+        // Should produce one ImportSpec with ImportSymbols::Dynamic and
+        // ImportKind::ManualImport (not Use — it's a method call, not a `use` statement).
         let specs = parse_and_extract(r#"Foo->import(@names);"#);
         let spec = specs
             .iter()
@@ -1170,6 +1180,11 @@ require $dynamic;
 
         assert_eq!(spec.provenance, Provenance::DynamicBoundary);
         assert_eq!(spec.confidence, Confidence::Low);
+        assert_eq!(
+            spec.kind,
+            ImportKind::ManualImport,
+            "Class->import(@names) must use ManualImport, not Use"
+        );
         Ok(())
     }
 

--- a/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
@@ -97,10 +97,7 @@ impl ImportExtractor {
     /// argument list contains any dynamic argument (e.g. `@names`, `$names`).
     /// Returns `None` when all arguments are static strings or `qw(...)` lists
     /// (those produce `Explicit` specs through `walk_statements`).
-    fn try_classify_standalone_class_import(
-        node: &Node,
-        file_id: FileId,
-    ) -> Option<ImportSpec> {
+    fn try_classify_standalone_class_import(node: &Node, file_id: FileId) -> Option<ImportSpec> {
         let (object, method, args) = match &node.kind {
             NodeKind::MethodCall { object, method, args } => (object, method, args),
             _ => return None,
@@ -1181,15 +1178,10 @@ require $dynamic;
         // `Foo->import('bar')` — static class, static arg list.
         // Should NOT produce a Dynamic ImportSpec (explicit symbols only).
         let specs = parse_and_extract(r#"Foo->import('bar');"#);
-        let dynamic_specs: Vec<_> = specs
-            .iter()
-            .filter(|s| matches!(s.symbols, ImportSymbols::Dynamic))
-            .collect();
+        let dynamic_specs: Vec<_> =
+            specs.iter().filter(|s| matches!(s.symbols, ImportSymbols::Dynamic)).collect();
 
-        assert!(
-            dynamic_specs.is_empty(),
-            "explicit import args must not produce a Dynamic spec"
-        );
+        assert!(dynamic_specs.is_empty(), "explicit import args must not produce a Dynamic spec");
         Ok(())
     }
 

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -205,6 +205,13 @@ pub struct ImportSpec {
     pub anchor_id: Option<AnchorId>,
     /// Scope enclosing this import site, when known.
     pub scope_id: Option<ScopeId>,
+    /// Byte offset of the start of this import statement in the source file.
+    ///
+    /// Used for order-aware suppression: a dynamic import only suppresses
+    /// barewords that appear **after** the import statement in the file.
+    /// `None` means the position is unknown; callers should be conservative
+    /// (no suppression) when this is absent.
+    pub span_start_byte: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -217,6 +224,13 @@ pub enum ImportKind {
     RequireThenImport,
     UseConstant,
     DynamicRequire,
+    /// A `Class->import(...)` method call — not a `use` statement.
+    ///
+    /// Used when a class's `import` method is called directly, typically with
+    /// a dynamic argument list (`Foo->import(@names)`).  This is distinct from
+    /// `Use` (which is a `use Foo` statement) and `Require` (which is a bare
+    /// `require Foo` statement).
+    ManualImport,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -947,6 +947,7 @@ mod tests {
             file_id: None,
             anchor_id: None,
             scope_id: None,
+            span_start_byte: None,
         };
 
         let serialized = serde_json::to_string(&spec)?;

--- a/crates/perl-workspace/src/semantic/eval_sub_extractor.rs
+++ b/crates/perl-workspace/src/semantic/eval_sub_extractor.rs
@@ -17,8 +17,8 @@
 //!   `UnquotedBareword` diagnostic for `NAME` at later call sites in the
 //!   same file.
 
-use crate::workspace::workspace_index::FileFactShard;
 use crate::ast::{Node, NodeKind};
+use crate::workspace::workspace_index::FileFactShard;
 use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EntityFact, EntityId, EntityKind, FileId, OccurrenceFact,
     OccurrenceId, OccurrenceKind, Provenance,
@@ -87,21 +87,18 @@ fn extract_from_eval_string(
 
     // Scan for `sub IDENTIFIER` patterns in the string content.
     let mut search = content;
-    let mut byte_pos = 0usize;
     while !search.is_empty() {
         // Find the next `sub ` keyword.
         let Some(sub_pos) = find_sub_keyword(search) else {
             break;
         };
 
-        byte_pos += sub_pos;
         let after_sub = &search[sub_pos + 3..]; // skip "sub"
-        byte_pos += 3;
 
         // Skip whitespace between `sub` and the name.
-        let ws_len = after_sub.len() - after_sub.trim_start_matches(|c: char| c.is_ascii_whitespace()).len();
+        let ws_len =
+            after_sub.len() - after_sub.trim_start_matches(|c: char| c.is_ascii_whitespace()).len();
         let after_ws = &after_sub[ws_len..];
-        byte_pos += ws_len;
 
         // Extract the identifier name.
         let name_len = after_ws
@@ -122,7 +119,6 @@ fn extract_from_eval_string(
             break;
         }
         search = &search[advance..];
-        byte_pos = byte_pos.saturating_sub(advance - advance); // reset relative tracking
     }
 }
 
@@ -131,9 +127,7 @@ fn extract_from_eval_string(
 fn find_sub_keyword(text: &str) -> Option<usize> {
     let mut start = 0;
     while start < text.len() {
-        let Some(pos) = text[start..].find("sub") else {
-            return None;
-        };
+        let pos = text[start..].find("sub")?;
         let abs_pos = start + pos;
 
         // Check left boundary: must be at start or preceded by non-word char.
@@ -283,7 +277,10 @@ mod tests {
 
     // ── Unit tests for extract_eval_sub_boundaries ──
 
-    fn parse_and_extract(code: &str, file_id: FileId) -> Vec<(EntityFact, AnchorFact, OccurrenceFact)> {
+    fn parse_and_extract(
+        code: &str,
+        file_id: FileId,
+    ) -> Vec<(EntityFact, AnchorFact, OccurrenceFact)> {
         let mut parser = crate::Parser::new(code);
         let ast = match parser.parse() {
             Ok(a) => a,
@@ -295,8 +292,7 @@ mod tests {
     #[test]
     fn extracts_single_sub_from_eval_string() -> Result<(), Box<dyn std::error::Error>> {
         let file_id = FileId(1);
-        let triples =
-            parse_and_extract(r#"eval "sub generated_from_string { 1 }";"#, file_id);
+        let triples = parse_and_extract(r#"eval "sub generated_from_string { 1 }";"#, file_id);
 
         assert_eq!(triples.len(), 1, "should extract exactly one sub");
         let (entity, _anchor, occurrence) = &triples[0];
@@ -312,10 +308,7 @@ mod tests {
     #[test]
     fn extracts_multiple_subs_from_eval_string() -> Result<(), Box<dyn std::error::Error>> {
         let file_id = FileId(2);
-        let triples = parse_and_extract(
-            r#"eval "sub foo { 1 } sub bar { 2 }";"#,
-            file_id,
-        );
+        let triples = parse_and_extract(r#"eval "sub foo { 1 } sub bar { 2 }";"#, file_id);
 
         assert_eq!(triples.len(), 2, "should extract two subs");
         let names: Vec<&str> = triples.iter().map(|(e, _, _)| e.canonical_name.as_str()).collect();
@@ -348,10 +341,7 @@ mod tests {
         // `eval "sub { 1 }"` — anonymous sub, no name to extract.
         let file_id = FileId(5);
         let triples = parse_and_extract(r#"eval "sub { 1 }";"#, file_id);
-        assert!(
-            triples.is_empty(),
-            "anonymous sub in eval must not produce named evidence"
-        );
+        assert!(triples.is_empty(), "anonymous sub in eval must not produce named evidence");
         Ok(())
     }
 

--- a/crates/perl-workspace/src/semantic/eval_sub_extractor.rs
+++ b/crates/perl-workspace/src/semantic/eval_sub_extractor.rs
@@ -1,0 +1,368 @@
+//! Literal-eval sub extractor for dynamic boundary evidence.
+//!
+//! Recognizes `eval "sub NAME { ... }"` patterns in an AST and emits an
+//! [`OccurrenceFact`] with `kind = OccurrenceKind::DynamicBoundary` keyed to
+//! the sub name `NAME`.
+//!
+//! # Scope
+//!
+//! Only literal string evals whose string value textually contains `sub NAME`
+//! are recognized. Non-literal evals (e.g. `eval $code`) are out of scope —
+//! the module name is not statically known and no evidence is emitted.
+//!
+//! # Requirements
+//!
+//! - **Req 7.5a**: Emit `DynamicBoundary` evidence for `eval "sub NAME { ... }"`
+//!   so that `dynamic_callable_may_be_visible_at` can suppress the
+//!   `UnquotedBareword` diagnostic for `NAME` at later call sites in the
+//!   same file.
+
+use crate::workspace::workspace_index::FileFactShard;
+use crate::ast::{Node, NodeKind};
+use perl_semantic_facts::{
+    AnchorFact, AnchorId, Confidence, EntityFact, EntityId, EntityKind, FileId, OccurrenceFact,
+    OccurrenceId, OccurrenceKind, Provenance,
+};
+
+/// Walk an AST and return `(EntityFact, AnchorFact, OccurrenceFact)` triples
+/// for each `eval "sub NAME { ... }"` pattern found.
+///
+/// The returned facts should be merged into the file's [`FileFactShard`] by
+/// the caller so that `dynamic_callable_may_be_visible_at` can find them.
+///
+/// # Algorithm
+///
+/// 1. Recursively walk every node.
+/// 2. For each `NodeKind::Eval { block }` where `block` is a
+///    `NodeKind::String { value, .. }` (a literal string eval), extract
+///    all sub names that appear as `sub NAME` in `value`.
+/// 3. For each name found, emit a triple with `Confidence::Low` and
+///    `Provenance::DynamicBoundary`.
+///
+/// # ID generation
+///
+/// IDs are derived from a stable hash of `(file_id, node_start_byte, name)`
+/// to avoid collisions across multiple eval strings in the same file.
+pub fn extract_eval_sub_boundaries(
+    ast: &Node,
+    file_id: FileId,
+) -> Vec<(EntityFact, AnchorFact, OccurrenceFact)> {
+    let mut out = Vec::new();
+    walk(ast, file_id, &mut out);
+    out
+}
+
+fn walk(node: &Node, file_id: FileId, out: &mut Vec<(EntityFact, AnchorFact, OccurrenceFact)>) {
+    if let NodeKind::Eval { block } = &node.kind {
+        // Only literal string evals produce evidence.
+        if let NodeKind::String { value, .. } = &block.kind {
+            extract_from_eval_string(value, node.location.start, file_id, out);
+        }
+        // Recurse into the block for nested evals.
+        walk(block, file_id, out);
+        return;
+    }
+
+    for child in node.children() {
+        walk(child, file_id, out);
+    }
+}
+
+/// Parse `eval_string` for `sub NAME` patterns and emit triples.
+///
+/// Handles simple identifiers: `sub foo_bar`, `sub _helper123`, etc.
+/// Does NOT handle `sub { ... }` anonymous subs (no name to extract).
+fn extract_from_eval_string(
+    eval_string: &str,
+    node_start_byte: usize,
+    file_id: FileId,
+    out: &mut Vec<(EntityFact, AnchorFact, OccurrenceFact)>,
+) {
+    // Strip surrounding quotes if present (the parser may or may not include them).
+    let content = eval_string
+        .trim_start_matches('"')
+        .trim_end_matches('"')
+        .trim_start_matches('\'')
+        .trim_end_matches('\'');
+
+    // Scan for `sub IDENTIFIER` patterns in the string content.
+    let mut search = content;
+    let mut byte_pos = 0usize;
+    while !search.is_empty() {
+        // Find the next `sub ` keyword.
+        let Some(sub_pos) = find_sub_keyword(search) else {
+            break;
+        };
+
+        byte_pos += sub_pos;
+        let after_sub = &search[sub_pos + 3..]; // skip "sub"
+        byte_pos += 3;
+
+        // Skip whitespace between `sub` and the name.
+        let ws_len = after_sub.len() - after_sub.trim_start_matches(|c: char| c.is_ascii_whitespace()).len();
+        let after_ws = &after_sub[ws_len..];
+        byte_pos += ws_len;
+
+        // Extract the identifier name.
+        let name_len = after_ws
+            .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .unwrap_or(after_ws.len());
+
+        if name_len > 0 {
+            let name = &after_ws[..name_len];
+            // Validate: must start with a letter or underscore.
+            if name.as_bytes().first().is_some_and(|&b| b.is_ascii_alphabetic() || b == b'_') {
+                emit_triple(name, node_start_byte, file_id, out);
+            }
+        }
+
+        // Advance past the name to continue scanning.
+        let advance = sub_pos + 3 + ws_len + name_len.max(1);
+        if advance >= search.len() {
+            break;
+        }
+        search = &search[advance..];
+        byte_pos = byte_pos.saturating_sub(advance - advance); // reset relative tracking
+    }
+}
+
+/// Find the byte offset of the next `sub` keyword in `text` that is preceded
+/// by a word boundary (not part of a longer identifier like `suburb`).
+fn find_sub_keyword(text: &str) -> Option<usize> {
+    let mut start = 0;
+    while start < text.len() {
+        let Some(pos) = text[start..].find("sub") else {
+            return None;
+        };
+        let abs_pos = start + pos;
+
+        // Check left boundary: must be at start or preceded by non-word char.
+        let left_ok = abs_pos == 0
+            || !text.as_bytes()[abs_pos - 1].is_ascii_alphanumeric()
+                && text.as_bytes()[abs_pos - 1] != b'_';
+
+        // Check right boundary: must be followed by whitespace or end.
+        let right_byte = text.as_bytes().get(abs_pos + 3).copied();
+        let right_ok = right_byte.map(|b| b.is_ascii_whitespace()).unwrap_or(true);
+
+        if left_ok && right_ok {
+            return Some(abs_pos);
+        }
+
+        start = abs_pos + 3;
+    }
+    None
+}
+
+/// Emit a `(EntityFact, AnchorFact, OccurrenceFact)` triple for a named sub
+/// found in an eval string.
+fn emit_triple(
+    name: &str,
+    node_start_byte: usize,
+    file_id: FileId,
+    out: &mut Vec<(EntityFact, AnchorFact, OccurrenceFact)>,
+) {
+    // Stable ID derivation: hash (file_id, node_start_byte, name).
+    let base_id = stable_id(file_id.0, node_start_byte as u64, name);
+
+    let entity_id = EntityId(base_id);
+    let anchor_id = AnchorId(base_id + 1);
+    let occurrence_id = OccurrenceId(base_id + 2);
+
+    let entity = EntityFact {
+        id: entity_id,
+        canonical_name: name.to_string(),
+        kind: EntityKind::Subroutine,
+        anchor_id: Some(anchor_id),
+        scope_id: None,
+        provenance: Provenance::DynamicBoundary,
+        confidence: Confidence::Low,
+    };
+
+    let anchor = AnchorFact {
+        id: anchor_id,
+        file_id,
+        // Use the eval node's span — the sub lives within the eval string.
+        span_start_byte: node_start_byte as u32,
+        span_end_byte: (node_start_byte + 1).max(node_start_byte + name.len()) as u32,
+        scope_id: None,
+        provenance: Provenance::DynamicBoundary,
+        confidence: Confidence::Low,
+    };
+
+    let occurrence = OccurrenceFact {
+        id: occurrence_id,
+        kind: OccurrenceKind::DynamicBoundary,
+        entity_id: Some(entity_id),
+        anchor_id,
+        scope_id: None,
+        provenance: Provenance::DynamicBoundary,
+        confidence: Confidence::Low,
+    };
+
+    out.push((entity, anchor, occurrence));
+}
+
+/// Compute a stable u64 ID from (file_id, node_start, name) using FNV-1a.
+fn stable_id(file_id: u64, node_start: u64, name: &str) -> u64 {
+    // FNV-1a 64-bit hash.
+    const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+    const FNV_PRIME: u64 = 1_099_511_628_211;
+
+    let mut hash = FNV_OFFSET;
+    for &byte in &file_id.to_le_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    for &byte in &node_start.to_le_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    for &byte in name.as_bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+
+    // Reserve 3 IDs per triple (entity, anchor, occurrence).
+    // Shift left by 3 bits so base_id, base_id+1, base_id+2 are in a cluster.
+    // Use a high-base offset (0xE_0000_0000) to avoid collisions with symbol
+    // adapter IDs which start from lower values.
+    0xE_0000_0000_u64.wrapping_add(hash.wrapping_shl(3))
+}
+
+/// Merge eval-sub boundary triples into a [`FileFactShard`].
+///
+/// Appends the new entities, anchors, and occurrences from
+/// [`extract_eval_sub_boundaries`] into the shard's respective vectors.
+/// Callers must re-hash the shard after merging if they rely on the
+/// per-category hashes (the hash recomputation is done in
+/// `build_canonical_fact_shard_for_ast`).
+pub fn merge_eval_sub_boundaries_into_shard(
+    shard: &mut FileFactShard,
+    triples: Vec<(EntityFact, AnchorFact, OccurrenceFact)>,
+) {
+    for (entity, anchor, occurrence) in triples {
+        shard.entities.push(entity);
+        shard.anchors.push(anchor);
+        shard.occurrences.push(occurrence);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_semantic_facts::FileId;
+
+    // ── Unit tests for find_sub_keyword ──
+
+    #[test]
+    fn find_sub_keyword_basic() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(find_sub_keyword("sub foo { 1 }"), Some(0));
+        assert_eq!(find_sub_keyword("  sub bar { }"), Some(2));
+        // The FIRST `sub` in the string is at position 3 ("no sub here").
+        assert_eq!(find_sub_keyword("no sub here really sub baz"), Some(3));
+        Ok(())
+    }
+
+    #[test]
+    fn find_sub_keyword_rejects_suburb() -> Result<(), Box<dyn std::error::Error>> {
+        // "suburb" contains "sub" but as part of a word — must not match.
+        assert_eq!(find_sub_keyword("suburb"), None);
+        // "subsub" also should not match as a keyword.
+        // Note: "sub sub" should match the second one.
+        assert_eq!(find_sub_keyword("sub sub foo"), Some(0));
+        Ok(())
+    }
+
+    #[test]
+    fn find_sub_keyword_none_when_absent() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(find_sub_keyword("hello world"), None);
+        assert_eq!(find_sub_keyword(""), None);
+        Ok(())
+    }
+
+    // ── Unit tests for extract_eval_sub_boundaries ──
+
+    fn parse_and_extract(code: &str, file_id: FileId) -> Vec<(EntityFact, AnchorFact, OccurrenceFact)> {
+        let mut parser = crate::Parser::new(code);
+        let ast = match parser.parse() {
+            Ok(a) => a,
+            Err(_) => return vec![],
+        };
+        extract_eval_sub_boundaries(&ast, file_id)
+    }
+
+    #[test]
+    fn extracts_single_sub_from_eval_string() -> Result<(), Box<dyn std::error::Error>> {
+        let file_id = FileId(1);
+        let triples =
+            parse_and_extract(r#"eval "sub generated_from_string { 1 }";"#, file_id);
+
+        assert_eq!(triples.len(), 1, "should extract exactly one sub");
+        let (entity, _anchor, occurrence) = &triples[0];
+        assert_eq!(entity.canonical_name, "generated_from_string");
+        assert_eq!(entity.kind, EntityKind::Subroutine);
+        assert_eq!(entity.provenance, Provenance::DynamicBoundary);
+        assert_eq!(entity.confidence, Confidence::Low);
+        assert_eq!(occurrence.kind, OccurrenceKind::DynamicBoundary);
+        assert_eq!(occurrence.entity_id, Some(entity.id));
+        Ok(())
+    }
+
+    #[test]
+    fn extracts_multiple_subs_from_eval_string() -> Result<(), Box<dyn std::error::Error>> {
+        let file_id = FileId(2);
+        let triples = parse_and_extract(
+            r#"eval "sub foo { 1 } sub bar { 2 }";"#,
+            file_id,
+        );
+
+        assert_eq!(triples.len(), 2, "should extract two subs");
+        let names: Vec<&str> = triples.iter().map(|(e, _, _)| e.canonical_name.as_str()).collect();
+        assert!(names.contains(&"foo"), "should include 'foo'");
+        assert!(names.contains(&"bar"), "should include 'bar'");
+        Ok(())
+    }
+
+    #[test]
+    fn non_literal_eval_does_not_produce_evidence() -> Result<(), Box<dyn std::error::Error>> {
+        // `eval $code` — non-literal, must not emit evidence.
+        let file_id = FileId(3);
+        let triples = parse_and_extract(r#"eval $code;"#, file_id);
+        assert!(triples.is_empty(), "non-literal eval must not produce evidence");
+        Ok(())
+    }
+
+    #[test]
+    fn eval_block_does_not_produce_evidence() -> Result<(), Box<dyn std::error::Error>> {
+        // `eval { ... }` — block eval, must not emit evidence.
+        let file_id = FileId(4);
+        let triples = parse_and_extract(r#"eval { die "oops" };"#, file_id);
+        assert!(triples.is_empty(), "block eval must not produce evidence");
+        Ok(())
+    }
+
+    #[test]
+    fn anonymous_sub_in_eval_does_not_produce_named_evidence()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // `eval "sub { 1 }"` — anonymous sub, no name to extract.
+        let file_id = FileId(5);
+        let triples = parse_and_extract(r#"eval "sub { 1 }";"#, file_id);
+        assert!(
+            triples.is_empty(),
+            "anonymous sub in eval must not produce named evidence"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stable_id_is_deterministic() -> Result<(), Box<dyn std::error::Error>> {
+        let id1 = stable_id(1, 42, "foo");
+        let id2 = stable_id(1, 42, "foo");
+        assert_eq!(id1, id2, "stable_id must be deterministic");
+
+        let id3 = stable_id(1, 42, "bar");
+        assert_ne!(id1, id3, "different names must produce different IDs");
+        Ok(())
+    }
+}

--- a/crates/perl-workspace/src/semantic/eval_sub_extractor.rs
+++ b/crates/perl-workspace/src/semantic/eval_sub_extractor.rs
@@ -10,6 +10,22 @@
 //! are recognized. Non-literal evals (e.g. `eval $code`) are out of scope —
 //! the module name is not statically known and no evidence is emitted.
 //!
+//! # Placement note — circular dependency debt
+//!
+//! This extractor lives in `perl-workspace` rather than `perl-semantic-analyzer`
+//! because of a circular dependency: `perl-semantic-analyzer/Cargo.toml` declares
+//! `perl-workspace` as a dependency (for workspace indexing), so moving any
+//! producer into `perl-semantic-analyzer` would create a cycle.
+//!
+//! This is **temporary architectural debt**. The correct long-term placement is
+//! `perl-semantic-analyzer`, which owns the semantic production layer.
+//! The blocker is the current `perl-semantic-analyzer → perl-workspace` dep arc.
+//!
+//! **Follow-up**: invert or remove the `perl-semantic-analyzer → perl-workspace`
+//! dependency (possibly by introducing a `perl-workspace-types` leaf crate for
+//! the fact types), then move this extractor to `perl-semantic-analyzer`.
+//! Track this as a follow-up issue after the dynamic-boundary suppression PRs merge.
+//!
 //! # Requirements
 //!
 //! - **Req 7.5a**: Emit `DynamicBoundary` evidence for `eval "sub NAME { ... }"`
@@ -55,7 +71,7 @@ fn walk(node: &Node, file_id: FileId, out: &mut Vec<(EntityFact, AnchorFact, Occ
     if let NodeKind::Eval { block } = &node.kind {
         // Only literal string evals produce evidence.
         if let NodeKind::String { value, .. } = &block.kind {
-            extract_from_eval_string(value, node.location.start, file_id, out);
+            extract_from_eval_string(value, node.location.start, node.location.end, file_id, out);
         }
         // Recurse into the block for nested evals.
         walk(block, file_id, out);
@@ -69,11 +85,23 @@ fn walk(node: &Node, file_id: FileId, out: &mut Vec<(EntityFact, AnchorFact, Occ
 
 /// Parse `eval_string` for `sub NAME` patterns and emit triples.
 ///
-/// Handles simple identifiers: `sub foo_bar`, `sub _helper123`, etc.
-/// Does NOT handle `sub { ... }` anonymous subs (no name to extract).
+/// Handles plausible Perl sub declarations of the form:
+/// - `sub NAME {`   — named sub with body
+/// - `sub NAME ;`   — forward declaration
+/// - `sub NAME (`   — named sub with prototype/signature
+///
+/// Does NOT match:
+/// - `sub { ... }` — anonymous sub (no name)
+/// - `sub $name { ... }` — interpolated name (sigil-prefixed)
+/// - `sub NAME` followed by arbitrary text (conservative: reject if no
+///   plausible Perl delimiter follows)
+///
+/// This conservative approach avoids false positives from strings that
+/// contain the word `sub` in prose (e.g. `"no sub here really"`).
 fn extract_from_eval_string(
     eval_string: &str,
     node_start_byte: usize,
+    node_end_byte: usize,
     file_id: FileId,
     out: &mut Vec<(EntityFact, AnchorFact, OccurrenceFact)>,
 ) {
@@ -99,6 +127,16 @@ fn extract_from_eval_string(
             after_sub.len() - after_sub.trim_start_matches(|c: char| c.is_ascii_whitespace()).len();
         let after_ws = &after_sub[ws_len..];
 
+        // Reject: anonymous sub (`sub {`) or sigil-prefixed (`sub $name`).
+        if after_ws.starts_with('{') || after_ws.starts_with(['$', '@', '%', '&', '*']) {
+            let advance = sub_pos + 3 + ws_len.max(1);
+            if advance >= search.len() {
+                break;
+            }
+            search = &search[advance..];
+            continue;
+        }
+
         // Extract the identifier name.
         let name_len = after_ws
             .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
@@ -106,9 +144,22 @@ fn extract_from_eval_string(
 
         if name_len > 0 {
             let name = &after_ws[..name_len];
-            // Validate: must start with a letter or underscore.
+            // Validate: must start with a letter or underscore (not a digit).
             if name.as_bytes().first().is_some_and(|&b| b.is_ascii_alphabetic() || b == b'_') {
-                emit_triple(name, node_start_byte, file_id, out);
+                // Validate: what follows the name must look like a Perl sub declaration.
+                // Accept: `{`, `;`, `(` (optionally preceded by whitespace).
+                // - `sub NAME {`   — named sub with body
+                // - `sub NAME ;`   — forward declaration
+                // - `sub NAME (`   — named sub with prototype or signature
+                // Reject everything else, including bare `sub NAME` at end-of-string
+                // (ambiguous — could be prose containing the word "sub").
+                let after_name = after_ws[name_len..].trim_start();
+                let plausible = after_name.starts_with('{')
+                    || after_name.starts_with(';')
+                    || after_name.starts_with('(');
+                if plausible {
+                    emit_triple(name, node_start_byte, node_end_byte, file_id, out);
+                }
             }
         }
 
@@ -149,9 +200,14 @@ fn find_sub_keyword(text: &str) -> Option<usize> {
 
 /// Emit a `(EntityFact, AnchorFact, OccurrenceFact)` triple for a named sub
 /// found in an eval string.
+///
+/// `node_start_byte` and `node_end_byte` are from the enclosing `Eval` AST
+/// node's `location.start` and `location.end` — these are the real source
+/// positions of the eval expression, used directly as the anchor span.
 fn emit_triple(
     name: &str,
     node_start_byte: usize,
+    node_end_byte: usize,
     file_id: FileId,
     out: &mut Vec<(EntityFact, AnchorFact, OccurrenceFact)>,
 ) {
@@ -172,12 +228,16 @@ fn emit_triple(
         confidence: Confidence::Low,
     };
 
+    // Use the real AST span from the enclosing eval node.
+    // node_end_byte comes from node.location.end, which is the source position
+    // of the end of the entire eval expression (including closing quote/paren).
+    let span_end =
+        if node_end_byte > node_start_byte { node_end_byte } else { node_start_byte + 1 };
     let anchor = AnchorFact {
         id: anchor_id,
         file_id,
-        // Use the eval node's span — the sub lives within the eval string.
         span_start_byte: node_start_byte as u32,
-        span_end_byte: (node_start_byte + 1).max(node_start_byte + name.len()) as u32,
+        span_end_byte: span_end as u32,
         scope_id: None,
         provenance: Provenance::DynamicBoundary,
         confidence: Confidence::Low,
@@ -323,6 +383,67 @@ mod tests {
         let file_id = FileId(5);
         let triples = parse_and_extract(r#"eval "sub { 1 }";"#, file_id);
         assert!(triples.is_empty(), "anonymous sub in eval must not produce named evidence");
+        Ok(())
+    }
+
+    #[test]
+    fn prose_sub_in_eval_does_not_produce_evidence() -> Result<(), Box<dyn std::error::Error>> {
+        // A string that contains the word "sub" in prose should not produce evidence.
+        // "no sub here really sub baz" has no Perl declaration delimiters after the name.
+        let file_id = FileId(6);
+        // Parse as a Perl string literal rather than through the parser to test
+        // the extractor function directly.
+        let triples = {
+            let mut out = Vec::new();
+            extract_from_eval_string("no sub here really sub baz", 0, 26, file_id, &mut out);
+            out
+        };
+        assert!(
+            triples.is_empty(),
+            "prose containing 'sub' without delimiters must not produce evidence, got: {:?}",
+            triples.iter().map(|(e, _, _)| e.canonical_name.as_str()).collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn sub_with_semicolon_delimiter_is_accepted() -> Result<(), Box<dyn std::error::Error>> {
+        // Forward declaration: `sub foo;`
+        let file_id = FileId(7);
+        let triples = {
+            let mut out = Vec::new();
+            extract_from_eval_string("sub forward_decl;", 0, 18, file_id, &mut out);
+            out
+        };
+        assert_eq!(triples.len(), 1, "sub NAME; (forward decl) should produce evidence");
+        assert_eq!(triples[0].0.canonical_name, "forward_decl");
+        Ok(())
+    }
+
+    #[test]
+    fn sub_with_prototype_is_accepted() -> Result<(), Box<dyn std::error::Error>> {
+        // Named sub with prototype: `sub proto_sub ($$) { }`
+        let file_id = FileId(8);
+        let triples = {
+            let mut out = Vec::new();
+            extract_from_eval_string("sub proto_sub ($$) { 1 }", 0, 24, file_id, &mut out);
+            out
+        };
+        assert_eq!(triples.len(), 1, "sub NAME (proto) should produce evidence");
+        assert_eq!(triples[0].0.canonical_name, "proto_sub");
+        Ok(())
+    }
+
+    #[test]
+    fn interpolated_name_sub_does_not_produce_evidence() -> Result<(), Box<dyn std::error::Error>> {
+        // `sub $name { ... }` — dynamic name, cannot be extracted.
+        let file_id = FileId(9);
+        let triples = {
+            let mut out = Vec::new();
+            extract_from_eval_string("sub $dynamic_name { 1 }", 0, 23, file_id, &mut out);
+            out
+        };
+        assert!(triples.is_empty(), "sub with sigil-prefixed name must not produce evidence");
         Ok(())
     }
 

--- a/crates/perl-workspace/src/semantic/eval_sub_extractor.rs
+++ b/crates/perl-workspace/src/semantic/eval_sub_extractor.rs
@@ -18,7 +18,6 @@
 //!   same file.
 
 use crate::ast::{Node, NodeKind};
-use crate::workspace::workspace_index::FileFactShard;
 use perl_semantic_facts::{
     AnchorFact, AnchorId, Confidence, EntityFact, EntityId, EntityKind, FileId, OccurrenceFact,
     OccurrenceId, OccurrenceKind, Provenance,
@@ -222,24 +221,6 @@ fn stable_id(file_id: u64, node_start: u64, name: &str) -> u64 {
     // Use a high-base offset (0xE_0000_0000) to avoid collisions with symbol
     // adapter IDs which start from lower values.
     0xE_0000_0000_u64.wrapping_add(hash.wrapping_shl(3))
-}
-
-/// Merge eval-sub boundary triples into a [`FileFactShard`].
-///
-/// Appends the new entities, anchors, and occurrences from
-/// [`extract_eval_sub_boundaries`] into the shard's respective vectors.
-/// Callers must re-hash the shard after merging if they rely on the
-/// per-category hashes (the hash recomputation is done in
-/// `build_canonical_fact_shard_for_ast`).
-pub fn merge_eval_sub_boundaries_into_shard(
-    shard: &mut FileFactShard,
-    triples: Vec<(EntityFact, AnchorFact, OccurrenceFact)>,
-) {
-    for (entity, anchor, occurrence) in triples {
-        shard.entities.push(entity);
-        shard.anchors.push(anchor);
-        shard.occurrences.push(occurrence);
-    }
 }
 
 #[cfg(test)]

--- a/crates/perl-workspace/src/semantic/facts.rs
+++ b/crates/perl-workspace/src/semantic/facts.rs
@@ -413,6 +413,7 @@ mod tests {
             file_id: None,
             anchor_id: None,
             scope_id: None,
+            span_start_byte: None,
         };
 
         let shard = build_canonical_fact_shard(

--- a/crates/perl-workspace/src/semantic/imports.rs
+++ b/crates/perl-workspace/src/semantic/imports.rs
@@ -196,6 +196,7 @@ mod tests {
             file_id: Some(FileId(1)),
             anchor_id: Some(AnchorId(10)),
             scope_id: Some(ScopeId(1)),
+            span_start_byte: None,
         }
     }
 
@@ -210,6 +211,7 @@ mod tests {
             file_id: Some(FileId(1)),
             anchor_id: Some(AnchorId(11)),
             scope_id: None,
+            span_start_byte: None,
         }
     }
 
@@ -429,6 +431,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(30)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![updated_import]);
 
@@ -484,6 +487,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(99)),
             scope_id: Some(ScopeId(5)),
+            span_start_byte: None,
         };
 
         index.add_file_imports("file:///lib/My/Module.pm", file_id, vec![import]);

--- a/crates/perl-workspace/src/semantic/mod.rs
+++ b/crates/perl-workspace/src/semantic/mod.rs
@@ -35,6 +35,9 @@ pub mod invalidation;
 /// Semantic query facade: `SemanticQueries` trait and `WorkspaceSemanticQueries` impl.
 pub mod queries;
 
+/// Literal-eval sub extractor for dynamic boundary evidence.
+pub mod eval_sub_extractor;
+
 /// Per-provider scorecard gate fixture suites (test-only).
 #[cfg(test)]
 mod scorecard_gate_fixtures;

--- a/crates/perl-workspace/src/semantic/queries.rs
+++ b/crates/perl-workspace/src/semantic/queries.rs
@@ -41,6 +41,37 @@ use super::value_shape::ValueShapeIndex;
 use super::visibility;
 use crate::workspace::workspace_index::FileFactShard;
 
+// ── DynamicCallableEvidence ──
+
+/// Evidence that a callable symbol may be visible at a given point due to a
+/// dynamic import or a literal-eval sub declaration.
+///
+/// Replaces the previous `Option<OccurrenceFact>` return from
+/// [`SemanticQueries::dynamic_callable_may_be_visible_at`], removing the
+/// use of placeholder `OccurrenceId(0)` / `AnchorId(0)` sentinel values.
+///
+/// Callers that only need suppress/no-suppress can use `.is_some()` on the
+/// wrapping `Option`.  Pattern-match for richer diagnostic messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DynamicCallableEvidence {
+    /// A `Class->import(@args)` or `require $var` call with a dynamic argument
+    /// list — the symbol set is not statically known.
+    DynamicImport {
+        /// The file that contains the dynamic import statement.
+        file_id: FileId,
+        /// Anchor of the import statement, when available.
+        anchor_id: Option<AnchorId>,
+        /// Class or module name from the `ImportSpec`.
+        module: String,
+    },
+    /// A literal-eval sub declaration — `eval "sub NAME { ... }"` — that names
+    /// the callable exactly.
+    EvalSub {
+        /// The real `OccurrenceFact` extracted from the eval string.
+        occurrence: OccurrenceFact,
+    },
+}
+
 // ── QueryContext ──
 
 /// Context for definition queries: file, scope, and byte offset.
@@ -215,7 +246,7 @@ pub trait SemanticQueries {
         file_id: FileId,
         byte_offset: u32,
         symbol: &str,
-    ) -> Option<OccurrenceFact>;
+    ) -> Option<DynamicCallableEvidence>;
 }
 
 // ── WorkspaceSemanticQueries ──
@@ -828,36 +859,43 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
     fn dynamic_callable_may_be_visible_at(
         &self,
         file_id: FileId,
-        _byte_offset: u32,
+        byte_offset: u32,
         symbol: &str,
-    ) -> Option<OccurrenceFact> {
+    ) -> Option<DynamicCallableEvidence> {
         // Guard: variables (sigil-prefixed) are not callables.
         if symbol.starts_with(['$', '@', '%', '&', '*']) {
             return None;
         }
 
-        // ── Path 1: file has a Dynamic import ──
+        // ── Path 1: file has a Dynamic import that precedes `byte_offset` ──
         //
         // `ImportSymbols::Dynamic` means the imported symbol list is not
         // statically known (e.g. `Foo->import(@names)` or `require $var`).
-        // Any bareword in the file could plausibly come from this import.
-        let has_dynamic_import = self
-            .import_export_index
-            .get_imports_for_file(file_id)
-            .iter()
-            .any(|spec| matches!(spec.symbols, perl_semantic_facts::ImportSymbols::Dynamic));
+        // Any bareword *after* the import could plausibly come from it.
+        //
+        // Order awareness: suppress only when the import's `span_start_byte`
+        // is at or before `byte_offset`.  When the position is unknown
+        // (`span_start_byte = None`), we prefer no suppression (conservative —
+        // this is a suppression path and false-suppressions are worse than
+        // false-diagnostics).
+        let dynamic_import =
+            self.import_export_index.get_imports_for_file(file_id).iter().find(|spec| {
+                if !matches!(spec.symbols, perl_semantic_facts::ImportSymbols::Dynamic) {
+                    return false;
+                }
+                // Use the import's own span_start_byte for position ordering.
+                // Conservative: if the position is unknown, do not suppress.
+                match spec.span_start_byte {
+                    Some(import_start) => import_start <= byte_offset,
+                    None => false,
+                }
+            });
 
-        if has_dynamic_import {
-            // Return a synthetic DynamicBoundary occurrence as evidence.
-            // anchor_id 0 is a placeholder — callers only check is_some().
-            return Some(OccurrenceFact {
-                id: perl_semantic_facts::OccurrenceId(0),
-                kind: OccurrenceKind::DynamicBoundary,
-                entity_id: None,
-                anchor_id: AnchorId(0),
-                scope_id: None,
-                provenance: perl_semantic_facts::Provenance::DynamicBoundary,
-                confidence: perl_semantic_facts::Confidence::Low,
+        if let Some(spec) = dynamic_import {
+            return Some(DynamicCallableEvidence::DynamicImport {
+                file_id,
+                anchor_id: spec.anchor_id,
+                module: spec.module.clone(),
             });
         }
 
@@ -885,7 +923,7 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
             });
 
             if entity_matches {
-                return Some(occurrence.clone());
+                return Some(DynamicCallableEvidence::EvalSub { occurrence: occurrence.clone() });
             }
         }
 
@@ -2285,6 +2323,7 @@ mod tests {
                 file_id: Some(file_importer),
                 anchor_id: None,
                 scope_id: None,
+                span_start_byte: None,
             }],
         );
 
@@ -2685,6 +2724,7 @@ mod tests {
                 file_id: Some(file_importer),
                 anchor_id: None,
                 scope_id: None,
+                span_start_byte: None,
             }],
         );
 
@@ -3311,6 +3351,7 @@ mod tests {
                         file_id: Some(file_importer),
                         anchor_id: None,
                         scope_id: None,
+                        span_start_byte: None,
                     }],
                 );
             }
@@ -3834,8 +3875,8 @@ mod tests {
     #[test]
     fn dynamic_callable_returns_some_when_file_has_dynamic_import()
     -> Result<(), Box<dyn std::error::Error>> {
-        // When a file has an ImportSpec with ImportSymbols::Dynamic, any
-        // bareword in that file is potentially visible.
+        // When a file has an ImportSpec with ImportSymbols::Dynamic and a known
+        // span_start_byte that precedes byte_offset, any bareword after it is covered.
         use crate::semantic::imports::ImportExportIndex;
         use perl_semantic_facts::{ImportKind, ImportSpec, ImportSymbols};
 
@@ -3848,7 +3889,7 @@ mod tests {
         let ref_index = ReferenceIndex::new();
         let mut ie_index = ImportExportIndex::new();
 
-        // Add a Dynamic import for this file.
+        // Add a Dynamic import with span_start_byte=0 so order-awareness applies.
         ie_index.add_file_imports(
             "file:///test/dyn_import.pl",
             file_id,
@@ -3861,18 +3902,66 @@ mod tests {
                 file_id: Some(file_id),
                 anchor_id: None,
                 scope_id: None,
+                span_start_byte: Some(0),
             }],
         );
 
         let queries = build_queries(&ref_index, &ie_index, &shards);
 
-        // Any bareword in this file should be covered.
+        // Bareword at offset 100 (after the import at byte 0) should be covered.
         let result = queries.dynamic_callable_may_be_visible_at(file_id, 100, "bar");
-        assert!(result.is_some(), "should return Some when file has Dynamic import");
-        let occ = result.ok_or("expected OccurrenceFact")?;
-        assert_eq!(occ.kind, OccurrenceKind::DynamicBoundary);
-        assert_eq!(occ.provenance, Provenance::DynamicBoundary);
-        assert_eq!(occ.confidence, Confidence::Low);
+        assert!(result.is_some(), "should return Some when file has Dynamic import before offset");
+        match result.ok_or("expected DynamicCallableEvidence")? {
+            DynamicCallableEvidence::DynamicImport { file_id: fid, module, .. } => {
+                assert_eq!(fid, file_id);
+                assert_eq!(module, "Foo");
+            }
+            DynamicCallableEvidence::EvalSub { .. } => {
+                return Err("expected DynamicImport variant".into());
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_callable_returns_none_when_import_comes_after_offset()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Order-aware: if the import's span_start_byte is AFTER byte_offset, no suppression.
+        use crate::semantic::imports::ImportExportIndex;
+        use perl_semantic_facts::{ImportKind, ImportSpec, ImportSymbols};
+
+        let file_id = FileId(110);
+        let shard =
+            make_shard("file:///test/late_import.pl", file_id, vec![], vec![], vec![], vec![]);
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let mut ie_index = ImportExportIndex::new();
+        ie_index.add_file_imports(
+            "file:///test/late_import.pl",
+            file_id,
+            vec![ImportSpec {
+                module: "Late".to_string(),
+                kind: ImportKind::Use,
+                symbols: ImportSymbols::Dynamic,
+                provenance: Provenance::DynamicBoundary,
+                confidence: Confidence::Low,
+                file_id: Some(file_id),
+                anchor_id: None,
+                scope_id: None,
+                span_start_byte: Some(200), // import at byte 200 — after the query at 50
+            }],
+        );
+
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // Query at byte 50, but import is at byte 200 — should NOT suppress.
+        let result = queries.dynamic_callable_may_be_visible_at(file_id, 50, "bar");
+        assert!(
+            result.is_none(),
+            "should return None when dynamic import comes AFTER the query byte_offset"
+        );
         Ok(())
     }
 
@@ -3903,6 +3992,7 @@ mod tests {
                 file_id: Some(file_id),
                 anchor_id: None,
                 scope_id: None,
+                span_start_byte: None,
             }],
         );
 
@@ -3970,6 +4060,15 @@ mod tests {
         // Should find the eval-sub boundary for "generated_sub".
         let result = queries.dynamic_callable_may_be_visible_at(file_id, 100, "generated_sub");
         assert!(result.is_some(), "should return Some for named eval-sub DynamicBoundary");
+        match result.ok_or("expected DynamicCallableEvidence")? {
+            DynamicCallableEvidence::EvalSub { occurrence: occ } => {
+                assert_eq!(occ.kind, OccurrenceKind::DynamicBoundary);
+                assert_eq!(occ.entity_id, Some(entity_id));
+            }
+            DynamicCallableEvidence::DynamicImport { .. } => {
+                return Err("expected EvalSub variant".into());
+            }
+        }
 
         // Should NOT find for a different name.
         let result2 =
@@ -3981,11 +4080,29 @@ mod tests {
     #[test]
     fn dynamic_callable_variable_sigil_never_matches() -> Result<(), Box<dyn std::error::Error>> {
         // Variables (sigil-prefixed names) are not callables.
-        // Even with a Dynamic import, sigil-prefixed names must return None.
+        // Even with a Dynamic import (with anchor before the query point),
+        // sigil-prefixed names must return None.
         use perl_semantic_facts::{ImportKind, ImportSpec, ImportSymbols};
 
         let file_id = FileId(103);
-        let shard = make_shard("file:///test/sigil.pl", file_id, vec![], vec![], vec![], vec![]);
+        let anchor_id = AnchorId(103_000);
+        let import_anchor = AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: 0,
+            span_end_byte: 10,
+            scope_id: None,
+            provenance: Provenance::DynamicBoundary,
+            confidence: Confidence::Low,
+        };
+        let shard = make_shard(
+            "file:///test/sigil.pl",
+            file_id,
+            vec![import_anchor],
+            vec![],
+            vec![],
+            vec![],
+        );
         let mut shards = HashMap::new();
         shards.insert(shard.source_uri.clone(), shard);
 
@@ -4001,8 +4118,9 @@ mod tests {
                 provenance: Provenance::DynamicBoundary,
                 confidence: Confidence::Low,
                 file_id: Some(file_id),
-                anchor_id: None,
+                anchor_id: Some(anchor_id),
                 scope_id: None,
+                span_start_byte: Some(0), // import at byte 0, before query at 100
             }],
         );
 
@@ -4010,7 +4128,7 @@ mod tests {
 
         // Variables with sigils must be rejected even when a dynamic import exists.
         for sigil_var in &["$foo", "@bar", "%baz", "&qux", "*glob"] {
-            let result = queries.dynamic_callable_may_be_visible_at(file_id, 0, sigil_var);
+            let result = queries.dynamic_callable_may_be_visible_at(file_id, 100, sigil_var);
             assert!(
                 result.is_none(),
                 "sigil-prefixed '{}' must never match dynamic_callable_may_be_visible_at",

--- a/crates/perl-workspace/src/semantic/queries.rs
+++ b/crates/perl-workspace/src/semantic/queries.rs
@@ -198,44 +198,65 @@ pub trait SemanticQueries {
     /// Return evidence that a dynamic callable named `symbol` may be visible at
     /// a given position in `file_id`.
     ///
-    /// # Contract (file-wide import coverage + named DynamicBoundary)
+    /// # Contract (order-aware import coverage + named DynamicBoundary)
     ///
-    /// Returns `Some(OccurrenceFact)` when **either** of the following holds:
+    /// Returns `Some(DynamicCallableEvidence)` when **either** of the following
+    /// holds:
     ///
-    /// 1. The file at `file_id` has at least one `ImportSpec` with
-    ///    `ImportSymbols::Dynamic` — the imported symbols are not statically
-    ///    known, so *any* bareword call in the file might have come from that
-    ///    import.  This covers `Foo->import(@names)` (static class, dynamic
-    ///    arg list) and `require $var` (dynamic module, unknown exports).
+    /// 1. The file at `file_id` has an `ImportSpec` with
+    ///    `ImportSymbols::Dynamic` whose `span_start_byte <= byte_offset` — the
+    ///    imported symbols are not statically known, so any bareword call *at
+    ///    or after the import* might have come from that import. This covers
+    ///    `Foo->import(@names)` (static class, dynamic arg list) and
+    ///    `require $var` (dynamic module, unknown exports). Returns
+    ///    [`DynamicCallableEvidence::DynamicImport`] with the file id, the
+    ///    import's anchor id (when known), and the module/class name.
     /// 2. The file has at least one occurrence with
     ///    `kind = OccurrenceKind::DynamicBoundary` whose associated entity's
-    ///    canonical name matches `symbol`.  This covers `eval "sub NAME { ... }"`
-    ///    patterns where the sub name is literally present in the string.
+    ///    canonical name matches `symbol`. This covers
+    ///    `eval "sub NAME { ... }"` patterns where the sub name is literally
+    ///    present in the string. Returns [`DynamicCallableEvidence::EvalSub`]
+    ///    with the matching `OccurrenceFact`.
+    ///
+    /// # Order-awareness
+    ///
+    /// The dynamic-import branch is **order-aware**: it only matches when
+    /// `byte_offset >= span_start_byte` of the import. This is critical to
+    /// avoid suppressing earlier static diagnostics in the file:
+    ///
+    /// ```text
+    /// Foo->import(@names);   bar();   // bar() suppressed (after import)
+    /// bar();                 Foo->import(@names);  // bar() still diagnosed (before import)
+    /// ```
+    ///
+    /// If an `ImportSpec` is `Dynamic` but has no `span_start_byte` (None),
+    /// it is **not** used for suppression — conservative default. The eval-sub
+    /// branch is name-scoped, not position-scoped (the entity name must match
+    /// `symbol`).
     ///
     /// # Differences from `dynamic_boundary_at`
     ///
-    /// - `dynamic_boundary_at` is *position-scoped*: the occurrence's anchor
-    ///   span must cover `byte_offset`.  It is designed for `UndeclaredVariable`
+    /// - `dynamic_boundary_at` is *position-scoped* on a `DynamicBoundary`
+    ///   occurrence's anchor span. Designed for `UndeclaredVariable`
     ///   suppression.
-    /// - `dynamic_callable_may_be_visible_at` is *file-wide* for the import
-    ///   path (any dynamic import in the file is sufficient) and *name-scoped*
-    ///   for the eval-sub path (entity name must match).  It is designed for
+    /// - `dynamic_callable_may_be_visible_at` is *order-aware* for the import
+    ///   path and *name-scoped* for the eval-sub path. Designed for
     ///   `UnquotedBareword` suppression where the callable is plausibly
-    ///   importable anywhere in the file.
+    ///   importable from a dynamic source visible at this position.
     ///
     /// # Anti-patterns
     ///
-    /// - Variables (sigil-prefixed names) are not callables and must never
-    ///   be matched by this query.  Callers must strip sigils before calling.
+    /// - Variables (sigil-prefixed names) are not callables and must never be
+    ///   matched by this query. Callers must strip sigils before calling.
     /// - A `None` return means "no evidence" — emit the diagnostic
     ///   (conservative default).
     ///
     /// # Returns
     ///
-    /// `None` when no dynamic import exists for the file and no eval-sub
-    /// evidence matches `symbol`, or when the semantic data for `file_id`
-    /// is unavailable.  Callers should fall back to emitting the diagnostic
-    /// when `None`.
+    /// `None` when no dynamic import precedes `byte_offset` in the file and
+    /// no eval-sub evidence matches `symbol`, or when the semantic data for
+    /// `file_id` is unavailable. Callers should fall back to emitting the
+    /// diagnostic when `None`.
     ///
     /// # Requirements
     ///

--- a/crates/perl-workspace/src/semantic/queries.rs
+++ b/crates/perl-workspace/src/semantic/queries.rs
@@ -841,10 +841,11 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
         // `ImportSymbols::Dynamic` means the imported symbol list is not
         // statically known (e.g. `Foo->import(@names)` or `require $var`).
         // Any bareword in the file could plausibly come from this import.
-        let has_dynamic_import =
-            self.import_export_index.get_imports_for_file(file_id).iter().any(|spec| {
-                matches!(spec.symbols, perl_semantic_facts::ImportSymbols::Dynamic)
-            });
+        let has_dynamic_import = self
+            .import_export_index
+            .get_imports_for_file(file_id)
+            .iter()
+            .any(|spec| matches!(spec.symbols, perl_semantic_facts::ImportSymbols::Dynamic));
 
         if has_dynamic_import {
             // Return a synthetic DynamicBoundary occurrence as evidence.
@@ -864,10 +865,7 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
         //
         // This covers `eval "sub NAME { ... }"` patterns where the extractor
         // has emitted an OccurrenceFact with entity name == NAME.
-        let shard = match self.shard_for_file(file_id) {
-            Some(s) => s,
-            None => return None,
-        };
+        let shard = self.shard_for_file(file_id)?;
 
         for occurrence in &shard.occurrences {
             if occurrence.kind != OccurrenceKind::DynamicBoundary {
@@ -3842,7 +3840,8 @@ mod tests {
         use perl_semantic_facts::{ImportKind, ImportSpec, ImportSymbols};
 
         let file_id = FileId(100);
-        let shard = make_shard("file:///test/dyn_import.pl", file_id, vec![], vec![], vec![], vec![]);
+        let shard =
+            make_shard("file:///test/dyn_import.pl", file_id, vec![], vec![], vec![], vec![]);
         let mut shards = HashMap::new();
         shards.insert(shard.source_uri.clone(), shard);
 
@@ -3986,8 +3985,7 @@ mod tests {
         use perl_semantic_facts::{ImportKind, ImportSpec, ImportSymbols};
 
         let file_id = FileId(103);
-        let shard =
-            make_shard("file:///test/sigil.pl", file_id, vec![], vec![], vec![], vec![]);
+        let shard = make_shard("file:///test/sigil.pl", file_id, vec![], vec![], vec![], vec![]);
         let mut shards = HashMap::new();
         shards.insert(shard.source_uri.clone(), shard);
 

--- a/crates/perl-workspace/src/semantic/queries.rs
+++ b/crates/perl-workspace/src/semantic/queries.rs
@@ -163,6 +163,59 @@ pub trait SemanticQueries {
         byte_offset: u32,
         symbol: Option<&str>,
     ) -> Option<OccurrenceFact>;
+
+    /// Return evidence that a dynamic callable named `symbol` may be visible at
+    /// a given position in `file_id`.
+    ///
+    /// # Contract (file-wide import coverage + named DynamicBoundary)
+    ///
+    /// Returns `Some(OccurrenceFact)` when **either** of the following holds:
+    ///
+    /// 1. The file at `file_id` has at least one `ImportSpec` with
+    ///    `ImportSymbols::Dynamic` — the imported symbols are not statically
+    ///    known, so *any* bareword call in the file might have come from that
+    ///    import.  This covers `Foo->import(@names)` (static class, dynamic
+    ///    arg list) and `require $var` (dynamic module, unknown exports).
+    /// 2. The file has at least one occurrence with
+    ///    `kind = OccurrenceKind::DynamicBoundary` whose associated entity's
+    ///    canonical name matches `symbol`.  This covers `eval "sub NAME { ... }"`
+    ///    patterns where the sub name is literally present in the string.
+    ///
+    /// # Differences from `dynamic_boundary_at`
+    ///
+    /// - `dynamic_boundary_at` is *position-scoped*: the occurrence's anchor
+    ///   span must cover `byte_offset`.  It is designed for `UndeclaredVariable`
+    ///   suppression.
+    /// - `dynamic_callable_may_be_visible_at` is *file-wide* for the import
+    ///   path (any dynamic import in the file is sufficient) and *name-scoped*
+    ///   for the eval-sub path (entity name must match).  It is designed for
+    ///   `UnquotedBareword` suppression where the callable is plausibly
+    ///   importable anywhere in the file.
+    ///
+    /// # Anti-patterns
+    ///
+    /// - Variables (sigil-prefixed names) are not callables and must never
+    ///   be matched by this query.  Callers must strip sigils before calling.
+    /// - A `None` return means "no evidence" — emit the diagnostic
+    ///   (conservative default).
+    ///
+    /// # Returns
+    ///
+    /// `None` when no dynamic import exists for the file and no eval-sub
+    /// evidence matches `symbol`, or when the semantic data for `file_id`
+    /// is unavailable.  Callers should fall back to emitting the diagnostic
+    /// when `None`.
+    ///
+    /// # Requirements
+    ///
+    /// - **Req 7.5**: Suppress `UnquotedBareword` diagnostics for barewords
+    ///   plausibly provided by a dynamic import or string-eval sub declaration.
+    fn dynamic_callable_may_be_visible_at(
+        &self,
+        file_id: FileId,
+        byte_offset: u32,
+        symbol: &str,
+    ) -> Option<OccurrenceFact>;
 }
 
 // ── WorkspaceSemanticQueries ──
@@ -767,6 +820,75 @@ impl<'a> SemanticQueries for WorkspaceSemanticQueries<'a> {
             }
 
             return Some(occurrence.clone());
+        }
+
+        None
+    }
+
+    fn dynamic_callable_may_be_visible_at(
+        &self,
+        file_id: FileId,
+        _byte_offset: u32,
+        symbol: &str,
+    ) -> Option<OccurrenceFact> {
+        // Guard: variables (sigil-prefixed) are not callables.
+        if symbol.starts_with(['$', '@', '%', '&', '*']) {
+            return None;
+        }
+
+        // ── Path 1: file has a Dynamic import ──
+        //
+        // `ImportSymbols::Dynamic` means the imported symbol list is not
+        // statically known (e.g. `Foo->import(@names)` or `require $var`).
+        // Any bareword in the file could plausibly come from this import.
+        let has_dynamic_import =
+            self.import_export_index.get_imports_for_file(file_id).iter().any(|spec| {
+                matches!(spec.symbols, perl_semantic_facts::ImportSymbols::Dynamic)
+            });
+
+        if has_dynamic_import {
+            // Return a synthetic DynamicBoundary occurrence as evidence.
+            // anchor_id 0 is a placeholder — callers only check is_some().
+            return Some(OccurrenceFact {
+                id: perl_semantic_facts::OccurrenceId(0),
+                kind: OccurrenceKind::DynamicBoundary,
+                entity_id: None,
+                anchor_id: AnchorId(0),
+                scope_id: None,
+                provenance: perl_semantic_facts::Provenance::DynamicBoundary,
+                confidence: perl_semantic_facts::Confidence::Low,
+            });
+        }
+
+        // ── Path 2: file has a DynamicBoundary occurrence for this exact name ──
+        //
+        // This covers `eval "sub NAME { ... }"` patterns where the extractor
+        // has emitted an OccurrenceFact with entity name == NAME.
+        let shard = match self.shard_for_file(file_id) {
+            Some(s) => s,
+            None => return None,
+        };
+
+        for occurrence in &shard.occurrences {
+            if occurrence.kind != OccurrenceKind::DynamicBoundary {
+                continue;
+            }
+
+            let entity_id = match occurrence.entity_id {
+                Some(eid) => eid,
+                // entity_id is None → fully dynamic, not a named eval-sub boundary.
+                // These are handled by Path 1 above; skip here to avoid over-matching.
+                None => continue,
+            };
+
+            let entity_matches = shard.entities.iter().any(|e| {
+                e.id == entity_id
+                    && (e.canonical_name == symbol || bare_name(&e.canonical_name) == symbol)
+            });
+
+            if entity_matches {
+                return Some(occurrence.clone());
+            }
         }
 
         None
@@ -3706,6 +3828,210 @@ mod tests {
 
         let result2 = queries.dynamic_boundary_at(file_id, 20, Some("foo"));
         assert!(result2.is_some(), "fully-dynamic boundary should accept 'foo'");
+        Ok(())
+    }
+
+    // ── dynamic_callable_may_be_visible_at tests ──
+
+    #[test]
+    fn dynamic_callable_returns_some_when_file_has_dynamic_import()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // When a file has an ImportSpec with ImportSymbols::Dynamic, any
+        // bareword in that file is potentially visible.
+        use crate::semantic::imports::ImportExportIndex;
+        use perl_semantic_facts::{ImportKind, ImportSpec, ImportSymbols};
+
+        let file_id = FileId(100);
+        let shard = make_shard("file:///test/dyn_import.pl", file_id, vec![], vec![], vec![], vec![]);
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let mut ie_index = ImportExportIndex::new();
+
+        // Add a Dynamic import for this file.
+        ie_index.add_file_imports(
+            "file:///test/dyn_import.pl",
+            file_id,
+            vec![ImportSpec {
+                module: "Foo".to_string(),
+                kind: ImportKind::Use,
+                symbols: ImportSymbols::Dynamic,
+                provenance: Provenance::DynamicBoundary,
+                confidence: Confidence::Low,
+                file_id: Some(file_id),
+                anchor_id: None,
+                scope_id: None,
+            }],
+        );
+
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // Any bareword in this file should be covered.
+        let result = queries.dynamic_callable_may_be_visible_at(file_id, 100, "bar");
+        assert!(result.is_some(), "should return Some when file has Dynamic import");
+        let occ = result.ok_or("expected OccurrenceFact")?;
+        assert_eq!(occ.kind, OccurrenceKind::DynamicBoundary);
+        assert_eq!(occ.provenance, Provenance::DynamicBoundary);
+        assert_eq!(occ.confidence, Confidence::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_callable_returns_none_when_no_dynamic_import()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // A file with no Dynamic imports: no evidence for any bareword.
+        use perl_semantic_facts::{ImportKind, ImportSpec, ImportSymbols};
+
+        let file_id = FileId(101);
+        let shard = make_shard("file:///test/no_dyn.pl", file_id, vec![], vec![], vec![], vec![]);
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let mut ie_index = ImportExportIndex::new();
+
+        // Add an Explicit import (NOT dynamic).
+        ie_index.add_file_imports(
+            "file:///test/no_dyn.pl",
+            file_id,
+            vec![ImportSpec {
+                module: "Bar".to_string(),
+                kind: ImportKind::UseExplicitList,
+                symbols: ImportSymbols::Explicit(vec!["known_sub".to_string()]),
+                provenance: Provenance::ExactAst,
+                confidence: Confidence::High,
+                file_id: Some(file_id),
+                anchor_id: None,
+                scope_id: None,
+            }],
+        );
+
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        let result = queries.dynamic_callable_may_be_visible_at(file_id, 100, "unknown_sub");
+        assert!(result.is_none(), "should return None when import is Explicit, not Dynamic");
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_callable_returns_some_when_eval_sub_boundary_matches_name()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // When a DynamicBoundary occurrence has an entity named "generated_sub",
+        // dynamic_callable_may_be_visible_at("generated_sub") returns Some.
+        let file_id = FileId(102);
+        // Build a shard with a DynamicBoundary occurrence for entity "generated_sub".
+        let entity_id = EntityId(200);
+        let anchor_id = AnchorId(201);
+        let occurrence_id = OccurrenceId(202);
+
+        let entity = EntityFact {
+            id: entity_id,
+            canonical_name: "generated_sub".to_string(),
+            kind: EntityKind::Subroutine,
+            anchor_id: Some(anchor_id),
+            scope_id: None,
+            provenance: Provenance::DynamicBoundary,
+            confidence: Confidence::Low,
+        };
+        let anchor = AnchorFact {
+            id: anchor_id,
+            file_id,
+            span_start_byte: 0,
+            span_end_byte: 50,
+            scope_id: None,
+            provenance: Provenance::DynamicBoundary,
+            confidence: Confidence::Low,
+        };
+        let occurrence = OccurrenceFact {
+            id: occurrence_id,
+            kind: OccurrenceKind::DynamicBoundary,
+            entity_id: Some(entity_id),
+            anchor_id,
+            scope_id: None,
+            provenance: Provenance::DynamicBoundary,
+            confidence: Confidence::Low,
+        };
+
+        let shard = make_shard(
+            "file:///test/eval_sub.pl",
+            file_id,
+            vec![anchor],
+            vec![entity],
+            vec![occurrence],
+            vec![],
+        );
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // Should find the eval-sub boundary for "generated_sub".
+        let result = queries.dynamic_callable_may_be_visible_at(file_id, 100, "generated_sub");
+        assert!(result.is_some(), "should return Some for named eval-sub DynamicBoundary");
+
+        // Should NOT find for a different name.
+        let result2 =
+            queries.dynamic_callable_may_be_visible_at(file_id, 100, "truly_undefined_sub");
+        assert!(result2.is_none(), "should return None for different name (no evidence)");
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_callable_variable_sigil_never_matches() -> Result<(), Box<dyn std::error::Error>> {
+        // Variables (sigil-prefixed names) are not callables.
+        // Even with a Dynamic import, sigil-prefixed names must return None.
+        use perl_semantic_facts::{ImportKind, ImportSpec, ImportSymbols};
+
+        let file_id = FileId(103);
+        let shard =
+            make_shard("file:///test/sigil.pl", file_id, vec![], vec![], vec![], vec![]);
+        let mut shards = HashMap::new();
+        shards.insert(shard.source_uri.clone(), shard);
+
+        let ref_index = ReferenceIndex::new();
+        let mut ie_index = ImportExportIndex::new();
+        ie_index.add_file_imports(
+            "file:///test/sigil.pl",
+            file_id,
+            vec![ImportSpec {
+                module: String::new(),
+                kind: ImportKind::DynamicRequire,
+                symbols: ImportSymbols::Dynamic,
+                provenance: Provenance::DynamicBoundary,
+                confidence: Confidence::Low,
+                file_id: Some(file_id),
+                anchor_id: None,
+                scope_id: None,
+            }],
+        );
+
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // Variables with sigils must be rejected even when a dynamic import exists.
+        for sigil_var in &["$foo", "@bar", "%baz", "&qux", "*glob"] {
+            let result = queries.dynamic_callable_may_be_visible_at(file_id, 0, sigil_var);
+            assert!(
+                result.is_none(),
+                "sigil-prefixed '{}' must never match dynamic_callable_may_be_visible_at",
+                sigil_var
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_callable_returns_none_for_unknown_file() -> Result<(), Box<dyn std::error::Error>> {
+        let ref_index = ReferenceIndex::new();
+        let ie_index = ImportExportIndex::new();
+        let shards = HashMap::new();
+        let queries = build_queries(&ref_index, &ie_index, &shards);
+
+        // FileId(999) has no shard and no import data.
+        let result = queries.dynamic_callable_may_be_visible_at(FileId(999), 0, "any_sub");
+        assert!(result.is_none(), "unknown file should return None");
         Ok(())
     }
 }

--- a/crates/perl-workspace/src/semantic/scorecard_gate_fixtures.rs
+++ b/crates/perl-workspace/src/semantic/scorecard_gate_fixtures.rs
@@ -318,6 +318,7 @@ mod tests {
                 file_id: Some(importer_fid),
                 anchor_id: None,
                 scope_id: None,
+                span_start_byte: None,
             }],
         );
 
@@ -748,6 +749,7 @@ mod tests {
                 file_id: Some(importer_fid),
                 anchor_id: None,
                 scope_id: None,
+                span_start_byte: None,
             }],
         );
 
@@ -835,6 +837,7 @@ mod tests {
                 file_id: Some(importer_fid),
                 anchor_id: None,
                 scope_id: None,
+                span_start_byte: None,
             }],
         );
 
@@ -958,6 +961,7 @@ mod tests {
                 file_id: Some(importer_fid),
                 anchor_id: None,
                 scope_id: None,
+                span_start_byte: None,
             }],
         );
 

--- a/crates/perl-workspace/src/semantic/visibility.rs
+++ b/crates/perl-workspace/src/semantic/visibility.rs
@@ -246,6 +246,13 @@ fn collect_import_visibility(
                 // Require without import and DynamicRequire do not make
                 // symbols visible in the importing file's namespace.
             }
+
+            ImportKind::ManualImport => {
+                // `Class->import(@dynamic)` — the symbol list is not statically
+                // known (ImportSymbols::Dynamic), so no specific symbols can be
+                // added to visibility here.  The dynamic_callable_may_be_visible_at
+                // query handles suppression at diagnostic time.
+            }
         }
     }
 }
@@ -549,6 +556,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(100)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -587,6 +595,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(101)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -626,6 +635,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(102)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -667,6 +677,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(103)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -739,6 +750,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(104)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -770,6 +782,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(104)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -797,6 +810,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(105)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -824,6 +838,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(106)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -861,6 +876,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(107)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -932,6 +948,7 @@ mod tests {
                     file_id: Some(file_id),
                     anchor_id: Some(AnchorId(100)),
                     scope_id: None,
+                                span_start_byte: None,
                 };
                 index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -1008,6 +1025,7 @@ mod tests {
                     file_id: Some(file_id),
                     anchor_id: Some(AnchorId(100)),
                     scope_id: None,
+                                span_start_byte: None,
                 };
                 index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -1099,6 +1117,7 @@ mod tests {
                     file_id: Some(file_id),
                     anchor_id: Some(AnchorId(100)),
                     scope_id: None,
+                                span_start_byte: None,
                 };
                 index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 
@@ -1149,6 +1168,7 @@ mod tests {
             file_id: Some(file_id),
             anchor_id: Some(AnchorId(108)),
             scope_id: None,
+            span_start_byte: None,
         };
         index.add_file_imports("file:///lib/Main.pm", file_id, vec![import]);
 

--- a/crates/perl-workspace/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace/src/workspace/workspace_index.rs
@@ -2494,6 +2494,13 @@ impl WorkspaceIndex {
         // The `build_canonical_fact_shard` function only accepts OccurrenceFact
         // slices for dynamic_boundaries; entities and anchors must be merged
         // manually so that the query can resolve entity names from occurrence IDs.
+        //
+        // NOTE: This post-build merge means `entities_hash` and `anchors_hash`
+        // do not reflect the eval-sub additions. Incremental replacement
+        // (`replace_fact_shard_incremental`) may miss a change if only the eval
+        // string changes — the `content_hash` (whole-file) will still catch it.
+        // A future refactor should extend `build_canonical_fact_shard`'s API to
+        // accept extra entity/anchor slices alongside `dynamic_boundaries`.
         for (entity, anchor, _) in eval_sub_triples {
             shard.entities.push(entity);
             shard.anchors.push(anchor);

--- a/crates/perl-workspace/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace/src/workspace/workspace_index.rs
@@ -2470,16 +2470,36 @@ impl WorkspaceIndex {
             decl_facts.entities.iter().map(|e| (e.canonical_name.clone(), e.id)).collect();
         let ref_facts = symbol_refs_to_semantic_facts(&refs, file_id, &entity_ids_by_name);
 
-        // No imports or dynamic boundaries available at this layer yet —
-        // those will be supplied by perl-semantic-analyzer in later phases.
-        crate::semantic::facts::build_canonical_fact_shard(
+        // Extract dynamic boundary evidence for `eval "sub NAME { ... }"` patterns.
+        // Non-literal evals (e.g. `eval $code`) are intentionally skipped — the
+        // sub name is not statically known and no evidence is emitted.
+        let eval_sub_triples =
+            crate::semantic::eval_sub_extractor::extract_eval_sub_boundaries(ast, file_id);
+        let dynamic_boundaries: Vec<perl_semantic_facts::OccurrenceFact> =
+            eval_sub_triples.iter().map(|(_, _, occ)| occ.clone()).collect();
+
+        // Build the canonical fact shard.
+        // Import specs (for `use`, `require`, `ClassName->import()`) are
+        // populated separately via ImportExportIndex — not passed here.
+        let mut shard = crate::semantic::facts::build_canonical_fact_shard(
             uri,
             content_hash,
             &decl_facts,
             &ref_facts,
             &[],
-            &[],
-        )
+            &dynamic_boundaries,
+        );
+
+        // Merge entity and anchor facts from eval-sub extraction into the shard.
+        // The `build_canonical_fact_shard` function only accepts OccurrenceFact
+        // slices for dynamic_boundaries; entities and anchors must be merged
+        // manually so that the query can resolve entity names from occurrence IDs.
+        for (entity, anchor, _) in eval_sub_triples {
+            shard.entities.push(entity);
+            shard.anchors.push(anchor);
+        }
+
+        shard
     }
 
     /// Replace a [`FileFactShard`] with per-category incremental invalidation.

--- a/docs/project/status/semantic_scorecard.json
+++ b/docs/project/status/semantic_scorecard.json
@@ -43,7 +43,7 @@
   "fact_rows": {
     "declaration_facts": {
       "status": "available",
-      "total_facts": 40,
+      "total_facts": 41,
       "fixture_coverage": {
         "covered_fixture_count": 16,
         "total_fixture_count": 16,
@@ -70,12 +70,12 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     },
     "definition_candidates": {
       "status": "available",
-      "total_facts": 40,
+      "total_facts": 41,
       "fixture_coverage": {
         "covered_fixture_count": 16,
         "total_fixture_count": 16,
@@ -102,7 +102,7 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     },
     "export_facts": {
@@ -134,7 +134,7 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     },
     "import_specs": {
@@ -166,7 +166,7 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     },
     "inheritance_edges": {
@@ -198,12 +198,12 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     },
     "occurrence_facts": {
       "status": "available",
-      "total_facts": 25,
+      "total_facts": 26,
       "fixture_coverage": {
         "covered_fixture_count": 16,
         "total_fixture_count": 16,
@@ -230,7 +230,7 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     },
     "package_graph_edges": {
@@ -262,7 +262,7 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     },
     "reference_edges": {
@@ -294,7 +294,7 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     },
     "role_composition_edges": {
@@ -326,7 +326,7 @@
         "exact_facts": 154,
         "high_confidence_facts": 152,
         "heuristic_facts": 1,
-        "dynamic_boundary_facts": 2
+        "dynamic_boundary_facts": 5
       }
     }
   },
@@ -387,7 +387,7 @@
     },
     "semantic_fact_counts_nonzero": {
       "status": "pass",
-      "value": "82",
+      "value": "84",
       "threshold": "> 0",
       "evidence": "semantic fixture indexing"
     },

--- a/docs/project/status/semantic_scorecard.md
+++ b/docs/project/status/semantic_scorecard.md
@@ -8,15 +8,15 @@ Fixtures loaded: `16`
 
 | Row | Status | Facts | Coverage | Exact | High | Heuristic | Dynamic boundary |
 |---|---|---:|---:|---:|---:|---:|---:|
-| declaration_facts | available | 40 | 16/16 | 154 | 152 | 1 | 2 |
-| definition_candidates | available | 40 | 16/16 | 154 | 152 | 1 | 2 |
-| export_facts | available | 3 | 16/16 | 154 | 152 | 1 | 2 |
-| import_specs | available | 11 | 16/16 | 154 | 152 | 1 | 2 |
-| inheritance_edges | available | 1 | 16/16 | 154 | 152 | 1 | 2 |
-| occurrence_facts | available | 25 | 16/16 | 154 | 152 | 1 | 2 |
-| package_graph_edges | available | 2 | 16/16 | 154 | 152 | 1 | 2 |
-| reference_edges | available | 1 | 16/16 | 154 | 152 | 1 | 2 |
-| role_composition_edges | available | 1 | 16/16 | 154 | 152 | 1 | 2 |
+| declaration_facts | available | 41 | 16/16 | 154 | 152 | 1 | 5 |
+| definition_candidates | available | 41 | 16/16 | 154 | 152 | 1 | 5 |
+| export_facts | available | 3 | 16/16 | 154 | 152 | 1 | 5 |
+| import_specs | available | 11 | 16/16 | 154 | 152 | 1 | 5 |
+| inheritance_edges | available | 1 | 16/16 | 154 | 152 | 1 | 5 |
+| occurrence_facts | available | 26 | 16/16 | 154 | 152 | 1 | 5 |
+| package_graph_edges | available | 2 | 16/16 | 154 | 152 | 1 | 5 |
+| reference_edges | available | 1 | 16/16 | 154 | 152 | 1 | 5 |
+| role_composition_edges | available | 1 | 16/16 | 154 | 152 | 1 | 5 |
 
 ## Readiness Rows
 
@@ -31,7 +31,7 @@ Fixtures loaded: `16`
 | rename_unsafe_edit_count | pass | 0 | 0 | rename plan query fixtures |
 | safe_delete_blocker_fixture_pass_rate | pass | 100% | 100% | safe-delete plan query fixtures |
 | safe_delete_plan | pass | 100% | 100% | safe-delete plan query fixtures |
-| semantic_fact_counts_nonzero | pass | 82 | > 0 | semantic fixture indexing |
+| semantic_fact_counts_nonzero | pass | 84 | > 0 | semantic fixture indexing |
 | undefined_symbol_false_positive_fixture_rate | pass | 0% | 0% | diagnostics fixture receipts |
 | visible_symbols_fixture_pass_rate | pass | 100% | 100% | workspace scorecard fixtures |
 

--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -650,6 +650,7 @@ fn rename_plan_cross_module_export_fixture() -> (RenamePlan, bool) {
             file_id: Some(importer_file),
             anchor_id: None,
             scope_id: None,
+            span_start_byte: None,
         }],
     );
 
@@ -969,6 +970,7 @@ fn safe_delete_plan_imported_symbol_fixture() -> (SafeDeletePlan, bool) {
             file_id: Some(importer_file),
             anchor_id: None,
             scope_id: None,
+            span_start_byte: None,
         }],
     );
 


### PR DESCRIPTION
## Status: Infrastructure PR (PR-B) — behavior live when runtime wiring lands

This PR builds the full infrastructure for dynamic strict-bareword diagnostic suppression. Runtime wiring (threading `WorkspaceSemanticQueries` through `DiagnosticsProvider`) requires architectural changes to `WorkspaceIndex`'s lifetime model (private `Arc<RwLock<...>>` indexes) that exceed the 100 LOC threshold. Per ChatGPT reviewer guidance, retitled to \"infrastructure\" framing. Runtime wiring is the explicit follow-up.

## ChatGPT Review Fixes (commits F-H on top of original build)

### P0 #1 — Runtime wiring decision: DEFER + RETITLE
`WorkspaceSemanticQueries` requires borrowed references to internal `RwLock`-guarded data that cannot be safely extracted into a short-lived scope at the diagnostics call site without architectural changes (add `with_semantic_scope` callback on `WorkspaceIndex`, or a new owned `WorkspaceSemanticQueries` type). Estimated >100 LOC across 4+ call sites in 3 crates. PR retitled from \"suppress\" to \"add... infrastructure\".

### P0 #2 — Replace fake OccurrenceFact evidence
Added `DynamicCallableEvidence` enum (`DynamicImport { file_id, anchor_id, module }` | `EvalSub { occurrence }`). `dynamic_callable_may_be_visible_at` now returns `Option<DynamicCallableEvidence>` — no more `OccurrenceId(0)` / `AnchorId(0)` sentinels. All 14 stub implementations updated.

### P0 #3 — Order-aware dynamic import suppression
`Foo->import(@names); bar()` → suppress. `bar(); Foo->import(@names)` → still diagnose.
Uses `ImportSpec::span_start_byte` (new field added to `perl-semantic-facts`), populated by `ImportExtractor` from `node.location.start`. Conservative: if position unknown, no suppression.

### P1 #4 — Document eval-sub extractor placement debt
Added module-level doc comment in `eval_sub_extractor.rs` explaining the circular dep constraint (`perl-semantic-analyzer → perl-workspace`), that this is temporary, and the follow-up action (invert dep, move extractor to `perl-semantic-analyzer`).

### P1 #5 — Tighten literal eval extraction
Now requires plausible Perl sub declaration delimiter after `NAME`: `{`, `;`, or `(`. Rejects:
- `sub NAME` followed by random text (was wrongly accepted)
- `sub { ... }` anonymous subs (already rejected, now explicit guard)
- `sub $name { ... }` sigil-prefixed names (new guard)
New tests cover all reject cases.

### P1 #6 — Real AST spans for eval-sub anchors
`emit_triple` now takes `node_end_byte` from `node.location.end` instead of the synthetic `(node_start_byte + 1).max(node_start_byte + name.len())` calculation.

### P1 #7 — Fix ImportKind semantics
`Foo->import(@names)` now emits `ImportKind::ManualImport` (new variant in `perl-semantic-facts`) instead of `ImportKind::Use`. Test asserts the correct kind. `visibility.rs` handles `ManualImport` in its match (treats like `DynamicRequire` — no static visibility).

### P1 #8 — Real integration proof
5 end-to-end tests in `crates/perl-lsp-rs-core/tests/dynamic_callable_integration_tests.rs` using real `WorkspaceSemanticQueries` (not stubs):
1. `Foo->import(@names); bar();` → suppress ✓
2. `bar(); Foo->import(@names);` → still diagnose ✓ (order-aware)
3. `eval "sub generated_from_string { 1 }"; generated_from_string();` → suppress ✓
4. `eval "sub generated_from_string { 1 }"; truly_undefined_sub();` → diagnose ✓
5. `truly_undefined_sub();` → diagnose ✓

## Architecture

### Three-layer approach

**Layer 1 — Producers:**
- `eval_sub_extractor.rs`: recognizes `eval "sub NAME { ... }"` and emits `DynamicBoundary` evidence into `FileFactShard`
- `import_extractor.rs`: recognizes standalone `ClassName->import(@names)` and emits `ImportSpec { kind: ManualImport, symbols: Dynamic, span_start_byte: Some(pos) }`
- `workspace_index.rs`: wires eval-sub extraction into `build_canonical_fact_shard_for_ast`

**Layer 2 — Query:**
- `DynamicCallableEvidence` enum in `queries.rs` — typed evidence replacing fake `OccurrenceFact`
- `dynamic_callable_may_be_visible_at` returns `Option<DynamicCallableEvidence>`
- Path 1: Order-aware dynamic import (`span_start_byte <= byte_offset`)
- Path 2: Name-scoped eval-sub boundary

**Layer 3 — Converter:**
- `scope_issues_to_diagnostics_with_semantics` handles `IssueKind::UnquotedBareword` via `dynamic_callable_may_be_visible_at`

## Architectural Debt Note

`eval_sub_extractor.rs` lives in `perl-workspace` (not `perl-semantic-analyzer`) due to circular dep:
`perl-semantic-analyzer` depends on `perl-workspace`, preventing the reverse. This is **temporary**.
Follow-up: invert or remove the `perl-semantic-analyzer → perl-workspace` dep arc, then move the extractor.

## Suppression Policy

| Issue kind | Query | Coverage |
|---|---|---|
| `UndeclaredVariable` | `dynamic_boundary_at` | Position-scoped |
| `UnquotedBareword` | `dynamic_callable_may_be_visible_at` | Order-aware import OR name-scoped eval-sub |
| All others | — | Always emit |

## Tests Added (this review pass)

- `queries.rs`: order-aware tests (import before/after offset)
- `eval_sub_extractor.rs`: prose rejection, forward-decl, prototype, sigil-prefixed, anonymous sub
- `import_extractor.rs`: `ManualImport` kind assertion
- `dynamic_callable_integration_tests.rs`: 5 real-workspace end-to-end tests

## Verification Results

```
cargo test -p perl-lsp-rs-core --lib:            1225 passed, 0 failed
cargo test -p perl-workspace --lib:               539 passed, 0 failed
cargo test -p perl-semantic-analyzer --lib:        235 passed, 0 failed
cargo test -p perl-lsp-rs-core --test dynamic_callable_integration_tests: 5 passed
cargo xtask semantic-scorecard --check:           passed
cargo xtask semantic-shadow-compare --check:      passed
cargo xtask fmt:                                  clean
cargo clippy -p perl-workspace -p perl-lsp-rs-core -p perl-semantic-analyzer: 0 warnings
```

Pre-existing failure (not introduced by this PR):
- `test_dap_build_includes_rs_core_catalog` — `perl-dap/build.rs` diverged from master before this branch was created

## Commit History

- A: trait + red tests + stub (original build)
- B: producers (eval-sub extractor + import extractor extension)
- D: converter (scope_issues_to_diagnostics_with_semantics extended)
- E: fmt + clippy + scorecard (original build cleanup)
- F (new): DynamicCallableEvidence + order-aware suppression + ImportKind::ManualImport + ImportSpec::span_start_byte
- G (new): tighten eval extraction + real AST spans
- H (new): real integration tests + scope pub + placement debt doc