### PR TITLE
test(perl-lsp-rs): add split-frame integration coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_content_length_framing_integration.rs
+++ b/crates/perl-lsp-rs/tests/lsp_content_length_framing_integration.rs
@@ -41,3 +41,36 @@ fn handles_back_to_back_frames_in_single_write() -> Result<(), Box<dyn std::erro
     assert_eq!(second_response.get("id"), Some(&json!(902)));
     Ok(())
 }
+
+#[test]
+fn handles_split_frame_header_and_body_across_writes() -> Result<(), Box<dyn std::error::Error>> {
+    let server = start_lsp_server();
+
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 903,
+        "method": "test/split",
+        "params": {}
+    })
+    .to_string();
+
+    let bytes = frame(request.as_bytes());
+    let split_at = bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|index| index + 4)
+        .ok_or("framed message missing header terminator")?;
+
+    server.stdin_writer().write_all(&bytes[..split_at])?;
+    server.stdin_writer().flush()?;
+    std::thread::sleep(Duration::from_millis(10));
+    server.stdin_writer().write_all(&bytes[split_at..])?;
+    server.stdin_writer().flush()?;
+
+    let timeout = Duration::from_secs(2);
+    let response =
+        read_response_matching_i64(&server, 903, timeout).ok_or("missing response 903")?;
+
+    assert_eq!(response.get("id"), Some(&json!(903)));
+    Ok(())
+}


### PR DESCRIPTION
Problem: LSP framing coverage did not exercise the case where a frame header and body arrive in separate flushed writes.
Fix: Add `handles_split_frame_header_and_body_across_writes` to the content-length framing integration test and assert the split request still receives the matching response ID.
Verification:
- `cargo test -p perl-lsp-rs --test lsp_content_length_framing_integration --profile agent --locked`
- `cargo check -p perl-lsp-rs --all-targets --profile agent --locked`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`
- Parser metrics unchanged: 46 fixtures / 28 families; 123 scored lines; 102 scored symbols; 0 failure packets; 12 provider rows, all insufficient_data; parser_accuracy ratchet passed.
- `cargo clippy -p perl-lsp-rs --test lsp_content_length_framing_integration --profile agent --locked -- -D warnings -A missing_docs` was attempted but is blocked by pre-existing shared test utility `panic!` lint failures outside this PR diff.