### PR TITLE
test(completion): cover quoted require file paths (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -2785,6 +2785,24 @@ fn test_require_statement_skips_file_path() -> Result<(), Box<dyn std::error::Er
 }
 
 #[test]
+fn test_require_statement_skips_double_quoted_file_path() -> Result<(), Box<dyn std::error::Error>>
+{
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(Url::parse("file:///lib/Utils.pm")?, "package Utils;\n1;\n".to_string())?;
+    let code = r#"require "Utils.pm""#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+    assert!(
+        !completions.iter().any(|c| c.kind == CompletionItemKind::Module),
+        r#"require "Utils.pm" should not trigger module-name completions; got: {:?}"#,
+        completions.iter().map(|c| (&c.label, &c.kind)).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
 fn test_require_statement_skips_version_check() -> Result<(), Box<dyn std::error::Error>> {
     let index = Arc::new(WorkspaceIndex::new());
     index.index_file(Url::parse("file:///lib/Utils.pm")?, "package Utils;\n1;\n".to_string())?;


### PR DESCRIPTION
### Motivation
- Add explicit coverage for the double-quoted `require "..."` file-path case so module-name completions stay suppressed and the existing regression gap is closed.

### Description
- Add `test_require_statement_skips_double_quoted_file_path` to `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs`.
- The test indexes `Utils.pm`, parses `require "Utils.pm"`, and asserts completion does not emit `CompletionItemKind::Module` entries while the cursor is inside the quoted file path.

### Verification
- `cargo test -p perl-lsp-rs-core test_require_statement_skips_double_quoted_file_path --profile agent --locked` passed.
- `cargo check -p perl-lsp-rs-core --all-targets --profile agent --locked` passed.
- `cargo xtask fmt --check` passed.
- `cargo xtask metrics parser-accuracy --check` passed: 46 fixtures / 28 families; 123 scored lines; 102 scored symbols; 0 active failure packets.
- `cargo xtask metrics ratchet-check parser_accuracy` passed; parser-accuracy floors unchanged.
- `git diff --check` passed.

### Known unrelated local blockers
- Full `cargo test -p perl-lsp-rs-core --profile agent --locked` is currently blocked by pre-existing diagnostic snapshot drift in `diag_snap__suspicious_regex_and_tainted_system_call` (`Nested quantifiers detected...` vs `Nested quantifiers may cause catastrophic backtracking`).
- Strict `cargo clippy -p perl-lsp-rs-core --all-targets --profile agent --locked -- -D warnings -A missing_docs` is currently blocked by broad pre-existing lint debt in unrelated tests (`expect_used`, `items_after_test_module`, `panic`, `bool_assert_comparison`, `needless_borrows_for_generic_args`, etc.).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94516b6ec8333be40dcbe08f0edcb)