### PR TITLE
chore(repo): ignore .claude/settings.local.json (#0000)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ scripts/__pycache__/
 /.claude/worktrees/
 # Codex worktree metadata — ephemeral agent artifacts, never committed.
 /.codex-worktrees/
+/.claude/settings.local.json
 
 # Swarm ops — ignore the entire directory (contains repo mirror artifacts),
 # but force-track the specific knowledge files we need.


### PR DESCRIPTION
Per-machine Claude Code settings file. Matches the anchored-pattern style of the existing \`/.claude/worktrees/\` line a few lines above.

One-line diff.