### PR TITLE
fix(perl-lexer): preserve start-of-file checkpoints after leading deletions (#7508)

### DIFF
--- a/crates/perl-lexer/src/checkpoint/cache.rs
+++ b/crates/perl-lexer/src/checkpoint/cache.rs
@@ -1,4 +1,4 @@
-use crate::checkpoint::{CheckpointContext, LexerCheckpoint};
+use crate::checkpoint::LexerCheckpoint;
 
 /// A checkpoint cache for efficient incremental parsing
 pub struct CheckpointCache {
@@ -135,11 +135,11 @@ impl CheckpointCache {
             *pos = checkpoint.position;
         }
 
-        self.checkpoints
-            .retain(|(_, cp)| !matches!(cp.context, CheckpointContext::Normal) || cp.position > 0);
-
         // Edits can move checkpoints backward (or to the same position), so
         // restore the sorted-order invariant required by binary-search lookups.
+        // NOTE: do NOT drop checkpoints that landed at position 0 — a Normal
+        // checkpoint shifted to byte 0 by a deletion is a valid start-of-file
+        // anchor and must be preserved for incremental re-lexing (#7508).
         self.checkpoints.sort_unstable_by_key(|(pos, _)| *pos);
     }
 }

--- a/crates/perl-lexer/src/checkpoint/tests.rs
+++ b/crates/perl-lexer/src/checkpoint/tests.rs
@@ -374,3 +374,23 @@ fn test_checkpoint_apply_edit_resets_position_tracking_on_shift_and_invalidate()
     assert_eq!(invalidated.mode, LexerMode::ExpectTerm);
     assert_eq!(invalidated.context, CheckpointContext::Normal);
 }
+
+// Regression test for #7508: a Normal checkpoint shifted to byte-0 by a
+// leading deletion must survive apply_edit so it can serve as a start-of-file
+// anchor for the next incremental re-lex pass.
+#[test]
+fn test_checkpoint_cache_apply_edit_preserves_start_checkpoint()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let mut cache = CheckpointCache::new(4);
+    cache.add(LexerCheckpoint::at_position(10));
+
+    // Delete the 10 bytes before it: checkpoint shifts from 10 → 0.
+    cache.apply_edit(0, 10, 0);
+
+    let cp = cache
+        .find_before(0)
+        .ok_or("checkpoint shifted to position 0 must be preserved as start-of-file anchor")?;
+    assert_eq!(cp.position, 0, "checkpoint should have shifted to byte 0");
+    assert_eq!(cp.context, CheckpointContext::Normal, "context must remain Normal");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes a bug in `CheckpointCache::apply_edit` where Normal checkpoints shifted to byte position 0 by a leading deletion were incorrectly discarded, breaking incremental re-lex anchors at start-of-file.

Fixes #7508.

## The Bug

`CheckpointCache::apply_edit` contained a `retain` clause:

```rust
self.checkpoints
    .retain(|(_, cp)| !matches!(cp.context, CheckpointContext::Normal) || cp.position > 0);
```

This drops any `Normal` checkpoint whose position becomes 0 after the edit shift. The intent was presumably to avoid a "redundant" position-0 entry, but it is wrong: **a checkpoint shifted to byte 0 by a leading deletion is a valid and valuable start-of-file anchor** for the next incremental re-lex pass.

### Concrete failure scenario

1. Lexer caches a `Normal` checkpoint at byte position 10.
2. User deletes the first 10 bytes of the document (`apply_edit(start=0, old_len=10, new_len=0)`).
3. `LexerCheckpoint::apply_edit` correctly shifts the checkpoint from 10 → 0 (shift path: `10 >= 0 + 10`).
4. The cache's `retain` then **drops** the checkpoint because it is `Normal` and `position == 0`.
5. `find_before(0)` returns `None` — the incremental parser has no anchor and must re-lex from scratch, or worse, misses the start of a re-lex window entirely.

## The Fix

Remove the `retain` clause entirely. A `Normal` checkpoint at byte 0 is exactly the start-of-file state and is the most useful possible incremental anchor. Non-Normal checkpoints (Heredoc, Regex, QuoteLike, Format) at position 0 are also valid — there is no correctness reason to discard any checkpoint that `LexerCheckpoint::apply_edit` kept.

Also removes the now-unused `CheckpointContext` import from `cache.rs`.

## Changes

| File | Change |
|------|--------|
| `crates/perl-lexer/src/checkpoint/cache.rs` | Remove `retain` clause + unused import; add explanatory comment |
| `crates/perl-lexer/src/checkpoint/tests.rs` | Add regression test `test_checkpoint_cache_apply_edit_preserves_start_checkpoint` |

## Test

The new regression test models the exact failure scenario:

```rust
#[test]
fn test_checkpoint_cache_apply_edit_preserves_start_checkpoint() {
    let mut cache = CheckpointCache::new(4);
    cache.add(LexerCheckpoint::at_position(10));

    // Delete the 10 bytes before it: checkpoint shifts from 10 → 0.
    cache.apply_edit(0, 10, 0);

    let cp = cache
        .find_before(0)
        .ok_or("checkpoint shifted to position 0 must be preserved")?;
    assert_eq!(cp.position, 0);
    assert_eq!(cp.context, CheckpointContext::Normal);
}
```

Without the fix this test fails: `find_before(0)` returns `None`. With the fix all 19 checkpoint tests pass.

## Verification

```bash
cargo test -p perl-lexer -- test_checkpoint   # 19 passed, 0 failed
cargo clippy -p perl-lexer --tests            # clean
cargo fmt --check -p perl-lexer               # clean
```

## Impact

- **No behavioral change** for edits that don't shift a checkpoint to exactly byte 0 — the retain only fired in that specific case.
- **Correctness improvement** for incremental re-lex after leading deletions: the cache now correctly retains the start-of-file anchor, allowing the incremental parser to avoid a full re-lex from scratch.
- **2 files changed, 24 insertions(+), 4 deletions(-)**

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkd3LSxcVW5eeZ2tbgm7BM)_