### PR TITLE
docs(roadmap): prioritize editor-trust execution order (#7952)

### DIFF
--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -136,6 +136,29 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Keep the install story verified across all distribution channels
 - Keep public-alpha release notes concise and tied to concrete channel receipts
 
+### Next-wave execution frame: editor trust first (#7952)
+
+The next product wave should optimize for editor trust before expanding capability surface area.
+
+Execution order:
+
+1. Availability and typing-time recovery hardening
+2. Completion fallback proof (bounded usefulness, no noise leakage)
+3. Diagnostics truth proof (semantic evidence required for suppression)
+4. Real-workspace semantic baselines
+5. `@INC` and module-resolution consumer consistency
+6. Parser recovery under incomplete code while typing
+7. Canonical UX harness + machine-checkable fixture schema
+8. Ratchet promotion (nightly first, then label-gated, merge-blocking only after stability)
+9. Semantic producer boundary cleanup before the next expansion wave
+
+Guardrails for this lane:
+
+- No all-workspace completion fallback broadening while bounded fallback ranking is still being calibrated.
+- No diagnostic suppression without indexed semantic evidence.
+- No merge-blocking ratchets until metrics are deterministic, low-flake, and cheap to run.
+- Keep queue triage focused on product value (availability, trust, and proof), not micro-shard throughput.
+
 ## Milestone Ladder
 
 ### v0.11.0


### PR DESCRIPTION
### Motivation
- Codify an "editor-trust-first" execution frame in the roadmap to prioritize availability, bounded completion proof, diagnostics truth, parser recovery under edit, UX harnessing, `@INC` consistency, ratchets, and semantic boundary cleanup before expanding capability surface.

### Description
- Added a new `Next-wave execution frame: editor trust first (#7952)` section to `docs/project/ROADMAP.md` that lists the recommended execution order and guardrails (availability → completion fallback proof → diagnostics truth → real-workspace baselines → include-path consistency → parser recovery → canonical UX harness/fixture schema → ratchet promotion → semantic producer boundary cleanup).

### Testing
- No crate tests were run for this docs-only change; an attempt to run the repository helper `just agent-pr-fast` failed because `just` is not installed in this environment, so verification was limited to committing the updated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c53396c8333acdab4e92af0dbaf)