### PR TITLE
docs(perl-ast): define AST compatibility contract (#0000)

### DIFF
--- a/crates/perl-ast/README.md
+++ b/crates/perl-ast/README.md
@@ -6,12 +6,26 @@ AST (Abstract Syntax Tree) node definitions for the Perl parser ecosystem.
 
 `perl-ast` provides the typed node structures used to represent parsed Perl source code. It contains two AST modules:
 
-- **`ast`** -- The primary AST used by `perl-parser`. Defines `Node` (kind + `SourceLocation`) and the `NodeKind` enum with 50+ variants covering declarations, expressions, control flow, regex, OO constructs, and error recovery nodes. Includes S-expression serialization via `to_sexp()`.
-- **`v2`** -- An enhanced AST for incremental parsing. Nodes carry a unique `NodeId` and use `Range` (line/column) positions instead of byte offsets. Adds `NodeIdGenerator`, `MissingKind`, `DiagnosticId`, and lightweight `ErrorRef` nodes.
+- **`ast`** -- The primary AST used by `perl-parser`. Defines `Node` (kind + `SourceLocation`) and the `NodeKind` enum with 50+ variants covering declarations, expressions, control flow, regex, OO constructs, and error recovery nodes.
+- **`v2`** -- Re-export of the extracted `perl-ast-v2` microcrate for incremental parsing use-cases. This compatibility tier is experimental while the workspace hardens incremental parser behavior.
+
+S-expression serialization remains available through `Node::to_sexp()` for tree-sitter-compatible snapshots, but rendering policy is treated as a compatibility/debug adapter rather than AST semantics.
+
+## Compatibility contract
+
+The canonical AST contract lives in [`docs/reference/ast-contract.md`](../../docs/reference/ast-contract.md).
+
+When adding or changing a `NodeKind`, update and test all required surfaces:
+
+- kind naming (`kind_name`, `ALL_KIND_NAMES`)
+- child traversal (`children`, `first_child`, `for_each_child`, `for_each_child_mut`)
+- S-expression rendering coverage (or explicit documented waiver)
+- parser fixture coverage
+- semantic analyzer handling decision
 
 ## Public API
 
-Re-exports from `lib.rs`: `Node`, `NodeKind`, `SourceLocation`.
+Re-exports from `lib.rs`: `Node`, `NodeKind`, `SourceLocation`, and experimental `v2`.
 
 ## Workspace Role
 

--- a/crates/perl-ast/src/lib.rs
+++ b/crates/perl-ast/src/lib.rs
@@ -45,6 +45,9 @@
 pub mod ast;
 
 /// Incremental parsing AST types extracted into a dedicated microcrate.
+///
+/// This re-export is experimental while incremental-parse compatibility is
+/// still being hardened.
 pub use perl_ast_v2 as v2;
 
 /// Primary AST node -- the building block of every syntax tree.

--- a/docs/reference/ast-contract.md
+++ b/docs/reference/ast-contract.md
@@ -1,0 +1,38 @@
+# AST Compatibility Contract
+
+This document defines the compatibility tiers for AST surfaces in the `perl-lsp`
+workspace.
+
+## Surface tiers
+
+- `perl_ast::Node` and `perl_ast::NodeKind` (from `perl-ast::ast`) are the
+  primary parser AST and should be treated as the stability-contract surface as
+  `perl-ast` approaches `v0.15`.
+- `perl_ast::v2` is an extracted, re-exported microcrate (`perl-ast-v2`) for
+  incremental-parsing consumers and remains experimental until the `v0.15.0`
+  compatibility window is declared complete.
+
+## Required updates when adding or changing `NodeKind`
+
+No `NodeKind` variant change is complete without all of the following:
+
+1. `kind_name()` coverage.
+2. `ALL_KIND_NAMES` coverage.
+3. Child traversal coverage (`children()`, `first_child()`,
+   `for_each_child()`, `for_each_child_mut()`).
+4. S-expression coverage (`to_sexp()` / `to_sexp_inner()`) or an explicit,
+   documented "not renderable" waiver.
+5. Parser fixture coverage proving when the variant is emitted.
+6. Semantic analyzer handling decision (handled, intentionally ignored, or
+   explicitly deferred).
+
+## Contributor checklist
+
+When introducing a new AST construct, include evidence in the PR that answers:
+
+- Parser: when is it emitted?
+- Traversal: what are its children?
+- S-expression: how is it rendered?
+- Semantic analyzer: how is it treated?
+- LSP-facing spans: does it expose the required symbol/name anchor(s)?
+- Tests: which fixture or unit test demonstrates the behavior?


### PR DESCRIPTION
### Motivation

- Provide a single canonical contract that clarifies the stability boundary between the primary AST (`ast`) and the extracted/re-exported incremental AST (`v2`) and reduce maintenance drift when adding or changing `NodeKind` variants.

### Description

- Added `docs/reference/ast-contract.md` which defines surface tiers, required coverage surfaces for `NodeKind` changes, and a contributor checklist. 
- Updated `crates/perl-ast/README.md` to reference the new contract, document that `v2` is an experimental re-export of `perl-ast-v2`, and list the maintenance surfaces to update when changing `NodeKind`.
- Clarified the `v2` re-export doc comment in `crates/perl-ast/src/lib.rs` to explicitly mark the compatibility status as experimental while incremental-parse compatibility is hardened.

### Testing

- Attempted to run `./scripts/cargo-safe test -p perl-ast --profile agent --locked`, but the run was blocked by an environment storage guard (`DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`), so automated tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c1abff883338c214713c5312612)