### PR TITLE
feat(perl-uri): centralize source path conversion (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/types.rs
+++ b/crates/perl-lsp-rs/src/runtime/types.rs
@@ -1,28 +1,9 @@
 use super::workspace_folder::WorkspaceFolderState;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Instant;
-use url::Url;
 
 pub(super) fn source_path_from_uri(uri: &str) -> Option<PathBuf> {
-    // On Windows, filesystem paths like `C:\file` can be misparsed by Url::parse()
-    // as having scheme `C`. Check for Windows drive letters first.
-    // Drive letter pattern: exactly one letter, followed by `:`, not followed by `//` (which would be a URL).
-    if uri.len() > 2 && uri.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
-        if uri.chars().nth(1) == Some(':') && !uri.starts_with("file://") {
-            // Looks like a Windows path (e.g., `C:\...`). Try to parse as path, not URL.
-            let path = Path::new(uri);
-            if path.is_absolute() {
-                return Some(path.to_path_buf());
-            }
-        }
-    }
-
-    if let Ok(value) = Url::parse(uri) {
-        return if value.scheme() == "file" { value.to_file_path().ok() } else { None };
-    }
-
-    let path = Path::new(uri);
-    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
+    perl_uri::source_path_from_uri_or_path(uri)
 }
 
 pub(super) fn workspace_folder_path(folder: &WorkspaceFolderState) -> Option<PathBuf> {

--- a/crates/perl-uri/src/lib.rs
+++ b/crates/perl-uri/src/lib.rs
@@ -82,6 +82,24 @@ pub fn uri_to_fs_path(uri: &str) -> Option<std::path::PathBuf> {
     Some(repair_path_mojibake(path))
 }
 
+/// Convert a source input to an absolute filesystem path.
+///
+/// Accepts either:
+/// - `file://` URIs (including localhost authority)
+/// - Absolute filesystem paths
+/// - Windows absolute drive paths such as `C:\foo\bar.pl`
+///
+/// Returns `None` for unsupported schemes and relative paths.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn source_path_from_uri_or_path(input: &str) -> Option<std::path::PathBuf> {
+    if let Some(path) = uri_to_fs_path(input) {
+        return Some(path);
+    }
+
+    let path = std::path::Path::new(input);
+    if path.is_absolute() { Some(path.to_path_buf()) } else { None }
+}
+
 /// Convert a filesystem path to a `file://` URI.
 ///
 /// Properly handles percent-encoding and works with spaces, Windows paths,
@@ -408,6 +426,36 @@ mod tests {
         fn test_fs_path_to_uri_with_spaces() {
             let uri = must(fs_path_to_uri("/tmp/path with spaces/test.pl"));
             assert!(uri.contains("%20") || uri.contains("path with spaces"));
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_supports_file_uri() {
+            let path = must_some(source_path_from_uri_or_path("file:///tmp/test.pl"));
+            assert!(path.ends_with("test.pl"));
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_supports_file_localhost_uri() {
+            let path = must_some(source_path_from_uri_or_path("file://localhost/tmp/test.pl"));
+            assert!(path.ends_with("test.pl"));
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_supports_absolute_path() {
+            let path = std::env::temp_dir().join("source-path-from-uri-or-path.pl");
+            let raw_path = path.to_string_lossy();
+
+            assert_eq!(source_path_from_uri_or_path(raw_path.as_ref()), Some(path));
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_rejects_non_file_uri() {
+            assert!(source_path_from_uri_or_path("https://example.com/path.pl").is_none());
+        }
+
+        #[test]
+        fn test_source_path_from_uri_or_path_rejects_relative_path() {
+            assert!(source_path_from_uri_or_path("lib/Foo.pm").is_none());
         }
 
         #[test]


### PR DESCRIPTION
### Motivation

- Remove duplicated URI↔path parsing logic in the runtime and make `perl-uri` the single conversion surface for LSP/DAP boundaries.

### Description

- Added `pub fn source_path_from_uri_or_path(input: &str) -> Option<PathBuf>` to `crates/perl-uri/src/lib.rs` which accepts `file://` URIs (including `file://localhost`), absolute filesystem paths, and Windows drive paths, and rejects non-file schemes and relative paths.
- Replaced the local parsing implementation in `crates/perl-lsp-rs/src/runtime/types.rs::source_path_from_uri` with a call to `perl_uri::source_path_from_uri_or_path`, removing duplicated URL/path parsing logic.
- Added unit tests in `crates/perl-uri/src/lib.rs` covering file URIs, `file://localhost`, absolute path pass-through, non-file URI rejection, and relative path rejection.

### Testing

- Ran `cargo test -p perl-uri`, which completed successfully (all relevant `perl-uri` tests passed). 
- Launched `cargo test -p perl-lsp-rs source_path_from_uri`; compilation and test execution progressed (build output and warnings were observed in the captured run) and no failures were observed in the captured window, but the full run exceeded the interactive capture window.
- Attempts to run `./scripts/cargo-safe` checks hit an environment storage guard (`DENY`) and could not be completed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c4abe7c8333940a59ffea472ecf)