### PR TITLE
fix(tree-sitter-perl-rs): make Node::kind tree-sitter canonical (#0000)

### DIFF
--- a/crates/tree-sitter-perl-rs/CLAUDE.md
+++ b/crates/tree-sitter-perl-rs/CLAUDE.md
@@ -36,8 +36,9 @@ impl Tree {
 
 pub struct Node<'tree> { /* borrows from Tree */ }
 impl<'tree> Node<'tree> {
-    pub fn kind(&self) -> &'static str;        // v3 internal name, e.g. "Program"
-    pub fn grammar_kind(&self) -> String;      // canonical grammar name, e.g. "source_file"
+    pub fn kind(&self) -> String;              // canonical grammar name, e.g. "source_file"
+    pub fn native_kind(&self) -> &'static str; // v3 internal name, e.g. "Program"
+    pub fn grammar_kind(&self) -> String;      // compatibility alias of kind()
     pub fn to_sexp(&self) -> String;           // delegates to perl_ast::Node::to_sexp()
     pub fn child_count(&self) -> usize;
     pub fn child(&self, i: usize) -> Option<Node<'tree>>;

--- a/crates/tree-sitter-perl-rs/README.md
+++ b/crates/tree-sitter-perl-rs/README.md
@@ -52,8 +52,9 @@ if let Some(tree) = parser.parse("my $x = 42;") {
 | `Tree::edit(&mut self, edit: &InputEdit)` | Records a source edit; pass the updated tree to `parse_with_old_tree` |
 | `Tree::root_node() -> Node<'_>` | Get the root of the syntax tree |
 | `Tree::source() -> &str` | Source text this tree was built from |
-| `Node::kind() -> &'static str` | Node type name (v3 internal, e.g. `"Program"`) |
-| `Node::grammar_kind() -> String` | Grammar-canonical name (e.g. `"source_file"`) matching tree-sitter output |
+| `Node::kind() -> String` | Grammar-canonical node type name (e.g. `"source_file"`) matching tree-sitter output |
+| `Node::native_kind() -> &'static str` | Native v3 internal node name (e.g. `"Program"`) |
+| `Node::grammar_kind() -> String` | Compatibility alias of `kind()` |
 | `Node::to_sexp() -> String` | Tree-sitter-compatible S-expression for this subtree |
 | `Node::child_count() -> usize` | Number of direct children |
 | `Node::child(i: usize) -> Option<Node>` | `i`-th direct child |
@@ -83,7 +84,7 @@ This means you can pipe any Perl source through this parser and rely on getting 
 
 - `Node::children()` allocates a `Vec` internally on each call. Prefer iterating once over calling repeatedly.
 - `RecursionLimit` / `NestingTooDeep` parse errors produce `None` rather than a partial tree.
-- `Node::kind()` returns v3 internal names (e.g. `"Program"`) rather than tree-sitter grammar names (e.g. `"source_file"`). Use `Node::grammar_kind()` for the canonical name or `Node::to_sexp()` for full canonical output.
+- `Node::kind()` now returns grammar-canonical names (e.g. `"source_file"`) for tree-sitter compatibility. Use `Node::native_kind()` when you need the v3 internal PascalCase name.
 
 ## Backlog roadmap
 

--- a/crates/tree-sitter-perl-rs/ROADMAP.md
+++ b/crates/tree-sitter-perl-rs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 - `Parser` / `Tree` / `Node<'tree>` types with tree-sitter-compatible API shape
 - `to_sexp()` — tree-sitter-compatible S-expression output
-- `kind()`, `grammar_kind()`, `child_count()`, `child()`, `children()` — tree traversal
+- `kind()`, `native_kind()`, `grammar_kind()`, `child_count()`, `child()`, `children()` — tree traversal
 - `start_byte()`, `end_byte()`, `start_position()`, `end_position()`, `utf8_text()` — source location and extraction
 - `is_leaf()`, `inner()`, `tree_source()` — utility and escape hatch
 - `TreeCursor` — zero-allocation streaming traversal (`walk()`, `goto_first_child()`, `goto_next_sibling()`, `goto_parent()`)
@@ -35,6 +35,6 @@ tree-sitter query API.
 - `RecursionLimit` / `NestingTooDeep` parse errors from the v3 parser produce `None` from
   `Parser::parse()` rather than a partial tree. In practice this only affects pathologically
   deep nesting.
-- `Node::kind()` returns v3 internal kind names, not tree-sitter grammar node type strings.
-  The root node reports `"Program"` rather than `"source_file"`. Use `to_sexp()` for output
-  that uses canonical grammar names.
+- `Node::kind()` returns grammar-canonical tree-sitter node type strings such as
+  `"source_file"`. Use `Node::native_kind()` when callers need v3 internal kind names
+  such as `"Program"`.

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -27,7 +27,7 @@
 //!   The v3 parser is highly error-tolerant and almost always produces a partial tree.
 //! - `Node::to_sexp()` delegates to `perl_ast::Node::to_sexp()` for tree-sitter-compatible
 //!   S-expression output.
-//! - `Node::kind()` returns the `NodeKind::kind_name()` string.
+//! - `Node::kind()` returns the tree-sitter grammar-canonical kind string.
 //! - `Node::start_byte()` / `Node::end_byte()` expose the `SourceLocation` byte offsets.
 //! - `Node::children()` and `Node::child()` mirror tree-sitter traversal conventions.
 //!
@@ -341,23 +341,25 @@ pub struct Node<'tree> {
 }
 
 impl<'tree> Node<'tree> {
-    /// Returns the node kind string (e.g. `"Program"`, `"Subroutine"`, `"Variable"`).
+    /// Returns the tree-sitter grammar-canonical node kind name.
     ///
-    /// Delegates to [`NodeKind::kind_name`][perl_ast::NodeKind::kind_name].
-    ///
-    /// Note: this returns the v3 internal kind name, not the tree-sitter grammar node
-    /// type string. For example, the root node returns `"Program"` rather than
-    /// `"source_file"`. Use [`grammar_kind`][Node::grammar_kind] for the canonical
-    /// tree-sitter grammar name, or [`to_sexp`][Node::to_sexp] for tree-sitter-compatible
-    /// S-expression output which uses the canonical grammar names.
-    pub fn kind(&self) -> &'static str {
+    /// This matches tree-sitter expectations for `Node::kind()`, for example the
+    /// root node kind is `"source_file"`. Use [`native_kind`][Node::native_kind]
+    /// for the v3 parser's internal PascalCase kind name.
+    pub fn kind(&self) -> String {
+        self.grammar_kind()
+    }
+
+    /// Returns the v3 parser's internal node kind name (e.g. `"Program"`).
+    pub fn native_kind(&self) -> &'static str {
         self.inner.kind.kind_name()
     }
 
     /// Returns the tree-sitter grammar-canonical node kind name.
     ///
-    /// Unlike [`kind`][Node::kind], which returns the v3 internal PascalCase name
-    /// (e.g., `"Program"`, `"Subroutine"`), this method returns the grammar name
+    /// Alias of [`kind`][Node::kind] kept for compatibility.
+    ///
+    /// This method returns the grammar name
     /// used in S-expressions (e.g., `"source_file"`, `"sub"`).
     /// This matches the kind strings returned by `tree-sitter-perl-c` and the
     /// upstream tree-sitter Perl grammar.
@@ -729,7 +731,8 @@ mod tests {
     fn test_root_node_kind() {
         let mut p = Parser::new();
         let tree = must_some(p.parse("my $x = 42;"));
-        assert_eq!(tree.root_node().kind(), "Program");
+        assert_eq!(tree.root_node().kind(), "source_file");
+        assert_eq!(tree.root_node().native_kind(), "Program");
     }
 
     #[test]

--- a/crates/tree-sitter-perl-rs/tests/behavior_spec_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/behavior_spec_tests.rs
@@ -22,10 +22,10 @@ fn when_parsing_valid_perl_then_tree_and_source_are_available() {
 }
 
 #[test]
-fn when_requesting_root_kind_then_program_is_returned() {
+fn when_requesting_root_kind_then_source_file_is_returned() {
     let tree = parse("my $x = 42;");
 
-    assert_eq!(tree.root_node().kind(), "Program");
+    assert_eq!(tree.root_node().kind(), "source_file");
 }
 
 #[test]
@@ -106,17 +106,17 @@ fn when_requesting_grammar_kind_of_subroutine_then_sub_is_returned() {
     let tree = parse("sub greet { 1 }");
     let root = tree.root_node();
     // Find the subroutine child
-    let sub_node = must_some(root.children().find(|n| n.kind() == "Subroutine"));
+    let sub_node = must_some(root.children().find(|n| n.native_kind() == "Subroutine"));
     assert_eq!(sub_node.grammar_kind(), "sub");
 }
 
 #[test]
-fn when_v3_kind_and_grammar_kind_are_both_available_then_they_differ_for_program() {
+fn when_v3_kind_and_grammar_kind_are_both_available_then_they_are_explicit() {
     let tree = parse("1;");
     let root = tree.root_node();
-    assert_eq!(root.kind(), "Program");
+    assert_eq!(root.kind(), "source_file");
     assert_eq!(root.grammar_kind(), "source_file");
-    assert_ne!(root.kind(), root.grammar_kind());
+    assert_eq!(root.native_kind(), "Program");
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn when_requesting_grammar_kind_of_variable_with_attributes_then_snake_case_fall
     let root = tree.root_node();
     // Walk the tree to find the VariableWithAttributes node if present.
     fn find_var_attrs(n: tree_sitter_perl_rs::Node<'_>) -> Option<String> {
-        if n.kind() == "VariableWithAttributes" {
+        if n.native_kind() == "VariableWithAttributes" {
             return Some(n.grammar_kind());
         }
         for child in n.children() {

--- a/crates/tree-sitter-perl-rs/tests/incremental_tests.rs
+++ b/crates/tree-sitter-perl-rs/tests/incremental_tests.rs
@@ -122,7 +122,7 @@ fn when_parse_with_old_tree_given_empty_new_source_then_tree_is_returned() {
     let new_tree = must_some(new_tree);
     assert_eq!(new_tree.source(), "", "tree source must be the empty string");
     // The root is still a Program node (empty program).
-    assert_eq!(new_tree.root_node().kind(), "Program");
+    assert_eq!(new_tree.root_node().kind(), "source_file");
 }
 
 #[test]
@@ -180,7 +180,7 @@ fn when_reparse_after_edit_then_new_tree_has_correct_ast() {
     let new_tree = must_some(parser.parse_with_old_tree(new_source, &old_tree));
     assert_eq!(new_tree.source(), new_source);
     // Root must still be a Program node.
-    assert_eq!(new_tree.root_node().kind(), "Program");
+    assert_eq!(new_tree.root_node().kind(), "source_file");
     // The new program has children (the sub declaration).
     assert!(
         new_tree.root_node().child_count() >= 1,


### PR DESCRIPTION
### Motivation

- `Node::kind()` historically returned v3 internal PascalCase names (e.g. `Program`) which is surprising for tree-sitter consumers who expect grammar-canonical names (e.g. `source_file`).
- Align the facade with tree-sitter expectations while preserving access to the v3 internal name to remove a long-term footgun before the crate reaches stronger stability guarantees.

### Description

- Change `Node::kind()` to return the grammar-canonical kind as a `String` and implement it by delegating to the existing grammar extraction (`grammar_kind()`), and add `Node::native_kind()` to expose the old v3 internal `&'static str` kind name. 
- Keep `Node::grammar_kind()` as a compatibility alias that documents its behavior and retains the existing double-paren S-exp fallback logic for edge cases such as `VariableWithAttributes`.
- Update public docs in `crates/tree-sitter-perl-rs/README.md` and update facade/tests in `crates/tree-sitter-perl-rs/src/lib.rs`, `crates/tree-sitter-perl-rs/tests/behavior_spec_tests.rs`, and `crates/tree-sitter-perl-rs/tests/incremental_tests.rs` to lock the new contract.

### Testing

- Ran `cargo test -p tree-sitter-perl-rs --locked` which executed unit tests, behavior specs, incremental tests, snapshots, and doctests; all tests passed locally (`48` unit tests, `18` behavior tests, `12` incremental tests, `11` snapshot tests, and `5` doctests passed).
- Attempt to run the wrapper `./scripts/cargo-safe test -p tree-sitter-perl-rs --profile agent --locked` was blocked by an environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so the canonical `cargo test` invocation was used for verification instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97bfbd0f88333914dc8d289f285cf)