### PR TITLE
feat(refactoring): add shared refactor plan and edit validation skeleton (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/edit_plan.rs
+++ b/crates/perl-refactoring/src/refactor/edit_plan.rs
@@ -1,0 +1,66 @@
+//! Shared refactor planning contract.
+
+use crate::refactor::workspace_refactor::FileEdit;
+use serde::{Deserialize, Serialize};
+
+/// Internal operation kind used by the refactoring plan contract.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RefactorOperationKind {
+    /// Symbol rename operation.
+    Rename,
+}
+
+/// Safety classification for a planned refactor.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RefactorSafety {
+    /// Safe to apply directly.
+    Safe,
+    /// Must be reviewed in a preview flow before applying.
+    NeedsPreview,
+    /// Blocked from application.
+    UnsafeBlocked,
+}
+
+/// Confidence classification for a planned refactor.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RefactorConfidence {
+    /// Exact, index-backed transformation.
+    Exact,
+    /// Scope-aware but not fully exact.
+    ScopeAware,
+    /// Heuristic result.
+    Heuristic,
+}
+
+/// Non-fatal planning/validation note.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RefactorDiagnostic {
+    /// Free-form diagnostic message.
+    pub message: String,
+}
+
+/// Shared statistics for plan-stage observability.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct RefactorStats {
+    /// Number of files touched by the plan.
+    pub files_changed: usize,
+    /// Number of text edits in the plan.
+    pub edit_count: usize,
+}
+
+/// A normalized internal plan for refactor operations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RefactorPlan {
+    /// Operation being planned.
+    pub operation: RefactorOperationKind,
+    /// File-level edits for the operation.
+    pub edits: Vec<FileEdit>,
+    /// Diagnostics produced while analyzing or validating the plan.
+    pub diagnostics: Vec<RefactorDiagnostic>,
+    /// Confidence level for the plan.
+    pub confidence: RefactorConfidence,
+    /// Safety level for the plan.
+    pub safety: RefactorSafety,
+    /// Aggregate stats for metrics and scorecards.
+    pub stats: RefactorStats,
+}

--- a/crates/perl-refactoring/src/refactor/edit_validation.rs
+++ b/crates/perl-refactoring/src/refactor/edit_validation.rs
@@ -1,0 +1,41 @@
+//! Shared edit validation helpers.
+
+use crate::refactor::edit_plan::{RefactorDiagnostic, RefactorPlan};
+
+/// Validate common edit invariants and return any non-fatal diagnostics.
+pub fn validate_refactor_plan(plan: &RefactorPlan) -> Vec<RefactorDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for file_edit in &plan.edits {
+        let mut previous_end = 0usize;
+
+        for edit in &file_edit.edits {
+            if edit.start > edit.end {
+                diagnostics.push(RefactorDiagnostic {
+                    message: format!(
+                        "Invalid edit range in {}: start {} is after end {}",
+                        file_edit.file_path.display(),
+                        edit.start,
+                        edit.end
+                    ),
+                });
+                continue;
+            }
+
+            if edit.start < previous_end {
+                diagnostics.push(RefactorDiagnostic {
+                    message: format!(
+                        "Overlapping edit range in {}: start {} overlaps previous end {}",
+                        file_edit.file_path.display(),
+                        edit.start,
+                        previous_end
+                    ),
+                });
+            }
+
+            previous_end = edit.end;
+        }
+    }
+
+    diagnostics
+}

--- a/crates/perl-refactoring/src/refactor/mod.rs
+++ b/crates/perl-refactoring/src/refactor/mod.rs
@@ -1,5 +1,7 @@
 //! Refactoring and modernization helpers.
 
+pub mod edit_plan;
+pub mod edit_validation;
 pub mod import_optimizer;
 pub mod inline;
 pub mod modernize;

--- a/crates/perl-refactoring/src/refactor/workspace_refactor.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_refactor.rs
@@ -51,6 +51,10 @@
 //! ```
 
 use crate::import_optimizer::ImportOptimizer;
+use crate::refactor::edit_plan::{
+    RefactorConfidence, RefactorOperationKind, RefactorPlan, RefactorSafety, RefactorStats,
+};
+use crate::refactor::edit_validation::validate_refactor_plan;
 use crate::workspace_index::{
     SymKind, SymbolKey, WorkspaceIndex, fs_path_to_uri, normalize_var, uri_to_fs_path,
 };
@@ -365,8 +369,23 @@ impl WorkspaceRefactor {
         let file_edits: Vec<FileEdit> =
             edits.into_iter().map(|(file_path, edits)| FileEdit { file_path, edits }).collect();
 
+        let mut plan = RefactorPlan {
+            operation: RefactorOperationKind::Rename,
+            edits: file_edits.clone(),
+            diagnostics: Vec::new(),
+            confidence: RefactorConfidence::ScopeAware,
+            safety: RefactorSafety::Safe,
+            stats: RefactorStats {
+                files_changed: file_edits.len(),
+                edit_count: file_edits.iter().map(|file_edit| file_edit.edits.len()).sum(),
+            },
+        };
+        plan.diagnostics = validate_refactor_plan(&plan);
+
         let description = format!("Rename '{}' to '{}'", old_name, new_name);
-        Ok(RefactorResult { file_edits, description, warnings: vec![] })
+        let warnings = plan.diagnostics.into_iter().map(|diagnostic| diagnostic.message).collect();
+
+        Ok(RefactorResult { file_edits, description, warnings })
     }
 
     /// Extract selected code into a new module


### PR DESCRIPTION
### Motivation

- Introduce a normalized planning contract and a single edit-validation primitive to make refactor operations plan-first, measurable, and safer before wiring larger behavior changes. 

### Description

- Add a new internal plan contract in `crates/perl-refactoring/src/refactor/edit_plan.rs` defining `RefactorPlan`, `RefactorDiagnostic`, `RefactorSafety`, `RefactorConfidence`, and `RefactorStats`.
- Add shared edit validation helpers in `crates/perl-refactoring/src/refactor/edit_validation.rs` that check for invalid and overlapping edit ranges and return diagnostics.
- Wire the workspace rename flow in `crates/perl-refactoring/src/refactor/workspace_refactor.rs` to build a `RefactorPlan`, run `validate_refactor_plan`, and surface plan diagnostics as warnings in the existing `RefactorResult` (behavior preserved while adding the planning/validation seam).
- Register the new modules in `crates/perl-refactoring/src/refactor/mod.rs` so the plan/validation types are available to other refactor operations going forward.

### Testing

- Ran formatting via `./scripts/cargo-safe xtask fmt`; the formatting pass was invoked in the environment during the change (tooling output produced in session).
- Attempted `./scripts/cargo-safe check -p perl-refactoring --all-targets --profile agent --locked`, but the check was blocked by the environment storage doctor (`DENY: /root/.cache/devplane/perl-lsp used=50% free=29G`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c3b87308333963d019b7c5eb2a4)