### PR TITLE
fix(perl-regex): align validate contract with safety checks (#0000)

### DIFF
--- a/crates/perl-regex/src/syntax/cursor.rs
+++ b/crates/perl-regex/src/syntax/cursor.rs
@@ -16,6 +16,10 @@ impl<'a> RegexCursor<'a> {
         self.bytes.get(self.pos + offset).copied()
     }
 
+    pub(crate) fn position(&self) -> usize {
+        self.pos
+    }
+
     pub(crate) fn bump(&mut self) {
         self.pos += 1;
     }

--- a/crates/perl-regex/src/validator/code_execution.rs
+++ b/crates/perl-regex/src/validator/code_execution.rs
@@ -1,6 +1,10 @@
 use crate::syntax::cursor::RegexCursor;
 
 pub(crate) fn detects_code_execution(pattern: &str) -> bool {
+    find_code_execution_offset(pattern).is_some()
+}
+
+pub(crate) fn find_code_execution_offset(pattern: &str) -> Option<usize> {
     let mut cursor = RegexCursor::new(pattern);
     while let Some(ch) = cursor.current() {
         if cursor.skip_escape() || cursor.skip_char_class() {
@@ -10,10 +14,10 @@ pub(crate) fn detects_code_execution(pattern: &str) -> bool {
             if cursor.peek(2) == Some(b'{')
                 || (cursor.peek(2) == Some(b'?') && cursor.peek(3) == Some(b'{'))
             {
-                return true;
+                return Some(cursor.position());
             }
         }
         cursor.bump();
     }
-    false
+    None
 }

--- a/crates/perl-regex/src/validator/mod.rs
+++ b/crates/perl-regex/src/validator/mod.rs
@@ -8,6 +8,11 @@ pub use config::RegexValidationConfig;
 
 use crate::error::RegexError;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegexFinding {
+    pub offset: usize,
+}
+
 pub struct RegexValidator {
     config: RegexValidationConfig,
 }
@@ -32,6 +37,15 @@ impl RegexValidator {
     }
 
     pub fn validate(&self, pattern: &str, start_pos: usize) -> Result<(), RegexError> {
+        if let Some(finding) = self.find_code_execution(pattern, start_pos) {
+            return Err(RegexError::syntax("Embedded code execution is not allowed", finding.offset));
+        }
+        if let Some(finding) = self.find_nested_quantifier(pattern, start_pos) {
+            return Err(RegexError::syntax(
+                "Nested quantifiers may cause catastrophic backtracking",
+                finding.offset,
+            ));
+        }
         complexity::check_complexity(pattern, start_pos, &self.config)
     }
 
@@ -41,5 +55,15 @@ impl RegexValidator {
 
     pub fn detect_nested_quantifiers(&self, pattern: &str) -> bool {
         nested_quantifier::detect_nested_quantifiers(pattern)
+    }
+
+    pub fn find_code_execution(&self, pattern: &str, start_pos: usize) -> Option<RegexFinding> {
+        code_execution::find_code_execution_offset(pattern)
+            .map(|offset| RegexFinding { offset: start_pos + offset })
+    }
+
+    pub fn find_nested_quantifier(&self, pattern: &str, start_pos: usize) -> Option<RegexFinding> {
+        nested_quantifier::find_nested_quantifier_offset(pattern)
+            .map(|offset| RegexFinding { offset: start_pos + offset })
     }
 }

--- a/crates/perl-regex/src/validator/nested_quantifier.rs
+++ b/crates/perl-regex/src/validator/nested_quantifier.rs
@@ -1,4 +1,8 @@
 pub(crate) fn detect_nested_quantifiers(pattern: &str) -> bool {
+    find_nested_quantifier_offset(pattern).is_some()
+}
+
+pub(crate) fn find_nested_quantifier_offset(pattern: &str) -> Option<usize> {
     let bytes = pattern.as_bytes();
     let mut i = 0;
     let mut group_stack = Vec::new();
@@ -35,13 +39,13 @@ pub(crate) fn detect_nested_quantifiers(pattern: &str) -> bool {
                     if bytes[i] == b'{' {
                         let mut j = i + 1;
                         if is_brace_quantifier(bytes, &mut j) {
-                            return true;
+                            return Some(i);
                         }
                         last_type = 0;
                         i += 1;
                         continue;
                     }
-                    return true;
+                    return Some(i);
                 }
                 if let Some(last) = group_stack.last_mut() {
                     *last = true;
@@ -52,7 +56,7 @@ pub(crate) fn detect_nested_quantifiers(pattern: &str) -> bool {
         }
         i += 1;
     }
-    false
+    None
 }
 
 fn is_brace_quantifier(bytes: &[u8], i: &mut usize) -> bool {

--- a/crates/perl-regex/tests/behavior_spec_tests.rs
+++ b/crates/perl-regex/tests/behavior_spec_tests.rs
@@ -43,7 +43,7 @@ fn scenario_excessive_unicode_properties_returns_offset_error()
 }
 
 #[test]
-fn scenario_nested_quantifier_is_advisory_not_fatal() -> Result<(), Box<dyn std::error::Error>> {
+fn scenario_nested_quantifier_is_fatal_validation_error() -> Result<(), Box<dyn std::error::Error>> {
     // Given: a nested-quantifier pattern that may cause catastrophic backtracking.
     let validator = RegexValidator::new();
     let pattern = "(a+)+";
@@ -52,8 +52,8 @@ fn scenario_nested_quantifier_is_advisory_not_fatal() -> Result<(), Box<dyn std:
     let validation_result = validator.validate(pattern, 0);
     let advisory_detected = validator.detect_nested_quantifiers(pattern);
 
-    // Then: validation remains non-fatal, while advisory detection flags the risk.
-    assert!(validation_result.is_ok());
+    // Then: validation fails and advisory detection still flags the risk.
+    assert!(validation_result.is_err());
     assert!(advisory_detected);
     Ok(())
 }

--- a/crates/perl-regex/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-regex/tests/comprehensive_unit_tests.rs
@@ -210,10 +210,10 @@ fn validate_single_unicode_property() -> Result<(), Box<dyn std::error::Error>> 
 }
 
 #[test]
-fn validate_nested_quantifiers_no_longer_hard_error() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_nested_quantifiers_is_hard_error() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    // validate() no longer rejects nested quantifiers (they are advisory, not fatal)
-    v.validate("(a+)+", 100)?;
+    // validate() rejects nested quantifiers as a safety error
+    assert!(v.validate("(a+)+", 100).is_err());
     // detect_nested_quantifiers() still detects them for callers that want to warn
     assert!(v.detect_nested_quantifiers("(a+)+"));
     Ok(())
@@ -236,55 +236,55 @@ fn validate_quantifier_on_group_without_inner_quantifier() -> Result<(), Box<dyn
     Ok(())
 }
 
-// ── validate() — nested quantifiers are now accepted (advisory only) ──
+// ── validate() — nested quantifiers are rejected ──
 
 #[test]
-fn validate_accepts_nested_plus() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_nested_plus() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
     // validate() no longer rejects nested quantifiers
-    v.validate("(a+)+", 0)?;
+    assert!(v.validate("(a+)+", 0).is_err());
     // but detect_nested_quantifiers() still flags them
     assert!(v.detect_nested_quantifiers("(a+)+"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_nested_star() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_nested_star() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    v.validate("(a*)*", 0)?;
+    assert!(v.validate("(a*)*", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a*)*"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_star_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_star_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    v.validate("(a+)*", 0)?;
+    assert!(v.validate("(a+)*", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a+)*"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_plus_on_star_group() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_plus_on_star_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    v.validate("(a*)+", 0)?;
+    assert!(v.validate("(a*)+", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a*)+"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_question_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_question_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    v.validate("(a+)?", 0)?;
+    assert!(v.validate("(a+)?", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a+)?"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_brace_quantifier_on_quantified_group() -> Result<(), Box<dyn std::error::Error>>
+fn validate_rejects_brace_quantifier_on_quantified_group() -> Result<(), Box<dyn std::error::Error>>
 {
     let v = RegexValidator::new();
-    v.validate("(a+){2,5}", 0)?;
+    assert!(v.validate("(a+){2,5}", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a+){2,5}"));
     Ok(())
 }
@@ -813,10 +813,10 @@ fn validate_accepts_non_capturing_group_with_escaped_dot() -> Result<(), Box<dyn
 }
 
 #[test]
-fn validate_accepts_word_class_quantifier_in_group() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_word_class_quantifier_in_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
     // (\w+)* is valid Perl (though possibly questionable practice)
-    v.validate(r"(\w+)*", 0)?;
+    assert!(v.validate(r"(\w+)*", 0).is_err());
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- The public `RegexValidator::validate()` was only enforcing complexity limits instead of the full safety contract (embedded code and nested-quantifier checks) described in docs. This made IDE diagnostics and validation inconsistent. 
- Provide offset-aware findings so LSP consumers can report precise diagnostics rather than boolean heuristics.

### Description

- Added a small `RegexFinding` type and two finder APIs: `find_code_execution` / `find_nested_quantifier` (backed by `find_code_execution_offset` and `find_nested_quantifier_offset`) that return offsets when a problem is located. 
- Wired these finders into `RegexValidator::validate()` so embedded code and nested-quantifier detections produce `RegexError::syntax(...)` with proper offsets before running complexity checks. 
- Kept compatibility wrappers `detects_code_execution` and `detect_nested_quantifiers` but refactored their implementations to reuse the new offset-finders. 
- Exposed `RegexCursor::position()` to allow scanners to report byte offsets. 
- Updated behavior and unit tests to reflect the tightened contract (nested-quantifier patterns now fail validation; advisory detectors still exist and are asserted).

### Testing

- Ran `cargo test -p perl-regex` locally and all test suites passed (`unit`, `behavior`, `comprehensive`, `named_capture`, and property tests) after the changes. 
- Attempted the canonical scripted check `./scripts/cargo-safe test -p perl-regex --profile agent --locked` but it was blocked by the environment storage policy; fallback `cargo test -p perl-regex` was used and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c2330c88333acb4c02b11e7a5bb)