### PR TITLE
feat(parser): add parser coverage risk map and baseline (#0000)

### DIFF
--- a/.ci/coverage/parser-baseline.json
+++ b/.ci/coverage/parser-baseline.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "crate_group": "parser",
+  "enforcement": "advisory",
+  "coverage_artifact": "target/coverage/parser.lcov",
+  "measured_scope": "perl-parser-lib + perl-parser-core-lib",
+  "source_of_truth_gate": ".ci/coverage-baseline.txt",
+  "ratchet_status": "existing parser-lib branch gate remains the enforceable baseline",
+  "candidate_scopes": [
+    "perl-parser --all-targets"
+  ],
+  "known_blockers": [
+    {
+      "scope": "perl-parser --all-targets coverage",
+      "reason": "coverage-mode regressions in tests/error_classifier_tests.rs"
+    }
+  ],
+  "risk_targets": {
+    "critical_parser_behavior": {
+      "priority": "highest",
+      "coverage_signal": "branch",
+      "paths": [
+        "crates/perl-parser-core/src/engine/parser/statements.rs",
+        "crates/perl-parser-core/src/syntax/heredoc.rs",
+        "crates/perl-parser-core/src/engine/parser/"
+      ]
+    },
+    "recovery_and_error_handling": {
+      "priority": "highest",
+      "coverage_signal": "branch",
+      "paths": [
+        "crates/perl-parser-core/src/engine/parser/",
+        "crates/perl-parser/src/"
+      ]
+    },
+    "span_and_position_correctness": {
+      "priority": "high",
+      "coverage_signal": "branch",
+      "paths": [
+        "crates/perl-parser-core/src/",
+        "crates/perl-parser/src/"
+      ]
+    },
+    "incremental_parsing": {
+      "priority": "high",
+      "coverage_signal": "branch",
+      "paths": [
+        "crates/perl-parser-core/src/"
+      ]
+    },
+    "facade_and_reexport_glue": {
+      "priority": "low",
+      "coverage_signal": "smoke",
+      "paths": [
+        "crates/perl-parser/src/"
+      ]
+    }
+  }
+}

--- a/docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md
+++ b/docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md
@@ -1,0 +1,129 @@
+# Parser Coverage Risk Map — 2026-05-05
+
+## Scope
+
+This map defines where parser coverage increases should focus first for the parser crate group (`perl-parser`, `perl-parser-core`) and where lower coverage is acceptable for now.
+
+This document is intentionally for *coverage triage*, not parser behavior changes.
+It does not add new enforceable coverage floors.
+
+## Coverage command and baseline
+
+- Recipe: `just coverage-parser`
+- Measured scope: `perl-parser --lib` and `perl-parser-core --lib`
+- Coverage artifact: `target/coverage/parser.lcov`
+- Current enforced parser coverage gate: `.ci/coverage-baseline.txt`
+- Advisory risk policy file: `.ci/coverage/parser-baseline.json`
+
+The checked-in gate remains the existing parser-lib ratchet in `.ci/coverage-baseline.txt`.
+This risk map records where parser-core and future all-target coverage should focus once those lanes are stable enough to ratchet.
+
+Current blocker for broadening beyond lib coverage:
+
+- `perl-parser --all-targets` coverage exposes existing integration failures in `tests/error_classifier_tests.rs`.
+
+That blocker should be fixed in behavior/test-focused PRs before adding enforceable all-target floors.
+
+## Risk classification
+
+### 1) Critical parser behavior (highest priority)
+
+Target high branch coverage because these code paths determine parse correctness and syntax tree shape.
+
+- `crates/perl-parser-core/src/engine/parser/statements.rs`
+- `crates/perl-parser-core/src/syntax/heredoc.rs`
+- Parser expression and statement dispatch paths in `crates/perl-parser-core/src/engine/parser/`
+
+Expected policy stance:
+
+- Candidate per-file branch floors on known-risk files (`statements.rs`, `heredoc.rs`) after fresh coverage proof
+- Trend upward over time; do not broaden crate-wide gates prematurely
+
+### 2) Recovery and error handling (highest priority)
+
+Coverage here correlates directly with live-edit reliability and post-error salvage behavior.
+
+Focus areas:
+
+- Error-node construction and resynchronization branches
+- End-of-input/incomplete-block handling
+- Recovery spillover boundaries in statement parsing
+
+Expected policy stance:
+
+- Prefer branch coverage over line coverage as the primary signal
+- Add targeted malformed fixtures before raising floors
+
+### 3) Span and position correctness (high priority)
+
+Coverage should emphasize edge branches affecting byte/line/UTF-16 mapping and downstream LSP coordinates.
+
+Focus areas:
+
+- Span propagation across recovered nodes
+- Position mapping helpers used by parser-facing APIs
+- Newline/offset edge cases
+
+Expected policy stance:
+
+- Treat branch gaps as significant when they can produce wrong editor coordinates
+
+### 4) Incremental parsing (high priority)
+
+Coverage should prioritize invalidation and equivalence branches that can silently diverge from full parse behavior.
+
+Focus areas:
+
+- Incremental cache invalidation conditions
+- Fast-path vs fallback parse equivalence branches
+- Stitching boundaries after edits
+
+Expected policy stance:
+
+- Ratchet branch coverage only after deterministic fixture coverage exists
+
+### 5) Facade and re-export glue (low priority)
+
+Lower coverage is acceptable where code mostly re-exports or forwards parser-core behavior.
+
+Focus areas:
+
+- `pub use`-heavy facade modules
+- Thin wrappers with no branching behavior of their own
+
+Expected policy stance:
+
+- Avoid spending high-value test budget chasing these lines first
+
+### 6) Deprecated compatibility surface (low priority)
+
+Coverage is useful for regression protection but should not dominate parser trust work.
+
+Focus areas:
+
+- Legacy aliases and compatibility exports
+- Deprecated API adapters maintained for migration
+
+Expected policy stance:
+
+- Keep smoke/regression coverage; prioritize critical parser behavior first
+
+### 7) Generated or static data (excluded/very low)
+
+Generated tables and static mappings should generally be excluded from risk-weighted coverage goals.
+
+Expected policy stance:
+
+- Do not use generated/static files to justify parser trust improvements
+
+## Operator guidance
+
+When coverage is below target, prioritize work in this order:
+
+1. Critical parser behavior
+2. Recovery/error handling
+3. Span/position correctness
+4. Incremental parsing
+5. Facade glue and compatibility surface
+
+This keeps parser trust improvements aligned with user-visible correctness rather than raw percentage growth.

