### PR TITLE
docs(perl-ast): define AST compatibility contract (#0000)

### DIFF
--- a/crates/perl-ast/README.md
+++ b/crates/perl-ast/README.md
@@ -6,8 +6,8 @@ AST (Abstract Syntax Tree) node definitions for the Perl parser ecosystem.
 
 `perl-ast` provides the typed node structures used to represent parsed Perl source code. It contains two AST modules:
 
-- **`ast`** -- The primary AST used by `perl-parser`. Defines `Node` (kind + `SourceLocation`) and the `NodeKind` enum with 50+ variants covering declarations, expressions, control flow, regex, OO constructs, and error recovery nodes. Includes S-expression serialization via `to_sexp()`.
-- **`v2`** -- An enhanced AST for incremental parsing. Nodes carry a unique `NodeId` and use `Range` (line/column) positions instead of byte offsets. Adds `NodeIdGenerator`, `MissingKind`, `DiagnosticId`, and lightweight `ErrorRef` nodes.
+- **`ast`** -- The primary AST used by `perl-parser`. Defines `Node` (kind + `SourceLocation`) and the `NodeKind` enum with 50+ variants covering declarations, expressions, control flow, regex, OO constructs, and error recovery nodes. Includes S-expression serialization via `to_sexp()` (implemented via a formatter boundary).
+- **`v2`** -- An enhanced AST for incremental parsing, re-exported from `perl-ast-v2`. This surface is currently experimental while compatibility hardens toward v0.15. Nodes carry a unique `NodeId` and use `Range` (line/column) positions instead of byte offsets.
 
 ## Public API
 
@@ -25,3 +25,9 @@ Tier 1 leaf crate. Depended on by `perl-parser-core`, `perl-tokenizer`, `perl-pr
 ## License
 
 MIT OR Apache-2.0
+
+
+## AST compatibility contract
+
+The compatibility contract and change policy are documented in `docs/reference/ast-contract.md`.
+Any `NodeKind` addition must include parser, traversal, kind-name, S-expression, and semantic-decision coverage.

--- a/crates/perl-ast/src/lib.rs
+++ b/crates/perl-ast/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! - [`ast`] -- The primary AST used by the current recursive-descent parser.
 //! - [`v2`] -- Experimental second-generation AST with full position tracking
-//!   for incremental parsing.
+//!   for incremental parsing. Re-exported from `perl-ast-v2`.
 //!
 //! # Quick start
 //!
@@ -44,7 +44,7 @@
 
 pub mod ast;
 
-/// Incremental parsing AST types extracted into a dedicated microcrate.
+/// Experimental incremental parsing AST types extracted into a dedicated microcrate.
 pub use perl_ast_v2 as v2;
 
 /// Primary AST node -- the building block of every syntax tree.

--- a/docs/reference/ast-contract.md
+++ b/docs/reference/ast-contract.md
@@ -1,0 +1,35 @@
+# AST Compatibility Contract
+
+`perl-ast` is in a stability-contract phase as the parser, semantic analyzer, and LSP layers converge on a durable AST surface.
+
+## Contract tiers
+
+- `perl_ast::ast::{Node, NodeKind}` is the **stable public AST** for the current parser pipeline.
+- `perl_ast::v2` (re-exported from `perl-ast-v2`) is **experimental** and may evolve until the v0.15 stabilization window.
+- `perl-ast-v2` remains a published microcrate so incremental parsing consumers can opt in directly while the API hardens.
+
+## NodeKind change policy
+
+No new `NodeKind` variant should land without explicitly updating and validating all required surfaces:
+
+- Variant definition and fields
+- `kind_name()`
+- `ALL_KIND_NAMES`
+- Child traversal helpers (`children`, `first_child`, `for_each_child`, `for_each_child_mut`)
+- S-expression rendering (`to_sexp()` / formatter coverage) or an explicit non-renderable waiver
+- Parser fixture coverage showing when the variant is emitted
+- Semantic analyzer handling decision (handled, ignored, or deferred)
+
+This policy is intentionally conservative: AST drift is expensive for parser, semantic, and LSP consumers.
+
+## Contributor checklist for AST changes
+
+When introducing or materially changing AST shapes, include:
+
+1. Parser evidence (fixture or targeted test)
+2. Traversal coverage
+3. Kind-name coverage
+4. S-expression coverage (or explicit waiver)
+5. Semantic analyzer decision note
+
+The goal is not maximal process; it is preserving a stable cross-crate contract as the project approaches v0.15.


### PR DESCRIPTION
### Motivation

- Reduce drift and ambiguity around `NodeKind` additions by codifying the AST stability contract and contributor expectations. 
- Clarify the role and stability of the `v2` incremental AST surface so consumers and contributors know it is experimental while the API hardens toward v0.15.

### Description

- Add `docs/reference/ast-contract.md` documenting contract tiers, a strict `NodeKind` change policy, and a contributor checklist for parser/traversal/sexp/semantic coverage. 
- Update `crates/perl-ast/README.md` to note that `to_sexp()` is implemented via a formatter boundary and that `v2` is re-exported from `perl-ast-v2` and currently experimental. 
- Update crate-level docs in `crates/perl-ast/src/lib.rs` to mark the `v2` re-export as experimental and clarify the public boundary.

### Testing

- Attempted to run `./scripts/cargo-safe test -p perl-ast --profile agent --locked`, but the run was blocked by the environment storage policy with the message `DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`.
- This change is documentation-only and did not modify runtime code paths, so no further automated tests were required for the edits themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c1abff883338c214713c5312612)