### PR TITLE
test(tree-sitter-perl-c): harden parser reuse regression coverage (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/tests/byte_and_recovery_regressions.rs
+++ b/crates/tree-sitter-perl-c/tests/byte_and_recovery_regressions.rs
@@ -7,7 +7,11 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use tree_sitter_perl_c::{parse_perl_bytes, parse_perl_code, parse_perl_file};
+use tree_sitter::Parser;
+use tree_sitter_perl_c::{
+    ParsePerlError, PerlParser, parse_perl_bytes, parse_perl_code, parse_perl_file,
+    try_parse_perl_bytes_with_parser,
+};
 
 fn unique_temp_file(name: &str) -> PathBuf {
     let nanos =
@@ -128,4 +132,28 @@ fn regression_file_parse_with_unclosed_construct_is_recoverable() -> Result<(), 
     assert!(tree.root_node().has_error(), "unclosed block should still return a partial tree");
 
     Ok(())
+}
+
+#[test]
+fn regression_reusable_parser_supports_multiple_back_to_back_parses() -> Result<(), Box<dyn Error>> {
+    let mut parser = PerlParser::new()?;
+
+    let first_tree = parser.parse_code("my $value = 1;\n")?;
+    assert_eq!(first_tree.root_node().kind(), "source_file");
+    assert!(!first_tree.root_node().has_error());
+
+    let second_tree = parser.parse_code("my $broken = ;\nmy $ok = 2;\n")?;
+    assert_eq!(second_tree.root_node().kind(), "source_file");
+    assert!(second_tree.root_node().has_error());
+
+    Ok(())
+}
+
+#[test]
+fn regression_typed_parse_with_unconfigured_parser_returns_parse_returned_none() {
+    let mut parser = Parser::new();
+
+    let result = try_parse_perl_bytes_with_parser(&mut parser, b"my $value = 1;\n");
+
+    assert!(matches!(result, Err(ParsePerlError::ParseReturnedNone)));
 }


### PR DESCRIPTION
### Motivation

- Ensure the C-backed tree-sitter Perl binding has explicit regression coverage for reusing a configured parser across consecutive parses and for the typed error returned when parsing with an unconfigured parser.

### Description

- Import the typed parser APIs (`PerlParser`, `ParsePerlError`) and the typed helper `try_parse_perl_bytes_with_parser` into the byte/recovery test module.
- Add `regression_reusable_parser_supports_multiple_back_to_back_parses` to verify a single `PerlParser` can parse a valid snippet then a malformed snippet and that errors are reported on the second parse.
- Add `regression_typed_parse_with_unconfigured_parser_returns_parse_returned_none` to assert that calling `try_parse_perl_bytes_with_parser` with an unconfigured `tree_sitter::Parser` yields `ParsePerlError::ParseReturnedNone`.

### Testing

- Ran the focused test file with `cargo test -p tree-sitter-perl-c --test byte_and_recovery_regressions --locked` and it passed.
- Ran the full crate test suite with `cargo test -p tree-sitter-perl-c --locked` and observed unrelated pre-existing failures in `query_conformance` tests; the new tests in this patch passed during that run while two upstream `query_conformance_*` expectations failed.
- An attempted `./scripts/cargo-safe test -p tree-sitter-perl-c --profile agent --locked` was blocked by the environment storage guard, so the script-run was not completed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9458b6158833395aaf4a2b617ba01)