### PR TITLE
docs(perl-ast): define AST compatibility contract (#0000)

### DIFF
--- a/crates/perl-ast/README.md
+++ b/crates/perl-ast/README.md
@@ -7,11 +7,17 @@ AST (Abstract Syntax Tree) node definitions for the Perl parser ecosystem.
 `perl-ast` provides the typed node structures used to represent parsed Perl source code. It contains two AST modules:
 
 - **`ast`** -- The primary AST used by `perl-parser`. Defines `Node` (kind + `SourceLocation`) and the `NodeKind` enum with 50+ variants covering declarations, expressions, control flow, regex, OO constructs, and error recovery nodes. Includes S-expression serialization via `to_sexp()`.
-- **`v2`** -- An enhanced AST for incremental parsing. Nodes carry a unique `NodeId` and use `Range` (line/column) positions instead of byte offsets. Adds `NodeIdGenerator`, `MissingKind`, `DiagnosticId`, and lightweight `ErrorRef` nodes.
+- **`v2`** -- A re-export of the extracted `perl-ast-v2` microcrate for incremental parsing experiments. Nodes carry a unique `NodeId` and use `Range` (line/column) positions instead of byte offsets. Adds `NodeIdGenerator`, `MissingKind`, `DiagnosticId`, and lightweight `ErrorRef` nodes. This surface is experimental until the incremental compatibility contract is finalized.
 
 ## Public API
 
 Re-exports from `lib.rs`: `Node`, `NodeKind`, `SourceLocation`.
+
+## Compatibility Contract
+
+- Stable contract: `perl_ast::Node` and `perl_ast::NodeKind` (`ast` module).
+- Experimental contract: `perl_ast::v2` (re-exported from `perl-ast-v2`).
+- See [`docs/reference/ast-contract.md`](../../docs/reference/ast-contract.md) for the required coverage checklist when introducing a new `NodeKind` variant.
 
 ## Workspace Role
 

--- a/crates/perl-ast/src/lib.rs
+++ b/crates/perl-ast/src/lib.rs
@@ -8,7 +8,7 @@
 //! # Modules
 //!
 //! - [`ast`] -- The primary AST used by the current recursive-descent parser.
-//! - [`v2`] -- Experimental second-generation AST with full position tracking
+//! - [`v2`] -- Experimental second-generation AST re-exported from `perl-ast-v2`
 //!   for incremental parsing.
 //!
 //! # Quick start

--- a/docs/reference/ast-contract.md
+++ b/docs/reference/ast-contract.md
@@ -1,0 +1,31 @@
+# AST Compatibility Contract
+
+This document defines the compatibility boundary between the primary AST API and the incremental AST experiment.
+
+## Stability tiers
+
+- **Stable public AST (`perl_ast::Node`, `perl_ast::NodeKind`)**
+  - The `ast` module is the primary parser-facing and consumer-facing AST surface.
+  - Treat this API as stability-contract surface as we move toward the v0.15 window.
+- **Experimental AST (`perl_ast::v2`)**
+  - `perl_ast::v2` is a re-export of the extracted `perl-ast-v2` microcrate.
+  - It remains experimental and may change while incremental parsing contracts harden.
+
+## NodeKind change policy
+
+No new `NodeKind` variant should land without all of the following:
+
+1. **Parser fixture coverage** (proof the variant is emitted in real parsing).
+2. **Traversal coverage** (`children`, `first_child`, and traversal helpers).
+3. **Kind-name coverage** (`kind_name` and `ALL_KIND_NAMES`).
+4. **S-expression coverage** (`to_sexp`) or an explicit, documented non-renderable waiver.
+5. **Semantic decision** (handled, intentionally ignored, or explicitly deferred).
+
+## Contributor checklist
+
+When adding or changing AST surface:
+
+- Keep changes scoped to one concern.
+- Add tests that fail if required `NodeKind` surfaces drift.
+- Preserve existing `Node::to_sexp()` API compatibility when refactoring internals.
+- Document any intentional compatibility exception in code comments and tests.


### PR DESCRIPTION
### Motivation

- Make the `perl-ast` stability boundary explicit so contributors understand which AST surface is treated as the stability contract and which is experimental. 
- Reduce drift risk when adding or changing `NodeKind` variants by requiring explicit coverage for traversal, names, S-expression rendering, and semantic decisioning.

### Description

- Add `docs/reference/ast-contract.md` which defines stability tiers and a mandatory `NodeKind` change checklist (`parser` fixture, `children`/traversal, `kind_name`/`ALL_KIND_NAMES`, `to_sexp` coverage or waiver, and a semantic decision). 
- Update `crates/perl-ast/README.md` to clarify that `v2` is a re-exported experimental microcrate and to link to the new compatibility contract. 
- Adjust crate-level documentation in `crates/perl-ast/src/lib.rs` to align the module description for `v2` with the re-export/experimental framing. 

### Testing

- Attempted `./scripts/cargo-safe test -p perl-ast --profile agent --locked`, but the run was blocked by the environment storage policy with the message `DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c1abff883338c214713c5312612)