### PR TITLE
test(perl-parser-pest): harden assignment normalization behavior specs (#0000)

### DIFF
--- a/crates/perl-parser-pest/tests/behavior_spec_tests.rs
+++ b/crates/perl-parser-pest/tests/behavior_spec_tests.rs
@@ -93,6 +93,53 @@ fn when_hash_uses_fat_comma_pairs_then_parser_keeps_hash_assignment_structure() 
 }
 
 #[test]
+fn when_hash_uses_quoted_fat_comma_keys_then_assignment_remains_parseable() {
+    let sexp = parse_to_sexp("%hash = ('alpha' => 1, \"beta\" => 2);");
+
+    assert!(
+        sexp.contains("(assignment (hash_variable %hash) (=)")
+            && sexp.contains("(string_literal 'alpha')")
+            && sexp.contains("(string_literal beta)"),
+        "expected quoted fat-comma hash assignment to parse; got: {sexp}"
+    );
+}
+
+#[test]
+fn when_scalar_assignment_uses_percent_string_then_normalization_keeps_assignment_shape() {
+    let sexp = parse_to_sexp(r#"my $symbol = "%";"#);
+
+    assert!(
+        sexp.contains("(variable_declaration")
+            && sexp.contains("$symbol")
+            && sexp.contains("(string_literal %)"),
+        "expected scalar percent-string assignment to parse; got: {sexp}"
+    );
+}
+
+#[test]
+fn when_foreach_iterates_over_hash_keys_then_foreach_shape_is_retained() {
+    let sexp = parse_to_sexp("foreach my $key (keys %hash) { print $key; }");
+
+    assert!(
+        sexp.contains("(foreach_statement") || sexp.contains("(for_statement"),
+        "expected foreach-compatible loop node in output; got: {sexp}"
+    );
+    assert!(sexp.contains("$key"), "expected loop variable to be preserved; got: {sexp}");
+}
+
+#[test]
+fn when_multiple_double_dollar_dereferences_are_used_then_normalization_remains_stable() {
+    let sexp = parse_to_sexp("my $value = $$name; my $again = $$other;");
+
+    let deref_count = sexp.matches("(dereference").count();
+    assert!(deref_count >= 2, "expected two dereference nodes; got: {sexp}");
+    assert!(
+        sexp.contains("$name") && sexp.contains("$other"),
+        "expected both dereference targets to be preserved; got: {sexp}"
+    );
+}
+
+#[test]
 fn when_given_when_has_default_clause_then_parser_emits_given_shape() {
     let sexp = parse_to_sexp(
         r#"


### PR DESCRIPTION
Problem: `perl-parser-pest` is a frozen compatibility oracle, but assignment-normalization edge cases lacked focused BDD coverage.

Fix: Added single-file behavior specs for quoted fat-comma hash keys, scalar percent-string assignment, `foreach keys %hash`, and repeated `$$` dereference normalization. No parser behavior or public API changes.

Verification:
- `cargo test -p perl-parser-pest --test behavior_spec_tests --profile agent --locked` passes: 16 behavior tests
- `cargo check -p perl-parser-pest --all-targets --profile agent --locked`
- `cargo test -p perl-parser-pest --profile agent --locked`
- `cargo clippy -p perl-parser-pest --all-targets --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check` passes: 46 fixtures across 28 families
- `cargo xtask metrics ratchet-check parser_accuracy` passes
- `git diff --check`

Parser accuracy receipt:
- denominator: 46 fixtures / 28 families / 123 scored lines / 102 scored symbols
- active failure packets: 0
- provider rows: 12, all `insufficient_data`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c6a6b188333b246f56fec06bb36)