--- a/justfile
+++ b/justfile
@@ -1874,6 +1874,20 @@ coverage-summary:
     @"$HOME/.cargo/bin/rustup" run nightly cargo llvm-cov -p perl-parser --lib --locked --branch \
         --ignore-filename-regex '(^|/)(archive|tests|benches|examples)(/|$)|(^|/)build\.rs$|(^|/)crates/tree-sitter-perl-c/'
 
+
+# Generate parser library branch coverage in LCOV format (CI-safe when cargo-llvm-cov is unavailable)
+coverage-parser:
+    @echo "📊 Generating parser coverage (perl-parser + perl-parser-core libs)..."
+    @if [[ ! -x "$HOME/.cargo/bin/cargo-llvm-cov" ]]; then \
+        echo "⚠️ cargo-llvm-cov not found. Skipping run."; \
+        echo "   Install and run:"; \
+        echo "   rustup run nightly cargo llvm-cov -p perl-parser -p perl-parser-core --lib --locked --branch --lcov --output-path target/coverage/parser.lcov"; \
+        exit 0; \
+    fi
+    @mkdir -p target/coverage
+    @"$HOME/.cargo/bin/rustup" run nightly cargo llvm-cov -p perl-parser -p perl-parser-core --lib --locked --branch --lcov --output-path target/coverage/parser.lcov \
+        --ignore-filename-regex '(^|/)(archive|tests|benches|examples)(/|$)|(^|/)build\.rs$|(^|/)crates/tree-sitter-perl-c/'
+    @echo "✅ Parser coverage: target/coverage/parser.lcov"
 # Generate branch coverage and fail if it regresses against the baseline policy
 coverage-branch-gate:
     @echo "📊 Generating branch coverage gate data..."


### PR DESCRIPTION
### Motivation

- Add a parser coverage risk map without turning unverified all-target coverage into an enforceable gate.
- Keep the existing parser-lib coverage ratchet as the source of truth while documenting where parser-core and future all-target coverage work should focus.

### Description

- Add `just coverage-parser` as an LCOV helper for `perl-parser --lib` plus `perl-parser-core --lib`, writing `target/coverage/parser.lcov`.
- Add `.ci/coverage/parser-baseline.json` as an advisory parser risk policy, not a new floor file; `.ci/coverage-baseline.txt` remains the enforceable parser coverage gate.
- Add `docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md` to classify parser coverage work by user-facing risk: critical behavior, recovery, spans, incremental parsing, facade glue, compatibility, and generated/static code.
- Record the remaining blocker before broadening coverage to all-targets.

### Testing

- `cargo xtask fmt --check` passed.
- `cargo check -p xtask --all-targets --profile agent --locked` passed.
- Direct underlying coverage command passed and saved `target/coverage/parser.lcov`:
  - `rustup run nightly cargo llvm-cov -p perl-parser -p perl-parser-core --lib --locked --branch --lcov --output-path target/coverage/parser.lcov --ignore-filename-regex ...`
- `cargo xtask metrics parser-accuracy --check` passed: 46 fixtures / 28 families.
- `cargo xtask metrics ratchet-check parser_accuracy` passed.
- `git diff --check` passed.

### Notes

- `cargo-safe` was blocked by the local devplane storage guard, so verification used direct Cargo with an external temp target directory.
- `just coverage-parser` could not be invoked directly in this Windows session because `just` could not find its configured shell; the command behind the recipe was run directly instead.
- The previous parser-core lib blocker was fixed separately in #8055 before this PR was rebased.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c0902c88333bec64a8dfeb593da)