### PR TITLE
docs(parser): add parser coverage risk map and baseline (#0000)

### DIFF
--- a/.ci/coverage/parser-baseline.json
+++ b/.ci/coverage/parser-baseline.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "crate_group": "parser",
+  "line_coverage_floor": 0.58,
+  "branch_coverage_floor": 0.40,
+  "tolerance_pct": 0.02,
+  "critical_files": {
+    "crates/perl-parser-core/src/engine/parser/statements.rs": {
+      "branch_coverage_floor": 0.70
+    },
+    "crates/perl-parser-core/src/syntax/heredoc.rs": {
+      "branch_coverage_floor": 0.75
+    },
+    "crates/perl-parser-core/src/engine/parser/expressions.rs": {
+      "branch_coverage_floor": 0.68
+    },
+    "crates/perl-parser/src/incremental.rs": {
+      "branch_coverage_floor": 0.55
+    }
+  }
+}

--- a/docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md
+++ b/docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md
@@ -1,0 +1,128 @@
+# Perl Parser Coverage Risk Map (2026-05-05)
+
+## Scope
+
+This map is intentionally limited to parser-facing crates:
+
+- `crates/perl-parser`
+- `crates/perl-parser-core`
+
+The goal is to separate high-impact uncovered logic from low-impact facade surface so future test work can improve parser trust before parser percentage.
+
+## Classification rubric
+
+- **Critical parser behavior**: syntax and statement/expression parsing where wrong branches produce wrong trees.
+- **Recovery/error handling**: broken-input behavior and salvage logic that determines live-edit quality.
+- **Span/position correctness**: byte/line/UTF-16 mapping and exact ranges consumed by editor providers.
+- **Incremental parsing**: cache invalidation and reparse path correctness.
+- **Facade/re-export glue**: public surface aggregation with little direct behavior.
+- **Deprecated compatibility surface**: transitional aliases and legacy exports.
+- **Generated/static data**: tables and static declarations where direct unit coverage value is low.
+
+## Risk map
+
+### 1) Critical parser behavior (highest priority)
+
+Representative paths to prioritize for branch coverage growth:
+
+- `crates/perl-parser-core/src/engine/parser/statements.rs`
+- `crates/perl-parser-core/src/engine/parser/expressions.rs`
+- `crates/perl-parser-core/src/syntax/heredoc.rs`
+- `crates/perl-parser-core/src/syntax/quotes.rs`
+
+Why this matters:
+
+- Branch gaps here produce wrong AST structure even when parse succeeds.
+- Heredoc and quote-like branches are already known cluster candidates in parser status tracking.
+
+### 2) Recovery/error handling (highest priority)
+
+Representative paths:
+
+- `crates/perl-parser-core/src/engine/parser/recovery.rs`
+- `crates/perl-parser-core/src/engine/parser/statements.rs` (error-restart arms)
+- `crates/perl-parser/src/parser_recovery.rs`
+
+Why this matters:
+
+- Branch gaps here drive spillover failures and post-error symbol loss in live editing.
+- A clean parse percentage cannot detect broken salvage behavior.
+
+### 3) Span/position correctness (high priority)
+
+Representative paths:
+
+- `crates/perl-parser/src/position_mapper.rs`
+- `crates/perl-parser/src/span_utils.rs`
+- `crates/perl-parser-core/src/ast/span.rs`
+
+Why this matters:
+
+- Wrong byte/line/UTF-16 mapping causes bad diagnostics, hover ranges, and goto definition placement.
+- Coverage should emphasize edge-case branches (CRLF boundaries, multibyte UTF-8, empty spans).
+
+### 4) Incremental parsing (high priority)
+
+Representative paths:
+
+- `crates/perl-parser/src/incremental.rs`
+- `crates/perl-parser/src/incremental_cache.rs`
+
+Why this matters:
+
+- Branch gaps can cause stale or divergent parse results between full and incremental paths.
+- These are correctness-sensitive even if they are not syntax-specific.
+
+### 5) Facade/re-export glue (low priority)
+
+Representative paths:
+
+- `crates/perl-parser/src/lib.rs`
+- `crates/perl-parser/src/compat.rs`
+
+Why this matters less:
+
+- These modules are mostly `pub use` surface and compatibility routing.
+- Low branch coverage here should not be treated as equivalent to parser-core branch gaps.
+
+### 6) Deprecated compatibility surface (low priority)
+
+Representative paths:
+
+- `crates/perl-parser/src/deprecated.rs`
+- compatibility aliases in `crates/perl-parser/src/lib.rs`
+
+Why this matters less:
+
+- These branches are migration aids.
+- They should remain tested enough to avoid breakage, but not dominate parser coverage goals.
+
+### 7) Generated/static data (exclude or de-prioritize)
+
+Representative paths:
+
+- generated keyword/operator tables
+- static lookup maps without behavioral branching
+
+Why this matters less:
+
+- Line/branch deltas here rarely correlate with parser trust.
+- Keep compilation coverage, but avoid gating parser quality on these files.
+
+## Practical targeting guidance
+
+Use `just coverage-parser` to generate `target/coverage/parser.lcov`, then prioritize branch improvements in this order:
+
+1. Recovery + heredoc/quote parsing.
+2. Statement/expression branch arms with known wrong-tree potential.
+3. Span/UTF-16 edge branches.
+4. Incremental invalidation/equivalence branches.
+5. Facade/deprecated branches only when needed for API safety.
+
+## Baseline policy link
+
+Parser-specific floors and critical-file branch floors live in:
+
+- `.ci/coverage/parser-baseline.json`
+
+This keeps parser lane interpretation separate from global coverage numbers.

