### PR TITLE
feat(completion): expose receiver evidence in method completion detail text (#7918)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1798,12 +1798,66 @@ sub bark { }
     assert_eq!(bark.label, "bark", "label must not change");
     assert_eq!(bark.insert_text.as_deref(), Some("bark()"), "insert_text must not change");
     assert_eq!(bark.filter_text.as_deref(), Some("bark"), "filter_text must not change");
-    let sort_text = must_some(bark.sort_text.as_deref());
-    assert!(
-        sort_text.ends_with("bark"),
-        "sort_text must still end with the method name (tier_<name> format unchanged); got {sort_text:?}"
+    assert_eq!(
+        bark.sort_text.as_deref(),
+        Some("2_bark"),
+        "sort_text must remain `<tier>_<name>` with tier 2 (own method); \
+         receiver-evidence detail must not change ranking"
     );
     Ok(())
+}
+
+#[test]
+fn detail_with_evidence_helper_handles_both_base_formats() {
+    // Direct unit test for the formatting helper that both the semantic
+    // and inline-fallback paths call. Forcing the inline-fallback path
+    // end-to-end requires synthetic workspace-index state not exposed by
+    // the public test harness (semantic cutover succeeds for fixtures
+    // where `index.index_file()` populates both the workspace symbol
+    // table and the semantic fact shards together). This unit test pins
+    // the contract that BOTH base-detail formats receive the same suffix
+    // treatment.
+    use super::workspace::detail_with_evidence;
+
+    // Inline-fallback path's base format ("Foo method" / "Foo method (from Base)"):
+    let fallback_own = detail_with_evidence(
+        "Foo method".to_string(),
+        &ReceiverEvidence::StaticPackage("Foo".to_string()),
+    );
+    assert_eq!(fallback_own, "Foo method — receiver: static package");
+
+    let fallback_inherited = detail_with_evidence(
+        "Foo method (from Base)".to_string(),
+        &ReceiverEvidence::SelfOrThis("Foo".to_string()),
+    );
+    assert_eq!(fallback_inherited, "Foo method (from Base) — receiver: self/this");
+
+    // Semantic path's base format ("method from Foo" / "inherited method from Parent"
+    // / "generated accessor from Foo"):
+    let semantic_own = detail_with_evidence(
+        "method from Foo".to_string(),
+        &ReceiverEvidence::LiteralBless("Foo".to_string()),
+    );
+    assert_eq!(semantic_own, "method from Foo — receiver: literal bless");
+
+    let semantic_inherited = detail_with_evidence(
+        "inherited method from Parent".to_string(),
+        &ReceiverEvidence::ConstructorAssignment("Foo".to_string()),
+    );
+    assert_eq!(
+        semantic_inherited,
+        "inherited method from Parent — receiver: constructor assignment"
+    );
+
+    let generated = detail_with_evidence(
+        "generated accessor from Foo".to_string(),
+        &ReceiverEvidence::TypeEngine("Foo".to_string()),
+    );
+    assert_eq!(generated, "generated accessor from Foo — receiver: type engine");
+
+    // Unknown evidence: base detail is returned unchanged.
+    let unknown = detail_with_evidence("Foo method".to_string(), &ReceiverEvidence::Unknown);
+    assert_eq!(unknown, "Foo method");
 }
 
 #[test]

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1209,15 +1209,15 @@ $self->"#;
     let own = must_some(completions.iter().find(|item| item.label == "own_method"));
     assert_eq!(
         own.detail.as_deref(),
-        Some("method from Child"),
-        "workspace own method should use semantic method candidate detail"
+        Some("method from Child — receiver: self/this"),
+        "workspace own method should use semantic method candidate detail with receiver evidence (#7918)"
     );
 
     let inherited = must_some(completions.iter().find(|item| item.label == "inherited_method"));
     assert_eq!(
         inherited.detail.as_deref(),
-        Some("inherited method from Parent"),
-        "inherited method should use semantic method candidate detail"
+        Some("inherited method from Parent — receiver: self/this"),
+        "inherited method should use semantic method candidate detail with receiver evidence (#7918)"
     );
 
     Ok(())
@@ -1265,8 +1265,8 @@ $self->"#;
 
     assert_eq!(
         method.detail.as_deref(),
-        Some("inherited method from Parent"),
-        "nearest ancestor should shadow a farther ancestor with the same method name"
+        Some("inherited method from Parent — receiver: self/this"),
+        "nearest ancestor should shadow a farther ancestor with the same method name (with #7918 receiver suffix)"
     );
 
     Ok(())
@@ -1613,6 +1613,225 @@ $x->"#;
         completions.iter().any(|c| c.label == "bark"),
         "bless [1, 2, 3], \"Foo\" should infer Foo and suggest bark; got: {:?}",
         completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// Receiver-evidence in method completion detail text (issue #7918)
+//
+// These tests assert that the existing `ReceiverEvidence` provenance
+// (#7917) is now appended to method completion `detail` text. They also
+// pin invariants that label / insert_text / filter_text / sort_text /
+// the candidate set itself are unchanged — this PR is detail-only.
+// -------------------------------------------------------------------------
+
+#[test]
+fn detail_includes_static_package_receiver_evidence() -> Result<(), Box<dyn std::error::Error>> {
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = "Foo->";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = must_some(completions.iter().find(|c| c.label == "bark"));
+    let detail = must_some(bark.detail.as_deref());
+    assert!(
+        detail.contains("receiver: static package"),
+        "Foo->bark detail should include static-package receiver evidence; got {detail:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn detail_includes_receiver_evidence_for_constructor_assignment()
+-> Result<(), Box<dyn std::error::Error>> {
+    // For `my $x = Foo->new; $x->`, two receiver-evidence paths could
+    // legitimately fire:
+    //   - text-pattern `ConstructorAssignment` (matches `Foo->new`
+    //     assignment in the source)
+    //   - `TypeInferenceEngine` (which DOES infer `$x : Foo` from
+    //     constructor-method calls in production today, contrary to the
+    //     `bless`-only limitation)
+    //
+    // `classify_receiver` tries the type engine first, so production
+    // currently produces `TypeEngine` for this fixture. Both
+    // suffix labels are correct receiver evidence; this test asserts
+    // either is present rather than pinning one path.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub new { bless {}, shift }
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = Foo->new;
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = must_some(completions.iter().find(|c| c.label == "bark"));
+    let detail = must_some(bark.detail.as_deref());
+    assert!(
+        detail.contains("receiver: constructor assignment")
+            || detail.contains("receiver: type engine"),
+        "my $$x = Foo->new; $$x->bark detail should include receiver evidence \
+         (constructor assignment or type engine); got {detail:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn detail_includes_literal_bless_receiver_evidence() -> Result<(), Box<dyn std::error::Error>> {
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless {}, "Foo";
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = must_some(completions.iter().find(|c| c.label == "bark"));
+    let detail = must_some(bark.detail.as_deref());
+    assert!(
+        detail.contains("receiver: literal bless"),
+        "literal bless detail should include literal-bless receiver evidence; got {detail:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn detail_for_inherited_preserves_from_annotation_and_appends_receiver()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Inherited methods must keep `(from Base)` (or the semantic-path
+    // equivalent `inherited method from Parent`) AND get the receiver
+    // suffix appended.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Parent.pm")?,
+        r#"package Parent;
+sub inherited_method { }
+1;
+"#
+        .to_string(),
+    )?;
+    index.index_file(
+        Url::parse("file:///workspace/Child.pm")?,
+        r#"package Child;
+use parent 'Parent';
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"package Child;
+sub run {
+my $self = shift;
+$self->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let inherited = must_some(completions.iter().find(|c| c.label == "inherited_method"));
+    let detail = must_some(inherited.detail.as_deref());
+    assert!(
+        detail.contains("Parent"),
+        "inherited detail should still mention defining package Parent; got {detail:?}"
+    );
+    assert!(
+        detail.contains("receiver: self/this"),
+        "inherited detail should append self/this receiver evidence; got {detail:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn detail_change_does_not_alter_label_insert_filter_or_sort_text()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Invariant: the only field that changes from #7918 is `detail`.
+    // `label`, `insert_text`, `filter_text`, and `sort_text` must remain
+    // unchanged for the same input (verified against literal expected
+    // values that match pre-#7918 production behavior).
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = "Foo->";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = must_some(completions.iter().find(|c| c.label == "bark"));
+    assert_eq!(bark.label, "bark", "label must not change");
+    assert_eq!(bark.insert_text.as_deref(), Some("bark()"), "insert_text must not change");
+    assert_eq!(bark.filter_text.as_deref(), Some("bark"), "filter_text must not change");
+    let sort_text = must_some(bark.sort_text.as_deref());
+    assert!(
+        sort_text.ends_with("bark"),
+        "sort_text must still end with the method name (tier_<name> format unchanged); got {sort_text:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn detail_unchanged_when_no_receiver_evidence_path_reachable()
+-> Result<(), Box<dyn std::error::Error>> {
+    // When receiver inference fails, the production callsite returns no
+    // method completions at all (existing pre-#7918 behavior). This test
+    // pins that contract: an unknown receiver yields no exact-receiver
+    // suggestions, so no method-detail text is produced for `bark`.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = "$nonexistent->";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        !completions.iter().any(|c| c.label == "bark"),
+        "unknown receiver must not produce Foo's methods (pre-#7918 behavior preserved)"
     );
     Ok(())
 }

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -576,6 +576,31 @@ impl ReceiverEvidence {
             Self::Unknown => None,
         }
     }
+
+    /// Short, user-facing suffix describing the evidence source, suitable
+    /// for appending to a `CompletionItem.detail` string. `Unknown`
+    /// returns `None` — when there is no evidence, there is nothing to
+    /// say. Issue #7918: explanatory only, no ranking / inclusion change.
+    pub(super) fn detail_suffix(&self) -> Option<&'static str> {
+        match self {
+            Self::StaticPackage(_) => Some("receiver: static package"),
+            Self::SelfOrThis(_) => Some("receiver: self/this"),
+            Self::ConstructorAssignment(_) => Some("receiver: constructor assignment"),
+            Self::LiteralBless(_) => Some("receiver: literal bless"),
+            Self::TypeEngine(_) => Some("receiver: type engine"),
+            Self::Unknown => None,
+        }
+    }
+}
+
+/// Apply the receiver-evidence detail suffix to an existing base detail
+/// string. Returns the unchanged base when the evidence carries no suffix
+/// (e.g. `Unknown`). Issue #7918.
+fn detail_with_evidence(base: String, evidence: &ReceiverEvidence) -> String {
+    match evidence.detail_suffix() {
+        Some(suffix) => format!("{base} — {suffix}"),
+        None => base,
+    }
 }
 
 /// Classify the receiver of a `->` method-completion call site.
@@ -895,6 +920,7 @@ pub fn add_workspace_method_completions(
         method_prefix,
         &method_symbols,
         auto_import_edit.as_ref(),
+        &evidence,
     ) {
         return;
     }
@@ -905,11 +931,15 @@ pub fn add_workspace_method_completions(
 
         // Show which package actually defines the method for inherited completions
         let defining_pkg = symbol.container_name.as_deref().unwrap_or(package_name.as_str());
-        let detail = if defining_pkg == package_name {
+        let base_detail = if defining_pkg == package_name {
             format!("{package_name} method")
         } else {
             format!("{package_name} method (from {defining_pkg})")
         };
+        // Append receiver-evidence suffix from #7918. Detail-only — no
+        // change to label, insert_text, filter_text, sort_text, or the
+        // candidate set.
+        let detail = detail_with_evidence(base_detail, &evidence);
 
         // Own-class methods rank above inherited: tier 2 for own, tier 3 for inherited.
         // This ensures $obj->zoom (own) sorts before $obj->abstract_method (inherited)
@@ -955,6 +985,7 @@ fn add_semantic_method_completions(
     method_prefix: &str,
     method_symbols: &[&WorkspaceSymbol],
     auto_import_edit: Option<&(SourceLocation, String)>,
+    evidence: &ReceiverEvidence,
 ) -> bool {
     let legacy_names = method_symbol_names(method_symbols);
     if legacy_names.is_empty() {
@@ -995,7 +1026,7 @@ fn add_semantic_method_completions(
         completions.push(CompletionItem {
             label: candidate.display_name.clone(),
             kind: CompletionItemKind::Function,
-            detail: Some(semantic_method_detail(package_name, &candidate)),
+            detail: Some(semantic_method_detail(package_name, &candidate, evidence)),
             documentation: Some(semantic_method_documentation(package_name, &candidate)),
             insert_text: Some(format!("{}()", candidate.display_name)),
             sort_text: Some(format!(
@@ -1139,13 +1170,18 @@ fn semantic_method_sort_rank(receiver_package: &str, candidate: &DefinitionCandi
     }
 }
 
-fn semantic_method_detail(receiver_package: &str, candidate: &DefinitionCandidate) -> String {
+fn semantic_method_detail(
+    receiver_package: &str,
+    candidate: &DefinitionCandidate,
+    evidence: &ReceiverEvidence,
+) -> String {
     let defining_pkg = candidate.package.as_deref().unwrap_or(receiver_package);
-    match candidate.kind {
+    let base = match candidate.kind {
         EntityKind::GeneratedMember => format!("generated accessor from {defining_pkg}"),
         _ if defining_pkg == receiver_package => format!("method from {receiver_package}"),
         _ => format!("inherited method from {defining_pkg}"),
-    }
+    };
+    detail_with_evidence(base, evidence)
 }
 
 fn semantic_method_documentation(

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -596,7 +596,7 @@ impl ReceiverEvidence {
 /// Apply the receiver-evidence detail suffix to an existing base detail
 /// string. Returns the unchanged base when the evidence carries no suffix
 /// (e.g. `Unknown`). Issue #7918.
-fn detail_with_evidence(base: String, evidence: &ReceiverEvidence) -> String {
+pub(super) fn detail_with_evidence(base: String, evidence: &ReceiverEvidence) -> String {
     match evidence.detail_suffix() {
         Some(suffix) => format!("{base} — {suffix}"),
         None => base,


### PR DESCRIPTION
Closes #7918
Plan source: #7918
Plan-review decisions: [#7918 comment](https://github.com/EffortlessMetrics/perl-lsp/issues/7918#issuecomment-4371085988)

## Summary

Builds on #7917's typed `ReceiverEvidence` provenance to give the user a concrete reason for the inferred receiver, by appending a short evidence-source suffix to method completion `detail` text.

```
Foo->bark                        → "Foo method — receiver: static package"
$self->bark (in package Foo)     → "method from Foo — receiver: self/this"
my $x = Foo->new; $x->bark       → "method from Foo — receiver: type engine"
                                   (or "receiver: constructor assignment" if
                                    the type engine does not infer $x)
my $x = bless {}, "Foo"; $x->bark → "Foo method — receiver: literal bless"
inherited method                 → "inherited method from Parent — receiver: …"
                                   ((from Parent) annotation preserved)
```

**Detail only.** No change to `label`, `insert_text`, `filter_text`, `sort_text`, the candidate set, ranking, parser behavior, semantic fact schema, or the UX dashboard.

## Paths changed

Both the **semantic** and **inline-fallback** method-completion detail-construction sites were updated, per Q2 of the plan-review:

- **Semantic path** (`add_semantic_method_completions` / `semantic_method_detail`): wired `&ReceiverEvidence` through and appended the suffix.
- **Inline-fallback path** (`add_workspace_method_completions` for-loop): appended the suffix to the existing `Foo method` / `Foo method (from Base)` strings.

Both call sites use the same `detail_with_evidence(base, evidence)` helper.

**Coverage caveat**: the integration tests in this PR exercise the **semantic path** end-to-end (the cutover gate succeeds for the standard `index.index_file()` fixture pattern, which populates both the workspace symbol table and the semantic fact shards together). Direct end-to-end proof of the inline-fallback path is deferred — forcing semantic cutover failure requires synthetic workspace-index state (empty fact shards or candidate-name mismatch) not exposed by the public test harness. The new `detail_with_evidence_helper_handles_both_base_formats` unit test pins the formatting contract for **both** base-detail formats (inline-fallback's `"Foo method"` / `"Foo method (from Base)"` *and* semantic's `"method from Foo"` / `"inherited method from Parent"` / `"generated accessor from Foo"`), and the production code calls `detail_with_evidence` from both construction sites.

## What changed

| File | Change |
|---|---|
| `crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs` | New `ReceiverEvidence::detail_suffix()` accessor + `detail_with_evidence(base, evidence)` helper. `add_workspace_method_completions` threads the existing `evidence` binding into both detail-construction sites. `add_semantic_method_completions` and `semantic_method_detail` now accept `&ReceiverEvidence`. |
| `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs` | 7 new tests under "Receiver-evidence in method completion detail text". 2 existing exact-match detail assertions updated to include the new `— receiver: self/this` suffix. |

Two files changed; exact diff stats reported by GitHub on the PR page.

## Tests added (7)

- `detail_includes_static_package_receiver_evidence` — `Foo->bark` detail contains `receiver: static package`
- `detail_includes_receiver_evidence_for_constructor_assignment` — `my $x = Foo->new; $x->bark` detail contains either `receiver: type engine` or `receiver: constructor assignment` (see Discovery note below)
- `detail_includes_literal_bless_receiver_evidence` — `my $x = bless {}, "Foo"; $x->bark` detail contains `receiver: literal bless`
- `detail_for_inherited_preserves_from_annotation_and_appends_receiver` — inherited methods still mention defining package AND get the receiver suffix
- `detail_change_does_not_alter_label_insert_filter_or_sort_text` — invariant: `label`, `insert_text`, `filter_text`, `sort_text` are exact-equal to pre-#7918 values (incl. `sort_text == "2_bark"` pinning the tier)
- `detail_with_evidence_helper_handles_both_base_formats` — direct unit test of the formatting helper covering both inline-fallback (`"Foo method"` / `"Foo method (from Base)"`) and semantic (`"method from Foo"` / `"inherited method from Parent"` / `"generated accessor from Foo"`) base formats, plus `Unknown` returns base unchanged
- `detail_unchanged_when_no_receiver_evidence_path_reachable` — unknown receivers still produce no method completions for foreign packages (existing behavior preserved)

## Tests updated (2)

The existing exact-match assertions in these tests were updated to include the `— receiver: self/this` suffix (those fixtures use `$self->`, which classifies as `SelfOrThis`):

- `test_method_completion_semantic_inheritance_detail` — own/inherited details now end with `— receiver: self/this`
- `test_method_completion_prefers_nearest_ancestor` — same

## Discovery note (corrects #7917's deferred-TypeEngine claim)

While writing the constructor-assignment test, the production `TypeInferenceEngine` was found to *successfully* infer `PerlType::Object("Foo")` from `my $x = Foo->new` — contrary to my earlier "TypeEngine never fires from natural source" claim in #7917. The bless-only limitation (cited in `real_world_patterns.rs:1718`: *"bless is not directly tracked by type inference"*) is real but is specific to `bless`. Production therefore produces `TypeEngine` evidence (not `ConstructorAssignment`) for `my $x = Foo->new; $x->`. The test asserts the detail contains *either* label so production reality wins; both are valid receiver evidence for that scenario.

## Hard-constraints honored

- ✅ no candidate inclusion change
- ✅ no ranking change — `sort_text` exact-asserted as `"2_bark"` (tier preserved)
- ✅ `label`, `insert_text`, `filter_text`, `sort_text` exact-equal to pre-#7918
- ✅ inherited `(from Base)` / `inherited method from Parent` annotations preserved
- ✅ literal `bless` detail explicitly says `receiver: literal bless`
- ✅ `Unknown` / dynamic receivers continue producing no method completions (existing behavior)
- ✅ no parser / semantic-fact schema / dashboard / generated-artifact changes
- ✅ no `TypeInferenceEngine` expansion

## Verification

| Command | Result |
|---|---|
| `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- detail` | 9 / 9 passed |
| `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- completion` | 260 / 260 passed (253 prior + 7 new) |
| `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- classify_receiver` | 15 / 15 passed |
| `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- bless` | 14 / 14 passed |
| `cargo test -p perl-workspace --profile agent --locked --lib -- method_candidates` | 9 / 9 passed |
| `cargo clippy -p perl-lsp-rs-core --profile agent --locked --lib -- -D warnings` | clean |
| `cargo xtask fmt --check` | clean |
| `cargo xtask semantic-scorecard --check` | passed |
| `cargo xtask semantic-shadow-compare --check` | passed |
| `git diff --check` | clean |

## Non-goals

- No confidence labels in detail text (deferred — would need user-research; "receiver: literal bless" is concrete; "medium confidence" is abstract noise)
- No broad fallback for unknown receivers (separate issue, would reopen candidate-invention policy)
- No UX dashboard update (follow-up docs PR after merge)

## Test plan

- [x] Inspect the rendered diff: confirm only the 2 expected files changed
- [x] Confirm semantic path emits the receiver suffix and inline-fallback construction site uses the same `detail_with_evidence` helper, with fallback e2e coverage caveat documented
- [x] Confirm `label`, `insert_text`, `filter_text`, `sort_text` are unchanged (exact-asserted)
- [x] Confirm literal `bless` detail explicitly says `receiver: literal bless`
- [x] Confirm inherited methods preserve `(from Base)` / `inherited method from Parent`
