### PR TITLE
fix(perl-lexer): report unclosed quote-like operators (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2868,7 +2868,8 @@ impl<'a> PerlLexer<'a> {
         start: usize,
         delimiter: char,
     ) -> Option<Token> {
-        self.read_delimited_body(delimiter);
+        let (_pattern, pattern_closed) = self.read_delimited_body(delimiter);
+        let replacement_closed;
 
         let pattern_is_paired = quote_handler::paired_close(delimiter).is_some();
         if pattern_is_paired {
@@ -2880,10 +2881,14 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                self.read_delimited_body(repl_delim);
+                let (_replacement, closed) = self.read_delimited_body(repl_delim);
+                replacement_closed = closed;
+            } else {
+                replacement_closed = false;
             }
         } else {
-            self.read_delimited_body(delimiter);
+            let (_replacement, closed) = self.read_delimited_body(delimiter);
+            replacement_closed = closed;
         }
 
         // Parse modifiers - include all alphanumeric for proper validation in parser (MUT_005 fix)
@@ -2898,12 +2903,16 @@ impl<'a> PerlLexer<'a> {
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
 
-        Some(Token {
-            token_type: TokenType::Substitution,
-            text: Arc::from(text),
-            start,
-            end: self.position,
-        })
+        let token_type = if pattern_closed && replacement_closed {
+            TokenType::Substitution
+        } else {
+            TokenType::Error(Arc::from(format!(
+                "unclosed quote-like operator 's' delimiter '{}'",
+                delimiter
+            )))
+        };
+
+        Some(Token { token_type, text: Arc::from(text), start, end: self.position })
     }
 
     fn parse_transliteration(&mut self, start: usize) -> Option<Token> {
@@ -2922,7 +2931,8 @@ impl<'a> PerlLexer<'a> {
         start: usize,
         delimiter: char,
     ) -> Option<Token> {
-        self.read_delimited_body(delimiter);
+        let (_search, search_closed) = self.read_delimited_body(delimiter);
+        let replacement_closed;
 
         let search_is_paired = quote_handler::paired_close(delimiter).is_some();
         if search_is_paired {
@@ -2934,10 +2944,14 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                self.read_delimited_body(repl_delim);
+                let (_replacement, closed) = self.read_delimited_body(repl_delim);
+                replacement_closed = closed;
+            } else {
+                replacement_closed = false;
             }
         } else {
-            self.read_delimited_body(delimiter);
+            let (_replacement, closed) = self.read_delimited_body(delimiter);
+            replacement_closed = closed;
         }
 
         // Parse modifiers - include all alphanumeric for proper validation in parser (MUT_005 fix)
@@ -2952,12 +2966,17 @@ impl<'a> PerlLexer<'a> {
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
 
-        Some(Token {
-            token_type: TokenType::Transliteration,
-            text: Arc::from(text),
-            start,
-            end: self.position,
-        })
+        let token_type = if search_closed && replacement_closed {
+            TokenType::Transliteration
+        } else {
+            TokenType::Error(Arc::from(format!(
+                "unclosed quote-like operator '{}' delimiter '{}'",
+                if self.input[start..].starts_with("tr") { "tr" } else { "y" },
+                delimiter
+            )))
+        };
+
+        Some(Token { token_type, text: Arc::from(text), start, end: self.position })
     }
 
     /// Read content between delimiters.

--- a/crates/perl-lexer/tests/quote_like_recovery_tests.rs
+++ b/crates/perl-lexer/tests/quote_like_recovery_tests.rs
@@ -1,0 +1,46 @@
+use perl_lexer::{PerlLexer, TokenType};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn first_non_whitespace_token(input: &str) -> Option<perl_lexer::Token> {
+    let mut lexer = PerlLexer::new(input);
+    loop {
+        let token = lexer.next_token()?;
+        if !matches!(token.token_type, TokenType::Whitespace) {
+            return Some(token);
+        }
+    }
+}
+
+#[test]
+fn unclosed_quote_like_tokens_return_unclosed_error() -> TestResult {
+    let cases = [
+        "qq{hello;",
+        "q{hello;",
+        "qx{cmd;",
+        "qr{pat;",
+        "s{a}{",
+        "tr{a}{",
+        "qq/hello;",
+        "qq[hello;",
+        "qq(hello;",
+        "qq<hello;",
+        "qq#hello;",
+    ];
+
+    for input in cases {
+        let token = first_non_whitespace_token(input)
+            .ok_or_else(|| format!("expected token for input {input}"))?;
+        match token.token_type {
+            TokenType::Error(message) => {
+                assert!(
+                    message.contains("unclosed"),
+                    "expected unclosed message for {input}, got {message}"
+                );
+            }
+            other => return Err(format!("expected error token for {input}, got {other:?}").into()),
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Improve lexer recovery for malformed quote-like inputs so the parser receives a clear "unclosed" diagnostic instead of a generic tokenization result.
- Address user-visible failures where constructs like `qq{hello;` or `s{a}{` produced `UnexpectedToken` rather than an explicit unclosed quote-like error.

### Description

- Updated `parse_substitution_with_delimiter` to track whether the pattern and replacement delimited bodies actually closed and emit a `TokenType::Error` with an "unclosed quote-like operator" message when they do not instead of always returning `TokenType::Substitution`.
- Updated `parse_transliteration_with_delimiter` to similarly track search/replacement closure and emit an explicit error token on incomplete delimiters instead of returning `TokenType::Transliteration` silently.
- Reused `read_delimited_body` return value `(String, bool)` to determine closure status and incorporated closure checks into token construction logic in `crates/perl-lexer/src/lib.rs` (`parse_substitution_with_delimiter` and `parse_transliteration_with_delimiter`).
- Added focused regression tests in `crates/perl-lexer/tests/quote_like_recovery_tests.rs` asserting malformed inputs (e.g. `qq{hello;`, `q{hello;`, `qx{cmd;`, `qr{pat;`, `s{a}{`, `tr{a}{`, and various delimiter forms) produce an error token whose message contains "unclosed".

### Testing

- Ran `cargo test -p perl-lexer quote_like` and the lexer-focused tests (including the new `quote_like_recovery_tests.rs`) passed. (OK)
- Ran `cargo test -p perl-parser-core fix_delimiter_owner_buckets` to ensure parser diagnostics mapping remains stable and that test passed. (OK)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c11e4d88333b69af12a08419a6c)