### PR TITLE
fix(perl-lexer): report unclosed quote-like delimiters (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2868,7 +2868,8 @@ impl<'a> PerlLexer<'a> {
         start: usize,
         delimiter: char,
     ) -> Option<Token> {
-        self.read_delimited_body(delimiter);
+        let (_pattern, pattern_closed) = self.read_delimited_body(delimiter);
+        let mut replacement_closed = false;
 
         let pattern_is_paired = quote_handler::paired_close(delimiter).is_some();
         if pattern_is_paired {
@@ -2880,10 +2881,12 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                self.read_delimited_body(repl_delim);
+                let (_replacement, closed) = self.read_delimited_body(repl_delim);
+                replacement_closed = closed;
             }
         } else {
-            self.read_delimited_body(delimiter);
+            let (_replacement, closed) = self.read_delimited_body(delimiter);
+            replacement_closed = closed;
         }
 
         // Parse modifiers - include all alphanumeric for proper validation in parser (MUT_005 fix)
@@ -2898,12 +2901,19 @@ impl<'a> PerlLexer<'a> {
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
 
-        Some(Token {
-            token_type: TokenType::Substitution,
-            text: Arc::from(text),
-            start,
-            end: self.position,
-        })
+        if !pattern_closed || !replacement_closed {
+            return Some(Token {
+                token_type: TokenType::Error(Arc::from(format!(
+                    "unclosed s delimiter '{}'",
+                    delimiter
+                ))),
+                text: Arc::from(text),
+                start,
+                end: self.position,
+            });
+        }
+
+        Some(Token { token_type: TokenType::Substitution, text: Arc::from(text), start, end: self.position })
     }
 
     fn parse_transliteration(&mut self, start: usize) -> Option<Token> {
@@ -2922,7 +2932,8 @@ impl<'a> PerlLexer<'a> {
         start: usize,
         delimiter: char,
     ) -> Option<Token> {
-        self.read_delimited_body(delimiter);
+        let (_search, search_closed) = self.read_delimited_body(delimiter);
+        let mut replacement_closed = false;
 
         let search_is_paired = quote_handler::paired_close(delimiter).is_some();
         if search_is_paired {
@@ -2934,10 +2945,12 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                self.read_delimited_body(repl_delim);
+                let (_replacement, closed) = self.read_delimited_body(repl_delim);
+                replacement_closed = closed;
             }
         } else {
-            self.read_delimited_body(delimiter);
+            let (_replacement, closed) = self.read_delimited_body(delimiter);
+            replacement_closed = closed;
         }
 
         // Parse modifiers - include all alphanumeric for proper validation in parser (MUT_005 fix)
@@ -2951,6 +2964,18 @@ impl<'a> PerlLexer<'a> {
 
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
+
+        if !search_closed || !replacement_closed {
+            return Some(Token {
+                token_type: TokenType::Error(Arc::from(format!(
+                    "unclosed tr delimiter '{}'",
+                    delimiter
+                ))),
+                text: Arc::from(text),
+                start,
+                end: self.position,
+            });
+        }
 
         Some(Token {
             token_type: TokenType::Transliteration,

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -720,6 +720,43 @@ fn malformed_quote_like_constructs_do_not_panic() -> R {
     Ok(())
 }
 
+#[test]
+fn malformed_quote_like_reports_unclosed_error() -> R {
+    let cases = [
+        "qq{hello;",
+        "q{hello;",
+        "qx{cmd;",
+        "qr{pat;",
+        "s{a}{",
+        "tr{a}{",
+        "qq/hello;",
+        "qq[hello;",
+        "qq(hello;",
+        "qq<hello;",
+        "qq#hello;",
+    ];
+
+    for input in cases {
+        let first = first_significant(input).ok_or("no token")?;
+        match &first.token_type {
+            TokenType::Error(message) => {
+                assert!(
+                    message.contains("unclosed"),
+                    "Expected unclosed diagnostic for {input:?}, got {message:?}"
+                );
+            }
+            other => {
+                return Err(format!(
+                    "Expected TokenType::Error for malformed quote-like {input:?}, got {other:?}"
+                )
+                .into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
 // ===========================================================================
 // 4. Special variables
 // ===========================================================================


### PR DESCRIPTION
### Motivation

- Malformed quote-like inputs (e.g. `qq{hello;`, incomplete `s`/`tr` legs) could produce normal tokens instead of an explicit unclosed diagnostic, which hides the real error from parser recovery and LSP UX. 
- There was insufficient focused regression coverage for unclosed quote-like delimiters across delimiter variants.

### Description

- Make `parse_substitution_with_delimiter` and `parse_transliteration_with_delimiter` track whether both the pattern/search and replacement legs actually closed, using the `(body, closed)` result from `read_delimited_body`. 
- Emit `TokenType::Error(Arc::from("unclosed ... delimiter 'x'"))` when any leg is unterminated instead of returning a normal `Substitution`/`Transliteration` token. 
- Add a focused test `malformed_quote_like_reports_unclosed_error` that exercises `qq`, `q`, `qx`, `qr`, `s`, `tr` and delimiter variants (`/`, `{}`, `[]`, `()`, `<>`, `#`) and asserts an unclosed error token is produced. 
- Preserve modifier consumption behavior (parser still validates modifiers) and keep lexer mode transitions unchanged aside from the error emission path.

### Testing

- Ran `cargo test -p perl-lexer quote_like` and the lexer quote-like test group passed. 
- Ran the focused test `cargo test -p perl-lexer --test edge_case_tests malformed_quote_like_reports_unclosed_error` and it passed. 
- Ran `cargo test -p perl-parser-core fix_delimiter_owner_buckets` to verify parser mapping of unclosed diagnostics and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c11e4d88333b69af12a08419a6c)