### PR TITLE
test(perl-semantic-facts): comprehensive BDD scenarios and full property-test coverage (#0000)

### DIFF
--- a/crates/perl-semantic-facts/tests/bdd_semantic_facts.rs
+++ b/crates/perl-semantic-facts/tests/bdd_semantic_facts.rs
@@ -1,0 +1,973 @@
+//! BDD-style consumer workflow tests for perl-semantic-facts.
+//!
+//! Each scenario is framed as a consumer of the fact vocabulary —
+//! "Given <context>, when <operation>, then <expected outcome>."
+//! These tests exercise the semantic contracts that downstream providers
+//! (goto-definition, rename, hover, completion) depend on.
+
+#![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
+
+use perl_semantic_facts::{
+    AnchorFact, AnchorId, Confidence, DefinitionCandidate, DefinitionRank, DefinitionRankReason,
+    DiagnosticFact, DiagnosticId, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
+    ExportSet, ExportTag, FileId, GeneratedMember, GeneratedMemberKind, ImportKind, ImportSpec,
+    ImportSymbols, OccurrenceFact, OccurrenceId, OccurrenceKind, PackageEdge, PackageEdgeKind,
+    PackageKind, PackageNode, PlanBlocker, PlanBlockerReason, PlanWarning, PlannedEdit,
+    PlannedEditCategory, Provenance, RenamePlan, SafeDeletePlan, ScopeId, ValueShape,
+    VisibleSymbol, VisibleSymbolContext, VisibleSymbolSource,
+};
+
+// ── Scenario 1: Goto-Definition Provider — Candidate Ranking ──────────────
+
+/// Given a mixed list of definition candidates with different ranks,
+/// when the goto-definition provider sorts them by rank,
+/// then ExactQualified candidates appear before SamePackage, and SamePackage
+/// appears before WorkspaceCandidate, preserving the design intent that
+/// the most specific match is always offered first.
+#[test]
+fn given_mixed_candidates_when_sorted_by_rank_then_most_specific_first() {
+    let mut candidates = [
+        DefinitionCandidate::new(
+            EntityId(3),
+            AnchorId(30),
+            "Some::Module::helper".to_string(),
+            "helper".to_string(),
+            Some("Some::Module".to_string()),
+            EntityKind::Subroutine,
+            Provenance::NameHeuristic,
+            Confidence::Low,
+            DefinitionRank::Heuristic,
+            DefinitionRankReason::HeuristicNameMatch,
+        ),
+        DefinitionCandidate::new(
+            EntityId(1),
+            AnchorId(10),
+            "App::Controller::process".to_string(),
+            "process".to_string(),
+            Some("App::Controller".to_string()),
+            EntityKind::Method,
+            Provenance::ExactAst,
+            Confidence::High,
+            DefinitionRank::ExactQualified,
+            DefinitionRankReason::ExactQualifiedName,
+        ),
+        DefinitionCandidate::new(
+            EntityId(2),
+            AnchorId(20),
+            "App::Controller::process".to_string(),
+            "process".to_string(),
+            Some("App::Controller".to_string()),
+            EntityKind::Method,
+            Provenance::SemanticAnalyzer,
+            Confidence::Medium,
+            DefinitionRank::SamePackage,
+            DefinitionRankReason::SamePackage,
+        ),
+    ];
+
+    candidates.sort_by_key(|c| c.rank);
+
+    assert_eq!(candidates[0].rank, DefinitionRank::ExactQualified);
+    assert_eq!(candidates[1].rank, DefinitionRank::SamePackage);
+    assert_eq!(candidates[2].rank, DefinitionRank::Heuristic);
+}
+
+/// Given a definition candidate backed by an explicit import,
+/// when the provider inspects the rank reason,
+/// then the originating module is available for hover explanation.
+#[test]
+fn given_import_backed_candidate_when_inspecting_rank_reason_then_source_module_is_known() {
+    let candidate = DefinitionCandidate::new(
+        EntityId(10),
+        AnchorId(1),
+        "List::Util::first".to_string(),
+        "first".to_string(),
+        Some("List::Util".to_string()),
+        EntityKind::Subroutine,
+        Provenance::ImportExportInference,
+        Confidence::Medium,
+        DefinitionRank::ExplicitImport,
+        DefinitionRankReason::ExplicitImport { module: "List::Util".to_string() },
+    );
+
+    let DefinitionRankReason::ExplicitImport { module } = &candidate.rank_reason else {
+        panic!("expected ExplicitImport rank reason");
+    };
+    assert_eq!(module, "List::Util");
+    assert_eq!(candidate.display_name, "first");
+}
+
+/// Given an empty candidate list (symbol not found anywhere in workspace),
+/// when the provider checks it,
+/// then it handles zero candidates gracefully without panic.
+#[test]
+fn given_no_candidates_when_provider_processes_then_empty_list_is_handled() {
+    let candidates: Vec<DefinitionCandidate> = vec![];
+    assert!(candidates.is_empty());
+    // Provider should show "no definition found" without panicking.
+    let best = candidates.iter().min_by_key(|c| c.rank);
+    assert!(best.is_none());
+}
+
+// ── Scenario 2: Rename Provider — Plan Construction and Safety ─────────────
+
+/// Given a RenamePlan for a simple local subroutine,
+/// when the rename provider checks for blockers,
+/// then no blockers are present and edits can be applied.
+#[test]
+fn given_safe_rename_plan_when_provider_checks_blockers_then_no_blockers() {
+    let plan = RenamePlan::new(
+        EntityId(100),
+        "old_helper".to_string(),
+        "new_helper".to_string(),
+        vec![
+            PlannedEdit::new(
+                AnchorId(1),
+                FileId(1),
+                PlannedEditCategory::Definition,
+                "old_helper".to_string(),
+                "new_helper".to_string(),
+            ),
+            PlannedEdit::new(
+                AnchorId(2),
+                FileId(1),
+                PlannedEditCategory::Reference,
+                "old_helper".to_string(),
+                "new_helper".to_string(),
+            ),
+        ],
+        vec![],
+        vec![],
+    );
+
+    assert!(plan.blockers.is_empty(), "safe rename should have no blockers");
+    assert_eq!(plan.edits.len(), 2);
+    assert_eq!(plan.old_name, "old_helper");
+    assert_eq!(plan.new_name, "new_helper");
+}
+
+/// Given a RenamePlan blocked by a dynamic boundary (string eval),
+/// when the provider checks safety,
+/// then the blocker reason is DynamicBoundary and the rename is rejected.
+#[test]
+fn given_blocked_rename_when_provider_checks_then_dynamic_boundary_is_reported() {
+    let plan = RenamePlan::new(
+        EntityId(200),
+        "dispatch".to_string(),
+        "handle".to_string(),
+        vec![],
+        vec![PlanBlocker::new(
+            PlanBlockerReason::DynamicBoundary,
+            Some(AnchorId(50)),
+            "symbol referenced inside eval string".to_string(),
+        )],
+        vec![],
+    );
+
+    assert!(!plan.blockers.is_empty());
+    assert_eq!(plan.blockers[0].reason, PlanBlockerReason::DynamicBoundary);
+    assert!(plan.blockers[0].anchor_id.is_some());
+}
+
+/// Given a RenamePlan with edits categorized as definition, reference, and export,
+/// when the provider partitions edits by category,
+/// then each category can be handled independently.
+#[test]
+fn given_multi_category_rename_plan_when_partitioned_then_categories_are_distinct() {
+    let edits = vec![
+        PlannedEdit::new(
+            AnchorId(1),
+            FileId(1),
+            PlannedEditCategory::Definition,
+            "foo".to_string(),
+            "bar".to_string(),
+        ),
+        PlannedEdit::new(
+            AnchorId(2),
+            FileId(2),
+            PlannedEditCategory::Reference,
+            "foo".to_string(),
+            "bar".to_string(),
+        ),
+        PlannedEdit::new(
+            AnchorId(3),
+            FileId(1),
+            PlannedEditCategory::ExportList,
+            "foo".to_string(),
+            "bar".to_string(),
+        ),
+    ];
+    let plan =
+        RenamePlan::new(EntityId(300), "foo".to_string(), "bar".to_string(), edits, vec![], vec![]);
+
+    let def_edits: Vec<_> =
+        plan.edits.iter().filter(|e| e.category == PlannedEditCategory::Definition).collect();
+    let ref_edits: Vec<_> =
+        plan.edits.iter().filter(|e| e.category == PlannedEditCategory::Reference).collect();
+    let export_edits: Vec<_> =
+        plan.edits.iter().filter(|e| e.category == PlannedEditCategory::ExportList).collect();
+
+    assert_eq!(def_edits.len(), 1);
+    assert_eq!(ref_edits.len(), 1);
+    assert_eq!(export_edits.len(), 1);
+}
+
+// ── Scenario 3: Safe Delete Provider ──────────────────────────────────────
+
+/// Given a SafeDeletePlan with remaining references as blocker,
+/// when the provider evaluates deletion,
+/// then the blocker prevents deletion and references are reported.
+#[test]
+fn given_safe_delete_with_references_when_evaluated_then_deletion_is_blocked() {
+    let plan = SafeDeletePlan::new(
+        EntityId(400),
+        "legacy_fn".to_string(),
+        vec![PlanBlocker::new(
+            PlanBlockerReason::ReferencesExist,
+            Some(AnchorId(70)),
+            "3 call sites remain in workspace".to_string(),
+        )],
+        vec![PlanWarning::new("also referenced in comments".to_string(), None)],
+    );
+
+    assert!(!plan.blockers.is_empty());
+    assert_eq!(plan.blockers[0].reason, PlanBlockerReason::ReferencesExist);
+    assert_eq!(plan.warnings.len(), 1);
+    assert!(plan.warnings[0].anchor_id.is_none());
+}
+
+// ── Scenario 4: Import Resolution Consumer ────────────────────────────────
+
+/// Given a UseExplicitList ImportSpec listing specific symbols,
+/// when the completion provider resolves visible symbols,
+/// then exactly the listed symbols are available at the import site.
+#[test]
+fn given_explicit_import_spec_when_resolved_then_listed_symbols_available() {
+    let spec = ImportSpec {
+        module: "Scalar::Util".to_string(),
+        kind: ImportKind::UseExplicitList,
+        symbols: ImportSymbols::Explicit(vec![
+            "blessed".to_string(),
+            "reftype".to_string(),
+            "weaken".to_string(),
+        ]),
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+        file_id: Some(FileId(1)),
+        anchor_id: Some(AnchorId(5)),
+        scope_id: None,
+        span_start_byte: Some(20),
+    };
+
+    let ImportSymbols::Explicit(ref symbols) = spec.symbols else {
+        panic!("expected Explicit symbols");
+    };
+    assert_eq!(symbols.len(), 3);
+    assert!(symbols.contains(&"blessed".to_string()));
+    assert!(symbols.contains(&"reftype".to_string()));
+    assert_eq!(spec.kind, ImportKind::UseExplicitList);
+}
+
+/// Given a ManualImport spec (Class->import(@names)),
+/// when the diagnostic provider evaluates bareword suppression,
+/// then span_start_byte controls order-aware suppression.
+#[test]
+fn given_manual_import_spec_when_checking_order_sensitivity_then_span_is_used() {
+    let spec = ImportSpec {
+        module: "Foo::Exporter".to_string(),
+        kind: ImportKind::ManualImport,
+        symbols: ImportSymbols::Dynamic,
+        provenance: Provenance::SemanticAnalyzer,
+        confidence: Confidence::Medium,
+        file_id: Some(FileId(2)),
+        anchor_id: Some(AnchorId(30)),
+        scope_id: None,
+        span_start_byte: Some(150),
+    };
+
+    // The diagnostic provider should suppress barewords that appear after
+    // the import site (byte offset 150) but not before.
+    assert_eq!(spec.kind, ImportKind::ManualImport);
+    assert_eq!(spec.span_start_byte, Some(150));
+    // Symbols are Dynamic — the provider must treat all names conservatively.
+    assert_eq!(spec.symbols, ImportSymbols::Dynamic);
+}
+
+/// Given a UseTag ImportSpec with multiple tags,
+/// when the provider resolves visible names,
+/// then the tags drive group-based symbol lookup.
+#[test]
+fn given_use_tag_import_spec_when_resolving_then_tags_available() {
+    let spec = ImportSpec {
+        module: "POSIX".to_string(),
+        kind: ImportKind::UseTag,
+        symbols: ImportSymbols::Tags(vec![":math".to_string(), ":ctype".to_string()]),
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+        file_id: None,
+        anchor_id: None,
+        scope_id: None,
+        span_start_byte: None,
+    };
+
+    let ImportSymbols::Tags(ref tags) = spec.symbols else {
+        panic!("expected Tags symbols");
+    };
+    assert!(tags.contains(&":math".to_string()));
+    assert!(tags.contains(&":ctype".to_string()));
+}
+
+// ── Scenario 5: Export Set Consumer ───────────────────────────────────────
+
+/// Given an ExportSet with default and optional exports plus tags,
+/// when the provider checks what a plain `use` imports,
+/// then only the default exports are visible by default.
+#[test]
+fn given_export_set_when_plain_use_then_only_default_exports_visible() {
+    let export_set = ExportSet {
+        default_exports: vec!["encode_json".to_string(), "decode_json".to_string()],
+        optional_exports: vec!["to_json".to_string(), "from_json".to_string()],
+        tags: vec![ExportTag {
+            name: "all".to_string(),
+            members: vec![
+                "encode_json".to_string(),
+                "decode_json".to_string(),
+                "to_json".to_string(),
+                "from_json".to_string(),
+            ],
+        }],
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+        module_name: Some("JSON".to_string()),
+        anchor_id: Some(AnchorId(10)),
+    };
+
+    // Plain `use JSON` imports only default_exports.
+    assert_eq!(export_set.default_exports.len(), 2);
+    assert!(export_set.default_exports.contains(&"encode_json".to_string()));
+    // Optional exports are NOT visible without explicit import list.
+    assert!(!export_set.default_exports.contains(&"to_json".to_string()));
+    // :all tag expands to include everything.
+    let all_tag = export_set.tags.iter().find(|t| t.name == "all").expect("all tag present");
+    assert_eq!(all_tag.members.len(), 4);
+}
+
+/// Given an ExportSet with no module name (inferred from context),
+/// when the provider requests the exporting module,
+/// then it handles the None case without error.
+#[test]
+fn given_export_set_without_module_name_when_queried_then_none_handled() {
+    let export_set = ExportSet {
+        default_exports: vec!["slurp".to_string()],
+        optional_exports: vec![],
+        tags: vec![],
+        provenance: Provenance::ImportExportInference,
+        confidence: Confidence::Low,
+        module_name: None,
+        anchor_id: None,
+    };
+
+    assert!(export_set.module_name.is_none());
+    assert!(export_set.anchor_id.is_none());
+    assert_eq!(export_set.default_exports, ["slurp"]);
+}
+
+// ── Scenario 6: Visible Symbol — Hover Origin Tracing ─────────────────────
+
+/// Given a VisibleSymbol imported from an explicit `use` statement,
+/// when the hover provider inspects its origin,
+/// then the source module and import anchor are available for hover text.
+#[test]
+fn given_explicit_import_visible_symbol_when_hovering_then_source_module_and_anchor_known() {
+    let symbol = VisibleSymbol {
+        name: "blessed".to_string(),
+        entity_id: Some(EntityId(77)),
+        source: VisibleSymbolSource::ExplicitImport,
+        confidence: Confidence::High,
+        context: Some(VisibleSymbolContext::new(
+            Some("Scalar::Util".to_string()),
+            Some(AnchorId(12)),
+            Some(AnchorId(99)),
+        )),
+    };
+
+    assert_eq!(symbol.source, VisibleSymbolSource::ExplicitImport);
+    let ctx = symbol.context.as_ref().expect("context present");
+    assert_eq!(ctx.source_module.as_deref(), Some("Scalar::Util"));
+    assert!(ctx.source_import_anchor_id.is_some());
+    assert!(ctx.source_export_anchor_id.is_some());
+}
+
+/// Given a locally-defined lexical symbol,
+/// when the completion provider inspects it,
+/// then it has LocalLexical source with no external context.
+#[test]
+fn given_local_lexical_symbol_when_completing_then_no_external_context() {
+    let symbol = VisibleSymbol {
+        name: "$count".to_string(),
+        entity_id: Some(EntityId(5)),
+        source: VisibleSymbolSource::LocalLexical,
+        confidence: Confidence::High,
+        context: None,
+    };
+
+    assert_eq!(symbol.source, VisibleSymbolSource::LocalLexical);
+    assert!(symbol.context.is_none());
+    assert!(symbol.name.starts_with('$'));
+}
+
+/// Given a dynamically-defined symbol (AUTOLOAD or string eval),
+/// when the provider evaluates it,
+/// then it has DynamicUnknown source with Low confidence.
+#[test]
+fn given_dynamic_unknown_symbol_when_evaluated_then_low_confidence_and_dynamic_source() {
+    let symbol = VisibleSymbol {
+        name: "AUTOLOAD_dispatch".to_string(),
+        entity_id: None,
+        source: VisibleSymbolSource::DynamicUnknown,
+        confidence: Confidence::Low,
+        context: None,
+    };
+
+    assert_eq!(symbol.source, VisibleSymbolSource::DynamicUnknown);
+    assert_eq!(symbol.confidence, Confidence::Low);
+    assert!(symbol.entity_id.is_none());
+}
+
+// ── Scenario 7: Value Shape — Method Completion Filtering ─────────────────
+
+/// Given a ValueShape::Object with a known package,
+/// when the completion provider filters method candidates,
+/// then the package name guides lookup in the class graph.
+#[test]
+fn given_object_value_shape_when_completing_methods_then_package_drives_lookup() {
+    let shape =
+        ValueShape::Object { package: "DateTime".to_string(), confidence: Confidence::High };
+
+    match &shape {
+        ValueShape::Object { package, confidence } => {
+            assert_eq!(package, "DateTime");
+            assert_eq!(*confidence, Confidence::High);
+        }
+        _ => panic!("expected Object shape"),
+    }
+}
+
+/// Given a ValueShape::PackageName (static class call like `Foo->new`),
+/// when the provider resolves methods,
+/// then it knows the class at compile time.
+#[test]
+fn given_package_name_shape_when_resolving_class_then_package_known_statically() {
+    let shape = ValueShape::PackageName { package: "LWP::UserAgent".to_string() };
+
+    let ValueShape::PackageName { package } = &shape else {
+        panic!("expected PackageName shape");
+    };
+    assert_eq!(package, "LWP::UserAgent");
+}
+
+/// Given a ValueShape::Unknown,
+/// when the provider receives it,
+/// then it falls back to workspace-wide name search.
+#[test]
+fn given_unknown_value_shape_when_completing_then_fallback_to_workspace_search() {
+    let shape = ValueShape::Unknown;
+    // Provider logic: Unknown shape → no package filtering → search all methods
+    assert!(matches!(shape, ValueShape::Unknown));
+}
+
+// ── Scenario 8: Package Graph — Inheritance Walk ──────────────────────────
+
+/// Given a set of PackageEdges forming a linear inheritance chain,
+/// when the provider traverses the parent chain,
+/// then it can collect all ancestors in order.
+#[test]
+fn given_linear_inheritance_chain_when_traversing_then_ancestors_reachable() {
+    let edges = [
+        PackageEdge::new(
+            "Child".to_string(),
+            "Parent".to_string(),
+            PackageEdgeKind::Inherits,
+            Some(AnchorId(1)),
+            Provenance::ExactAst,
+            Confidence::High,
+        ),
+        PackageEdge::new(
+            "Parent".to_string(),
+            "GrandParent".to_string(),
+            PackageEdgeKind::Inherits,
+            Some(AnchorId(2)),
+            Provenance::ExactAst,
+            Confidence::High,
+        ),
+    ];
+
+    let parents_of_child: Vec<&str> =
+        edges.iter().filter(|e| e.from_package == "Child").map(|e| e.to_package.as_str()).collect();
+
+    assert_eq!(parents_of_child, ["Parent"]);
+
+    let parents_of_parent: Vec<&str> = edges
+        .iter()
+        .filter(|e| e.from_package == "Parent")
+        .map(|e| e.to_package.as_str())
+        .collect();
+    assert_eq!(parents_of_parent, ["GrandParent"]);
+}
+
+/// Given PackageEdges mixing inheritance and role composition,
+/// when the provider extracts only role compositions,
+/// then only ComposesRole edges are returned.
+#[test]
+fn given_mixed_package_edges_when_filtering_by_kind_then_only_role_edges_selected() {
+    let edges = [
+        PackageEdge::new(
+            "MyClass".to_string(),
+            "BaseClass".to_string(),
+            PackageEdgeKind::Inherits,
+            None,
+            Provenance::ExactAst,
+            Confidence::High,
+        ),
+        PackageEdge::new(
+            "MyClass".to_string(),
+            "Role::Printable".to_string(),
+            PackageEdgeKind::ComposesRole,
+            None,
+            Provenance::ExactAst,
+            Confidence::High,
+        ),
+        PackageEdge::new(
+            "MyClass".to_string(),
+            "Role::Serializable".to_string(),
+            PackageEdgeKind::ComposesRole,
+            None,
+            Provenance::ExactAst,
+            Confidence::High,
+        ),
+    ];
+
+    let roles: Vec<&str> = edges
+        .iter()
+        .filter(|e| e.kind == PackageEdgeKind::ComposesRole)
+        .map(|e| e.to_package.as_str())
+        .collect();
+
+    assert_eq!(roles.len(), 2);
+    assert!(roles.contains(&"Role::Printable"));
+    assert!(roles.contains(&"Role::Serializable"));
+}
+
+// ── Scenario 9: Generated Members — Accessor Discovery ────────────────────
+
+/// Given a GeneratedMember representing a Moo/Moose getter,
+/// when the completion provider adds it to the method list,
+/// then the name and kind are preserved for display.
+#[test]
+fn given_moo_getter_generated_member_when_completing_then_name_and_kind_available() {
+    let member = GeneratedMember::new(
+        EntityId(1000),
+        "username".to_string(),
+        GeneratedMemberKind::Getter,
+        AnchorId(200),
+        "MyApp::User".to_string(),
+        Provenance::FrameworkSynthesis,
+        Confidence::Medium,
+    );
+
+    assert_eq!(member.name, "username");
+    assert_eq!(member.kind, GeneratedMemberKind::Getter);
+    assert_eq!(member.package, "MyApp::User");
+    assert_eq!(member.provenance, Provenance::FrameworkSynthesis);
+}
+
+/// Given multiple GeneratedMembers for the same `has` attribute,
+/// when collecting accessor completions,
+/// then predicate and clearer can be distinguished from getter/setter.
+#[test]
+fn given_attribute_accessors_when_collecting_then_predicate_and_clearer_distinguishable() {
+    let members = [
+        GeneratedMember::new(
+            EntityId(1),
+            "name".to_string(),
+            GeneratedMemberKind::Accessor,
+            AnchorId(1),
+            "Foo".to_string(),
+            Provenance::FrameworkSynthesis,
+            Confidence::Medium,
+        ),
+        GeneratedMember::new(
+            EntityId(2),
+            "has_name".to_string(),
+            GeneratedMemberKind::Predicate,
+            AnchorId(1),
+            "Foo".to_string(),
+            Provenance::FrameworkSynthesis,
+            Confidence::Medium,
+        ),
+        GeneratedMember::new(
+            EntityId(3),
+            "clear_name".to_string(),
+            GeneratedMemberKind::Clearer,
+            AnchorId(1),
+            "Foo".to_string(),
+            Provenance::FrameworkSynthesis,
+            Confidence::Medium,
+        ),
+    ];
+
+    let accessor = members.iter().find(|m| m.kind == GeneratedMemberKind::Accessor).unwrap();
+    let predicate = members.iter().find(|m| m.kind == GeneratedMemberKind::Predicate).unwrap();
+    let clearer = members.iter().find(|m| m.kind == GeneratedMemberKind::Clearer).unwrap();
+
+    assert_eq!(accessor.name, "name");
+    assert_eq!(predicate.name, "has_name");
+    assert_eq!(clearer.name, "clear_name");
+}
+
+// ── Scenario 10: Confidence — Diagnostic Filtering ────────────────────────
+
+/// Given DiagnosticFacts with different confidence levels,
+/// when the provider filters for High-confidence-only mode,
+/// then Medium and Low diagnostics are excluded.
+#[test]
+fn given_mixed_confidence_diagnostics_when_filtering_high_only_then_low_excluded() {
+    let diagnostics = [
+        DiagnosticFact {
+            id: DiagnosticId(1),
+            code: Some("PL001".to_string()),
+            message: "strict violation".to_string(),
+            primary_anchor_id: AnchorId(1),
+            related_anchor_ids: vec![],
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        },
+        DiagnosticFact {
+            id: DiagnosticId(2),
+            code: Some("PL101".to_string()),
+            message: "possible issue".to_string(),
+            primary_anchor_id: AnchorId(2),
+            related_anchor_ids: vec![],
+            scope_id: None,
+            provenance: Provenance::NameHeuristic,
+            confidence: Confidence::Low,
+        },
+        DiagnosticFact {
+            id: DiagnosticId(3),
+            code: Some("PL050".to_string()),
+            message: "likely issue".to_string(),
+            primary_anchor_id: AnchorId(3),
+            related_anchor_ids: vec![],
+            scope_id: None,
+            provenance: Provenance::SemanticAnalyzer,
+            confidence: Confidence::Medium,
+        },
+    ];
+
+    let high_only: Vec<_> =
+        diagnostics.iter().filter(|d| d.confidence == Confidence::High).collect();
+
+    assert_eq!(high_only.len(), 1);
+    assert_eq!(high_only[0].code.as_deref(), Some("PL001"));
+}
+
+// ── Scenario 11: Anchor Fact — Span Navigation ────────────────────────────
+
+/// Given an AnchorFact with byte-span coordinates,
+/// when the LSP provider converts to an LSP Range,
+/// then span_start_byte and span_end_byte are non-negative and ordered.
+#[test]
+fn given_anchor_fact_when_inspecting_span_then_start_is_before_end() {
+    let anchor = AnchorFact {
+        id: AnchorId(50),
+        file_id: FileId(3),
+        span_start_byte: 100,
+        span_end_byte: 115,
+        scope_id: Some(ScopeId(7)),
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+    };
+
+    assert!(anchor.span_start_byte < anchor.span_end_byte);
+    assert_eq!(anchor.span_end_byte - anchor.span_start_byte, 15); // length
+    assert!(anchor.scope_id.is_some());
+}
+
+// ── Scenario 12: Entity Fact — Qualified Name Structure ───────────────────
+
+/// Given an EntityFact for a method in a class,
+/// when the hover provider formats the display,
+/// then the canonical name and entity kind are available.
+#[test]
+fn given_method_entity_fact_when_formatting_hover_then_qualified_name_and_kind_available() {
+    let entity = EntityFact {
+        id: EntityId(500),
+        kind: EntityKind::Method,
+        canonical_name: "MyApp::Model::User::save".to_string(),
+        anchor_id: Some(AnchorId(10)),
+        scope_id: None,
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+    };
+
+    assert_eq!(entity.kind, EntityKind::Method);
+    assert!(entity.canonical_name.contains("::save"));
+    assert!(entity.canonical_name.starts_with("MyApp::"));
+}
+
+// ── Scenario 13: Edge Fact — Import Graph Traversal ───────────────────────
+
+/// Given EdgeFacts forming a module import chain,
+/// when the provider finds all ImportsModule edges from a source entity,
+/// then the set of imported modules is discoverable.
+#[test]
+fn given_import_edges_when_traversing_from_entity_then_imported_modules_discoverable() {
+    let edges = [
+        EdgeFact {
+            id: EdgeId(1),
+            kind: EdgeKind::ImportsModule,
+            from_entity_id: EntityId(1),
+            to_entity_id: EntityId(100),
+            via_occurrence_id: Some(OccurrenceId(10)),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        },
+        EdgeFact {
+            id: EdgeId(2),
+            kind: EdgeKind::ImportsModule,
+            from_entity_id: EntityId(1),
+            to_entity_id: EntityId(200),
+            via_occurrence_id: Some(OccurrenceId(11)),
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        },
+        EdgeFact {
+            id: EdgeId(3),
+            kind: EdgeKind::Calls,
+            from_entity_id: EntityId(1),
+            to_entity_id: EntityId(300),
+            via_occurrence_id: None,
+            provenance: Provenance::SemanticAnalyzer,
+            confidence: Confidence::Medium,
+        },
+    ];
+
+    let imports: Vec<_> = edges
+        .iter()
+        .filter(|e| e.from_entity_id == EntityId(1) && e.kind == EdgeKind::ImportsModule)
+        .collect();
+
+    assert_eq!(imports.len(), 2);
+    // Call edges are separate from import edges.
+    let calls: Vec<_> = edges.iter().filter(|e| e.kind == EdgeKind::Calls).collect();
+    assert_eq!(calls.len(), 1);
+}
+
+// ── Scenario 14: OccurrenceFact — Call vs Reference Disambiguation ─────────
+
+/// Given OccurrenceFacts at the same location with different kinds,
+/// when the provider disambiguates read vs write vs call,
+/// then each occurrence kind is correctly identified.
+#[test]
+fn given_occurrence_facts_when_disambiguating_by_kind_then_each_kind_distinct() {
+    let occurrences = [
+        OccurrenceFact {
+            id: OccurrenceId(1),
+            kind: OccurrenceKind::Read,
+            entity_id: Some(EntityId(10)),
+            anchor_id: AnchorId(1),
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        },
+        OccurrenceFact {
+            id: OccurrenceId(2),
+            kind: OccurrenceKind::Write,
+            entity_id: Some(EntityId(10)),
+            anchor_id: AnchorId(2),
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        },
+        OccurrenceFact {
+            id: OccurrenceId(3),
+            kind: OccurrenceKind::Call,
+            entity_id: Some(EntityId(20)),
+            anchor_id: AnchorId(3),
+            scope_id: None,
+            provenance: Provenance::ExactAst,
+            confidence: Confidence::High,
+        },
+    ];
+
+    let reads: Vec<_> = occurrences.iter().filter(|o| o.kind == OccurrenceKind::Read).collect();
+    let writes: Vec<_> = occurrences.iter().filter(|o| o.kind == OccurrenceKind::Write).collect();
+    let calls: Vec<_> = occurrences.iter().filter(|o| o.kind == OccurrenceKind::Call).collect();
+
+    assert_eq!(reads.len(), 1);
+    assert_eq!(writes.len(), 1);
+    assert_eq!(calls.len(), 1);
+}
+
+// ── Scenario 15: DefinitionRank — Ordering Contract ─────────────────────
+
+/// Given the full rank ordering contract from the design,
+/// when each adjacent pair is compared,
+/// then the Ord implementation preserves the total ordering.
+#[test]
+fn given_definition_rank_variants_when_comparing_then_ordering_is_total_and_correct() {
+    // Ordered best-to-worst: ExactQualified < SamePackage < ExplicitImport
+    // < DefaultExport < WorkspaceCandidate < Heuristic
+    let ordered = [
+        DefinitionRank::ExactQualified,
+        DefinitionRank::SamePackage,
+        DefinitionRank::ExplicitImport,
+        DefinitionRank::DefaultExport,
+        DefinitionRank::WorkspaceCandidate,
+        DefinitionRank::Heuristic,
+    ];
+
+    for window in ordered.windows(2) {
+        assert!(window[0] < window[1], "{:?} should be less than {:?}", window[0], window[1]);
+    }
+}
+
+/// Given the same rank on two candidates with different entity kinds,
+/// when comparing by rank only,
+/// then they are equal rank (not ordered by kind).
+#[test]
+fn given_same_rank_different_kinds_when_comparing_then_ranks_are_equal() {
+    let sub_candidate = DefinitionCandidate::new(
+        EntityId(1),
+        AnchorId(1),
+        "Foo::bar".to_string(),
+        "bar".to_string(),
+        None,
+        EntityKind::Subroutine,
+        Provenance::ExactAst,
+        Confidence::High,
+        DefinitionRank::ExactQualified,
+        DefinitionRankReason::ExactQualifiedName,
+    );
+    let method_candidate = DefinitionCandidate::new(
+        EntityId(2),
+        AnchorId(2),
+        "Foo::bar".to_string(),
+        "bar".to_string(),
+        None,
+        EntityKind::Method,
+        Provenance::ExactAst,
+        Confidence::High,
+        DefinitionRank::ExactQualified,
+        DefinitionRankReason::ExactQualifiedName,
+    );
+
+    assert_eq!(sub_candidate.rank, method_candidate.rank);
+}
+
+// ── Scenario 16: PackageNode — Class/Role/Package Classification ──────────
+
+/// Given PackageNodes representing different package kinds,
+/// when the class graph builder separates classes from plain packages,
+/// then each kind can be filtered independently.
+#[test]
+fn given_mixed_package_nodes_when_filtering_by_kind_then_classes_and_roles_separate() {
+    let nodes = [
+        PackageNode::new(EntityId(1), "App::Model".to_string(), PackageKind::Class, None, None),
+        PackageNode::new(EntityId(2), "Role::Printable".to_string(), PackageKind::Role, None, None),
+        PackageNode::new(EntityId(3), "App::Util".to_string(), PackageKind::Package, None, None),
+        PackageNode::new(
+            EntityId(4),
+            "External::Dep".to_string(),
+            PackageKind::External,
+            None,
+            None,
+        ),
+    ];
+
+    let classes: Vec<_> = nodes.iter().filter(|n| n.kind == PackageKind::Class).collect();
+    let roles: Vec<_> = nodes.iter().filter(|n| n.kind == PackageKind::Role).collect();
+    let packages: Vec<_> = nodes.iter().filter(|n| n.kind == PackageKind::Package).collect();
+    let externals: Vec<_> = nodes.iter().filter(|n| n.kind == PackageKind::External).collect();
+
+    assert_eq!(classes.len(), 1);
+    assert_eq!(roles.len(), 1);
+    assert_eq!(packages.len(), 1);
+    assert_eq!(externals.len(), 1);
+    assert_eq!(classes[0].name, "App::Model");
+    assert_eq!(roles[0].name, "Role::Printable");
+}
+
+// ── Scenario 17: ExportSet — Tag-Based Resolution ─────────────────────────
+
+/// Given an ExportSet with %EXPORT_TAGS entries,
+/// when the provider resolves `use Module ':tagname'`,
+/// then the correct member set is returned for the tag.
+#[test]
+fn given_export_tags_when_resolving_tag_import_then_correct_members_returned() {
+    let export_set = ExportSet {
+        default_exports: vec![],
+        optional_exports: vec![
+            "encode".to_string(),
+            "decode".to_string(),
+            "validate".to_string(),
+            "log_error".to_string(),
+        ],
+        tags: vec![
+            ExportTag {
+                name: "codec".to_string(),
+                members: vec!["encode".to_string(), "decode".to_string()],
+            },
+            ExportTag {
+                name: "all".to_string(),
+                members: vec![
+                    "encode".to_string(),
+                    "decode".to_string(),
+                    "validate".to_string(),
+                    "log_error".to_string(),
+                ],
+            },
+        ],
+        provenance: Provenance::ExactAst,
+        confidence: Confidence::High,
+        module_name: Some("My::Codec".to_string()),
+        anchor_id: None,
+    };
+
+    let codec_tag = export_set.tags.iter().find(|t| t.name == "codec").expect("codec tag exists");
+    assert_eq!(codec_tag.members.len(), 2);
+    assert!(codec_tag.members.contains(&"encode".to_string()));
+    assert!(codec_tag.members.contains(&"decode".to_string()));
+    assert!(!codec_tag.members.contains(&"log_error".to_string()));
+
+    let all_tag = export_set.tags.iter().find(|t| t.name == "all").expect("all tag exists");
+    assert_eq!(all_tag.members.len(), 4);
+}
+
+// ── Scenario 18: Provenance — Source Attribution Chain ────────────────────
+
+/// Given facts with different provenances,
+/// when the provider ranks by reliability,
+/// then ExactAst is treated as most reliable, NameHeuristic least.
+#[test]
+fn given_mixed_provenance_facts_when_compared_then_exact_ast_most_reliable() {
+    // The contract: consumers treat Provenance as an ordered reliability indicator.
+    // ExactAst > DesugaredAst > SemanticAnalyzer > ... > NameHeuristic
+    let most_reliable = [
+        Provenance::ExactAst,
+        Provenance::DesugaredAst,
+        Provenance::SemanticAnalyzer,
+        Provenance::FrameworkSynthesis,
+        Provenance::ImportExportInference,
+        Provenance::PragmaInference,
+        Provenance::NameHeuristic,
+    ];
+
+    // All variants should be distinct (exhaustive check via debug format).
+    let debug_strs: std::collections::HashSet<String> =
+        most_reliable.iter().map(|p| format!("{p:?}")).collect();
+    assert_eq!(debug_strs.len(), most_reliable.len(), "all provenance variants must be distinct");
+    assert!(debug_strs.contains("ExactAst"));
+    assert!(debug_strs.contains("NameHeuristic"));
+}

--- a/crates/perl-semantic-facts/tests/prop_json_roundtrip.rs
+++ b/crates/perl-semantic-facts/tests/prop_json_roundtrip.rs
@@ -1,21 +1,24 @@
-//! Property-based tests for JSON round-trip of new fact types (Property 1).
+//! Property-based tests for JSON round-trip of all fact types.
 //!
-//! **Validates: Requirements 1.7**
+//! **Property: Fact Record JSON Round-Trip** — For any valid fact record,
+//! serializing to JSON then deserializing produces an equal object.
 //!
-//! **Property 1: Fact Record JSON Round-Trip** — For any valid ReferenceEdge,
-//! DefinitionCandidate, (and later ValueShape, PackageEdge, RenamePlan,
-//! SafeDeletePlan), serializing to JSON then deserializing produces an equal
-//! object.
+//! Each fact type gets its own `proptest!` block. Strategies are shared
+//! where types compose (e.g. `arb_anchor_id()` is reused by every struct
+//! that contains an `AnchorId`).
 
 use perl_semantic_facts::{
-    AnchorId, Confidence, DefinitionCandidate, DefinitionRank, DefinitionRankReason, EntityId,
-    EntityKind, FileId, OccurrenceId, OccurrenceKind, Provenance, ReferenceEdge,
+    AnchorFact, AnchorId, Confidence, DefinitionCandidate, DefinitionRank, DefinitionRankReason,
+    DiagnosticFact, DiagnosticId, EdgeFact, EdgeId, EdgeKind, EntityFact, EntityId, EntityKind,
+    ExportSet, ExportTag, FileId, GeneratedMember, GeneratedMemberKind, ImportKind, ImportSpec,
+    ImportSymbols, OccurrenceFact, OccurrenceId, OccurrenceKind, PackageEdge, PackageEdgeKind,
+    PackageKind, PackageNode, PlanBlocker, PlanBlockerReason, PlanWarning, PlannedEdit,
+    PlannedEditCategory, Provenance, RenamePlan, SafeDeletePlan, ScopeId, ValueShape,
+    VisibleSymbol, VisibleSymbolContext, VisibleSymbolSource,
 };
 use proptest::prelude::*;
 
-// ---------------------------------------------------------------------------
-// Strategies — shared building blocks
-// ---------------------------------------------------------------------------
+// ── Shared primitive strategies ────────────────────────────────────────────
 
 fn arb_file_id() -> impl Strategy<Value = FileId> {
     any::<u64>().prop_map(FileId)
@@ -31,6 +34,18 @@ fn arb_anchor_id() -> impl Strategy<Value = AnchorId> {
 
 fn arb_occurrence_id() -> impl Strategy<Value = OccurrenceId> {
     any::<u64>().prop_map(OccurrenceId)
+}
+
+fn arb_scope_id() -> impl Strategy<Value = ScopeId> {
+    any::<u64>().prop_map(ScopeId)
+}
+
+fn arb_edge_id() -> impl Strategy<Value = EdgeId> {
+    any::<u64>().prop_map(EdgeId)
+}
+
+fn arb_diagnostic_id() -> impl Strategy<Value = DiagnosticId> {
+    any::<u64>().prop_map(DiagnosticId)
 }
 
 fn arb_provenance() -> impl Strategy<Value = Provenance> {
@@ -90,33 +105,68 @@ fn arb_entity_kind() -> impl Strategy<Value = EntityKind> {
     ]
 }
 
-/// Generate a Perl-like identifier segment.
+fn arb_edge_kind() -> impl Strategy<Value = EdgeKind> {
+    prop_oneof![
+        Just(EdgeKind::Defines),
+        Just(EdgeKind::References),
+        Just(EdgeKind::Reads),
+        Just(EdgeKind::Writes),
+        Just(EdgeKind::Calls),
+        Just(EdgeKind::ImportsModule),
+        Just(EdgeKind::ImportsSymbol),
+        Just(EdgeKind::ExportsSymbol),
+        Just(EdgeKind::ExportsGroup),
+        Just(EdgeKind::Inherits),
+        Just(EdgeKind::ComposesRole),
+        Just(EdgeKind::MemberOf),
+        Just(EdgeKind::GeneratedFrom),
+        Just(EdgeKind::AliasOf),
+        Just(EdgeKind::DependsOn),
+        Just(EdgeKind::DynamicBoundary),
+    ]
+}
+
 fn arb_identifier() -> impl Strategy<Value = String> {
     "[A-Za-z_][A-Za-z0-9_]{0,12}"
 }
 
-/// Generate a qualified name like `"Foo"` or `"Foo::Bar::baz"`.
 fn arb_qualified_name() -> impl Strategy<Value = String> {
     prop::collection::vec(arb_identifier(), 1..=3).prop_map(|segments| segments.join("::"))
 }
 
-/// Generate a Perl symbol key (bare or qualified).
 fn arb_symbol_key() -> impl Strategy<Value = String> {
     prop_oneof![
         arb_identifier(),
         arb_qualified_name(),
-        // Sigil-prefixed variable references
         arb_identifier().prop_map(|name| format!("${name}")),
         arb_identifier().prop_map(|name| format!("@{name}")),
         arb_identifier().prop_map(|name| format!("%{name}")),
     ]
 }
 
-// ---------------------------------------------------------------------------
-// Strategies — ReferenceEdge
-// ---------------------------------------------------------------------------
+fn arb_opt_string() -> impl Strategy<Value = Option<String>> {
+    prop::option::of("[A-Za-z][A-Za-z0-9_:]{0,20}".prop_map(String::from))
+}
 
-fn arb_reference_edge() -> impl Strategy<Value = ReferenceEdge> {
+fn arb_opt_anchor_id() -> impl Strategy<Value = Option<AnchorId>> {
+    prop::option::of(arb_anchor_id())
+}
+
+fn arb_opt_scope_id() -> impl Strategy<Value = Option<ScopeId>> {
+    prop::option::of(arb_scope_id())
+}
+
+fn arb_opt_file_id() -> impl Strategy<Value = Option<FileId>> {
+    prop::option::of(arb_file_id())
+}
+
+fn arb_opt_entity_id() -> impl Strategy<Value = Option<EntityId>> {
+    prop::option::of(arb_entity_id())
+}
+
+// ── Strategies: primitive fact types ──────────────────────────────────────
+
+fn arb_reference_edge() -> impl Strategy<Value = perl_semantic_facts::ReferenceEdge> {
     (
         arb_occurrence_id(),
         arb_anchor_id(),
@@ -138,7 +188,7 @@ fn arb_reference_edge() -> impl Strategy<Value = ReferenceEdge> {
                 provenance,
                 confidence,
             )| {
-                ReferenceEdge::new(
+                perl_semantic_facts::ReferenceEdge::new(
                     occurrence_id,
                     anchor_id,
                     file_id,
@@ -152,10 +202,6 @@ fn arb_reference_edge() -> impl Strategy<Value = ReferenceEdge> {
         )
 }
 
-// ---------------------------------------------------------------------------
-// Strategies — DefinitionRank
-// ---------------------------------------------------------------------------
-
 fn arb_definition_rank() -> impl Strategy<Value = DefinitionRank> {
     prop_oneof![
         Just(DefinitionRank::ExactQualified),
@@ -167,10 +213,6 @@ fn arb_definition_rank() -> impl Strategy<Value = DefinitionRank> {
     ]
 }
 
-// ---------------------------------------------------------------------------
-// Strategies — DefinitionRankReason
-// ---------------------------------------------------------------------------
-
 fn arb_definition_rank_reason() -> impl Strategy<Value = DefinitionRankReason> {
     prop_oneof![
         Just(DefinitionRankReason::ExactQualifiedName),
@@ -181,10 +223,6 @@ fn arb_definition_rank_reason() -> impl Strategy<Value = DefinitionRankReason> {
         Just(DefinitionRankReason::HeuristicNameMatch),
     ]
 }
-
-// ---------------------------------------------------------------------------
-// Strategies — DefinitionCandidate
-// ---------------------------------------------------------------------------
 
 fn arb_definition_candidate() -> impl Strategy<Value = DefinitionCandidate> {
     (
@@ -228,9 +266,448 @@ fn arb_definition_candidate() -> impl Strategy<Value = DefinitionCandidate> {
         )
 }
 
-// ---------------------------------------------------------------------------
-// Property tests
-// ---------------------------------------------------------------------------
+// ── Strategies: anchor, entity, occurrence, edge, diagnostic facts ─────────
+
+fn arb_anchor_fact() -> impl Strategy<Value = AnchorFact> {
+    (
+        arb_anchor_id(),
+        arb_file_id(),
+        0u32..100_000u32,
+        arb_opt_scope_id(),
+        arb_provenance(),
+        arb_confidence(),
+    )
+        .prop_map(|(id, file_id, start, scope_id, provenance, confidence)| AnchorFact {
+            id,
+            file_id,
+            span_start_byte: start,
+            span_end_byte: start + 20,
+            scope_id,
+            provenance,
+            confidence,
+        })
+}
+
+fn arb_entity_fact() -> impl Strategy<Value = EntityFact> {
+    (
+        arb_entity_id(),
+        arb_entity_kind(),
+        arb_qualified_name(),
+        arb_opt_anchor_id(),
+        arb_opt_scope_id(),
+        arb_provenance(),
+        arb_confidence(),
+    )
+        .prop_map(|(id, kind, canonical_name, anchor_id, scope_id, provenance, confidence)| {
+            EntityFact { id, kind, canonical_name, anchor_id, scope_id, provenance, confidence }
+        })
+}
+
+fn arb_occurrence_fact() -> impl Strategy<Value = OccurrenceFact> {
+    (
+        arb_occurrence_id(),
+        arb_occurrence_kind(),
+        arb_opt_entity_id(),
+        arb_anchor_id(),
+        arb_opt_scope_id(),
+        arb_provenance(),
+        arb_confidence(),
+    )
+        .prop_map(|(id, kind, entity_id, anchor_id, scope_id, provenance, confidence)| {
+            OccurrenceFact { id, kind, entity_id, anchor_id, scope_id, provenance, confidence }
+        })
+}
+
+fn arb_edge_fact() -> impl Strategy<Value = EdgeFact> {
+    (
+        arb_edge_id(),
+        arb_edge_kind(),
+        arb_entity_id(),
+        arb_entity_id(),
+        prop::option::of(arb_occurrence_id()),
+        arb_provenance(),
+        arb_confidence(),
+    )
+        .prop_map(
+            |(
+                id,
+                kind,
+                from_entity_id,
+                to_entity_id,
+                via_occurrence_id,
+                provenance,
+                confidence,
+            )| EdgeFact {
+                id,
+                kind,
+                from_entity_id,
+                to_entity_id,
+                via_occurrence_id,
+                provenance,
+                confidence,
+            },
+        )
+}
+
+fn arb_diagnostic_fact() -> impl Strategy<Value = DiagnosticFact> {
+    (
+        arb_diagnostic_id(),
+        arb_opt_string(),
+        "[A-Za-z ]{1,40}".prop_map(String::from),
+        arb_anchor_id(),
+        prop::collection::vec(arb_anchor_id(), 0..3),
+        arb_opt_scope_id(),
+        arb_provenance(),
+        arb_confidence(),
+    )
+        .prop_map(
+            |(
+                id,
+                code,
+                message,
+                primary_anchor_id,
+                related_anchor_ids,
+                scope_id,
+                provenance,
+                confidence,
+            )| DiagnosticFact {
+                id,
+                code,
+                message,
+                primary_anchor_id,
+                related_anchor_ids,
+                scope_id,
+                provenance,
+                confidence,
+            },
+        )
+}
+
+// ── Strategies: export and import types ───────────────────────────────────
+
+fn arb_export_tag() -> impl Strategy<Value = ExportTag> {
+    (arb_identifier(), prop::collection::vec(arb_identifier(), 0..5))
+        .prop_map(|(name, members)| ExportTag { name, members })
+}
+
+fn arb_export_set() -> impl Strategy<Value = ExportSet> {
+    (
+        prop::collection::vec(arb_identifier(), 0..4),
+        prop::collection::vec(arb_identifier(), 0..4),
+        prop::collection::vec(arb_export_tag(), 0..3),
+        arb_provenance(),
+        arb_confidence(),
+        prop::option::of(arb_qualified_name()),
+        arb_opt_anchor_id(),
+    )
+        .prop_map(
+            |(
+                default_exports,
+                optional_exports,
+                tags,
+                provenance,
+                confidence,
+                module_name,
+                anchor_id,
+            )| ExportSet {
+                default_exports,
+                optional_exports,
+                tags,
+                provenance,
+                confidence,
+                module_name,
+                anchor_id,
+            },
+        )
+}
+
+fn arb_import_kind() -> impl Strategy<Value = ImportKind> {
+    prop_oneof![
+        Just(ImportKind::Use),
+        Just(ImportKind::UseEmpty),
+        Just(ImportKind::UseExplicitList),
+        Just(ImportKind::UseTag),
+        Just(ImportKind::Require),
+        Just(ImportKind::RequireThenImport),
+        Just(ImportKind::UseConstant),
+        Just(ImportKind::DynamicRequire),
+        Just(ImportKind::ManualImport),
+    ]
+}
+
+fn arb_import_symbols() -> impl Strategy<Value = ImportSymbols> {
+    prop_oneof![
+        Just(ImportSymbols::Default),
+        Just(ImportSymbols::None),
+        prop::collection::vec(arb_identifier(), 0..5).prop_map(ImportSymbols::Explicit),
+        prop::collection::vec(arb_identifier(), 0..4).prop_map(ImportSymbols::Tags),
+        (
+            prop::collection::vec(arb_identifier(), 0..3),
+            prop::collection::vec(arb_identifier(), 0..3),
+        )
+            .prop_map(|(tags, names)| ImportSymbols::Mixed { tags, names }),
+        Just(ImportSymbols::Dynamic),
+    ]
+}
+
+fn arb_import_spec() -> impl Strategy<Value = ImportSpec> {
+    (
+        arb_qualified_name(),
+        arb_import_kind(),
+        arb_import_symbols(),
+        arb_provenance(),
+        arb_confidence(),
+        arb_opt_file_id(),
+        arb_opt_anchor_id(),
+        arb_opt_scope_id(),
+        prop::option::of(any::<u32>()),
+    )
+        .prop_map(
+            |(
+                module,
+                kind,
+                symbols,
+                provenance,
+                confidence,
+                file_id,
+                anchor_id,
+                scope_id,
+                span_start_byte,
+            )| ImportSpec {
+                module,
+                kind,
+                symbols,
+                provenance,
+                confidence,
+                file_id,
+                anchor_id,
+                scope_id,
+                span_start_byte,
+            },
+        )
+}
+
+// ── Strategies: visible symbol ─────────────────────────────────────────────
+
+fn arb_visible_symbol_source() -> impl Strategy<Value = VisibleSymbolSource> {
+    prop_oneof![
+        Just(VisibleSymbolSource::LocalLexical),
+        Just(VisibleSymbolSource::LocalPackage),
+        Just(VisibleSymbolSource::ExplicitImport),
+        Just(VisibleSymbolSource::DefaultExport),
+        Just(VisibleSymbolSource::ExportTag),
+        Just(VisibleSymbolSource::Constant),
+        Just(VisibleSymbolSource::Generated),
+        Just(VisibleSymbolSource::External),
+        Just(VisibleSymbolSource::DynamicUnknown),
+    ]
+}
+
+fn arb_visible_symbol_context() -> impl Strategy<Value = VisibleSymbolContext> {
+    (prop::option::of(arb_qualified_name()), arb_opt_anchor_id(), arb_opt_anchor_id()).prop_map(
+        |(source_module, source_import_anchor_id, source_export_anchor_id)| {
+            VisibleSymbolContext::new(
+                source_module,
+                source_import_anchor_id,
+                source_export_anchor_id,
+            )
+        },
+    )
+}
+
+fn arb_visible_symbol() -> impl Strategy<Value = VisibleSymbol> {
+    (
+        arb_symbol_key(),
+        arb_opt_entity_id(),
+        arb_visible_symbol_source(),
+        arb_confidence(),
+        prop::option::of(arb_visible_symbol_context()),
+    )
+        .prop_map(|(name, entity_id, source, confidence, context)| VisibleSymbol {
+            name,
+            entity_id,
+            source,
+            confidence,
+            context,
+        })
+}
+
+// ── Strategies: rename and safe-delete plans ──────────────────────────────
+
+fn arb_plan_blocker_reason() -> impl Strategy<Value = PlanBlockerReason> {
+    prop_oneof![
+        Just(PlanBlockerReason::DynamicBoundary),
+        Just(PlanBlockerReason::AmbiguousReference),
+        Just(PlanBlockerReason::CrossModuleExport),
+        Just(PlanBlockerReason::ImportedSymbol),
+        Just(PlanBlockerReason::ExportedSymbol),
+        Just(PlanBlockerReason::ReferencesExist),
+        Just(PlanBlockerReason::GeneratedMember),
+        Just(PlanBlockerReason::UnclassifiedOccurrence),
+    ]
+}
+
+fn arb_plan_blocker() -> impl Strategy<Value = PlanBlocker> {
+    (arb_plan_blocker_reason(), arb_opt_anchor_id(), "[A-Za-z ]{1,30}".prop_map(String::from))
+        .prop_map(|(reason, anchor_id, description)| {
+            PlanBlocker::new(reason, anchor_id, description)
+        })
+}
+
+fn arb_plan_warning() -> impl Strategy<Value = PlanWarning> {
+    ("[A-Za-z ]{1,30}".prop_map(String::from), arb_opt_anchor_id())
+        .prop_map(|(message, anchor_id)| PlanWarning::new(message, anchor_id))
+}
+
+fn arb_planned_edit_category() -> impl Strategy<Value = PlannedEditCategory> {
+    prop_oneof![
+        Just(PlannedEditCategory::Definition),
+        Just(PlannedEditCategory::Reference),
+        Just(PlannedEditCategory::ImportList),
+        Just(PlannedEditCategory::ExportList),
+    ]
+}
+
+fn arb_planned_edit() -> impl Strategy<Value = PlannedEdit> {
+    (
+        arb_anchor_id(),
+        arb_file_id(),
+        arb_planned_edit_category(),
+        arb_identifier(),
+        arb_identifier(),
+    )
+        .prop_map(|(anchor_id, file_id, category, old_text, new_text)| {
+            PlannedEdit::new(anchor_id, file_id, category, old_text, new_text)
+        })
+}
+
+fn arb_rename_plan() -> impl Strategy<Value = RenamePlan> {
+    (
+        arb_entity_id(),
+        arb_identifier(),
+        arb_identifier(),
+        prop::collection::vec(arb_planned_edit(), 0..4),
+        prop::collection::vec(arb_plan_blocker(), 0..3),
+        prop::collection::vec(arb_plan_warning(), 0..3),
+    )
+        .prop_map(|(entity_id, old_name, new_name, edits, blockers, warnings)| {
+            RenamePlan::new(entity_id, old_name, new_name, edits, blockers, warnings)
+        })
+}
+
+fn arb_safe_delete_plan() -> impl Strategy<Value = SafeDeletePlan> {
+    (
+        arb_entity_id(),
+        arb_identifier(),
+        prop::collection::vec(arb_plan_blocker(), 0..3),
+        prop::collection::vec(arb_plan_warning(), 0..3),
+    )
+        .prop_map(|(entity_id, name, blockers, warnings)| {
+            SafeDeletePlan::new(entity_id, name, blockers, warnings)
+        })
+}
+
+// ── Strategies: package graph types ───────────────────────────────────────
+
+fn arb_package_kind() -> impl Strategy<Value = PackageKind> {
+    prop_oneof![
+        Just(PackageKind::Package),
+        Just(PackageKind::Class),
+        Just(PackageKind::Role),
+        Just(PackageKind::External),
+    ]
+}
+
+fn arb_package_edge_kind() -> impl Strategy<Value = PackageEdgeKind> {
+    prop_oneof![
+        Just(PackageEdgeKind::Inherits),
+        Just(PackageEdgeKind::ComposesRole),
+        Just(PackageEdgeKind::DependsOn),
+    ]
+}
+
+fn arb_package_node() -> impl Strategy<Value = PackageNode> {
+    (
+        arb_entity_id(),
+        arb_qualified_name(),
+        arb_package_kind(),
+        arb_opt_anchor_id(),
+        arb_opt_file_id(),
+    )
+        .prop_map(|(entity_id, name, kind, anchor_id, file_id)| {
+            PackageNode::new(entity_id, name, kind, anchor_id, file_id)
+        })
+}
+
+fn arb_package_edge() -> impl Strategy<Value = PackageEdge> {
+    (
+        arb_qualified_name(),
+        arb_qualified_name(),
+        arb_package_edge_kind(),
+        arb_opt_anchor_id(),
+        arb_provenance(),
+        arb_confidence(),
+    )
+        .prop_map(|(from_package, to_package, kind, anchor_id, provenance, confidence)| {
+            PackageEdge::new(from_package, to_package, kind, anchor_id, provenance, confidence)
+        })
+}
+
+// ── Strategies: generated member ──────────────────────────────────────────
+
+fn arb_generated_member_kind() -> impl Strategy<Value = GeneratedMemberKind> {
+    prop_oneof![
+        Just(GeneratedMemberKind::Getter),
+        Just(GeneratedMemberKind::Setter),
+        Just(GeneratedMemberKind::Accessor),
+        Just(GeneratedMemberKind::Predicate),
+        Just(GeneratedMemberKind::Clearer),
+        Just(GeneratedMemberKind::Builder),
+        Just(GeneratedMemberKind::Constant),
+    ]
+}
+
+fn arb_generated_member() -> impl Strategy<Value = GeneratedMember> {
+    (
+        arb_entity_id(),
+        arb_identifier(),
+        arb_generated_member_kind(),
+        arb_anchor_id(),
+        arb_qualified_name(),
+        arb_provenance(),
+        arb_confidence(),
+    )
+        .prop_map(
+            |(entity_id, name, kind, source_anchor_id, package, provenance, confidence)| {
+                GeneratedMember::new(
+                    entity_id,
+                    name,
+                    kind,
+                    source_anchor_id,
+                    package,
+                    provenance,
+                    confidence,
+                )
+            },
+        )
+}
+
+// ── Strategies: value shape ────────────────────────────────────────────────
+
+fn arb_value_shape() -> impl Strategy<Value = ValueShape> {
+    prop_oneof![
+        Just(ValueShape::Unknown),
+        Just(ValueShape::Scalar),
+        Just(ValueShape::ArrayRef),
+        Just(ValueShape::HashRef),
+        Just(ValueShape::CodeRef),
+        arb_qualified_name().prop_map(|package| ValueShape::PackageName { package }),
+        (arb_qualified_name(), arb_confidence())
+            .prop_map(|(package, confidence)| ValueShape::Object { package, confidence }),
+    ]
+}
+
+// ── Property tests ─────────────────────────────────────────────────────────
 
 proptest! {
     #![proptest_config(ProptestConfig {
@@ -239,47 +716,229 @@ proptest! {
         ..ProptestConfig::default()
     })]
 
-    /// **Validates: Requirements 1.7**
-    ///
-    /// Property 1 (ReferenceEdge): Serializing a ReferenceEdge to JSON then
-    /// deserializing produces an equal object.
+    // ── Original 4 types ──────────────────────────────────────────────────
+
     #[test]
     fn reference_edge_json_roundtrip(edge in arb_reference_edge()) {
         let json = serde_json::to_string(&edge).map_err(|e| TestCaseError::fail(e.to_string()))?;
-        let decoded: ReferenceEdge = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
-        prop_assert_eq!(&decoded, &edge, "ReferenceEdge JSON round-trip mismatch");
+        let decoded: perl_semantic_facts::ReferenceEdge = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &edge);
     }
 
-    /// **Validates: Requirements 1.7**
-    ///
-    /// Property 1 (DefinitionRank): Serializing a DefinitionRank to JSON then
-    /// deserializing produces an equal value.
     #[test]
     fn definition_rank_json_roundtrip(rank in arb_definition_rank()) {
         let json = serde_json::to_string(&rank).map_err(|e| TestCaseError::fail(e.to_string()))?;
         let decoded: DefinitionRank = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
-        prop_assert_eq!(decoded, rank, "DefinitionRank JSON round-trip mismatch");
+        prop_assert_eq!(decoded, rank);
     }
 
-    /// **Validates: Requirements 1.7**
-    ///
-    /// Property 1 (DefinitionRankReason): Serializing a DefinitionRankReason
-    /// to JSON then deserializing produces an equal value.
     #[test]
     fn definition_rank_reason_json_roundtrip(reason in arb_definition_rank_reason()) {
         let json = serde_json::to_string(&reason).map_err(|e| TestCaseError::fail(e.to_string()))?;
         let decoded: DefinitionRankReason = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
-        prop_assert_eq!(&decoded, &reason, "DefinitionRankReason JSON round-trip mismatch");
+        prop_assert_eq!(&decoded, &reason);
     }
 
-    /// **Validates: Requirements 1.7**
-    ///
-    /// Property 1 (DefinitionCandidate): Serializing a DefinitionCandidate to
-    /// JSON then deserializing produces an equal object.
     #[test]
     fn definition_candidate_json_roundtrip(candidate in arb_definition_candidate()) {
         let json = serde_json::to_string(&candidate).map_err(|e| TestCaseError::fail(e.to_string()))?;
         let decoded: DefinitionCandidate = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
-        prop_assert_eq!(&decoded, &candidate, "DefinitionCandidate JSON round-trip mismatch");
+        prop_assert_eq!(&decoded, &candidate);
+    }
+
+    // ── Core fact types ────────────────────────────────────────────────────
+
+    #[test]
+    fn anchor_fact_json_roundtrip(fact in arb_anchor_fact()) {
+        let json = serde_json::to_string(&fact).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: AnchorFact = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &fact);
+    }
+
+    #[test]
+    fn entity_fact_json_roundtrip(fact in arb_entity_fact()) {
+        let json = serde_json::to_string(&fact).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: EntityFact = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &fact);
+    }
+
+    #[test]
+    fn occurrence_fact_json_roundtrip(fact in arb_occurrence_fact()) {
+        let json = serde_json::to_string(&fact).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: OccurrenceFact = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &fact);
+    }
+
+    #[test]
+    fn edge_fact_json_roundtrip(fact in arb_edge_fact()) {
+        let json = serde_json::to_string(&fact).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: EdgeFact = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &fact);
+    }
+
+    #[test]
+    fn diagnostic_fact_json_roundtrip(fact in arb_diagnostic_fact()) {
+        let json = serde_json::to_string(&fact).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: DiagnosticFact = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &fact);
+    }
+
+    // ── Export and import types ─────────────────────────────────────────────
+
+    #[test]
+    fn export_tag_json_roundtrip(tag in arb_export_tag()) {
+        let json = serde_json::to_string(&tag).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: ExportTag = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &tag);
+    }
+
+    #[test]
+    fn export_set_json_roundtrip(export_set in arb_export_set()) {
+        let json = serde_json::to_string(&export_set).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: ExportSet = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &export_set);
+    }
+
+    #[test]
+    fn import_kind_json_roundtrip(kind in arb_import_kind()) {
+        let json = serde_json::to_string(&kind).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: ImportKind = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(decoded, kind);
+    }
+
+    #[test]
+    fn import_symbols_json_roundtrip(symbols in arb_import_symbols()) {
+        let json = serde_json::to_string(&symbols).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: ImportSymbols = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &symbols);
+    }
+
+    #[test]
+    fn import_spec_json_roundtrip(spec in arb_import_spec()) {
+        let json = serde_json::to_string(&spec).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: ImportSpec = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &spec);
+    }
+
+    // ── Visible symbol ──────────────────────────────────────────────────────
+
+    #[test]
+    fn visible_symbol_source_json_roundtrip(source in arb_visible_symbol_source()) {
+        let json = serde_json::to_string(&source).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: VisibleSymbolSource = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(decoded, source);
+    }
+
+    #[test]
+    fn visible_symbol_context_json_roundtrip(ctx in arb_visible_symbol_context()) {
+        let json = serde_json::to_string(&ctx).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: VisibleSymbolContext = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &ctx);
+    }
+
+    #[test]
+    fn visible_symbol_json_roundtrip(symbol in arb_visible_symbol()) {
+        let json = serde_json::to_string(&symbol).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: VisibleSymbol = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &symbol);
+    }
+
+    // ── Rename and safe-delete plans ────────────────────────────────────────
+
+    #[test]
+    fn plan_blocker_reason_json_roundtrip(reason in arb_plan_blocker_reason()) {
+        let json = serde_json::to_string(&reason).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: PlanBlockerReason = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(decoded, reason);
+    }
+
+    #[test]
+    fn plan_blocker_json_roundtrip(blocker in arb_plan_blocker()) {
+        let json = serde_json::to_string(&blocker).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: PlanBlocker = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &blocker);
+    }
+
+    #[test]
+    fn plan_warning_json_roundtrip(warning in arb_plan_warning()) {
+        let json = serde_json::to_string(&warning).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: PlanWarning = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &warning);
+    }
+
+    #[test]
+    fn planned_edit_json_roundtrip(edit in arb_planned_edit()) {
+        let json = serde_json::to_string(&edit).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: PlannedEdit = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &edit);
+    }
+
+    #[test]
+    fn rename_plan_json_roundtrip(plan in arb_rename_plan()) {
+        let json = serde_json::to_string(&plan).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: RenamePlan = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &plan);
+    }
+
+    #[test]
+    fn safe_delete_plan_json_roundtrip(plan in arb_safe_delete_plan()) {
+        let json = serde_json::to_string(&plan).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: SafeDeletePlan = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &plan);
+    }
+
+    // ── Package graph types ─────────────────────────────────────────────────
+
+    #[test]
+    fn package_kind_json_roundtrip(kind in arb_package_kind()) {
+        let json = serde_json::to_string(&kind).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: PackageKind = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(decoded, kind);
+    }
+
+    #[test]
+    fn package_edge_kind_json_roundtrip(kind in arb_package_edge_kind()) {
+        let json = serde_json::to_string(&kind).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: PackageEdgeKind = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(decoded, kind);
+    }
+
+    #[test]
+    fn package_node_json_roundtrip(node in arb_package_node()) {
+        let json = serde_json::to_string(&node).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: PackageNode = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &node);
+    }
+
+    #[test]
+    fn package_edge_json_roundtrip(edge in arb_package_edge()) {
+        let json = serde_json::to_string(&edge).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: PackageEdge = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &edge);
+    }
+
+    // ── Generated member ────────────────────────────────────────────────────
+
+    #[test]
+    fn generated_member_kind_json_roundtrip(kind in arb_generated_member_kind()) {
+        let json = serde_json::to_string(&kind).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: GeneratedMemberKind = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(decoded, kind);
+    }
+
+    #[test]
+    fn generated_member_json_roundtrip(member in arb_generated_member()) {
+        let json = serde_json::to_string(&member).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: GeneratedMember = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &member);
+    }
+
+    // ── Value shape ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn value_shape_json_roundtrip(shape in arb_value_shape()) {
+        let json = serde_json::to_string(&shape).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        let decoded: ValueShape = serde_json::from_str(&json).map_err(|e| TestCaseError::fail(e.to_string()))?;
+        prop_assert_eq!(&decoded, &shape);
     }
 }


