### PR TITLE
refactor(perl-semantic-analyzer): remove direct perl-workspace coupling (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,6 @@ dependencies = [
  "perl-symbol",
  "perl-tdd-support",
  "perl-test-generators",
- "perl-workspace",
  "proptest",
  "regex",
  "rustc-hash",

--- a/crates/perl-lsp-rs/src/runtime/language/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/mod.rs
@@ -33,3 +33,24 @@ mod semantic_tokens;
 mod streaming;
 mod symbols;
 mod virtual_content;
+
+#[cfg(feature = "workspace")]
+fn to_workspace_sym_kind(kind: perl_parser::index::SymKind) -> crate::workspace_index::SymKind {
+    match kind {
+        perl_parser::index::SymKind::Pack => crate::workspace_index::SymKind::Pack,
+        perl_parser::index::SymKind::Sub => crate::workspace_index::SymKind::Sub,
+        perl_parser::index::SymKind::Var => crate::workspace_index::SymKind::Var,
+    }
+}
+
+#[cfg(feature = "workspace")]
+fn to_workspace_symbol_key(
+    key: &perl_parser::index::SymbolKey,
+) -> crate::workspace_index::SymbolKey {
+    crate::workspace_index::SymbolKey {
+        pkg: key.pkg.clone(),
+        name: key.name.clone(),
+        sigil: key.sigil,
+        kind: to_workspace_sym_kind(key.kind),
+    }
+}

--- a/crates/perl-lsp-rs/src/runtime/language/moniker.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/moniker.rs
@@ -78,7 +78,7 @@ impl LspServer {
 
                         // For subroutines in packages with base/parent,
                         // add monikers pointing to potential parent definitions
-                        if key.kind == crate::workspace_index::SymKind::Sub {
+                        if key.kind == perl_parser::index::SymKind::Sub {
                             for parent_pkg in Self::find_base_parents(ast) {
                                 let parent_id =
                                     format!("{}.{}", parent_pkg.replace("::", "."), key.name);
@@ -105,7 +105,7 @@ impl LspServer {
         &self,
         ast: &crate::ast::Node,
         text: &str,
-        key: &crate::workspace_index::SymbolKey,
+        key: &perl_parser::index::SymbolKey,
     ) -> (&'static str, &'static str) {
         // Check if symbol is exported via @EXPORT or @EXPORT_OK (AST-first, regex fallback)
         let uses_exporter = Self::has_use_exporter(ast);
@@ -126,8 +126,8 @@ impl LspServer {
 
         // Determine uniqueness
         let unique = match key.kind {
-            crate::workspace_index::SymKind::Pack => "global",
-            crate::workspace_index::SymKind::Sub => {
+            perl_parser::index::SymKind::Pack => "global",
+            perl_parser::index::SymKind::Sub => {
                 if is_exported {
                     "global"
                 } else if uses_exporter && key.pkg.as_ref() != "main" {
@@ -139,8 +139,12 @@ impl LspServer {
                     "document"
                 }
             }
-            crate::workspace_index::SymKind::Var => {
-                if self.is_our_variable(ast, &key.name, key.sigil) { "project" } else { "document" }
+            perl_parser::index::SymKind::Var => {
+                if self.is_our_variable(ast, &key.name, key.sigil) {
+                    "project"
+                } else {
+                    "document"
+                }
             }
         };
 

--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -1427,10 +1427,12 @@ impl LspServer {
                                 )
                             {
                                 tracing::debug!(symbol_key = ?symbol_key, "looking for definition");
+                                let workspace_symbol_key =
+                                    super::to_workspace_symbol_key(&symbol_key);
 
                                 if let Some(def_location) = find_symbol_key_definition_location(
                                     workspace_index,
-                                    &symbol_key,
+                                    &workspace_symbol_key,
                                 ) {
                                     tracing::debug!(location = ?def_location, "found definition");
                                     // Convert internal Location to LSP Location
@@ -1443,14 +1445,14 @@ impl LspServer {
                                     }
                                 }
 
-                                if symbol_key.kind == crate::workspace_index::SymKind::Sub
-                                    && symbol_key.sigil.is_none()
+                                if workspace_symbol_key.kind == crate::workspace_index::SymKind::Sub
+                                    && workspace_symbol_key.sigil.is_none()
                                     && let Some(import_source) =
-                                        self.find_import_source(ast, &symbol_key.name)
+                                        self.find_import_source(ast, &workspace_symbol_key.name)
                                     && let Some(def_location) = find_workspace_definition_location(
                                         workspace_index,
                                         &import_source,
-                                        &symbol_key.name,
+                                        &workspace_symbol_key.name,
                                     )
                                     && let Some(lsp_location) =
                                         crate::workspace_index::lsp_adapter::to_lsp_location(
@@ -1458,7 +1460,7 @@ impl LspServer {
                                         )
                                 {
                                     tracing::debug!(
-                                        symbol = %symbol_key.name,
+                                        symbol = %workspace_symbol_key.name,
                                         source_pkg = %import_source,
                                         "resolved bare imported symbol through require/import source"
                                     );

--- a/crates/perl-lsp-rs/src/runtime/language/references.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/references.rs
@@ -71,11 +71,13 @@ impl LspServer {
                     #[cfg(feature = "workspace")]
                     {
                         let access_mode = route_index_access(self.coordinator());
+                        let workspace_symbol_key =
+                            symbol_key.as_ref().map(super::to_workspace_symbol_key);
 
                         match access_mode {
                             IndexAccessMode::Full(coordinator) => {
                                 let index = coordinator.index();
-                                if let Some(symbol_key) = symbol_key.as_ref() {
+                                if let Some(symbol_key) = workspace_symbol_key.as_ref() {
                                     tracing::debug!(key = ?symbol_key, "Looking for references");
 
                                     // Try to find references using the symbol key
@@ -371,7 +373,7 @@ impl LspServer {
                                     "References: attempting partial workspace lookup"
                                 );
                                 if let (Some(coordinator), Some(symbol_key)) =
-                                    (self.coordinator(), symbol_key.as_ref())
+                                    (self.coordinator(), workspace_symbol_key.as_ref())
                                 {
                                     let index = coordinator.index();
                                     let mut partial_refs = index.find_refs(symbol_key);

--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -244,11 +244,13 @@ impl LspServer {
                         Some(c) if is_perl_sigil(c) => &normalized_name[c.len_utf8()..],
                         _ => normalized_name.as_str(),
                     };
+                    let workspace_symbol_key =
+                        symbol_key.as_ref().map(super::to_workspace_symbol_key);
 
                     match access_mode {
                         IndexAccessMode::Partial(reason) => {
                             if let (Some(coordinator), Some(key)) =
-                                (self.coordinator(), symbol_key.as_ref())
+                                (self.coordinator(), workspace_symbol_key.as_ref())
                             {
                                 match crate::workspace_rename::build_rename_edit(
                                     coordinator.index(),
@@ -292,7 +294,7 @@ impl LspServer {
                             // Fall through to same-file rename
                         }
                         IndexAccessMode::Full(coordinator) => {
-                            if let Some(key) = symbol_key.as_ref() {
+                            if let Some(key) = workspace_symbol_key.as_ref() {
                                 // Use coordinator.index() directly instead of workspace_index()
                                 // to ensure we go through routing policy
                                 let idx = coordinator.index();

--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -26,7 +26,6 @@ doctest = false
 [dependencies]
 perl-parser-core = { workspace = true }
 perl-module = { workspace = true }
-perl-workspace = { workspace = true }
 perl-symbol = { workspace = true }
 perl-semantic-facts = { workspace = true }
 regex.workspace = true

--- a/crates/perl-semantic-analyzer/src/analysis/index.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/index.rs
@@ -3,8 +3,36 @@
 //! This module provides efficient indexing of symbols across all files in a workspace,
 //! enabling fast cross-file navigation, references, and refactoring.
 
+use crate::analysis::import_extractor::ImportExtractor;
 use crate::symbol::{SymbolKind, SymbolTable};
+use crate::{Node, NodeKind, Parser};
+use perl_semantic_facts::FileId;
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, RwLock};
+
+/// Symbol kinds for cross-file indexing during Index/Navigate workflows.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum SymKind {
+    /// Variable symbol ($, @, or % sigil)
+    Var,
+    /// Subroutine definition (sub foo)
+    Sub,
+    /// Package declaration (package Foo)
+    Pack,
+}
+
+/// A normalized symbol key for cross-file lookups in Index/Navigate workflows.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct SymbolKey {
+    /// Package name containing this symbol
+    pub pkg: Arc<str>,
+    /// Bare name without sigil prefix
+    pub name: Arc<str>,
+    /// Variable sigil ($, @, or %) if applicable
+    pub sigil: Option<char>,
+    /// Kind of symbol (variable, subroutine, package)
+    pub kind: SymKind,
+}
 
 /// A symbol definition in the workspace
 #[derive(Clone, Debug)]
@@ -28,6 +56,8 @@ pub struct WorkspaceIndex {
     by_name: HashMap<String, Vec<SymbolDef>>,
     /// Index from URI to all symbol names in that file (for fast removal)
     by_uri: HashMap<String, HashSet<String>>,
+    /// Import/module dependencies by URI.
+    imports_by_uri: RwLock<HashMap<String, HashSet<String>>>,
 }
 
 impl WorkspaceIndex {
@@ -37,7 +67,7 @@ impl WorkspaceIndex {
     }
 
     /// Update the index with symbols from a document
-    pub fn update_from_document(&mut self, uri: &str, _content: &str, symtab: &SymbolTable) {
+    pub fn update_from_document(&mut self, uri: &str, content: &str, symtab: &SymbolTable) {
         // Remove old symbols from this file
         self.remove_document(uri);
 
@@ -64,6 +94,12 @@ impl WorkspaceIndex {
 
         // Track which names are in this file
         self.by_uri.insert(uri.to_string(), names_in_file);
+
+        if !content.is_empty()
+            && let Ok(dependencies) = Self::extract_dependencies(content)
+        {
+            self.set_file_dependencies(uri, dependencies);
+        }
     }
 
     /// Remove all symbols from a document
@@ -78,6 +114,107 @@ impl WorkspaceIndex {
                 }
             }
         }
+        self.remove_file_dependencies(uri);
+    }
+
+    /// Index import dependencies from raw file contents.
+    pub fn index_file_str(&self, uri: &str, content: &str) -> Result<(), String> {
+        let dependencies = Self::extract_dependencies(content)?;
+        let mut imports = self
+            .imports_by_uri
+            .write()
+            .map_err(|_| "workspace import index lock poisoned".to_string())?;
+        imports.insert(uri.to_string(), dependencies);
+        Ok(())
+    }
+
+    /// Return modules imported or required by a file.
+    pub fn file_dependencies(&self, uri: &str) -> HashSet<String> {
+        let Ok(imports) = self.imports_by_uri.read() else {
+            return HashSet::new();
+        };
+        imports.get(uri).cloned().unwrap_or_default()
+    }
+
+    fn set_file_dependencies(&self, uri: &str, dependencies: HashSet<String>) {
+        if let Ok(mut imports) = self.imports_by_uri.write() {
+            imports.insert(uri.to_string(), dependencies);
+        }
+    }
+
+    fn remove_file_dependencies(&self, uri: &str) {
+        if let Ok(mut imports) = self.imports_by_uri.write() {
+            imports.remove(uri);
+        }
+    }
+
+    fn extract_dependencies(content: &str) -> Result<HashSet<String>, String> {
+        let mut parser = Parser::new(content);
+        let ast = parser.parse().map_err(|err| format!("Parse error: {err}"))?;
+        let mut dependencies: HashSet<String> = ImportExtractor::extract(&ast, FileId(0))
+            .into_iter()
+            .filter_map(|spec| {
+                if spec.module.is_empty() || matches!(spec.module.as_str(), "parent" | "base") {
+                    None
+                } else {
+                    Some(spec.module)
+                }
+            })
+            .collect();
+
+        Self::collect_parent_dependencies(&ast, &mut dependencies);
+        Ok(dependencies)
+    }
+
+    fn collect_parent_dependencies(node: &Node, dependencies: &mut HashSet<String>) {
+        if let NodeKind::Use { module, args, .. } = &node.kind
+            && matches!(module.as_str(), "parent" | "base")
+        {
+            for name in Self::parent_names_from_args(args) {
+                dependencies.insert(name);
+            }
+        }
+
+        for child in node.children() {
+            Self::collect_parent_dependencies(child, dependencies);
+        }
+    }
+
+    fn parent_names_from_args(args: &[String]) -> Vec<String> {
+        args.iter()
+            .flat_map(|arg| Self::expand_parent_arg(arg))
+            .filter(|name| !name.starts_with('-'))
+            .collect()
+    }
+
+    fn expand_parent_arg(arg: &str) -> Vec<String> {
+        let trimmed = arg.trim();
+        if trimmed.is_empty() {
+            return Vec::new();
+        }
+
+        if let Some(content) = Self::parse_qw_content(trimmed) {
+            return content.split_whitespace().map(str::to_string).collect();
+        }
+
+        let unquoted = trimmed.trim_matches('\'').trim_matches('"').trim();
+        if unquoted.is_empty() { Vec::new() } else { vec![unquoted.to_string()] }
+    }
+
+    fn parse_qw_content(arg: &str) -> Option<&str> {
+        let rest = arg.strip_prefix("qw")?;
+        let mut chars = rest.chars();
+        let open = chars.next()?;
+        let close = match open {
+            '(' => ')',
+            '{' => '}',
+            '[' => ']',
+            '<' => '>',
+            delimiter => delimiter,
+        };
+        let start = open.len_utf8();
+        let end = rest.rfind(close)?;
+        (end >= start).then_some(&rest[start..end])
     }
 
     /// Find all definitions of a symbol by name

--- a/crates/perl-semantic-analyzer/src/lib.rs
+++ b/crates/perl-semantic-analyzer/src/lib.rs
@@ -56,11 +56,11 @@
     clippy::uninlined_format_args
 )]
 
+pub use analysis::index as workspace_index;
 pub use perl_parser_core::{Node, NodeKind, SourceLocation};
 pub use perl_parser_core::{
     Parser, ast, edit, error, parser, parser_context, position, pragma_tracker, quote_parser, util,
 };
-pub use perl_workspace::workspace_index;
 
 /// Semantic analysis, symbol extraction, and type inference.
 pub mod analysis;


### PR DESCRIPTION
Problem: `perl-semantic-analyzer` had a direct `perl-workspace` dependency through the public `workspace_index` seam.
Fix: remove the direct dependency, re-export the analyzer-local index module, keep the small analyzer compatibility surface (`SymKind`, `SymbolKey`, `index_file_str`, `file_dependencies`), and convert analyzer symbol keys to workspace symbol keys at LSP runtime boundaries.
Verification: `cargo test -p perl-semantic-analyzer --profile agent --locked`; `cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked`; `cargo check -p perl-lsp-rs --all-targets --profile agent --locked`; `cargo check --all-targets --profile agent --locked`; `cargo clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `git diff --check`; `cargo tree -p perl-semantic-analyzer --edges normal --depth 1`.

Parser accuracy receipt: 46 fixtures across 28 families; ratchet floors passed. Informational rows remain `line_construct_f1=0.8182`, `symbol_decl_f1=0.9231`, and AST/symbol edge/ref rows at `1.0000`.

Direct dependency check: `cargo tree -p perl-semantic-analyzer --edges normal --depth 1` no longer lists `perl-workspace` as a direct dependency. `perl-workspace` still appears transitively through `perl-module`, which is outside this PR's direct-edge boundary.

CI follow-up: the first refreshed CI run exposed downstream `SymbolKey` type mismatches in `perl-lsp-rs` all-targets compile. Fixed by adding explicit analyzer-key to workspace-key conversion at the LSP runtime boundary and reproduced with `cargo check --all-targets --profile agent --locked` locally.