### PR TITLE
test(perl-parser-pest): harden assignment normalization behavior specs (#0000)

### DIFF
--- a/crates/perl-parser-pest/tests/behavior_spec_tests.rs
+++ b/crates/perl-parser-pest/tests/behavior_spec_tests.rs
@@ -93,6 +93,42 @@ fn when_hash_uses_fat_comma_pairs_then_parser_keeps_hash_assignment_structure() 
 }
 
 #[test]
+fn when_hash_uses_quoted_fat_comma_keys_then_parser_preserves_key_shape() {
+    let sexp = parse_to_sexp(r#"%hash = ("alpha" => 1, "beta" => 2);"#);
+
+    assert!(
+        sexp.contains("(assignment (hash_variable %hash) (=)")
+            && sexp.contains("(string_literal alpha)")
+            && sexp.contains("(string_literal beta)"),
+        "expected quoted fat-comma key assignment; got: {sexp}"
+    );
+}
+
+#[test]
+fn when_hash_uses_bareword_and_string_mix_then_parser_accepts_assignment() {
+    let sexp = parse_to_sexp(r#"%hash = (kind => "x", "mode" => "y");"#);
+
+    assert!(
+        sexp.contains("(assignment (hash_variable %hash) (=)")
+            && sexp.contains("(identifier kind )")
+            && sexp.contains("(string_literal mode)"),
+        "expected mixed key styles in hash fat-comma assignment; got: {sexp}"
+    );
+}
+
+#[test]
+fn when_percent_scalar_string_assignment_is_reassigned_then_parser_keeps_assignment_shape() {
+    let sexp = parse_to_sexp(r#"my $v = "%"; $v = "%";"#);
+
+    assert!(
+        sexp.contains("(variable_declaration")
+            && sexp.contains("(assignment")
+            && sexp.contains("(string_literal %)"),
+        "expected percent-string assignment and reassignment to parse; got: {sexp}"
+    );
+}
+
+#[test]
 fn when_given_when_has_default_clause_then_parser_emits_given_shape() {
     let sexp = parse_to_sexp(
         r#"


### PR DESCRIPTION
### Motivation

- Improve legacy `perl-parser-pest` test coverage around assignment normalization edge cases so the frozen v2 parser remains a reliable compatibility oracle. 

### Description

- Add focused BDD tests to `crates/perl-parser-pest/tests/behavior_spec_tests.rs` for quoted fat-comma hash keys, mixed bareword/string fat-comma keys, and percent-string reassignment. 
- Change is test-only and limited to a single file; no parser implementation or public API was modified. 
- Commit message used: `test(perl-parser-pest): harden assignment normalization behavior specs (#0000)`. 

### Testing

- Ran `cargo test -p perl-parser-pest`, which executed unit and behavior suites and completed successfully (all tests passed). 
- Attempted `./scripts/cargo-safe test -p perl-parser-pest --profile agent --locked` but it was blocked by a storage guard (`DENY`), so the canonical safe-script run did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c6a6b188333b246f56fec06bb36)