### PR TITLE
refactor(perl-refactoring): add RefactorPlan contract and edit validation skeleton (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/mod.rs
+++ b/crates/perl-refactoring/src/refactor/mod.rs
@@ -5,6 +5,8 @@ pub mod inline;
 pub mod modernize;
 pub mod modernize_refactored;
 pub mod module_move_imports;
+pub mod refactor_plan;
+pub mod refactor_validation;
 pub mod refactoring;
 pub mod workspace_refactor;
 pub mod workspace_rename;

--- a/crates/perl-refactoring/src/refactor/refactor_plan.rs
+++ b/crates/perl-refactoring/src/refactor/refactor_plan.rs
@@ -1,0 +1,74 @@
+//! Shared planning contract for refactoring operations.
+
+use crate::workspace_refactor::FileEdit;
+use serde::{Deserialize, Serialize};
+
+/// Shared, operation-level refactoring plan emitted by analyzers before apply.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RefactorPlan {
+    /// Refactor operation kind.
+    pub operation: RefactorOperationKind,
+    /// Planned file edits.
+    pub edits: Vec<FileEdit>,
+    /// Non-fatal diagnostics discovered while planning.
+    pub diagnostics: Vec<RefactorDiagnostic>,
+    /// Confidence level for this plan.
+    pub confidence: RefactorConfidence,
+    /// Safety posture for apply-time behavior.
+    pub safety: RefactorSafety,
+    /// Operation statistics.
+    pub stats: RefactorStats,
+}
+
+/// Refactor operation families supported by the planner.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RefactorOperationKind {
+    /// Import optimization operation.
+    OptimizeImports,
+}
+
+/// Safety level for a refactor plan.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RefactorSafety {
+    /// Plan is safe for direct apply.
+    Safe,
+    /// Plan should be previewed before apply.
+    NeedsPreview,
+    /// Plan is blocked from apply.
+    UnsafeBlocked,
+}
+
+/// Confidence level attached to a plan.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RefactorConfidence {
+    /// Exact symbol/range matching.
+    Exact,
+    /// Scope-aware but not exact.
+    ScopeAware,
+    /// Heuristic-only inference.
+    Heuristic,
+}
+
+/// Human-readable diagnostic for refactoring plans.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RefactorDiagnostic {
+    /// Machine-readable code.
+    pub code: String,
+    /// Diagnostic message.
+    pub message: String,
+}
+
+/// Basic operation stats to keep planning measurable.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RefactorStats {
+    /// Number of changed files.
+    pub files_changed: usize,
+    /// Number of edits across all files.
+    pub edits_count: usize,
+}

