### PR TITLE
docs(perl-semantic-analyzer): audit workspace coupling points (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/docs/dependency-boundary-audit.md
+++ b/crates/perl-semantic-analyzer/docs/dependency-boundary-audit.md
@@ -1,0 +1,35 @@
+# Dependency Boundary Audit: `perl-semantic-analyzer` → `perl-workspace`
+
+This note captures all current `perl-workspace` coupling points in `perl-semantic-analyzer` and classifies each one to guide follow-up extractions.
+
+## Current coupling map
+
+1. **Crate-level re-export of workspace index module**
+   - Location: `src/lib.rs`
+   - Usage: `pub use perl_workspace::workspace_index;`
+   - Classification: **accidental convenience**
+   - Why: This forwards workspace-facing storage/query types through the analyzer crate boundary.
+
+2. **Symbol key vocabulary used by declaration provider logic**
+   - Location: `src/analysis/declaration.rs`
+   - Usage: `SymKind`, `SymbolKey`
+   - Classification: **shared vocabulary**
+   - Why: Declaration lookup currently returns workspace key types.
+
+3. **Semantic query facade accepts workspace index object**
+   - Location: `src/analysis/semantic/query_facade.rs`
+   - Usage: `WorkspaceIndex`
+   - Classification: **query/store coupling**
+   - Why: Query facade takes workspace-owned index state directly.
+
+## Extraction order
+
+1. Move `SymKind` / `SymbolKey` vocabulary to semantic-neutral shared crate surface.
+2. Replace `lib.rs` re-export with analyzer-owned neutral fact interfaces.
+3. Refactor `query_facade` methods to consume semantic fact collections and keep workspace query policy in `perl-workspace`.
+
+## Non-goals for this audit
+
+- No behavior change.
+- No scorecard/fixture movement.
+- No provider-facing API reshaping in this PR.


### PR DESCRIPTION
### Motivation
- Record and classify current `perl-semantic-analyzer` → `perl-workspace` coupling points to guide follow-up extractions that push workspace-facing types out of the analyzer and harden the producer contract.

### Description
- Add `crates/perl-semantic-analyzer/docs/dependency-boundary-audit.md` which enumerates three coupling sites (crate re-export of the workspace index, `SymbolKey`/`SymKind` vocabulary usage, and `WorkspaceIndex` parameter coupling) and provides a simple 3-step extraction plan; this is documentation-only with no behavioral or API changes.

### Testing
- Executed `cargo tree -p perl-semantic-analyzer` which succeeded; attempts to run `./scripts/cargo-safe test -p perl-semantic-analyzer --profile agent --locked` and `./scripts/cargo-safe check --all-targets -p perl-semantic-analyzer --profile agent --locked` were blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c72f0e08333ae2a2f450ed70ad6)