### PR TITLE
feat(metrics): wire scorecard ratchet into nightly CI and add operational guide (#4105)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -459,6 +459,39 @@ jobs:
         # Uses cargo public-api --simplified to omit blanket-impl noise; baselines in .ci/public-api-baselines/
         run: just public-api-check
 
+  scorecard-ratchet-check:
+    name: Scorecard Floor-Metric Ratchet Check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'ci:metrics-ratchet'))
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          key: scorecard-ratchet-${{ hashFiles('Cargo.lock') }}
+          cache-on-failure: true
+
+      - name: Install just
+        uses: taiki-e/install-action@cf39a74df4a72510be4e5b63348d61067f11e64a  # v2.75.0
+        with:
+          tool: just
+
+      - name: Check floor-metric ratchet (bootstrap-safe)
+        # Passes if no receipt exists; compares against committed baselines when receipt is present.
+        # See docs/project/metrics/RATCHET.md for the four-layer model and promotion workflow.
+        run: just ci-metrics-ratchet
+
   clippy-strict:
     name: Clippy (Strict)
     timeout-minutes: 20

--- a/docs/project/metrics/RATCHET.md
+++ b/docs/project/metrics/RATCHET.md
@@ -1,0 +1,203 @@
+# Scorecard Floor-Metric Ratchet — Operational Guide
+
+> **Audience**: contributors and CI operators.
+> **What this is**: the operational layer on top of the conceptual scorecard
+> framework in [README.md](README.md).  It answers the practical questions:
+> how do you run a ratchet check, how do you promote a baseline, and where
+> does the CI enforcement live?
+>
+> For the *why* and the four-layer model rationale, read [README.md](README.md)
+> and tracking issue [#4105](https://github.com/effortlessmetrics/perl-lsp/issues/4105).
+
+---
+
+## Quick Reference
+
+```bash
+# Check that all committed baselines pass (bootstrap-safe: passes if no receipt)
+just ci-metrics-ratchet
+
+# Check a single subsystem
+just ci-metrics-ratchet-check parser
+
+# Promote a metric from improvement → floor (after stable-wins threshold)
+cargo xtask metrics promote-baseline parser
+
+# Ratchet parser baseline up after a confirmed improvement
+# (edit .ci/metrics/baselines/parser.json, run just ci-metrics-ratchet, commit)
+```
+
+---
+
+## Four-Layer Model (Summary)
+
+Full rationale is in [README.md](README.md).  The operational summary:
+
+| Layer | What it means | Who touches it |
+|-------|---------------|----------------|
+| **1. One JSON file per subsystem** | `.ci/metrics/baselines/<subsystem>.json` is the committed truth | CI + maintainer |
+| **2. Floor vs improvement split** | `floor_metrics` block a merge; `improvement_metrics` are informational | Baseline author |
+| **3. Ratchet only on stable wins** | Don't raise the floor after one lucky run — require `STABLE_WIN_THRESHOLD` consecutive improvements | `cargo xtask metrics promote-baseline` |
+| **4. Issue ↔ scorecard linkage** | Every open issue states which scorecard metric it improves | Issue author |
+
+---
+
+## Committed Baselines
+
+Baselines live at `.ci/metrics/baselines/<subsystem>.json`.  The schema is
+defined in `xtask/src/tasks/metrics/ratchet.rs` (`SubsystemBaseline`):
+
+```json
+{
+  "schema_version": 1,
+  "measured_at": "2026-04-24T00:00:00Z",
+  "subsystem": "parser",
+  "commit": "522c47f",
+  "floor_metrics": {
+    "system_clean_rate": 0.944816,
+    "system_crash_count": 0,
+    "cpan_clean_rate": 0.952945,
+    "strict_clean_subset_pass_rate": 1.0
+  },
+  "improvement_metrics": {
+    "recovery_salvage_rate": 0.204545,
+    "error_density_per_1k_loc": 1.95,
+    "node_kind_coverage": 0.942029
+  },
+  "tolerance_pct": 0.005
+}
+```
+
+### Active subsystems
+
+| File | Subsystem | Floor gate |
+|------|-----------|------------|
+| `.ci/metrics/baselines/parser.json` | Parser corpus cleanliness | `system_clean_rate`, `cpan_clean_rate`, `system_crash_count`, `strict_clean_subset_pass_rate` |
+| `.ci/metrics/baselines/engineering_health.json` | Build/test hygiene | `strict_clean_subset_pass_rate` |
+| `.ci/metrics/baselines/parser_accuracy.json` | Span / AST correctness | See file |
+| `.ci/metrics/baselines/token.json` | Lexer token health | See file |
+| `.ci/metrics/baselines/editor_ux.json` | Editor UX scorecard | See file |
+
+---
+
+## Metric Direction Convention
+
+The ratchet determines regression direction from the metric name:
+
+| Suffix | Direction | Regression = |
+|--------|-----------|--------------|
+| `_count`, `_nodes`, `_unreadable` | **Lower is better** | current > baseline × (1 + tolerance) |
+| anything else | **Higher is better** | current < baseline × (1 − tolerance) |
+| listed in `lower_is_better` array | **Lower is better** | same as `_count` |
+
+Tolerance default is `0.005` (0.5 %).  Each baseline can override via
+`"tolerance_pct": <value>`.
+
+---
+
+## Running the Ratchet Locally
+
+```bash
+# Check both committed subsystems (bootstrap-safe)
+just ci-metrics-ratchet
+
+# Single subsystem
+just ci-metrics-ratchet-check parser
+```
+
+**Bootstrap mode**: when no receipt exists at
+`target/receipts/metrics/<subsystem>.json`, the xtask falls back to the
+committed baseline values.  This means the check always passes until a sweep
+generates a fresh receipt.  This is intentional — infrastructure validation
+before measurement instrumentation.
+
+**With a fresh receipt**: after running the parser sweep the xtask reads the
+receipt and compares against the baseline.  Any floor-metric regression causes
+a non-zero exit.
+
+---
+
+## CI Integration
+
+### Nightly gate (`ci-nightly.yml`)
+
+A dedicated `scorecard-ratchet-check` job runs the committed scorecard floor
+checks:
+
+- **Trigger**: nightly schedule, `workflow_dispatch`, or `ci:metrics-ratchet`
+  label on a PR.
+- **Effect**: non-zero exit on any floor-metric regression.  If a subsystem has
+  no fresh receipt in `target/receipts/metrics/`, the check uses baseline values
+  as current values and reports bootstrap mode.
+- **Bootstrap safety**: job passes if no receipt exists (see above).
+
+### Merge gate (`ci-gate`)
+
+`just ci-metrics-ratchet` is NOT currently in `ci-gate` (merge-blocking).
+The nightly job is the enforcement point for v1.  Rationale: receipts are
+generated by the full corpus sweep which is too slow for every PR.  Once
+a per-PR parser-smoke step emits a lightweight receipt, `ci-gate` can include
+a ratchet check against a smoke-subset baseline.
+
+---
+
+## Promoting a Baseline
+
+Use `promote-baseline` to raise a floor after confirming stable improvement:
+
+```bash
+# 1.  Check which improvement metrics are stable (≥3 consecutive runs, +1%)
+cargo xtask metrics promote-baseline parser
+
+# 2.  If candidates are listed, edit .ci/metrics/baselines/parser.json:
+#     - Move the metric from improvement_metrics to floor_metrics (or raise the floor value)
+#     - Update measured_at and commit fields
+
+# 3.  Verify the promoted baseline still passes
+just ci-metrics-ratchet
+
+# 4.  Commit the updated baseline as a standalone PR titled:
+#     "chore(ratchet): promote parser <metric> floor to <value>"
+```
+
+The stable-wins state is written to `target/metrics/stable_wins/<subsystem>.json`
+by `cargo xtask metrics ratchet-check <subsystem> --record`.  The nightly CI
+job does not record stable-wins state yet; use `--record` during an intentional
+baseline-promotion run after collecting fresh receipts.
+
+---
+
+## Adding a New Subsystem
+
+1. Create `.ci/metrics/baselines/<subsystem>.json` following the schema above.
+   Set `improvement_metrics` fields to `null` until you have a measurement.
+2. Add `cargo run -p xtask -- metrics ratchet-check <subsystem>` to
+   `just ci-metrics-ratchet` in the justfile.
+3. Add the subsystem to the active subsystems table in this document.
+4. Open a follow-up issue linking the subsystem to its improvement metrics.
+
+---
+
+## Issue ↔ Scorecard Linkage
+
+Every open issue that changes parser or engineering-health behavior should
+include a line:
+
+> **Scorecard impact**: improves `parser` → `<metric>` from `<baseline>` toward `<target>`.
+
+This creates an auditable chain from "work merged" to "floor moved".  See
+[README.md §Layer 4](README.md) for the full issue-family → scorecard mapping.
+
+---
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `xtask/src/tasks/metrics/ratchet.rs` | Ratchet check implementation + tests |
+| `xtask/src/tasks/metrics/stable_wins.rs` | Stable-wins state tracking |
+| `.ci/metrics/baselines/` | Committed floor baselines |
+| `target/receipts/metrics/` | Runtime receipts (gitignored) |
+| `target/metrics/stable_wins/` | Stable-wins ledger (gitignored) |
+| `.github/workflows/ci-nightly.yml` | Nightly ratchet job |
+| `justfile` (recipe `ci-metrics-ratchet`) | Local ratchet runner |

--- a/docs/project/metrics/README.md
+++ b/docs/project/metrics/README.md
@@ -368,6 +368,7 @@ A: Nothing. Those are generated per-subsystem status files that describe *what i
 
 ### Related docs
 
+- [docs/project/metrics/RATCHET.md](RATCHET.md) — operational guide: how to run ratchet checks locally, promote a baseline, and read the CI enforcement job.
 - [docs/project/metrics/WORKFLOW_SCORECARDS.md](WORKFLOW_SCORECARDS.md) — workflow-level scorecard contracts layered above the subsystem scorecards.
 - [docs/project/status/index.md](../status/index.md) — generated per-subsystem status surface (what is true *right now*).
 - [docs/project/ROADMAP.md](../ROADMAP.md) — milestone view of what each scorecard is aiming at.

--- a/justfile
+++ b/justfile
@@ -2682,12 +2682,15 @@ ci-metrics-ratchet-check subsystem:
     cargo run -p xtask -- metrics ratchet-check {{subsystem}}
     @echo "Scorecard ratchet passed for {{subsystem}}"
 
-# Check all committed scorecard baselines (parser + engineering_health).
+# Check all committed scorecard baselines.
 # Soft gate: run after ci-gate, warns on violation, does not block PR in v1.
 ci-metrics-ratchet:
     @echo "Checking scorecard floor metrics..."
     cargo run -p xtask -- metrics ratchet-check parser
     cargo run -p xtask -- metrics ratchet-check engineering_health
+    cargo run -p xtask -- metrics ratchet-check parser_accuracy
+    cargo run -p xtask -- metrics ratchet-check token
+    cargo run -p xtask -- metrics ratchet-check editor_ux
     @echo "Scorecard ratchet passed"
 
 # Tier C: full suite (nightly, all integration tests)

--- a/xtask/tests/metrics_ratchet_control_tests.rs
+++ b/xtask/tests/metrics_ratchet_control_tests.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn project_root() -> PathBuf {
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    dir.pop();
+    dir
+}
+
+fn committed_metric_baselines() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let root = project_root();
+    let baseline_dir = root.join(".ci/metrics/baselines");
+    let mut baselines = Vec::new();
+
+    for entry in fs::read_dir(baseline_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| format!("baseline path has non-utf8 file stem: {}", path.display()))?;
+        baselines.push(stem.to_string());
+    }
+
+    baselines.sort();
+    Ok(baselines)
+}
+
+#[test]
+fn ci_metrics_ratchet_recipe_checks_every_committed_baseline()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let justfile = fs::read_to_string(root.join("justfile"))?;
+
+    for subsystem in committed_metric_baselines()? {
+        let command = format!("metrics ratchet-check {subsystem}");
+        assert!(
+            justfile.contains(&command),
+            "just ci-metrics-ratchet must check committed baseline `{subsystem}`"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn ratchet_guide_lists_every_committed_baseline() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let guide = fs::read_to_string(root.join("docs/project/metrics/RATCHET.md"))?;
+
+    for subsystem in committed_metric_baselines()? {
+        let path = format!(".ci/metrics/baselines/{subsystem}.json");
+        assert!(guide.contains(&path), "RATCHET.md must list `{path}`");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn nightly_ratchet_job_is_label_gated_and_bootstrap_safe() -> Result<(), Box<dyn std::error::Error>>
+{
+    let root = project_root();
+    let workflow = fs::read_to_string(root.join(".github/workflows/ci-nightly.yml"))?;
+
+    assert!(
+        workflow.contains("scorecard-ratchet-check:"),
+        "ci-nightly.yml must define the scorecard ratchet job"
+    );
+    assert!(
+        workflow.contains("ci:metrics-ratchet"),
+        "scorecard ratchet job must stay label-gated for PRs"
+    );
+    assert!(
+        workflow.contains("just ci-metrics-ratchet"),
+        "scorecard ratchet job must use the shared just recipe"
+    );
+    assert!(
+        workflow.contains("bootstrap-safe"),
+        "workflow should document that missing receipts pass in bootstrap mode"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #4105.

This PR wires the existing scorecard ratchet machinery into the nightly/label-gated CI surface and adds an operator guide for running, reading, and promoting scorecard floor baselines.

## What changed

- Adds `scorecard-ratchet-check` to `.github/workflows/ci-nightly.yml`.
  - Runs on nightly schedule, `workflow_dispatch`, or PRs labeled `ci:metrics-ratchet`.
  - Uses `just ci-metrics-ratchet`.
  - Remains bootstrap-safe when no fresh metric receipts exist.
- Adds `docs/project/metrics/RATCHET.md` as the operational guide for the four-layer ratchet model.
- Links the guide from `docs/project/metrics/README.md`.
- Expands `just ci-metrics-ratchet` so it checks every committed metric baseline:
  - `parser`
  - `engineering_health`
  - `parser_accuracy`
  - `token`
  - `editor_ux`
- Adds xtask regression tests that keep the recipe, guide, and workflow aligned with committed baselines.

## Verification

- `cargo test -p xtask --test metrics_ratchet_control_tests --locked`
- `cargo check -p xtask --all-targets --locked`
- `cargo clippy -p xtask --test metrics_ratchet_control_tests --locked -- -D warnings`
- `just --shell cmd.exe --shell-arg /c ci-metrics-ratchet`
- `cargo xtask fmt --check`
- `git diff --check`

Broad `cargo clippy -p xtask --all-targets --locked -- -D warnings` is currently blocked by unrelated current-master clippy findings in existing xtask files (`wave1_perl_module_collapse_tests.rs`, `gates.rs`, `parser_accuracy.rs`, `queue_reconciler.rs`, `queue_snapshot.rs`, `update_status/token.rs`). This PR keeps those out of scope.

## Scorecard impact

Ratchet-control-plane coverage increases from two checked baselines to all five committed metric baselines. No parser accuracy denominator, failure-packet, or provider-impact rows are changed by this PR.