### PR TITLE
feat(parser): add parser coverage risk map lane (#0000)

### DIFF
--- a/.ci/coverage/parser-baseline.json
+++ b/.ci/coverage/parser-baseline.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "crate_group": "parser",
+  "line_coverage_floor": 0.58,
+  "branch_coverage_floor": 0.40,
+  "tolerance_pct": 0.50,
+  "critical_files": {
+    "crates/perl-parser-core/src/engine/parser/statements.rs": {
+      "branch_coverage_floor": 0.70
+    },
+    "crates/perl-parser-core/src/syntax/heredoc.rs": {
+      "branch_coverage_floor": 0.75
+    }
+  }
+}

--- a/docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md
+++ b/docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md
@@ -1,0 +1,113 @@
+# Perl parser coverage risk map (2026-05-05)
+
+## Scope
+
+This forensic note scopes parser coverage work to the parser subsystem only:
+
+- `perl-parser` (facade and parser-facing APIs)
+- `perl-parser-core` (parse engine and syntax handlers)
+
+It intentionally does **not** raise global workspace coverage thresholds.
+
+## Coverage collection command
+
+Use `just coverage-parser`.
+
+Command executed by the recipe:
+
+```bash
+rustup run nightly cargo llvm-cov \
+  -p perl-parser \
+  -p perl-parser-core \
+  --all-features \
+  --locked \
+  --branch \
+  --lcov \
+  --output-path target/coverage/parser.lcov
+```
+
+If `cargo-llvm-cov` is not installed, the recipe exits successfully and prints installation guidance so CI/dev flows remain safe.
+
+## Risk classification for uncovered or weakly covered areas
+
+### 1) Critical parser behavior (highest value)
+
+Target these first when increasing branch coverage:
+
+- Statement parsing and control-flow branch handling
+  - `crates/perl-parser-core/src/engine/parser/statements.rs`
+- Syntax-specific handlers with known failure clusters
+  - `crates/perl-parser-core/src/syntax/heredoc.rs`
+
+Why critical: misses here directly change AST shape, symbol edges, and downstream editor trust.
+
+### 2) Recovery and error handling (highest value)
+
+Prioritize paths that determine salvage quality after malformed input:
+
+- Recovery resynchronization decisions
+- Error node containment and spillover behavior
+- Post-error statement and symbol salvage
+
+Why critical: these paths govern live-edit resilience and prevent cascading parse degradation.
+
+### 3) Span/position correctness (high value)
+
+Prioritize branch coverage in byte/line/UTF-16 mapping paths:
+
+- Span construction and conversion helpers
+- Off-by-one and newline-boundary branches
+- Multibyte/UTF-16 offset handling
+
+Why high value: these branches determine goto/highlight/diagnostic correctness even when parse succeeds.
+
+### 4) Incremental parsing (high value)
+
+Prioritize invalidation and equivalence branches:
+
+- Changed-region invalidation decisions
+- Fast-path equivalence checks
+- Fallback-to-full-parse branch paths
+
+Why high value: branch misses here can produce stale or wrong editor facts under normal typing.
+
+### 5) Facade and re-export glue (lower value)
+
+Examples include thin pass-through APIs, `pub use` surfaces, and module wiring in `perl-parser`.
+
+Why lower value: these lines can be under-covered without materially reducing parser correctness, as long as core behavior branches are covered.
+
+### 6) Deprecated compatibility surface (lower value)
+
+Compatibility aliases and migration shims should remain tested for smoke behavior but are not a first target for branch improvements.
+
+Why lower value: correctness risk is typically bounded and isolated compared to parser-core logic.
+
+### 7) Generated/static data (exclude or de-prioritize)
+
+Generated tables/static declarations are low signal for branch-quality investment unless they contain nontrivial control flow.
+
+Why excluded/de-prioritized: increasing coverage here often does not improve parser trust or live-edit outcomes.
+
+## Baseline policy
+
+Parser-specific baseline lives at:
+
+- `.ci/coverage/parser-baseline.json`
+
+Initial floor policy:
+
+- line coverage floor: `0.58`
+- branch coverage floor: `0.40`
+- critical file floors:
+  - `statements.rs`: `0.70` branch
+  - `heredoc.rs`: `0.75` branch
+
+## Intended outcome
+
+This map lets operators distinguish:
+
+- low-value uncovered facade/compat areas, from
+- high-value uncovered parser-core recovery and syntax logic.
+
+That enables future parser PRs to target coverage work where it most improves parser trust.

--- a/justfile
+++ b/justfile
@@ -1863,6 +1863,17 @@ coverage-lcov:
         --ignore-filename-regex '(^|/)(archive|tests|benches|examples)(/|$)|(^|/)build\.rs$|(^|/)crates/tree-sitter-perl-c/'
     @echo "✅ Coverage: lcov.info"
 
+
+# Parser-focused branch coverage snapshot (perl-parser + perl-parser-core).
+# Writes target/coverage/parser.lcov when cargo-llvm-cov is available.
+# CI-safe: exits successfully with guidance when cargo-llvm-cov is not installed.
+coverage-parser:
+    @echo "📊 Generating parser coverage snapshot (branch + lcov)..."
+    @if [[ ! -x "$HOME/.cargo/bin/cargo-llvm-cov" ]]; then         echo "⚠️  cargo-llvm-cov is not installed; skipping execution.";         echo "   Install with: rustup run nightly cargo install cargo-llvm-cov --locked";         echo "   Then run: just coverage-parser";         exit 0;     fi
+    @mkdir -p target/coverage
+    @"$HOME/.cargo/bin/rustup" run nightly cargo llvm-cov         -p perl-parser         -p perl-parser-core         --all-features         --locked         --branch         --lcov         --output-path target/coverage/parser.lcov
+    @echo "✅ Parser coverage: target/coverage/parser.lcov"
+
 # Show coverage summary (terminal)
 coverage-summary:
     @echo "📊 Coverage Summary"


### PR DESCRIPTION
### Motivation

- Provide a parser-focused coverage workflow to distinguish high-value parser-core gaps from low-value facade coverage gaps.  
- Capture an initial parser-only baseline and a risk map so future work can target recovery, heredoc, span, and incremental branches rather than facade wiring.

### Description

- Add a CI-safe `just` recipe `coverage-parser` that runs `cargo llvm-cov` for `perl-parser` and `perl-parser-core` and writes `target/coverage/parser.lcov`.  
- Add `.ci/coverage/parser-baseline.json` containing schema version, `crate_group: "parser"`, line/branch floors, tolerance, and per-file critical branch floors for `statements.rs` and `heredoc.rs`.  
- Add `docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md` classifying uncovered areas into critical parser behavior, recovery/error handling, span/position correctness, incremental parsing, facade glue, deprecated compatibility, and generated/static data.

### Testing

- `cargo fmt --all -- --check` succeeded.  
- `./scripts/cargo-safe check -p xtask --all-targets --profile agent --locked` could not complete due to a local devplane storage guard (`DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`).  
- `./scripts/cargo-safe test -p perl-parser --all-targets --profile agent --locked` and `./scripts/cargo-safe test -p perl-parser-core --all-targets --profile agent --locked` were blocked by the same environment storage guard and were not run.  
- `just coverage-parser` was not executed in this environment because `just` and/or `cargo-llvm-cov` were not available; the recipe is CI-safe and documents installation guidance in-repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c0902c88333bec64a8dfeb593da)