### PR TITLE
docs(perl-dap): align DAP truth surface and scorecard status (#0000)

### DIFF
--- a/crates/perl-dap/README.md
+++ b/crates/perl-dap/README.md
@@ -23,13 +23,21 @@ DAP-capable editors and tools.
 - `BridgeAdapter` supports migration from `Perl::LanguageServer`.
 - `TcpAttachConfig` and `BreakpointStore` support socket attach and breakpoint tracking.
 
-## Run
+## Modes
 
 ```bash
 perl-dap --stdio
-perl-dap --socket --port 13603
+perl-dap --socket --port 13603   # native TCP attach endpoint
 perl-dap --bridge
 ```
+
+## External dependency requirements
+
+Mode guidance:
+
+- **Native launch** (`--stdio`) is the default editor flow for running/debugging a Perl script.
+- **Native TCP attach** (`--socket --port ...`) connects through the native adapter to a TCP debugger target.
+- **Legacy bridge mode** (`--bridge`) proxies DAP to `Perl::LanguageServer` for migration compatibility.
 
 ## BridgeAdapter dependency
 

--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! # Quick Start
 //!
-//! ## Bridge Mode (Phase 1 - Implemented)
+//! ## Bridge Mode (Legacy Compatibility Layer)
 //!
 //! The bridge adapter proxies DAP messages to Perl::LanguageServer:
 //!
@@ -103,45 +103,31 @@
 //!
 //! # Architecture
 //!
-//! The DAP adapter follows a phased implementation approach:
+//! The DAP adapter uses a native-first architecture with an optional legacy bridge path:
 //!
-//! ## Phase 1: Bridge Adapter (Implemented)
+//! ## Native Adapter (Current Default)
 //!
-//! **Acceptance Criteria: AC1-AC4**
+//! The native adapter is production-ready and is the default runtime path. It
+//! provides launch/attach, breakpoint management, stepping, stack traces,
+//! scopes/variables, evaluate, and exception breakpoint support through
+//! [`DapServer`], [`DapDispatcher`], and [`DebugAdapter`].
 //!
-//! - **[`BridgeAdapter`]**: Message proxy between VSCode and Perl::LanguageServer
-//! - **[`LaunchConfiguration`]**: Launch debugging configuration and validation
-//! - **[`AttachConfiguration`]**: Attach debugging configuration for TCP connections
-//! - **[`platform`]**: Cross-platform path resolution and environment setup
+//! ## TCP Attach
 //!
-//! Phase 1 provides immediate debugging support by bridging to the mature
-//! Perl::LanguageServer implementation while the native adapter is developed.
+//! Attach sessions connect the native adapter to a debugger endpoint over TCP.
+//! This supports local loopback and remote-style topologies where the editor
+//! talks to `perl-dap`, and `perl-dap` attaches to a debugger socket.
 //!
-//! ## Phase 2: Native Adapter (Planned)
+//! ## Bridge Adapter (Migration/Compatibility)
 //!
-//! **Acceptance Criteria: AC5-AC12**
+//! [`BridgeAdapter`] remains available as a compatibility and migration path
+//! for environments that still rely on `Perl::LanguageServer`.
 //!
-//! - **[`protocol`]**: DAP protocol types and message definitions
-//! - **[`dispatcher`]**: Request routing and method dispatch
-//! - **[`breakpoints`]**: Breakpoint management with AST validation
-//! - **Session Management**: Debug session lifecycle and state tracking
-//! - **Variable Renderer**: Lazy variable expansion for complex data structures
-//! - **Stack Trace Provider**: Call stack navigation with source mapping
-//! - **Control Flow**: Step, continue, pause, and breakpoint control
-//! - **Safe Evaluation**: Expression evaluation in debug context
+//! ## Platform + Validation Layers
 //!
-//! Phase 2 will provide a native Rust DAP implementation with tighter integration
-//! to `perl_parser` for enhanced validation and performance.
-//!
-//! ## Phase 3: Production Hardening (Planned)
-//!
-//! **Acceptance Criteria: AC13-AC19**
-//!
-//! - **Security Validation**: Input sanitization and command injection prevention
-//! - **Performance Optimization**: Efficient variable inspection and stepping
-//! - **Packaging**: Distribution via cargo, VSCode marketplace, and package managers
-//! - **Documentation**: Comprehensive usage guides and troubleshooting
-//! - **Testing**: End-to-end integration tests with real debugging scenarios
+//! - **[`platform`]** handles Perl discovery and cross-platform path behavior
+//! - **[`breakpoints`]** validates source breakpoint placement against parsed code
+//! - **Configuration helpers** generate launch/attach snippets for editors
 //!
 //! # Protocol Support
 //!

--- a/docs/project/status/dap.md
+++ b/docs/project/status/dap.md
@@ -9,10 +9,10 @@
 <!-- BEGIN: DAP_LAUNCH_SCORECARD -->
 | Metric | Value | Target | Status |
 |---|---|---|---|
-| Launch success rate | receipt missing (`cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture`) | ≥ 80 % | SKIP |
+| Launch success rate | 5/5 (100 %) | ≥ 80 % | PASS |
 | Fixtures tested | hello, loops, eval, args, begin_end | 5 | — |
-| cold_launch_p50 | — | ≤ 2 000 ms | SKIP |
-| cold_launch_p95 | — | ≤ 5 000 ms | SKIP |
+| cold_launch_p50 | 12 ms | ≤ 2 000 ms | PASS |
+| cold_launch_p95 | 15 ms | ≤ 5 000 ms | PASS |
 <!-- END: DAP_LAUNCH_SCORECARD -->
 
 ## Session Correctness & Attach
@@ -20,11 +20,11 @@
 <!-- BEGIN: DAP_SESSION_SCORECARD -->
 | Metric | Value | Target | Status |
 |---|---|---|---|
-| Attach success rate (TCP loopback) | receipt missing (`cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture`) | ≥ 80 % | SKIP |
-| Variables pane correctness (real session) | receipt missing | expected named variables in scope | SKIP |
-| Evaluate correctness (real session) | receipt missing | evaluate($x + 1) => 42 | SKIP |
-| Deep truncation/pagination correctness | receipt missing | page [250..274] over @big | SKIP |
-| Memory footprint baseline (portable proxy) | receipt missing | best-effort baseline | SKIP |
+| Attach success rate (TCP loopback) | 5/5 (100 %) | ≥ 80 % | PASS |
+| Variables pane correctness (real session) | globals scope returned 1 named variable | expected named variables in scope | PASS |
+| Evaluate correctness (real session) | evaluate($x + 1) returns 42 | evaluate($x + 1) => 42 | PASS |
+| Deep truncation/pagination correctness | no indexedVariables >= 200 found in this real-session scope | page [250..274] over @big | SKIP |
+| Memory footprint baseline (portable proxy) | debug_adapter_struct_size=176 bytes; best_effort_process_rss=11016 KiB | best-effort baseline | MEASURED |
 <!-- END: DAP_SESSION_SCORECARD -->
 
 ## Test Coverage

--- a/xtask/src/tasks/update_status/dap.rs
+++ b/xtask/src/tasks/update_status/dap.rs
@@ -5,7 +5,7 @@
 use std::fs;
 use std::path::Path;
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use serde::Deserialize;
 
 use super::replace_block;
@@ -74,6 +74,12 @@ pub(super) fn count_dap_tests(root: &Path) -> DapTestCounts {
         .unwrap_or(0);
 
     DapTestCounts { integration_test_targets, scorecard_fixtures }
+}
+
+fn require_receipt_for_release() -> bool {
+    std::env::var("PERL_LSP_DAP_RECEIPT_REQUIRED")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
 }
 
 fn read_receipt(root: &Path) -> Option<ScorecardReceipt> {
@@ -186,6 +192,11 @@ pub(super) fn generate_dap_status(
     );
 
     let receipt = read_receipt(root);
+    if receipt.is_none() && require_receipt_for_release() {
+        return Err(eyre!(
+            "missing DAP scorecard receipt at {RECEIPT_PATH}; run `cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture` before `cargo xtask update-status --only dap`"
+        ));
+    }
     let launch_table = launch_table_from_receipt(receipt.as_ref());
     let session_table = session_table_from_receipt(receipt.as_ref());
 
@@ -226,8 +237,8 @@ mod tests {
             counts.integration_test_targets
         );
         assert_eq!(
-            counts.scorecard_fixtures, 5,
-            "expected 5 scorecard fixtures (hello, loops, eval, args, breakpoints_begin_end), got {}",
+            counts.scorecard_fixtures, 6,
+            "expected 6 scorecard fixtures in crates/perl-dap/tests/fixtures, got {}",
             counts.scorecard_fixtures
         );
         Ok(())


### PR DESCRIPTION
### Motivation

- Fix truth drift between crate docs, README guidance, and the DAP status page so public documentation matches the implemented native/bridge architecture.\
- Ensure the DAP status generator surfaces a missing scorecard receipt as an actionable condition in stricter contexts (release-style runs).\
- Reconcile discovered fixture counts so the status generator and tests agree on the actual fixtures present.

### Description

- Update crate documentation in `crates/perl-dap/src/lib.rs` to describe a native-first DAP adapter with an explicit TCP attach path and the bridge adapter presented as a legacy compatibility layer.\
- Clarify runtime modes and external dependency guidance in `crates/perl-dap/README.md` (native launch, native TCP attach, legacy bridge).\
- Change the status generator `xtask/src/tasks/update_status/dap.rs` to add an environment-gated strict mode (`PERL_LSP_DAP_RECEIPT_REQUIRED`) that causes `generate_dap_status` to fail when the scorecard receipt is missing, and add the helper `require_receipt_for_release()`.\
- Reconcile test expectations and fixture counting by updating the expected scorecard fixture count from 5 to 6 and refresh `docs/project/status/dap.md` using a freshly-generated scorecard receipt so generated blocks are up-to-date.

### Testing

- Ran the DAP harness: `cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture` and it passed.\
- Regenerated status: `cargo xtask update-status --write --only dap` and the command succeeded, updating `docs/project/status/dap.md`.\
- Ran xtask unit tests for the update-status DAP generator: `cargo test -p xtask update_status::dap` and they passed.\
- Verified formatting: `cargo fmt --all -- --check` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c2b0b048333bd983992ecf49e42)