### PR TITLE
docs: add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 </p>
 
 <p align="center">
-  <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
+  <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp"><img src="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="code coverage" /></a>
   <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.92-blue" alt="MSRV" /></a>
+  <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

- Adds the Codecov badge to the README evidence row.
- Keeps the existing three-row badge layout:
  - project state
  - distribution/adoption
  - quality/governance/constraints
- Leaves RIPR, SBOM, provenance, and marketplace badge changes for later PRs.

## Notes

The coverage docs already describe Codecov as the aggregation and PR reporting surface, and document the intended README badge. This PR makes the README match that documented state.

## Verification

- [ ] README renders cleanly on GitHub
- [ ] Codecov badge links to `https://codecov.io/gh/EffortlessMetrics/perl-lsp`
- [ ] No crates.io version badge was reintroduced
- [ ] No RIPR/SBOM/provenance badges were added
- [ ] `cargo xtask docs-check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTD1E2ETjcPXp4DpiRKpV9)_