### PR TITLE
fix(release): add v0.13.3 to RELEASE_HISTORY ledger (#0000)

### DIFF
--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -14,6 +14,7 @@ Tag commit timestamps may differ from release dates.
 
 | Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
 |---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
+| [0.13.3] | `v0.13.3` | [yes][gh-0.13.3] | 2026-05-03 | `06fc1443` | [v0.13.2...v0.13.3] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.3 (31 crates) | [perl-lsp-rs][vsce] | [v0.13.3][n-0.13.3] |
 | [0.13.2] | `v0.13.2` | [yes][gh-0.13.2] | 2026-05-02 | `0e9c5d78` | [v0.13.1...v0.13.2] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.2 (31 crates) | [perl-lsp-rs][vsce] | [v0.13.2][n-0.13.2] |
 | [0.13.1] | `v0.13.1` | [yes][gh-0.13.1] (prerelease) | 2026-05-01 | `6ef20484` | [v0.13.0...v0.13.1] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.1 (32 crates) | [perl-lsp-rs][vsce] | [v0.13.1][n-0.13.1] |
 | [0.12.4] | `v0.12.4` | [yes][gh-0.12.4] | 2026-04-12 | `5ebb37aa` | [v0.12.3...v0.12.4] | 9 (7 binaries, SHA256SUMS, SBOM) | deferred | [perl-lsp-rs][vsce] | [v0.12.4][n-0.12.4] |
@@ -57,6 +58,7 @@ Tag commit timestamps may differ from release dates.
 ## Links
 
 <!-- Notes files -->
+[n-0.13.3]: docs/releases/v0.13.3.md
 [n-0.13.2]: docs/releases/v0.13.2.md
 [n-0.13.1]: docs/releases/v0.13.1.md
 [n-0.12.4]: docs/releases/v0.12.4.md
@@ -73,6 +75,7 @@ Tag commit timestamps may differ from release dates.
 [n-0.8.3]: docs/releases/v0.8.3.md
 
 <!-- Version links (to notes files) -->
+[0.13.3]: docs/releases/v0.13.3.md
 [0.13.2]: docs/releases/v0.13.2.md
 [0.13.1]: docs/releases/v0.13.1.md
 [0.12.4]: docs/releases/v0.12.4.md
@@ -89,6 +92,7 @@ Tag commit timestamps may differ from release dates.
 [0.8.3]: docs/releases/v0.8.3.md
 
 <!-- GitHub Releases -->
+[gh-0.13.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.3
 [gh-0.13.2]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.2
 [gh-0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.1
 [gh-0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.12.4
@@ -101,6 +105,7 @@ Tag commit timestamps may differ from release dates.
 [gh-0.8.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3
 
 <!-- Compare ranges -->
+[v0.13.2...v0.13.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.2...v0.13.3
 [v0.13.1...v0.13.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.1...v0.13.2
 [v0.13.0...v0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0...v0.13.1
 [v0.12.3...v0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4


### PR DESCRIPTION
## Summary

- v0.13.3 shipped on master at \`06fc1443\` (#7870 hardening + #7872 release-prep), but \`RELEASE_HISTORY.md\` was not updated as part of either PR.
- The release-history drift check fails with \`Missing RELEASE_HISTORY.md entry for 0.13.3\`, blocking PR Smoke + CI Gate on every PR opened against master.
- This PR is the master-fix.

## Detection

\`\`\`
$ bash scripts/check_release_history.sh
ERROR: Missing RELEASE_HISTORY.md entry for 0.13.3
$ just ci-release-history → exit 1
$ just ci-release-history-check → exit 1
\`\`\`

Reproduced on PR #7874 (test-only regression locks for managed install hardening) — the only failing gates were \`release_history\` + \`release_history_check\`, both rooted in master state, not the PR's diff.

## Fix

Adds the canonical 0.13.3 row + four link refs (notes, version, GitHub release, compare range), matching the schema of the surrounding entries.

## Verification

\`\`\`
bash scripts/check_release_history.sh -> Release history drift check passed
cargo xtask install-surface-check    -> 4617 active files scanned, passed
\`\`\`

## Follow-up worth filing separately

The release orchestration should append the new RELEASE_HISTORY row as part of the publish flow so this drift can't recur after a release-prep PR merges. The 0.13.2 release didn't hit this because the prior release-prep landed in a single PR that included the row; #7872 unbundled it and the row was never added.

## Test plan

- [ ] CI: \`release_history\` + \`release_history_check\` gates green
- [ ] CI: PR Smoke + CI Gate (Merge-Blocking) green
- [ ] Merge with admin if needed (this PR unblocks itself by definition)