### PR TITLE
refactor(perl-uri): centralize source path conversion in runtime (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -859,6 +859,15 @@ mod tests {
     }
 
     #[test]
+    fn source_path_from_uri_accepts_local_file_uris() {
+        let from_file_uri = source_path_from_uri("file:///tmp/from-uri.pl");
+        assert!(from_file_uri.is_some_and(|path| path.ends_with("from-uri.pl")));
+
+        let from_localhost_uri = source_path_from_uri("file://localhost/tmp/localhost.pl");
+        assert!(from_localhost_uri.is_some_and(|path| path.ends_with("localhost.pl")));
+    }
+
+    #[test]
     fn source_path_from_uri_rejects_relative_filesystem_paths() {
         assert_eq!(source_path_from_uri("lib/Foo.pm"), None);
     }

--- a/crates/perl-lsp-rs/src/runtime/types.rs
+++ b/crates/perl-lsp-rs/src/runtime/types.rs
@@ -1,28 +1,9 @@
 use super::workspace_folder::WorkspaceFolderState;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
-use url::Url;
 
 pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    // On Windows, filesystem paths like `C:\file` can be misparsed by Url::parse()
-    // as having scheme `C`. Check for Windows drive letters first.
-    // Drive letter pattern: exactly one letter, followed by `:`, not followed by `//` (which would be a URL).
-    if uri.len() > 2 && uri.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
-        if uri.chars().nth(1) == Some(':') && !uri.starts_with("file://") {
-            // Looks like a Windows path (e.g., `C:\...`). Try to parse as path, not URL.
-            let path = Path::new(uri);
-            if path.is_absolute() {
-                return Some(path.to_path_buf());
-            }
-        }
-    }
-
-    if let Ok(value) = Url::parse(uri) {
-        return if value.scheme() == "file" { value.to_file_path().ok() } else { None };
-    }
-
-    let path = Path::new(uri);
-    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
+    perl_uri::source_path_from_uri_or_path(uri)
 }
 
 pub(super) fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {

--- a/crates/perl-uri/src/lib.rs
+++ b/crates/perl-uri/src/lib.rs
@@ -82,6 +82,23 @@ pub fn uri_to_fs_path(uri: &str) -> Option<std::path::PathBuf> {
     Some(repair_path_mojibake(path))
 }
 
+/// Convert either a `file://` URI or absolute filesystem path to a source path.
+///
+/// This helper accepts:
+/// - absolute native paths (including Windows drive paths)
+/// - `file://` URIs that map to local filesystem paths
+///
+/// It returns `None` for non-file schemes, invalid inputs, and relative paths.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn source_path_from_uri_or_path(input: &str) -> Option<std::path::PathBuf> {
+    let path = std::path::Path::new(input);
+    if path.is_absolute() {
+        return Some(path.to_path_buf());
+    }
+
+    uri_to_fs_path(input)
+}
+
 /// Convert a filesystem path to a `file://` URI.
 ///
 /// Properly handles percent-encoding and works with spaces, Windows paths,
@@ -442,6 +459,40 @@ mod tests {
             let uri = must(fs_path_to_uri(original));
             let path = must_some(uri_to_fs_path(&uri));
             assert!(path.ends_with("roundtrip-test.pl"));
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_rejects_non_file_scheme() {
+            assert!(source_path_from_uri_or_path("https://example.com/a.pl").is_none());
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_rejects_relative_path() {
+            assert!(source_path_from_uri_or_path("lib/Foo.pm").is_none());
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_accepts_file_uri_and_absolute_path() {
+            let from_uri = must_some(source_path_from_uri_or_path("file:///tmp/from-uri.pl"));
+            assert!(from_uri.ends_with("from-uri.pl"));
+
+            let absolute_path = std::env::temp_dir().join("from-path.pl");
+            let from_path =
+                must_some(source_path_from_uri_or_path(absolute_path.to_string_lossy().as_ref()));
+            assert!(from_path.ends_with("from-path.pl"));
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_localhost_file_uri() {
+            let path = must_some(source_path_from_uri_or_path("file://localhost/tmp/localhost.pl"));
+            assert!(path.ends_with("localhost.pl"));
+        }
+
+        #[cfg(windows)]
+        #[test]
+        fn test_source_path_from_uri_or_path_accepts_windows_drive_path() {
+            let path = must_some(source_path_from_uri_or_path("C:\\tmp\\drive-path.pl"));
+            assert!(path.ends_with("drive-path.pl"));
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Eliminate duplicated URI/filesystem parsing logic by making `perl-uri` the single conversion surface for runtime callers.
- Ensure consistent handling of absolute native paths and local `file://` URIs across workspace matching and document resolution.

### Description

- Added `source_path_from_uri_or_path(input: &str) -> Option<PathBuf>` in `perl-uri`.
- Replaced the local `perl-lsp-rs` runtime parsing heuristic with the shared helper.
- Added focused tests for non-file rejection, relative-path rejection, file URI conversion, localhost file URI conversion, absolute native paths, Windows drive paths on Windows, and the LSP runtime wrapper.

### Accuracy-control delta

- Denominator unchanged: 46 fixtures / 28 families; 123 scored lines; 102 scored symbols.
- Failure packets unchanged: 0 active.
- Provider metric rows unchanged: 12.
- Ratchet floors unchanged: `dynamic_false_precision_count=0`, `fast_path_wrong_result_count=0`.

### Verification

- `cargo test -p perl-uri source_path_from_uri_or_path --locked`
- `cargo test -p perl-lsp-rs source_path_from_uri --locked`
- `cargo check -p perl-uri --all-targets --locked`
- `cargo check -p perl-lsp-rs --all-targets --locked`
- `cargo clippy -p perl-uri --all-targets --locked -- -D warnings`
- `cargo clippy -p perl-lsp-rs --lib --locked -- -D warnings`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`

Note: `cargo check -p perl-lsp-rs --all-targets --locked` passes but still reports pre-existing test warnings unrelated to this URI/path change.