### PR TITLE
test(perl-symbol): harden SymbolIndex mutation coverage (#0000)

### DIFF
--- a/crates/perl-symbol/src/index/mod.rs
+++ b/crates/perl-symbol/src/index/mod.rs
@@ -108,9 +108,14 @@ impl SymbolIndex {
             }
         }
 
-        // Sort by relevance (number of matching tokens)
+        // Sort by relevance with deterministic tie-breakers.
         let mut sorted: Vec<_> = results.into_iter().collect();
-        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
+        sorted.sort_by(|(name_a, score_a), (name_b, score_b)| {
+            score_b
+                .cmp(score_a)
+                .then_with(|| name_a.len().cmp(&name_b.len()))
+                .then_with(|| name_a.cmp(name_b))
+        });
 
         sorted.into_iter().map(|(symbol, _)| symbol).collect()
     }
@@ -226,6 +231,7 @@ impl SymbolTrie {
         // Collect all symbols from this node and descendants
         let mut results = Vec::new();
         Self::collect_all(node, &mut results);
+        results.sort();
         results
     }
 
@@ -360,6 +366,81 @@ mod tests {
         assert!(
             !results.contains(&"get_user_name".to_string()),
             "replaced symbol must be removed from fuzzy index"
+        );
+    }
+
+    #[test]
+    fn duplicate_add_symbol_is_idempotent_for_prefix_and_fuzzy() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("foo_bar".to_string());
+        index.add_symbol("foo_bar".to_string());
+
+        assert_eq!(index.search_prefix("foo"), vec!["foo_bar".to_string()]);
+        assert_eq!(index.search_fuzzy("foo bar"), vec!["foo_bar".to_string()]);
+    }
+
+    #[test]
+    fn replace_document_symbols_deduplicates_symbols_within_document() {
+        let mut index = SymbolIndex::new();
+        index.replace_document_symbols(
+            "file:///a.pl",
+            vec!["dedup_me".to_string(), "dedup_me".to_string(), "dedup_me".to_string()],
+        );
+
+        assert_eq!(index.search_prefix("dedup"), vec!["dedup_me".to_string()]);
+        assert_eq!(index.search_fuzzy("dedup me"), vec!["dedup_me".to_string()]);
+    }
+
+    #[test]
+    fn fuzzy_ranking_prefers_symbols_matching_more_query_tokens() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("foo_bar_baz".to_string());
+        index.add_symbol("foo_bar".to_string());
+        index.add_symbol("foo".to_string());
+
+        let results = index.search_fuzzy("foo bar baz");
+        assert_eq!(results[0], "foo_bar_baz".to_string());
+        assert_eq!(results[1], "foo_bar".to_string());
+        assert_eq!(results[2], "foo".to_string());
+    }
+
+    #[test]
+    fn fuzzy_search_tokenizes_camel_snake_and_mixed_delimiters() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("getUserName".to_string());
+        index.add_symbol("get_user_email".to_string());
+        index.add_symbol("set-user-name".to_string());
+
+        assert!(index.search_fuzzy("user name").contains(&"getUserName".to_string()));
+        assert!(index.search_fuzzy("user email").contains(&"get_user_email".to_string()));
+        assert!(index.search_fuzzy("user name").contains(&"set-user-name".to_string()));
+    }
+
+    #[test]
+    fn empty_query_and_unknown_prefix_return_empty_results() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("known_symbol".to_string());
+
+        assert!(index.search_fuzzy("").is_empty());
+        assert!(index.search_fuzzy("   ").is_empty());
+        assert!(index.search_prefix("missing").is_empty());
+    }
+
+    #[test]
+    fn deterministic_ordering_for_equal_fuzzy_scores_and_prefix_results() {
+        let mut index = SymbolIndex::new();
+        index.add_symbol("beta_symbol".to_string());
+        index.add_symbol("alpha_symbol".to_string());
+        index.add_symbol("gamma_symbol".to_string());
+
+        assert_eq!(
+            index.search_prefix(""),
+            vec!["alpha_symbol".to_string(), "beta_symbol".to_string(), "gamma_symbol".to_string()]
+        );
+
+        assert_eq!(
+            index.search_fuzzy("symbol"),
+            vec!["beta_symbol".to_string(), "alpha_symbol".to_string(), "gamma_symbol".to_string()]
         );
     }
 }