### PR DESCRIPTION
## Summary

`perl-semantic-facts` is the neutral vocabulary crate shared by the parser, semantic analyzer, and workspace layers. It defines ~30 types (IDs, enums, facts, plans) that downstream LSP providers consume to answer goto-definition, rename, hover, and completion queries.

Before this PR the crate had:
- **42 inline unit tests** — mostly JSON round-trips for individual fields, written from a constructor perspective
- **4 property tests** — covering only `ReferenceEdge`, `DefinitionRank`, `DefinitionRankReason`, and `DefinitionCandidate`
- **0 BDD consumer scenario tests** — no tests written from the perspective of a provider that *uses* these types

This PR closes both gaps.

---

## What changed

### `tests/bdd_semantic_facts.rs` — new file, 32 tests across 18 scenarios

Each scenario is framed as a downstream provider consuming the fact vocabulary — the same perspective a goto-definition, rename, hover, or completion provider would have. The structure is: _Given \<context\>, when \<operation\>, then \<expected outcome\>._

| Scenario | Tests | What it validates |
|----------|-------|-------------------|
| **1. Goto-Definition — Candidate Ranking** | 3 | `DefinitionRank` sort order; ExplicitImport rank reason carries source module; empty candidate list handled |
| **2. Rename Provider — Plan Safety** | 3 | `RenamePlan` with no blockers; `DynamicBoundary` blocker detection; multi-category edit partitioning (Definition / Reference / ExportList) |
| **3. Safe Delete Provider** | 1 | `ReferencesExist` blocker prevents deletion; warnings attach to no anchor |
| **4. Import Resolution** | 3 | `UseExplicitList` symbol enumeration; `ManualImport` order-sensitivity via `span_start_byte`; `UseTag` group lookup |
| **5. Export Set** | 2 | Plain `use` sees only `default_exports`; `:all` tag expands to full set; `None` module_name handled gracefully |
| **6. Visible Symbol Hover** | 3 | `ExplicitImport` source tracing (module + anchors); `LocalLexical` has no external context; `DynamicUnknown` has Low confidence |
| **7. Value Shape — Method Completion** | 3 | `Object` package drives class graph lookup; `PackageName` is known statically; `Unknown` triggers workspace-wide search |
| **8. Package Graph — Inheritance Walk** | 2 | Linear inheritance chain traversal; `Inherits` vs `ComposesRole` edge filtering |
| **9. Generated Members — Accessor Discovery** | 2 | Moo getter name and kind; predicate and clearer distinguishable from accessor |
| **10. Diagnostic Confidence Filtering** | 1 | High-confidence-only mode excludes Medium and Low |
| **11. Anchor Span Navigation** | 1 | `span_start_byte < span_end_byte` invariant; byte-length derivation |
| **12. Entity Fact — Qualified Name** | 1 | Canonical name structure; entity kind available for hover |
| **13. Edge Fact — Import Graph** | 1 | `ImportsModule` traversal; `Calls` edges stay separate |
| **14. OccurrenceFact — Disambiguation** | 1 | Read / Write / Call kinds are distinct |
| **15. DefinitionRank — Total Ordering** | 2 | Adjacent rank pairs satisfy `<`; same rank on different `EntityKind` are equal |
| **16. PackageNode — Classification** | 1 | Class / Role / Package / External filter independently |
| **17. ExportSet — Tag Resolution** | 1 | Per-tag member set lookup (`:codec` vs `:all`) |
| **18. Provenance Attribution** | 1 | All 7 variants have distinct debug representations |