--- a/justfile
+++ b/justfile
@@ -1863,6 +1863,21 @@ coverage-lcov:
         --ignore-filename-regex '(^|/)(archive|tests|benches|examples)(/|$)|(^|/)build\.rs$|(^|/)crates/tree-sitter-perl-c/'
     @echo "✅ Coverage: lcov.info"
 
+# Generate parser-focused branch coverage output for perl-parser and perl-parser-core.
+# Writes LCOV output to target/coverage/parser.lcov.
+coverage-parser:
+    @echo "📊 Generating parser coverage (branch + lcov)..."
+    @if ! command -v cargo-llvm-cov >/dev/null 2>&1; then \
+        echo "⚠️ cargo-llvm-cov is not installed."; \
+        echo "   Install with: cargo install cargo-llvm-cov --locked"; \
+        echo "   Then run: just coverage-parser"; \
+        exit 0; \
+    fi
+    @mkdir -p target/coverage
+    @cargo llvm-cov -p perl-parser -p perl-parser-core --all-features --branch --lcov \
+        --output-path target/coverage/parser.lcov --locked
+    @echo "✅ Parser coverage: target/coverage/parser.lcov"
+
 # Show coverage summary (terminal)
 coverage-summary:
     @echo "📊 Coverage Summary"


### PR DESCRIPTION
### Motivation

- The repository lacked a parser-focused coverage workflow and guidance to distinguish high-impact parser-core gaps from low-value facade coverage, which made prioritizing test work noisy.
- Provide an operator-friendly baseline and risk map so future efforts can target recovery, heredoc, span, and incremental branches rather than facade re-exports.

### Description

- Added a `just coverage-parser` recipe that runs branch-aware `cargo llvm-cov` for `perl-parser` and `perl-parser-core` and emits `target/coverage/parser.lcov` without changing parser behavior. (`justfile`)
- Added a parser-scoped baseline policy at `.ci/coverage/parser-baseline.json` containing `schema_version`, `crate_group`, global floors, `tolerance_pct`, and per-file `branch_coverage_floor` entries for critical files. (`.ci/coverage/parser-baseline.json`)
- Added a forensic risk-map document that classifies uncovered code into lanes (critical parser behavior, recovery, spans, incremental, facade, deprecated, generated) and gives practical targeting guidance. (`docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md`)
- No parser runtime or parsing logic was modified; this is purely observability and policy documentation and tooling.

### Testing

- `cargo fmt --all -- --check` succeeded. 
- Attempts to run `./scripts/cargo-safe check -p xtask --all-targets --profile agent --locked` and `./scripts/cargo-safe test -p perl-parser --all-targets --profile agent --locked` and `./scripts/cargo-safe test -p perl-parser-core --all-targets --profile agent --locked` were blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so those checks did not complete. 
- Attempt to run `just coverage-parser` could not be executed in this environment because `just` is not installed, so the coverage recipe was validated by inspection only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c0902c88333bec64a8dfeb593da)