### PR TITLE
test(xtask): harden ci-gate mapping coverage (#0000)

### DIFF
--- a/xtask/tests/published_crate_count_gate_integration.rs
+++ b/xtask/tests/published_crate_count_gate_integration.rs
@@ -276,6 +276,15 @@ fn published_crate_count_gate_is_in_ci_gate_job_mapping() {
          The gate must be listed in the ci-gate job mapping to run in CI.",
         gate_names
     );
+
+    let published_count = gate_names.iter().filter(|name| **name == GATE_NAME).count();
+    assert_eq!(
+        published_count, 1,
+        "published_crate_count gate must appear exactly once in ci-gate mapping.\n\
+         Duplicate entries can mask policy drift and lead to confusing receipts.\n\
+         Found gates: {:?}",
+        gate_names
+    );
 }
 
 /// Test that `nested_lock_check` gate precedes `published_crate_count` in policy.


### PR DESCRIPTION
Problem: `published_crate_count` could be duplicated in the ci-gate mapping without a focused regression catching the drift.
Fix: Add an assertion that `published_crate_count` appears exactly once in `workflow_integration.job_mapping.ci-gate.gates`.
Verification:
- `cargo test -p xtask --test published_crate_count_gate_integration --profile agent --locked`
- `cargo check -p xtask --all-targets --profile agent --locked`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`
- `cargo clippy -p xtask --all-targets --profile agent --locked -- -D warnings -A missing_docs` was attempted but fails on pre-existing unrelated xtask lints outside this one-file diff.