### PR TITLE
docs(handoff): v0.13.3 closeout handoff for the next thread (#0000)

### DIFF
--- a/docs/handoff/2026-05-03-v0.13.3-closeout-handoff.md
+++ b/docs/handoff/2026-05-03-v0.13.3-closeout-handoff.md
@@ -1,0 +1,179 @@
+# Handoff: 2026-05-03 — v0.13.3 install-reliability closeout
+
+This is a state transfer for the next agent picking up where this session ended. It collects what shipped, what's in flight, what's parked, what to read first, and the operating rules that emerged. It complements but doesn't duplicate the dated forensic notes and reference docs that landed during the session.
+
+## Where this lands you
+
+The v0.13.3 install-reliability release is shipped, proven on every channel users actually touch, and codified into reference docs. Six PRs landed during the session; three preventive PRs were filed afterward to harden the seams that almost cost the release. One of those preventive PRs (#7883) is in CI as of session end; the other two merged.
+
+The release pipeline is structurally better than it was 24 hours ago in three concrete ways:
+
+1. The Windows install path (which had been silently broken for users despite green hosted CI) now has architectural fixes for both failure modes (source-side AV scan + destination-side running-binary lock) plus 25 unit-level regression locks attributing future breakage to the right fix.
+2. The orchestration's two known seam-fragilities (validate-release timing race and RELEASE_HISTORY ledger drift) have follow-up PRs that close the gaps.
+3. The repo has 16 new docs under `docs/reference/`, `docs/articles/`, and `docs/forensics/` capturing the protocol, the synthesis lessons, and per-incident gotchas.
+
+## What got shipped this session
+
+Merged in chronological order:
+
+| PR | Subject | Merge SHA |
+|---|---|---|
+| #7870 | `fix(vscode): harden managed binary install for 0.13.3` | `eb6d282ec` |
+| #7872 | `chore(release): prepare v0.13.3` | `06fc1443d` |
+| #7876 | `fix(release): add v0.13.3 to RELEASE_HISTORY ledger` | `f1372b576` |
+| #7877 | `chore(repo): ignore .claude/settings.local.json` | `2b10cd35a` |
+| #7874 | `test(vscode): regression locks for managed install hardening` | `1c843f83e` |
+| #7879 | `docs(reference): orchestration learnings + findings from v0.13.3 closeout` | `8b8c62436` |
+| #7881 | `docs(readme): bump release track to v0.13.3` | `67b3c593c` |
+| #7882 | `fix(release): validate-release polls combined-status with timeout instead of fail-fast on pending` | `6688d9bfa` |
+| #7884 | `docs(readme): remove README_STATUS markers` | `72a660cc2` |
+
+Plus: v0.13.3 published to crates.io, VS Code Marketplace, Open VSX, Docker Hub, and the public Homebrew tap. Marketplace and Open VSX published-extension smokes green on Windows / macOS / Ubuntu.
+
+## What's in flight or parked
+
+**In flight as of session end:**
+
+- **#7883** `fix(release): bump-version generates RELEASE_HISTORY row + release finalization verifies it` — rebased onto post-#7884 master, fmt drift fixed (force-pushed), CI re-running. Expected to land cleanly. Local verification: 27/27 unit tests, ci-audit-workflows passed, check-version-sync clean.
+
+**User-driven (CTO will handle):**
+
+- Manual Windows VS Code Stable + Insiders smoke (the human-verifiable proof tier per `docs/reference/RELEASE_PROOF_PROTOCOL.md`).
+- Issue closeouts on #7670 (Homebrew install path confusion) and #7671 (GNU/musl chooser confusion).
+
+**Explicitly parked (separate lanes; don't bundle):**
+
+- #7868 — CI gate ambiguity / draft-status / stale-title polish. Useful devex but separate from release hardening.
+- #7832 — Rust 1.93.1 MSRV/toolchain bump. Toolchain floor changes don't belong in a release-polish lane.
+- #7880 — Live behavior change for runtime semantic-aware bareword diagnostics. Goes through product-risk review, not release-polish review. Per the CTO's note, it is the right next user-facing item once release-polish PRs are in.
+
+## Reading order for your first cycle
+
+If you're picking this up cold, in this order:
+
+1. **`CLAUDE.md`** at repo root — the canonical orchestration overview.
+2. **`docs/reference/AGENT_HANDOFF_PROTOCOL.md`** — the four-party model, Step-0 verify rule, packet templates, decision-table format. Most operationally important doc.
+3. **`docs/reference/FAILURE_CLASSIFICATION.md`** — the five-class taxonomy. Small but referenced from everywhere; understanding it makes downstream triage cheap.
+4. **`docs/reference/RELEASE_PROOF_PROTOCOL.md`** — the four-tier proof stack and channel verification commands. Read this before touching anything release-shaped.
+5. **`docs/articles/THREE_PARTY_LLM_WORKFLOW.md`** — the synthesis essay on how this loop runs. Optional but high-leverage; explains *why* the protocol is shaped the way it is.
+6. **`docs/articles/RELEASES_FAIL_AT_SEAMS.md`** — the orchestration-correctness reframe. Useful when triaging any workflow failure.
+7. **`docs/articles/CI_VS_REAL_USER_PARITY.md`** — read before trusting hosted-CI greenness on any user-install surface.
+8. **`docs/articles/EVIDENCE_DURABILITY_TIERS.md`** — the receipt / artifact / test design. Useful when deciding where to put evidence.
+9. **Dated forensic notes** at `docs/forensics/2026-05-03-*.md` — read on demand when you hit the corresponding pattern. These capture nine specific gotchas from the v0.13.3 cycle.
+
+The reading order matters: #2 makes #3 make sense, #4 builds on #3, the articles synthesize across the references. Don't skip ahead to forensics without the protocol context.
+
+## Operating rules summary
+
+The protocol distilled to one page:
+
+**Step 0: verify the premise.** Every executor cycle starts with a `Ground truth at <time>: ... / Delta from your packet: ... / Now executing: ...` header. When delta is non-empty, surface it before continuing. When the delta invalidates the premise, ask before executing.
+
+**If authorized, proceed without re-asking.** Re-confirming actions the CTO already authorized costs cycles and signals untrust. Surface deltas, not confirmations.
+
+**Failure classification is stable.** Once you label a failure (product / workflow / flake / state-drift / permission), the label persists across cycles. Re-classify only on new evidence, and surface the change.
+
+**Push back firmly with evidence on stale premises.** When a research-partner packet's premise has drifted, don't politely over-explain — surface the correction in one line, attach hard evidence, ask whether the rest of the packet still applies.
+
+**One-source-of-truth artifacts bridge cycles.** Receipts at `target/receipts/` for ephemeral session state; handoff docs at `docs/handoff/` for cross-session state; tests for permanent invariants. Don't conflate the tiers.
+
+**Don't touch issues.** The CTO handles issue comments and closeouts. Standing rule throughout this session. Includes #7670, #7671, and any related install/UX issues.
+
+**Don't bundle scope.** Every PR has explicit `Include` / `Exclude`. Release-polish doesn't get MSRV bumps. Install hardening doesn't get docs cleanups. The narrow PR is the change vehicle that makes this loop fast.
+
+**PR bodies are durable execution records.** Audience is future LLMs reconstructing context. Optimize for density, not skim-readability. Compressed PR bodies break the protocol.
+
+## Cross-cutting lessons not yet codified
+
+Things observed during the session that are worth knowing but didn't fit cleanly into any single doc:
+
+**Local repro beats hosted CI for any user-install path.** Not occasionally — *as a default rule*. Hosted runners have aggressive Defender exclusions and pre-warmed signature caches. Real users have neither. If hosted CI says green and a user reports broken install, trust the user. The forensic note `2026-05-03-windows-defender-source-side-ebusy.md` is the worked example; the article `CI_VS_REAL_USER_PARITY.md` is the calibration.
+
+**One symptom may be two bugs.** Especially with platform-specific failure modes. The first hypothesis is rarely the complete picture. For Windows install: source-side AV scan and destination-side running-binary lock both manifest as `EBUSY` on `fs.copyFileSync` but require architecturally distinct fixes. The smoke that proves one fix may not test the other surface — verify what the test actually exercises.
+
+**Workflow artifacts uploaded `if: always()` are in-flight backup, not just logging.** When a join-point fails (VSIX-attach race, propagation lag, etc.), the artifact is the recovery vehicle. The pattern generalizes: every join-point in a multi-step orchestration should produce an artifact that downstream can consume even if the immediate consumer failed.
+
+**The slow loop and fast loop don't compete for cycles — they compose.** Strategy lives in the slow loop (research partner, batched). Tactics live in the fast loop (executor, real-time). Trying to make either loop the other speed loses the property that makes it valuable. The asymmetric latency is a feature.
+
+**The executor's load-bearing role is reality-check, not throughput.** Of the high-leverage moments during this session, the throughput-shaped ones (write code, run tests, open PR, merge) were maybe 40% of the value. The rest was the three "your premise has changed" callbacks that prevented wasted iteration. The protocol's Step-0 rule operationalizes this.
+
+**Drift gates protect strongly *and* spread blast radius.** A missing `RELEASE_HISTORY.md` row failed CI for *every* PR opened against master, not just release PRs. Drift gates make any unbundling of related invariants a tripwire. Either bundle the invariants enforceably (generator) or instrument the gate to be self-recovering (auto-PR) or fail fast at the join-point (trip-wire). Don't rely on humans remembering both halves.
+
+**Architectural property does as much work as the LLM substrate.** The session's pace was downstream of microcrate decomposition, narrow-PR norms, tests-as-spec, drift gates, and atomic version surfaces. None of this would be tractable in a monolith. The substrate amplifies; the architecture enables.
+
+## Specific gotchas to know about
+
+In one-line summary, with full detail at the linked forensic note:
+
+- **Windows Defender can lock the *source* of a copy, not just the destination** — `2026-05-03-windows-defender-source-side-ebusy.md`
+- **GitHub auto-*closes* dependent PRs when the base branch is deleted, not retargets** — `2026-05-03-github-pr-auto-close-on-base-branch-delete.md`
+- **`target/` is gitignored, so receipts can't be PR'd** — `2026-05-03-target-gitignore-vs-receipt-pr.md`
+- **`Validate Release` races post-merge master CI on combined-status** — addressed by #7882 — `2026-05-03-validate-release-squash-timing-race.md`
+- **Marketplace/Open VSX gallery API indexes new versions instantly; install endpoints lag minutes** — `2026-05-03-marketplace-publish-vs-install-endpoint-lag.md`
+- **`Attach VSIX` races release creation in `Publish VSCode Extension` workflow** — `2026-05-03-release-orchestration-attach-vsix-race.md`
+- **Missing `RELEASE_HISTORY.md` row breaks master CI for *all* PRs** — addressed by #7883 — `2026-05-03-release-history-ledger-drift.md`
+- **Two architecturally distinct failure modes can present as the same `EBUSY` symptom** — `2026-05-03-v0.13.3-windows-install-dual-lock.md`
+- **Research-partner packets can carry stale premises that the executor must catch** — `2026-05-03-chatgpt-claude-protocol-drift.md`
+
+## How to extend the protocol
+
+When you encounter something new during your work, the lifecycle is:
+
+```
+Encounter the failure
+       ↓
+Capture in target/receipts/ (rich, free-form, ephemeral)
+       ↓
+If recurring or has long-term debugging value:
+   docs/forensics/<date>-<topic>.md (medium durability, structured)
+       ↓
+If a code path can lock the regression:
+   Add a unit test (permanent, asserted)
+       ↓
+If the pattern is broader than one incident:
+   Update or extend a synthesis article in docs/articles/
+       ↓
+If the pattern changes operating rules:
+   Update docs/reference/AGENT_HANDOFF_PROTOCOL.md or related reference doc
+```
+
+Don't promote things upward unnecessarily — receipts and forensic notes are valid endpoints. Tests and protocol docs require careful authoring; the cost is justified only when the pattern has cross-incident reach.
+
+## What's not in this thread
+
+Things the CTO has explicitly parked or owned:
+
+- Manual Windows reinstall smoke on Stable + Insiders (CTO will run; reports back in target/receipts/).
+- Issue closeouts (#7670, #7671, related install-UX threads). Standing rule throughout the session.
+- Marketplace + Open VSX storefront copy review (out of scope; release notes carry the durable detail).
+- Homebrew/core proposal. Explicitly deferred.
+- Homebrew livecheck. Explicitly deferred.
+
+Things in separate lanes (don't fold into release-polish):
+
+- #7868 (CI gate polish) — separate CI lane.
+- #7832 (Rust 1.93.1 MSRV) — separate toolchain lane.
+- #7880 (semantic-aware bareword diagnostics) — separate product-behavior lane; the CTO has flagged this as the right next user-facing item.
+
+## Pre-empt-able state-drift questions
+
+Things the next research-partner cycle might assume from a stale snapshot — verify before acting:
+
+- *"#7883 hasn't merged yet."* — Check `gh pr view 7883 --json state`. CI was in flight when the session ended; it may have landed.
+- *"v0.13.3 is the current release."* — Probably true, but check `gh release view --repo EffortlessMetrics/perl-lsp` for the latest. If a 0.13.4 has shipped, the orchestration follow-ups in #7882 + #7883 already proved themselves once.
+- *"The Windows install bug is fixed."* — The unit tests in `vscode-extension/src/test/downloader.test.ts` lock the regressions. If they're still passing, the fixes hold. If they're not, that's a real regression to triage.
+- *"target/receipts/ is the canonical receipt location."* — True, and it's gitignored. Receipts are local-only forensic artifacts. Anything that needs to survive a session goes in `docs/handoff/` or `docs/forensics/` instead.
+
+## Suggested first action for the next thread
+
+If you're picking up cold:
+
+1. Check #7883 status. If green, merge it. If failing, classify (probably state-drift if master moved, otherwise fmt/clippy follow-up).
+2. Read `CLAUDE.md`, then this handoff doc, then `docs/reference/AGENT_HANDOFF_PROTOCOL.md`.
+3. Run `cargo xtask check-version-sync && cargo xtask install-surface-check && bash scripts/check_release_history.sh` to confirm master is healthy.
+4. Wait for the CTO's manual Windows smoke results before considering the v0.13.3 lane fully closed.
+5. The next high-value lane is #7880 (semantic-aware diagnostics) per the CTO's direction. Treat it as live behavior change with proper product-risk review.
+
+That's the picture as of session end. The shape of the loop, the lessons, the artifacts, the parked items, and the pre-empt-able assumptions are all here. The 16 reference + article + forensic docs carry the durable detail; this handoff carries the session-state and the operating distillation.
+
+Welcome to the next cycle.


### PR DESCRIPTION
## Summary

Single-file handoff doc capturing what shipped, what's in flight, what's parked, what to read first, and the operating rules that emerged across the v0.13.3 install-reliability closeout session.

Sits at \`docs/handoff/2026-05-03-v0.13.3-closeout-handoff.md\` per the naming convention designated in \`docs/reference/AGENT_HANDOFF_PROTOCOL.md\` (#7879). Cross-references but doesn't duplicate the protocol references, synthesis articles, or dated forensic notes filed during the session.

## Audience

The next agent (LLM or human) picking up this work cold. The doc is structured for both quick-scan (status + reading order + suggested first action) and deep-read (cross-cutting lessons + protocol distillation).

## What's in it

- **Where this lands you** — executive summary of session state.
- **What got shipped this session** — 9 PRs by merge SHA.
- **What's in flight or parked** — #7883 in CI, plus user-driven manual smoke + issue closeouts, plus separate-lane items (#7868, #7832, #7880).
- **Reading order for your first cycle** — which docs to read in which order.
- **Operating rules summary** — the protocol distilled to one page.
- **Cross-cutting lessons not yet codified** — the wisdom that doesn't fit any single doc (local repro beats hosted CI, one symptom may be two bugs, artifacts as in-flight backup, asymmetric latency as feature, executor's reality-check role, drift gates spread blast radius, architecture amplifies substrate).
- **Specific gotchas** — one-line summaries with forensic-note links.
- **How to extend the protocol** — the receipt → forensic → test → article → reference promotion lifecycle.
- **What's NOT in this thread** — CTO-owned and separate-lane items.
- **Pre-empt-able state-drift questions** — things to verify before acting.
- **Suggested first action** — concrete starting point.

Doc-only. No code or production behavior changes.

## Test plan

- [ ] CI green (no behavioral change)
- [ ] Reviewer reads through to confirm tone matches existing \`docs/handoff/\` and \`docs/forensics/\` conventions
- [ ] Merge

## References

- Companion to: #7879 (the 16 reference + article + forensic docs filed during the session)
- Sits in: \`docs/handoff/\` per \`AGENT_HANDOFF_PROTOCOL.md\` designated home
- Documents session that landed: #7870, #7872, #7874, #7876, #7877, #7879, #7881, #7882, #7884
- Documents in-flight: #7883