### PR TITLE
feat(completion): infer literal bless receivers for method completion (#7896)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1320,6 +1320,16 @@ sub fetch { }
 "#
         .to_string(),
     )?;
+    // Index an unrelated package to prove the inference stays scoped to Foo
+    // and does not leak unrelated workspace methods into completions.
+    index.index_file(
+        Url::parse("file:///workspace/Unrelated.pm")?,
+        r#"package Unrelated;
+sub quack { }
+1;
+"#
+        .to_string(),
+    )?;
 
     let code = r#"my $x = bless {}, "Foo";
 $x->"#;
@@ -1336,6 +1346,10 @@ $x->"#;
     assert!(
         completions.iter().any(|c| c.label == "fetch"),
         "bless {{}}, \"Foo\" should infer Foo and suggest fetch"
+    );
+    assert!(
+        !completions.iter().any(|c| c.label == "quack"),
+        "bless {{}}, \"Foo\" must not leak Unrelated::quack into completions"
     );
     Ok(())
 }
@@ -1476,6 +1490,96 @@ $x->"#;
     assert!(
         !completions.iter().any(|c| c.label == "bark"),
         "bless {{}}, $class is dynamic — must not infer Foo. got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bless_with_concat_class_does_not_resolve() -> Result<(), Box<dyn std::error::Error>> {
+    // `bless {}, "Foo" . $suffix` is a non-literal class expression — must
+    // fail closed and not infer Foo even though the literal `"Foo"` appears.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $suffix = "Bar";
+my $x = bless {}, "Foo" . $suffix;
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        !completions.iter().any(|c| c.label == "bark"),
+        "bless {{}}, \"Foo\" . $suffix is non-literal — must not infer Foo. got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bless_nested_in_call_does_not_resolve() -> Result<(), Box<dyn std::error::Error>> {
+    // `wrapper(bless {}, "Foo")` does not establish that `$x` is Foo — the
+    // assignment result is whatever `wrapper` returns. The helper must
+    // anchor on RHS-starts-with-bless and reject this nested case.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"sub wrapper { return $_[0]; }
+my $x = wrapper(bless {}, "Foo");
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        !completions.iter().any(|c| c.label == "bark"),
+        "wrapper(bless {{}}, \"Foo\") is nested — must not infer Foo. got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bless_array_ref_with_class_resolves_methods() -> Result<(), Box<dyn std::error::Error>> {
+    // Array-ref content with internal commas must not confuse the
+    // arg-separator scan (delimiter-balanced top-level comma finder).
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless [1, 2, 3], "Foo";
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        completions.iter().any(|c| c.label == "bark"),
+        "bless [1, 2, 3], \"Foo\" should infer Foo and suggest bark; got: {:?}",
         completions.iter().map(|c| &c.label).collect::<Vec<_>>()
     );
     Ok(())

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1557,6 +1557,38 @@ $x->"#;
 }
 
 #[test]
