### PR TITLE
feat(completion): typed receiver-evidence provenance for method completion (#7910)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1108,7 +1108,7 @@ fn test_self_arrow_resolves_workspace_methods() -> Result<(), Box<dyn std::error
     //
     // The methods are ONLY in the workspace index (a separate .pm file), not in
     // the currently-parsed source. This tests the workspace path specifically:
-    // `infer_receiver_package` must return `MyService` for `$self->` when
+    // `classify_text_pattern_receiver` must return `SelfOrThis("MyService")` for `$self->` when
     // `context.current_package == "MyService"`.
     let index = Arc::new(WorkspaceIndex::new());
     let module_uri = Url::parse("file:///workspace/MyService.pm")?;
@@ -1615,6 +1615,163 @@ $x->"#;
         completions.iter().map(|c| &c.label).collect::<Vec<_>>()
     );
     Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Receiver-evidence classification (issue #7910, outcome B)
+//
+// These tests pin the typed receiver-evidence provenance produced by
+// `classify_text_pattern_receiver` and `classify_receiver`. They do not
+// assert on completion ordering — outcome B explicitly does not change
+// ordering — they assert on the evidence variant and confidence level.
+// -------------------------------------------------------------------------
+
+use super::workspace::{ReceiverEvidence, classify_text_pattern_receiver};
+use perl_semantic_facts::Confidence;
+
+fn ctx_for(prefix: &str, current_package: &str, source_position: usize) -> CompletionContext {
+    CompletionContext {
+        position: source_position,
+        trigger_character: None,
+        in_string: false,
+        in_regex: false,
+        in_comment: false,
+        in_use_statement: false,
+        current_package: current_package.to_string(),
+        prefix: prefix.to_string(),
+        prefix_start: source_position.saturating_sub(prefix.len()),
+        cursor_scope_id: 0,
+    }
+}
+
+#[test]
+fn classify_receiver_static_package_is_high_confidence() {
+    let source = "Foo->";
+    let ctx = ctx_for("Foo->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::StaticPackage("Foo".to_string()));
+    assert_eq!(ev.package(), Some("Foo"));
+    assert_eq!(ev.confidence(), Some(Confidence::High));
+}
+
+#[test]
+fn classify_receiver_qualified_static_package() {
+    let source = "Foo::Bar->";
+    let ctx = ctx_for("Foo::Bar->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::StaticPackage("Foo::Bar".to_string()));
+    assert_eq!(ev.confidence(), Some(Confidence::High));
+}
+
+#[test]
+fn classify_receiver_self_is_high_confidence() {
+    let source = "package MyService;\n$self->";
+    let ctx = ctx_for("$self->", "MyService", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::SelfOrThis("MyService".to_string()));
+    assert_eq!(ev.confidence(), Some(Confidence::High));
+}
+
+#[test]
+fn classify_receiver_this_is_high_confidence() {
+    let source = "package MyHandler;\n$this->";
+    let ctx = ctx_for("$this->", "MyHandler", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::SelfOrThis("MyHandler".to_string()));
+    assert_eq!(ev.confidence(), Some(Confidence::High));
+}
+
+#[test]
+fn classify_receiver_self_in_main_package_is_unknown() {
+    // `$self->` in main package does not classify — guard matches the
+    // existing receiver-inference behavior pre-#7910.
+    let source = "$self->";
+    let ctx = ctx_for("$self->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
+    assert_eq!(ev.confidence(), None);
+}
+
+#[test]
+fn classify_receiver_constructor_assignment_is_high_confidence() {
+    let source = "my $x = Foo->new;\n$x->";
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::ConstructorAssignment("Foo".to_string()));
+    assert_eq!(ev.confidence(), Some(Confidence::High));
+}
+
+#[test]
+fn classify_receiver_qualified_constructor_assignment() {
+    let source = "my $x = Foo::Bar->new;\n$x->";
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::ConstructorAssignment("Foo::Bar".to_string()));
+    assert_eq!(ev.confidence(), Some(Confidence::High));
+}
+
+#[test]
+fn classify_receiver_literal_bless_is_medium_confidence() {
+    let source = r#"my $x = bless {}, "Foo";
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::LiteralBless("Foo".to_string()));
+    assert_eq!(ev.confidence(), Some(Confidence::Medium));
+}
+
+#[test]
+fn classify_receiver_literal_bless_qualified_class_is_medium_confidence() {
+    let source = r#"my $x = bless {}, "Foo::Bar";
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::LiteralBless("Foo::Bar".to_string()));
+    assert_eq!(ev.confidence(), Some(Confidence::Medium));
+}
+
+#[test]
+fn classify_receiver_dynamic_bless_is_unknown() {
+    // `bless {}, $class` is dynamic — extract_bless_literal_class fails
+    // closed, and the classifier therefore reports Unknown rather than
+    // inventing a package.
+    let source = r#"my $class = "Foo";
+my $x = bless {}, $class;
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
+    assert_eq!(ev.confidence(), None);
+}
+
+#[test]
+fn classify_receiver_no_assignment_is_unknown() {
+    // Variable with no preceding assignment — no evidence, classifier
+    // reports Unknown and the production callsite returns no method
+    // completions.
+    let source = "$nonexistent->";
+    let ctx = ctx_for("$nonexistent->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
+    assert_eq!(ev.confidence(), None);
+}
+
+#[test]
+fn classify_receiver_lowercase_static_prefix_is_unknown() {
+    // Lowercase identifier on the left of `->` is not a Perl package name
+    // (packages start uppercase by convention). The classifier falls
+    // through to Unknown.
+    let source = "foo->";
+    let ctx = ctx_for("foo->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
+}
+
+#[test]
+fn classify_receiver_unknown_has_no_package() {
+    let ev = ReceiverEvidence::Unknown;
+    assert_eq!(ev.package(), None);
+    assert_eq!(ev.confidence(), None);
 }
 
 // -------------------------------------------------------------------------

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1626,7 +1626,8 @@ $x->"#;
 // ordering — they assert on the evidence variant and confidence level.
 // -------------------------------------------------------------------------
 
-use super::workspace::{ReceiverEvidence, classify_text_pattern_receiver};
+use super::workspace::{ReceiverEvidence, classify_receiver, classify_text_pattern_receiver};
+use perl_semantic_analyzer::type_inference::TypeInferenceEngine;
 use perl_semantic_facts::Confidence;
 
 fn ctx_for(prefix: &str, current_package: &str, source_position: usize) -> CompletionContext {
@@ -1772,6 +1773,50 @@ fn classify_receiver_unknown_has_no_package() {
     let ev = ReceiverEvidence::Unknown;
     assert_eq!(ev.package(), None);
     assert_eq!(ev.confidence(), None);
+}
+
+#[test]
+fn type_engine_variant_has_medium_confidence() {
+    // Direct accessor proof for the TypeEngine variant. End-to-end
+    // production-callsite proof (a `classify_receiver` call that returns
+    // TypeEngine from a natural Perl source) is deferred: the current
+    // `TypeInferenceEngine` does not infer `PerlType::Object` from
+    // `my $x = Foo->new` or `bless` (per `real_world_patterns.rs:1718`,
+    // "bless is not directly tracked by type inference"), and its
+    // `global_env` is private with no public setter, so we cannot seed
+    // an Object type in tests through the supported API. This test
+    // pins the variant's package / confidence accessors so the future
+    // PR that wires Object types into the engine has a stable contract
+    // to land against.
+    let ev = ReceiverEvidence::TypeEngine("Foo".to_string());
+    assert_eq!(ev.package(), Some("Foo"));
+    assert_eq!(ev.confidence(), Some(Confidence::Medium));
+}
+
+#[test]
+fn classify_receiver_engine_present_but_empty_falls_through_to_text_pattern() {
+    // Proves the type-engine arm of `classify_receiver` is wired
+    // correctly and fails over to the text-pattern arm when the engine
+    // has no Object type for the receiver variable. With the engine
+    // supplied but empty, `my $x = Foo->new; $x->` should classify as
+    // ConstructorAssignment (text-pattern), not TypeEngine.
+    let source = "my $x = Foo->new;\n$x->";
+    let ctx = ctx_for("$x->", "main", source.len());
+    let engine = TypeInferenceEngine::new();
+    let ev = classify_receiver(&ctx, source, Some(&engine));
+    assert_eq!(ev, ReceiverEvidence::ConstructorAssignment("Foo".to_string()));
+    assert_eq!(ev.confidence(), Some(Confidence::High));
+}
+
+#[test]
+fn classify_receiver_no_engine_uses_text_pattern() {
+    // Sanity counterpart: with no type engine supplied, the same source
+    // must still classify (via the text-pattern arm) as
+    // ConstructorAssignment.
+    let source = "my $x = Foo->new;\n$x->";
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_receiver(&ctx, source, None);
+    assert_eq!(ev, ReceiverEvidence::ConstructorAssignment("Foo".to_string()));
 }
 
 // -------------------------------------------------------------------------

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -498,76 +498,190 @@ pub fn add_use_qw_import_completions(
     }
 }
 
-/// Infer the package type of a `->` receiver from the source context.
+/// Classification of how a method-completion receiver was inferred at the
+/// call site.
 ///
-/// Looks for patterns like `My::Package->method` (static call) or attempts to
-/// find the type from variable assignment context like `my $obj = My::Package->new`.
-fn infer_receiver_package(context: &CompletionContext, source: &str) -> Option<String> {
+/// This is *typed receiver-evidence provenance*: it does not change which
+/// candidates appear in the completion list, and it does not (yet) reorder
+/// candidates. It records *why* a particular package was inferred, so that
+/// a later PR can wire confidence into ordering or explanation when a real
+/// seam emerges.
+///
+/// Today, the existing method-completion path infers a single receiver
+/// package and collects candidates only from that package's `@ISA` graph;
+/// there are no candidates from multiple receiver sources competing for
+/// ordering, so confidence has nothing to re-order between. Outcome B in
+/// issue #7910: provenance + classification tests, no ranking change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ReceiverEvidence {
+    /// Literal package name on the left of `->`, e.g. `Foo->method` or
+    /// `Foo::Bar->method`. High confidence.
+    StaticPackage(String),
+    /// `$self->` or `$this->` inside a non-`main` `package Foo;` block.
+    /// Resolves to the enclosing package via `context.current_package`.
+    /// High confidence.
+    SelfOrThis(String),
+    /// Variable-method call against `$x` assigned earlier in the source as
+    /// `my $x = Foo->new(...)`. The constructor convention pins the
+    /// receiver to `Foo`. High confidence.
+    ConstructorAssignment(String),
+    /// Variable-method call against `$x` assigned earlier as
+    /// `my $x = bless ..., "Foo"`. Literal `bless` with a literal class.
+    /// Medium confidence — strong static evidence, still a Perl runtime
+    /// construct.
+    LiteralBless(String),
+    /// Receiver type was resolved by [`TypeInferenceEngine`] for a `$var`
+    /// call site. Medium confidence — confidence ultimately follows the
+    /// engine's source, but at this layer we treat all engine results as
+    /// medium.
+    TypeEngine(String),
+    /// No receiver evidence found, OR a positively-detected dynamic form
+    /// (e.g. `bless {}, $class`, expression-tail class, nested call,
+    /// non-builtin `bless`-prefixed identifier). Method completion does
+    /// not suggest any specific package's methods in this case — same as
+    /// the pre-#7910 behavior.
+    Unknown,
+}
+
+impl ReceiverEvidence {
+    /// Returns the inferred receiver package, if any. `Unknown` returns
+    /// `None`.
+    pub(super) fn package(&self) -> Option<&str> {
+        match self {
+            Self::StaticPackage(p)
+            | Self::SelfOrThis(p)
+            | Self::ConstructorAssignment(p)
+            | Self::LiteralBless(p)
+            | Self::TypeEngine(p) => Some(p.as_str()),
+            Self::Unknown => None,
+        }
+    }
+
+    /// Returns the confidence level for this evidence kind, using the
+    /// shared `perl_semantic_facts::Confidence` vocabulary so the rest of
+    /// the semantic stack speaks the same language. `Unknown` returns
+    /// `None` — there is no confidence when there is no evidence.
+    ///
+    /// Today the production method-completion callsite does not read this;
+    /// it is exposed for tests and for the future PR that wires confidence
+    /// into ranking or detail text once a real seam emerges (issue #7910,
+    /// outcome B).
+    #[allow(dead_code)]
+    pub(super) fn confidence(&self) -> Option<Confidence> {
+        match self {
+            Self::StaticPackage(_) | Self::SelfOrThis(_) | Self::ConstructorAssignment(_) => {
+                Some(Confidence::High)
+            }
+            Self::LiteralBless(_) | Self::TypeEngine(_) => Some(Confidence::Medium),
+            Self::Unknown => None,
+        }
+    }
+}
+
+/// Classify the receiver of a `->` method-completion call site.
+///
+/// Tries the type-inference engine first (matching the historical
+/// precedence of `infer_receiver_package_from_type_engine`), then falls
+/// back to text-pattern receiver inference. Returns
+/// [`ReceiverEvidence::Unknown`] when no evidence is found.
+pub(super) fn classify_receiver(
+    context: &CompletionContext,
+    source: &str,
+    type_engine: Option<&TypeInferenceEngine>,
+) -> ReceiverEvidence {
+    if let Some(pkg) = type_engine_receiver(context, type_engine) {
+        return ReceiverEvidence::TypeEngine(pkg);
+    }
+    classify_text_pattern_receiver(context, source)
+}
+
+/// Type-engine arm of [`classify_receiver`]. Extracted from the legacy
+/// `infer_receiver_package_from_type_engine` body, behavior preserved.
+fn type_engine_receiver(
+    context: &CompletionContext,
+    type_engine: Option<&TypeInferenceEngine>,
+) -> Option<String> {
+    let arrow_prefix = context.prefix.trim_end_matches("->");
+    let var_name = arrow_prefix.strip_prefix('$')?;
+    let ty = type_engine?.get_type_at(var_name)?;
+    match ty {
+        PerlType::Object(class) => Some(class),
+        PerlType::Reference(inner) => match inner.as_ref() {
+            PerlType::Object(class) => Some(class.clone()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Text-pattern arm of [`classify_receiver`]. Looks for `Foo->method`
+/// (static), `$self->` / `$this->` (self), `my $x = Foo->new` (constructor
+/// assignment), and `my $x = bless ..., "Foo"` (literal bless).
+pub(super) fn classify_text_pattern_receiver(
+    context: &CompletionContext,
+    source: &str,
+) -> ReceiverEvidence {
     let arrow_prefix = context.prefix.trim_end_matches("->");
 
-    // Case 1: Static method call like `My::Package->meth` or `Package->meth`
-    // The prefix already contains the package name (starts with uppercase, no sigil)
+    // Case 1: Static method call like `My::Package->meth` or `Package->meth`.
+    // The prefix already contains the package name (starts with uppercase, no sigil).
     if !arrow_prefix.starts_with('$')
         && !arrow_prefix.starts_with('@')
         && !arrow_prefix.starts_with('%')
         && arrow_prefix.chars().next().is_some_and(|c| c.is_ascii_uppercase())
     {
-        return Some(arrow_prefix.to_string());
+        return ReceiverEvidence::StaticPackage(arrow_prefix.to_string());
     }
 
-    // Case 3: Self-call inside a method — `$self->` or `$this->` resolves to the
-    // current package. Standard Perl OO convention: the invocant of `bless` is
-    // assigned to `$self` (or `$this`) via `my $self = shift`.  The RHS is just
-    // `shift`, so Case 2 would not match any constructor pattern.  Instead we
-    // fall back to `context.current_package` which the context analyser already
-    // sets correctly from the surrounding `package` declaration.
+    // Case 3: Self-call inside a method — `$self->` or `$this->` resolves to
+    // the current package. Standard Perl OO convention: the invocant of `bless`
+    // is assigned to `$self` (or `$this`) via `my $self = shift`. The RHS is
+    // just `shift`, so Case 2 below would not match any constructor pattern.
+    // Instead we fall back to `context.current_package` which the context
+    // analyser already sets correctly from the surrounding `package`
+    // declaration.
     if matches!(arrow_prefix, "$self" | "$this")
         && !context.current_package.is_empty()
         && context.current_package != "main"
     {
-        return Some(context.current_package.clone());
+        return ReceiverEvidence::SelfOrThis(context.current_package.clone());
     }
 
-    // Case 2: Variable method call like `$obj->meth`
-    // Try to find the type from assignment context
+    // Case 2: Variable method call like `$obj->meth` — try to find the
+    // receiver type from a recent assignment.
     if arrow_prefix.starts_with('$') {
         let var_name = arrow_prefix;
-        // Look for assignment pattern: `my $var = Package->new`
-        // Search backwards in source for the variable assignment
         let before = &source[..context.position.min(source.len())];
 
-        // Find the most recent assignment to this variable
         for line in before.lines().rev() {
             let trimmed = line.trim();
-            // Match patterns like: `my $var = Package::Name->new(...)`
-            // or `$var = Package::Name->new(...)`
-            // We need a single `=` that is not part of `==`, `!=`, `<=`, `>=`, `=~`.
             let assign_pos = find_assignment_eq(trimmed);
             if let Some(assign_pos) = assign_pos {
                 let lhs = trimmed[..assign_pos].trim();
                 if lhs.ends_with(var_name) || lhs.contains(&format!("{var_name} ")) {
                     let rhs = trimmed[assign_pos + 1..].trim();
-                    // Extract package name from `Package::Name->new(...)` pattern
+                    // Pattern: `Package::Name->new(...)`
                     if let Some(arrow_pos) = rhs.find("->") {
                         let pkg = rhs[..arrow_pos].trim();
                         if pkg.contains("::")
                             || pkg.chars().next().is_some_and(|c| c.is_ascii_uppercase())
                         {
-                            return Some(pkg.to_string());
+                            return ReceiverEvidence::ConstructorAssignment(pkg.to_string());
                         }
                     }
-                    // Pattern: `bless REF, "Class"` / `bless REF, 'Class'`
+                    // Pattern: `bless REF, "Class"` / `bless REF, 'Class'`.
                     // Only literal-string class names produce inference; dynamic
-                    // forms like `bless {}, $class` intentionally fall through.
+                    // forms like `bless {}, $class` intentionally fall through
+                    // (extract_bless_literal_class is fail-closed).
                     if let Some(class) = extract_bless_literal_class(rhs) {
-                        return Some(class);
+                        return ReceiverEvidence::LiteralBless(class);
                     }
                 }
             }
         }
     }
 
-    None
+    ReceiverEvidence::Unknown
 }
 
 /// Extract the literal class name from a `bless REF, "Class"` expression.
@@ -727,24 +841,6 @@ fn is_valid_perl_package_name(s: &str) -> bool {
     !start_of_segment
 }
 
-fn infer_receiver_package_from_type_engine(
-    context: &CompletionContext,
-    type_engine: Option<&TypeInferenceEngine>,
-) -> Option<String> {
-    let arrow_prefix = context.prefix.trim_end_matches("->");
-    let var_name = arrow_prefix.strip_prefix('$')?;
-    let ty = type_engine?.get_type_at(var_name)?;
-
-    match ty {
-        PerlType::Object(class) => Some(class),
-        PerlType::Reference(inner) => match inner.as_ref() {
-            PerlType::Object(class) => Some(class.clone()),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
 /// Add method completions from the workspace index for `->` expressions.
 ///
 /// When the user types `$obj->` or `Package->`, queries the workspace index for
@@ -766,10 +862,14 @@ pub fn add_workspace_method_completions(
         return;
     }
 
-    let package_name = infer_receiver_package_from_type_engine(context, type_engine)
-        .or_else(|| infer_receiver_package(context, source));
-
-    let Some(package_name) = package_name else {
+    // The receiver-evidence kind / confidence is now classified, but is not
+    // yet used to reorder or annotate completions: today's pipeline scopes
+    // candidates to a single inferred package's `@ISA` graph, so there are no
+    // candidates from multiple receiver sources competing for ordering. A
+    // future PR can wire confidence into ranking or detail text once a real
+    // seam emerges. See issue #7910 (outcome B).
+    let evidence = classify_receiver(context, source, type_engine);
+    let Some(package_name) = evidence.package().map(str::to_string) else {
         return;
     };
 


### PR DESCRIPTION
Closes #7910
Plan source: #7910
Plan-review decisions: [#7910 comment](https://github.com/EffortlessMetrics/perl-lsp/issues/7910#issuecomment-4370508534)

## Outcome: B (provenance + classification tests, no ranking change)

The discovery before writing any production code: **today's method-completion pipeline scopes candidates to a single inferred package's `@ISA` graph**. Within that single hierarchy, methods are tier-sorted (own > inherited). There are no candidates from multiple receiver sources competing for ordering — confidence has nothing to re-order between.

A "fake ranking change" would have been inventing one. Outcome B is the honest answer: introduce typed receiver-evidence provenance plus classification tests so a future PR can wire confidence into ordering or detail text once a real seam emerges, without claiming this PR shipped behavior change.

**Ranking did not change in this PR.** Existing method-completion behavior is behaviorally unchanged; existing completion suites still pass (237 prior completion tests + 16 new classification tests = 253 total, all green).

## What changed

| File | Change |
|---|---|
| `crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs` | New `ReceiverEvidence` enum + `classify_receiver` / `classify_text_pattern_receiver` / `type_engine_receiver`. Production callsite in `add_workspace_method_completions` reads `evidence.package()` instead of the two legacy helpers. Legacy `infer_receiver_package` and `infer_receiver_package_from_type_engine` removed (their bodies are now inside the classifier). |
| `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs` | 13 new tests under a new "Receiver-evidence classification" section. One existing-test comment updated to reference the new helper name. |

Total: 2 files changed, 308 insertions, 51 deletions.

## Receiver-evidence variants

| Variant | Source | Confidence (`perl_semantic_facts::Confidence`) |
|---|---|---|
| `StaticPackage(p)` | `Foo->method` (literal package on left of arrow) | `High` |
| `SelfOrThis(p)` | `$self->` / `$this->` resolving to non-`main` `current_package` | `High` |
| `ConstructorAssignment(p)` | `my $x = Foo->new; $x->` | `High` |
| `LiteralBless(p)` | `my $x = bless ..., "Foo"; $x->` (#7901) | `Medium` |
| `TypeEngine(p)` | `TypeInferenceEngine::get_type_at` | `Medium` |
| `Unknown` | no inference, dynamic forms, or fail-closed bless cases | none |

`Confidence` is the shared `perl_semantic_facts::Confidence` so the rest of the semantic stack speaks the same vocabulary.

## Tests added (16)

**Text-pattern classifier (13)** — call `classify_text_pattern_receiver` directly with a constructed `CompletionContext`:

- `classify_receiver_static_package_is_high_confidence`
- `classify_receiver_qualified_static_package`
- `classify_receiver_self_is_high_confidence`
- `classify_receiver_this_is_high_confidence`
- `classify_receiver_self_in_main_package_is_unknown`
- `classify_receiver_constructor_assignment_is_high_confidence`
- `classify_receiver_qualified_constructor_assignment`
- `classify_receiver_literal_bless_is_medium_confidence`
- `classify_receiver_literal_bless_qualified_class_is_medium_confidence`
- `classify_receiver_dynamic_bless_is_unknown`
- `classify_receiver_no_assignment_is_unknown`
- `classify_receiver_lowercase_static_prefix_is_unknown`
- `classify_receiver_unknown_has_no_package`

**TypeEngine evidence (3)**:

- `type_engine_variant_has_medium_confidence` — direct accessor proof for the `TypeEngine` variant
- `classify_receiver_engine_present_but_empty_falls_through_to_text_pattern` — wires a real (empty) `TypeInferenceEngine` into `classify_receiver` and asserts the type-engine arm correctly short-circuits to the text-pattern arm when the engine has no match
- `classify_receiver_no_engine_uses_text_pattern` — sanity counterpart with no engine

Each test asserts both the variant and the confidence (or `None` for Unknown). Pre-#7910 receiver-inference behavior is preserved exactly.

### Why end-to-end TypeEngine production-callsite proof is deferred

The current `TypeInferenceEngine` does not infer `PerlType::Object` from natural Perl source like `my $x = Foo->new` or `bless` — verbatim from `real_world_patterns.rs:1718`: *"bless is not directly tracked by type inference"*. Its `global_env` is private with no public setter, so seeding an Object type in tests would require expanding the PR scope into `perl-semantic-analyzer`. The variant accessor test (`type_engine_variant_has_medium_confidence`) pins the contract a future enhancement can land against, and the engine-present-but-empty test proves the type-engine arm is correctly wired in `classify_receiver`.

## Why this PR explicitly does **not** change ranking

The current pipeline:

1. `infer_receiver_package*` produces a single package name (or none).
2. `collect_all_package_members(index, &package_name)` BFS-collects candidates from that package + its `@ISA` graph + roles.
3. `add_workspace_method_completions` builds `CompletionItem`s with `sort_text` tier 2 (own) or tier 3 (inherited).

Within step 3, candidates all come from the *same* receiver hierarchy. Confidence cannot meaningfully re-rank between them — they share the same evidence source. The seam where confidence would matter does not exist in today's pipeline.

A future PR can introduce that seam by:

- adding receiver-derived candidates from broader sources (would reopen the candidate-invention question — separate issue), or
- adding a confidence-aware detail text (e.g., "Foo method (literal bless)") — explanation, not ordering.

Either change is out of scope here.

## Hard-constraints honored

- ✅ no broad fallback candidates
- ✅ no candidate invention
- ✅ no candidate deletion
- ✅ no parser changes
- ✅ no semantic fact schema changes
- ✅ no dashboard/status update
- ✅ no generated artifact updates
- ✅ no unrelated PR inspection
- ✅ existing receiver inference behavior preserved (250 completion tests pass)

## Verification

- [x] `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- completion` — **253 / 253 passed** (237 prior + 16 new)
- [x] `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- classify_receiver` — **15 / 15 passed**
- [x] `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- type_engine` — **1 / 1 passed**
- [x] `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- bless` — **13 / 13 passed** (10 prior + 3 new bless-named classifier tests)
- [x] `cargo test -p perl-workspace --profile agent --locked --lib -- method_candidates` — **9 / 9 passed**
- [x] `cargo clippy -p perl-lsp-rs-core --profile agent --locked --lib -- -D warnings` — clean
- [x] `cargo xtask fmt --check` — clean
- [x] `cargo xtask semantic-scorecard --check` — passed
- [x] `cargo xtask semantic-shadow-compare --check` — passed
- [x] `git diff --check` — clean

## Non-goals

- No confidence-aware ordering (no real seam exists in today's pipeline)
- No confidence-aware detail text (deferred to a follow-up that can demonstrate UX value)
- No broad fallback for unknown receivers (separate issue — would reopen candidate-invention)
- No dashboard / status update (follow-up docs PR after merge)

## Test plan

- [ ] Inspect the rendered diff: confirm the 2 expected files changed, no other files touched
- [ ] Confirm `ReceiverEvidence` enum has all 6 variants with correct package + confidence accessors
- [ ] Spot-check one classifier test asserts both variant and confidence
- [ ] Confirm production callsite reads `evidence.package()` correctly
