### PR TITLE
test(perl-symbol): harden SymbolIndex mutation coverage (#0000)

### DIFF
--- a/crates/perl-symbol/src/index/mod.rs
+++ b/crates/perl-symbol/src/index/mod.rs
@@ -89,7 +89,9 @@ impl SymbolIndex {
     /// Returns all symbols starting with the given prefix.
     #[must_use]
     pub fn search_prefix(&self, prefix: &str) -> Vec<String> {
-        self.trie.search_prefix(prefix)
+        let mut results = self.trie.search_prefix(prefix);
+        results.sort();
+        results
     }
 
     /// Fuzzy search symbols.
@@ -110,7 +112,12 @@ impl SymbolIndex {
 
         // Sort by relevance (number of matching tokens)
         let mut sorted: Vec<_> = results.into_iter().collect();
-        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
+        sorted.sort_by(|(name_a, score_a), (name_b, score_b)| {
+            score_b
+                .cmp(score_a)
+                .then_with(|| name_a.len().cmp(&name_b.len()))
+                .then_with(|| name_a.cmp(name_b))
+        });
 
         sorted.into_iter().map(|(symbol, _)| symbol).collect()
     }
@@ -278,6 +285,16 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_add_symbol_does_not_duplicate_search_results() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("get_user_name".to_string());
+        index.add_symbol("get_user_name".to_string());
+
+        assert_eq!(index.search_prefix("get"), vec!["get_user_name".to_string()]);
+        assert_eq!(index.search_fuzzy("user name"), vec!["get_user_name".to_string()]);
+    }
+
+    #[test]
     fn replace_document_symbols_removes_stale_entries() {
         let mut index = SymbolIndex::new();
         index.replace_document_symbols(
@@ -360,6 +377,84 @@ mod tests {
         assert!(
             !results.contains(&"get_user_name".to_string()),
             "replaced symbol must be removed from fuzzy index"
+        );
+    }
+
+    #[test]
+    fn replace_document_symbols_deduplicates_same_symbol_in_one_document() {
+        let mut index = SymbolIndex::new();
+        index.replace_document_symbols(
+            "file:///a.pl",
+            vec!["shared_name".to_string(), "shared_name".to_string()],
+        );
+
+        assert_eq!(index.search_prefix("shared"), vec!["shared_name".to_string()]);
+        assert_eq!(index.search_fuzzy("shared name"), vec!["shared_name".to_string()]);
+    }
+
+    #[test]
+    fn fuzzy_ranking_prefers_more_matching_tokens() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("alpha_beta_gamma".to_string());
+        index.add_symbol("alpha_beta".to_string());
+        index.add_symbol("alpha_only".to_string());
+
+        assert_eq!(
+            index.search_fuzzy("alpha beta gamma"),
+            vec![
+                "alpha_beta_gamma".to_string(),
+                "alpha_beta".to_string(),
+                "alpha_only".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn fuzzy_handles_camel_snake_and_mixed_delimiters() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("parseHTTPHeader".to_string());
+        index.add_symbol("parse_http_header".to_string());
+        index.add_symbol("parse-http-header".to_string());
+
+        let results = index.search_fuzzy("parse http header");
+        assert_eq!(
+            results,
+            vec![
+                "parse-http-header".to_string(),
+                "parse_http_header".to_string(),
+                "parseHTTPHeader".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_query_returns_empty_result() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("anything".to_string());
+        assert!(index.search_fuzzy("").is_empty());
+    }
+
+    #[test]
+    fn unknown_prefix_returns_empty_result() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("known_symbol".to_string());
+        assert!(index.search_prefix("zzz").is_empty());
+    }
+
+    #[test]
+    fn fuzzy_tie_breakers_are_deterministic() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("alpha_zeta".to_string());
+        index.add_symbol("alpha_beta".to_string());
+        index.add_symbol("alpha".to_string());
+
+        assert_eq!(
+            index.search_fuzzy("alpha"),
+            vec![
+                "alpha".to_string(),
+                "alpha_beta".to_string(),
+                "alpha_zeta".to_string()
+            ]
         );
     }
 }


### PR DESCRIPTION
### Motivation

- Symbol index behavior around duplicate insertions, per-document replacement, fuzzy tokenization, and result ordering was underspecified and made downstream UX/tests flaky.
- Making prefix and fuzzy search deterministic and adding focused mutation-coverage tests prevents regressions and documents intended behavior for future refactors.

### Description

- `search_prefix` now sorts collected results before returning to provide deterministic ordering for prefix queries.
- `search_fuzzy` now applies a deterministic tie-breaker ordering of (1) descending match score, (2) shorter qualified name, and (3) lexicographic name length to stabilize fuzzy results.
- Added targeted tests exercising duplicate `add_symbol()` idempotency, `replace_document_symbols()` deduping, shared-symbol lifetime across documents, fuzzy ranking by token match count, camel/snake/mixed-delimiter tokenization, empty-query/unknown-prefix guardrails, and deterministic fuzzy tie-breaks in `crates/perl-symbol/src/index/mod.rs` test module.

### Testing

- Ran `cargo test -p perl-symbol --locked` and the perl-symbol test suite passed (unit and integration tests exercised the new cases). 
- Ran `cargo check --all-targets -p perl-symbol --locked` which completed successfully.
- Ran `cargo clippy -p perl-symbol --all-targets --locked -- -D warnings -A missing_docs` which failed on pre-existing `expect()` usage in `crates/perl-symbol/src/surface/facts.rs` tests unrelated to these changes and therefore left for a separate cleanup PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c62016c8333b082010ebd9e0f7c)