### PR TITLE
feat(completion): add medium-confidence labels to receiver detail text (#7925)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1718,10 +1718,106 @@ $x->"#;
 
     let bark = must_some(completions.iter().find(|c| c.label == "bark"));
     let detail = must_some(bark.detail.as_deref());
+    // Outcome C from #7925: medium-confidence evidence (LiteralBless) gets
+    // an explicit `, medium confidence` suffix.
     assert!(
-        detail.contains("receiver: literal bless"),
-        "literal bless detail should include literal-bless receiver evidence; got {detail:?}"
+        detail.contains("receiver: literal bless, medium confidence"),
+        "literal bless detail should include `receiver: literal bless, medium confidence`; got {detail:?}"
     );
+    Ok(())
+}
+
+#[test]
+fn detail_omits_confidence_label_for_high_confidence_static_package()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Outcome C from #7925: high-confidence evidence (StaticPackage) stays
+    // unlabelled — the detail must not contain "medium confidence" or
+    // "high confidence" noise.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = "Foo->";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = must_some(completions.iter().find(|c| c.label == "bark"));
+    let detail = must_some(bark.detail.as_deref());
+    assert!(
+        detail.contains("receiver: static package"),
+        "static-package detail should still include receiver suffix; got {detail:?}"
+    );
+    assert!(
+        !detail.contains("medium confidence"),
+        "high-confidence StaticPackage detail must not be labelled medium confidence; got {detail:?}"
+    );
+    assert!(
+        !detail.contains("high confidence"),
+        "high-confidence StaticPackage detail must not be labelled high confidence; got {detail:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn detail_includes_medium_confidence_label_for_type_engine_or_constructor_assignment()
+-> Result<(), Box<dyn std::error::Error>> {
+    // For `my $x = Foo->new; $x->`, two paths can fire:
+    //   - TypeEngine (medium) → labelled
+    //   - ConstructorAssignment (high) → unlabelled
+    //
+    // Outcome C from #7925: detail must include the medium label only
+    // when the firing variant is medium-confidence. This test asserts the
+    // (label present) ⇔ (TypeEngine fired) implication so neither path
+    // accidentally drops or adds a label.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub new { bless {}, shift }
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = Foo->new;
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = must_some(completions.iter().find(|c| c.label == "bark"));
+    let detail = must_some(bark.detail.as_deref());
+
+    let has_type_engine = detail.contains("receiver: type engine");
+    let has_constructor = detail.contains("receiver: constructor assignment");
+    let has_medium_label = detail.contains("medium confidence");
+
+    assert!(
+        has_type_engine || has_constructor,
+        "constructor-assignment fixture must emit one of the two valid receiver labels; got {detail:?}"
+    );
+    if has_type_engine {
+        assert!(
+            has_medium_label,
+            "TypeEngine evidence is medium-confidence; detail must include `medium confidence`; got {detail:?}"
+        );
+    } else {
+        // ConstructorAssignment fired; high-confidence, unlabelled.
+        assert!(
+            !has_medium_label,
+            "ConstructorAssignment is high-confidence; detail must NOT include `medium confidence`; got {detail:?}"
+        );
+    }
     Ok(())
 }
 
@@ -1834,12 +1930,15 @@ fn detail_with_evidence_helper_handles_both_base_formats() {
 
     // Semantic path's base format ("method from Foo" / "inherited method from Parent"
     // / "generated accessor from Foo"):
+    // LiteralBless is medium-confidence — outcome C from #7925 appends
+    // ", medium confidence".
     let semantic_own = detail_with_evidence(
         "method from Foo".to_string(),
         &ReceiverEvidence::LiteralBless("Foo".to_string()),
     );
-    assert_eq!(semantic_own, "method from Foo — receiver: literal bless");
+    assert_eq!(semantic_own, "method from Foo — receiver: literal bless, medium confidence");
 
+    // ConstructorAssignment is high-confidence — no label appended.
     let semantic_inherited = detail_with_evidence(
         "inherited method from Parent".to_string(),
         &ReceiverEvidence::ConstructorAssignment("Foo".to_string()),
@@ -1849,11 +1948,12 @@ fn detail_with_evidence_helper_handles_both_base_formats() {
         "inherited method from Parent — receiver: constructor assignment"
     );
 
+    // TypeEngine is medium-confidence — outcome C appends label.
     let generated = detail_with_evidence(
         "generated accessor from Foo".to_string(),
         &ReceiverEvidence::TypeEngine("Foo".to_string()),
     );
-    assert_eq!(generated, "generated accessor from Foo — receiver: type engine");
+    assert_eq!(generated, "generated accessor from Foo — receiver: type engine, medium confidence");
 
     // Unknown evidence: base detail is returned unchanged.
     let unknown = detail_with_evidence("Foo method".to_string(), &ReceiverEvidence::Unknown);

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -597,9 +597,16 @@ impl ReceiverEvidence {
 /// string. Returns the unchanged base when the evidence carries no suffix
 /// (e.g. `Unknown`). Issue #7918.
 pub(super) fn detail_with_evidence(base: String, evidence: &ReceiverEvidence) -> String {
-    match evidence.detail_suffix() {
-        Some(suffix) => format!("{base} — {suffix}"),
-        None => base,
+    let Some(suffix) = evidence.detail_suffix() else {
+        return base;
+    };
+    // Outcome C from #7925: append `, medium confidence` only to medium-
+    // confidence evidence. High-confidence evidence (the common case)
+    // stays clean. `Unknown` already returns `None` from `detail_suffix`
+    // and was handled by the early return above.
+    match evidence.confidence() {
+        Some(Confidence::Medium) => format!("{base} — {suffix}, medium confidence"),
+        _ => format!("{base} — {suffix}"),
     }
 }
 


### PR DESCRIPTION
Closes #7925
Plan source: #7925
Plan-review decisions: [#7925 comment](https://github.com/EffortlessMetrics/perl-lsp/issues/7925#issuecomment-4372128130)

## Outcome: C (medium-confidence labels only)

Append `, medium confidence` to method-completion `detail` text only for medium-confidence receiver evidence. High-confidence evidence (the common case) stays unlabelled — explicitly labelling it would shout "high confidence" on the most common completion items and bury the signal where it matters.

## What the user sees

```
Foo method                    — receiver: static package
method from Foo               — receiver: self/this
method from Foo               — receiver: constructor assignment
Foo method                    — receiver: literal bless, medium confidence
method from Foo               — receiver: type engine, medium confidence
inherited method from Parent  — receiver: self/this
```

## Why outcome C, not A or B

- **Outcome A (label everything)** would clutter the most common completion items.
- **Outcome B (no labels)** leaves the user with no signal that literal `bless` and type-engine inferences are weaker than literal-package or `$self` cases.
- **Outcome C** lands the signal where it matters: runtime constructs (literal `bless`) and type-engine inferences are visibly flagged as medium confidence; literal package / `$self` / `Foo->new` stay clean.

## What changed

| File | Change |
|---|---|
| `crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs` | `detail_with_evidence` now branches on `evidence.confidence()`. `Some(Medium)` → append `, medium confidence`; otherwise unchanged. |
| `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs` | Updated `detail_with_evidence_helper_handles_both_base_formats` exact assertions for the new strings. Strengthened `detail_includes_literal_bless_receiver_evidence` to assert the exact medium suffix. Added 2 new tests pinning the high-stays-clean and the (label ↔ TypeEngine) implication invariants. |

Two files; the production-code change is a single match arm.

## Hard-constraints honored

- ✅ Detail-only — no `label`, `insert_text`, `filter_text`, `sort_text` change
- ✅ No candidate inclusion or ranking change
- ✅ `Unknown` / dynamic receivers continue producing no method completions
- ✅ No parser / semantic-fact schema / `TypeInferenceEngine` changes
- ✅ No dashboard / status / scorecard / generated-artifact changes

## Tests

| Test | Asserts |
|---|---|
| `detail_with_evidence_helper_handles_both_base_formats` (updated) | LiteralBless and TypeEngine produce `, medium confidence`; StaticPackage / SelfOrThis / ConstructorAssignment stay unlabelled; Unknown returns base unchanged |
| `detail_includes_literal_bless_receiver_evidence` (strengthened) | Production callsite emits `receiver: literal bless, medium confidence` |
| `detail_omits_confidence_label_for_high_confidence_static_package` (new) | StaticPackage detail does NOT contain `medium confidence` or `high confidence` |
| `detail_includes_medium_confidence_label_for_type_engine_or_constructor_assignment` (new) | (label present) ⇔ (TypeEngine fired) for the ambiguous-path fixture |

## Verification (all green)

- `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- detail` — **11 / 11 passed**
- `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- completion` — 262 / 262
- `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- classify_receiver` — 15 / 15
- `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- bless` — 14 / 14
- `cargo test -p perl-workspace --profile agent --locked --lib -- method_candidates` — 9 / 9
- clippy clean, fmt clean, scorecard + shadow-compare green, `git diff --check` clean

## Non-goals

- No high-confidence labels (would be noise on common completion items)
- No unknown-receiver fallback (separate policy issue — changes candidate inclusion)
- No UX dashboard update (follow-up docs PR after merge)
- No `TypeInferenceEngine` expansion

## Test plan

- [x] Inspect rendered diff: confirm only the 2 expected files changed
- [x] Confirm medium-confidence variants get the suffix; high stays clean
- [x] Confirm `label`, `insert_text`, `filter_text`, `sort_text` unchanged
- [x] Confirm Unknown / dynamic receivers continue producing no completions for foreign packages