### PR TITLE
feat(xtask): harden ux regression receipt routing (#0000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,10 +547,18 @@ jobs:
               lines.append(f"- Result: `{data.get('result', 'unknown')}`")
               if data.get("failure_class"):
                   lines.append(f"- Failure class: `{data.get('failure_class')}`")
+              if data.get("route"):
+                  lines.append(f"- Route: `{data.get('route')}`")
+              if data.get("merge_action"):
+                  lines.append(f"- Merge action: `{data.get('merge_action')}`")
               if data.get("first_failing_test"):
                   lines.append(f"- First failing test: `{data.get('first_failing_test')}`")
               if data.get("first_failing_line"):
                   lines.append(f"- First failing line: `{data.get('first_failing_line')}`")
+              if data.get("canonical_repro"):
+                  lines.append(f"- Repro: `{data.get('canonical_repro')}`")
+              if data.get("human_summary"):
+                  lines.append(f"- Summary: {data.get('human_summary')}")
           else:
               lines.append("- Receipt unavailable.")
 

--- a/docs/reference/CI_ARCHITECTURE.md
+++ b/docs/reference/CI_ARCHITECTURE.md
@@ -599,3 +599,25 @@ differing only in `metadata.environment.type` ("local" vs "ci").
 - `xtask/src/tasks/gates.rs` — gate runner with receipt emission
 - `xtask/src/tasks/queue_reconciler.rs` — reconciler that grounds `ci-green` in live state (planned; tracked in #7085)
 - Issue #7072 — merge queue implementation (enables `merge_group` trigger)
+
+## UX Regression pre-merge behavior
+
+The `UX Regression Tests` lane is merge-blocking. It always emits:
+
+- `target/receipts/ux-regression.log`
+- `target/receipts/ux-regression.json`
+
+The JSON receipt classifies the first observed failure and provides repro commands.
+Classification improves routing and triage only; it does not convert failing UX runs into a pass.
+
+| Failure class | Route | Expected action |
+| --- | --- | --- |
+| `provider_regression` | `provider_fix` | Fix LSP/provider behavior before merge |
+| `test_race` | `test_fix` | Stabilize or quarantine with tracked issue |
+| `matrix_drift` | `fixture_update` | Update fixture matrix |
+| `baseline_drift` | `baseline_update` | Regenerate accepted baseline |
+| `timeout` | `timeout_triage` | Separate CI slowness from product regression |
+| `infra` | `ci_investigation` | Fix CI/harness infra |
+| `server_crash` | `crash_fix` | Fix server crash before merge |
+| `new_test_bug` | `test_fix` | Fix test logic and keep lane blocking |
+| `unknown` | `triage` | Inspect log and add classifier coverage |

--- a/xtask/src/tasks/ux_regression_receipt.rs
+++ b/xtask/src/tasks/ux_regression_receipt.rs
@@ -45,6 +45,9 @@ pub struct UxRegressionReceipt {
     friendly_repro: Option<String>,
     first_failing_line: Option<String>,
     route: UxRoute,
+    blocking: bool,
+    merge_action: String,
+    human_summary: String,
     component: Option<UxComponent>,
     run_id: Option<String>,
     attempt: Option<u32>,
@@ -83,6 +86,7 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
     let workflow = first_failing_test.as_ref().and_then(|name| workflow_from_test_name(name));
 
     let failure_class = infer_failure_class(raw);
+    let result = if raw.contains("test result: ok") { "pass" } else { "fail" }.to_string();
 
     let canonical_repro = first_failing_test.as_ref().map(|name| {
         format!("cargo test -p perl-lsp-ux-tests {name} -- --test-threads=1 --nocapture")
@@ -95,6 +99,30 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
     });
 
     let route = route_for_failure_class(failure_class);
+    let blocking = result != "pass";
+    let merge_action = match failure_class {
+        UxFailureClass::TestRace => "quarantine_or_fix_test",
+        UxFailureClass::ProviderRegression => "fix_provider",
+        UxFailureClass::MatrixDrift => "update_fixture_matrix",
+        UxFailureClass::BaselineDrift => "update_baseline",
+        UxFailureClass::Timeout => "triage_timeout",
+        UxFailureClass::Infra => "fix_ci_infra",
+        UxFailureClass::ServerCrash => "fix_crash",
+        UxFailureClass::NewTestBug => "fix_test",
+        UxFailureClass::Unknown => "triage",
+    }
+    .to_string();
+    let merge_action = if result == "pass" { "merge_allowed".to_string() } else { merge_action };
+    let human_summary = if result == "pass" {
+        "UX regression lane passed; merge allowed.".to_string()
+    } else {
+        let test = first_failing_test.as_deref().unwrap_or("unknown_test");
+        let repro = canonical_repro.as_deref().unwrap_or("receipt did not include canonical repro");
+        format!(
+            "UX regression failed in {test}; classified as {}; repro: {repro}",
+            failure_class.as_str()
+        )
+    };
 
     UxRegressionReceipt {
         kind: "ux_regression_receipt",
@@ -105,13 +133,16 @@ fn classify(raw: &str, sha: Option<String>) -> UxRegressionReceipt {
         scenario_file: scenario.clone(),
         scenario,
         first_failing_test,
-        result: if raw.contains("test result: ok") { "pass" } else { "fail" }.to_string(),
+        result,
         failure_class,
         panic_location,
         canonical_repro,
         friendly_repro,
         first_failing_line: first_fail_line,
         route,
+        blocking,
+        merge_action,
+        human_summary,
         component: None,
         run_id: None,
         attempt: None,
@@ -126,7 +157,11 @@ fn scenario_from_test_name(test: &str) -> Option<String> {
 
 fn infer_failure_class(raw: &str) -> UxFailureClass {
     let lower = raw.to_ascii_lowercase();
-    if lower.contains("fixture matrix") || lower.contains("matrix drift") {
+    if looks_like_scenario_19_race(&lower) {
+        UxFailureClass::TestRace
+    } else if looks_like_scenario_14_provider_regression(&lower) {
+        UxFailureClass::ProviderRegression
+    } else if lower.contains("fixture matrix") || lower.contains("matrix drift") {
         UxFailureClass::MatrixDrift
     } else if lower.contains("baseline") || lower.contains("snapshot") {
         UxFailureClass::BaselineDrift
@@ -150,6 +185,26 @@ fn infer_failure_class(raw: &str) -> UxFailureClass {
     } else {
         UxFailureClass::Unknown
     }
+}
+
+fn looks_like_scenario_19_race(lower: &str) -> bool {
+    lower.contains("scenario_19_diagnostics_clear_after_fix")
+        && (lower.contains("pre-fix")
+            || lower.contains("post-fix")
+            || lower.contains("diagnostics race")
+            || lower.contains("events:")
+            || lower.contains("expected diagnostics to clear"))
+}
+
+fn looks_like_scenario_14_provider_regression(lower: &str) -> bool {
+    lower.contains("ux_scenario_14_inc_conformance")
+        && (lower.contains("goto-definition")
+            || lower.contains("include path")
+            || lower.contains("include_paths")
+            || lower.contains("includepaths")
+            || lower.contains("perl5lib")
+            || lower.contains("usesysteminc")
+            || lower.contains("@inc"))
 }
 
 fn workflow_from_test_name(test: &str) -> Option<String> {
@@ -184,8 +239,8 @@ mod tests {
             "test name should be extracted from log"
         );
         assert!(
-            matches!(receipt.failure_class, UxFailureClass::NewTestBug),
-            "failure_class should be NewTestBug for panicked test in ux_scenario"
+            matches!(receipt.failure_class, UxFailureClass::TestRace),
+            "failure_class should be TestRace for scenario_19 diagnostics clear failures"
         );
         assert_eq!(
             receipt.panic_location.as_deref(),
@@ -193,6 +248,8 @@ mod tests {
             "panic_location should be extracted from panic line (Rust 1.73+ format)"
         );
         assert_eq!(receipt.route, UxRoute::TestFix, "race/new test bug routes to test fix");
+        assert!(receipt.blocking);
+        assert_eq!(receipt.merge_action, "quarantine_or_fix_test");
     }
 
     #[test]
@@ -245,6 +302,7 @@ mod tests {
             "fixture matrix log should classify as MatrixDrift"
         );
         assert_eq!(receipt.route, UxRoute::FixtureUpdate, "MatrixDrift routes to FixtureUpdate");
+        assert_eq!(receipt.merge_action, "update_fixture_matrix");
     }
 
     #[test]
@@ -260,6 +318,7 @@ mod tests {
             UxRoute::BaselineUpdate,
             "BaselineDrift routes to BaselineUpdate"
         );
+        assert_eq!(receipt.merge_action, "update_baseline");
     }
 
     #[test]
@@ -274,6 +333,8 @@ mod tests {
             receipt.failure_class
         );
         assert_eq!(receipt.route, UxRoute::ProviderFix, "ProviderRegression routes to ProviderFix");
+        assert!(receipt.blocking);
+        assert_eq!(receipt.merge_action, "fix_provider");
     }
 
     #[test]
@@ -299,6 +360,8 @@ mod tests {
         let log = "running 5 tests\ntest result: ok. 5 passed; 0 failed";
         let receipt = classify(log, Some("sha7".to_string()));
         assert_eq!(receipt.result, "pass", "log with 'test result: ok' should produce result=pass");
+        assert!(!receipt.blocking);
+        assert_eq!(receipt.merge_action, "merge_allowed");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- UX regression failures were noisy and hard to route automatically, so receipts and CI summaries must expose deterministic failure classification and merge-routing guidance while keeping UX failures merge-blocking.
- Make known incident families (scenario_19 diagnostics race, scenario_14 include/@INC provider problems, fixture/baseline drift, timeouts, infra, etc.) easy to recognize and route from the receipt to reduce manual triage.

### Description

- Added three routing fields to the UX receipt (`blocking: bool`, `merge_action: String`, `human_summary: String`) and ensure `blocking` remains true for failing runs so classification never converts failures to passes. (`xtask/src/tasks/ux_regression_receipt.rs`) 
- Hardened the classifier by adding high-priority detection helpers for `scenario_19_diagnostics_clear_after_fix` → `TestRace` and `ux_scenario_14_inc_conformance` include/@INC failures → `ProviderRegression`, and reordered rules so these match before generic fallbacks. (`xtask/src/tasks/ux_regression_receipt.rs`) 
- Updated unit tests in the `xtask` receipt module to assert the new routing semantics (`blocking` and `merge_action`) for scenario 14/19, matrix/baseline drift, and pass cases. (`xtask/src/tasks/ux_regression_receipt.rs` tests) 
- Surface the new receipt fields in the GitHub Actions UX summary step so `route`, `merge_action`, `canonical_repro`, and `human_summary` appear in the action summary without opening artifacts. (`.github/workflows/ci.yml`) 
- Documented the UX pre-merge behavior and failure-class → route → action mapping in the CI architecture docs. (`docs/reference/CI_ARCHITECTURE.md`) 

### Testing

- Ran `cargo fmt --all -- --check`, which passed. 
- Started `cargo test -p xtask ux_regression -- --nocapture`; the test invocation began and the updated classifier/unit tests are in place, but a full test run was long-running in this environment and did not finish to completion during the session. 
- `cargo check` / broader xtask target checks were not fully executed here due to an in-session long compile/test run occupying the build directory, so final CI verification will run in the repository CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97be565fc8333995e35cc502b2686)