### PR TITLE
docs(readme): bump release track to v0.13.3 (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These are behavioral and corpus-backed signals, not feature-inventory counts. Pr
 <!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
-| Release track | `v0.13.2` public-alpha patch |
+| Release track | `v0.13.3` public-alpha patch |
 | Published crate surface | 31 crates in `[workspace.metadata.publish.allow]` |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |


### PR DESCRIPTION
## Summary

Visible-copy audit after the v0.13.3 release closeout found one stale reference in \`README.md\`: the status banner showed \`Release track | v0.13.2 public-alpha patch\` while v0.13.3 had already shipped (crates.io, Marketplace, Open VSX, Docker Hub, public Homebrew tap).

One-line fix.

## Other surfaces audited and clean

- \`docs/how-to/INSTALLATION.md\` — brew install with tap context, \`cargo install perllsp\`, GNU/musl chooser, \`perllsp --health\` all present and correct.
- \`docs/releases/v0.13.3.md\` — complete and accurate.
- v0.13.3 GitHub release body — chooser table + gnu/musl/windows-msvc rows all present.

## Note for follow-up

The \`README_STATUS\` banner has \`<!-- BEGIN/END: README_STATUS -->\` markers but is currently hand-maintained (no generator regenerates between the markers). Worth filing as separate hygiene work to either wire up regeneration or remove the markers. Not blocking.

## Test plan

- [ ] CI green
- [ ] Merge