### PR TITLE
docs(perl-dap): align DAP truth surface and status gating (#0000)

### DIFF
--- a/crates/perl-dap/README.md
+++ b/crates/perl-dap/README.md
@@ -23,17 +23,31 @@ DAP-capable editors and tools.
 - `BridgeAdapter` supports migration from `Perl::LanguageServer`.
 - `TcpAttachConfig` and `BreakpointStore` support socket attach and breakpoint tracking.
 
-## Run
+## Run modes
+
+- **Native launch (stdio DAP server):**
 
 ```bash
 perl-dap --stdio
+```
+
+- **TCP attach endpoint (native DAP over socket):**
+
+```bash
 perl-dap --socket --port 13603
+```
+
+- **Legacy bridge mode (proxy to Perl::LanguageServer):**
+
+```bash
 perl-dap --bridge
 ```
 
-## BridgeAdapter dependency
+## External dependencies
 
-`--bridge` mode requires the CPAN module `Perl::LanguageServer`.
+Native launch and TCP attach use the built-in Rust runtime plus a local Perl installation.
+
+`--bridge` mode additionally requires the CPAN module `Perl::LanguageServer`.
 Install it with either:
 
 ```bash

--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -8,18 +8,21 @@
 //!
 //! # Features
 //!
-//! - **Bridge Mode**: Proxy to existing Perl::LanguageServer DAP implementation
+//! - **Native Runtime**: Current launch/attach implementation for Perl debugging sessions
 //! - **Launch Debugging**: Start and debug Perl processes with full control
 //! - **Attach Debugging**: Attach to running Perl processes via TCP
+//! - **Legacy Bridge Mode**: Compatibility proxy for Perl::LanguageServer installations
 //! - **AST-Based Validation**: Breakpoint validation using parsed syntax trees
 //! - **Cross-Platform**: Windows, macOS, and Linux support with path normalization
 //! - **Configuration Snippets**: VSCode launch.json generation
 //!
 //! # Quick Start
 //!
-//! ## Bridge Mode (Phase 1 - Implemented)
+//! ## Native and Bridge Modes
 //!
-//! The bridge adapter proxies DAP messages to Perl::LanguageServer:
+//! Native launch and attach are the current default runtime paths for new sessions.
+//! The legacy bridge adapter remains available when an installation still needs to
+//! proxy DAP messages to Perl::LanguageServer:
 //!
 //! ```no_run
 //! use perl_dap::BridgeAdapter;
@@ -103,45 +106,20 @@
 //!
 //! # Architecture
 //!
-//! The DAP adapter follows a phased implementation approach:
+//! `perl-dap` exposes a dual architecture that supports both current runtime use
+//! and compatibility migration:
 //!
-//! ## Phase 1: Bridge Adapter (Implemented)
+//! - **Native runtime (`DapServer` + `DebugAdapter`)** handles launch/attach
+//!   flows, request dispatch, breakpoint/state management, and variable/evaluate
+//!   inspection paths.
+//! - **Legacy bridge (`BridgeAdapter`)** proxies traffic to
+//!   `Perl::LanguageServer` for compatibility when teams are still migrating.
+//! - **Shared foundations** (`protocol`, `dispatcher`, `breakpoints`,
+//!   `platform`) provide message contracts, routing, validation, and
+//!   cross-platform process setup.
 //!
-//! **Acceptance Criteria: AC1-AC4**
-//!
-//! - **[`BridgeAdapter`]**: Message proxy between VSCode and Perl::LanguageServer
-//! - **[`LaunchConfiguration`]**: Launch debugging configuration and validation
-//! - **[`AttachConfiguration`]**: Attach debugging configuration for TCP connections
-//! - **[`platform`]**: Cross-platform path resolution and environment setup
-//!
-//! Phase 1 provides immediate debugging support by bridging to the mature
-//! Perl::LanguageServer implementation while the native adapter is developed.
-//!
-//! ## Phase 2: Native Adapter (Planned)
-//!
-//! **Acceptance Criteria: AC5-AC12**
-//!
-//! - **[`protocol`]**: DAP protocol types and message definitions
-//! - **[`dispatcher`]**: Request routing and method dispatch
-//! - **[`breakpoints`]**: Breakpoint management with AST validation
-//! - **Session Management**: Debug session lifecycle and state tracking
-//! - **Variable Renderer**: Lazy variable expansion for complex data structures
-//! - **Stack Trace Provider**: Call stack navigation with source mapping
-//! - **Control Flow**: Step, continue, pause, and breakpoint control
-//! - **Safe Evaluation**: Expression evaluation in debug context
-//!
-//! Phase 2 will provide a native Rust DAP implementation with tighter integration
-//! to `perl_parser` for enhanced validation and performance.
-//!
-//! ## Phase 3: Production Hardening (Planned)
-//!
-//! **Acceptance Criteria: AC13-AC19**
-//!
-//! - **Security Validation**: Input sanitization and command injection prevention
-//! - **Performance Optimization**: Efficient variable inspection and stepping
-//! - **Packaging**: Distribution via cargo, VSCode marketplace, and package managers
-//! - **Documentation**: Comprehensive usage guides and troubleshooting
-//! - **Testing**: End-to-end integration tests with real debugging scenarios
+//! This keeps one crate boundary for editor integrations while allowing
+//! per-session selection between native execution and bridge fallback behavior.
 //!
 //! # Protocol Support
 //!

--- a/docs/project/status/dap.md
+++ b/docs/project/status/dap.md
@@ -9,10 +9,10 @@
 <!-- BEGIN: DAP_LAUNCH_SCORECARD -->
 | Metric | Value | Target | Status |
 |---|---|---|---|
-| Launch success rate | receipt missing (`cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture`) | ≥ 80 % | SKIP |
+| Launch success rate | 5/5 (100 %) | ≥ 80 % | PASS |
 | Fixtures tested | hello, loops, eval, args, begin_end | 5 | — |
-| cold_launch_p50 | — | ≤ 2 000 ms | SKIP |
-| cold_launch_p95 | — | ≤ 5 000 ms | SKIP |
+| cold_launch_p50 | 21 ms | ≤ 2 000 ms | PASS |
+| cold_launch_p95 | 27 ms | ≤ 5 000 ms | PASS |
 <!-- END: DAP_LAUNCH_SCORECARD -->
 
 ## Session Correctness & Attach
@@ -20,11 +20,11 @@
 <!-- BEGIN: DAP_SESSION_SCORECARD -->
 | Metric | Value | Target | Status |
 |---|---|---|---|
-| Attach success rate (TCP loopback) | receipt missing (`cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture`) | ≥ 80 % | SKIP |
-| Variables pane correctness (real session) | receipt missing | expected named variables in scope | SKIP |
-| Evaluate correctness (real session) | receipt missing | evaluate($x + 1) => 42 | SKIP |
-| Deep truncation/pagination correctness | receipt missing | page [250..274] over @big | SKIP |
-| Memory footprint baseline (portable proxy) | receipt missing | best-effort baseline | SKIP |
+| Attach success rate (TCP loopback) | 5/5 (100 %) | ≥ 80 % | PASS |
+| Variables pane correctness (real session) | globals scope returned 1 named variable | expected named variables in scope | PASS |
+| Evaluate correctness (real session) | evaluate($x + 1) returns 42 | evaluate($x + 1) => 42 | PASS |
+| Deep truncation/pagination correctness | no indexedVariables >= 200 found in this real-session scope | page [250..274] over @big | SKIP |
+| Memory footprint baseline (portable proxy) | debug_adapter_struct_size=176 bytes; best_effort_process_rss=11252 KiB | best-effort baseline | MEASURED |
 <!-- END: DAP_SESSION_SCORECARD -->
 
 ## Test Coverage
@@ -33,7 +33,7 @@
 | Suite | Count |
 |---|---|
 | Integration tests (`perl-dap`) | 58 test targets |
-| Scorecard fixtures | 6 |
+| Scorecard fixtures | 5 |
 <!-- END: DAP_TEST_COUNTS -->
 
 ## How to Update

--- a/xtask/src/tasks/update_status/dap.rs
+++ b/xtask/src/tasks/update_status/dap.rs
@@ -5,7 +5,7 @@
 use std::fs;
 use std::path::Path;
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, bail};
 use serde::Deserialize;
 
 use super::replace_block;
