### PR TITLE
fix(tree-sitter-perl-rs): align Node::kind with grammar names (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/README.md
+++ b/crates/tree-sitter-perl-rs/README.md
@@ -52,8 +52,9 @@ if let Some(tree) = parser.parse("my $x = 42;") {
 | `Tree::edit(&mut self, edit: &InputEdit)` | Records a source edit; pass the updated tree to `parse_with_old_tree` |
 | `Tree::root_node() -> Node<'_>` | Get the root of the syntax tree |
 | `Tree::source() -> &str` | Source text this tree was built from |
-| `Node::kind() -> &'static str` | Node type name (v3 internal, e.g. `"Program"`) |
-| `Node::grammar_kind() -> String` | Grammar-canonical name (e.g. `"source_file"`) matching tree-sitter output |
+| `Node::kind() -> String` | Grammar-canonical name (e.g. `"source_file"`) matching tree-sitter output |
+| `Node::grammar_kind() -> String` | Alias of `Node::kind()` for compatibility |
+| `Node::native_kind() -> &'static str` | Node type name (v3 internal, e.g. `"Program"`) |
 | `Node::to_sexp() -> String` | Tree-sitter-compatible S-expression for this subtree |
 | `Node::child_count() -> usize` | Number of direct children |
 | `Node::child(i: usize) -> Option<Node>` | `i`-th direct child |
@@ -83,7 +84,6 @@ This means you can pipe any Perl source through this parser and rely on getting 
 
 - `Node::children()` allocates a `Vec` internally on each call. Prefer iterating once over calling repeatedly.
 - `RecursionLimit` / `NestingTooDeep` parse errors produce `None` rather than a partial tree.
-- `Node::kind()` returns v3 internal names (e.g. `"Program"`) rather than tree-sitter grammar names (e.g. `"source_file"`). Use `Node::grammar_kind()` for the canonical name or `Node::to_sexp()` for full canonical output.
 
 ## Backlog roadmap
 

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -27,7 +27,8 @@
 //!   The v3 parser is highly error-tolerant and almost always produces a partial tree.
 //! - `Node::to_sexp()` delegates to `perl_ast::Node::to_sexp()` for tree-sitter-compatible
 //!   S-expression output.
-//! - `Node::kind()` returns the `NodeKind::kind_name()` string.
+//! - `Node::kind()` returns the tree-sitter grammar-canonical kind string.
+//! - `Node::native_kind()` returns the v3 internal `NodeKind::kind_name()` string.
 //! - `Node::start_byte()` / `Node::end_byte()` expose the `SourceLocation` byte offsets.
 //! - `Node::children()` and `Node::child()` mirror tree-sitter traversal conventions.
 //!
@@ -341,24 +342,25 @@ pub struct Node<'tree> {
 }
 
 impl<'tree> Node<'tree> {
-    /// Returns the node kind string (e.g. `"Program"`, `"Subroutine"`, `"Variable"`).
+    /// Returns the tree-sitter grammar-canonical node kind name.
     ///
-    /// Delegates to [`NodeKind::kind_name`][perl_ast::NodeKind::kind_name].
+    /// This mirrors what tree-sitter users expect from `Node::kind()`; for example,
+    /// the root node kind is `"source_file"`.
+    pub fn kind(&self) -> String {
+        self.grammar_kind()
+    }
+
+    /// Returns the native v3 internal node kind name.
     ///
-    /// Note: this returns the v3 internal kind name, not the tree-sitter grammar node
-    /// type string. For example, the root node returns `"Program"` rather than
-    /// `"source_file"`. Use [`grammar_kind`][Node::grammar_kind] for the canonical
-    /// tree-sitter grammar name, or [`to_sexp`][Node::to_sexp] for tree-sitter-compatible
-    /// S-expression output which uses the canonical grammar names.
-    pub fn kind(&self) -> &'static str {
+    /// This exposes the PascalCase internal kind (e.g. `"Program"`, `"Subroutine"`).
+    pub fn native_kind(&self) -> &'static str {
         self.inner.kind.kind_name()
     }
 
     /// Returns the tree-sitter grammar-canonical node kind name.
     ///
-    /// Unlike [`kind`][Node::kind], which returns the v3 internal PascalCase name
-    /// (e.g., `"Program"`, `"Subroutine"`), this method returns the grammar name
-    /// used in S-expressions (e.g., `"source_file"`, `"sub"`).
+    /// This method is retained as an alias of [`kind`][Node::kind] for compatibility.
+    /// It returns the grammar name used in S-expressions (e.g., `"source_file"`, `"sub"`).
     /// This matches the kind strings returned by `tree-sitter-perl-c` and the
     /// upstream tree-sitter Perl grammar.
     /// Error nodes use `"ERROR"` (uppercase), matching tree-sitter convention.
@@ -729,7 +731,8 @@ mod tests {
     fn test_root_node_kind() {
         let mut p = Parser::new();
         let tree = must_some(p.parse("my $x = 42;"));
-        assert_eq!(tree.root_node().kind(), "Program");
+        assert_eq!(tree.root_node().kind(), "source_file");
+        assert_eq!(tree.root_node().native_kind(), "Program");
     }
 
     #[test]

--- a/crates/tree-sitter-perl-rs/tests/behavior_spec_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/behavior_spec_tests.rs
@@ -22,10 +22,10 @@ fn when_parsing_valid_perl_then_tree_and_source_are_available() {
 }
 
 #[test]
-fn when_requesting_root_kind_then_program_is_returned() {
+fn when_requesting_root_kind_then_source_file_is_returned() {
     let tree = parse("my $x = 42;");
 
-    assert_eq!(tree.root_node().kind(), "Program");
+    assert_eq!(tree.root_node().kind(), "source_file");
 }
 
 #[test]
@@ -106,15 +106,16 @@ fn when_requesting_grammar_kind_of_subroutine_then_sub_is_returned() {
     let tree = parse("sub greet { 1 }");
     let root = tree.root_node();
     // Find the subroutine child
-    let sub_node = must_some(root.children().find(|n| n.kind() == "Subroutine"));
+    let sub_node = must_some(root.children().find(|n| n.native_kind() == "Subroutine"));
     assert_eq!(sub_node.grammar_kind(), "sub");
 }
 
 #[test]
-fn when_v3_kind_and_grammar_kind_are_both_available_then_they_differ_for_program() {
+fn when_native_kind_and_grammar_kind_are_both_available_then_they_differ_for_program() {
     let tree = parse("1;");
     let root = tree.root_node();
-    assert_eq!(root.kind(), "Program");
+    assert_eq!(root.kind(), "source_file");
+    assert_eq!(root.native_kind(), "Program");
     assert_eq!(root.grammar_kind(), "source_file");
     assert_ne!(root.kind(), root.grammar_kind());
 }
@@ -128,7 +129,7 @@ fn when_requesting_grammar_kind_of_variable_with_attributes_then_snake_case_fall
     let root = tree.root_node();
     // Walk the tree to find the VariableWithAttributes node if present.
     fn find_var_attrs(n: tree_sitter_perl_rs::Node<'_>) -> Option<String> {
-        if n.kind() == "VariableWithAttributes" {
+        if n.native_kind() == "VariableWithAttributes" {
             return Some(n.grammar_kind());
         }
         for child in n.children() {

--- a/crates/tree-sitter-perl-rs/tests/incremental_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/incremental_tests.rs
@@ -121,8 +121,8 @@ fn when_parse_with_old_tree_given_empty_new_source_then_tree_is_returned() {
     assert!(new_tree.is_some(), "parse_with_old_tree must handle empty new source");
     let new_tree = must_some(new_tree);
     assert_eq!(new_tree.source(), "", "tree source must be the empty string");
-    // The root is still a Program node (empty program).
-    assert_eq!(new_tree.root_node().kind(), "Program");
+    // The root is still a source_file node (empty program).
+    assert_eq!(new_tree.root_node().kind(), "source_file");
 }
 
 #[test]
@@ -179,8 +179,8 @@ fn when_reparse_after_edit_then_new_tree_has_correct_ast() {
 
     let new_tree = must_some(parser.parse_with_old_tree(new_source, &old_tree));
     assert_eq!(new_tree.source(), new_source);
-    // Root must still be a Program node.
-    assert_eq!(new_tree.root_node().kind(), "Program");
+    // Root must still be a source_file node.
+    assert_eq!(new_tree.root_node().kind(), "source_file");
     // The new program has children (the sub declaration).
     assert!(
         new_tree.root_node().child_count() >= 1,


### PR DESCRIPTION
### Motivation

- `Node::kind()` previously exposed the v3 internal PascalCase kind names (e.g. `Program`) which is surprising for tree-sitter consumers who expect grammar-canonical names like `source_file`.
- Make the facade behave like tree-sitter by default while keeping access to the native v3 kind names for tooling that needs them.

### Description

- Changed `Node::kind()` to return the grammar-canonical tree-sitter name as a `String` (delegates to `grammar_kind()`).
- Added `Node::native_kind()` to expose the v3 internal PascalCase `NodeKind::kind_name()` (`&'static str`).
- Retained `Node::grammar_kind()` as an alias (and documented it) to preserve compatibility while moving callers toward the canonical `kind()` behavior.
- Updated unit tests and BDD-style behavior tests to assert `root.kind() == "source_file"` and to validate `native_kind()` where v3 names are needed, and updated the crate README API table to reflect the new contract.

### Testing

- Attempted to run `./scripts/cargo-safe test -p tree-sitter-perl-rs --profile agent --locked` but execution was blocked by the environment storage policy (`DENY: /root/.cache/devplane/perl-lsp ...`), so automated tests could not be run in this session.
- Unit tests in the repository were updated to match the new `kind()`/`native_kind()` behavior (changes included in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97bfbd0f88333914dc8d289f285cf)