### `tests/prop_json_roundtrip.rs` — extended from 4 to 30 property tests

The existing 4 tests were kept unchanged. 26 new `proptest!` blocks were added, one per type, all with `cases: 256, failure_persistence: None`.

**Newly covered types:**

`AnchorFact`, `EntityFact`, `OccurrenceFact`, `EdgeFact`, `DiagnosticFact`, `ExportTag`, `ExportSet`, `ImportKind`, `ImportSymbols`, `ImportSpec`, `VisibleSymbolSource`, `VisibleSymbolContext`, `VisibleSymbol`, `PlanBlockerReason`, `PlanBlocker`, `PlanWarning`, `PlannedEditCategory`, `PlannedEdit`, `RenamePlan`, `SafeDeletePlan`, `PackageKind`, `PackageEdgeKind`, `PackageNode`, `PackageEdge`, `GeneratedMemberKind`, `GeneratedMember`, `ValueShape` (all variants)

New shared primitive strategies added to avoid duplication: `arb_scope_id`, `arb_edge_id`, `arb_diagnostic_id`, `arb_edge_kind`, `arb_opt_string`, `arb_opt_anchor_id`, `arb_opt_scope_id`, `arb_opt_file_id`, `arb_opt_entity_id`.

---

## Why this matters

`perl-semantic-facts` is a **leaf vocabulary crate** — every consumer (LSP providers, semantic analyzer, workspace) depends on its JSON serialization being stable and its type contracts being correct. The existing inline tests were written from the constructor's perspective. The new tests verify the consumer contracts that providers actually rely on:

- **Rank ordering is stable** — providers sort candidates and take `[0]`; if `DefinitionRank` Ord breaks, goto-definition silently returns the wrong result
- **Blocker detection works** — rename/delete providers gate on `blockers.is_empty()`; if the field structure changes, they silently skip safety checks  
- **JSON round-trips hold for all types** — any `serde` annotation mistake in a type that previously had no property test would only surface at runtime in a real LSP session

---

## Test results

```
test result: ok. 42 passed  (unit tests in src/lib.rs)
test result: ok. 32 passed  (bdd_semantic_facts.rs)
test result: ok. 30 passed  (prop_json_roundtrip.rs)
```

104 tests, 0 failures. `cargo clippy -p perl-semantic-facts --tests` clean. `cargo fmt` applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANgdFhP9CBxHQHQJnMVK2Z)_