### PR TITLE
feat(refactoring): add refactor plan and edit validation skeleton (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/edit_plan.rs
+++ b/crates/perl-refactoring/src/refactor/edit_plan.rs
@@ -1,0 +1,90 @@
+use crate::refactor::workspace_refactor::FileEdit;
+use serde::{Deserialize, Serialize};
+
+/// Operation kind for refactoring plans.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum RefactorOperationKind {
+    /// Symbol rename operations.
+    Rename,
+    /// Import optimization operations.
+    OptimizeImports,
+    /// Module extraction operations.
+    ExtractModule,
+    /// Subroutine move operations.
+    MoveSubroutine,
+}
+
+/// Safety level for a generated refactoring plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum RefactorSafety {
+    /// Operation is safe to apply directly.
+    Safe,
+    /// Operation should be previewed before apply.
+    NeedsPreview,
+    /// Operation was blocked as unsafe.
+    UnsafeBlocked,
+}
+
+/// Confidence level for the analysis producing a plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum RefactorConfidence {
+    /// Exact symbol/range evidence.
+    Exact,
+    /// Scope-aware but not exact identity.
+    ScopeAware,
+    /// Heuristic/textual matching.
+    Heuristic,
+}
+
+/// Machine-readable diagnostic attached to a refactoring plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefactorDiagnostic {
+    /// Diagnostic code for stable assertions in tests.
+    pub code: String,
+    /// Human-readable diagnostic message.
+    pub message: String,
+}
+
+/// Lightweight statistics for a generated plan.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefactorStats {
+    /// Count of files touched by the plan.
+    pub files_touched: usize,
+    /// Count of edits emitted by the plan.
+    pub edits_emitted: usize,
+}
+
+/// Normalized internal refactoring contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefactorPlan {
+    /// Operation that produced this plan.
+    pub operation: RefactorOperationKind,
+    /// File edits to apply for the operation.
+    pub edits: Vec<FileEdit>,
+    /// Non-fatal diagnostics generated during planning.
+    pub diagnostics: Vec<RefactorDiagnostic>,
+    /// Confidence of the generated edits.
+    pub confidence: RefactorConfidence,
+    /// Safety classification for the plan.
+    pub safety: RefactorSafety,
+    /// Emitted plan statistics.
+    pub stats: RefactorStats,
+}
+
+impl RefactorPlan {
+    /// Build a plan and derive simple stats from edits.
+    pub fn with_edits(
+        operation: RefactorOperationKind,
+        edits: Vec<FileEdit>,
+        diagnostics: Vec<RefactorDiagnostic>,
+        confidence: RefactorConfidence,
+        safety: RefactorSafety,
+    ) -> Self {
+        let edits_emitted = edits.iter().map(|f| f.edits.len()).sum();
+        let stats = RefactorStats { files_touched: edits.len(), edits_emitted };
+        Self { operation, edits, diagnostics, confidence, safety, stats }
+    }
+}

--- a/crates/perl-refactoring/src/refactor/edit_validation.rs
+++ b/crates/perl-refactoring/src/refactor/edit_validation.rs
@@ -1,0 +1,93 @@
+use crate::refactor::workspace_refactor::{FileEdit, TextEdit};
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Validation failures for refactoring edit plans.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditValidationError {
+    /// File path escaped configured workspace roots.
+    FileOutsideWorkspace { path: String },
+    /// Edit has invalid range ordering or bounds.
+    InvalidRange { file: String, start: usize, end: usize, len: usize },
+    /// Edits overlap within a single file.
+    OverlappingRanges { file: String, previous_end: usize, next_start: usize },
+    /// Edit boundary falls inside a UTF-8 codepoint.
+    NonUtf8Boundary { file: String, offset: usize },
+}
+
+/// Validate generated file edits against basic safety invariants.
+pub fn validate_file_edits(
+    file_edits: &[FileEdit],
+    workspace_roots: &[&Path],
+    file_text: &dyn Fn(&Path) -> Option<String>,
+) -> Result<(), EditValidationError> {
+    let mut seen_files = HashSet::new();
+
+    for file_edit in file_edits {
+        let canonical = file_edit.file_path.canonicalize().unwrap_or(file_edit.file_path.clone());
+        if !workspace_roots.is_empty()
+            && !workspace_roots.iter().any(|root| canonical.starts_with(root))
+        {
+            return Err(EditValidationError::FileOutsideWorkspace {
+                path: file_edit.file_path.display().to_string(),
+            });
+        }
+
+        if !seen_files.insert(canonical.clone()) {
+            // Allow multiple entries targeting same file only if callers merge first.
+            return Err(EditValidationError::OverlappingRanges {
+                file: file_edit.file_path.display().to_string(),
+                previous_end: 0,
+                next_start: 0,
+            });
+        }
+
+        let content = file_text(&file_edit.file_path).unwrap_or_default();
+        validate_text_edits(&file_edit.edits, &content, &file_edit.file_path)?;
+    }
+
+    Ok(())
+}
+
+fn validate_text_edits(
+    edits: &[TextEdit],
+    content: &str,
+    path: &Path,
+) -> Result<(), EditValidationError> {
+    let mut sorted = edits.to_vec();
+    sorted.sort_by_key(|e| (e.start, e.end));
+
+    let mut previous_end = 0usize;
+    for (idx, edit) in sorted.iter().enumerate() {
+        if edit.start > edit.end || edit.end > content.len() {
+            return Err(EditValidationError::InvalidRange {
+                file: path.display().to_string(),
+                start: edit.start,
+                end: edit.end,
+                len: content.len(),
+            });
+        }
+        if !content.is_char_boundary(edit.start) {
+            return Err(EditValidationError::NonUtf8Boundary {
+                file: path.display().to_string(),
+                offset: edit.start,
+            });
+        }
+        if !content.is_char_boundary(edit.end) {
+            return Err(EditValidationError::NonUtf8Boundary {
+                file: path.display().to_string(),
+                offset: edit.end,
+            });
+        }
+        if idx > 0 && edit.start < previous_end {
+            return Err(EditValidationError::OverlappingRanges {
+                file: path.display().to_string(),
+                previous_end,
+                next_start: edit.start,
+            });
+        }
+        previous_end = edit.end;
+    }
+
+    Ok(())
+}

