### PR TITLE
docs: Add marketplace install badges to root README (#4329)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
   <a href="https://crates.io/crates/perl-lsp-rs"><img src="https://img.shields.io/crates/v/perl-lsp-rs.svg" alt="crates.io" /></a>
   <a href="https://docs.rs/perl-lsp-rs"><img src="https://docs.rs/perl-lsp-rs/badge.svg" alt="docs.rs" /></a>
   <a href="https://github.com/EffortlessMetrics/perl-lsp/releases"><img src="https://img.shields.io/github/v/release/EffortlessMetrics/perl-lsp?display_name=tag" alt="GitHub release" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/badge/VS%20Marketplace-277%20installs-0078D4" alt="VS Marketplace installs" /></a>
+  <a href="https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs"><img src="https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads" alt="Open VSX downloads" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.92-blue" alt="MSRV" /></a>
 </p>


### PR DESCRIPTION
## Summary

Added VS Marketplace installs badge (static, 277 installs) and Open VSX downloads badge (dynamic) to the root README badge block.

- Placed after the GitHub release badge and before the license/MSRV badges
- Matches the badge setup in `vscode-extension/README.md`
- VS Marketplace installs count is manually maintained and should be synchronized with the vscode-extension/README.md whenever metrics change after a release

## Test plan

- [x] Badges render correctly in GitHub preview
- [x] Badge links point to correct marketplace pages
- [x] Badge styling is consistent with existing badges

https://claude.ai/code/session_01W3sTjjrTwuC8zGLhqo6Gby

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3sTjjrTwuC8zGLhqo6Gby)_