### PR TITLE
test(perl-workspace): expand invalidation planner coverage (#0000)

### DIFF
--- a/crates/perl-workspace/src/semantic/invalidation.rs
+++ b/crates/perl-workspace/src/semantic/invalidation.rs
@@ -137,4 +137,26 @@ mod tests {
         assert!(plan.occurrences_updated);
         assert!(!plan.edges_updated);
     }
+
+    #[test]
+    fn first_insert_marks_all_categories_updated() {
+        let new = hashes(7, Some(70), Some(80), Some(90), Some(100));
+
+        let plan = plan_shard_replacement(None, new);
+
+        assert!(!plan.content_unchanged);
+        assert!(plan.anchors_updated);
+        assert!(plan.entities_updated);
+        assert!(plan.occurrences_updated);
+        assert!(plan.edges_updated);
+    }
+
+    #[test]
+    fn category_hash_changed_handles_all_hash_presence_combinations() {
+        assert!(!category_hash_changed(Some(5), Some(5)));
+        assert!(category_hash_changed(Some(5), Some(6)));
+        assert!(category_hash_changed(None, Some(6)));
+        assert!(category_hash_changed(Some(5), None));
+        assert!(category_hash_changed(None, None));
+    }
 }


### PR DESCRIPTION
Problem: Incremental semantic shard invalidation coverage did not prove first-insert behavior or all per-category hash-presence combinations.

Fix: Added focused tests in `crates/perl-workspace/src/semantic/invalidation.rs` for first insert planning and `category_hash_changed` `Some`/`None` combinations.

Verification:
- `cargo test -p perl-workspace first_insert_marks_all_categories_updated --profile agent --locked` passed.
- `cargo test -p perl-workspace category_hash_changed_handles_all_hash_presence_combinations --profile agent --locked` passed.
- `cargo test -p perl-workspace --profile agent --locked` passed.
- `cargo check -p perl-workspace --all-targets --profile agent --locked` passed.
- `cargo xtask fmt --check` passed.
- `cargo xtask metrics parser-accuracy --check` passed: 46 fixtures / 28 families.
- `cargo xtask metrics ratchet-check parser_accuracy` passed.
- `git diff --check` passed.

Clippy note:
- `cargo clippy -p perl-workspace --all-targets --profile agent --locked -- -D warnings -A missing_docs` is blocked by pre-existing test lints outside this PR (`expect_used` and `unnecessary_to_owned` in existing `perl-workspace` test files).

Metrics delta:
- Denominator unchanged: 46 fixtures / 28 families; 123 scored lines; 102 scored symbols.
- Failure packets unchanged: 0 active.
- Provider rows unchanged: 12 provider metric rows, all `insufficient_data`.
- Ratchet delta: no floor movement; parser_accuracy floors still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94516b6ec8333be40dcbe08f0edcb)