### PR TITLE
feat(parser-accuracy): expand malformed recovery fixtures (#7921)

### DIFF
--- a/crates/perl-corpus/fixtures/parser_accuracy/bad_heredoc_terminator.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/bad_heredoc_terminator.pl
@@ -1,0 +1,5 @@
+package Accuracy::BadHeredocTerminator;
+
+my $payload = <<'END';
+payload
+END;

--- a/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
+++ b/crates/perl-corpus/fixtures/parser_accuracy/manifest.json
@@ -1875,6 +1875,246 @@
           ]
         }
       ]
+    },
+    {
+      "id": "unterminated_heredoc",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/unterminated_heredoc.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "bad_heredoc_terminator",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/bad_heredoc_terminator.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "unclosed_quote_like_operator",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/unclosed_quote_like_operator.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "unclosed_regex",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/unclosed_regex_operator.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "unbalanced_bracket",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/unbalanced_bracket.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "partial_sub_body",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/partial_sub_body.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "orphan_close_delimiters",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/orphan_close_delimiters.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "missing_comma_list",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/missing_comma_list.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "nested_malformed_delimiters",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/nested_malformed_delimiters.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "post_error_package_sub_recovery",
+      "family": "recovery",
+      "label_mode": "partial",
+      "source_path": "crates/perl-corpus/fixtures/parser_accuracy/post_error_package_sub_recovery.pl",
+      "scored_lines": 1,
+      "scored_symbols": 1,
+      "fully_labeled_regions": 0,
+      "partial_labeled_regions": 1,
+      "unknown_regions": 1,
+      "negative_regions": 0,
+      "dynamic_boundaries": 0,
+      "unsupported_constructs": 0,
+      "real_project_file": false,
+      "generated": false,
+      "line_expectations": [
+        {
+          "line": 1,
+          "expected_tags": [
+            "package_decl"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/crates/perl-corpus/fixtures/parser_accuracy/missing_comma_list.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/missing_comma_list.pl
@@ -1,0 +1,4 @@
+package Accuracy::MissingCommaList;
+
+my @numbers = (1 2, 3, 4);
+sub recovered { return 1; }

--- a/crates/perl-corpus/fixtures/parser_accuracy/nested_malformed_delimiters.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/nested_malformed_delimiters.pl
@@ -1,0 +1,3 @@
+package Accuracy::NestedMalformedDelimiters;
+
+my $value = ([1, 2, 3);

--- a/crates/perl-corpus/fixtures/parser_accuracy/orphan_close_delimiters.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/orphan_close_delimiters.pl
@@ -1,0 +1,4 @@
+package Accuracy::OrphanCloseDelimiters;
+
+my $value = 1;
+]

--- a/crates/perl-corpus/fixtures/parser_accuracy/partial_sub_body.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/partial_sub_body.pl
@@ -1,0 +1,4 @@
+package Accuracy::PartialSubBody;
+
+sub partial {
+    return 1;

--- a/crates/perl-corpus/fixtures/parser_accuracy/post_error_package_sub_recovery.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/post_error_package_sub_recovery.pl
@@ -1,0 +1,5 @@
+package Accuracy::PostErrorPackageRecovery;
+
+my $value = (1 + 2;
+package Accuracy::Recovered;
+sub next_sub { return 1; }

--- a/crates/perl-corpus/fixtures/parser_accuracy/unbalanced_bracket.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/unbalanced_bracket.pl
@@ -1,0 +1,3 @@
+package Accuracy::UnbalancedBracket;
+
+my $value = [1, 2, 3));

--- a/crates/perl-corpus/fixtures/parser_accuracy/unclosed_quote_like_operator.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/unclosed_quote_like_operator.pl
@@ -1,0 +1,3 @@
+package Accuracy::UnclosedQuoteLike;
+
+my $message = q{still open

--- a/crates/perl-corpus/fixtures/parser_accuracy/unclosed_regex_operator.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/unclosed_regex_operator.pl
@@ -1,0 +1,3 @@
+package Accuracy::UnclosedRegex;
+
+my $pattern = s/unterminated/foo;

--- a/crates/perl-corpus/fixtures/parser_accuracy/unterminated_heredoc.pl
+++ b/crates/perl-corpus/fixtures/parser_accuracy/unterminated_heredoc.pl
@@ -1,0 +1,4 @@
+package Accuracy::UnterminatedHeredocRecovery;
+
+my $payload = <<'EOF';
+unterminated payload

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -31,9 +31,9 @@
 | Layer | State | Notes | Source |
 | --- | --- | --- |
 <!-- BEGIN: PARSER_ACCURACY_SUMMARY -->
-| **Accuracy denominator** | 25 fixtures / 25 families | 105 scored lines, 92 scored symbols, 2 fully labeled, 22 partial, 21 unknown, 5 negative, 4 dynamic boundaries, 5 unsupported, 0 real-project, 0 generated, 25 hand-labeled; cadence `pr` | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
+| **Accuracy denominator** | 35 fixtures / 25 families | 115 scored lines, 102 scored symbols, 2 fully labeled, 32 partial, 31 unknown, 5 negative, 4 dynamic boundaries, 5 unsupported, 0 real-project, 0 generated, 35 hand-labeled; cadence `pr` | `target/metrics/parser_accuracy.json`; `.kiro/specs/parser-accuracy-observability` |
 | **Accuracy families** | autoload (1), control_flow (1), dynamic_require (1), eval_string (1), export_tags (1), format (1), +19 more | fixture family inventory from parser accuracy manifest | `target/metrics/parser_accuracy.json` |
-| **Accuracy scorers** | selected line_construct_f1=1.0 (n=83), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=1.0 (n=36), symbol_ref_f1=1.0 (n=11), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 118 additional measured rows; 53 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
+| **Accuracy scorers** | selected line_construct_f1=1.0 (n=93), ast_node_kind_f1=1.0 (n=9), symbol_decl_f1=1.0 (n=36), symbol_ref_f1=1.0 (n=11), dynamic_false_precision_count=0.0 (n=1), fast_path_wrong_result_count=0.0 (n=1); 118 additional measured rows; 53 insufficient_data rows preserved | missing accuracy rows stay `insufficient_data`; they are not rendered as zero or pass | `.ci/schemas/parser-accuracy.schema.json` |
 <!-- END: PARSER_ACCURACY_SUMMARY -->
 
 ## Parser Performance Regimes


### PR DESCRIPTION
## ProblemExpand parser-accuracy denominator coverage for recovery/malformed scenarios so parser recovery and incomplete-code behavior becomes measurable in editor-relevant fixtures.## FixAdd malformed recovery fixtures and manifest rows for:- unterminated_heredoc- bad_heredoc_terminator- unclosed_quote_like_operator- unclosed_regex_operator- unbalanced_bracket- partial_sub_body- orphan_close_delimiters- missing_comma_list- nested_malformed_delimiters- post_error_package_sub_recoveryRegenerate parser status after fixture changes.## Validation- cargo xtask metrics parser-accuracy --json- cargo xtask metrics parser-accuracy --check- cargo xtask metrics ratchet-check parser_accuracy --current target/receipts/metrics/parser_accuracy.json- cargo xtask update-status --only parser --write- cargo xtask update-status --only parser --check- cargo test -p xtask --profile agent --locked -j 1 parser_accuracy -- --nocapture- cargo clippy -p xtask --profile agent --locked -j 1 -- -D warnings -A missing_docs- git diff --check## Notes- failure_packets against regenerated origin/master baseline remain unchanged at 12.- dynamic_false_precision_count = 0- fast_path_wrong_result_count = 0- no parser runtime, no semantic schema, and no status drift outside parser.md and parser manifest.