### PR TITLE
docs(perl-ast): define AST compatibility contract (#0000)

### DIFF
--- a/crates/perl-ast-v2/README.md
+++ b/crates/perl-ast-v2/README.md
@@ -13,3 +13,8 @@ incremental parsing consumers can depend on a smaller, more focused microcrate.
 - `NodeIdGenerator`
 - `DiagnosticId`
 - `MissingKind`
+## Stability
+
+`perl-ast-v2` is intentionally published for incremental parsing integration
+experiments, but remains pre-stability and may evolve until promoted by the
+project [AST compatibility contract](../../docs/reference/ast-contract.md).

--- a/crates/perl-ast/README.md
+++ b/crates/perl-ast/README.md
@@ -7,7 +7,7 @@ AST (Abstract Syntax Tree) node definitions for the Perl parser ecosystem.
 `perl-ast` provides the typed node structures used to represent parsed Perl source code. It contains two AST modules:
 
 - **`ast`** -- The primary AST used by `perl-parser`. Defines `Node` (kind + `SourceLocation`) and the `NodeKind` enum with 50+ variants covering declarations, expressions, control flow, regex, OO constructs, and error recovery nodes. Includes S-expression serialization via `to_sexp()`.
-- **`v2`** -- An enhanced AST for incremental parsing. Nodes carry a unique `NodeId` and use `Range` (line/column) positions instead of byte offsets. Adds `NodeIdGenerator`, `MissingKind`, `DiagnosticId`, and lightweight `ErrorRef` nodes.
+- **`v2`** -- Re-exported from the extracted `perl-ast-v2` microcrate. This incremental-parsing surface is currently experimental/pre-stability; nodes carry a unique `NodeId` and use `Range` (line/column) positions instead of byte offsets. Adds `NodeIdGenerator`, `MissingKind`, `DiagnosticId`, and lightweight `ErrorRef` nodes.
 
 ## Public API
 
@@ -25,3 +25,8 @@ Tier 1 leaf crate. Depended on by `perl-parser-core`, `perl-tokenizer`, `perl-pr
 ## License
 
 MIT OR Apache-2.0
+## AST compatibility contract
+
+See the [AST compatibility contract](../../docs/reference/ast-contract.md) for
+the stability tiers and required coverage when adding or changing `NodeKind`
+variants.

--- a/crates/perl-ast/src/lib.rs
+++ b/crates/perl-ast/src/lib.rs
@@ -8,7 +8,7 @@
 //! # Modules
 //!
 //! - [`ast`] -- The primary AST used by the current recursive-descent parser.
-//! - [`v2`] -- Experimental second-generation AST with full position tracking
+//! - [`v2`] -- Experimental second-generation AST re-exported from `perl-ast-v2`
 //!   for incremental parsing.
 //!
 //! # Quick start

--- a/docs/reference/ast-contract.md
+++ b/docs/reference/ast-contract.md
@@ -1,0 +1,36 @@
+# AST Compatibility Contract
+
+This document defines compatibility expectations for the AST crates while
+`perl-ast` moves toward a more explicit public stability contract.
+
+## Surfaces and stability tier
+
+- `perl_ast::ast` (`Node`, `NodeKind`, `SourceLocation`) is the primary parser AST
+  surface and is treated as the stable public contract.
+- `perl_ast::v2` (re-export of `perl-ast-v2`) is an experimental compatibility tier
+  intended for incremental parsing consumers.
+- `perl-ast-v2` is published for focused integration work, but its API is
+  considered pre-stability until explicitly promoted.
+
+## NodeKind change gate
+
+No new `NodeKind` variant should land without all of the following:
+
+- Child traversal coverage (`children`, `first_child`, immutable traversal,
+  mutable traversal).
+- Kind-name coverage (`kind_name`, `ALL_KIND_NAMES`).
+- S-expression coverage, or an explicit "not renderable" decision documented in
+  tests.
+- Parser fixture coverage proving when the variant is emitted.
+- Semantic analyzer decision: handled, intentionally ignored, or explicitly
+  deferred.
+
+## Contributor checklist (AST behavior changes)
+
+Before opening a PR that adds or changes an AST node shape, verify:
+
+1. Parser emission is tested with a fixture.
+2. Traversal behavior is covered.
+3. S-expression output expectation is covered.
+4. Semantic analyzer handling decision is encoded in tests/docs.
+5. `perl-ast` and `perl-ast-v2` test suites pass.


### PR DESCRIPTION
Problem: the AST stability boundary and `perl-ast-v2` role were not documented in one canonical place.
Fix: add an AST compatibility contract, link it from the AST crate docs, and mark the v2 surface as experimental/pre-stability.

Review notes:
- `perl_ast::ast` is documented as the primary public parser AST surface.
- `perl_ast::v2` / `perl-ast-v2` are documented as experimental/pre-stability.
- The `NodeKind` change gate now calls out traversal, kind-name, sexp, parser fixture, and semantic-analyzer coverage.
- Crate README links use valid repo-relative paths.
- Removed an unnecessary hardcoded version-window claim from the new reference doc.

Accuracy-control delta:
- Parser accuracy denominator unchanged: 46 fixtures across 28 families.
- Failure packets unchanged: 0.
- Ratchet floor metrics pass.

Verification:
- `cargo test -p perl-ast --locked`
- `cargo test -p perl-ast-v2 --locked`
- `cargo check -p perl-ast --all-targets --locked`
- `cargo check -p perl-ast-v2 --all-targets --locked`
- `cargo clippy -p perl-ast --all-targets --locked -- -D warnings`
- `cargo clippy -p perl-ast-v2 --all-targets --locked -- -D warnings`
- `cargo xtask fmt --check`
- `git diff --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`