### PR TITLE
feat(completion): add bounded low-confidence fallback for unknown method receivers (#7929)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -171,6 +171,12 @@ pub struct CompletionProvider {
     type_engine: Option<TypeInferenceEngine>,
     workspace_index: Option<Arc<WorkspaceIndex>>,
     import_map: ImportMap,
+    /// Modules referenced by `use` statements in the buffer, regardless
+    /// of explicit symbol lists. Used by the bounded Unknown-receiver
+    /// method-completion fallback (#7929) — bare `use Foo;` *is*
+    /// captured here, while `import_map` only tracks explicit symbol
+    /// lists.
+    used_modules: HashSet<String>,
     include_paths: Vec<PathBuf>,
     system_inc_paths: Vec<PathBuf>,
     include_system_inc: bool,
@@ -287,6 +293,7 @@ impl CompletionProvider {
             type_engine
         });
         let import_map = import_map::extract_import_map(ast);
+        let used_modules = import_map::collect_used_module_names(ast);
 
         CompletionProvider {
             symbol_table,
@@ -294,6 +301,7 @@ impl CompletionProvider {
             type_engine,
             workspace_index,
             import_map,
+            used_modules,
             include_paths,
             system_inc_paths,
             include_system_inc,
@@ -553,6 +561,7 @@ impl CompletionProvider {
                 source,
                 self.type_engine.as_ref(),
                 &self.workspace_index,
+                &self.used_modules,
             );
         } else if context.prefix.starts_with('$') && context.prefix.contains("::") {
             packages::add_package_completions(&mut completions, &context, &self.workspace_index);

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map.rs
@@ -283,3 +283,38 @@ pub(super) fn extract_import_map(ast: &Node) -> ImportMap {
     collect(ast, &mut map);
     map
 }
+
+/// Collect the set of module names that the buffer's AST `use`s,
+/// regardless of whether each `use` has an explicit symbol list.
+///
+/// Unlike [`extract_import_map`] this does NOT track which symbols were
+/// imported; it only records *which packages* are referenced by `use`
+/// statements. Used by the bounded Unknown-receiver method-completion
+/// fallback (#7929) to know which workspace packages are visible from
+/// the current file.
+///
+/// `use Foo;`, `use Foo ();`, `use Foo qw(bar);`, and `use Foo BAR;`
+/// all add `Foo` to the returned set. Pragma-style lowercase modules
+/// (e.g. `use strict;`) are excluded.
+pub(super) fn collect_used_module_names(ast: &Node) -> HashSet<String> {
+    let mut modules: HashSet<String> = HashSet::new();
+
+    fn walk(node: &Node, modules: &mut HashSet<String>) {
+        match &node.kind {
+            NodeKind::Use { module, .. } => {
+                if module.chars().next().is_some_and(|c: char| c.is_ascii_uppercase()) {
+                    modules.insert(module.clone());
+                }
+            }
+            NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                for stmt in statements {
+                    walk(stmt, modules);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    walk(ast, &mut modules);
+    modules
+}

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -2187,12 +2187,17 @@ sub bark { }
 }
 
 #[test]
-fn fallback_sorts_below_exact_receiver_completions() -> Result<(), Box<dyn std::error::Error>> {
-    // When both an exact receiver and a fallback could produce the same
-    // method label, the existing dedup means the fallback skips
-    // already-emitted labels. This test pins the tier discipline:
-    // fallback uses tier 6, exact uses tiers 2/3, so any overlap-free
-    // fallback method sorts after exact-receiver methods.
+fn fallback_tier_is_below_exact_receiver_tiers() -> Result<(), Box<dyn std::error::Error>> {
+    // Pins the tier-vs-tier contract by running two completion requests
+    // against the same workspace index:
+    //   1. exact:    `Foo->`         must surface `bark` at tier 2 or 3
+    //                                with no `unknown` in detail
+    //   2. fallback: `use Bar;\n$obj->` must surface `mew` at tier 6
+    //                                with `receiver: unknown, low confidence`
+    // The earlier `fallback_sorts_below_exact_receiver_completions` test
+    // only exercised path #1 (fallback never fires for `Foo->`), so it
+    // could not actually prove the tier discipline. This replacement
+    // exercises both paths and asserts the numeric tier ordering.
     let index = Arc::new(WorkspaceIndex::new());
     index.index_file(
         Url::parse("file:///workspace/Foo.pm")?,
@@ -2211,27 +2216,60 @@ sub mew { }
         .to_string(),
     )?;
 
-    // Use Bar (its method `mew` should be in fallback) and call exact
-    // `Foo->bark`. The exact `bark` is tier 2; fallback `mew` is tier 6.
-    let code = r#"use Bar;
-Foo->"#;
-    let mut parser = Parser::new(code);
-    let ast = must(parser.parse());
-    let provider = CompletionProvider::new_with_index(&ast, Some(index));
-    let completions = provider.get_completions(code, code.len());
+    // Request 1 — exact receiver via `Foo->`.
+    let exact_code = "Foo->";
+    let mut parser_exact = Parser::new(exact_code);
+    let exact_ast = must(parser_exact.parse());
+    let exact_provider = CompletionProvider::new_with_index(&exact_ast, Some(index.clone()));
+    let exact_completions = exact_provider.get_completions(exact_code, exact_code.len());
+    let bark = must_some(exact_completions.iter().find(|c| c.label == "bark"));
+    let bark_sort = must_some(bark.sort_text.as_deref());
+    let bark_detail = must_some(bark.detail.as_deref());
+    assert!(
+        bark_sort.starts_with("2_") || bark_sort.starts_with("3_"),
+        "exact Foo->bark must use tier 2 or 3; got {bark_sort:?}"
+    );
+    assert!(
+        !bark_detail.contains("unknown"),
+        "exact-receiver detail must not contain 'unknown'; got {bark_detail:?}"
+    );
 
-    let bark = completions.iter().find(|c| c.label == "bark");
-    if let Some(bark) = bark {
-        // Static `Foo->` is exact receiver, so we expect tier 2 here.
-        let s = must_some(bark.sort_text.as_deref());
-        assert!(
-            s.starts_with("2_") || s.starts_with("3_"),
-            "exact Foo->bark must use tier 2 or 3; got {s:?}"
-        );
-    }
-    // Note: in the "Foo->" prefix case, fallback does not fire because
-    // the receiver is `StaticPackage`. We're really pinning that exact-
-    // receiver completion went through tier 2/3 unchanged.
+    // Request 2 — Unknown receiver fallback via `use Bar;\n$obj->`.
+    let fallback_code = "use Bar;\n$obj->";
+    let mut parser_fb = Parser::new(fallback_code);
+    let fallback_ast = must(parser_fb.parse());
+    let fallback_provider = CompletionProvider::new_with_index(&fallback_ast, Some(index));
+    let fallback_completions =
+        fallback_provider.get_completions(fallback_code, fallback_code.len());
+    let mew = must_some(fallback_completions.iter().find(|c| c.label == "mew"));
+    let mew_sort = must_some(mew.sort_text.as_deref());
+    let mew_detail = must_some(mew.detail.as_deref());
+    assert!(
+        mew_sort.starts_with("6_"),
+        "Unknown-receiver fallback `mew` must use tier 6; got {mew_sort:?}"
+    );
+    assert!(
+        mew_detail.contains("receiver: unknown, low confidence"),
+        "fallback detail should say receiver: unknown, low confidence; got {mew_detail:?}"
+    );
+
+    // Numeric tier proof: exact tier (2 or 3) < fallback tier (6).
+    let exact_tier: u8 = bark_sort
+        .as_bytes()
+        .first()
+        .copied()
+        .and_then(|b| (b as char).to_digit(10).map(|d| d as u8))
+        .expect("exact sort_text must start with a digit");
+    let fallback_tier: u8 = mew_sort
+        .as_bytes()
+        .first()
+        .copied()
+        .and_then(|b| (b as char).to_digit(10).map(|d| d as u8))
+        .expect("fallback sort_text must start with a digit");
+    assert!(
+        exact_tier < fallback_tier,
+        "exact tier {exact_tier} must sort above fallback tier {fallback_tier}"
+    );
     Ok(())
 }
 
@@ -2452,6 +2490,46 @@ $x->"#;
     let ctx = ctx_for("$x->", "main", source.len());
     let ev = classify_text_pattern_receiver(&ctx, source);
     assert_eq!(ev, ReceiverEvidence::Unknown);
+}
+
+#[test]
+fn classify_receiver_variable_named_bless_is_unknown_fallback_eligible() {
+    // `$bless` as RHS — the substring `bless` is preceded by a `$` sigil
+    // and is therefore an identifier suffix, not a call-like `bless`
+    // keyword. Must NOT be classified as Dynamic; must remain Unknown so
+    // the bounded fallback (#7929) is still eligible.
+    let source = r#"my $x = $bless;
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
+    assert!(ev.is_unknown_fallback_eligible());
+}
+
+#[test]
+fn classify_receiver_bless_in_comment_is_not_dynamic() {
+    // A `# bless ...` comment after the assignment must not be treated as
+    // a dynamic bless expression. The RHS scan should stop at `#`
+    // (single-line comment terminator), keeping evidence Unknown.
+    let source = r#"my $x = $obj; # bless this later
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
+    assert!(ev.is_unknown_fallback_eligible());
+}
+
+#[test]
+fn classify_receiver_hash_key_bless_is_not_dynamic() {
+    // `$obj->{bless}` is a hash-key access whose key happens to be the
+    // word `bless`. Preceded by `{`, this is not a call-like `bless`
+    // and must not become Dynamic.
+    let source = r#"my $x = $obj->{bless};
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
+    assert!(ev.is_unknown_fallback_eligible());
 }
 
 #[test]
@@ -3601,4 +3679,66 @@ fn test_non_empty_inc_paths_do_not_change_phase1_completions()
         "non-empty include paths must not change completions in phase 1 (no filesystem scanning yet)"
     );
     Ok(())
+}
+
+// -------------------------------------------------------------------------
+// `collect_used_module_names` direct tests (issue #7929)
+//
+// The Unknown-receiver bounded fallback consumes this helper to decide
+// which workspace packages count as "visible" to the buffer. Pin the
+// inclusion / exclusion contract directly so the source-policy is
+// reviewable without going through the full completion pipeline.
+// -------------------------------------------------------------------------
+
+#[test]
+fn collect_used_module_names_includes_bare_use() {
+    let code = "use Foo;\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let modules = super::import_map::collect_used_module_names(&ast);
+    assert!(modules.contains("Foo"), "bare `use Foo;` should include Foo; got {modules:?}");
+}
+
+#[test]
+fn collect_used_module_names_includes_empty_import_list() {
+    let code = "use Foo ();\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let modules = super::import_map::collect_used_module_names(&ast);
+    assert!(
+        modules.contains("Foo"),
+        "`use Foo ();` should still include Foo as a visible package; got {modules:?}"
+    );
+}
+
+#[test]
+fn collect_used_module_names_includes_qw_list() {
+    let code = "use Foo qw(bar baz);\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let modules = super::import_map::collect_used_module_names(&ast);
+    assert!(
+        modules.contains("Foo"),
+        "`use Foo qw(...);` should include Foo as a visible package; got {modules:?}"
+    );
+}
+
+#[test]
+fn collect_used_module_names_excludes_lowercase_pragmas() {
+    let code = "use strict;\nuse warnings;\nuse feature 'say';\n";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let modules = super::import_map::collect_used_module_names(&ast);
+    assert!(
+        !modules.contains("strict"),
+        "`use strict` (lowercase pragma) must be excluded; got {modules:?}"
+    );
+    assert!(
+        !modules.contains("warnings"),
+        "`use warnings` (lowercase pragma) must be excluded; got {modules:?}"
+    );
+    assert!(
+        !modules.contains("feature"),
+        "`use feature` (lowercase pragma) must be excluded; got {modules:?}"
+    );
 }

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1991,6 +1991,281 @@ sub bark { }
 }
 
 // -------------------------------------------------------------------------
+// Unknown-receiver bounded fallback (issue #7929, outcome A)
+//
+// These tests pin the production-callsite behavior of the bounded
+// low-confidence fallback. Source policy:
+//   - imported / visible packages from the buffer's `import_map`
+//   - current package (when not `main`) and its `@ISA` chain
+// All-workspace fallback is intentionally NOT used. Dynamic (positively
+// detected fail-closed bless forms) is NOT fallback-eligible.
+// -------------------------------------------------------------------------
+
+#[test]
+fn fallback_offers_imported_package_methods_for_unknown_receiver()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    // Buffer imports Foo and calls a method on a variable that has no
+    // receiver-evidence assignment (`$obj` is undeclared / unknown).
+    // Receiver evidence is `Unknown` — fallback should fire from the
+    // imported `Foo` package.
+    let code = r#"use Foo;
+1;
+$obj->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = completions.iter().find(|c| c.label == "bark");
+    if bark.is_none() {
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        panic!("fallback should include imported Foo's `bark`; got labels: {labels:?}");
+    }
+    let bark = bark.expect("checked above");
+    let detail = must_some(bark.detail.as_deref());
+    assert!(
+        detail.contains("receiver: unknown, low confidence"),
+        "fallback detail should say receiver: unknown, low confidence; got {detail:?}"
+    );
+    let sort_text = must_some(bark.sort_text.as_deref());
+    assert!(sort_text.starts_with("6_"), "fallback sort_text should be tier 6; got {sort_text:?}");
+    Ok(())
+}
+
+#[test]
+fn fallback_offers_current_package_methods_for_unknown_receiver()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/MyService.pm")?,
+        r#"package MyService;
+sub helper { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    // In package MyService, calling a method on an undeclared variable —
+    // receiver is Unknown, current-package methods are the bounded source.
+    let code = r#"package MyService;
+$obj->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let helper = must_some(completions.iter().find(|c| c.label == "helper"));
+    let detail = must_some(helper.detail.as_deref());
+    assert!(
+        detail.contains("receiver: unknown, low confidence"),
+        "fallback detail should say receiver: unknown, low confidence; got {detail:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn fallback_does_not_include_unrelated_workspace_packages() -> Result<(), Box<dyn std::error::Error>>
+{
+    // `Unrelated` is indexed in the workspace but neither imported by
+    // the buffer nor part of the current package graph. Bounded fallback
+    // must NOT include `Unrelated::quack`.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+    index.index_file(
+        Url::parse("file:///workspace/Unrelated.pm")?,
+        r#"package Unrelated;
+sub quack { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"use Foo;
+1;
+$obj->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        completions.iter().any(|c| c.label == "bark"),
+        "fallback should include imported Foo's methods; got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    assert!(
+        !completions.iter().any(|c| c.label == "quack"),
+        "fallback must NOT include unrelated workspace packages (#7929 bounded source policy)"
+    );
+    Ok(())
+}
+
+#[test]
+fn fallback_does_not_fire_for_dynamic_receiver() -> Result<(), Box<dyn std::error::Error>> {
+    // `bless {}, $class` is Dynamic — fail-closed. Even though Foo is
+    // imported, fallback must not fire (Dynamic is explicitly not
+    // fallback-eligible per #7929).
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"use Foo;
+my $class = "Foo";
+my $x = bless {}, $class;
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        !completions.iter().any(|c| c.label == "bark"),
+        "Dynamic receiver must stay fail-closed even with Foo imported; got {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn fallback_does_not_alter_exact_receiver_detail_or_order() -> Result<(), Box<dyn std::error::Error>>
+{
+    // Exact receiver case: `Foo->bark`. After this PR fallback exists,
+    // but exact-receiver completions must keep their existing detail
+    // (with `receiver: static package`), tier-2 sort, and label/insert
+    // shape. No `receiver: unknown` should leak into exact completions.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = "Foo->";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = must_some(completions.iter().find(|c| c.label == "bark"));
+    let detail = must_some(bark.detail.as_deref());
+    assert!(
+        detail.contains("receiver: static package"),
+        "exact static-package detail unchanged; got {detail:?}"
+    );
+    assert!(
+        !detail.contains("unknown"),
+        "exact-receiver detail must not contain 'unknown'; got {detail:?}"
+    );
+    assert_eq!(bark.sort_text.as_deref(), Some("2_bark"), "exact-receiver sort tier unchanged");
+    Ok(())
+}
+
+#[test]
+fn fallback_sorts_below_exact_receiver_completions() -> Result<(), Box<dyn std::error::Error>> {
+    // When both an exact receiver and a fallback could produce the same
+    // method label, the existing dedup means the fallback skips
+    // already-emitted labels. This test pins the tier discipline:
+    // fallback uses tier 6, exact uses tiers 2/3, so any overlap-free
+    // fallback method sorts after exact-receiver methods.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+    index.index_file(
+        Url::parse("file:///workspace/Bar.pm")?,
+        r#"package Bar;
+sub mew { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    // Use Bar (its method `mew` should be in fallback) and call exact
+    // `Foo->bark`. The exact `bark` is tier 2; fallback `mew` is tier 6.
+    let code = r#"use Bar;
+Foo->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = completions.iter().find(|c| c.label == "bark");
+    if let Some(bark) = bark {
+        // Static `Foo->` is exact receiver, so we expect tier 2 here.
+        let s = must_some(bark.sort_text.as_deref());
+        assert!(
+            s.starts_with("2_") || s.starts_with("3_"),
+            "exact Foo->bark must use tier 2 or 3; got {s:?}"
+        );
+    }
+    // Note: in the "Foo->" prefix case, fallback does not fire because
+    // the receiver is `StaticPackage`. We're really pinning that exact-
+    // receiver completion went through tier 2/3 unchanged.
+    Ok(())
+}
+
+#[test]
+fn fallback_omits_when_no_imports_and_main_package() -> Result<(), Box<dyn std::error::Error>> {
+    // No `use` and the buffer is in main package — `allowed_packages`
+    // is empty in `add_unknown_receiver_fallback`, so fallback emits
+    // no candidates. This is the `detail_unchanged_when_no_receiver_…`
+    // contract: bounded fallback respects the bound.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = "$nonexistent->";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        !completions.iter().any(|c| c.label == "bark"),
+        "no imports + main package + Unknown receiver = no fallback (bounded source empty); got {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
 // Receiver-evidence classification (issue #7910, outcome B)
 //
 // These tests pin the typed receiver-evidence provenance produced by
@@ -2105,17 +2380,78 @@ $x->"#;
 }
 
 #[test]
-fn classify_receiver_dynamic_bless_is_unknown() {
+fn classify_receiver_dynamic_bless_is_dynamic() {
     // `bless {}, $class` is dynamic — extract_bless_literal_class fails
-    // closed, and the classifier therefore reports Unknown rather than
-    // inventing a package.
+    // closed. After #7929 the classifier reports `Dynamic` (not
+    // `Unknown`) so the Unknown-receiver fallback stays fail-closed
+    // instead of offering bounded fallback methods for the variable.
     let source = r#"my $class = "Foo";
 my $x = bless {}, $class;
 $x->"#;
     let ctx = ctx_for("$x->", "main", source.len());
     let ev = classify_text_pattern_receiver(&ctx, source);
-    assert_eq!(ev, ReceiverEvidence::Unknown);
+    assert_eq!(ev, ReceiverEvidence::Dynamic);
     assert_eq!(ev.confidence(), None);
+    assert!(!ev.is_unknown_fallback_eligible());
+}
+
+#[test]
+fn classify_receiver_dynamic_concat_class_is_dynamic() {
+    // `bless {}, "Foo" . $suffix` is non-literal — Dynamic, not Unknown.
+    let source = r#"my $suffix = "Bar";
+my $x = bless {}, "Foo" . $suffix;
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Dynamic);
+    assert!(!ev.is_unknown_fallback_eligible());
+}
+
+#[test]
+fn classify_receiver_dynamic_nested_bless_is_dynamic() {
+    // `wrapper(bless {}, "Foo")` is nested — assignment result is the
+    // wrapper return, not the blessed object. Dynamic, not Unknown.
+    let source = r#"sub wrapper { return $_[0]; }
+my $x = wrapper(bless {}, "Foo");
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Dynamic);
+    assert!(!ev.is_unknown_fallback_eligible());
+}
+
+#[test]
+fn classify_receiver_dynamic_qualified_prefix_is_dynamic() {
+    // `bless::class {}, "Foo"` is a non-builtin qualified call. Dynamic.
+    let source = r#"my $x = bless::class {}, "Foo";
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Dynamic);
+    assert!(!ev.is_unknown_fallback_eligible());
+}
+
+#[test]
+fn classify_receiver_unknown_is_fallback_eligible() {
+    // True unknown — no `bless` keyword, no assignment evidence — is
+    // fallback-eligible.
+    let source = "$nonexistent->";
+    let ctx = ctx_for("$nonexistent->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
+    assert!(ev.is_unknown_fallback_eligible());
+}
+
+#[test]
+fn classify_receiver_bless_keyword_inside_string_is_not_dynamic() {
+    // The substring `bless` appears in a string literal, not as a Perl
+    // keyword. The `rhs_has_bless_keyword_outside_strings` helper must
+    // skip string contents — this scenario is Unknown, not Dynamic.
+    let source = r#"my $x = "I bless this house";
+$x->"#;
+    let ctx = ctx_for("$x->", "main", source.len());
+    let ev = classify_text_pattern_receiver(&ctx, source);
+    assert_eq!(ev, ReceiverEvidence::Unknown);
 }
 
 #[test]

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -742,14 +742,21 @@ pub(super) fn classify_text_pattern_receiver(
     ReceiverEvidence::Unknown
 }
 
-/// Returns `true` when the RHS contains the `bless` keyword as a whole
-/// word, outside string literals. Used by `classify_text_pattern_receiver`
-/// to detect dynamic / fail-closed bless expressions that could not be
-/// resolved to a literal class — these include nested calls
-/// (`wrapper(bless {}, "Foo")`), expression-tail forms
-/// (`bless {}, "Foo" . $suffix`), dynamic class
+/// Returns `true` when the RHS contains a *call-like* `bless` keyword
+/// outside string literals and comments. Used by
+/// `classify_text_pattern_receiver` to detect dynamic / fail-closed bless
+/// expressions that could not be resolved to a literal class — these
+/// include nested calls (`wrapper(bless {}, "Foo")`), expression-tail
+/// forms (`bless {}, "Foo" . $suffix`), dynamic class
 /// (`bless {}, $class`), and non-builtin `bless`-prefixed identifiers
 /// (`bless::class {}, "Foo"`). Issue #7929.
+///
+/// "Call-like" means `bless` is followed by ASCII whitespace, `(`, or
+/// `::` (the qualified non-builtin form), and is not preceded by a Perl
+/// sigil (`$`/`@`/`%`/`&`), an identifier byte, or a hash-key opener
+/// (`{`). This rejects harmless mentions like `$bless`, `$obj->{bless}`,
+/// and `# bless ...` comments which should remain Unknown / fallback-
+/// eligible rather than fail-closed Dynamic.
 fn rhs_has_bless_keyword_outside_strings(rhs: &str) -> bool {
     let bytes = rhs.as_bytes();
     let needle = b"bless";
@@ -767,22 +774,54 @@ fn rhs_has_bless_keyword_outside_strings(rhs: &str) -> bool {
             continue;
         }
         prev_was_backslash = false;
+        // Outside strings, `#` starts a comment that runs to end-of-line.
+        // The RHS scan is single-line, so terminate here.
+        if b == b'#' {
+            return false;
+        }
         if b == b'"' || b == b'\'' {
             in_string = Some(b);
             i += 1;
             continue;
         }
-        if i + needle.len() <= bytes.len() && &bytes[i..i + needle.len()] == needle {
-            let prev_ok = i == 0 || !is_perl_ident_byte_local(bytes[i - 1]);
-            let next_idx = i + needle.len();
-            let next_ok = next_idx >= bytes.len() || !is_perl_ident_byte_local(bytes[next_idx]);
-            if prev_ok && next_ok {
-                return true;
-            }
+        if i + needle.len() <= bytes.len()
+            && &bytes[i..i + needle.len()] == needle
+            && is_call_like_bless(bytes, i)
+        {
+            return true;
         }
         i += 1;
     }
     false
+}
+
+/// Returns `true` when the `bless` token at `bytes[i..i+5]` is *call-like*:
+/// not preceded by a sigil/ident-byte/hash-key opener, and followed by
+/// whitespace, `(`, or `::`. See [`rhs_has_bless_keyword_outside_strings`].
+fn is_call_like_bless(bytes: &[u8], i: usize) -> bool {
+    let prev_ok = match i.checked_sub(1).map(|j| bytes[j]) {
+        None => true,
+        Some(p) => {
+            !is_perl_ident_byte_local(p)
+                && p != b'$'
+                && p != b'@'
+                && p != b'%'
+                && p != b'&'
+                && p != b'{'
+        }
+    };
+    if !prev_ok {
+        return false;
+    }
+    let next_idx = i + b"bless".len();
+    match bytes.get(next_idx).copied() {
+        None => false,
+        Some(n) => {
+            n.is_ascii_whitespace()
+                || n == b'('
+                || (n == b':' && bytes.get(next_idx + 1).copied() == Some(b':'))
+        }
+    }
 }
 
 fn is_perl_ident_byte_local(b: u8) -> bool {

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -537,15 +537,23 @@ pub(super) enum ReceiverEvidence {
     TypeEngine(String),
     /// No receiver evidence found, OR a positively-detected dynamic form
     /// (e.g. `bless {}, $class`, expression-tail class, nested call,
-    /// non-builtin `bless`-prefixed identifier). Method completion does
-    /// not suggest any specific package's methods in this case — same as
-    /// the pre-#7910 behavior.
+    /// Positively-detected dynamic / fail-closed receiver form — e.g.
+    /// `bless {}, $class`, `bless {}, "Foo" . $suffix`,
+    /// `wrapper(bless {}, "Foo")`, `bless::class {}, "Foo"`. The user
+    /// typed something we *can* see is a `bless` expression but the
+    /// resulting class is not a literal we can pin down. Method
+    /// completion stays fail-closed for these — no exact receiver
+    /// completions and no Unknown-receiver fallback (#7929 outcome A).
+    Dynamic,
+    /// No receiver evidence found at all (e.g. `$obj->` where `$obj` is
+    /// a sub parameter with no assignment in scope). Eligible for the
+    /// bounded low-confidence fallback added in #7929 outcome A.
     Unknown,
 }
 
 impl ReceiverEvidence {
-    /// Returns the inferred receiver package, if any. `Unknown` returns
-    /// `None`.
+    /// Returns the inferred receiver package, if any. `Dynamic` and
+    /// `Unknown` both return `None`.
     pub(super) fn package(&self) -> Option<&str> {
         match self {
             Self::StaticPackage(p)
@@ -553,19 +561,26 @@ impl ReceiverEvidence {
             | Self::ConstructorAssignment(p)
             | Self::LiteralBless(p)
             | Self::TypeEngine(p) => Some(p.as_str()),
-            Self::Unknown => None,
+            Self::Dynamic | Self::Unknown => None,
         }
+    }
+
+    /// Returns `true` only when this evidence is eligible for the
+    /// bounded Unknown-receiver fallback (#7929). `Dynamic` is
+    /// explicitly *not* eligible — dynamic boundaries stay fail-closed.
+    pub(super) fn is_unknown_fallback_eligible(&self) -> bool {
+        matches!(self, Self::Unknown)
     }
 
     /// Returns the confidence level for this evidence kind, using the
     /// shared `perl_semantic_facts::Confidence` vocabulary so the rest of
-    /// the semantic stack speaks the same language. `Unknown` returns
-    /// `None` — there is no confidence when there is no evidence.
+    /// the semantic stack speaks the same language. `Dynamic` and
+    /// `Unknown` return `None` — there is no confidence when there is
+    /// no exact evidence.
     ///
-    /// Today the production method-completion callsite does not read this;
-    /// it is exposed for tests and for the future PR that wires confidence
-    /// into ranking or detail text once a real seam emerges (issue #7910,
-    /// outcome B).
+    /// Today the production method-completion callsite reads this only
+    /// to decide medium-confidence labelling on detail text (#7925
+    /// outcome C). It does not yet drive ranking.
     #[allow(dead_code)]
     pub(super) fn confidence(&self) -> Option<Confidence> {
         match self {
@@ -573,14 +588,15 @@ impl ReceiverEvidence {
                 Some(Confidence::High)
             }
             Self::LiteralBless(_) | Self::TypeEngine(_) => Some(Confidence::Medium),
-            Self::Unknown => None,
+            Self::Dynamic | Self::Unknown => None,
         }
     }
 
     /// Short, user-facing suffix describing the evidence source, suitable
-    /// for appending to a `CompletionItem.detail` string. `Unknown`
-    /// returns `None` — when there is no evidence, there is nothing to
-    /// say. Issue #7918: explanatory only, no ranking / inclusion change.
+    /// for appending to a `CompletionItem.detail` string. `Dynamic` and
+    /// `Unknown` return `None` — when there is no exact evidence, there
+    /// is nothing to label. Issue #7918: explanatory only, no ranking /
+    /// inclusion change.
     pub(super) fn detail_suffix(&self) -> Option<&'static str> {
         match self {
             Self::StaticPackage(_) => Some("receiver: static package"),
@@ -588,7 +604,7 @@ impl ReceiverEvidence {
             Self::ConstructorAssignment(_) => Some("receiver: constructor assignment"),
             Self::LiteralBless(_) => Some("receiver: literal bless"),
             Self::TypeEngine(_) => Some("receiver: type engine"),
-            Self::Unknown => None,
+            Self::Dynamic | Self::Unknown => None,
         }
     }
 }
@@ -708,12 +724,69 @@ pub(super) fn classify_text_pattern_receiver(
                     if let Some(class) = extract_bless_literal_class(rhs) {
                         return ReceiverEvidence::LiteralBless(class);
                     }
+                    // Pattern: dynamic / fail-closed `bless` form (#7929).
+                    // We saw a `bless` keyword in the RHS (outside string
+                    // literals) but could not extract a literal class —
+                    // covers `bless {}, $class`, `bless {}, "Foo" . $suffix`,
+                    // `wrapper(bless {}, "Foo")`, `bless::class {}, "Foo"`,
+                    // etc. The receiver is dynamic; fail closed (no exact
+                    // package and no Unknown-receiver fallback).
+                    if rhs_has_bless_keyword_outside_strings(rhs) {
+                        return ReceiverEvidence::Dynamic;
+                    }
                 }
             }
         }
     }
 
     ReceiverEvidence::Unknown
+}
+
+/// Returns `true` when the RHS contains the `bless` keyword as a whole
+/// word, outside string literals. Used by `classify_text_pattern_receiver`
+/// to detect dynamic / fail-closed bless expressions that could not be
+/// resolved to a literal class — these include nested calls
+/// (`wrapper(bless {}, "Foo")`), expression-tail forms
+/// (`bless {}, "Foo" . $suffix`), dynamic class
+/// (`bless {}, $class`), and non-builtin `bless`-prefixed identifiers
+/// (`bless::class {}, "Foo"`). Issue #7929.
+fn rhs_has_bless_keyword_outside_strings(rhs: &str) -> bool {
+    let bytes = rhs.as_bytes();
+    let needle = b"bless";
+    let mut in_string: Option<u8> = None;
+    let mut prev_was_backslash = false;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(q) = in_string {
+            if !prev_was_backslash && b == q {
+                in_string = None;
+            }
+            prev_was_backslash = !prev_was_backslash && b == b'\\';
+            i += 1;
+            continue;
+        }
+        prev_was_backslash = false;
+        if b == b'"' || b == b'\'' {
+            in_string = Some(b);
+            i += 1;
+            continue;
+        }
+        if i + needle.len() <= bytes.len() && &bytes[i..i + needle.len()] == needle {
+            let prev_ok = i == 0 || !is_perl_ident_byte_local(bytes[i - 1]);
+            let next_idx = i + needle.len();
+            let next_ok = next_idx >= bytes.len() || !is_perl_ident_byte_local(bytes[next_idx]);
+            if prev_ok && next_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+fn is_perl_ident_byte_local(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
 }
 
 /// Extract the literal class name from a `bless REF, "Class"` expression.
@@ -879,12 +952,21 @@ fn is_valid_perl_package_name(s: &str) -> bool {
 /// methods defined in the receiver's package and suggests them.
 ///
 /// Auto-import edits are attached when the receiver package is not yet imported.
+///
+/// When receiver inference returns [`ReceiverEvidence::Unknown`] (no exact
+/// receiver evidence found), the bounded low-confidence fallback added in
+/// #7929 fires: methods from imported / visible packages plus the current
+/// file's package and its `@ISA` chain are offered with a low-confidence
+/// detail label and a sort tier that puts them below all exact-receiver
+/// completions. [`ReceiverEvidence::Dynamic`] (positively-detected dynamic
+/// `bless` forms) is *not* fallback-eligible and stays fail-closed.
 pub fn add_workspace_method_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
     source: &str,
     type_engine: Option<&TypeInferenceEngine>,
     workspace_index: &Option<Arc<WorkspaceIndex>>,
+    used_modules: &HashSet<String>,
 ) {
     let Some(index) = workspace_index else {
         return;
@@ -902,6 +984,12 @@ pub fn add_workspace_method_completions(
     // seam emerges. See issue #7910 (outcome B).
     let evidence = classify_receiver(context, source, type_engine);
     let Some(package_name) = evidence.package().map(str::to_string) else {
+        // No exact receiver package. Trigger bounded Unknown-receiver
+        // fallback (#7929) only for `Unknown` evidence; `Dynamic` stays
+        // fail-closed.
+        if evidence.is_unknown_fallback_eligible() {
+            add_unknown_receiver_fallback(completions, context, index, used_modules);
+        }
         return;
     };
 
@@ -968,6 +1056,83 @@ pub fn add_workspace_method_completions(
             commit_characters: None,
             label_details: None,
         });
+    }
+}
+
+/// Bounded low-confidence fallback for method completion when receiver
+/// evidence is [`ReceiverEvidence::Unknown`] (#7929 outcome A).
+///
+/// Sources are restricted to:
+/// - imported / visible packages from the current file's `import_map`
+/// - the current package and its `@ISA` chain (via
+///   [`collect_all_package_members`]) when `current_package` is set and
+///   not `main`
+///
+/// All-workspace fallback is intentionally not used. Fallback candidates
+/// carry a `receiver: unknown, low confidence` detail suffix and use sort
+/// tier 6 so they always sort below exact-receiver completions (which
+/// use tiers 1–4).
+fn add_unknown_receiver_fallback(
+    completions: &mut Vec<CompletionItem>,
+    context: &CompletionContext,
+    index: &WorkspaceIndex,
+    used_modules: &HashSet<String>,
+) {
+    let mut allowed_packages: HashSet<String> = used_modules.clone();
+    if !context.current_package.is_empty() && context.current_package != "main" {
+        allowed_packages.insert(context.current_package.clone());
+    }
+    if allowed_packages.is_empty() {
+        return;
+    }
+
+    let method_prefix = context.prefix.rsplit("->").next().unwrap_or("");
+    let existing_labels: HashSet<String> =
+        completions.iter().map(|item| item.label.clone()).collect();
+    let mut emitted: HashSet<String> = HashSet::new();
+
+    for package_name in &allowed_packages {
+        let members = collect_all_package_members(index, package_name);
+        for symbol in members {
+            if !matches!(symbol.kind, WsSymbolKind::Subroutine | WsSymbolKind::Method) {
+                continue;
+            }
+            if !method_prefix.is_empty() && !symbol.name.starts_with(method_prefix) {
+                continue;
+            }
+            if existing_labels.contains(&symbol.name) {
+                continue;
+            }
+            if !emitted.insert(symbol.name.clone()) {
+                continue;
+            }
+
+            let defining_pkg = symbol.container_name.as_deref().unwrap_or(package_name.as_str());
+            let detail = format!(
+                "workspace method — receiver: unknown, low confidence (from {defining_pkg})"
+            );
+
+            completions.push(CompletionItem {
+                label: symbol.name.clone(),
+                kind: CompletionItemKind::Function,
+                detail: Some(detail),
+                documentation: symbol.documentation.clone().or_else(|| {
+                    Some(format!(
+                        "Workspace method `{}::{}` (low-confidence fallback for unknown receiver).",
+                        defining_pkg, symbol.name
+                    ))
+                }),
+                insert_text: Some(format!("{}()", symbol.name)),
+                // Tier 6: below all exact-receiver completion tiers
+                // (existing tiers 1–4) and below other tier-5 catch-alls.
+                sort_text: Some(format!("6_{}", symbol.name)),
+                filter_text: Some(symbol.name.clone()),
+                additional_edits: vec![],
+                text_edit_range: Some((context.prefix_start, context.position)),
+                commit_characters: None,
+                label_details: None,
+            });
+        }
     }
 }
 


### PR DESCRIPTION
Closes #7929
Plan source: #7929
Plan-review decisions: [#7929 comment](https://github.com/EffortlessMetrics/perl-lsp/issues/7929#issuecomment-4372876089)

## Outcome: A — bounded low-confidence Unknown-receiver fallback

When receiver inference returns `ReceiverEvidence::Unknown` (no exact evidence), the completion provider now offers methods from a **bounded** source — `use`d packages plus the current file's package and its `@ISA` chain — with low-confidence detail labels and a sort tier below all exact-receiver completions.

This is the first PR in this lane that **changes candidate inclusion**. Every hard constraint from the issue is honored.

## What the user sees

Before — `$obj->` with no receiver evidence produced no method completions:

```
$obj->          (no completions)
```

After — bounded fallback offers methods from imported / current packages:

```perl
use Foo;          # exports `bark`
package MyService;
sub helper { ... }
sub run {
    my ($obj) = @_;
    $obj->         # ← Unknown receiver
}
```

```
bark            workspace method — receiver: unknown, low confidence (from Foo)
helper          workspace method — receiver: unknown, low confidence (from MyService)
```

Sort tier 6 — below every exact-receiver tier.

## Hard-constraints honored

- Exact receiver unchanged. `StaticPackage` / `SelfOrThis` / `ConstructorAssignment` / `LiteralBless` / `TypeEngine` produce identical candidates, sort, and detail (with #7920 / #7926 contracts intact).
- Dynamic stays fail-closed. `ReceiverEvidence::Dynamic` positively distinguishes the four fail-closed bless forms (`bless {}, $class`, `bless {}, "Foo" . $suffix`, `wrapper(bless {}, "Foo")`, `bless::class {}, "Foo"`). Fallback explicitly does not fire for `Dynamic`.
- Bounded source. Only `used_modules` ∪ `{current_package}` are eligible. All-workspace fallback is *not* used.
- No public API expansion. `add_workspace_method_completions` is module-private; the new `used_modules` parameter is private to `perl-lsp-rs-core`.
- Tier 6 below all exact tiers. Fallback `sort_text` is `6_<name>`; exact-receiver completions stay at tiers 1–5.
- Detail label honest. `workspace method — receiver: unknown, low confidence (from <pkg>)` — both `unknown` and `low confidence` present.
- No candidate deletion. Existing labels are deduped against the existing completions list before emitting fallback items.
- No parser / schema / `TypeInferenceEngine` / dashboard / generated-artifact changes.

## Code changes

| File | Change |
|---|---|
| `crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs` | New `ReceiverEvidence::Dynamic` variant + accessors. New `rhs_has_bless_keyword_outside_strings` helper (call-like detection only, see below). New `add_unknown_receiver_fallback` function. `add_workspace_method_completions` takes `used_modules: &HashSet<String>` and triggers fallback only when `evidence.is_unknown_fallback_eligible()`. |
| `crates/perl-lsp-rs-core/src/providers/completion/completion/import_map.rs` | New `collect_used_module_names(ast) -> HashSet<String>` helper. Walks the AST for `Use` nodes and collects module names regardless of explicit symbol lists. |
| `crates/perl-lsp-rs-core/src/providers/completion/completion.rs` | `CompletionProvider` gains `used_modules: HashSet<String>`. Populated alongside `import_map`. Passed to `add_workspace_method_completions`. |
| `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs` | New fallback tests, classifier tests for `Unknown`/`Dynamic` split, two-request tier-proof test, and direct `collect_used_module_names` tests. |

## Dynamic-bless detection: call-like only (review fix-forward)

`rhs_has_bless_keyword_outside_strings` matches `bless` only when it is **call-like** — followed by ASCII whitespace, `(`, or `::` — and is **not** preceded by a sigil (`$`, `@`, `%`, `&`), a hash-key opener (`{`), or an identifier byte. Comments (`#`) terminate the RHS scan.

This rejects harmless `bless` mentions that earlier broad-word matching would have flagged as Dynamic:

| RHS | Classification | Why |
|---|---|---|
| `bless {}, $class` | Dynamic | call-like (whitespace), variable class |
| `bless {}, "Foo" . $suffix` | Dynamic | call-like, expression-tail class |
| `wrapper(bless {}, "Foo")` | Dynamic | call-like (preceded by `(`), nested |
| `bless::class {}, "Foo"` | Dynamic | call-like (`::` follow), non-builtin |
| `$bless` | Unknown | sigil-preceded — variable named `bless`, not a call |
| `$obj; # bless later` | Unknown | `#` ends the RHS scan |
| `$obj->{bless}` | Unknown | `{`-preceded — hash key, not a call |
| `"I bless this house"` | Unknown | inside string literal |

## How `Unknown` vs `Dynamic` is distinguished

The classifier's variable-case loop tries three patterns on the assignment RHS:

1. `Package->method(...)` arrow — produces `ConstructorAssignment(pkg)`
2. `extract_bless_literal_class(rhs)` — produces `LiteralBless(class)` if rhs is a literal-class bless, fails closed otherwise
3. `rhs_has_bless_keyword_outside_strings(rhs)` — if a *call-like* `bless` keyword is present outside string literals/comments AND the literal extractor rejected it, produces `Dynamic`

`Unknown` is reserved for the no-evidence case (sub parameter, undeclared variable, harmless `bless` identifier) and remains the only variant that triggers fallback.

## Tests

**Unknown-receiver bounded fallback (7):**

- `fallback_offers_imported_package_methods_for_unknown_receiver`
- `fallback_offers_current_package_methods_for_unknown_receiver`
- `fallback_does_not_include_unrelated_workspace_packages`
- `fallback_does_not_fire_for_dynamic_receiver` — Dynamic stays fail-closed
- `fallback_does_not_alter_exact_receiver_detail_or_order`
- `fallback_tier_is_below_exact_receiver_tiers` — **two-request tier proof**: exact `Foo->bark` at tier 2/3, fallback `mew` at tier 6, asserts `exact_tier < fallback_tier` numerically (replaces the earlier weak `fallback_sorts_below_exact_receiver_completions` test that only fired the exact path)
- `fallback_omits_when_no_imports_and_main_package`

**Receiver-evidence classification (Dynamic vs Unknown — 9):**

- `classify_receiver_dynamic_bless_is_dynamic`
- `classify_receiver_dynamic_concat_class_is_dynamic`
- `classify_receiver_dynamic_nested_bless_is_dynamic`
- `classify_receiver_dynamic_qualified_prefix_is_dynamic`
- `classify_receiver_unknown_is_fallback_eligible`
- `classify_receiver_bless_keyword_inside_string_is_not_dynamic`
- **NEW** `classify_receiver_variable_named_bless_is_unknown_fallback_eligible` — `my $x = $bless;` stays Unknown
- **NEW** `classify_receiver_bless_in_comment_is_not_dynamic` — `# bless …` stays Unknown
- **NEW** `classify_receiver_hash_key_bless_is_not_dynamic` — `$obj->{bless}` stays Unknown

**Direct `collect_used_module_names` (4, new):**

- `collect_used_module_names_includes_bare_use` — `use Foo;`
- `collect_used_module_names_includes_empty_import_list` — `use Foo ();`
- `collect_used_module_names_includes_qw_list` — `use Foo qw(bar baz);`
- `collect_used_module_names_excludes_lowercase_pragmas` — `use strict;` etc. excluded

## Verification (all green)

- `cargo test -p perl-lsp-rs-core --profile agent --locked --lib` — 1279 / 1279 passed
- `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- classify_receiver bless fallback collect_used_module_names` — 65 / 65
- `cargo test -p perl-lsp-rs-core --profile agent --locked --lib -- completion detail` — 281 / 281
- `cargo test -p perl-workspace --profile agent --locked --lib -- method_candidates` — 9 / 9
- `cargo clippy -p perl-lsp-rs-core --profile agent --locked --lib -- -D warnings` — clean
- `cargo xtask fmt --check` — clean
- `cargo xtask semantic-scorecard --check` — passed
- `cargo xtask semantic-shadow-compare --check` — passed
- `git diff --check` — clean

## Non-goals

- No all-workspace fallback (separate question; would reopen broad candidate-invention)
- No fallback for `Dynamic` receivers (stays fail-closed by design)
- No generated-member expansion (only what `collect_all_package_members` naturally returns)
- No diagnostic / rename / reference / safe-delete changes
- No `TypeInferenceEngine` expansion
- No UX dashboard update (follow-up docs PR after merge)

## Test plan

- [x] Inspect the rendered diff: confirm only the 4 expected files changed
- [x] Confirm `Dynamic` and `Unknown` are positively distinguished in the classifier
- [x] Confirm fallback only fires for `Unknown`, never `Dynamic`
- [x] Confirm fallback source is bounded (imported + current package only)
- [x] Confirm exact-receiver completions are byte-equal to pre-PR for `Foo->bark` (tier 2, no `unknown` in detail)
- [x] Confirm fallback detail says `receiver: unknown, low confidence`
- [x] Confirm fallback sort tier is `6_<name>`
- [x] Confirm dynamic-bless detection is call-like (rejects `$bless`, `# bless`, `$obj->{bless}`)
- [x] Confirm fallback tier proof exercises both exact and fallback in the same test