--- a/crates/perl-refactoring/src/refactor/refactor_validation.rs
+++ b/crates/perl-refactoring/src/refactor/refactor_validation.rs
@@ -1,0 +1,90 @@
+//! Shared validation primitives for refactor plans and edit batches.
+
+use crate::refactor::refactor_plan::{RefactorDiagnostic, RefactorPlan};
+use crate::workspace_refactor::TextEdit;
+
+/// Validate per-file edit ordering and overlap invariants.
+pub fn validate_plan(plan: &RefactorPlan) -> Vec<RefactorDiagnostic> {
+    let mut diagnostics = Vec::new();
+    for file_edit in &plan.edits {
+        if file_edit.edits.is_empty() {
+            continue;
+        }
+
+        if !is_sorted_non_overlapping(&file_edit.edits) {
+            diagnostics.push(RefactorDiagnostic {
+                code: "edit_overlap_or_order".to_string(),
+                message: format!(
+                    "Edits must be sorted and non-overlapping: {}",
+                    file_edit.file_path.display()
+                ),
+            });
+        }
+    }
+    diagnostics
+}
+
+fn is_sorted_non_overlapping(edits: &[TextEdit]) -> bool {
+    let mut previous_end = 0usize;
+    for (index, edit) in edits.iter().enumerate() {
+        if edit.start > edit.end {
+            return false;
+        }
+        if index > 0 && edit.start < previous_end {
+            return false;
+        }
+        previous_end = edit.end;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_plan;
+    use crate::refactor::refactor_plan::{
+        RefactorConfidence, RefactorOperationKind, RefactorPlan, RefactorSafety, RefactorStats,
+    };
+    use crate::workspace_refactor::{FileEdit, TextEdit};
+    use std::path::PathBuf;
+
+    #[test]
+    fn validate_plan_accepts_non_overlapping_sorted_edits() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let plan = RefactorPlan {
+            operation: RefactorOperationKind::OptimizeImports,
+            edits: vec![FileEdit {
+                file_path: PathBuf::from("a.pm"),
+                edits: vec![
+                    TextEdit { start: 0, end: 1, new_text: "x".to_string() },
+                    TextEdit { start: 1, end: 2, new_text: "y".to_string() },
+                ],
+            }],
+            diagnostics: vec![],
+            confidence: RefactorConfidence::Exact,
+            safety: RefactorSafety::Safe,
+            stats: RefactorStats { files_changed: 1, edits_count: 2 },
+        };
+        assert!(validate_plan(&plan).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_plan_rejects_overlapping_edits() -> Result<(), Box<dyn std::error::Error>> {
+        let plan = RefactorPlan {
+            operation: RefactorOperationKind::OptimizeImports,
+            edits: vec![FileEdit {
+                file_path: PathBuf::from("a.pm"),
+                edits: vec![
+                    TextEdit { start: 0, end: 3, new_text: "x".to_string() },
+                    TextEdit { start: 2, end: 4, new_text: "y".to_string() },
+                ],
+            }],
+            diagnostics: vec![],
+            confidence: RefactorConfidence::Exact,
+            safety: RefactorSafety::Safe,
+            stats: RefactorStats { files_changed: 1, edits_count: 2 },
+        };
+        assert_eq!(validate_plan(&plan).len(), 1);
+        Ok(())
+    }
+}

--- a/crates/perl-refactoring/src/refactor/workspace_refactor.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_refactor.rs
@@ -51,6 +51,10 @@
 //! ```
 
 use crate::import_optimizer::ImportOptimizer;
+use crate::refactor::refactor_plan::{
+    RefactorConfidence, RefactorOperationKind, RefactorPlan, RefactorSafety, RefactorStats,
+};
+use crate::refactor::refactor_validation::validate_plan;
 use crate::workspace_index::{
     SymKind, SymbolKey, WorkspaceIndex, fs_path_to_uri, normalize_var, uri_to_fs_path,
 };
@@ -485,6 +489,20 @@ impl WorkspaceRefactor {
     /// * `Ok(RefactorResult)` - Contains all file edits to optimize imports
     /// * `Err(String)` - If import analysis encounters issues
     pub fn optimize_imports(&self) -> Result<RefactorResult, String> {
+        let plan = self.plan_optimize_imports()?;
+        let diagnostics = validate_plan(&plan);
+        if let Some(diagnostic) = diagnostics.first() {
+            return Err(format!("Invalid refactor plan: {}", diagnostic.message));
+        }
+
+        Ok(RefactorResult {
+            file_edits: plan.edits,
+            description: "Optimize imports across workspace".to_string(),
+            warnings: plan.diagnostics.into_iter().map(|d| d.message).collect(),
+        })
+    }
+
+    fn plan_optimize_imports(&self) -> Result<RefactorPlan, String> {
         let optimizer = ImportOptimizer::new();
         let mut file_edits = Vec::new();
 
@@ -517,10 +535,15 @@ impl WorkspaceRefactor {
             });
         }
 
-        Ok(RefactorResult {
-            file_edits,
-            description: "Optimize imports across workspace".to_string(),
-            warnings: vec![],
+        let edits_count = file_edits.iter().map(|file_edit| file_edit.edits.len()).sum();
+        let files_changed = file_edits.len();
+        Ok(RefactorPlan {
+            operation: RefactorOperationKind::OptimizeImports,
+            edits: file_edits,
+            diagnostics: vec![],
+            confidence: RefactorConfidence::ScopeAware,
+            safety: RefactorSafety::Safe,
+            stats: RefactorStats { files_changed, edits_count },
         })
     }
 


### PR DESCRIPTION
Problem: refactor operations lacked a shared plan-first contract and reusable edit ordering/overlap validation surface.

Fix: Add the `RefactorPlan` contract, focused plan validation helpers, and route `WorkspaceRefactor::optimize_imports` through the new plan/validate path while preserving the existing `RefactorResult` return shape.

Verification:
- `cargo test -p perl-refactoring --profile agent --locked`
- `cargo check -p perl-refactoring --all-targets --profile agent --locked`
- `cargo clippy -p perl-refactoring --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`

Note: `cargo clippy -p perl-refactoring --all-targets --profile agent --locked -- -D warnings -A missing_docs` still fails on existing `clippy::cmp_owned` warnings in `crates/perl-refactoring/tests/module_move_import_rewrite_tests.rs`, which this PR does not touch.

Parser accuracy contract: unchanged; 46 fixtures / 28 families, 123 scored lines, 102 scored symbols, 0 active failure packets.
