### PR TITLE
fix(parser): prevent infinite loop on orphan closing delimiters in synchronize() (#7890)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -759,12 +759,17 @@ impl<'a> Parser<'a> {
             if self.is_sync_point() {
                 // Consume tokens that would cause infinite loops if left unconsumed.
                 // Semicolon: standard statement terminator, safe to skip.
-                // RightBrace: orphan closing brace at top level must be consumed
-                //             to prevent parse_program from looping forever.
-                // Both are valid sync points but need to be consumed for progress.
+                // RightBrace/RightParen/RightBracket: orphan closing delimiters
+                //   that must be consumed so parse_program does not loop forever.
+                //   Without consuming these, the caller re-calls parse_statement,
+                //   which fails on the same orphan closer, which calls synchronize
+                //   again in an infinite cycle (#parser-hang-orphan-closer).
                 if matches!(
                     self.peek_kind(),
-                    Some(TokenKind::Semicolon) | Some(TokenKind::RightBrace)
+                    Some(TokenKind::Semicolon)
+                        | Some(TokenKind::RightBrace)
+                        | Some(TokenKind::RightParen)
+                        | Some(TokenKind::RightBracket)
                 ) {
                     let _ = self.consume_token();
                 }

--- a/crates/perl-parser-core/tests/orphan_closer_hang_tests.rs
+++ b/crates/perl-parser-core/tests/orphan_closer_hang_tests.rs
@@ -1,0 +1,57 @@
+mod cpan_test_helpers;
+
+use perl_parser_core::Parser;
+
+// Regression tests for parser hang on orphan closing delimiters
+// (issue: synchronize() did not consume RightParen/RightBracket,
+//  causing parse_program to loop forever on malformed input).
+
+/// Verify that parsing a list with missing commas in parens terminates.
+/// Previously: `(1 2 3)` caused synchronize() to leave `)` unconsumed,
+/// which made parse_program loop forever calling parse_statement on `)`.
+#[test]
+fn when_paren_list_missing_commas_then_parse_terminates() {
+    let mut parser = Parser::new("my @list = (1 2 3);\n");
+    // Must terminate — no timeout/hang.
+    let _ = parser.parse();
+    // Parser should have collected errors rather than looping.
+    // (We don't assert clean parse since the input IS malformed.)
+}
+
+/// Orphan `)` at statement level must not loop.
+#[test]
+fn when_orphan_right_paren_at_top_level_then_parse_terminates() {
+    let mut parser = Parser::new(");\n");
+    let _ = parser.parse();
+}
+
+/// Orphan `]` at statement level must not loop.
+#[test]
+fn when_orphan_right_bracket_at_top_level_then_parse_terminates() {
+    let mut parser = Parser::new("];\n");
+    let _ = parser.parse();
+}
+
+/// Multiple orphan closers must not loop.
+#[test]
+fn when_multiple_orphan_closers_then_parse_terminates() {
+    let mut parser = Parser::new(") ] ) ;\n");
+    let _ = parser.parse();
+}
+
+/// Multiple statements: one with malformed parens, followed by valid code.
+/// The parser must not hang and must continue to parse the second statement.
+#[test]
+fn when_bad_paren_list_followed_by_valid_code_then_both_parsed() {
+    let mut parser = Parser::new("my @x = (1 2 3);\nmy $y = 4;\n");
+    // Must terminate. Both statements should have been attempted.
+    let _ = parser.parse();
+    // If we get here without hanging, the fix is working.
+}
+
+/// Paren with missing comma inside a block must not hang.
+#[test]
+fn when_paren_missing_comma_inside_block_then_parse_terminates() {
+    let mut parser = Parser::new("sub foo { my @x = (1 2 3); }\n");
+    let _ = parser.parse();
+}


### PR DESCRIPTION
## Summary

Fixes a parser hang (infinite loop) triggered by malformed input containing parenthesized lists with missing commas, e.g. `my @list = (1 2 3);`.

## Root cause

`synchronize()` in `helpers.rs` is the panic-mode error recovery function called when `parse_program` (or `parse_block`) encounters a failed statement. It skips tokens until it reaches a "sync point," then returns `true` so the outer loop can continue parsing.

The bug: when `synchronize()` hit a `)` or `]` sync point, it returned `true` **without consuming the token**. Back in `parse_program`, the loop saw `!is_eof()` as true, called `parse_statement()` again — which immediately failed again on the same orphan closer — which called `synchronize()` again — infinite loop.

The pre-existing code only consumed `Semicolon` and `RightBrace` at sync points, with a comment explaining that `RightBrace` must be consumed "to prevent parse_program from looping forever." The same logic applies identically to `RightParen` and `RightBracket`, but those were omitted.

## Trace for `my @list = (1 2 3);`

1. `parse_statement` → `parse_variable_declaration` → parse RHS `(1 2 3)`
2. Inside the `LeftParen` branch: parses `1`, sees `2` (not a comma/fat-arrow/closer) → calls `expect_closing_delimiter(RightParen)` → **Err**: `2` is not `)`
3. Error propagates to `parse_program`. Remaining tokens: `2 3 ) ;`
4. `synchronize()`: skips `2` (not sync), skips `3` (not sync), hits `)` (IS sync point: close delimiter = recovery boundary) → returns `true` **without consuming `)`**
5. `parse_program` loop continues. Calls `parse_statement` with `)` as first token
6. `parse_primary` on `)` → **Err** (no match in primary expression dispatch)
7. Back to `parse_program` error handler → `synchronize()` → hits `)` again → returns `true` again → **∞ loop**

## Fix

Two-line change in `synchronize()`: add `RightParen` and `RightBracket` to the set of orphan delimiters that are consumed before returning `true`.

```rust
// Before
if matches!(
    self.peek_kind(),
    Some(TokenKind::Semicolon) | Some(TokenKind::RightBrace)
) {
    let _ = self.consume_token();
}

// After
if matches!(
    self.peek_kind(),
    Some(TokenKind::Semicolon)
        | Some(TokenKind::RightBrace)
        | Some(TokenKind::RightParen)
        | Some(TokenKind::RightBracket)
) {
    let _ = self.consume_token();
}
```

This is safe at both call sites of `synchronize()` (`parse_program` and `parse_block`): by the time error recovery runs at either level, the error has already propagated all the way up — any residual `)` or `]` is an orphan with no outer frame to own it.

## Files changed

- `crates/perl-parser-core/src/engine/parser/helpers.rs` — fix in `synchronize()`
- `crates/perl-parser-core/tests/orphan_closer_hang_tests.rs` — new regression test file (6 tests)

## Test results

```
# New regression tests
running 6 tests
test when_bad_paren_list_followed_by_valid_code_then_both_parsed ... ok
test when_multiple_orphan_closers_then_parse_terminates ... ok
test when_orphan_right_bracket_at_top_level_then_parse_terminates ... ok
test when_orphan_right_paren_at_top_level_then_parse_terminates ... ok
test when_paren_list_missing_commas_then_parse_terminates ... ok
test when_paren_missing_comma_inside_block_then_parse_terminates ... ok
test result: ok. 6 passed; 0 failed

# pull_diagnostics_tests (previously hanging)
running 14 tests
test parse_error_fallback_missing_comma_includes_hint ... ok   ← was hanging
...all 14 passed

# perl-parser-core lib tests (no regressions)
test result: ok. 591 passed; 0 failed

# error_recovery_regression (no regressions)
test result: ok. 20 passed; 0 failed

# error_recovery_context_tests (no regressions)
test result: ok. 14 passed; 0 failed
```

## Why this matters

A parser that hangs on malformed input is a hard LSP availability bug: any user who opens a file containing a parenthesized list without commas (a common typo) would freeze the diagnostics provider. The fix is a minimal, targeted change to the error recovery hot path with no behavioral change for well-formed input.

https://claude.ai/code/session_01K8iRdQTZ1WJwWMXtDiSBtE

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8iRdQTZ1WJwWMXtDiSBtE)_