### PR TITLE
test(tree-sitter-perl-c): extend autoquote whitespace regressions (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/tests/scanner_autoquote_regressions.rs
+++ b/crates/tree-sitter-perl-c/tests/scanner_autoquote_regressions.rs
@@ -61,3 +61,27 @@ fn fat_comma_autoquote_skips_pod_like_gap() -> Result<(), Box<dyn Error>> {
     );
     Ok(())
 }
+
+#[test]
+fn fat_comma_autoquote_skips_blank_lines_between_key_and_arrow() -> Result<(), Box<dyn Error>> {
+    let source = "my %h = ( key\n\n\n  => 1 );\n";
+    let captures = captured_autoquoted_barewords(source)?;
+
+    assert!(
+        captures.iter().any(|capture| capture == "key"),
+        "expected autoquoted_bareword capture for `key`, got {captures:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn brace_autoquote_skips_whitespace_only_gap_before_closing_brace() -> Result<(), Box<dyn Error>> {
+    let source = "my %h = ( key => 1 );\nmy $v = $h{key\n\n\n};\n";
+    let captures = captured_autoquoted_barewords(source)?;
+
+    assert!(
+        captures.iter().any(|capture| capture == "key"),
+        "expected autoquoted_bareword capture for `key`, got {captures:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Problem: autoquote scanner regression coverage did not explicitly cover whitespace-only multiline gaps around fat-comma and brace autoquote positions.
Fix: Add targeted scanner autoquote tests for blank-line gaps before `=>` and before `}`.
Verification:
- `cargo test -p tree-sitter-perl-c --test scanner_autoquote_regressions --profile agent --locked`
- `cargo test -p tree-sitter-perl-c --profile agent --locked`
- `cargo check -p tree-sitter-perl-c --all-targets --profile agent --locked`
- `cargo clippy -p tree-sitter-perl-c --all-targets --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`