--- a/crates/perl-symbol/src/surface/facts.rs
+++ b/crates/perl-symbol/src/surface/facts.rs
@@ -268,6 +268,7 @@ fn stable_id(namespace: &str, name: &str, start: usize, end: usize) -> u64 {
 mod tests {
     use super::*;
     use crate::types::VarKind;
+    use perl_tdd_support::must_some;
 
     #[test]
     fn adapter_is_deterministic_for_mixed_decls() {
@@ -367,20 +368,13 @@ mod tests {
         // "FooBar" would be a wrong resolution.
         assert_eq!(facts.defines_edges.len(), 1, "should have exactly one Defines edge");
         let edge = &facts.defines_edges[0];
-        let bar_entity = facts
-            .entities
-            .iter()
-            .find(|e| e.canonical_name == "Bar")
-            .expect("Bar entity must exist");
+        let bar_entity = must_some(facts.entities.iter().find(|e| e.canonical_name == "Bar"));
         assert_eq!(
             edge.from_entity_id, bar_entity.id,
             "Defines edge must point FROM Bar (not FooBar)"
         );
-        let baz_entity = facts
-            .entities
-            .iter()
-            .find(|e| e.canonical_name == "FooBar::baz")
-            .expect("FooBar::baz entity must exist");
+        let baz_entity =
+            must_some(facts.entities.iter().find(|e| e.canonical_name == "FooBar::baz"));
         assert_eq!(edge.to_entity_id, baz_entity.id, "Defines edge must point TO FooBar::baz");
         // No false unsupported reports — "Bar" container was found.
         assert!(
@@ -471,21 +465,9 @@ mod tests {
         assert_eq!(facts.defines_edges.len(), 3, "should have 3 Defines edges");
         assert!(facts.unsupported.is_empty(), "no unsupported entries");
 
-        let c_entity = facts
-            .entities
-            .iter()
-            .find(|e| e.canonical_name == "A::B::C")
-            .expect("A::B::C entity must exist");
-        let d_entity = facts
-            .entities
-            .iter()
-            .find(|e| e.canonical_name == "A::B::C::D")
-            .expect("A::B::C::D entity must exist");
-        let d_edge = facts
-            .defines_edges
-            .iter()
-            .find(|e| e.to_entity_id == d_entity.id)
-            .expect("Defines edge to A::B::C::D must exist");
+        let c_entity = must_some(facts.entities.iter().find(|e| e.canonical_name == "A::B::C"));
+        let d_entity = must_some(facts.entities.iter().find(|e| e.canonical_name == "A::B::C::D"));
+        let d_edge = must_some(facts.defines_edges.iter().find(|e| e.to_entity_id == d_entity.id));
         assert_eq!(
             d_edge.from_entity_id, c_entity.id,
             "Defines edge for A::B::C::D must come FROM A::B::C"


### PR DESCRIPTION
### Motivation

- Prevent flaky editor UX and snapshot churn by making `SymbolIndex` search behaviors deterministic and by adding mutation-focused tests for deduplication and tokenization edge cases.
- Capture regressions around duplicate insertions, per-document replacements, empty-query guardrails, and fuzzy ranking so future refactors are safer.

### Description

- Make prefix results stable by sorting collected trie results in `SymbolTrie::search_prefix` before returning.
- Make fuzzy search deterministic by sorting `search_fuzzy` results with tie-breakers: descending match score, shorter qualified name, then lexicographic order.
- Add focused unit tests for duplicate `add_symbol()` idempotency, `replace_document_symbols()` deduplication, fuzzy ranking by matched token count, tokenization across camelCase/snake/mixed delimiters, empty-query/unknown-prefix behavior, and deterministic ordering.
- Replace five stale `expect()` calls in same-crate tests with `perl_tdd_support::must_some` so focused `perl-symbol` clippy passes under the repo no-unwrap/no-expect test policy.

### Testing

- `cargo test -p perl-symbol --profile agent --locked`
- `cargo check -p perl-symbol --all-targets --profile agent --locked`
- `cargo clippy -p perl-symbol --all-targets --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`