### PR TITLE
fix(release): validate-release polls combined-status with timeout instead of fail-fast on pending (#0000)

### DIFF
--- a/.github/workflows/release-orchestration.yml
+++ b/.github/workflows/release-orchestration.yml
@@ -104,15 +104,43 @@ jobs:
             exit 1
           fi
 
-          echo "Checking CI status for ${HEAD_SHA}..."
-          CI_STATE="$(gh api repos/${{ github.repository }}/commits/${HEAD_SHA}/status --jq '.state')"
-          if [ -z "$CI_STATE" ]; then
-            echo "::error::Unable to determine CI state for ${HEAD_SHA}"
-            exit 1
-          fi
+          # Poll combined-status with a bounded window. Master CI on a just-
+          # squash-merged commit can return `pending` for several minutes
+          # before all required checks report; that is "no signal yet," not
+          # "negative signal." Treat `pending` as wait-and-retry; fail fast
+          # only on explicit `failure`/`error` from a required check, or on
+          # timeout. See docs/forensics/2026-05-03-validate-release-squash-
+          # timing-race.md for the incident this prevents.
+          POLL_TIMEOUT_SECONDS="${VALIDATE_RELEASE_CI_TIMEOUT_SECONDS:-300}"
+          POLL_INTERVAL_SECONDS="${VALIDATE_RELEASE_CI_POLL_INTERVAL_SECONDS:-30}"
+          DEADLINE=$(($(date +%s) + POLL_TIMEOUT_SECONDS))
+          CI_STATE=""
+
+          echo "Polling CI status for ${HEAD_SHA} (timeout ${POLL_TIMEOUT_SECONDS}s)..."
+          while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+            CI_STATE="$(gh api repos/${{ github.repository }}/commits/${HEAD_SHA}/status --jq '.state' 2>/dev/null || true)"
+            case "$CI_STATE" in
+              success)
+                break
+                ;;
+              failure|error)
+                echo "::error::Commit ${HEAD_SHA} CI reported ${CI_STATE}"
+                exit 1
+                ;;
+              pending|"")
+                REMAINING=$((DEADLINE - $(date +%s)))
+                echo "  CI state: ${CI_STATE:-unknown}; waiting ${POLL_INTERVAL_SECONDS}s (${REMAINING}s remaining)"
+                sleep "$POLL_INTERVAL_SECONDS"
+                ;;
+              *)
+                echo "::warning::Unexpected CI state '${CI_STATE}' for ${HEAD_SHA}; retrying"
+                sleep "$POLL_INTERVAL_SECONDS"
+                ;;
+            esac
+          done
 
           if [ "$CI_STATE" != "success" ]; then
-            echo "::error::Commit ${HEAD_SHA} is not in a successful CI state (${CI_STATE})"
+            echo "::error::Commit ${HEAD_SHA} did not reach success CI state within ${POLL_TIMEOUT_SECONDS}s (last state: ${CI_STATE:-unknown})"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Replaces the single-shot \`gh api .../commits/\$SHA/status\` query in \`Validate Release\` with a bounded poll loop. Master CI on a just-squash-merged commit can return \`pending\` for several minutes before required checks report; the previous fail-fast logic conflated \`pending\` ("no signal yet, retry") with \`failure\` ("explicit negative signal").

## Background

This bit the v0.13.3 release. Orchestration run \`25273613531\` dispatched ~1 minute after \`#7872\` merged and failed at validate-release:

\`\`\`
##[error]Commit 06fc1443dc... is not in a successful CI state (pending)
\`\`\`

Re-dispatching as \`25274134830\` a few minutes later succeeded with no code change. The recovery is mechanical and reliable, but the failure shouldn't happen.

Forensic note: \`docs/forensics/2026-05-03-validate-release-squash-timing-race.md\`.

## Behavior change

For a \`workflow_dispatch\` from master, \`Validate Release\` now:

- Polls combined-status every 30 seconds (configurable via \`VALIDATE_RELEASE_CI_POLL_INTERVAL_SECONDS\`).
- Total wait of 5 minutes (configurable via \`VALIDATE_RELEASE_CI_TIMEOUT_SECONDS\`).
- Passes immediately when state reports \`success\`.
- Fails immediately on explicit \`failure\` or \`error\` (decisive negative — no retry).
- Logs progress on each poll iteration with remaining-time countdown.
- Fails on timeout with the last-seen state in the error message.

## Failure-mode comparison

| Pre-existing state | Old behavior | New behavior |
|---|---|---|
| \`success\` immediately | pass | pass |
| \`pending\` then \`success\` within 5min | **fail** | pass |
| \`pending\` then \`success\` after >5min | fail | fail (timeout) |
| \`failure\` immediately | fail | fail |
| \`pending\` then \`failure\` | fail (lucky timing) | fail (decisive) |
| Unknown/unexpected state | fail | warn + retry |

## Verification

- \`cargo xtask ci-audit-workflows\` → \`CI workflow spend audit passed\`
- Diff: 35 insertions, 7 deletions in one workflow file. No behavior change to other jobs.

## Test plan

- [ ] CI green on this PR (workflow YAML changes don't run the changed step until next release dispatch)
- [ ] Manual proof on the next release: dispatch within ~1 minute of release-prep merge; should now succeed without manual re-dispatch
- [ ] Merge

## References

- Forensic: \`docs/forensics/2026-05-03-validate-release-squash-timing-race.md\`
- Synthesis: \`docs/articles/RELEASES_FAIL_AT_SEAMS.md\`
- Reference: \`docs/reference/RELEASE_PROOF_PROTOCOL.md\` (known seam-fragility addressed)