### PR TITLE
test(perl-parser-pest): harden assignment normalization BDD coverage (#0000)

### DIFF
--- a/crates/perl-parser-pest/tests/behavior_spec_tests.rs
+++ b/crates/perl-parser-pest/tests/behavior_spec_tests.rs
@@ -93,6 +93,45 @@ fn when_hash_uses_fat_comma_pairs_then_parser_keeps_hash_assignment_structure() 
 }
 
 #[test]
+fn when_hash_uses_quoted_fat_comma_pairs_then_parser_keeps_assignment_shape() {
+    let sexp = parse_to_sexp(r#"%labels = ("alpha" => 1, "beta" => 2);"#);
+
+    assert!(
+        sexp.contains("(assignment (hash_variable %labels) (=)")
+            && sexp.contains("(string_literal alpha)")
+            && sexp.contains("(string_literal beta)"),
+        "expected quoted fat-comma hash assignment to parse; got: {sexp}"
+    );
+}
+
+#[test]
+fn when_hash_assignment_uses_mixed_pair_value_shapes_then_parser_preserves_pair_entries() {
+    let sexp = parse_to_sexp("%config = (workers => 4, mode => $mode, active => 1);\n");
+
+    assert!(
+        sexp.contains("(assignment (hash_variable %config) (=)")
+            && sexp.contains("(identifier workers )")
+            && sexp.contains("(identifier mode )")
+            && sexp.contains("(identifier active )"),
+        "expected mixed hash pairs in assignment output; got: {sexp}"
+    );
+}
+
+#[test]
+fn when_foreach_and_double_dollar_and_spaced_bitnot_appear_together_then_parser_still_parses() {
+    let sexp = parse_to_sexp(
+        "foreach my $name (@names) { my $value = $$name; $value = ~ $value; print $value; }",
+    );
+
+    assert!(sexp.contains("(foreach_statement") || sexp.contains("(for_statement"));
+    assert!(sexp.contains("(dereference"), "expected dereference node; got: {sexp}");
+    assert!(
+        sexp.contains("(assignment") || sexp.contains("bitnot"),
+        "expected spaced bitnot assignment-compatible output; got: {sexp}"
+    );
+}
+
+#[test]
 fn when_given_when_has_default_clause_then_parser_emits_given_shape() {
     let sexp = parse_to_sexp(
         r#"


### PR DESCRIPTION
### Motivation

- Harden the legacy `perl-parser-pest` BDD suite around assignment and normalization seams so the crate remains a reliable compatibility oracle without changing parser behavior.

### Description

- Add focused behavior tests in `crates/perl-parser-pest/tests/behavior_spec_tests.rs` that cover quoted fat-comma hash assignments, mixed-value fat-comma pairs, and a combined `foreach my` + `$$` dereference + spaced bitnot normalization scenario.

### Testing

- Ran `cargo test -p perl-parser-pest`, which completed successfully and all tests passed; the behavior spec suite exercised the new tests.  
- An attempt to run `./scripts/cargo-safe test -p perl-parser-pest --profile agent --locked` was blocked by the environment storage guard (`DENY: /root/.cache/devplane/...`), so the direct `cargo test` run was used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c6a6b188333b246f56fec06bb36)