### PR TITLE
test(completion): add cutover ranking coverage (#7935)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
@@ -1217,9 +1217,40 @@ mod tests {
     }
 
     #[test]
+    fn rank_external_high_confidence_is_medium() -> Result<(), Box<dyn std::error::Error>> {
+        let sym = make_visible("external", VisibleSymbolSource::External, Confidence::High);
+        let ranked = rank_visible_symbol(sym);
+        assert_eq!(ranked.tier, CompletionRankTier::Medium);
+        Ok(())
+    }
+
+    #[test]
     fn rank_tier_ordering() -> Result<(), Box<dyn std::error::Error>> {
         assert!(CompletionRankTier::High < CompletionRankTier::Medium);
         assert!(CompletionRankTier::Medium < CompletionRankTier::Low);
+        Ok(())
+    }
+
+    #[test]
+    fn cutover_sorts_symbols_by_tier_source_confidence_then_name()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let queries = StubSemanticQueries {
+            visible_result: vec![
+                make_visible("zlex", VisibleSymbolSource::LocalLexical, Confidence::Medium),
+                make_visible("bext", VisibleSymbolSource::External, Confidence::High),
+                make_visible("adyn", VisibleSymbolSource::DynamicUnknown, Confidence::High),
+                make_visible("alex", VisibleSymbolSource::LocalLexical, Confidence::High),
+                make_visible("aext", VisibleSymbolSource::External, Confidence::High),
+            ],
+        };
+
+        let outcome = completion_visibility_cutover(vec![], &queries, FileId(1), 10, None, "test");
+        let CompletionCutoverResult::Semantic(ranked) = outcome.result else {
+            return Err("expected semantic completion result".into());
+        };
+
+        let ordered_names: Vec<&str> = ranked.iter().map(|r| r.symbol.name.as_str()).collect();
+        assert_eq!(ordered_names, vec!["alex", "zlex", "aext", "bext", "adyn"]);
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- Improve unit test coverage around completion cutover ranking decisions to ensure external symbols and multi-key sorting are handled deterministically.

### Description

- Added two unit tests in `crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs` that assert `VisibleSymbolSource::External` with `Confidence::High` maps to `CompletionRankTier::Medium` and that `completion_visibility_cutover` produces a deterministic ordering by tier, source priority, confidence, then name.

### Testing

- Attempted to run `./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked completion_shadow`, but the test run was blocked by an environment storage guard error (`DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94516b6ec8333be40dcbe08f0edcb)