### PR TITLE
test(perl-parser-pest): harden hash/percent assignment behavior specs (#0000)

### DIFF
--- a/crates/perl-parser-pest/tests/behavior_spec_tests.rs
+++ b/crates/perl-parser-pest/tests/behavior_spec_tests.rs
@@ -93,6 +93,43 @@ fn when_hash_uses_fat_comma_pairs_then_parser_keeps_hash_assignment_structure() 
 }
 
 #[test]
+fn when_hash_uses_mixed_fat_comma_key_forms_then_assignment_shape_is_preserved() {
+    let sexp = parse_to_sexp("%hash = ('a' => 1, b => 2, \"c\" => 3);");
+
+    assert!(
+        sexp.contains("(assignment (hash_variable %hash) (=)")
+            && sexp.contains("(string_literal 'a')")
+            && sexp.contains("(identifier b )")
+            && sexp.contains("(string_literal c)"),
+        "expected mixed fat-comma key forms to remain in assignment shape; got: {sexp}"
+    );
+}
+
+#[test]
+fn when_hash_assignment_contains_trailing_comma_then_parse_stays_successful() {
+    let sexp = parse_to_sexp("%hash = (a => 1, b => 2,);");
+
+    assert!(
+        sexp.contains("(assignment (hash_variable %hash) (=)")
+            && sexp.contains("(identifier a )")
+            && sexp.contains("(identifier b )"),
+        "expected trailing-comma hash assignment to parse; got: {sexp}"
+    );
+}
+
+#[test]
+fn when_percent_scalar_is_assigned_percent_string_then_assignment_stays_distinct() {
+    let sexp = parse_to_sexp("my $fmt = \"%\";");
+
+    assert!(
+        sexp.contains("(variable_declaration")
+            && sexp.contains("$fmt")
+            && sexp.contains("(string_literal %)"),
+        "expected percent string assignment to remain a string literal; got: {sexp}"
+    );
+}
+
+#[test]
 fn when_given_when_has_default_clause_then_parser_emits_given_shape() {
     let sexp = parse_to_sexp(
         r#"


### PR DESCRIPTION
### Motivation
- Harden the legacy `perl-parser-pest` BDD surface for assignment/normalization edge cases so the crate remains a stable reference/compatibility oracle without changing parser behavior.

### Description
- Added three focused tests in `crates/perl-parser-pest/tests/behavior_spec_tests.rs`: `when_hash_uses_mixed_fat_comma_key_forms_then_assignment_shape_is_preserved`, `when_hash_assignment_contains_trailing_comma_then_parse_stays_successful`, and `when_percent_scalar_is_assigned_percent_string_then_assignment_stays_distinct` to cover mixed key forms, trailing commas, and percent-string assignment shapes.

### Testing
- Ran `cargo test -p perl-parser-pest --test behavior_spec_tests`, which passed (all tests in that suite succeeded).
- Ran `cargo test -p perl-parser-pest` (unit tests) which also passed for the crate.
- An invocation of `./scripts/cargo-safe test -p perl-parser-pest --profile agent --locked` was attempted but was blocked by the environment storage guard (DENY), so the scripted agent-profile check was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c6a6b188333b246f56fec06bb36)