### PR TITLE
feat(perl-uri): centralize source path conversion (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/types.rs
+++ b/crates/perl-lsp-rs/src/runtime/types.rs
@@ -1,28 +1,9 @@
 use super::workspace_folder::WorkspaceFolderState;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
-use url::Url;
 
 pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    // On Windows, filesystem paths like `C:\file` can be misparsed by Url::parse()
-    // as having scheme `C`. Check for Windows drive letters first.
-    // Drive letter pattern: exactly one letter, followed by `:`, not followed by `//` (which would be a URL).
-    if uri.len() > 2 && uri.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
-        if uri.chars().nth(1) == Some(':') && !uri.starts_with("file://") {
-            // Looks like a Windows path (e.g., `C:\...`). Try to parse as path, not URL.
-            let path = Path::new(uri);
-            if path.is_absolute() {
-                return Some(path.to_path_buf());
-            }
-        }
-    }
-
-    if let Ok(value) = Url::parse(uri) {
-        return if value.scheme() == "file" { value.to_file_path().ok() } else { None };
-    }
-
-    let path = Path::new(uri);
-    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
+    perl_uri::source_path_from_uri_or_path(uri)
 }
 
 pub(super) fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {

--- a/crates/perl-uri/src/lib.rs
+++ b/crates/perl-uri/src/lib.rs
@@ -82,6 +82,34 @@ pub fn uri_to_fs_path(uri: &str) -> Option<std::path::PathBuf> {
     Some(repair_path_mojibake(path))
 }
 
+/// Convert a URI or absolute filesystem path into a source path.
+///
+/// This helper accepts:
+/// - `file://` URIs (including localhost authority)
+/// - absolute filesystem paths (Unix or Windows)
+///
+/// Returns `None` for non-file URI schemes and relative paths.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn source_path_from_uri_or_path(input: &str) -> Option<std::path::PathBuf> {
+    // On Windows, filesystem paths like `C:\file` can be misparsed by Url::parse()
+    // as having scheme `C`. Check for Windows drive letters first.
+    if input.len() > 2 && input.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
+        if input.chars().nth(1) == Some(':') && !input.starts_with("file://") {
+            let path = std::path::Path::new(input);
+            if path.is_absolute() {
+                return Some(path.to_path_buf());
+            }
+        }
+    }
+
+    if let Some(path) = uri_to_fs_path(input) {
+        return Some(path);
+    }
+
+    let path = std::path::Path::new(input);
+    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
+}
+
 /// Convert a filesystem path to a `file://` URI.
 ///
 /// Properly handles percent-encoding and works with spaces, Windows paths,
@@ -379,6 +407,22 @@ mod tests {
         fn test_uri_to_fs_path_non_file() {
             assert!(uri_to_fs_path("https://example.com").is_none());
             assert!(uri_to_fs_path("untitled:Untitled-1").is_none());
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path() {
+            let file_uri_path = source_path_from_uri_or_path("file:///tmp/test.pl");
+            assert!(file_uri_path.is_some());
+
+            let localhost_path = source_path_from_uri_or_path("file://localhost/tmp/test.pl");
+            assert!(localhost_path.is_some());
+
+            assert!(source_path_from_uri_or_path("https://example.com/tmp/test.pl").is_none());
+
+            let absolute_path = source_path_from_uri_or_path("/tmp/test.pl");
+            assert!(absolute_path.is_some());
+
+            assert!(source_path_from_uri_or_path("tmp/test.pl").is_none());
         }
 
         #[test]


### PR DESCRIPTION
### Motivation
- Eliminate duplicated runtime URI ↔ path conversion logic in `perl-lsp-rs` by making `perl-uri` the single boundary for converting file URIs and absolute filesystem paths, reducing drift and improving maintenance.

### Description
- Add `source_path_from_uri_or_path(input: &str) -> Option<PathBuf>` in `crates/perl-uri/src/lib.rs` that accepts `file://` URIs (including `localhost`) and absolute filesystem paths while rejecting relative/non-file inputs and preserving existing Windows drive and mojibake handling.
- Replace the local implementation of `source_path_from_uri` in `crates/perl-lsp-rs/src/runtime/types.rs` with a delegate to `perl_uri::source_path_from_uri_or_path` so runtime code uses the central helper.
- Add unit tests in `perl-uri` that cover file URIs, `file://localhost`, absolute paths, non-file rejection, and relative-path rejection.

### Testing
- Ran `cargo test -p perl-uri` and all `perl-uri` unit tests passed (test suites and doctests completed successfully).
- Ran `cargo fmt` to fix formatting; format check passed after changes.
- Started `cargo test -p perl-lsp-rs source_path_from_uri`; compilation progressed (with warnings) but the full test run did not complete within the session window, so `perl-lsp-rs` verification is inconclusive in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c4abe7c8333940a59ffea472ecf)