### PR TITLE
docs(perl-semantic-analyzer): add workspace coupling audit (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/Cargo.toml
+++ b/crates/perl-semantic-analyzer/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["perl", "semantic-analysis", "symbol-table", "type-inference", "lsp"
 categories = ["parsing", "development-tools", "text-editors"]
 include = [
   "src/**",
+  "docs/**",
   "Cargo.toml",
   "LICENSE*",
   "README.md"

--- a/crates/perl-semantic-analyzer/README.md
+++ b/crates/perl-semantic-analyzer/README.md
@@ -36,3 +36,7 @@ let _symbols = SymbolExtractor::new().extract(&ast);
 Use `perl-semantic-analyzer` when you are building hover, declaration, type,
 or diagnostics features from parsed Perl source. If you need cross-file lookup
 or document caching, pair it with `perl-workspace`.
+
+## Architecture notes
+
+- [Dependency boundary audit](docs/dependency-boundary-audit.md)

--- a/crates/perl-semantic-analyzer/docs/dependency-boundary-audit.md
+++ b/crates/perl-semantic-analyzer/docs/dependency-boundary-audit.md
@@ -1,0 +1,50 @@
+# Dependency boundary audit: `perl-semantic-analyzer` → `perl-workspace`
+
+Date: 2026-05-05
+
+## Goal
+
+Document concrete coupling points so follow-up PRs can remove analyzer → workspace dependencies while preserving behavior.
+
+## Current dependency shape
+
+`crates/perl-semantic-analyzer/Cargo.toml` currently depends on `perl-workspace`.
+
+## Direct usages found
+
+### 1) Public re-export (API coupling)
+
+- `src/lib.rs` re-exports `perl_workspace::workspace_index`.
+- Impact: downstream crates can import workspace index types through the analyzer crate, creating a reverse-layer convenience dependency.
+- Classification: **accidental convenience**.
+
+### 2) Declaration-provider key types (shared vocabulary)
+
+- `src/analysis/declaration.rs` imports `SymKind` and `SymbolKey` from `workspace_index`.
+- Impact: analyzer-side declaration lookup returns workspace-defined symbol identifiers.
+- Classification: **shared vocabulary (currently hosted in workspace)**.
+
+### 3) Semantic query facade (`WorkspaceIndex`) references (query/store)
+
+- `src/analysis/semantic/query_facade.rs` accepts `workspace_index::WorkspaceIndex`.
+- Impact: semantic facade APIs in analyzer crate require workspace storage/query types.
+- Classification: **query/store coupling**.
+
+## Recommended migration slices
+
+1. **Vocabulary extraction (first):** move `SymKind` and `SymbolKey` into a neutral crate (`perl-symbol-types` or `perl-semantic-facts`) and update both crates to consume it.
+2. **API decoupling (second):** remove `workspace_index` re-export from analyzer public API after downstream call sites switch to explicit workspace imports.
+3. **Facade relocation (third):** move `analysis/semantic/query_facade.rs` workspace-facing query APIs into `perl-workspace` (or keep analyzer-only facts facade and add workspace adapters there).
+
+## Safety checks for follow-up PRs
+
+- `./scripts/cargo-safe test -p perl-semantic-analyzer --profile agent --locked`
+- `./scripts/cargo-safe check --all-targets -p perl-semantic-analyzer --profile agent --locked`
+- `./scripts/cargo-safe clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs`
+- `./scripts/cargo-safe xtask fmt`
+
+## Non-goals in this audit PR
+
+- No behavior changes.
+- No schema or scorecard changes.
+- No provider behavior changes.

--- a/crates/perl-semantic-analyzer/tests/prop_symbol_extraction.rs
+++ b/crates/perl-semantic-analyzer/tests/prop_symbol_extraction.rs
@@ -141,7 +141,7 @@ proptest! {
         let table = SymbolExtractor::new_with_source(&src).extract(&ast);
         let src_len = src.len();
 
-        for (_, syms) in &table.symbols {
+        for syms in table.symbols.values() {
             for sym in syms {
                 prop_assert!(
                     sym.location.start <= sym.location.end,
@@ -168,7 +168,7 @@ proptest! {
         let Ok(ast) = parser.parse() else { return Ok(()) };
 
         let table = SymbolExtractor::new_with_source(&src).extract(&ast);
-        for (name, _) in &table.symbols {
+        for name in table.symbols.keys() {
             prop_assert!(!name.is_empty(), "empty symbol name found in {:?}", src);
         }
     }


### PR DESCRIPTION
Problem: `perl-semantic-analyzer` has known analyzer-to-workspace coupling, but the coupling points and migration order were not captured in a crate-local audit.

Fix: Added a crate docs audit, linked it from the crate README, included crate docs in the package surface, and cleaned up two semantic-analyzer test loops that clippy now rejects.

Verification:
- `cargo xtask fmt --check`
- `cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked`
- `cargo test -p perl-semantic-analyzer --profile agent --locked`
- `cargo clippy -p perl-semantic-analyzer --all-targets --profile agent --locked -- -D warnings -A missing_docs`
- `cargo package -p perl-semantic-analyzer --locked --allow-dirty --no-verify --list` includes `README.md` and `docs/dependency-boundary-audit.md`
- `cargo xtask metrics parser-accuracy --check` passes: 46 fixtures across 28 families
- `cargo xtask metrics ratchet-check parser_accuracy` passes
- `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c72f0e08333ae2a2f450ed70ad6)