### PR TITLE
refactor(perl-uri): centralize source path conversion in perl-uri (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/types.rs
+++ b/crates/perl-lsp-rs/src/runtime/types.rs
@@ -1,28 +1,9 @@
 use super::workspace_folder::WorkspaceFolderState;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
-use url::Url;
 
 pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    // On Windows, filesystem paths like `C:\file` can be misparsed by Url::parse()
-    // as having scheme `C`. Check for Windows drive letters first.
-    // Drive letter pattern: exactly one letter, followed by `:`, not followed by `//` (which would be a URL).
-    if uri.len() > 2 && uri.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
-        if uri.chars().nth(1) == Some(':') && !uri.starts_with("file://") {
-            // Looks like a Windows path (e.g., `C:\...`). Try to parse as path, not URL.
-            let path = Path::new(uri);
-            if path.is_absolute() {
-                return Some(path.to_path_buf());
-            }
-        }
-    }
-
-    if let Ok(value) = Url::parse(uri) {
-        return if value.scheme() == "file" { value.to_file_path().ok() } else { None };
-    }
-
-    let path = Path::new(uri);
-    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
+    perl_uri::source_path_from_uri_or_path(uri)
 }
 
 pub(super) fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {

--- a/crates/perl-uri/src/lib.rs
+++ b/crates/perl-uri/src/lib.rs
@@ -317,6 +317,34 @@ pub fn normalize_uri(uri: &str) -> String {
 
 /// URI classification and key normalization helpers (previously `perl-uri-classify`).
 pub mod classify;
+
+/// Convert a URI or absolute filesystem path into a source path.
+///
+/// This helper accepts:
+/// - `file://` URIs
+/// - absolute filesystem paths
+/// - Windows drive paths like `C:\path\file.pl`
+///
+/// Relative paths and non-file schemes return `None`.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn source_path_from_uri_or_path(input: &str) -> Option<std::path::PathBuf> {
+    if input.len() > 2 && input.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        if input.chars().nth(1) == Some(':') && !input.starts_with("file://") {
+            let path = std::path::Path::new(input);
+            if path.is_absolute() {
+                return Some(path.to_path_buf());
+            }
+        }
+    }
+
+    if let Some(path) = uri_to_fs_path(input) {
+        return Some(path);
+    }
+
+    let path = std::path::Path::new(input);
+    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
+}
+
 pub use classify::{is_file_uri, is_special_scheme, uri_extension, uri_key};
 
 #[cfg(test)]
@@ -443,5 +471,30 @@ mod tests {
             let path = must_some(uri_to_fs_path(&uri));
             assert!(path.ends_with("roundtrip-test.pl"));
         }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_file_uri() {
+            let path = must_some(source_path_from_uri_or_path("file:///tmp/test.pl"));
+            assert!(path.ends_with("test.pl"));
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_file_localhost_uri() {
+            let path = must_some(source_path_from_uri_or_path("file://localhost/tmp/test.pl"));
+            assert!(path.ends_with("test.pl"));
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_absolute_path() {
+            let input = std::env::temp_dir().join("source-path-absolute.pl");
+            let parsed = must_some(source_path_from_uri_or_path(&input.to_string_lossy()));
+            assert_eq!(parsed, input);
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_non_file_scheme() {
+            assert!(source_path_from_uri_or_path("https://example.com").is_none());
+        }
+
     }
 }


### PR DESCRIPTION
### Motivation

- Runtime code in `perl-lsp-rs` duplicated URI↔path heuristics that belong at the protocol boundary, causing drift and maintenance overhead.
- Centralizing conversion ensures consistent behavior for `file://` URIs, absolute filesystem paths, and Windows drive-style inputs across the workspace.
- Providing a single, tested lens for source-path resolution makes downstream consumers (workspace matching, diagnostics, module resolution) rely on one well-defined helper.

### Description

- Added `pub fn source_path_from_uri_or_path(input: &str) -> Option<PathBuf>` to `crates/perl-uri/src/lib.rs` to accept `file://` URIs, `file://localhost/...`, absolute paths, and Windows drive paths, while rejecting relative and non-file schemes.
- Replaced the previous ad-hoc implementation in `crates/perl-lsp-rs/src/runtime/types.rs::source_path_from_uri` with a call to `perl_uri::source_path_from_uri_or_path`, removing duplicated parsing logic and the local `url::Url` dependency from that module.
- Added unit tests in `perl-uri` to cover the new helper for file URIs, `file://localhost` URIs, absolute filesystem paths, and non-file schemes, preserving existing mojibake repair and roundtrip expectations.

### Testing

- Ran `cargo test -p perl-uri source_path_from_uri_or_path --locked` and the new `perl-uri` unit tests passed (all new helper tests OK).
- Exercised `cargo test -p perl-lsp-rs source_path_from_uri --locked` to validate call sites compile and the runtime helper integration, although a full `perl-lsp-rs` test suite run is large and should be verified in CI.  
- Suggested verification commands: `cargo test -p perl-uri`, `cargo test -p perl-lsp-rs source_path_from_uri`, and `./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c4abe7c8333940a59ffea472ecf)