### PR TITLE
Update store badges: remove live listing, bump installs to 277

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,7 +1,6 @@
 # Perl Language Server
 
-[![Visual Studio Marketplace](https://img.shields.io/badge/VS%20Marketplace-live%20listing-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
-[![VS Marketplace Installs (manual)](https://img.shields.io/badge/VS%20Marketplace-180%20installs-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+[![VS Marketplace Installs (manual)](https://img.shields.io/badge/VS%20Marketplace-277%20installs-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
 [![Open VSX Version](https://img.shields.io/open-vsx/v/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 


### PR DESCRIPTION
## Summary

- Remove VS Marketplace "live listing" badge (not needed)
- Update VS Marketplace installs badge from 180 to 277

## Changed Files

- `vscode-extension/README.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMWAPmrpTbFKjxBpDTpc2L)_