### PR TITLE
docs(readme): remove README_STATUS markers (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Perl has decades of real production code, but editor tooling still struggles wit
 
 These are behavioral and corpus-backed signals, not feature-inventory counts. Protocol coverage and full capability catalogs live in the generated status docs.
 
-<!-- BEGIN: README_STATUS -->
 | Area | Current signal |
 |---|---:|
 | Release track | `v0.13.3` public-alpha patch |
@@ -42,7 +41,6 @@ These are behavioral and corpus-backed signals, not feature-inventory counts. Pr
 | Issue-regression UX workflows | 13 workflows tracked |
 | Workspace stale-index defects | 0 / 7 tested scenarios |
 | Multi-root workspace tests | 8 / 8 |
-<!-- END: README_STATUS -->
 
 See [project status](docs/project/status/index.md), [parser status](docs/project/status/parser.md), [workspace status](docs/project/status/workspace.md), and [quality metrics](docs/project/status/quality.md) for generated details.
 


### PR DESCRIPTION
## Summary

The README "Status at a glance" section is bracketed by \`<!-- BEGIN: README_STATUS -->\` and \`<!-- END: README_STATUS -->\` markers, implying a generator regenerates the content between them. There is no such generator: the section is hand-maintained.

Caught during the v0.13.3 release closeout audit (#7881) — the release-track line was stale and the markers gave the misleading impression that running a generator would refresh it.

Markers imply automation. If the section is hand-edited, unmarked copy is less misleading.

## Diff

Two-line removal:

\`\`\`diff
- <!-- BEGIN: README_STATUS -->
| Area | Current signal |
...
| Multi-root workspace tests | 8 / 8 |
- <!-- END: README_STATUS -->
\`\`\`

Table content unchanged.

## Verified no consumers

\`\`\`
$ grep -rn 'README_STATUS' .
README.md:30:<!-- BEGIN: README_STATUS -->
README.md:45:<!-- END: README_STATUS -->
\`\`\`

Only the markers themselves match. Nothing in scripts, workflows, or xtask reads or writes between them.

## Future option

If a generator gets wired in later (e.g., \`just status-update\` extending to README), the markers can be re-added as part of that change. Today they're load-bearing fiction.

## Test plan

- [ ] CI green (no behavioral change)
- [ ] Merge

## References

- v0.13.3 release closeout audit: #7881 (the PR that found the drift)