### PR TITLE
docs(workspace): remove stale perl-workspace-index naming (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The v0.13 architecture collapsed the old microcrate graph into a smaller publish
 | Parser engine | `perl-parser-core` |
 | Lexer | `perl-lexer` |
 | Semantic analysis | `perl-semantic-analyzer` |
-| Workspace index | `perl-workspace-index` |
+| Workspace index | `perl-workspace` |
 | Diagnostics catalog | `perl-diagnostics` |
 | Debug adapter | `perl-dap` |
 | Tree-sitter integration | `tree-sitter-perl-rs`, `tree-sitter-perl-c` |

--- a/crates/perl-workspace/README.md
+++ b/crates/perl-workspace/README.md
@@ -1,4 +1,4 @@
-# perl-workspace-index
+# perl-workspace
 
 Workspace indexing and cross-file lookup for Perl tooling.
 
@@ -7,7 +7,7 @@ answer workspace-wide queries such as references, symbols, and rename targets.
 
 ## Where it fits
 
-`perl-workspace-index` sits above `perl-parser-core` and below the editor and
+`perl-workspace` sits above `perl-parser-core` and below the editor and
 refactoring layers. It owns document storage, incremental updates, and the
 workspace symbol index that the rest of the stack queries.
 
@@ -20,6 +20,6 @@ workspace symbol index that the rest of the stack queries.
 
 ## Typical use
 
-Use `perl-workspace-index` when you already have parsed documents and need to
+Use `perl-workspace` when you already have parsed documents and need to
 keep the workspace view current as files change. If you only need syntax trees,
 depend on `perl-parser-core` instead.

--- a/crates/perl-workspace/src/api.rs
+++ b/crates/perl-workspace/src/api.rs
@@ -1,4 +1,4 @@
-//! Unified public API surface for `perl-workspace-index`.
+//! Unified public API surface for `perl-workspace`.
 //!
 //! This module defines the crate's stable "import once" entry-point for callers
 //! that only need discovery, folder parsing, and ignore-policy helpers.
@@ -16,7 +16,7 @@
 //! # Typical usage
 //!
 //! ```rust
-//! use perl_workspace_index::api::{
+//! use perl_workspace::api::{
 //!     discover_perl_files, extract_workspace_folder_uris, is_skipped_dir_name,
 //! };
 //!

--- a/docs/project/status/workspace.md
+++ b/docs/project/status/workspace.md
@@ -22,7 +22,7 @@ This scorecard measures three properties of the index substrate:
 ## Stale-Index Defect Rate
 
 <!-- BEGIN: WORKSPACE_STALE_RATE -->
-| **Stale-index defect rate** | 0 / 7 scenarios tested | 0% | see `cargo test -p perl-workspace-index -- scorecard` |
+| **Stale-index defect rate** | 0 / 7 scenarios tested | 0% | see `cargo test -p perl-workspace -- scorecard` |
 <!-- END: WORKSPACE_STALE_RATE -->
 
 ## SLO Targets
@@ -75,6 +75,6 @@ This scorecard measures three properties of the index substrate:
 ```bash
 cargo xtask update-status --only workspace   # regenerate all marked sections
 cargo xtask update-status --check --only workspace   # verify (CI gate)
-cargo test -p perl-workspace-index -- scorecard_  # run the scorecard tests
+cargo test -p perl-workspace -- scorecard_  # run the scorecard tests
 just ci-workspace-multiroot                  # run multi-root integration tests (nightly)
 ```

--- a/justfile
+++ b/justfile
@@ -1373,6 +1373,9 @@ clean:
 ci-docs-check:
     @echo "📝 Checking missing docs baseline..."
     @cargo xtask ci-hygiene check-missing-docs
+    @if rg -n "perl-workspace-index" README.md docs/project/status/workspace.md crates/perl-workspace/README.md crates/perl-workspace/src/api.rs | rg -v "MIGRATION|compat|renamed"; then \
+        echo "❌ stale crate name perl-workspace-index found in canonical docs"; exit 1; \
+    fi
     @echo "✅ Missing docs check passed"
 
 # Policy and governance checks


### PR DESCRIPTION
### Motivation
- Public docs and rustdoc still referenced the retired package name `perl-workspace-index`, causing confusing commands, examples, and status pages; this should be canonicalized to `perl-workspace`.

### Description
- Updated the root `README.md` crate surface to show `perl-workspace` instead of `perl-workspace-index`.
- Renamed occurrences in `crates/perl-workspace/README.md` and corrected the rustdoc sample import and header in `crates/perl-workspace/src/api.rs` to the new crate name.
- Fixed `docs/project/status/workspace.md` scorecard command examples to use `cargo test -p perl-workspace`.
- Added a lightweight docs drift guard to the `ci-docs-check` recipe in `justfile` that fails if `perl-workspace-index` appears in canonical files (excluding explicit migration/compat notes).

### Testing
- Ran `cargo xtask ci-hygiene check-missing-docs`, which executed successfully during development and progressed through compilation without reported failures in this session.
- Verified via targeted grep that the edited canonical files no longer contain `perl-workspace-index` (the new `ci-docs-check` guard will enforce this in CI).
- Attempted to run `just ci-docs-check` locally but `just` is not installed in this environment, so the full recipe could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c4314808333b207942b651ea27a)