### PR TITLE
test(perl-corpus): cover parse_dir hidden-file filtering in integration flow (#0000)

### DIFF
--- a/crates/perl-corpus/tests/bdd_corpus_workflows.rs
+++ b/crates/perl-corpus/tests/bdd_corpus_workflows.rs
@@ -108,3 +108,46 @@ my ($lhs, $rhs) = ('left', 'right') =~ /(left).*(right)/;
     fs::remove_dir_all(&dir)?;
     Ok(())
 }
+
+#[test]
+fn bdd_given_mixed_visible_and_hidden_files_when_parse_dir_then_only_visible_sections_are_sorted()
+-> Result<(), Box<dyn Error>> {
+    // Given: one visible corpus file plus hidden/private files in the same tree.
+    let dir = scenario_temp_dir("perl_corpus_bdd_visibility");
+    let visible = r#"==========================================
+Visible section
+==========================================
+# @id: b.visible
+# @tags: regex
+my $line = "visible";
+"#;
+    let hidden = r#"==========================================
+Hidden section
+==========================================
+# @id: a.hidden
+# @tags: regex
+my $line = "hidden";
+"#;
+    let private = r#"==========================================
+Private section
+==========================================
+# @id: c.private
+# @tags: regex
+my $line = "private";
+"#;
+
+    must(write_corpus_file(&dir, "z_visible.txt", visible));
+    must(write_corpus_file(&dir, ".hidden.txt", hidden));
+    must(write_corpus_file(&dir, "_private.txt", private));
+
+    // When: parsing the directory.
+    let sections = must(parse_dir(&dir));
+
+    // Then: only the visible file contributes sections and results remain sorted.
+    assert_eq!(sections.len(), 1);
+    assert_eq!(sections[0].id, "b.visible");
+    assert!(sections[0].file.ends_with("z_visible.txt"));
+
+    fs::remove_dir_all(&dir)?;
+    Ok(())
+}


### PR DESCRIPTION
Problem: `perl-corpus::parse_dir` hidden/private-file filtering needed end-to-end integration coverage.
Fix: Add a BDD corpus workflow test that mixes visible, hidden, and private files, then asserts only the visible section is parsed and ordering remains deterministic.
Verification:
- `cargo test -p perl-corpus bdd_given_mixed_visible_and_hidden_files_when_parse_dir_then_only_visible_sections_are_sorted --profile agent --locked`
- `cargo test -p perl-corpus --profile agent --locked`
- `cargo check -p perl-corpus --all-targets --profile agent --locked`
- `cargo clippy -p perl-corpus --all-targets --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`