### PR TITLE
test(completion): add type-engine receiver detail edge case (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -1822,6 +1822,48 @@ $x->"#;
 }
 
 #[test]
+fn detail_marks_type_engine_receiver_as_medium_confidence() -> Result<(), Box<dyn std::error::Error>>
+{
+    // Edge case: constructor assignment pattern does not apply because the
+    // receiver variable is assigned from another variable. This should force
+    // TypeEngine evidence (medium confidence) rather than constructor assignment.
+    let index = Arc::new(WorkspaceIndex::new());
+    index.index_file(
+        Url::parse("file:///workspace/Foo.pm")?,
+        r#"package Foo;
+sub new { bless {}, shift }
+sub bark { }
+1;
+"#
+        .to_string(),
+    )?;
+
+    let code = r#"my $factory = Foo;
+my $x = $factory->new;
+$x->"#;
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index(&ast, Some(index));
+    let completions = provider.get_completions(code, code.len());
+
+    let bark = must_some(completions.iter().find(|c| c.label == "bark"));
+    let detail = must_some(bark.detail.as_deref());
+    assert!(
+        detail.contains("receiver: type engine"),
+        "variable-dispatched constructor should use type-engine receiver evidence; got {detail:?}"
+    );
+    assert!(
+        detail.contains("medium confidence"),
+        "type-engine receiver evidence should include medium-confidence label; got {detail:?}"
+    );
+    assert!(
+        !detail.contains("receiver: constructor assignment"),
+        "variable-dispatched constructor should not be classified as constructor assignment; got {detail:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn detail_for_inherited_preserves_from_annotation_and_appends_receiver()
 -> Result<(), Box<dyn std::error::Error>> {
     // Inherited methods must keep `(from Base)` (or the semantic-path


### PR DESCRIPTION
### Motivation
- The completion receiver-evidence tests did not cover the variable-dispatched constructor case (`my $x = $factory->new;`) which can be misclassified as a constructor-assignment; this gap risks regressions in receiver provenance and confidence labeling.

### Description
- Added a focused unit test `detail_marks_type_engine_receiver_as_medium_confidence` to `crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs` that exercises a variable-dispatched constructor scenario and asserts `TypeEngine` evidence is emitted.
- The test asserts the `detail` text contains `receiver: type engine` and `medium confidence` and explicitly rejects `receiver: constructor assignment` for this fixture.
- Change is test-only and scoped to a single new test in the existing `completion/tests.rs` file.

### Testing
- Attempted to run the focused test via `./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked detail_marks_type_engine_receiver_as_medium_confidence`, but execution was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so the test could not be completed here.
- Ran `./scripts/storage-doctor`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96298a24c8333a2580389226ed8e4)