### PR TITLE
fix(perl-lexer): report unclosed quote-like delimiters (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2868,7 +2868,8 @@ impl<'a> PerlLexer<'a> {
         start: usize,
         delimiter: char,
     ) -> Option<Token> {
-        self.read_delimited_body(delimiter);
+        let (_pattern, pattern_closed) = self.read_delimited_body(delimiter);
+        let mut replacement_closed = true;
 
         let pattern_is_paired = quote_handler::paired_close(delimiter).is_some();
         if pattern_is_paired {
@@ -2880,10 +2881,12 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                self.read_delimited_body(repl_delim);
+                let (_, closed) = self.read_delimited_body(repl_delim);
+                replacement_closed = closed;
             }
         } else {
-            self.read_delimited_body(delimiter);
+            let (_, closed) = self.read_delimited_body(delimiter);
+            replacement_closed = closed;
         }
 
         // Parse modifiers - include all alphanumeric for proper validation in parser (MUT_005 fix)
@@ -2897,6 +2900,18 @@ impl<'a> PerlLexer<'a> {
 
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
+
+        if !pattern_closed || !replacement_closed {
+            return Some(Token {
+                token_type: TokenType::Error(Arc::from(format!(
+                    "unclosed substitution delimiter '{}'",
+                    delimiter
+                ))),
+                text: Arc::from(text),
+                start,
+                end: self.position,
+            });
+        }
 
         Some(Token {
             token_type: TokenType::Substitution,
@@ -2922,7 +2937,8 @@ impl<'a> PerlLexer<'a> {
         start: usize,
         delimiter: char,
     ) -> Option<Token> {
-        self.read_delimited_body(delimiter);
+        let (_search, search_closed) = self.read_delimited_body(delimiter);
+        let mut replacement_closed = true;
 
         let search_is_paired = quote_handler::paired_close(delimiter).is_some();
         if search_is_paired {
@@ -2934,10 +2950,12 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                self.read_delimited_body(repl_delim);
+                let (_, closed) = self.read_delimited_body(repl_delim);
+                replacement_closed = closed;
             }
         } else {
-            self.read_delimited_body(delimiter);
+            let (_, closed) = self.read_delimited_body(delimiter);
+            replacement_closed = closed;
         }
 
         // Parse modifiers - include all alphanumeric for proper validation in parser (MUT_005 fix)
@@ -2951,6 +2969,18 @@ impl<'a> PerlLexer<'a> {
 
         let text = &self.input[start..self.position];
         self.mode = LexerMode::ExpectOperator;
+
+        if !search_closed || !replacement_closed {
+            return Some(Token {
+                token_type: TokenType::Error(Arc::from(format!(
+                    "unclosed transliteration delimiter '{}'",
+                    delimiter
+                ))),
+                text: Arc::from(text),
+                start,
+                end: self.position,
+            });
+        }
 
         Some(Token {
             token_type: TokenType::Transliteration,

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -32,6 +32,10 @@ fn first_significant(input: &str) -> Option<perl_lexer::Token> {
     significant(input).into_iter().next()
 }
 
+fn first_error(input: &str) -> Option<perl_lexer::Token> {
+    tokens(input).into_iter().find(|token| matches!(token.token_type, TokenType::Error(_)))
+}
+
 /// Assert that every token span is within the input and the lexer terminates.
 fn assert_terminates(input: &str) {
     let toks = tokens(input);
@@ -717,6 +721,40 @@ fn malformed_quote_like_constructs_do_not_panic() -> R {
     for case in cases {
         assert_terminates(case);
     }
+    Ok(())
+}
+
+#[test]
+fn malformed_quote_like_constructs_report_unclosed_diagnostic() -> R {
+    let cases = [
+        "qq{hello;",
+        "q{hello;",
+        "qx{cmd;",
+        "qr{pat;",
+        "s{a}{",
+        "tr{a}{",
+        "q/hello;",
+        "qq[hello;",
+        "qx(hello;",
+        "qr<hello;",
+        "q#hello;",
+    ];
+
+    for case in cases {
+        let Some(token) = first_error(case) else {
+            return Err(format!("expected error token for malformed quote-like input: {case}").into());
+        };
+        match token.token_type {
+            TokenType::Error(message) => {
+                assert!(
+                    message.contains("unclosed"),
+                    "expected unclosed diagnostic for {case}, got: {message}"
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- Malformed quote-like inputs (e.g. `qq{hello;`, `s{a}{`) were being tokenized as normal operators instead of producing a stable unclosed-delimiter diagnostic, which degrades parser recovery and LSP UX.

### Description

- Make `read_delimited_body` return a `(body, closed)` tuple and propagate the `closed` flag through `parse_substitution_with_delimiter` and `parse_transliteration_with_delimiter` so both sides of `s///` and `tr///` are checked for termination.
- Emit explicit `TokenType::Error(Arc::from("unclosed ..."))` tokens when a pattern or replacement side is unterminated instead of returning a normal operator token.
- Add a test helper `first_error` and a new focused regression test `malformed_quote_like_constructs_report_unclosed_diagnostic` covering malformed `q/qq/qx/qr/s/tr` inputs and a variety of delimiter styles to ensure an `unclosed` diagnostic is produced.

### Testing

- Ran `cargo test -p perl-lexer malformed_quote_like_constructs_report_unclosed_diagnostic` and the new test passed.
- A broader agent-profile run `./scripts/cargo-safe test -p perl-lexer quote_like --profile agent --locked` was attempted but blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so it did not complete in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c11e4d88333b69af12a08419a6c)