### PR TITLE
docs(workspace): fix crate identity drift in public docs (#0000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The v0.13 architecture collapsed the old microcrate graph into a smaller publish
 | Parser engine | `perl-parser-core` |
 | Lexer | `perl-lexer` |
 | Semantic analysis | `perl-semantic-analyzer` |
-| Workspace index | `perl-workspace-index` |
+| Workspace index | `perl-workspace` |
 | Diagnostics catalog | `perl-diagnostics` |
 | Debug adapter | `perl-dap` |
 | Tree-sitter integration | `tree-sitter-perl-rs`, `tree-sitter-perl-c` |

--- a/crates/perl-workspace/README.md
+++ b/crates/perl-workspace/README.md
@@ -1,4 +1,4 @@
-# perl-workspace-index
+# perl-workspace
 
 Workspace indexing and cross-file lookup for Perl tooling.
 
@@ -7,7 +7,7 @@ answer workspace-wide queries such as references, symbols, and rename targets.
 
 ## Where it fits
 
-`perl-workspace-index` sits above `perl-parser-core` and below the editor and
+`perl-workspace` sits above `perl-parser-core` and below the editor and
 refactoring layers. It owns document storage, incremental updates, and the
 workspace symbol index that the rest of the stack queries.
 
@@ -20,6 +20,6 @@ workspace symbol index that the rest of the stack queries.
 
 ## Typical use
 
-Use `perl-workspace-index` when you already have parsed documents and need to
+Use `perl-workspace` when you already have parsed documents and need to
 keep the workspace view current as files change. If you only need syntax trees,
 depend on `perl-parser-core` instead.

--- a/crates/perl-workspace/src/api.rs
+++ b/crates/perl-workspace/src/api.rs
@@ -1,4 +1,4 @@
-//! Unified public API surface for `perl-workspace-index`.
+//! Unified public API surface for `perl-workspace`.
 //!
 //! This module defines the crate's stable "import once" entry-point for callers
 //! that only need discovery, folder parsing, and ignore-policy helpers.
@@ -16,7 +16,7 @@
 //! # Typical usage
 //!
 //! ```rust
-//! use perl_workspace_index::api::{
+//! use perl_workspace::api::{
 //!     discover_perl_files, extract_workspace_folder_uris, is_skipped_dir_name,
 //! };
 //!

--- a/docs/project/status/workspace.md
+++ b/docs/project/status/workspace.md
@@ -22,7 +22,7 @@ This scorecard measures three properties of the index substrate:
 ## Stale-Index Defect Rate
 
 <!-- BEGIN: WORKSPACE_STALE_RATE -->
-| **Stale-index defect rate** | 0 / 7 scenarios tested | 0% | see `cargo test -p perl-workspace-index -- scorecard` |
+| **Stale-index defect rate** | 0 / 7 scenarios tested | 0% | see `cargo test -p perl-workspace -- scorecard` |
 <!-- END: WORKSPACE_STALE_RATE -->
 
 ## SLO Targets
@@ -57,7 +57,7 @@ This scorecard measures three properties of the index substrate:
 ## Metrics Bullets
 
 <!-- BEGIN: WORKSPACE_METRICS_BULLETS -->
-- **Stale-index defect rate**: 0 stale-symbol defects across 7 tested deletion/rename scenarios (unit tests in `crates/perl-workspace-index/tests/workspace_scorecard.rs`)
+- **Stale-index defect rate**: 0 stale-symbol defects across 7 tested deletion/rename scenarios (unit tests in `crates/perl-workspace/tests/workspace_scorecard.rs`)
 - **Incremental reindex SLO**: P95 target = 100ms (from `perl-workspace-index-slo`); measured in `scorecard_incremental_reindex_latency_within_slo`
 - **Multi-root tests**: 8 integration tests in `crates/perl-lsp-rs/tests/multi_root_workspace_tests.rs` activated in nightly CI gate via `just ci-workspace-multiroot` (PR #4137)
 - **Fixture workspaces**: 4 scales at `test_corpus/workspaces/` (10 / 100 / 1000 committed + xlarge generated on demand)
@@ -67,7 +67,7 @@ This scorecard measures three properties of the index substrate:
 
 - PR 3 of 3 (per plan-reviewer option A): stale-index defect harness with realistic LSP session replay (didOpen → didChange → didSave → delete → assert)
 - Promote `ci-workspace-multiroot` from nightly to merge gate once 10 consecutive nightly passes are confirmed
-- Surface real P50/P95 latency numbers from benchmarks (`perl-workspace-index/benches/workspace_index_benchmark.rs`) into this file via `xtask update-status --only workspace`
+- Surface real P50/P95 latency numbers from benchmarks (`crates/perl-workspace/benches/workspace_index_benchmark.rs`) into this file via `xtask update-status --only workspace`
 - Add a direct signal row for the shipped `workspace/configuration` handler (#3515) in the next `xtask update-status --only workspace` refresh
 
 ## How to Update
@@ -75,6 +75,6 @@ This scorecard measures three properties of the index substrate:
 ```bash
 cargo xtask update-status --only workspace   # regenerate all marked sections
 cargo xtask update-status --check --only workspace   # verify (CI gate)
-cargo test -p perl-workspace-index -- scorecard_  # run the scorecard tests
+cargo test -p perl-workspace -- scorecard_  # run the scorecard tests
 just ci-workspace-multiroot                  # run multi-root integration tests (nightly)
 ```

--- a/justfile
+++ b/justfile
@@ -1374,6 +1374,12 @@ ci-docs-check:
     @echo "📝 Checking missing docs baseline..."
     @cargo xtask ci-hygiene check-missing-docs
     @echo "✅ Missing docs check passed"
+    @echo "🧹 Checking stale crate-name references in public docs..."
+    @if rg -n "`perl-workspace-index`" README.md crates/perl-workspace/README.md docs/project/status/workspace.md; then \
+        echo "❌ Found stale perl-workspace-index references in public docs"; \
+        exit 1; \
+    fi
+    @echo "✅ Public crate-name docs check passed"
 
 # Policy and governance checks
 ci-policy:


### PR DESCRIPTION
### Motivation

- Public documentation and status pages still referred to the old `perl-workspace-index` package name which causes mismatches in docs.rs, status commands, and user-facing guidance. 
- Add a small docs hygiene guard so future drift of the public crate name is detected early by CI.

### Description

- Updated the root `README.md` crate surface to list `perl-workspace` instead of `perl-workspace-index`.
- Renamed headings and usage text in `crates/perl-workspace/README.md` and updated the rustdoc example in `crates/perl-workspace/src/api.rs` to use `perl_workspace`.
- Fixed workspace status documentation paths and commands in `docs/project/status/workspace.md` to reference `crates/perl-workspace` and `cargo test -p perl-workspace`.
- Added a grep-based guard to the `ci-docs-check` recipe in `justfile` that fails when backticked `perl-workspace-index` references appear in the selected public docs.

### Testing

- Verified the edits with a targeted search using `rg -n "perl-workspace-index" README.md crates/perl-workspace/README.md crates/perl-workspace/src/api.rs docs/project/status/workspace.md justfile`, which confirmed the public docs were updated as intended.
- Attempted to run `just ci-docs-check` but the `just` tool was not available in the execution environment so the new guard was not executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c4314808333b207942b651ea27a)