### PR TITLE
fix(tree-sitter-perl-rs): align Node::kind with tree-sitter kinds (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/README.md
+++ b/crates/tree-sitter-perl-rs/README.md
@@ -52,8 +52,9 @@ if let Some(tree) = parser.parse("my $x = 42;") {
 | `Tree::edit(&mut self, edit: &InputEdit)` | Records a source edit; pass the updated tree to `parse_with_old_tree` |
 | `Tree::root_node() -> Node<'_>` | Get the root of the syntax tree |
 | `Tree::source() -> &str` | Source text this tree was built from |
-| `Node::kind() -> &'static str` | Node type name (v3 internal, e.g. `"Program"`) |
-| `Node::grammar_kind() -> String` | Grammar-canonical name (e.g. `"source_file"`) matching tree-sitter output |
+| `Node::kind() -> String` | Grammar-canonical node type (e.g. `"source_file"`) matching tree-sitter output |
+| `Node::grammar_kind() -> String` | Alias for `Node::kind()` (kept for compatibility) |
+| `Node::native_kind() -> &'static str` | Native v3 internal node kind (e.g. `"Program"`) |
 | `Node::to_sexp() -> String` | Tree-sitter-compatible S-expression for this subtree |
 | `Node::child_count() -> usize` | Number of direct children |
 | `Node::child(i: usize) -> Option<Node>` | `i`-th direct child |
@@ -83,7 +84,7 @@ This means you can pipe any Perl source through this parser and rely on getting 
 
 - `Node::children()` allocates a `Vec` internally on each call. Prefer iterating once over calling repeatedly.
 - `RecursionLimit` / `NestingTooDeep` parse errors produce `None` rather than a partial tree.
-- `Node::kind()` returns v3 internal names (e.g. `"Program"`) rather than tree-sitter grammar names (e.g. `"source_file"`). Use `Node::grammar_kind()` for the canonical name or `Node::to_sexp()` for full canonical output.
+- `Node::grammar_kind()` remains available as a compatibility alias for `Node::kind()`. Use `Node::native_kind()` when you need the v3 internal node names.
 
 ## Backlog roadmap
 

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -27,7 +27,7 @@
 //!   The v3 parser is highly error-tolerant and almost always produces a partial tree.
 //! - `Node::to_sexp()` delegates to `perl_ast::Node::to_sexp()` for tree-sitter-compatible
 //!   S-expression output.
-//! - `Node::kind()` returns the `NodeKind::kind_name()` string.
+//! - `Node::kind()` returns the tree-sitter grammar-canonical kind string.
 //! - `Node::start_byte()` / `Node::end_byte()` expose the `SourceLocation` byte offsets.
 //! - `Node::children()` and `Node::child()` mirror tree-sitter traversal conventions.
 //!
@@ -341,24 +341,9 @@ pub struct Node<'tree> {
 }
 
 impl<'tree> Node<'tree> {
-    /// Returns the node kind string (e.g. `"Program"`, `"Subroutine"`, `"Variable"`).
-    ///
-    /// Delegates to [`NodeKind::kind_name`][perl_ast::NodeKind::kind_name].
-    ///
-    /// Note: this returns the v3 internal kind name, not the tree-sitter grammar node
-    /// type string. For example, the root node returns `"Program"` rather than
-    /// `"source_file"`. Use [`grammar_kind`][Node::grammar_kind] for the canonical
-    /// tree-sitter grammar name, or [`to_sexp`][Node::to_sexp] for tree-sitter-compatible
-    /// S-expression output which uses the canonical grammar names.
-    pub fn kind(&self) -> &'static str {
-        self.inner.kind.kind_name()
-    }
-
     /// Returns the tree-sitter grammar-canonical node kind name.
     ///
-    /// Unlike [`kind`][Node::kind], which returns the v3 internal PascalCase name
-    /// (e.g., `"Program"`, `"Subroutine"`), this method returns the grammar name
-    /// used in S-expressions (e.g., `"source_file"`, `"sub"`).
+    /// Returns the same tree-sitter grammar name as [`kind`][Node::kind].
     /// This matches the kind strings returned by `tree-sitter-perl-c` and the
     /// upstream tree-sitter Perl grammar.
     /// Error nodes use `"ERROR"` (uppercase), matching tree-sitter convention.
@@ -377,6 +362,22 @@ impl<'tree> Node<'tree> {
     /// assert!(tree.is_some());
     /// assert_eq!(tree.unwrap().root_node().grammar_kind(), "source_file");
     /// ```
+    pub fn kind(&self) -> String {
+        self.grammar_kind()
+    }
+
+    /// Returns the v3 internal node kind string (e.g. `"Program"`, `"Subroutine"`).
+    ///
+    /// This reflects the native parser AST naming and is primarily useful for
+    /// backend diagnostics and compatibility checks. Tree-sitter-facing callers
+    /// should prefer [`kind`][Node::kind].
+    pub fn native_kind(&self) -> &'static str {
+        self.inner.kind.kind_name()
+    }
+
+    /// Returns the tree-sitter grammar-canonical node kind name.
+    ///
+    /// Alias of [`kind`][Node::kind]. Kept for compatibility with earlier releases.
     pub fn grammar_kind(&self) -> String {
         // Extract the node type from the leading `(word` in the S-expression.
         // to_sexp() always starts with `(kind_name` or just `(kind_name)`.
@@ -729,7 +730,7 @@ mod tests {
     fn test_root_node_kind() {
         let mut p = Parser::new();
         let tree = must_some(p.parse("my $x = 42;"));
-        assert_eq!(tree.root_node().kind(), "Program");
+        assert_eq!(tree.root_node().kind(), "source_file");
     }
 
     #[test]
@@ -1148,7 +1149,7 @@ mod tests {
         // and still have a node (the last sibling).
         let node = cursor.node();
         assert!(
-            !node.kind().is_empty(),
+            !node.native_kind().is_empty(),
             "cursor should remain at valid node after exhausting siblings"
         );
     }

--- a/crates/tree-sitter-perl-rs/tests/behavior_spec_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/behavior_spec_tests.rs
@@ -25,7 +25,7 @@ fn when_parsing_valid_perl_then_tree_and_source_are_available() {
 fn when_requesting_root_kind_then_program_is_returned() {
     let tree = parse("my $x = 42;");
 
-    assert_eq!(tree.root_node().kind(), "Program");
+    assert_eq!(tree.root_node().kind(), "source_file");
 }
 
 #[test]
@@ -106,7 +106,7 @@ fn when_requesting_grammar_kind_of_subroutine_then_sub_is_returned() {
     let tree = parse("sub greet { 1 }");
     let root = tree.root_node();
     // Find the subroutine child
-    let sub_node = must_some(root.children().find(|n| n.kind() == "Subroutine"));
+    let sub_node = must_some(root.children().find(|n| n.native_kind() == "Subroutine"));
     assert_eq!(sub_node.grammar_kind(), "sub");
 }
 
@@ -114,9 +114,9 @@ fn when_requesting_grammar_kind_of_subroutine_then_sub_is_returned() {
 fn when_v3_kind_and_grammar_kind_are_both_available_then_they_differ_for_program() {
     let tree = parse("1;");
     let root = tree.root_node();
-    assert_eq!(root.kind(), "Program");
+    assert_eq!(root.kind(), "source_file");
     assert_eq!(root.grammar_kind(), "source_file");
-    assert_ne!(root.kind(), root.grammar_kind());
+    assert_eq!(root.native_kind(), "Program");
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn when_requesting_grammar_kind_of_variable_with_attributes_then_snake_case_fall
     let root = tree.root_node();
     // Walk the tree to find the VariableWithAttributes node if present.
     fn find_var_attrs(n: tree_sitter_perl_rs::Node<'_>) -> Option<String> {
-        if n.kind() == "VariableWithAttributes" {
+        if n.native_kind() == "VariableWithAttributes" {
             return Some(n.grammar_kind());
         }
         for child in n.children() {

--- a/crates/tree-sitter-perl-rs/tests/incremental_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/incremental_tests.rs
@@ -122,7 +122,7 @@ fn when_parse_with_old_tree_given_empty_new_source_then_tree_is_returned() {
     let new_tree = must_some(new_tree);
     assert_eq!(new_tree.source(), "", "tree source must be the empty string");
     // The root is still a Program node (empty program).
-    assert_eq!(new_tree.root_node().kind(), "Program");
+    assert_eq!(new_tree.root_node().kind(), "source_file");
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn when_reparse_after_edit_then_new_tree_has_correct_ast() {
     let new_tree = must_some(parser.parse_with_old_tree(new_source, &old_tree));
     assert_eq!(new_tree.source(), new_source);
     // Root must still be a Program node.
-    assert_eq!(new_tree.root_node().kind(), "Program");
+    assert_eq!(new_tree.root_node().kind(), "source_file");
     // The new program has children (the sub declaration).
     assert!(
         new_tree.root_node().child_count() >= 1,


### PR DESCRIPTION
### Motivation

- Remove a long-standing compatibility footgun where `Node::kind()` returned v3 internal PascalCase names (e.g. `Program`) instead of tree-sitter grammar names (e.g. `source_file`).
- Provide a clear escape hatch for tooling and diagnostics that still need the native v3 names.

### Description

- Changed `Node::kind()` to return the grammar-canonical tree-sitter kind as a `String` and implemented `Node::native_kind()` returning the native v3 `&'static str` name.  `Node::grammar_kind()` is retained as an alias for compatibility. (changes in `crates/tree-sitter-perl-rs/src/lib.rs`).
- Updated unit/integration tests to assert the new `kind()` semantics and to use `native_kind()` where tests intentionally target v3 names (changes in `crates/tree-sitter-perl-rs/tests/behavior_spec_tests.rs` and `crates/tree-sitter-perl-rs/tests/incremental_tests.rs`).
- Updated the crate README/API table and Known Limitations section to document `Node::kind()`, `Node::grammar_kind()`, and `Node::native_kind()` behavior (changes in `crates/tree-sitter-perl-rs/README.md`).
- Kept `to_sexp()` behavior unchanged and preserved the snake_case fallback for double-paren sexp forms.

### Testing

- Updated tests in `crates/tree-sitter-perl-rs/tests/*` to reflect the API change; these test files were committed with the change.
- Attempted to run `./scripts/cargo-safe test -p tree-sitter-perl-rs --profile agent --locked`, but the execution was blocked by an environment storage guard: `DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`, so automated test execution could not complete in this environment.
- Local code-level assertions and test updates were applied to the repository to ensure CI can validate the change once tests are allowed to run in CI or a dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97bfbd0f88333914dc8d289f285cf)