### PR TITLE
refactor(perl-pragma): introduce PragmaMap and PragmaEntry timeline API (#0000)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -151,7 +151,27 @@ impl PragmaStateQuery {
 /// queries and expose immutable snapshots.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CompileTimePragmaEnvironment {
-    map: Vec<(Range<usize>, PragmaSnapshot)>,
+    map: PragmaMap,
+}
+
+/// One effective pragma-state transition over a source byte range.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct PragmaEntry {
+    /// Source byte range covered by this snapshot.
+    ///
+    /// Lexical scope restores are represented as zero-length ranges at the
+    /// scope end so callers can observe the restored state at that byte offset.
+    pub range: Range<usize>,
+    /// Immutable pragma state active for this transition.
+    pub snapshot: PragmaSnapshot,
+}
+
+/// Explicit pragma transition timeline.
+#[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
+pub struct PragmaMap {
+    entries: Box<[PragmaEntry]>,
 }
 
 impl CompileTimePragmaEnvironment {
@@ -163,10 +183,13 @@ impl CompileTimePragmaEnvironment {
         PragmaTracker::build_ranges(ast, &mut current_state, &mut ranges);
         ranges.sort_by_key(|(range, _)| range.start);
 
-        let map =
-            ranges.into_iter().map(|(range, state)| (range, PragmaSnapshot::from(state))).collect();
+        let entries = ranges
+            .into_iter()
+            .map(|(range, state)| PragmaEntry { range, snapshot: PragmaSnapshot::from(state) })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
 
-        Self { map }
+        Self { map: PragmaMap { entries } }
     }
 
     /// Return a position query object with immutable state snapshot.
@@ -178,24 +201,90 @@ impl CompileTimePragmaEnvironment {
     /// Return the immutable snapshot active at the given byte offset.
     #[must_use]
     pub fn snapshot_at(&self, offset: usize) -> PragmaSnapshot {
-        let idx = self.map.partition_point(|(range, _)| range.start <= offset);
-        let mut snapshot =
-            if idx > 0 { self.map[idx - 1].1.clone() } else { PragmaSnapshot::default() };
+        self.map.snapshot_at(offset)
+    }
 
-        if snapshot.state.signatures_strict {
-            snapshot.state.strict_vars = true;
-            snapshot.state.strict_subs = true;
-            snapshot.state.strict_refs = true;
-        }
-
-        snapshot
+    /// Access the underlying transition map.
+    #[must_use]
+    pub fn map(&self) -> &PragmaMap {
+        &self.map
     }
 
     /// Access the underlying range map for advanced consumers.
     #[must_use]
-    pub fn as_map(&self) -> &[(Range<usize>, PragmaSnapshot)] {
-        &self.map
+    pub fn as_map(&self) -> Vec<(Range<usize>, PragmaSnapshot)> {
+        self.map.to_tuples()
     }
+}
+
+impl PragmaMap {
+    /// Return the immutable snapshot active at the given byte offset.
+    #[must_use]
+    pub fn snapshot_at(&self, offset: usize) -> PragmaSnapshot {
+        let idx = self.entries.partition_point(|entry| entry.range.start <= offset);
+        let snapshot = if idx > 0 {
+            self.entries[idx - 1].snapshot.clone()
+        } else {
+            PragmaSnapshot::default()
+        };
+
+        normalize_snapshot(snapshot)
+    }
+
+    /// Return the concrete pragma state active at the given byte offset.
+    #[must_use]
+    pub fn state_at(&self, offset: usize) -> PragmaState {
+        self.snapshot_at(offset).into()
+    }
+
+    /// Return the final top-level pragma state after all lexical restores.
+    #[must_use]
+    pub fn final_state(&self) -> PragmaState {
+        let state = self
+            .entries
+            .last()
+            .map_or_else(PragmaState::default, |entry| entry.snapshot.clone().into());
+
+        normalize_state(state)
+    }
+
+    /// Create a cursor for monotonic queries against this map.
+    #[must_use]
+    pub fn cursor(&self) -> PragmaQueryCursor {
+        PragmaQueryCursor::new()
+    }
+
+    /// Return all transition entries in source order.
+    #[must_use]
+    pub fn entries(&self) -> &[PragmaEntry] {
+        &self.entries
+    }
+
+    /// Convert this map to the legacy tuple representation.
+    #[must_use]
+    pub fn to_tuples(&self) -> Vec<(Range<usize>, PragmaSnapshot)> {
+        self.entries.iter().map(|e| (e.range.clone(), e.snapshot.clone())).collect()
+    }
+}
+
+fn normalize_snapshot(mut snapshot: PragmaSnapshot) -> PragmaSnapshot {
+    if snapshot.state.signatures_strict {
+        snapshot.state.strict_vars = true;
+        snapshot.state.strict_subs = true;
+        snapshot.state.strict_refs = true;
+    }
+
+    snapshot
+}
+
+fn normalize_state(mut state: PragmaState) -> PragmaState {
+    if state.signatures_strict {
+        state.strict_vars = true;
+        state.strict_subs = true;
+        state.strict_refs = true;
+    }
+
+    state
 }
 
 impl PragmaState {
@@ -631,6 +720,25 @@ impl PragmaQueryCursor {
 
     /// Query state at `offset` assuming lookups are mostly non-decreasing.
     ///
+    /// This is the primary cursor API for the explicit pragma map.
+    /// If the caller queries an older offset, this falls back to a binary
+    /// search and repositions the cursor.
+    pub fn snapshot_at(&mut self, pragma_map: &PragmaMap, offset: usize) -> PragmaSnapshot {
+        let snapshot = self
+            .entry_for_offset(pragma_map.entries(), offset)
+            .map_or_else(PragmaSnapshot::default, |entry| entry.snapshot.clone());
+
+        normalize_snapshot(snapshot)
+    }
+
+    /// Query state at `offset` against the explicit pragma map.
+    pub fn state_at(&mut self, pragma_map: &PragmaMap, offset: usize) -> PragmaState {
+        self.snapshot_at(pragma_map, offset).into()
+    }
+
+    /// Query state at `offset` assuming lookups are mostly non-decreasing.
+    ///
+    /// This legacy tuple API is retained for existing `PragmaTracker` callers.
     /// If the caller queries an older offset, this falls back to a binary
     /// search and repositions the cursor.
     pub fn state_for_offset(
@@ -658,19 +766,40 @@ impl PragmaQueryCursor {
             }
         }
 
-        let mut state = if pragma_map[self.index].0.start <= offset {
+        let state = if pragma_map[self.index].0.start <= offset {
             pragma_map[self.index].1.clone()
         } else {
             PragmaState::default()
         };
 
-        if state.signatures_strict {
-            state.strict_vars = true;
-            state.strict_subs = true;
-            state.strict_refs = true;
+        normalize_state(state)
+    }
+
+    fn entry_for_offset<'a>(
+        &mut self,
+        entries: &'a [PragmaEntry],
+        offset: usize,
+    ) -> Option<&'a PragmaEntry> {
+        if entries.is_empty() {
+            return None;
         }
 
-        state
+        if self.index >= entries.len() {
+            self.index = entries.len() - 1;
+        }
+
+        if entries[self.index].range.start > offset {
+            self.index = entries.partition_point(|entry| entry.range.start <= offset);
+            if self.index > 0 {
+                self.index -= 1;
+            }
+        } else {
+            while self.index + 1 < entries.len() && entries[self.index + 1].range.start <= offset {
+                self.index += 1;
+            }
+        }
+
+        if entries[self.index].range.start <= offset { Some(&entries[self.index]) } else { None }
     }
 }
 
@@ -689,26 +818,18 @@ impl PragmaTracker {
         pragma_map: &[(Range<usize>, PragmaState)],
         offset: usize,
     ) -> PragmaState {
-        let map = pragma_map
-            .iter()
-            .map(|(range, state)| (range.clone(), PragmaSnapshot::from(state.clone())))
-            .collect();
-        let environment = CompileTimePragmaEnvironment { map };
-        environment.snapshot_at(offset).into()
+        let idx = pragma_map.partition_point(|(range, _)| range.start <= offset);
+        let state = if idx > 0 { pragma_map[idx - 1].1.clone() } else { PragmaState::default() };
+
+        normalize_state(state)
     }
 
     /// Get the final top-level pragma state after all lexical scopes close.
     #[must_use]
     pub fn final_state(pragma_map: &[(Range<usize>, PragmaState)]) -> PragmaState {
-        let mut state = pragma_map.last().map_or_else(PragmaState::default, |(_, s)| s.clone());
+        let state = pragma_map.last().map_or_else(PragmaState::default, |(_, s)| s.clone());
 
-        if state.signatures_strict {
-            state.strict_vars = true;
-            state.strict_subs = true;
-            state.strict_refs = true;
-        }
-
-        state
+        normalize_state(state)
     }
 
     /// Process a lexically scoped body and then restore the caller state.

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -5,7 +5,7 @@
 
 use perl_ast::SourceLocation;
 use perl_ast::ast::{Node, NodeKind};
-use perl_pragma::{PragmaQueryCursor, PragmaState, PragmaTracker};
+use perl_pragma::{CompileTimePragmaEnvironment, PragmaQueryCursor, PragmaState, PragmaTracker};
 
 fn loc(start: usize, end: usize) -> SourceLocation {
     SourceLocation { start, end }
@@ -373,6 +373,29 @@ fn given_monotonic_lookups_when_using_cursor_then_states_match_offset_queries() 
     assert_eq!(s3, PragmaTracker::state_for_offset(&map, 50));
 }
 
+#[test]
+fn given_explicit_pragma_map_when_using_cursor_then_states_match_map_queries() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        block(vec![no_node("strict", &["refs"], 20, 36)], 18, 40),
+        use_node("warnings", &[], 42, 57),
+    ]);
+    let environment = CompileTimePragmaEnvironment::build(&ast);
+    let map = environment.map();
+
+    let mut cursor = map.cursor();
+    let s1 = cursor.state_at(map, 8);
+    let s2 = cursor.state_at(map, 30);
+    let s3 = cursor.state_at(map, 50);
+
+    assert_eq!(s1, map.state_at(8));
+    assert_eq!(s2, map.state_at(30));
+    assert_eq!(s3, map.state_at(50));
+
+    let backward = cursor.snapshot_at(map, 8);
+    assert_eq!(backward, environment.snapshot_at(8));
+}
+
 /// The cursor's fallback to binary search must produce the same result as the
 /// static `state_for_offset` when called with a backward (decreasing) offset.
 /// This is important when a caller (e.g., a diagnostic pass) queries nodes out
