### PR TITLE
fix(perl-regex): align validate with safety checks (#0000)

### DIFF
--- a/crates/perl-regex/src/lib.rs
+++ b/crates/perl-regex/src/lib.rs
@@ -153,6 +153,28 @@ mod tests {
         assert!(v.validate("[(?{]", 0).is_ok());
     }
 
+    #[test]
+    fn validate_rejects_embedded_code() {
+        let v = RegexValidator::new();
+        assert!(v.validate("(?{ print 'hi' })", 0).is_err());
+        assert!(v.validate("(??{ some_code() })", 0).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_nested_quantifiers() {
+        let v = RegexValidator::new();
+        assert!(v.validate("(a+)+", 0).is_err());
+        assert!(v.validate("(a+){2,5}", 0).is_err());
+    }
+
+    #[test]
+    fn validate_allows_escaped_and_char_class_quantifiers() {
+        let v = RegexValidator::new();
+        assert!(v.validate(r"(a\+)+", 0).is_ok());
+        assert!(v.validate("([a+])+", 0).is_ok());
+        assert!(v.validate("([a{2}])+", 0).is_ok());
+    }
+
     // --- RegexValidator::detects_code_execution ---
 
     #[test]

--- a/crates/perl-regex/src/syntax/cursor.rs
+++ b/crates/perl-regex/src/syntax/cursor.rs
@@ -16,6 +16,10 @@ impl<'a> RegexCursor<'a> {
         self.bytes.get(self.pos + offset).copied()
     }
 
+    pub(crate) fn position(&self) -> usize {
+        self.pos
+    }
+
     pub(crate) fn bump(&mut self) {
         self.pos += 1;
     }

--- a/crates/perl-regex/src/validator/code_execution.rs
+++ b/crates/perl-regex/src/validator/code_execution.rs
@@ -1,6 +1,12 @@
 use crate::syntax::cursor::RegexCursor;
 
+use super::RegexFinding;
+
 pub(crate) fn detects_code_execution(pattern: &str) -> bool {
+    find_code_execution(pattern, 0).is_some()
+}
+
+pub(crate) fn find_code_execution(pattern: &str, start_pos: usize) -> Option<RegexFinding> {
     let mut cursor = RegexCursor::new(pattern);
     while let Some(ch) = cursor.current() {
         if cursor.skip_escape() || cursor.skip_char_class() {
@@ -10,10 +16,10 @@ pub(crate) fn detects_code_execution(pattern: &str) -> bool {
             if cursor.peek(2) == Some(b'{')
                 || (cursor.peek(2) == Some(b'?') && cursor.peek(3) == Some(b'{'))
             {
-                return true;
+                return Some(RegexFinding { offset: start_pos + cursor.position() });
             }
         }
         cursor.bump();
     }
-    false
+    None
 }

--- a/crates/perl-regex/src/validator/mod.rs
+++ b/crates/perl-regex/src/validator/mod.rs
@@ -8,6 +8,11 @@ pub use config::RegexValidationConfig;
 
 use crate::error::RegexError;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegexFinding {
+    pub offset: usize,
+}
+
 pub struct RegexValidator {
     config: RegexValidationConfig,
 }
@@ -32,6 +37,20 @@ impl RegexValidator {
     }
 
     pub fn validate(&self, pattern: &str, start_pos: usize) -> Result<(), RegexError> {
+        if let Some(finding) = self.find_code_execution(pattern, start_pos) {
+            return Err(RegexError::syntax(
+                "Embedded code execution is not allowed in regex patterns",
+                finding.offset,
+            ));
+        }
+
+        if let Some(finding) = self.find_nested_quantifier(pattern, start_pos) {
+            return Err(RegexError::syntax(
+                "Nested quantifiers may cause catastrophic backtracking",
+                finding.offset,
+            ));
+        }
+
         complexity::check_complexity(pattern, start_pos, &self.config)
     }
 
@@ -39,7 +58,19 @@ impl RegexValidator {
         code_execution::detects_code_execution(pattern)
     }
 
+    pub fn find_code_execution(&self, pattern: &str, start_pos: usize) -> Option<RegexFinding> {
+        code_execution::find_code_execution(pattern, start_pos)
+    }
+
     pub fn detect_nested_quantifiers(&self, pattern: &str) -> bool {
         nested_quantifier::detect_nested_quantifiers(pattern)
+    }
+
+    pub fn find_nested_quantifier(
+        &self,
+        pattern: &str,
+        start_pos: usize,
+    ) -> Option<RegexFinding> {
+        nested_quantifier::find_nested_quantifier(pattern, start_pos)
     }
 }

--- a/crates/perl-regex/src/validator/nested_quantifier.rs
+++ b/crates/perl-regex/src/validator/nested_quantifier.rs
@@ -1,28 +1,34 @@
+use crate::syntax::cursor::RegexCursor;
+
+use super::RegexFinding;
+
 pub(crate) fn detect_nested_quantifiers(pattern: &str) -> bool {
+    find_nested_quantifier(pattern, 0).is_some()
+}
+
+pub(crate) fn find_nested_quantifier(pattern: &str, start_pos: usize) -> Option<RegexFinding> {
+    let mut cursor = RegexCursor::new(pattern);
     let bytes = pattern.as_bytes();
-    let mut i = 0;
     let mut group_stack = Vec::new();
     let mut last_type = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'\\' => {
-                i += 2;
-                last_type = 0;
-                continue;
-            }
+    while let Some(ch) = cursor.current() {
+        if cursor.skip_escape() || cursor.skip_char_class() {
+            last_type = 0;
+            continue;
+        }
+
+        match ch {
             b'(' => {
-                if i + 1 < bytes.len() && bytes[i + 1] == b'?' {
-                    i += 2;
-                    if i < bytes.len()
-                        && matches!(bytes[i], b':' | b'=' | b'!' | b'<' | b'>' | b'|' | b'P' | b'#')
+                cursor.bump();
+                if cursor.current() == Some(b'?') {
+                    cursor.bump();
+                    if let Some(marker) = cursor.current()
+                        && matches!(marker, b':' | b'=' | b'!' | b'<' | b'>' | b'|' | b'P' | b'#')
                     {
-                        i += 1;
+                        cursor.bump();
                     }
-                } else {
-                    i += 1;
                 }
                 group_stack.push(false);
-                last_type = 0;
                 continue;
             }
             b')' => {
@@ -32,16 +38,14 @@ pub(crate) fn detect_nested_quantifiers(pattern: &str) -> bool {
             }
             b'+' | b'*' | b'?' | b'{' => {
                 if last_type == 2 {
-                    if bytes[i] == b'{' {
-                        let mut j = i + 1;
+                    if ch == b'{' {
+                        let mut j = cursor.position() + 1;
                         if is_brace_quantifier(bytes, &mut j) {
-                            return true;
+                            return Some(RegexFinding { offset: start_pos + cursor.position() });
                         }
-                        last_type = 0;
-                        i += 1;
-                        continue;
+                    } else {
+                        return Some(RegexFinding { offset: start_pos + cursor.position() });
                     }
-                    return true;
                 }
                 if let Some(last) = group_stack.last_mut() {
                     *last = true;
@@ -50,9 +54,9 @@ pub(crate) fn detect_nested_quantifiers(pattern: &str) -> bool {
             }
             _ => last_type = 0,
         }
-        i += 1;
+        cursor.bump();
     }
-    false
+    None
 }
 
 fn is_brace_quantifier(bytes: &[u8], i: &mut usize) -> bool {

--- a/crates/perl-regex/tests/behavior_spec_tests.rs
+++ b/crates/perl-regex/tests/behavior_spec_tests.rs
@@ -43,7 +43,7 @@ fn scenario_excessive_unicode_properties_returns_offset_error()
 }
 
 #[test]
-fn scenario_nested_quantifier_is_advisory_not_fatal() -> Result<(), Box<dyn std::error::Error>> {
+fn scenario_nested_quantifier_is_fatal_during_validation() -> Result<(), Box<dyn std::error::Error>> {
     // Given: a nested-quantifier pattern that may cause catastrophic backtracking.
     let validator = RegexValidator::new();
     let pattern = "(a+)+";
@@ -52,8 +52,8 @@ fn scenario_nested_quantifier_is_advisory_not_fatal() -> Result<(), Box<dyn std:
     let validation_result = validator.validate(pattern, 0);
     let advisory_detected = validator.detect_nested_quantifiers(pattern);
 
-    // Then: validation remains non-fatal, while advisory detection flags the risk.
-    assert!(validation_result.is_ok());
+    // Then: validation fails, and advisory detection still flags the risk.
+    assert!(validation_result.is_err());
     assert!(advisory_detected);
     Ok(())
 }

--- a/crates/perl-regex/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-regex/tests/comprehensive_unit_tests.rs
@@ -210,11 +210,13 @@ fn validate_single_unicode_property() -> Result<(), Box<dyn std::error::Error>> 
 }
 
 #[test]
-fn validate_nested_quantifiers_no_longer_hard_error() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_nested_quantifiers_are_hard_errors() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    // validate() no longer rejects nested quantifiers (they are advisory, not fatal)
-    v.validate("(a+)+", 100)?;
-    // detect_nested_quantifiers() still detects them for callers that want to warn
+    // validate() rejects nested quantifiers and reports a source-relative offset.
+    let err = v.validate("(a+)+", 100).expect_err("expected nested quantifier rejection");
+    match err {
+        RegexError::Syntax { offset, .. } => assert_eq!(offset, 104),
+    }
     assert!(v.detect_nested_quantifiers("(a+)+"));
     Ok(())
 }
@@ -236,55 +238,53 @@ fn validate_quantifier_on_group_without_inner_quantifier() -> Result<(), Box<dyn
     Ok(())
 }
 
-// ── validate() — nested quantifiers are now accepted (advisory only) ──
+// ── validate() — nested quantifiers are rejected ──
 
 #[test]
-fn validate_accepts_nested_plus() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_nested_plus() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    // validate() no longer rejects nested quantifiers
-    v.validate("(a+)+", 0)?;
-    // but detect_nested_quantifiers() still flags them
+    assert!(v.validate("(a+)+", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a+)+"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_nested_star() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_nested_star() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    v.validate("(a*)*", 0)?;
+    assert!(v.validate("(a*)*", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a*)*"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_star_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_star_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    v.validate("(a+)*", 0)?;
+    assert!(v.validate("(a+)*", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a+)*"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_plus_on_star_group() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_plus_on_star_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    v.validate("(a*)+", 0)?;
+    assert!(v.validate("(a*)+", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a*)+"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_question_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_question_on_plus_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    v.validate("(a+)?", 0)?;
+    assert!(v.validate("(a+)?", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a+)?"));
     Ok(())
 }
 
 #[test]
-fn validate_accepts_brace_quantifier_on_quantified_group() -> Result<(), Box<dyn std::error::Error>>
+fn validate_rejects_brace_quantifier_on_quantified_group() -> Result<(), Box<dyn std::error::Error>>
 {
     let v = RegexValidator::new();
-    v.validate("(a+){2,5}", 0)?;
+    assert!(v.validate("(a+){2,5}", 0).is_err());
     assert!(v.detect_nested_quantifiers("(a+){2,5}"));
     Ok(())
 }
@@ -813,10 +813,10 @@ fn validate_accepts_non_capturing_group_with_escaped_dot() -> Result<(), Box<dyn
 }
 
 #[test]
-fn validate_accepts_word_class_quantifier_in_group() -> Result<(), Box<dyn std::error::Error>> {
+fn validate_rejects_word_class_quantifier_in_group() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
-    // (\w+)* is valid Perl (though possibly questionable practice)
-    v.validate(r"(\w+)*", 0)?;
+    // (w+)* is intentionally rejected by safety validation due to nested quantifiers.
+    assert!(v.validate(r"(\w+)*", 0).is_err());
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- `RegexValidator::validate` only ran complexity checks, so embedded-code and nested-quantifier risks were not enforced by the main validation contract. 
- The LSP integration needs offset-aware findings (not just booleans) to produce accurate diagnostics. 
- Keep public compatibility while exposing finder APIs that return structured offsets for downstream mapping.

### Description

- Added `RegexFinding` and new finder APIs `find_code_execution` and `find_nested_quantifier`, and left boolean wrappers (`detects_code_execution`, `detect_nested_quantifiers`) for compatibility. 
- Wired the new finders into `RegexValidator::validate` so embedded-code and nested-quantifier findings now produce `RegexError::syntax` with source-relative offsets before running complexity checks. 
- Refactored `code_execution` and `nested_quantifier` validators to return offset-aware findings and to reuse `RegexCursor` skip helpers, and added `RegexCursor::position()` to expose the scanner position. 
- Updated behavior and comprehensive tests to expect the stricter validation contract and added unit tests covering rejected embedded code, rejected nested quantifiers, and allowed escaped/char-class quantifier forms.

### Testing

- Ran `cargo test -p perl-regex`, which executed unit, behavior, comprehensive, named-capture and property tests; the test suite passed locally after the changes (all relevant tests passed). 
- Attempted the repository-standard `./scripts/cargo-safe test -p perl-regex --profile agent --locked` but it was blocked by the environment storage policy. 
- Attempted `just agent-test -p perl-regex` but `just` was not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c2330c88333acb4c02b11e7a5bb)