### PR TITLE
feat(refactoring): add refactor planning and edit validation skeleton (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/edit_plan.rs
+++ b/crates/perl-refactoring/src/refactor/edit_plan.rs
@@ -1,0 +1,60 @@
+use crate::refactor::workspace_refactor::FileEdit;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefactorOperationKind {
+    Rename,
+    ExtractModule,
+    MoveSubroutine,
+    InlineVariable,
+    OptimizeImports,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefactorSafety {
+    Safe,
+    NeedsPreview,
+    UnsafeBlocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefactorConfidence {
+    Exact,
+    ScopeAware,
+    Heuristic,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefactorDiagnostic {
+    pub code: &'static str,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RefactorStats {
+    pub files_changed: usize,
+    pub edits: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefactorPlan {
+    pub operation: RefactorOperationKind,
+    pub edits: Vec<FileEdit>,
+    pub diagnostics: Vec<RefactorDiagnostic>,
+    pub confidence: RefactorConfidence,
+    pub safety: RefactorSafety,
+    pub stats: RefactorStats,
+}
+
+impl RefactorPlan {
+    pub fn new(operation: RefactorOperationKind, edits: Vec<FileEdit>) -> Self {
+        let edits_count = edits.iter().map(|file_edit| file_edit.edits.len()).sum();
+        Self {
+            operation,
+            stats: RefactorStats { files_changed: edits.len(), edits: edits_count },
+            edits,
+            diagnostics: vec![],
+            confidence: RefactorConfidence::Exact,
+            safety: RefactorSafety::Safe,
+        }
+    }
+}

--- a/crates/perl-refactoring/src/refactor/edit_validation.rs
+++ b/crates/perl-refactoring/src/refactor/edit_validation.rs
@@ -1,0 +1,76 @@
+use std::path::Path;
+
+use crate::refactor::workspace_refactor::FileEdit;
+
+#[derive(Debug)]
+pub enum EditValidationError {
+    InvalidRange { file: String, start: usize, end: usize },
+    OverlappingRanges { file: String, prior_end: usize, next_start: usize },
+    InvalidUtf8Boundary { file: String, start: usize, end: usize },
+}
+
+impl std::fmt::Display for EditValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidRange { file, start, end } => {
+                write!(f, "edit range is invalid for file {file}: start={start}, end={end}")
+            }
+            Self::OverlappingRanges { file, prior_end, next_start } => write!(
+                f,
+                "edit ranges overlap in file {file}: prior_end={prior_end}, next_start={next_start}"
+            ),
+            Self::InvalidUtf8Boundary { file, start, end } => write!(
+                f,
+                "edit range is not aligned to UTF-8 boundaries in file {file}: start={start}, end={end}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EditValidationError {}
+
+pub fn validate_file_edits<F>(file_edits: &[FileEdit], mut get_contents: F) -> Result<(), EditValidationError>
+where
+    F: FnMut(&Path) -> Option<String>,
+{
+    for file_edit in file_edits {
+        let file = file_edit.file_path.display().to_string();
+        let contents = get_contents(&file_edit.file_path).unwrap_or_default();
+        let mut ordered_edits = file_edit.edits.clone();
+        ordered_edits.sort_by_key(|edit| (edit.start, edit.end));
+
+        let mut prior_end = 0usize;
+        let mut has_prior = false;
+
+        for edit in ordered_edits {
+            if edit.start > edit.end || edit.end > contents.len() {
+                return Err(EditValidationError::InvalidRange {
+                    file,
+                    start: edit.start,
+                    end: edit.end,
+                });
+            }
+
+            if !contents.is_char_boundary(edit.start) || !contents.is_char_boundary(edit.end) {
+                return Err(EditValidationError::InvalidUtf8Boundary {
+                    file,
+                    start: edit.start,
+                    end: edit.end,
+                });
+            }
+
+            if has_prior && edit.start < prior_end {
+                return Err(EditValidationError::OverlappingRanges {
+                    file,
+                    prior_end,
+                    next_start: edit.start,
+                });
+            }
+
+            prior_end = edit.end;
+            has_prior = true;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/perl-refactoring/src/refactor/mod.rs
+++ b/crates/perl-refactoring/src/refactor/mod.rs
@@ -1,5 +1,7 @@
 //! Refactoring and modernization helpers.
 
+pub mod edit_plan;
+pub mod edit_validation;
 pub mod import_optimizer;
 pub mod inline;
 pub mod modernize;

--- a/crates/perl-refactoring/src/refactor/workspace_refactor.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_refactor.rs
@@ -54,6 +54,9 @@ use crate::import_optimizer::ImportOptimizer;
 use crate::workspace_index::{
     SymKind, SymbolKey, WorkspaceIndex, fs_path_to_uri, normalize_var, uri_to_fs_path,
 };
+
+use super::edit_plan::{RefactorOperationKind, RefactorPlan, RefactorSafety};
+use super::edit_validation::validate_file_edits;
 use perl_module::path::module_name_to_path;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -336,6 +339,8 @@ impl WorkspaceRefactor {
             }
         }
 
+        let used_fallback = locations.is_empty();
+
         for loc in locations {
             let path = uri_to_fs_path(&loc.uri).ok_or_else(|| {
                 RefactorError::UriConversion(format!("Failed to convert URI to path: {}", loc.uri))
@@ -365,8 +370,20 @@ impl WorkspaceRefactor {
         let file_edits: Vec<FileEdit> =
             edits.into_iter().map(|(file_path, edits)| FileEdit { file_path, edits }).collect();
 
+        validate_file_edits(&file_edits, |path| {
+            fs_path_to_uri(path).ok().and_then(|uri| {
+                store.get(&uri).map(|document| document.text.clone())
+            })
+        })
+        .map_err(|error| RefactorError::InvalidInput(error.to_string()))?;
+
+        let mut plan = RefactorPlan::new(RefactorOperationKind::Rename, file_edits);
+        if used_fallback {
+            plan.safety = RefactorSafety::NeedsPreview;
+        }
+
         let description = format!("Rename '{}' to '{}'", old_name, new_name);
-        Ok(RefactorResult { file_edits, description, warnings: vec![] })
+        Ok(RefactorResult { file_edits: plan.edits, description, warnings: vec![] })
     }
 
     /// Extract selected code into a new module


### PR DESCRIPTION
### Motivation

- Provide a single internal planning contract for refactor operations so higher-level flows can be plan-first, measurable, and LSP-friendly.
- Centralize basic edit validation to prevent invalid/overlapping/invalid-UTF8 edits from being emitted by refactors.
- Start consolidating rename output to a plan-aware shape while retaining the existing external result for compatibility.

### Description

- Added `crates/perl-refactoring/src/refactor/edit_plan.rs` with `RefactorPlan`, `RefactorOperationKind`, `RefactorSafety`, `RefactorConfidence`, `RefactorDiagnostic`, and `RefactorStats` types and a small `RefactorPlan::new` helper.
- Added `crates/perl-refactoring/src/refactor/edit_validation.rs` with `validate_file_edits` and `EditValidationError` to check ordered ranges, overlapping ranges, bounds, and UTF-8 character boundaries.
- Registered the new modules in `crates/perl-refactoring/src/refactor/mod.rs` so they are part of the crate internal refactor surface.
- Wired `WorkspaceRefactor::rename_symbol` to call `validate_file_edits` before returning edits and to produce a `RefactorPlan` (marking `NeedsPreview` when a text-search fallback was used) while preserving the existing `RefactorResult` return shape.

### Testing

- Attempted `./scripts/cargo-safe check -p perl-refactoring --all-targets --profile agent --locked`, but the environment aborted the run due to a storage guard: `DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`, so automated checks could not be completed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c3b87308333963d019b7c5eb2a4)