@@ -463,4 +486,24 @@ fn given_sub_last_in_file_when_querying_final_state_then_outer_state_is_returned
         final_state.strict_subs,
         "final_state must reflect outer (restored) strict=true after a scoped block"
     );
+}
+
+#[test]
+fn given_scoped_block_when_building_explicit_map_then_restore_point_is_zero_length() {
+    let ast = program(vec![
+        use_node("strict", &[], 0, 12),
+        block(vec![no_node("strict", &[], 14, 24)], 13, 25),
+    ]);
+    let environment = CompileTimePragmaEnvironment::build(&ast);
+    let map = environment.map();
+
+    assert!(
+        map.entries().iter().any(|entry| entry.range.start == 25 && entry.range.end == 25),
+        "lexical scope restore should be recorded as a zero-length transition"
+    );
+
+    let final_state = map.final_state();
+    assert!(final_state.strict_vars);
+    assert!(final_state.strict_subs);
+    assert!(final_state.strict_refs);
 }


### PR DESCRIPTION
Problem: pragma consumers only had an opaque tuple timeline, which made transition entries and scoped restore points hard to reason about.
Fix: introduce `PragmaMap` / `PragmaEntry` as the explicit primary timeline API, keep the legacy tuple surface, and let `PragmaQueryCursor` query the new map directly without tuple conversion.

Review notes:
- `PragmaEntry` and `PragmaMap` are non-exhaustive public structs.
- Zero-length lexical restore transitions are documented and covered.
- Legacy `PragmaTracker::build`, `state_for_offset`, and `final_state` remain available.
- `PragmaMap::snapshot_at`, `state_at`, `final_state`, `entries`, `to_tuples`, and map-native cursor queries are covered.

Accuracy-control delta:
- Parser accuracy denominator unchanged: 46 fixtures across 28 families.
- Failure packets unchanged: 0.
- Ratchet floor metrics pass.

Verification:
- `cargo test -p perl-pragma --locked`
- `cargo check -p perl-pragma --all-targets --locked`
- `cargo clippy -p perl-pragma --all-targets --locked -- -D warnings`
- `cargo xtask fmt --check`
- `git diff --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`