### PR TITLE
Improve Codecov setup with Test Analytics and enhanced metadata

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -302,8 +302,12 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        continue-on-error: true
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
+          flags: parser
+          name: parser-branch-coverage
           fail_ci_if_error: false
 
   tautology-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,24 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Convert PR-fast receipt to JUnit
+        if: always()
+        run: |
+          python3 scripts/ci/receipts-to-junit.py \
+            --input target/receipts/receipt.json \
+            --output target/test-results/pr-fast-junit.xml \
+            --suite-name pr-fast
+
+      - name: Upload PR-fast test results to Codecov
+        if: always() && env.CODECOV_TOKEN != ''
+        continue-on-error: true
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/test-results/pr-fast-junit.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       # Note: workspace-wide integration-test compilation is covered by the
       # parallel check-all-targets job (just check-all-targets), which runs
       # cargo check --workspace --all-targets --locked independently of pr-smoke.
@@ -264,6 +282,24 @@ jobs:
             target/receipts/artifacts/*
           if-no-files-found: warn
           retention-days: 7
+
+      - name: Convert gate shard receipts to JUnit
+        if: always()
+        run: |
+          python3 scripts/ci/receipts-to-junit.py \
+            --input target/receipts/shards \
+            --output target/test-results/gate-shard-${{ matrix.name }}-junit.xml \
+            --suite-name "gate-${{ matrix.name }}"
+
+      - name: Upload gate shard test results to Codecov
+        if: always() && env.CODECOV_TOKEN != ''
+        continue-on-error: true
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/test-results/gate-shard-${{ matrix.name }}-junit.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Dump gate failures on error
         if: failure()
@@ -471,6 +507,24 @@ jobs:
             target/receipts/ux-regression.log
           if-no-files-found: warn
           retention-days: 7
+
+      - name: Convert UX regression receipt to JUnit
+        if: always()
+        run: |
+          python3 scripts/ci/receipts-to-junit.py \
+            --input target/receipts/ux-regression.json \
+            --output target/test-results/ux-regression-junit.xml \
+            --suite-name ux-regression
+
+      - name: Upload UX regression test results to Codecov
+        if: always() && env.CODECOV_TOKEN != ''
+        continue-on-error: true
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/test-results/ux-regression-junit.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: UX regression summary
         if: always()

--- a/.github/workflows/ux-regression-gate.yml
+++ b/.github/workflows/ux-regression-gate.yml
@@ -141,6 +141,24 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      - name: Convert UX regression receipt to JUnit
+        if: always() && steps.harness_check.outputs.harness_available == 'true'
+        run: |
+          python3 scripts/ci/receipts-to-junit.py \
+            --input target/receipts/ux-regression.json \
+            --output target/test-results/ux-regression-gate-junit.xml \
+            --suite-name ux-regression-gate
+
+      - name: Upload UX regression gate test results to Codecov
+        if: always() && steps.harness_check.outputs.harness_available == 'true' && env.CODECOV_TOKEN != ''
+        continue-on-error: true
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/test-results/ux-regression-gate-junit.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Parse and summarize UX test results
         if: always() && steps.harness_check.outputs.harness_available == 'true'
         run: |

--- a/docs/how-to/COVERAGE.md
+++ b/docs/how-to/COVERAGE.md
@@ -140,6 +140,14 @@ The workflow uses optimized settings:
 - `CARGO_BUILD_JOBS=2` - Limit parallelism to avoid memory pressure
 - `RUST_TEST_THREADS=2` - Adaptive threading for LSP tests
 
+## Codecov Repository Secret
+
+Set this GitHub Actions secret at the repository or organization level:
+
+- `CODECOV_TOKEN`
+
+The coverage and test-results uploads use this token. Codecov upload failures are configured as non-blocking so service outages or missing token setup do not block merge-gate CI.
+
 ## Configuration Files
 
 ### codecov.yml
@@ -188,6 +196,15 @@ The workflow sets `fail_ci_if_error: false` so Codecov upload failures don't blo
 1. Codecov service status: https://status.codecov.io/
 2. Workflow logs for upload details
 3. Codecov dashboard for processing status
+
+### Test Analytics upload fails
+
+Check:
+
+1. `CODECOV_TOKEN` is configured as a GitHub Actions secret.
+2. The JUnit file exists under `target/test-results/`.
+3. The receipt JSON exists under `target/receipts/`.
+4. The Codecov upload step is non-blocking, so failures should be visible in logs without failing the gate.
 
 ### Coverage numbers look wrong
 
@@ -245,6 +262,29 @@ Coverage is **not** part of the fast merge gate (`just ci-gate`) to avoid slowin
 Branch coverage in the parser coverage lane is enforced separately through the baseline ratchet in `.ci/coverage-baseline.txt`.
 
 This keeps the merge gate fast (<5 min) while providing coverage visibility when needed.
+
+## Test Analytics
+
+Codecov Test Analytics is populated from CI receipt artifacts.
+
+The CI gates already emit structured receipts under `target/receipts/`. The helper script `scripts/ci/receipts-to-junit.py` converts those receipts into JUnit XML and uploads them with `codecov/test-results-action@v1`.
+
+Current uploaded suites:
+
+- `pr-fast` — PR smoke test results
+- `gate-<shard>` — Merge gate shard results (meta, foundation, analysis, lsp, support, corpus, policy)
+- `ux-regression` — UX regression test results from main CI
+- `ux-regression-gate` — UX regression gate results (standalone workflow)
+
+This avoids rerunning tests solely to produce JUnit XML and keeps the existing `xtask gates` runner as the source of truth.
+
+## Bundle Analysis
+
+Codecov Bundle Analysis is intentionally deferred.
+
+The VS Code extension currently compiles TypeScript and packages a VSIX. It does not use Vite, Rollup, Webpack, Remix, Nuxt, SvelteKit, or SolidStart as its production bundler.
+
+Do not add `@codecov/vite-plugin` until the extension adopts a supported JavaScript bundler. When that happens, add the Codecov bundler plugin to the actual bundler config and use `CODECOV_TOKEN` for upload.
 
 ## Related Documentation
 

--- a/scripts/ci/receipts-to-junit.py
+++ b/scripts/ci/receipts-to-junit.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+Convert CI receipt JSON files to JUnit XML format for Codecov Test Analytics.
+
+Supports both single files and directories containing multiple receipt files.
+Handles gate receipts with structured gate metadata and UX regression receipts.
+"""
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def escape_xml(text: str) -> str:
+    """Escape XML special characters."""
+    if not isinstance(text, str):
+        text = str(text)
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+def parse_receipt(data: Any) -> Optional[List[Dict[str, Any]]]:
+    """
+    Parse receipt data and extract testcases.
+    Returns a list of testcase dicts or None if not a valid receipt.
+    """
+    if not isinstance(data, dict):
+        return None
+
+    testcases = []
+
+    # Handle gate receipts with a 'gates' array
+    if "gates" in data and isinstance(data["gates"], list):
+        for gate in data["gates"]:
+            if isinstance(gate, dict):
+                testcases.append(gate)
+        return testcases if testcases else None
+
+    # Handle UX regression receipt
+    if "result" in data or "failure_class" in data:
+        return [data]
+
+    return None
+
+
+def gate_to_testcase(
+    gate: Dict[str, Any], classname: str
+) -> Tuple[ET.Element, bool]:
+    """
+    Convert a gate receipt to a JUnit testcase element.
+    Returns (element, is_passed).
+    """
+    name = gate.get("gate_name") or gate.get("name") or "unnamed"
+    duration_ms = gate.get("duration_ms", 0)
+    duration_sec = duration_ms / 1000.0
+    status = str(gate.get("status", "unknown")).lower()
+
+    testcase = ET.Element("testcase")
+    testcase.set("classname", escape_xml(classname))
+    testcase.set("name", escape_xml(name))
+    testcase.set("time", str(duration_sec))
+
+    # Determine pass/skip/fail
+    is_passed = False
+    if status in ("pass", "passed"):
+        is_passed = True
+    elif status in ("skip", "skipped"):
+        skipped = ET.SubElement(testcase, "skipped")
+        skipped.set("message", "Skipped")
+    else:
+        # Treat as failure or error
+        is_error = status in ("timeout", "error")
+        tag = "error" if is_error else "failure"
+        failure = ET.SubElement(testcase, tag)
+        failure.set("type", status)
+
+        # Build diagnostic message
+        diag_lines = []
+        diag_lines.append(f"Gate: {name}")
+        diag_lines.append(f"Status: {status}")
+        if "command" in gate:
+            diag_lines.append(f"Command: {gate['command']}")
+        if "exit_code" in gate:
+            diag_lines.append(f"Exit code: {gate['exit_code']}")
+        failure.text = "\n".join(diag_lines)
+
+    return testcase, is_passed
+
+
+def ux_to_testcase(receipt: Dict[str, Any], classname: str) -> Tuple[ET.Element, bool]:
+    """
+    Convert a UX regression receipt to a JUnit testcase element.
+    Returns (element, is_passed).
+    """
+    testcase = ET.Element("testcase")
+    testcase.set("classname", escape_xml(classname))
+    testcase.set("name", "ux-regression")
+    testcase.set("time", "0.0")
+
+    result = receipt.get("result", "").lower()
+    is_passed = result in ("pass", "passed", "success", "ok")
+    is_skipped = result in ("skip", "skipped")
+
+    if is_skipped:
+        skipped = ET.SubElement(testcase, "skipped")
+        skipped.set("message", "Skipped")
+    elif not is_passed:
+        failure = ET.SubElement(testcase, "failure")
+        failure.set("type", receipt.get("failure_class", "unknown"))
+
+        # Build diagnostic message
+        diag_lines = []
+        if receipt.get("failure_class"):
+            diag_lines.append(f"Failure class: {receipt['failure_class']}")
+        if receipt.get("first_failing_test"):
+            diag_lines.append(f"First failing test: {receipt['first_failing_test']}")
+        if receipt.get("panic_location"):
+            diag_lines.append(f"Panic location: {receipt['panic_location']}")
+        if receipt.get("canonical_repro"):
+            diag_lines.append(f"Canonical repro: {receipt['canonical_repro']}")
+        if receipt.get("route"):
+            diag_lines.append(f"Route: {receipt['route']}")
+        failure.text = "\n".join(diag_lines)
+
+    return testcase, is_passed
+
+
+def receipts_to_junit(
+    input_path: Path, suite_name: str
+) -> Tuple[ET.Element, int, int, int]:
+    """
+    Convert receipt file(s) to JUnit XML structure.
+    Returns (root_element, total_tests, failures, skipped).
+    """
+    root = ET.Element("testsuites")
+
+    if not input_path.exists():
+        # No files found, emit a skipped testcase
+        testsuite = ET.SubElement(root, "testsuite")
+        testsuite.set("name", escape_xml(suite_name))
+        testsuite.set("tests", "1")
+        testsuite.set("failures", "0")
+        testsuite.set("skipped", "1")
+        testsuite.set("errors", "0")
+        testsuite.set("time", "0.0")
+
+        testcase = ET.SubElement(testsuite, "testcase")
+        testcase.set("classname", escape_xml(suite_name))
+        testcase.set("name", "no-files-found")
+        testcase.set("time", "0.0")
+        skipped = ET.SubElement(testcase, "skipped")
+        skipped.set("message", "No receipt files found")
+
+        return root, 1, 0, 1
+
+    # Determine if input is file or directory
+    json_files = []
+    if input_path.is_file():
+        json_files = [input_path]
+    elif input_path.is_dir():
+        json_files = sorted(input_path.glob("*.json"))
+
+    if not json_files:
+        # No files found, emit a skipped testcase
+        testsuite = ET.SubElement(root, "testsuite")
+        testsuite.set("name", escape_xml(suite_name))
+        testsuite.set("tests", "1")
+        testsuite.set("failures", "0")
+        testsuite.set("skipped", "1")
+        testsuite.set("errors", "0")
+        testsuite.set("time", "0.0")
+
+        testcase = ET.SubElement(testsuite, "testcase")
+        testcase.set("classname", escape_xml(suite_name))
+        testcase.set("name", "no-files-found")
+        testcase.set("time", "0.0")
+        skipped = ET.SubElement(testcase, "skipped")
+        skipped.set("message", "No JSON files found")
+
+        return root, 1, 0, 1
+
+    all_testcases = []
+    total_failures = 0
+    total_skipped = 0
+    total_time = 0.0
+
+    for json_file in json_files:
+        try:
+            with open(json_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+
+            testcases = parse_receipt(data)
+            if testcases is None:
+                # Not a recognized receipt format, emit an error testcase
+                testcase = ET.Element("testcase")
+                testcase.set("classname", escape_xml(suite_name))
+                testcase.set("name", escape_xml(f"parse-{json_file.name}"))
+                testcase.set("time", "0.0")
+                error = ET.SubElement(testcase, "error")
+                error.set("type", "UnrecognizedFormat")
+                error.text = f"Receipt at {json_file} does not match known format"
+                all_testcases.append(testcase)
+                continue
+
+            # Convert each testcase
+            for tc_data in testcases:
+                # Detect if this is a UX receipt or gate receipt
+                if "result" in tc_data or "failure_class" in tc_data:
+                    testcase, is_passed = ux_to_testcase(tc_data, suite_name)
+                else:
+                    testcase, is_passed = gate_to_testcase(tc_data, suite_name)
+
+                duration_sec = float(testcase.get("time", 0))
+                total_time += duration_sec
+
+                if not is_passed:
+                    # Check if it's skipped or failed/error
+                    if testcase.find("skipped") is not None:
+                        total_skipped += 1
+                    else:
+                        total_failures += 1
+
+                all_testcases.append(testcase)
+
+        except json.JSONDecodeError as e:
+            # JSON parse error, emit an error testcase
+            testcase = ET.Element("testcase")
+            testcase.set("classname", escape_xml(suite_name))
+            testcase.set("name", escape_xml(f"parse-{json_file.name}"))
+            testcase.set("time", "0.0")
+            error = ET.SubElement(testcase, "error")
+            error.set("type", "JSONDecodeError")
+            error.text = f"Failed to parse {json_file}: {e}"
+            all_testcases.append(testcase)
+
+        except Exception as e:
+            # General error, emit an error testcase
+            testcase = ET.Element("testcase")
+            testcase.set("classname", escape_xml(suite_name))
+            testcase.set("name", escape_xml(f"parse-{json_file.name}"))
+            testcase.set("time", "0.0")
+            error = ET.SubElement(testcase, "error")
+            error.set("type", type(e).__name__)
+            error.text = f"Error processing {json_file}: {e}"
+            all_testcases.append(testcase)
+
+    # Build testsuite
+    testsuite = ET.SubElement(root, "testsuite")
+    testsuite.set("name", escape_xml(suite_name))
+    total_tests = len(all_testcases)
+    testsuite.set("tests", str(total_tests))
+    testsuite.set("failures", str(total_failures))
+    testsuite.set("skipped", str(total_skipped))
+    testsuite.set("errors", str(max(0, total_failures - total_skipped)))
+    testsuite.set("time", str(total_time))
+
+    for testcase in all_testcases:
+        testsuite.append(testcase)
+
+    return root, total_tests, total_failures, total_skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert CI receipt JSON files to JUnit XML for Codecov Test Analytics.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 receipts-to-junit.py --input receipt.json --output junit.xml --suite-name pr-fast
+  python3 receipts-to-junit.py --input target/receipts/shards --output junit.xml --suite-name gate-meta
+        """,
+    )
+
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Input: single JSON file or directory containing *.json receipt files",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Output JUnit XML file path",
+    )
+    parser.add_argument(
+        "--suite-name",
+        required=True,
+        help="Test suite name (e.g., 'pr-fast', 'gate-meta', 'ux-regression')",
+    )
+
+    args = parser.parse_args()
+
+    # Create output directory if needed
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    # Convert receipts to JUnit
+    root, total_tests, total_failures, total_skipped = receipts_to_junit(
+        args.input, args.suite_name
+    )
+
+    # Write XML
+    tree = ET.ElementTree(root)
+    tree.write(args.output, encoding="utf-8", xml_declaration=True)
+
+    print(f"✓ Generated JUnit XML: {args.output}")
+    print(f"  Suite: {args.suite_name}")
+    print(f"  Tests: {total_tests}, Failures: {total_failures}, Skipped: {total_skipped}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/receipts-to-junit.py
+++ b/scripts/ci/receipts-to-junit.py
@@ -14,19 +14,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 
-def escape_xml(text: str) -> str:
-    """Escape XML special characters."""
-    if not isinstance(text, str):
-        text = str(text)
-    return (
-        text.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-        .replace("'", "&apos;")
-    )
-
-
 def parse_receipt(data: Any) -> Optional[List[Dict[str, Any]]]:
     """
     Parse receipt data and extract testcases.
@@ -64,8 +51,8 @@ def gate_to_testcase(
     status = str(gate.get("status", "unknown")).lower()
 
     testcase = ET.Element("testcase")
-    testcase.set("classname", escape_xml(classname))
-    testcase.set("name", escape_xml(name))
+    testcase.set("classname", classname)
+    testcase.set("name", name)
     testcase.set("time", str(duration_sec))
 
     # Determine pass/skip/fail
@@ -101,7 +88,7 @@ def ux_to_testcase(receipt: Dict[str, Any], classname: str) -> Tuple[ET.Element,
     Returns (element, is_passed).
     """
     testcase = ET.Element("testcase")
-    testcase.set("classname", escape_xml(classname))
+    testcase.set("classname", classname)
     testcase.set("name", "ux-regression")
     testcase.set("time", "0.0")
 
@@ -135,17 +122,17 @@ def ux_to_testcase(receipt: Dict[str, Any], classname: str) -> Tuple[ET.Element,
 
 def receipts_to_junit(
     input_path: Path, suite_name: str
-) -> Tuple[ET.Element, int, int, int]:
+) -> Tuple[ET.Element, int, int, int, int]:
     """
     Convert receipt file(s) to JUnit XML structure.
-    Returns (root_element, total_tests, failures, skipped).
+    Returns (root_element, total_tests, failures, errors, skipped).
     """
     root = ET.Element("testsuites")
 
     if not input_path.exists():
         # No files found, emit a skipped testcase
         testsuite = ET.SubElement(root, "testsuite")
-        testsuite.set("name", escape_xml(suite_name))
+        testsuite.set("name", suite_name)
         testsuite.set("tests", "1")
         testsuite.set("failures", "0")
         testsuite.set("skipped", "1")
@@ -153,13 +140,13 @@ def receipts_to_junit(
         testsuite.set("time", "0.0")
 
         testcase = ET.SubElement(testsuite, "testcase")
-        testcase.set("classname", escape_xml(suite_name))
+        testcase.set("classname", suite_name)
         testcase.set("name", "no-files-found")
         testcase.set("time", "0.0")
         skipped = ET.SubElement(testcase, "skipped")
         skipped.set("message", "No receipt files found")
 
-        return root, 1, 0, 1
+        return root, 1, 0, 0, 1
 
     # Determine if input is file or directory
     json_files = []
@@ -171,7 +158,7 @@ def receipts_to_junit(
     if not json_files:
         # No files found, emit a skipped testcase
         testsuite = ET.SubElement(root, "testsuite")
-        testsuite.set("name", escape_xml(suite_name))
+        testsuite.set("name", suite_name)
         testsuite.set("tests", "1")
         testsuite.set("failures", "0")
         testsuite.set("skipped", "1")
@@ -179,17 +166,15 @@ def receipts_to_junit(
         testsuite.set("time", "0.0")
 
         testcase = ET.SubElement(testsuite, "testcase")
-        testcase.set("classname", escape_xml(suite_name))
+        testcase.set("classname", suite_name)
         testcase.set("name", "no-files-found")
         testcase.set("time", "0.0")
         skipped = ET.SubElement(testcase, "skipped")
         skipped.set("message", "No JSON files found")
 
-        return root, 1, 0, 1
+        return root, 1, 0, 0, 1
 
     all_testcases = []
-    total_failures = 0
-    total_skipped = 0
     total_time = 0.0
 
     for json_file in json_files:
@@ -201,8 +186,8 @@ def receipts_to_junit(
             if testcases is None:
                 # Not a recognized receipt format, emit an error testcase
                 testcase = ET.Element("testcase")
-                testcase.set("classname", escape_xml(suite_name))
-                testcase.set("name", escape_xml(f"parse-{json_file.name}"))
+                testcase.set("classname", suite_name)
+                testcase.set("name", f"parse-{json_file.name}")
                 testcase.set("time", "0.0")
                 error = ET.SubElement(testcase, "error")
                 error.set("type", "UnrecognizedFormat")
@@ -221,20 +206,13 @@ def receipts_to_junit(
                 duration_sec = float(testcase.get("time", 0))
                 total_time += duration_sec
 
-                if not is_passed:
-                    # Check if it's skipped or failed/error
-                    if testcase.find("skipped") is not None:
-                        total_skipped += 1
-                    else:
-                        total_failures += 1
-
                 all_testcases.append(testcase)
 
         except json.JSONDecodeError as e:
             # JSON parse error, emit an error testcase
             testcase = ET.Element("testcase")
-            testcase.set("classname", escape_xml(suite_name))
-            testcase.set("name", escape_xml(f"parse-{json_file.name}"))
+            testcase.set("classname", suite_name)
+            testcase.set("name", f"parse-{json_file.name}")
             testcase.set("time", "0.0")
             error = ET.SubElement(testcase, "error")
             error.set("type", "JSONDecodeError")
@@ -244,8 +222,8 @@ def receipts_to_junit(
         except Exception as e:
             # General error, emit an error testcase
             testcase = ET.Element("testcase")
-            testcase.set("classname", escape_xml(suite_name))
-            testcase.set("name", escape_xml(f"parse-{json_file.name}"))
+            testcase.set("classname", suite_name)
+            testcase.set("name", f"parse-{json_file.name}")
             testcase.set("time", "0.0")
             error = ET.SubElement(testcase, "error")
             error.set("type", type(e).__name__)
@@ -254,18 +232,22 @@ def receipts_to_junit(
 
     # Build testsuite
     testsuite = ET.SubElement(root, "testsuite")
-    testsuite.set("name", escape_xml(suite_name))
+    testsuite.set("name", suite_name)
     total_tests = len(all_testcases)
+    total_failures = sum(1 for tc in all_testcases if tc.find("failure") is not None)
+    total_errors = sum(1 for tc in all_testcases if tc.find("error") is not None)
+    total_skipped = sum(1 for tc in all_testcases if tc.find("skipped") is not None)
+
     testsuite.set("tests", str(total_tests))
     testsuite.set("failures", str(total_failures))
+    testsuite.set("errors", str(total_errors))
     testsuite.set("skipped", str(total_skipped))
-    testsuite.set("errors", str(max(0, total_failures - total_skipped)))
     testsuite.set("time", str(total_time))
 
     for testcase in all_testcases:
         testsuite.append(testcase)
 
-    return root, total_tests, total_failures, total_skipped
+    return root, total_tests, total_failures, total_errors, total_skipped
 
 
 def main() -> int:
@@ -303,7 +285,8 @@ Examples:
     args.output.parent.mkdir(parents=True, exist_ok=True)
 
     # Convert receipts to JUnit
-    root, total_tests, total_failures, total_skipped = receipts_to_junit(
+    # Convert receipts to JUnit
+    root, total_tests, total_failures, total_errors, total_skipped = receipts_to_junit(
         args.input, args.suite_name
     )
 
@@ -313,7 +296,7 @@ Examples:
 
     print(f"✓ Generated JUnit XML: {args.output}")
     print(f"  Suite: {args.suite_name}")
-    print(f"  Tests: {total_tests}, Failures: {total_failures}, Skipped: {total_skipped}")
+    print(f"  Tests: {total_tests}, Failures: {total_failures}, Errors: {total_errors}, Skipped: {total_skipped}")
 
     return 0
 


### PR DESCRIPTION
## Summary

Improve Codecov integration for perl-lsp by adding **Codecov Test Analytics** and hardening the existing coverage upload.

- Add receipt-to-JUnit converter script (`scripts/ci/receipts-to-junit.py`)
- Integrate Test Analytics uploads from CI receipt artifacts (pr-fast, merge-gate shards, UX regression tests)
- Enhance coverage upload with token, flags, and metadata
- Document the new features and defer Bundle Analysis

## Changes

### 1. Receipt-to-JUnit Converter

Created `scripts/ci/receipts-to-junit.py`:
- Converts structured CI receipt JSON files to JUnit XML format
- Supports both single files and directories of receipts
- Handles gate receipts (with gate names, status, duration, command, exit code)
- Handles UX regression receipts (result, failure_class, first_failing_test, etc.)
- Python 3 only, no external dependencies
- Deterministic XML output with proper escaping
- Fallback: emits valid JUnit with skipped testcase if no files found

### 2. Codecov Test Analytics Integration

#### `.github/workflows/ci.yml`
- **PR-fast job**: Add `Convert PR-fast receipt to JUnit` + `Upload PR-fast test results to Codecov`
- **Merge-gate-shards job**: Add `Convert gate shard receipts to JUnit` + `Upload gate shard test results to Codecov`
- **UX regression job**: Add `Convert UX regression receipt to JUnit` + `Upload UX regression test results to Codecov`

#### `.github/workflows/ux-regression-gate.yml`
- **Standalone UX gate**: Add JUnit conversion and Codecov upload steps (conditional on harness availability)

#### Configuration
- All uploads use `codecov/test-results-action@v1`
- All uploads include `token: ${{ secrets.CODECOV_TOKEN }}`
- All uploads have `continue-on-error: true` (non-blocking)
- All uploads check `env.CODECOV_TOKEN != ''` to avoid running without token

### 3. Enhanced Coverage Upload

#### `.github/workflows/ci-nightly.yml`
Updated Codecov coverage action:
- Added `token: ${{ secrets.CODECOV_TOKEN }}`
- Added `flags: parser` (matches existing flag in codecov.yml)
- Added `name: parser-branch-coverage` (for clarity)
- Added `continue-on-error: true` (non-blocking)

### 4. Documentation

#### `docs/how-to/COVERAGE.md`
- **New section**: "Codecov Repository Secret" — documents CODECOV_TOKEN setup
- **New section**: "Test Analytics" — explains receipt conversion, lists uploaded suites (pr-fast, gate-*, ux-regression*)
- **New section**: "Bundle Analysis" — clarifies deferral until extension adopts a bundler
- **Expanded troubleshooting**: Added "Test Analytics upload fails" section

## Non-Goals (Explicitly Not Done)

- ✗ No Vite/Rollup/Webpack bundler plugin (`@codecov/vite-plugin`)
- ✗ No changes to existing `xtask gates` runner
- ✗ No changes to `codecov.yml`
- ✗ No rerunning tests solely to generate JUnit
- ✗ No merge-blocking Codecov uploads

## Test Plan

### Local validation
```bash
# Script help
python3 scripts/ci/receipts-to-junit.py --help

# Synthetic gate receipt
mkdir -p target/receipts target/test-results
cat > target/receipts/receipt.json <<'JSON'
{ "gates": [ { "gate_name": "fmt", "status": "pass", "duration_ms": 1200 } ] }
JSON
python3 scripts/ci/receipts-to-junit.py \
  --input target/receipts/receipt.json \
  --output target/test-results/test.xml \
  --suite-name pr-fast

# Verify XML is valid
python3 -c "import xml.etree.ElementTree as ET; ET.parse('target/test-results/test.xml'); print('✓ XML is valid')"

# Synthetic UX receipt
cat > target/receipts/ux.json <<'JSON'
{ "result": "fail", "failure_class": "startup" }
JSON
python3 scripts/ci/receipts-to-junit.py \
  --input target/receipts/ux.json \
  --output target/test-results/ux.xml \
  --suite-name ux
```

### CI validation
- PR-fast receipt conversion and upload
- Merge-gate shard receipt conversion and uploads (7 shards)
- UX regression receipt conversion and upload (main CI)
- UX regression gate receipt conversion and upload (standalone)
- Coverage upload with metadata

## Acceptance Criteria Met

- ✓ `scripts/ci/receipts-to-junit.py` exists, executable, handles files and directories
- ✓ Main CI uploads Test Analytics for pr-fast, merge-gate shards, UX regression
- ✓ Standalone UX gate uploads Test Analytics (harness-gated)
- ✓ Nightly coverage includes token, flags, name, non-blocking behavior
- ✓ Documentation updated (token, Test Analytics, Bundle Analysis deferral)
- ✓ No Vite/Rollup/Webpack additions
- ✓ No CI gate becomes dependent on Codecov

## Related Files

- `scripts/ci/receipts-to-junit.py` - Receipt converter
- `.github/workflows/ci.yml` - PR smoke, merge gate, UX regression uploads
- `.github/workflows/ci-nightly.yml` - Coverage upload metadata
- `.github/workflows/ux-regression-gate.yml` - Standalone UX gate uploads
- `docs/how-to/COVERAGE.md` - Documentation

---
_Generated by [Claude Code](https://claude.ai/code/session_01FN4zCTCKYxkukTkQapGgvp)_