### PR TITLE
fix(perl-lexer): report unclosed quote-like delimiters (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2868,7 +2868,7 @@ impl<'a> PerlLexer<'a> {
         start: usize,
         delimiter: char,
     ) -> Option<Token> {
-        self.read_delimited_body(delimiter);
+        let (_, pattern_closed) = self.read_delimited_body(delimiter);
 
         let pattern_is_paired = quote_handler::paired_close(delimiter).is_some();
         if pattern_is_paired {
@@ -2880,10 +2880,16 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                self.read_delimited_body(repl_delim);
+                let (_, replacement_closed) = self.read_delimited_body(repl_delim);
+                if !pattern_closed || !replacement_closed {
+                    return Some(self.unclosed_quote_like_error(start, "s", delimiter));
+                }
             }
         } else {
-            self.read_delimited_body(delimiter);
+            let (_, replacement_closed) = self.read_delimited_body(delimiter);
+            if !pattern_closed || !replacement_closed {
+                return Some(self.unclosed_quote_like_error(start, "s", delimiter));
+            }
         }
 
         // Parse modifiers - include all alphanumeric for proper validation in parser (MUT_005 fix)
@@ -2898,12 +2904,7 @@ impl<'a> PerlLexer<'a> {
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
 
-        Some(Token {
-            token_type: TokenType::Substitution,
-            text: Arc::from(text),
-            start,
-            end: self.position,
-        })
+        Some(Token { token_type: TokenType::Substitution, text: Arc::from(text), start, end: self.position })
     }
 
     fn parse_transliteration(&mut self, start: usize) -> Option<Token> {
@@ -2922,7 +2923,7 @@ impl<'a> PerlLexer<'a> {
         start: usize,
         delimiter: char,
     ) -> Option<Token> {
-        self.read_delimited_body(delimiter);
+        let (_, search_closed) = self.read_delimited_body(delimiter);
 
         let search_is_paired = quote_handler::paired_close(delimiter).is_some();
         if search_is_paired {
@@ -2934,10 +2935,16 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                self.read_delimited_body(repl_delim);
+                let (_, replacement_closed) = self.read_delimited_body(repl_delim);
+                if !search_closed || !replacement_closed {
+                    return Some(self.unclosed_quote_like_error(start, "tr", delimiter));
+                }
             }
         } else {
-            self.read_delimited_body(delimiter);
+            let (_, replacement_closed) = self.read_delimited_body(delimiter);
+            if !search_closed || !replacement_closed {
+                return Some(self.unclosed_quote_like_error(start, "tr", delimiter));
+            }
         }
 
         // Parse modifiers - include all alphanumeric for proper validation in parser (MUT_005 fix)
@@ -2958,6 +2965,19 @@ impl<'a> PerlLexer<'a> {
             start,
             end: self.position,
         })
+    }
+
+    fn unclosed_quote_like_error(&self, start: usize, operator: &str, delimiter: char) -> Token {
+        let text = &self.input[start..self.position];
+        Token {
+            token_type: TokenType::Error(Arc::from(format!(
+                "unclosed {} delimiter '{}'",
+                operator, delimiter
+            ))),
+            text: Arc::from(text),
+            start,
+            end: self.position,
+        }
     }
 
     /// Read content between delimiters.
@@ -3055,15 +3075,7 @@ impl<'a> PerlLexer<'a> {
         if !closed {
             // EOF reached before finding the closing delimiter — emit an error
             // token so the parser's recovery mechanism records a diagnostic.
-            return Some(Token {
-                token_type: TokenType::Error(Arc::from(format!(
-                    "unclosed {} delimiter '{}'",
-                    operator, delimiter
-                ))),
-                text: Arc::from(text),
-                start,
-                end: self.position,
-            });
+            return Some(self.unclosed_quote_like_error(start, &operator, delimiter));
         }
 
         let token_type = quote_handler::get_quote_token_type(&operator);

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -720,6 +720,30 @@ fn malformed_quote_like_constructs_do_not_panic() -> R {
     Ok(())
 }
 
+#[test]
+fn unclosed_quote_like_constructs_emit_unclosed_errors() -> R {
+    let cases = [
+        ("qq{hello;", "unclosed qq delimiter '{'"),
+        ("q{hello;", "unclosed q delimiter '{'"),
+        ("qx{cmd;", "unclosed qx delimiter '{'"),
+        ("qr{pat;", "unclosed qr delimiter '{'"),
+        ("s{a}{", "unclosed s delimiter '{'"),
+        ("tr{a}{", "unclosed tr delimiter '{'"),
+    ];
+
+    for (src, expected) in cases {
+        let token = first_significant(src).ok_or("no token")?;
+        assert!(matches!(token.token_type, TokenType::Error(_)), "{src:?} should lex as error");
+        assert_eq!(token.text.as_ref(), src, "error token should retain original text");
+        match &token.token_type {
+            TokenType::Error(message) => assert_eq!(message.as_ref(), expected),
+            _ => unreachable!(),
+        }
+    }
+
+    Ok(())
+}
+
 // ===========================================================================
 // 4. Special variables
 // ===========================================================================

--- a/crates/perl-parser-core/tests/fix_delimiter_owner_buckets.rs
+++ b/crates/perl-parser-core/tests/fix_delimiter_owner_buckets.rs
@@ -84,6 +84,12 @@ fn malformed_missing_quote_like_closer_still_reports_error() {
 }
 
 #[test]
+fn malformed_missing_substitution_or_transliteration_closer_reports_unclosed() {
+    assert_has_error(r#"my $s = s{a}{;"#, "unclosed");
+    assert_has_error(r#"my $s = tr{a}{;"#, "unclosed");
+}
+
+#[test]
 fn malformed_missing_call_paren_still_reports_error() {
     assert_has_error(r#"my $x = func($a, $b;"#, "insertedcloser");
 }


### PR DESCRIPTION
### Motivation

- Quote-like constructs (notably `s///` and `tr///`) could complete lexing without emitting a stable "unclosed" diagnostic when a pattern or replacement body ran to EOF, weakening parser recovery and user-facing diagnostics.

### Description

- Make `parse_substitution_with_delimiter` and `parse_transliteration_with_delimiter` track whether both delimited bodies closed and return a structured error token when either side is unclosed.  
- Add a single helper `unclosed_quote_like_error` to produce consistent `TokenType::Error("unclosed <op> delimiter '<delim>'")` tokens and reuse it from generic quote-op parsing.  
- Add lexer regression tests in `crates/perl-lexer/tests/edge_case_tests.rs` asserting unclosed quote-like inputs lex as error tokens and preserve original text.  
- Add parser-core regression tests in `crates/perl-parser-core/tests/fix_delimiter_owner_buckets.rs` to ensure malformed `s{a}{` and `tr{a}{` forms surface the expected "unclosed" recovery diagnostics.

### Testing

- Ran `cargo test -p perl-lexer quote_like` and the focused lexer suite passed.  
- Ran `cargo test -p perl-parser-core fix_delimiter_owner_buckets` and the parser-core regression tests passed.  
- Attempted the recommended guarded run `./scripts/cargo-safe test -p perl-lexer --profile agent --locked quote_like` but it was blocked by the environment storage policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c11e4d88333b69af12a08419a6c)