@@ -68,6 +68,7 @@ pub(super) fn count_dap_tests(root: &Path) -> DapTestCounts {
                         && !e.file_name().to_string_lossy().starts_with("breakpoints_heredocs")
                         && !e.file_name().to_string_lossy().starts_with("breakpoints_multiline")
                         && !e.file_name().to_string_lossy().starts_with("breakpoints_pod")
+                        && e.file_name().to_string_lossy() != "dap_real_session_data.pl"
                 })
                 .count()
         })
@@ -80,6 +81,12 @@ fn read_receipt(root: &Path) -> Option<ScorecardReceipt> {
     let path = root.join(RECEIPT_PATH);
     let content = fs::read_to_string(path).ok()?;
     serde_json::from_str(&content).ok()
+}
+
+fn require_receipt_for_status_refresh() -> bool {
+    std::env::var("XTASK_UPDATE_STATUS_REQUIRE_DAP_RECEIPT")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
 }
 
 fn format_rate(criterion: &RateMetric) -> String {
@@ -186,6 +193,11 @@ pub(super) fn generate_dap_status(
     );
 
     let receipt = read_receipt(root);
+    if receipt.is_none() && require_receipt_for_status_refresh() {
+        bail!(
+            "missing {RECEIPT_PATH}; run `cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture` before `cargo xtask update-status --only dap`"
+        );
+    }
     let launch_table = launch_table_from_receipt(receipt.as_ref());
     let session_table = session_table_from_receipt(receipt.as_ref());
 


### PR DESCRIPTION
### Motivation

- Crate docs and the status page had drifted from the shipped native runtime + bridge architecture and described earlier phased plans. 
- The DAP status page rendered as “receipt missing” even though a harness and receipt exist, which hides real metrics and allows stale updates. 
- The scorecard fixture counting included a non-scorecard real-session data file, causing a fixture-count mismatch between generator tests and the status page.

### Description

- Updated crate-level docs in `crates/perl-dap/src/lib.rs` to describe the current dual architecture (native runtime + legacy bridge) and to remove phased/planned wording. 
- Clarified run modes and external dependency expectations in `crates/perl-dap/README.md` to list native stdio launch, TCP attach, and legacy bridge modes. 
- Added an opt-in strict gate in `xtask/src/tasks/update_status/dap.rs` (`XTASK_UPDATE_STATUS_REQUIRE_DAP_RECEIPT`) that makes `generate_dap_status` fail when `target/dap_scorecard_receipt.json` is missing for release-style refreshes. 
- Fixed fixture-count drift by excluding `dap_real_session_data.pl` from the scorecard fixture tally and regenerated `docs/project/status/dap.md` from a fresh harness receipt so the status blocks now show real values. 

### Testing

- Ran `cargo test -p perl-dap --test dap_scorecard_harness -- --nocapture` and the scorecard harness completed and produced `target/dap_scorecard_receipt.json` (tests passed). 
- Ran `cargo xtask update-status --only dap --write` to regenerate `docs/project/status/dap.md` and it completed successfully. 
- Ran `cargo test -p xtask update_status::dap` and the xtask unit tests (including the dap status generator tests) passed. 
- Ran `cargo fmt --all -- --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97c2b0b048333bd983992ecf49e42)