### PR TITLE
test(completion): add detail formatting edge-case coverage (#7955)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1992,6 +1992,24 @@ fn detail_with_evidence_helper_handles_both_base_formats() {
 }
 
 #[test]
+fn detail_with_evidence_helper_handles_empty_and_punctuated_base_details() {
+    use super::workspace::detail_with_evidence;
+
+    // Edge case: empty base detail should still format deterministically.
+    let empty_base =
+        detail_with_evidence(String::new(), &ReceiverEvidence::TypeEngine("Foo".to_string()));
+    assert_eq!(empty_base, " — receiver: type engine, medium confidence");
+
+    // Edge case: inherited details can already include punctuation; suffix
+    // insertion should append cleanly without altering the original text.
+    let punctuated = detail_with_evidence(
+        "method from Foo (experimental; v2)".to_string(),
+        &ReceiverEvidence::StaticPackage("Foo".to_string()),
+    );
+    assert_eq!(punctuated, "method from Foo (experimental; v2) — receiver: static package");
+}
+
+#[test]
 fn detail_unchanged_when_no_receiver_evidence_path_reachable()
 -> Result<(), Box<dyn std::error::Error>> {
     // When receiver inference fails, the production callsite returns no


### PR DESCRIPTION
### Motivation
- Pin deterministic behavior for `detail_with_evidence` when the base detail is empty or already contains punctuation so method-completion detail formatting is stable for these edge cases.

### Description
- Add a focused unit test `detail_with_evidence_helper_handles_empty_and_punctuated_base_details` in `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs` which asserts the helper formats an empty base and appends the receiver suffix cleanly to a punctuation-heavy base.

### Testing
- Attempted to run `./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked detail_with_evidence_helper_handles_empty_and_punctuated_base_details`, but execution was blocked by a repository storage guardrail (`DENY: /root/.cache/devplane/perl-lsp`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96298a24c8333a2580389226ed8e4)