### PR TITLE
docs(roadmap): codify editor-trust sequencing (#7952)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -135,6 +135,10 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Resume parser, corpus, semantic, and DAP hardening after the release-channel receipts close
 - Keep the install story verified across all distribution channels
 - Keep public-alpha release notes concise and tied to concrete channel receipts
+- Editor-trust sequencing for #7952 should remain the product-ordering default: availability first, bounded completion proof next, diagnostics truth after that, then real-workspace semantic baseline, `@INC` consumer consistency, parser recovery-under-edit, UX fixture substrate consolidation, ratchet promotion, and semantic producer-boundary cleanup.
+- Completion follow-ups should improve **ranking** inside the existing bounded unknown-receiver fallback candidate set (no all-workspace fallback broadening) and keep uncertainty labels explicit.
+- Diagnostics suppression should stay semantic and conservative: suppress only when indexed evidence shows a symbol may exist; keep dynamic uncertainty fail-closed and preserve legacy behavior when no semantic index is available.
+- Ratchet policy should stay phased: nightly evidence first, label-gated PR checks second, merge-blocking floors only for cheap deterministic invariants (panic-free parser, no exact-receiver regressions, no dynamic false-precision leaks, no stale-index regressions).
 
 ## Milestone Ladder
 


### PR DESCRIPTION
### Motivation
- Encode a concise, canonical ordering for the "editor-trust" wave so the roadmap explicitly prioritizes availability, bounded completion proof, diagnostics truth, real-workspace semantic baselines, `@INC` consistency, parser recovery under edit, UX fixture consolidation, ratchets, and semantic-producer boundary cleanup as described in #7952.

### Description
- Add four bullet points under `Next (post v0.13.2)` in `docs/project/ROADMAP.md` that prescribe the editor-trust sequencing, conservative completion-ranking guidance, semantic-only diagnostics suppression, and phased ratchet policy.

### Testing
- No automated test suite was run because `just agent-pr-fast` is not available in this environment; attempting to run `just agent-pr-fast` failed with `just: command not found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c53396c8333acdab4e92af0dbaf)