### PR TITLE
feat(parser): add parser coverage risk map lane (#0000)

### DIFF
--- a/.ci/coverage/parser-baseline.json
+++ b/.ci/coverage/parser-baseline.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "crate_group": "parser",
+  "line_coverage_floor": 0.58,
+  "branch_coverage_floor": 0.40,
+  "tolerance_pct": 0.5,
+  "critical_files": {
+    "crates/perl-parser-core/src/engine/parser/statements.rs": {
+      "branch_coverage_floor": 0.70
+    },
+    "crates/perl-parser-core/src/syntax/heredoc.rs": {
+      "branch_coverage_floor": 0.75
+    }
+  }
+}

--- a/docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md
+++ b/docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md
@@ -1,0 +1,81 @@
+# perl-parser coverage risk map (2026-05-05)
+
+## Scope
+
+This forensic note defines parser-specific coverage priorities so coverage work improves parser trust rather than inflating a single global percentage.
+
+- Crates in scope: `perl-parser`, `perl-parser-core`
+- Artifact target: `target/coverage/parser.lcov`
+- Baseline policy: `.ci/coverage/parser-baseline.json`
+
+## Risk-classified coverage lanes
+
+### 1) Critical parser behavior (highest priority)
+
+Coverage deficits in these paths can directly produce wrong parse trees or wrong statement boundaries while still reporting a "clean parse":
+
+- `crates/perl-parser-core/src/engine/parser/statements.rs`
+- `crates/perl-parser-core/src/syntax/heredoc.rs`
+- Quote-like operator handling in `crates/perl-parser-core/src/syntax/`
+
+Coverage work in this lane should focus on branch behavior, not line-only coverage.
+
+### 2) Recovery and error handling (highest priority)
+
+Coverage gaps in recovery branches reduce live-edit stability and can cause cascade failures:
+
+- Unclosed block and delimiter recovery branches
+- Error-node boundary and resume-path branches
+- Multi-error files where parser should salvage post-error statements
+
+Coverage in this lane should prioritize malformed fixtures and spillover checks.
+
+### 3) Span/position correctness (high priority)
+
+Coverage should validate byte, line, and UTF-16 mapping behavior where parser facts cross the editor boundary:
+
+- Position mapper pathways used by diagnostics and goto
+- Node span assignment for delimiter-heavy constructs
+- Error-region span boundaries during recovery
+
+### 4) Incremental parsing (high priority)
+
+Coverage should exercise invalidation and equivalence branches where edits mutate parse state:
+
+- Minimal edit invalidation paths
+- Fast-path reuse vs full reparse fallback
+- Equivalence checks between incremental and fresh parse output
+
+### 5) Facade and re-export glue (low priority)
+
+The `perl-parser` facade intentionally re-exports broad surface area. Low coverage here is expected when branches are shallow and behavior lives downstream.
+
+- `pub use` glue and compatibility aliases
+- Thin forwarders into parser-core and semantic layers
+
+This lane should not block parser trust improvements unless branches carry non-trivial behavior.
+
+### 6) Deprecated compatibility surface (low priority)
+
+Coverage in deprecated shims is useful only to avoid regressions during migration windows. It should not dominate parser-focused coverage effort.
+
+### 7) Generated/static data (excluded/monitor only)
+
+Generated tables and static registries should generally be excluded from parser branch-floor decisions unless they contain executable branching logic.
+
+## Operating guidance
+
+1. Use `just coverage-parser` for parser-only branch-aware lcov output.
+2. Compare parser coverage changes against `.ci/coverage/parser-baseline.json` rather than global workspace thresholds.
+3. Prioritize new tests in this order:
+   1. Recovery cascade containment
+   2. Heredoc and delimiter ambiguity
+   3. Span and UTF-16 correctness
+   4. Incremental invalidation/equivalence
+   5. Facade glue only when behavioral branches are added
+
+## Non-goals for this slice
+
+- No parser behavior changes.
+- No global coverage threshold changes.
+- No all-crates coverage gate expansion.

--- a/justfile
+++ b/justfile
@@ -1890,6 +1890,23 @@ coverage-baseline-refresh:
     @just coverage-lcov
     @bash ./scripts/update-coverage-baseline.sh lcov.info .ci/coverage-baseline.txt
 
+# Generate parser-focused branch coverage output for perl-parser and perl-parser-core.
+# Writes target/coverage/parser.lcov when cargo-llvm-cov is available.
+# In environments without cargo-llvm-cov, records the intended command and exits successfully.
+coverage-parser:
+    @echo "📊 Generating parser coverage (perl-parser + perl-parser-core)..."
+    @mkdir -p target/coverage
+    @if [[ ! -x "$HOME/.cargo/bin/cargo-llvm-cov" ]]; then \
+        echo "⚠️  cargo-llvm-cov not installed; recording the expected command instead."; \
+        printf '%s\n' \
+          'cargo llvm-cov -p perl-parser -p perl-parser-core --all-features --branch --lcov --output-path target/coverage/parser.lcov' \
+          > target/coverage/parser.command.txt; \
+        echo "📝 Wrote target/coverage/parser.command.txt"; \
+        exit 0; \
+    fi
+    @"$HOME/.cargo/bin/rustup" run nightly cargo llvm-cov -p perl-parser -p perl-parser-core --all-features --branch --lcov --output-path target/coverage/parser.lcov
+    @echo "✅ Parser coverage: target/coverage/parser.lcov"
+
 # ============================================================================
 # Technical Debt Tracking (Issue #XXX)
 # ============================================================================


### PR DESCRIPTION
### Motivation

- Distinguish high-risk parser-core coverage gaps from low-value facade/re-export coverage so future tests improve parser trust rather than inflate a global percentage. 
- Provide an operator-friendly, parser-scoped coverage workflow and a baseline to guide targeted coverage investment.

### Description

- Add a `just` recipe `coverage-parser` that invokes `cargo llvm-cov` for `perl-parser` and `perl-parser-core`, writes `target/coverage/parser.lcov`, and records a fallback command when `cargo-llvm-cov` is unavailable. 
- Add `.ci/coverage/parser-baseline.json` with `schema_version`, `crate_group`, global `line_coverage_floor`/`branch_coverage_floor`, `tolerance_pct`, and `critical_files` branch floors for `statements.rs` and `heredoc.rs`. 
- Add `docs/forensics/2026-05-05-perl-parser-coverage-risk-map.md` classifying coverage lanes by trust impact and documenting operating guidance and non-goals for this slice.

### Testing

- Ran `cargo fmt --all -- --check`, which passed. 
- Attempted `./scripts/cargo-safe check` and `./scripts/cargo-safe test` for `xtask`, `perl-parser`, and `perl-parser-core`, but they were blocked in this environment by a storage policy (`DENY` from the runner). 
- Attempted `just coverage-parser` but `just` is not installed in the runner, so the recipe could not be executed here; the recipe records a fallback command in `target/coverage/parser.command.txt` when tooling is missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c0902c88333bec64a8dfeb593da)