+fn test_bless_qualified_prefix_does_not_resolve() -> Result<(), Box<dyn std::error::Error>> {
+    // `bless::class {}, "Foo"` is a fully-qualified call to a sub named
+    // `class` in package `bless`, NOT the builtin `bless` expression. The
+    // assignment result is whatever that sub returns, not a Foo. The
+    // stricter `starts_with_bless_expression` guard must reject this even
+    // though the byte after `bless` (`:`) is not a Perl identifier byte.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless::class {}, "Foo";
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        !completions.iter().any(|c| c.label == "bark"),
+        "bless::class {{}}, \"Foo\" is not the builtin bless — must not infer Foo. got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
 fn test_bless_array_ref_with_class_resolves_methods() -> Result<(), Box<dyn std::error::Error>> {
     // Array-ref content with internal commas must not confuse the
     // arg-separator scan (delimiter-balanced top-level comma finder).

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1305,6 +1305,183 @@ $self->"#;
 }
 
 // -------------------------------------------------------------------------
+// Literal `bless` receiver inference (issue #7896)
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_bless_double_quoted_class_resolves_methods() -> Result<(), Box<dyn std::error::Error>> {
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+sub fetch { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless {}, "Foo";
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        completions.iter().any(|c| c.label == "bark"),
+        "bless {{}}, \"Foo\" should infer Foo and suggest bark; got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    assert!(
+        completions.iter().any(|c| c.label == "fetch"),
+        "bless {{}}, \"Foo\" should infer Foo and suggest fetch"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bless_single_quoted_class_resolves_methods() -> Result<(), Box<dyn std::error::Error>> {
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless {}, 'Foo';
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        completions.iter().any(|c| c.label == "bark"),
+        "bless {{}}, 'Foo' should infer Foo and suggest bark; got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bless_with_hash_content_resolves_methods() -> Result<(), Box<dyn std::error::Error>> {
+    // Hash content with internal commas must not confuse the arg-separator
+    // comma finder.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless { a => 1, b => 2 }, "Foo";
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        completions.iter().any(|c| c.label == "bark"),
+        "bless with hash content + class should still infer Foo; got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bless_with_parens_resolves_methods() -> Result<(), Box<dyn std::error::Error>> {
+    // `bless({}, "Foo")` form — parenthesized call.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless({}, "Foo");
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        completions.iter().any(|c| c.label == "bark"),
+        "bless({{}}, \"Foo\") should infer Foo and suggest bark; got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bless_qualified_class_resolves_methods() -> Result<(), Box<dyn std::error::Error>> {
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo/Bar.pm")?,
+        r#"package Foo::Bar;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless {}, "Foo::Bar";
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        completions.iter().any(|c| c.label == "bark"),
+        "bless {{}}, \"Foo::Bar\" should infer Foo::Bar and suggest bark; got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bless_dynamic_class_does_not_resolve() -> Result<(), Box<dyn std::error::Error>> {
+    // `bless {}, $class` is dynamic — we must not infer a static package and
+    // must not suggest methods from any specific package on its behalf.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $class = "Foo";
+my $x = bless {}, $class;
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        !completions.iter().any(|c| c.label == "bark"),
+        "bless {{}}, $class is dynamic — must not infer Foo. got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
 // Tests for is_use_statement_context and add_use_module_completions
 // -------------------------------------------------------------------------
 

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -572,11 +572,14 @@ fn infer_receiver_package(context: &CompletionContext, source: &str) -> Option<S
 
 /// Extract the literal class name from a `bless REF, "Class"` expression.
 ///
-/// Anchored to RHS-as-bless-expression: only succeeds when the RHS, after
-/// trimming leading whitespace, *starts* with `bless` as a whole word
-/// (optionally followed by `(`). This means the helper returns `None`
-/// for nested forms like `wrapper(bless {}, "Foo")` where the assignment
-/// result is not necessarily the blessed object.
+/// Anchored to RHS-as-builtin-bless-expression: only succeeds when the
+/// RHS, after trimming leading whitespace, *starts* with `bless` followed
+/// by end-of-string, ASCII whitespace, or `(`. This means the helper
+/// returns `None` for nested forms like `wrapper(bless {}, "Foo")` (where
+/// the assignment result is not necessarily the blessed object) and for
+/// non-builtin punctuation-suffixed forms like `bless::factory {}, "Foo"`
+/// (where the call target is a different sub that merely shares the
+/// `bless` prefix).
 ///
 /// Trailing content after the closing quote of the class literal must be
 /// only whitespace, the matching closing paren if a leading `(` was
@@ -590,9 +593,9 @@ fn infer_receiver_package(context: &CompletionContext, source: &str) -> Option<S
 /// here), nested forms, expression-tail forms, and anything that fails
 /// to parse cleanly.
 fn extract_bless_literal_class(rhs: &str) -> Option<String> {
-    // Anchor: RHS must START with `bless` as a whole word.
+    // Anchor: RHS must START with the builtin `bless` expression.
     let trimmed = rhs.trim_start();
-    if !starts_with_word(trimmed, "bless") {
+    if !starts_with_bless_expression(trimmed) {
         return None;
     }
     let after_bless = &trimmed["bless".len()..];
@@ -641,21 +644,21 @@ fn extract_bless_literal_class(rhs: &str) -> Option<String> {
     Some(class.to_string())
 }
 
-/// Returns `true` when `s` begins with `word` as a whole word (i.e., the
-/// character following `word` is absent or not a Perl identifier
-/// character).
-fn starts_with_word(s: &str, word: &str) -> bool {
-    if !s.starts_with(word) {
+/// Returns `true` when `s` begins with the builtin `bless` expression.
+///
+/// Stricter than a generic word-boundary check: after `bless`, only end
+/// of string, ASCII whitespace, or `(` are accepted. This rejects
+/// non-builtin forms like `bless::factory(...)`, `bless+REF`, `bless.foo`,
+/// and similar punctuation-suffixed identifiers that happen to share the
+/// `bless` prefix but are not the Perl builtin.
+fn starts_with_bless_expression(s: &str) -> bool {
+    if !s.starts_with("bless") {
         return false;
     }
-    match s.as_bytes().get(word.len()).copied() {
+    match s.as_bytes().get("bless".len()).copied() {
         None => true,
-        Some(b) => !is_perl_ident_byte(b),
+        Some(b) => b.is_ascii_whitespace() || b == b'(',
     }
-}
-
-fn is_perl_ident_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_'
 }
 
 /// Find the first top-level `,` outside of `()`, `{}`, `[]`, and string

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -572,22 +572,41 @@ fn infer_receiver_package(context: &CompletionContext, source: &str) -> Option<S
 
 /// Extract the literal class name from a `bless REF, "Class"` expression.
 ///
-/// Returns `Some(class)` when the second argument to `bless` is a literal
-/// double- or single-quoted string containing a valid Perl package name.
-/// Returns `None` for dynamic forms (`bless {}, $class`), missing-class
-/// forms (`bless {}` — defaults to caller package, intentionally not
-/// inferred here), or anything that fails to parse cleanly.
+/// Anchored to RHS-as-bless-expression: only succeeds when the RHS, after
+/// trimming leading whitespace, *starts* with `bless` as a whole word
+/// (optionally followed by `(`). This means the helper returns `None`
+/// for nested forms like `wrapper(bless {}, "Foo")` where the assignment
+/// result is not necessarily the blessed object.
+///
+/// Trailing content after the closing quote of the class literal must be
+/// only whitespace, the matching closing paren if a leading `(` was
+/// consumed, and an optional terminating `;`. Anything else — `. $suffix`,
+/// `|| "Bar"`, `, $extra`, etc. — disables inference (fails closed) so
+/// non-literal class expressions never produce false-precision evidence.
+///
+/// Returns `Some(class)` only for the conservative literal form. Returns
+/// `None` for dynamic forms (`bless {}, $class`), 1-arg forms
+/// (`bless {}` — defaults to caller package, intentionally not inferred
+/// here), nested forms, expression-tail forms, and anything that fails
+/// to parse cleanly.
 fn extract_bless_literal_class(rhs: &str) -> Option<String> {
-    let bless_start = find_word(rhs, "bless")?;
-    let after_bless = &rhs[bless_start + "bless".len()..];
+    // Anchor: RHS must START with `bless` as a whole word.
+    let trimmed = rhs.trim_start();
+    if !starts_with_word(trimmed, "bless") {
+        return None;
+    }
+    let after_bless = &trimmed["bless".len()..];
 
-    // Allow optional `(` and whitespace after `bless`.
+    // Allow optional `(` and whitespace.
     let scan = after_bless.trim_start();
-    let scan = scan.strip_prefix('(').unwrap_or(scan);
+    let (scan, expect_rparen) = match scan.strip_prefix('(') {
+        Some(rest) => (rest, true),
+        None => (scan, false),
+    };
 
     // Find the comma separating the two args, respecting balanced delimiters
     // and string literals so that hash/array contents like
-    // `bless { a => 1, b => 2 }, "Foo"` parse correctly.
+    // `bless { a => 1, b => 2 }, "Foo"` and `bless [1, 2, 3], "Foo"` parse.
     let comma_pos = find_top_level_comma(scan)?;
     let after_comma = scan[comma_pos + 1..].trim_start();
 
@@ -605,25 +624,34 @@ fn extract_bless_literal_class(rhs: &str) -> Option<String> {
     if !is_valid_perl_package_name(class) {
         return None;
     }
+
+    // Validate trailing content: only whitespace, the matching `)` if a
+    // leading `(` was consumed, and an optional `;` then EOF. Anything else
+    // (concatenation, logical-or, extra arg, expression continuation) means
+    // the class expression is not a plain literal — fail closed.
+    let mut tail = body[close_pos + 1..].trim_start();
+    if expect_rparen {
+        tail = tail.strip_prefix(')')?.trim_start();
+    }
+    let tail = tail.strip_prefix(';').unwrap_or(tail).trim();
+    if !tail.is_empty() {
+        return None;
+    }
+
     Some(class.to_string())
 }
 
-/// Find `needle` in `haystack` as a whole word (not inside an identifier).
-fn find_word(haystack: &str, needle: &str) -> Option<usize> {
-    let bytes = haystack.as_bytes();
-    let nlen = needle.len();
-    let mut start = 0;
-    while let Some(rel) = haystack[start..].find(needle) {
-        let abs = start + rel;
-        let before_ok = abs == 0 || !is_perl_ident_byte(bytes[abs - 1]);
-        let after_idx = abs + nlen;
-        let after_ok = after_idx >= bytes.len() || !is_perl_ident_byte(bytes[after_idx]);
-        if before_ok && after_ok {
-            return Some(abs);
-        }
-        start = abs + nlen;
+/// Returns `true` when `s` begins with `word` as a whole word (i.e., the
+/// character following `word` is absent or not a Perl identifier
+/// character).
+fn starts_with_word(s: &str, word: &str) -> bool {
+    if !s.starts_with(word) {
+        return false;
     }
-    None
+    match s.as_bytes().get(word.len()).copied() {
+        None => true,
+        Some(b) => !is_perl_ident_byte(b),
+    }
 }
 
 fn is_perl_ident_byte(b: u8) -> bool {

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -556,12 +556,144 @@ fn infer_receiver_package(context: &CompletionContext, source: &str) -> Option<S
                             return Some(pkg.to_string());
                         }
                     }
+                    // Pattern: `bless REF, "Class"` / `bless REF, 'Class'`
+                    // Only literal-string class names produce inference; dynamic
+                    // forms like `bless {}, $class` intentionally fall through.
+                    if let Some(class) = extract_bless_literal_class(rhs) {
+                        return Some(class);
+                    }
                 }
             }
         }
     }
 
     None
+}
+
+/// Extract the literal class name from a `bless REF, "Class"` expression.
+///
+/// Returns `Some(class)` when the second argument to `bless` is a literal
+/// double- or single-quoted string containing a valid Perl package name.
+/// Returns `None` for dynamic forms (`bless {}, $class`), missing-class
+/// forms (`bless {}` — defaults to caller package, intentionally not
+/// inferred here), or anything that fails to parse cleanly.
+fn extract_bless_literal_class(rhs: &str) -> Option<String> {
+    let bless_start = find_word(rhs, "bless")?;
+    let after_bless = &rhs[bless_start + "bless".len()..];
+
+    // Allow optional `(` and whitespace after `bless`.
+    let scan = after_bless.trim_start();
+    let scan = scan.strip_prefix('(').unwrap_or(scan);
+
+    // Find the comma separating the two args, respecting balanced delimiters
+    // and string literals so that hash/array contents like
+    // `bless { a => 1, b => 2 }, "Foo"` parse correctly.
+    let comma_pos = find_top_level_comma(scan)?;
+    let after_comma = scan[comma_pos + 1..].trim_start();
+
+    // Require a literal quoted string for the class.
+    let bytes = after_comma.as_bytes();
+    let close_char = match bytes.first()? {
+        b'"' => '"',
+        b'\'' => '\'',
+        _ => return None,
+    };
+    let body = &after_comma[1..];
+    let close_pos = body.find(close_char)?;
+    let class = &body[..close_pos];
+
+    if !is_valid_perl_package_name(class) {
+        return None;
+    }
+    Some(class.to_string())
+}
+
+/// Find `needle` in `haystack` as a whole word (not inside an identifier).
+fn find_word(haystack: &str, needle: &str) -> Option<usize> {
+    let bytes = haystack.as_bytes();
+    let nlen = needle.len();
+    let mut start = 0;
+    while let Some(rel) = haystack[start..].find(needle) {
+        let abs = start + rel;
+        let before_ok = abs == 0 || !is_perl_ident_byte(bytes[abs - 1]);
+        let after_idx = abs + nlen;
+        let after_ok = after_idx >= bytes.len() || !is_perl_ident_byte(bytes[after_idx]);
+        if before_ok && after_ok {
+            return Some(abs);
+        }
+        start = abs + nlen;
+    }
+    None
+}
+
+fn is_perl_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Find the first top-level `,` outside of `()`, `{}`, `[]`, and string
+/// literals. Used to identify the arg separator in `bless REF, CLASS`.
+fn find_top_level_comma(s: &str) -> Option<usize> {
+    let mut depth_paren: i32 = 0;
+    let mut depth_brace: i32 = 0;
+    let mut depth_bracket: i32 = 0;
+    let mut in_string: Option<char> = None;
+    let mut prev_was_backslash = false;
+
+    for (i, c) in s.char_indices() {
+        if let Some(q) = in_string {
+            if !prev_was_backslash && c == q {
+                in_string = None;
+            }
+            prev_was_backslash = !prev_was_backslash && c == '\\';
+            continue;
+        }
+        prev_was_backslash = false;
+        match c {
+            '(' => depth_paren += 1,
+            ')' => depth_paren -= 1,
+            '{' => depth_brace += 1,
+            '}' => depth_brace -= 1,
+            '[' => depth_bracket += 1,
+            ']' => depth_bracket -= 1,
+            '"' => in_string = Some('"'),
+            '\'' => in_string = Some('\''),
+            ',' if depth_paren <= 0 && depth_brace <= 0 && depth_bracket <= 0 => {
+                return Some(i);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Validate a Perl package name: identifier segments separated by `::`.
+fn is_valid_perl_package_name(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let mut start_of_segment = true;
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if start_of_segment {
+            if !(c.is_ascii_alphabetic() || c == '_') {
+                return false;
+            }
+            start_of_segment = false;
+            continue;
+        }
+        if c == ':' {
+            // Must be `::`, then a fresh segment.
+            if chars.next() != Some(':') {
+                return false;
+            }
+            start_of_segment = true;
+            continue;
+        }
+        if !(c.is_ascii_alphanumeric() || c == '_') {
+            return false;
+        }
+    }
+    !start_of_segment
 }
 
 fn infer_receiver_package_from_type_engine(


### PR DESCRIPTION
Closes #7896
Plan source: #7896
Discovery + revised scope: [#7896 comment](https://github.com/EffortlessMetrics/perl-lsp/issues/7896#issuecomment-4368899454)

## Summary

Adds literal-`bless` receiver inference to the existing method-completion path, so:

```perl
my $x = bless {}, "Foo";
$x->         # ← now suggests Foo's methods
```

This is the narrow gap-fill version of the original receiver-aware-ranking issue. Master already filters method-completion candidates to the inferred receiver package (`Foo->method`, `$self->`, `$this->`, `my $x = Foo->new`, type-engine inferred), and already tiers candidates as local / own / inherited. Discovery in #7896 confirmed the only meaningful gap was literal `bless`; this PR closes that gap.

## Why "ranking-only" is not the framing

There are no "unrelated workspace methods" in the candidate set today — they're already filtered out by package inference. So this PR is **not** ranking-only; it's a **new receiver-evidence case** plugged into the existing inference pipeline. No candidates are invented or dropped beyond what the existing pipeline already produces for any other receiver shape.

## What changed

| File | Change |
|---|---|
| `crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs` | New `extract_bless_literal_class` helper (anchored on RHS-starts-with-bless-expression, with strict trailing-content validation), plus 3 supporting privates (`starts_with_bless_expression`, `find_top_level_comma`, `is_valid_perl_package_name`). Wired into `infer_receiver_package` after the existing `Package->new` arrow recognizer. |
| `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs` | 10 new tests under a new `Literal bless receiver inference (issue #7896)` section. |

## Fail-closed semantics

The helper succeeds only when the RHS, after trimming leading whitespace, **is** a bless expression (`bless ...` or `bless(...)`) and the second arg is a literal quoted string with no trailing expression continuation:

| RHS shape | Inferred? |
|---|---|
| `bless {}, "Foo"` | ✅ `Foo` |
| `bless {}, 'Foo'` | ✅ `Foo` |
| `bless { a => 1, b => 2 }, "Foo"` | ✅ `Foo` (delimiter-balanced comma scan) |
| `bless [1, 2, 3], "Foo"` | ✅ `Foo` |
| `bless({}, "Foo")` | ✅ `Foo` (parenthesized form) |
| `bless {}, "Foo::Bar"` | ✅ `Foo::Bar` |
| `bless {}, $class` | ❌ dynamic class (variable) |
| `bless {}, "Foo" . $suffix` | ❌ non-literal class expression |
| `bless {}, "Foo" \|\| "Bar"` | ❌ non-literal class expression |
| `bless {}, "Foo", $extra` | ❌ extra args |
| `bless {}` | ❌ 1-arg form (defaults to caller package; not inferred to avoid surprising users) |
| `wrapper(bless {}, "Foo")` | ❌ nested — `$x` is `wrapper`'s return, not the blessed object |
| `foo ? bless {}, "Foo" : $bar` | ❌ ternary — RHS doesn't start with `bless` |
| `bless::class {}, "Foo"` | ❌ non-builtin prefix — `bless::class` is a qualified sub call, not the builtin `bless` |

The central safety property: **dynamic or ambiguous Perl never produces false exact receiver evidence.** When `bless` inference fails, behavior matches today's master exactly: the existing `Package->new` arrow recognizer continues, then unknown-receiver fallback returns no method completions.

## Non-goals

- No confidence-aware ranking enum
- No broad fallback when receiver inference fails
- No dashboard status update
- No semantic fact schema changes
- No parser changes

## Verification

| Command | Result |
|---|---|
| `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- bless` | 10 / 10 passed |
| `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- completion` | 237 / 237 passed |
| `cargo test -p perl-workspace --profile agent --locked --lib -- method_candidates` | 9 / 9 passed |
| `cargo clippy -p perl-lsp-rs-core --profile agent --locked --lib -- -D warnings` | clean |
| `cargo xtask fmt --check` | clean |
| `cargo xtask semantic-scorecard --check` | passed |
| `cargo xtask semantic-shadow-compare --check` | passed |
| `git diff --check` | clean |

## Tests

Positive (6):

- `test_bless_double_quoted_class_resolves_methods` — primary positive, plus an unrelated package indexed in the same workspace whose method must NOT appear (proves scope isolation)
- `test_bless_single_quoted_class_resolves_methods` — single-quoted literal
- `test_bless_with_hash_content_resolves_methods` — `bless { a => 1, b => 2 }, "Foo"`
- `test_bless_with_parens_resolves_methods` — `bless({}, "Foo")`
- `test_bless_qualified_class_resolves_methods` — `Foo::Bar`
- `test_bless_array_ref_with_class_resolves_methods` — `bless [1, 2, 3], "Foo"`

Negative (4):

- `test_bless_dynamic_class_does_not_resolve` — `bless {}, $class`
- `test_bless_with_concat_class_does_not_resolve` — `bless {}, "Foo" . $suffix`
- `test_bless_nested_in_call_does_not_resolve` — `wrapper(bless {}, "Foo")`
- `test_bless_qualified_prefix_does_not_resolve` — `bless::class {}, "Foo"` (non-builtin prefix)

## Test plan

- [x] Inspect the rendered diff for the 2 file changes (`workspace.rs`, `tests.rs`)
- [x] Confirm no other files were touched
- [x] Spot-check one of the bless tests for assertion strength
- [x] Confirm fail-closed cases are explicitly tested (concat, nested, dynamic class)
