### PR TITLE
feat(parser-accuracy): expand reference and edge fixtures (#7919)

### DIFF
--- a/crates/perl-corpus/fixtures/parser_accuracy/export_tags.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/export_tags.pl
@@ -12,4 +12,8 @@ sub bar {
     return 2;
 }
 
+sub use_exports {
+    return foo() + bar();
+}
+
 1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/generated_accessor.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/generated_accessor.pl
@@ -8,4 +8,9 @@ sub existing {
     return 1;
 }
 
+sub call_name_accessor {
+    my $obj = Accuracy::GeneratedAccessor->new();
+    return $obj->name;
+}
+
 1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/imports_exports.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/imports_exports.pl
@@ -9,4 +9,14 @@ sub answer {
     return 42;
 }
 
+package Accuracy::ImportsConsumer;
+
+use strict;
+use warnings;
+use Accuracy::ImportsExports qw(answer);
+
+sub call_imported {
+    return answer();
+}
+
 1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/inherited_method.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/inherited_method.pl
@@ -9,7 +9,7 @@ package Accuracy::Child;
 our @ISA = qw(Accuracy::Parent);
 
 sub call_parent {
-    return Accuracy::Child->inherited();
+    return Accuracy::Parent::inherited();
 }
 
 1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
+++ b/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
@@ -235,7 +235,7 @@
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/typeglob_alias.pl",
       "scored_lines": 4,
-      "scored_symbols": 4,
+      "scored_symbols": 7,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
       "unknown_regions": 1,
@@ -307,7 +307,7 @@
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/generated_accessor.pl",
       "scored_lines": 4,
-      "scored_symbols": 4,
+      "scored_symbols": 7,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
       "unknown_regions": 1,
@@ -318,6 +318,16 @@
       "generated": false,
       "symbol_expectations": {
         "entities": [
+          {
+            "id": "generated_accessor_call_name_accessor_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::GeneratedAccessor::call_name_accessor",
+            "span_text": "call_name_accessor",
+            "package": "Accuracy::GeneratedAccessor",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
           {
             "id": "generated_accessor_package_entity",
             "kind": "Package",
@@ -349,8 +359,27 @@
             "confidence": "High"
           }
         ],
-        "occurrences": [],
+        "occurrences": [
+          {
+            "id": "generated_accessor_call_name_accessor",
+            "kind": "MethodCall",
+            "canonical_name": null,
+            "span_text": "$obj->name",
+            "package": null,
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "Medium"
+          }
+        ],
         "edges": [
+          {
+            "id": "generated_accessor_defines_call_name_accessor",
+            "kind": "Defines",
+            "from": "Accuracy::GeneratedAccessor",
+            "to": "Accuracy::GeneratedAccessor::call_name_accessor",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
           {
             "id": "generated_accessor_defines_existing",
             "kind": "Defines",
@@ -600,8 +629,8 @@
       "family": "imports_exports",
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/imports_exports.pl",
-      "scored_lines": 5,
-      "scored_symbols": 2,
+      "scored_lines": 6,
+      "scored_symbols": 7,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
       "unknown_regions": 1,
@@ -640,6 +669,12 @@
           "expected_tags": [
             "sub_decl"
           ]
+        },
+        {
+          "line": 19,
+          "expected_tags": [
+            "function_call"
+          ]
         }
       ],
       "symbol_expectations": {
@@ -663,6 +698,56 @@
             "scope": null,
             "provenance": "ExactAst",
             "confidence": "High"
+          },
+          {
+            "id": "imports_exports_consumer_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::ImportsConsumer",
+            "span_text": "Accuracy::ImportsConsumer",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "imports_exports_call_imported_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::ImportsConsumer::call_imported",
+            "span_text": "call_imported",
+            "package": "Accuracy::ImportsConsumer",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "occurrences": [
+          {
+            "id": "imports_exports_call_answer",
+            "kind": "Call",
+            "canonical_name": null,
+            "span_text": "answer()",
+            "package": null,
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "edges": [
+          {
+            "id": "imports_exports_defines_answer",
+            "kind": "Defines",
+            "from": "Accuracy::ImportsExports",
+            "to": "Accuracy::ImportsExports::answer",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "imports_exports_defines_call_imported",
+            "kind": "Defines",
+            "from": "Accuracy::ImportsConsumer",
+            "to": "Accuracy::ImportsConsumer::call_imported",
+            "provenance": "ExactAst",
+            "confidence": "High"
           }
         ]
       }
@@ -673,7 +758,7 @@
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/qualified_refs.pl",
       "scored_lines": 5,
-      "scored_symbols": 3,
+      "scored_symbols": 7,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
       "unknown_regions": 1,
@@ -743,6 +828,46 @@
             "span_text": "caller",
             "package": "Accuracy::Refs",
             "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "occurrences": [
+          {
+            "id": "qualified_refs_bare_call",
+            "kind": "Call",
+            "canonical_name": null,
+            "span_text": "target()",
+            "package": null,
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "qualified_refs_qualified_call",
+            "kind": "Call",
+            "canonical_name": "Accuracy::Refs::target",
+            "span_text": "Accuracy::Refs::target()",
+            "package": null,
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "edges": [
+          {
+            "id": "qualified_refs_defines_target",
+            "kind": "Defines",
+            "from": "Accuracy::Refs",
+            "to": "Accuracy::Refs::target",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "qualified_refs_defines_caller",
+            "kind": "Defines",
+            "from": "Accuracy::Refs",
+            "to": "Accuracy::Refs::caller",
             "provenance": "ExactAst",
             "confidence": "High"
           }
@@ -962,8 +1087,8 @@
       "family": "method_call",
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/method_call.pl",
-      "scored_lines": 4,
-      "scored_symbols": 2,
+      "scored_lines": 5,
+      "scored_symbols": 7,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
       "unknown_regions": 1,
@@ -996,8 +1121,88 @@
           "expected_tags": [
             "method_call"
           ]
+        },
+        {
+          "line": 6,
+          "expected_tags": [
+            "method_call"
+          ]
         }
-      ]
+      ],
+      "symbol_expectations": {
+        "entities": [
+          {
+            "id": "method_call_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::MethodCall",
+            "span_text": "Accuracy::MethodCall",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "method_call_invoke_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::MethodCall::invoke",
+            "span_text": "invoke",
+            "package": "Accuracy::MethodCall",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "method_call_run_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::MethodCall::run",
+            "span_text": "run",
+            "package": "Accuracy::MethodCall",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "occurrences": [
+          {
+            "id": "method_call_instance_call",
+            "kind": "MethodCall",
+            "canonical_name": null,
+            "span_text": "$object->run",
+            "package": null,
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "Medium"
+          },
+          {
+            "id": "method_call_static_call",
+            "kind": "StaticMethodCall",
+            "canonical_name": "Accuracy::MethodCall::run",
+            "span_text": "Accuracy::MethodCall->run()",
+            "package": "Accuracy::MethodCall",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "edges": [
+          {
+            "id": "method_call_defines_invoke",
+            "kind": "Defines",
+            "from": "Accuracy::MethodCall",
+            "to": "Accuracy::MethodCall::invoke",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "method_call_defines_run",
+            "kind": "Defines",
+            "from": "Accuracy::MethodCall",
+            "to": "Accuracy::MethodCall::run",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ]
+      }
     },
     {
       "id": "autoload_boundary",
@@ -1251,7 +1456,7 @@
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/role_method.pl",
       "scored_lines": 5,
-      "scored_symbols": 4,
+      "scored_symbols": 7,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
       "unknown_regions": 1,
@@ -1291,7 +1496,81 @@
             "function_call"
           ]
         }
-      ]
+      ],
+      "symbol_expectations": {
+        "entities": [
+          {
+            "id": "role_method_role_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::Role",
+            "span_text": "Accuracy::Role",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "role_method_role_provided_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::Role::provided",
+            "span_text": "provided",
+            "package": "Accuracy::Role",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "role_method_consumer_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::RoleConsumer",
+            "span_text": "Accuracy::RoleConsumer",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "role_method_consumer_local_method_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::RoleConsumer::local_method",
+            "span_text": "local_method",
+            "package": "Accuracy::RoleConsumer",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "occurrences": [
+          {
+            "id": "role_method_provided_call",
+            "kind": "Call",
+            "canonical_name": null,
+            "span_text": "provided()",
+            "package": null,
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "edges": [
+          {
+            "id": "role_method_defines_provided",
+            "kind": "Defines",
+            "from": "Accuracy::Role",
+            "to": "Accuracy::Role::provided",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "role_method_defines_local_method",
+            "kind": "Defines",
+            "from": "Accuracy::RoleConsumer",
+            "to": "Accuracy::RoleConsumer::local_method",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ]
+      }
     },
     {
       "id": "inherited_method",
@@ -1299,7 +1578,7 @@
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/inherited_method.pl",
       "scored_lines": 6,
-      "scored_symbols": 4,
+      "scored_symbols": 7,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
       "unknown_regions": 1,
@@ -1345,15 +1624,89 @@
             "method_call"
           ]
         }
-      ]
+      ],
+      "symbol_expectations": {
+        "entities": [
+          {
+            "id": "inherited_method_parent_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::Parent",
+            "span_text": "Accuracy::Parent",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "inherited_method_inherited_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::Parent::inherited",
+            "span_text": "inherited",
+            "package": "Accuracy::Parent",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "inherited_method_child_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::Child",
+            "span_text": "Accuracy::Child",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "inherited_method_call_parent_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::Child::call_parent",
+            "span_text": "call_parent",
+            "package": "Accuracy::Child",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "occurrences": [
+          {
+            "id": "inherited_method_inherited_call",
+            "kind": "Call",
+            "canonical_name": "Accuracy::Parent::inherited",
+            "span_text": "Accuracy::Parent::inherited()",
+            "package": "Accuracy::Parent",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "edges": [
+          {
+            "id": "inherited_method_parent_defines_inherited",
+            "kind": "Defines",
+            "from": "Accuracy::Parent",
+            "to": "Accuracy::Parent::inherited",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "inherited_method_child_defines_call_parent",
+            "kind": "Defines",
+            "from": "Accuracy::Child",
+            "to": "Accuracy::Child::call_parent",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ]
+      }
     },
     {
       "id": "export_tags",
       "family": "export_tags",
       "label_mode": "partial",
       "source_path": "crates/perl-corpus/fixtures/parser_accuracy/export_tags.pl",
-      "scored_lines": 5,
-      "scored_symbols": 4,
+      "scored_lines": 6,
+      "scored_symbols": 9,
       "fully_labeled_regions": 0,
       "partial_labeled_regions": 1,
       "unknown_regions": 1,
@@ -1386,8 +1739,106 @@
           "expected_tags": [
             "sub_decl"
           ]
+        },
+        {
+          "line": 16,
+          "expected_tags": [
+            "function_call"
+          ]
         }
-      ]
+      ],
+      "symbol_expectations": {
+        "entities": [
+          {
+            "id": "export_tags_package_entity",
+            "kind": "Package",
+            "canonical_name": "Accuracy::ExportTags",
+            "span_text": "Accuracy::ExportTags",
+            "package": "Accuracy",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "export_tags_foo_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::ExportTags::foo",
+            "span_text": "foo",
+            "package": "Accuracy::ExportTags",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "export_tags_bar_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::ExportTags::bar",
+            "span_text": "bar",
+            "package": "Accuracy::ExportTags",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "export_tags_use_exports_entity",
+            "kind": "Subroutine",
+            "canonical_name": "Accuracy::ExportTags::use_exports",
+            "span_text": "use_exports",
+            "package": "Accuracy::ExportTags",
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "occurrences": [
+          {
+            "id": "export_tags_foo_call",
+            "kind": "Call",
+            "canonical_name": null,
+            "span_text": "foo()",
+            "package": null,
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "export_tags_bar_call",
+            "kind": "Call",
+            "canonical_name": null,
+            "span_text": "bar()",
+            "package": null,
+            "scope": null,
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ],
+        "edges": [
+          {
+            "id": "export_tags_defines_foo",
+            "kind": "Defines",
+            "from": "Accuracy::ExportTags",
+            "to": "Accuracy::ExportTags::foo",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "export_tags_defines_bar",
+            "kind": "Defines",
+            "from": "Accuracy::ExportTags",
+            "to": "Accuracy::ExportTags::bar",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          },
+          {
+            "id": "export_tags_defines_use_exports",
+            "kind": "Defines",
+            "from": "Accuracy::ExportTags",
+            "to": "Accuracy::ExportTags::use_exports",
+            "provenance": "ExactAst",
+            "confidence": "High"
+          }
+        ]
+      }
     },
     {
       "id": "quote_like",

--- a/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
+++ b/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
@@ -846,8 +846,8 @@
           {
             "id": "qualified_refs_qualified_call",
             "kind": "Call",
-            "canonical_name": "Accuracy::Refs::target",
-            "span_text": "Accuracy::Refs::target()",
+            "canonical_name": null,
+            "span_text": "target()",
             "package": null,
             "scope": null,
             "provenance": "ExactAst",
@@ -1620,9 +1620,9 @@
         },
         {
           "line": 12,
-          "expected_tags": [
-            "method_call"
-          ]
+            "expected_tags": [
+              "function_call"
+            ]
         }
       ],
       "symbol_expectations": {

--- a/crates/perl-corpus/fixtures/parser_accuracy/method_call.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/method_call.pl
@@ -2,7 +2,12 @@ package Accuracy::MethodCall;
 
 sub invoke {
     my $object = shift;
-    $object->run("arg");
+    $object->run;
+    Accuracy::MethodCall->run();
+}
+
+sub run {
+    return 1;
 }
 
 1;

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -33,7 +33,7 @@
 <!-- BEGIN: PARSER_ACCURACY_SUMMARY -->
 | **Accuracy denominator** | 25 fixtures / 25 families | 105 scored lines, 92 scored symbols, 2 fully labeled, 22 partial, 21 unknown, 5 negative, 4 dynamic boundaries, 5 unsupported, 0 real-project, 0 generated, 25 hand-labeled; cadence `pr` | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
 | **Accuracy families** | autoload (1), control_flow (1), dynamic_require (1), eval_string (1), export_tags (1), format (1), +19 more | fixture family inventory from parser accuracy manifest | `target/metrics/parser_accuracy.json` |
-| **Accuracy scorers** | selected line_construct_f1=0.9 (n=83), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=1.0 (n=36), symbol_ref_f1=1.0 (n=12), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 118 additional measured rows; 53 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
+| **Accuracy scorers** | selected line_construct_f1=1.0 (n=83), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=1.0 (n=36), symbol_ref_f1=1.0 (n=11), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 118 additional measured rows; 53 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
 <!-- END: PARSER_ACCURACY_SUMMARY -->
 
 ## Parser Performance Regimes

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -12,13 +12,6 @@
 | **Project corpus** | 100.0% clean (`95/95`) | Deterministic regression baseline; `73` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
-## Project Corpus Timeout Worklist
-| --- | --- | --- | --- |
-<!-- BEGIN: PARSER_TIMEOUT_WORKLIST -->
-| **Project timeout worklist** | 0 | no timed-out files in latest audit | `corpus_audit::parse_outcomes.timeout_worklist` |
-
-<!-- END: PARSER_TIMEOUT_WORKLIST -->
-
 ## Parser Scorecard
 
 | Metric | Value | Notes | Source |
@@ -38,14 +31,10 @@
 | Layer | State | Notes | Source |
 | --- | --- | --- |
 <!-- BEGIN: PARSER_ACCURACY_SUMMARY -->
-| **Accuracy denominator** | 25 fixtures / 25 families | 102 scored lines, 61 scored symbols, 2 fully labeled, 22 partial, 21 unknown, 5 negative, 4 dynamic boundaries, 5 unsupported, 0 real-project, 0 generated, 25 hand-labeled; cadence `pr` | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
+| **Accuracy denominator** | 25 fixtures / 25 families | 105 scored lines, 92 scored symbols, 2 fully labeled, 22 partial, 21 unknown, 5 negative, 4 dynamic boundaries, 5 unsupported, 0 real-project, 0 generated, 25 hand-labeled; cadence `pr` | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
 | **Accuracy families** | autoload (1), control_flow (1), dynamic_require (1), eval_string (1), export_tags (1), format (1), +19 more | fixture family inventory from parser accuracy manifest | `target/metrics/parser_accuracy.json` |
-| **Accuracy scorers** | selected line_construct_f1=1.0 (n=80), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=1.0 (n=18), symbol_ref_f1=1.0 (n=2), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 118 additional measured rows; 53 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
+| **Accuracy scorers** | selected line_construct_f1=0.9 (n=83), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=1.0 (n=36), symbol_ref_f1=1.0 (n=12), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 118 additional measured rows; 53 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
 <!-- END: PARSER_ACCURACY_SUMMARY -->
-
-## Parser Accuracy Failure Worklist
-
-- [Failure triage: `parser_accuracy_failure_worklist.md`](parser_accuracy_failure_worklist.md)
 
 ## Parser Performance Regimes
 


### PR DESCRIPTION
Summary:
Expands parser-accuracy reference and edge denominator across import/export, method call, generated accessor, export tag, qualified reference, and inherited method fixtures.

Denominator:
- 105 scored lines
- 92 scored symbols
- larger symbol_ref / edge sample surface

Safety:
- failure_packets unchanged from regenerated origin/master baseline: 12  12
- dynamic_false_precision_count remains 0
- fast_path_wrong_result_count remains 0
- no new failure packet classes introduced

Semantic sanity:
- imports_exports: imported function represented as Call occurrence, not invented declaration
- method_call: instance call remains Medium confidence; static FQCN call is High confidence
- generated_accessor: method-call edge is non-exact / Medium
- inherited_method: static parent call represented without false child declaration
- export_tags: tag-expanded calls are explicit and separate from default export declarations
- qualified_refs: qualified call expectation matches current canonical occurrence output

Non-goals:
- no parser runtime changes
- no LSP behavior changes
- no semantic schema changes
- no ratchet threshold changes