### PR TITLE
fix(completion): support newline-separated bless receiver evidence (#7953)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1439,6 +1439,37 @@ $x->"#;
 }
 
 #[test]
+fn test_bless_with_newline_separated_args_resolves_methods()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Newline-separated bless arguments are valid Perl and should still be
+    // classified as a literal-bless receiver for completion inference.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $x = bless {},
+    "Foo";
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    assert!(
+        completions.iter().any(|c| c.label == "bark"),
+        "newline-separated bless args should infer Foo and suggest bark; got: {:?}",
+        completions.iter().map(|c| &c.label).collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
 fn test_bless_qualified_class_resolves_methods() -> Result<(), Box<dyn std::error::Error>> {
     let index = Arc::new(WorkspaceIndex::new());
     index.index_file(

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -701,13 +701,15 @@ pub(super) fn classify_text_pattern_receiver(
         let var_name = arrow_prefix;
         let before = &source[..context.position.min(source.len())];
 
-        for line in before.lines().rev() {
+        let lines: Vec<&str> = before.lines().collect();
+        for (line_idx, line) in lines.iter().enumerate().rev() {
             let trimmed = line.trim();
             let assign_pos = find_assignment_eq(trimmed);
             if let Some(assign_pos) = assign_pos {
                 let lhs = trimmed[..assign_pos].trim();
                 if lhs.ends_with(var_name) || lhs.contains(&format!("{var_name} ")) {
-                    let rhs = trimmed[assign_pos + 1..].trim();
+                    let rhs = collect_assignment_rhs(&lines, line_idx, assign_pos);
+                    let rhs = rhs.trim();
                     // Pattern: `Package::Name->new(...)`
                     if let Some(arrow_pos) = rhs.find("->") {
                         let pkg = rhs[..arrow_pos].trim();
@@ -740,6 +742,62 @@ pub(super) fn classify_text_pattern_receiver(
     }
 
     ReceiverEvidence::Unknown
+}
+
+fn collect_assignment_rhs(lines: &[&str], line_idx: usize, assign_pos: usize) -> String {
+    let first_line = lines[line_idx].trim();
+    let mut rhs = first_line[assign_pos + 1..].trim().to_string();
+    if truncate_after_top_level_semicolon(&rhs).len() < rhs.len() {
+        return truncate_after_top_level_semicolon(&rhs).to_string();
+    }
+
+    for continuation in lines.iter().skip(line_idx + 1) {
+        if !rhs.is_empty() {
+            rhs.push('\n');
+        }
+        rhs.push_str(continuation.trim_end());
+        let truncated = truncate_after_top_level_semicolon(&rhs);
+        if truncated.len() < rhs.len() {
+            return truncated.to_string();
+        }
+    }
+
+    rhs
+}
+
+fn truncate_after_top_level_semicolon(s: &str) -> &str {
+    let mut depth_paren: i32 = 0;
+    let mut depth_brace: i32 = 0;
+    let mut depth_bracket: i32 = 0;
+    let mut in_string: Option<char> = None;
+    let mut prev_was_backslash = false;
+
+    for (idx, ch) in s.char_indices() {
+        if let Some(q) = in_string {
+            if !prev_was_backslash && ch == q {
+                in_string = None;
+            }
+            prev_was_backslash = !prev_was_backslash && ch == '\\';
+            continue;
+        }
+
+        prev_was_backslash = false;
+        match ch {
+            '"' | '\'' => in_string = Some(ch),
+            '(' => depth_paren += 1,
+            ')' => depth_paren -= 1,
+            '{' => depth_brace += 1,
+            '}' => depth_brace -= 1,
+            '[' => depth_bracket += 1,
+            ']' => depth_bracket -= 1,
+            ';' if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 => {
+                return &s[..idx + ch.len_utf8()];
+            }
+            _ => {}
+        }
+    }
+
+    s
 }
 
 /// Returns `true` when the RHS contains a *call-like* `bless` keyword


### PR DESCRIPTION
### Motivation
- Cover an edge case where a `bless` call's class argument appears on the following line so the receiver-inference logic still recognizes a literal class and surfaces expected method completions.

### Description
- Add a focused unit test `test_bless_with_newline_separated_args_resolves_methods` to `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs` that indexes a `Foo` package and asserts that `my $x = bless {},\n"Foo"; $x->` completion suggestions include `bark`.

### Testing
- I attempted to run `./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked completion::tests::test_bless_with_newline_separated_args_resolves_methods` but the run was blocked by a local storage policy (`DENY: /root/.cache/devplane/perl-lsp`), so the test could not be executed here; the change was committed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96298a24c8333a2580389226ed8e4)