### PR TITLE
test(class-model): add coverage for framework and qw parsing (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/class_model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/class_model.rs
@@ -1800,6 +1800,32 @@ has [qw(first_name last_name)] => (is => 'ro');
     }
 
     #[test]
+    fn has_framework_false_for_none() {
+        let model = ClassModel {
+            name: "No::Framework".to_string(),
+            framework: Framework::None,
+            attributes: Vec::new(),
+            fields: Vec::new(),
+            methods: Vec::new(),
+            adjusts: Vec::new(),
+            parents: Vec::new(),
+            mro: MethodResolutionOrder::Dfs,
+            roles: Vec::new(),
+            modifiers: Vec::new(),
+            exports: Vec::new(),
+            export_ok: Vec::new(),
+            exporter_metadata: None,
+        };
+
+        assert!(!model.has_framework());
+    }
+
+    #[test]
+    fn expand_symbol_list_supports_qw_angle_delimiters() {
+        assert_eq!(expand_symbol_list("qw<alpha beta gamma>"), vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
     fn has_framework_helper() {
         let models = build_models(
             r#"


### PR DESCRIPTION
Problem: Class-model unit coverage did not exercise `Framework::None` in `has_framework()` or `qw<...>` symbol-list delimiters.

Fix: Added focused tests in `crates/perl-semantic-analyzer/src/analysis/class_model.rs` for `Framework::None` and `expand_symbol_list("qw<alpha beta gamma>")`.

Verification:
- `cargo test -p perl-semantic-analyzer has_framework_false_for_none --profile agent --locked` passed.
- `cargo test -p perl-semantic-analyzer expand_symbol_list_supports_qw_angle_delimiters --profile agent --locked` passed.
- `cargo test -p perl-semantic-analyzer --profile agent --locked` passed.
- `cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked` passed.
- `cargo clippy -p perl-semantic-analyzer --all-targets --profile agent --locked -- -D warnings -A missing_docs` passed.
- `cargo xtask fmt --check` passed.
- `cargo xtask metrics parser-accuracy --check` passed: 46 fixtures / 28 families.
- `cargo xtask metrics ratchet-check parser_accuracy` passed.
- `git diff --check` passed.

Metrics delta:
- Denominator unchanged: 46 fixtures / 28 families; 123 scored lines; 102 scored symbols.
- Failure packets unchanged: 0 active.
- Provider rows unchanged: 12 provider metric rows, all `insufficient_data`.
- Ratchet delta: no floor movement; parser_accuracy floors still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94516b6ec8333be40dcbe08f0edcb)