--- a/crates/perl-refactoring/src/refactor/mod.rs
+++ b/crates/perl-refactoring/src/refactor/mod.rs
@@ -1,5 +1,7 @@
 //! Refactoring and modernization helpers.
 
+pub mod edit_plan;
+pub mod edit_validation;
 pub mod import_optimizer;
 pub mod inline;
 pub mod modernize;

--- a/crates/perl-refactoring/src/refactor/workspace_refactor.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_refactor.rs
@@ -50,6 +50,10 @@
 //! let optimized = refactor.optimize_imports()?;
 //! ```
 
+use super::edit_plan::{
+    RefactorConfidence, RefactorDiagnostic, RefactorOperationKind, RefactorPlan, RefactorSafety,
+};
+use super::edit_validation::validate_file_edits;
 use crate::import_optimizer::ImportOptimizer;
 use crate::workspace_index::{
     SymKind, SymbolKey, WorkspaceIndex, fs_path_to_uri, normalize_var, uri_to_fs_path,
@@ -517,10 +521,25 @@ impl WorkspaceRefactor {
             });
         }
 
-        Ok(RefactorResult {
+        let plan = RefactorPlan::with_edits(
+            RefactorOperationKind::OptimizeImports,
             file_edits,
+            vec![RefactorDiagnostic {
+                code: "import-optimizer.regex-compat".to_string(),
+                message: "Using compatibility import optimizer implementation".to_string(),
+            }],
+            RefactorConfidence::ScopeAware,
+            RefactorSafety::NeedsPreview,
+        );
+
+        let roots = [Path::new(".")];
+        validate_file_edits(&plan.edits, &roots, &|path| std::fs::read_to_string(path).ok())
+            .map_err(|err| format!("Edit validation failed: {err:?}"))?;
+
+        Ok(RefactorResult {
+            file_edits: plan.edits,
             description: "Optimize imports across workspace".to_string(),
-            warnings: vec![],
+            warnings: plan.diagnostics.into_iter().map(|d| d.message).collect(),
         })
     }
 


### PR DESCRIPTION
### Motivation

- Establish a normalized plan-first contract for refactoring operations so downstream flows can `analyze -> plan -> validate -> apply` with measurable safety and confidence metadata.
- Centralize basic edit-safety checks to make edit validation boring and reusable across rename/import/extract operations.

### Description

- Add a new `RefactorPlan` model and supporting enums/structs in `crates/perl-refactoring/src/refactor/edit_plan.rs` to record `operation`, `edits`, `diagnostics`, `confidence`, `safety`, and `stats`.
- Add shared edit validation primitives in `crates/perl-refactoring/src/refactor/edit_validation.rs` that enforce workspace-root containment, UTF-8 boundary checks, range ordering, and overlap detection.
- Wire the new modules into the refactor module tree by exporting `edit_plan` and `edit_validation` from `crates/perl-refactoring/src/refactor/mod.rs`.
- Route `WorkspaceRefactor::optimize_imports` through the new `RefactorPlan` path and call `validate_file_edits` before returning, while surfacing plan diagnostics into `RefactorResult.warnings` to maintain behavioral compatibility with the existing optimizer.

### Testing

- Ran the intended verification command `./scripts/cargo-safe check -p perl-refactoring --all-targets --profile agent --locked` but it was blocked by the environment storage guard with error `DENY: /root/.cache/devplane/perl-lsp used=48% free=31G` so the compile check could not complete.
- No automated tests were modified or disabled as part of this change and the patch is limited to a small, backward-compatible plan/validation skeleton.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c3b87308333963d019b7c5eb2a4)