### PR TITLE
test(tree-sitter-perl-c): add typed API regression coverage (#0000)

### DIFF
--- a/crates/tree-sitter-perl-c/tests/typed_api_regressions.rs
+++ b/crates/tree-sitter-perl-c/tests/typed_api_regressions.rs
@@ -1,0 +1,38 @@
+use std::{
+    error::Error,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use tree_sitter_perl_c::{
+    ParsePerlError, try_create_parser, try_parse_perl_code_with_parser, try_parse_perl_file,
+};
+
+fn unique_missing_file(name: &str) -> PathBuf {
+    let nanos =
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0_u128, |duration| duration.as_nanos());
+
+    std::env::temp_dir().join(format!("tree_sitter_perl_c_missing_{name}_{nanos}.pl"))
+}
+
+#[test]
+fn regression_try_parse_perl_file_surfaces_typed_io_error() {
+    let missing = unique_missing_file("typed_io_error");
+
+    let result = try_parse_perl_file(&missing);
+
+    assert!(matches!(result, Err(ParsePerlError::Io(_))));
+}
+
+#[test]
+fn regression_reused_parser_typed_api_recovers_after_invalid_input() -> Result<(), Box<dyn Error>> {
+    let mut parser = try_create_parser()?;
+
+    let invalid = try_parse_perl_code_with_parser(&mut parser, "my $x = ;\n")?;
+    assert!(invalid.root_node().has_error());
+
+    let valid = try_parse_perl_code_with_parser(&mut parser, "my $x = 42;\n")?;
+    assert!(!valid.root_node().has_error());
+
+    Ok(())
+}


### PR DESCRIPTION
Problem: `tree-sitter-perl-c` typed parsing behavior needs focused regression coverage for IO error classification and parser reuse after recoverable invalid input.
Fix: Add `typed_api_regressions.rs` covering `ParsePerlError::Io` from missing-file parses and reuse of a typed parser after an invalid parse.
Verification:
- `cargo test -p tree-sitter-perl-c --test typed_api_regressions --profile agent --locked`
- `cargo test -p tree-sitter-perl-c --profile agent --locked`
- `cargo check -p tree-sitter-perl-c --all-targets --profile agent --locked`
- `cargo clippy -p tree-sitter-perl-c --all-targets --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`