### PR TITLE
fix(lexer-checkpoint): preserve Normal checkpoints shifted to position 0 (#7508)

### DIFF
--- a/crates/perl-lexer/src/checkpoint/cache.rs
+++ b/crates/perl-lexer/src/checkpoint/cache.rs
@@ -1,4 +1,4 @@
-use crate::checkpoint::{CheckpointContext, LexerCheckpoint};
+use crate::checkpoint::LexerCheckpoint;
 
 /// A checkpoint cache for efficient incremental parsing
 pub struct CheckpointCache {
@@ -134,9 +134,6 @@ impl CheckpointCache {
             checkpoint.apply_edit(start, old_len, new_len);
             *pos = checkpoint.position;
         }
-
-        self.checkpoints
-            .retain(|(_, cp)| !matches!(cp.context, CheckpointContext::Normal) || cp.position > 0);
 
         // Edits can move checkpoints backward (or to the same position), so
         // restore the sorted-order invariant required by binary-search lookups.

--- a/crates/perl-lexer/src/checkpoint/tests.rs
+++ b/crates/perl-lexer/src/checkpoint/tests.rs
@@ -374,3 +374,36 @@ fn test_checkpoint_apply_edit_resets_position_tracking_on_shift_and_invalidate()
     assert_eq!(invalidated.mode, LexerMode::ExpectTerm);
     assert_eq!(invalidated.context, CheckpointContext::Normal);
 }
+
+/// Regression test: a Normal checkpoint shifted to position 0 by a leading deletion
+/// must be preserved in the cache (prior bug: retain dropped it, breaking
+/// `find_before(0)` after start-of-file edits).
+#[test]
+fn test_checkpoint_cache_apply_edit_preserves_start_checkpoint()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let mut cache = CheckpointCache::new(5);
+    cache.add(LexerCheckpoint::at_position(10));
+
+    // Delete the 10 bytes before the checkpoint; it shifts from 10 to 0.
+    cache.apply_edit(0, 10, 0);
+
+    let cp =
+        cache.find_before(0).ok_or("Normal checkpoint shifted to position 0 must be preserved")?;
+    assert_eq!(cp.position, 0, "shifted checkpoint must remain in cache at position 0");
+    Ok(())
+}
+
+/// A checkpoint that was overlapped-and-reset to position 0 must also survive.
+#[test]
+fn test_checkpoint_cache_apply_edit_preserves_overlap_reset_to_start()
+-> std::result::Result<(), Box<dyn std::error::Error>> {
+    let mut cache = CheckpointCache::new(5);
+    // Checkpoint at 5, inside an edit spanning [0, 8) — reset to start=0.
+    cache.add(LexerCheckpoint::at_position(5));
+    cache.apply_edit(0, 8, 0);
+
+    let cp =
+        cache.find_before(0).ok_or("overlap-reset checkpoint at position 0 must be preserved")?;
+    assert_eq!(cp.position, 0, "overlap-reset checkpoint must remain as a start-of-file anchor");
+    Ok(())
+}


### PR DESCRIPTION
Problem: `CheckpointCache::apply_edit` dropped valid start-of-file checkpoints after leading edits, removing useful incremental parsing anchors.

Fix: Remove the post-edit retain that discarded `Normal` checkpoints at byte 0 and add regressions for both shift-to-zero and overlap-reset-to-zero paths.

Verification:
- `cargo test -p perl-lexer --lib -- checkpoint` passes
- `cargo test -p perl-lexer --profile agent --locked` passes
- `cargo clippy -p perl-lexer --tests --profile agent --locked -- -D warnings` passes
- `cargo xtask fmt --check` passes
- `git diff --check` passes