### PR TITLE
fix(perl-corpus): preserve section id provenance and expected blocks (#0000)

### DIFF
--- a/crates/perl-corpus/src/inventory.rs
+++ b/crates/perl-corpus/src/inventory.rs
@@ -1,6 +1,6 @@
 use crate::files::{CorpusPaths, get_test_files_from};
 use crate::lint::KNOWN_TAGS;
-use crate::meta::Section;
+use crate::meta::{IdSource, Section};
 use crate::parse_file;
 use anyhow::Result;
 use serde::Serialize;
@@ -28,9 +28,13 @@ pub struct CorpusInventory {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct InventoryIds {
-    pub total: usize,
-    pub missing: usize,
-    pub duplicates: Vec<String>,
+    pub explicit: usize,
+    pub generated: usize,
+    pub missing_explicit_ids: usize,
+    pub generated_ids: Vec<String>,
+    pub duplicate_effective_ids: Vec<String>,
+    pub duplicate_explicit_ids: Vec<String>,
+    pub id_source_breakdown: BTreeMap<String, usize>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -68,7 +72,12 @@ pub fn build_inventory_from_paths(paths: &CorpusPaths) -> Result<CorpusInventory
 /// Build an inventory from explicit section data.
 pub fn inventory_from_sections(file_count: usize, sections: &[Section]) -> CorpusInventory {
     let mut id_counts: BTreeMap<&str, usize> = BTreeMap::new();
-    let mut missing_ids = 0usize;
+    let mut explicit_ids: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut explicit_count = 0usize;
+    let mut generated_count = 0usize;
+    let mut missing_explicit_ids = 0usize;
+    let mut generated_ids = BTreeSet::new();
+    let mut id_source_breakdown: BTreeMap<String, usize> = BTreeMap::new();
     let mut known_tags = BTreeSet::new();
     let mut unknown_tags = BTreeSet::new();
     let known_tag_set: BTreeSet<&str> = KNOWN_TAGS.iter().copied().collect();
@@ -76,10 +85,25 @@ pub fn inventory_from_sections(file_count: usize, sections: &[Section]) -> Corpu
     let mut markers = InventoryMarkers { expected_error: 0, wip: 0, parser_sensitive: 0 };
 
     for section in sections {
-        if section.id.trim().is_empty() {
-            missing_ids += 1;
-        } else {
+        if !section.id.trim().is_empty() {
             *id_counts.entry(section.id.as_str()).or_default() += 1;
+        }
+        match section.id_source {
+            IdSource::Explicit => {
+                explicit_count += 1;
+                *id_source_breakdown.entry("explicit".to_string()).or_default() += 1;
+                if let Some(explicit_id) = section.explicit_id.as_deref() {
+                    *explicit_ids.entry(explicit_id).or_default() += 1;
+                } else {
+                    missing_explicit_ids += 1;
+                }
+            }
+            IdSource::Generated => {
+                generated_count += 1;
+                *id_source_breakdown.entry("generated".to_string()).or_default() += 1;
+                missing_explicit_ids += 1;
+                generated_ids.insert(section.id.clone());
+            }
         }
 
         for tag in &section.tags {
@@ -105,20 +129,28 @@ pub fn inventory_from_sections(file_count: usize, sections: &[Section]) -> Corpu
         }
     }
 
-    let duplicates = id_counts
+    let duplicate_effective_ids = id_counts
+        .into_iter()
+        .filter_map(|(id, count)| (count > 1).then_some(id.to_string()))
+        .collect::<Vec<_>>();
+    let duplicate_explicit_ids = explicit_ids
         .into_iter()
         .filter_map(|(id, count)| (count > 1).then_some(id.to_string()))
         .collect::<Vec<_>>();
 
     CorpusInventory {
-        schema_version: 1,
+        schema_version: 2,
         files: file_count,
         sections: sections.len(),
         cases: sections.len(),
         ids: InventoryIds {
-            total: sections.len().saturating_sub(missing_ids),
-            missing: missing_ids,
-            duplicates,
+            explicit: explicit_count,
+            generated: generated_count,
+            missing_explicit_ids,
+            generated_ids: generated_ids.into_iter().collect(),
+            duplicate_effective_ids,
+            duplicate_explicit_ids,
+            id_source_breakdown,
         },
         tags: InventoryTags {
             known: known_tags.into_iter().collect(),
@@ -220,14 +252,21 @@ mod tests {
     use super::*;
 
     fn sample_section(id: &str, tags: &[&str], flags: &[&str]) -> Section {
+        let explicit_id =
+            (!id.is_empty()).then(|| id.to_string()).or_else(|| Some("generated-id".to_string()));
+        let id_source = if id.is_empty() { IdSource::Generated } else { IdSource::Explicit };
         Section {
-            id: id.to_string(),
+            id: if id.is_empty() { "generated-id".to_string() } else { id.to_string() },
+            id_source,
+            explicit_id: if id.is_empty() { None } else { explicit_id.clone() },
+            generated_id: (id.is_empty()).then(|| "generated-id".to_string()),
             title: "title".to_string(),
             file: "sample.txt".to_string(),
             tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
             perl: None,
             flags: flags.iter().map(|flag| (*flag).to_string()).collect(),
             body: "my $x = 1;".to_string(),
+            expected: None,
             line: Some(1),
         }
     }
@@ -242,12 +281,13 @@ mod tests {
 
         let inventory = inventory_from_sections(2, &sections);
 
-        assert_eq!(inventory.schema_version, 1);
+        assert_eq!(inventory.schema_version, 2);
         assert_eq!(inventory.files, 2);
         assert_eq!(inventory.sections, 3);
-        assert_eq!(inventory.ids.total, 2);
-        assert_eq!(inventory.ids.missing, 1);
-        assert_eq!(inventory.ids.duplicates, vec!["case.1".to_string()]);
+        assert_eq!(inventory.ids.explicit, 2);
+        assert_eq!(inventory.ids.generated, 1);
+        assert_eq!(inventory.ids.missing_explicit_ids, 1);
+        assert_eq!(inventory.ids.duplicate_effective_ids, vec!["case.1".to_string()]);
         assert_eq!(inventory.tags.known, vec!["regex".to_string()]);
         assert_eq!(inventory.tags.unknown, vec!["custom-tag".to_string()]);
         assert_eq!(inventory.markers.parser_sensitive, 1);
@@ -265,6 +305,6 @@ mod tests {
         let second = inventory_from_sections(1, &sections);
         assert_eq!(first, second);
         assert_eq!(first.tags.unknown, vec!["a-unknown".to_string(), "z-unknown".to_string()]);
-        assert_eq!(first.ids.duplicates, Vec::<String>::new());
+        assert_eq!(first.ids.duplicate_effective_ids, Vec::<String>::new());
     }
 }

--- a/crates/perl-corpus/src/lib.rs
+++ b/crates/perl-corpus/src/lib.rs
@@ -297,8 +297,12 @@ my $y = 2;
         let tagged_section = must_some(sections.iter().find(|s| s.id == "custom.id"));
 
         assert_eq!(sample_section.body, "my $x = 1;");
+        assert!(sample_section.explicit_id.is_none());
+        assert!(sample_section.generated_id.is_some());
+        assert!(sample_section.expected.is_some());
         assert!(!sample_section.body.contains("---"));
         assert_eq!(tagged_section.id, "custom.id");
+        assert_eq!(tagged_section.explicit_id.as_deref(), Some("custom.id"));
         assert_eq!(tagged_section.tags, vec!["alpha".to_string(), "beta".to_string()]);
         assert_eq!(tagged_section.flags, vec!["parser-sensitive".to_string()]);
         assert_eq!(tagged_section.body, "my $y = 2;");

--- a/crates/perl-corpus/src/lint.rs
+++ b/crates/perl-corpus/src/lint.rs
@@ -1,4 +1,4 @@
-use crate::meta::Section;
+use crate::meta::{IdSource, Section};
 use anyhow::{Result, bail};
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -297,7 +297,13 @@ pub fn check_sections(sections: &[Section], config: &LintConfig) -> LintResult {
     for section in sections {
         // Check ID format
         if section.id.is_empty() {
-            result.errors.push(format!("Missing @id in {}: {}", section.file, section.title));
+            result
+                .errors
+                .push(format!("Missing effective ID in {}: {}", section.file, section.title));
+        } else if section.id_source == IdSource::Generated {
+            result
+                .errors
+                .push(format!("Missing explicit @id in {}: {}", section.file, section.title));
         } else if !ID_RE.as_ref().is_some_and(|re| re.is_match(&section.id)) {
             result.errors.push(format!(
                 "Invalid @id format '{}' in {}: {} (must match [a-z0-9._-]+)",

--- a/crates/perl-corpus/src/meta.rs
+++ b/crates/perl-corpus/src/meta.rs
@@ -1,1 +1,1 @@
-pub use crate::metadata::Section;
+pub use crate::metadata::{IdSource, Section};

--- a/crates/perl-corpus/src/metadata/mod.rs
+++ b/crates/perl-corpus/src/metadata/mod.rs
@@ -4,4 +4,4 @@ mod query;
 mod section;
 
 pub use query::{find_by_flag, find_by_tag};
-pub use section::Section;
+pub use section::{ExpectedBlock, ExpectedFormat, IdSource, Section};

--- a/crates/perl-corpus/src/metadata/parser.rs
+++ b/crates/perl-corpus/src/metadata/parser.rs
@@ -1,5 +1,5 @@
-use crate::metadata::Section;
 use crate::metadata::ids::{make_section_id, slugify_title};
+use crate::metadata::{ExpectedBlock, ExpectedFormat, IdSource, Section};
 use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
@@ -82,13 +82,19 @@ pub fn parse_sections(text: &str, path: &Path) -> Vec<Section> {
             }
         }
 
+        let explicit_id = meta.get("id").cloned().filter(|value| !value.trim().is_empty());
         let id = make_section_id(
-            &meta.get("id").cloned().unwrap_or_default(),
+            explicit_id.as_deref().unwrap_or_default(),
             &file_stem,
             &title,
             section_index,
             &mut auto_ids,
         );
+        let (id_source, generated_id) = if explicit_id.is_some() {
+            (IdSource::Explicit, None)
+        } else {
+            (IdSource::Generated, Some(id.clone()))
+        };
         let tags = meta
             .get("tags")
             .map(|s| {
@@ -107,20 +113,45 @@ pub fn parse_sections(text: &str, path: &Path) -> Vec<Section> {
         let body_end =
             body_lines.iter().position(|line| line.trim() == "---").unwrap_or(body_lines.len());
         let body = body_lines[..body_end].join("\n").trim().to_string();
+        let expected = body_lines.get(body_end + 1..).and_then(|lines| {
+            let raw = lines.join("\n").trim().to_string();
+            (!raw.is_empty()).then(|| ExpectedBlock { format: infer_expected_format(&raw), raw })
+        });
         let line_num = text[..start].lines().count() + 1;
         let file_name = path.file_name().unwrap_or_default();
 
         sections.push(Section {
             id,
+            id_source,
+            explicit_id,
+            generated_id,
             title,
             file: file_name.to_string_lossy().into(),
             tags,
             perl,
             flags,
             body,
+            expected,
             line: Some(line_num),
         });
     }
 
     sections
+}
+
+fn infer_expected_format(raw: &str) -> ExpectedFormat {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return ExpectedFormat::Unknown;
+    }
+    if trimmed.starts_with('(') {
+        return ExpectedFormat::TreeSitterSexp;
+    }
+    if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        if trimmed.contains("\"diagnostic\"") || trimmed.contains("\"diagnostics\"") {
+            return ExpectedFormat::DiagnosticsJson;
+        }
+        return ExpectedFormat::AstJson;
+    }
+    ExpectedFormat::PlainText
 }

--- a/crates/perl-corpus/src/metadata/section.rs
+++ b/crates/perl-corpus/src/metadata/section.rs
@@ -1,10 +1,40 @@
 use serde::{Deserialize, Serialize};
 
+/// Source of a section identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdSource {
+    Explicit,
+    Generated,
+}
+
+/// Optional expected output block after a section body separator (`---`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpectedBlock {
+    pub raw: String,
+    pub format: ExpectedFormat,
+}
+
+/// Best-effort format classification for expected output blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExpectedFormat {
+    TreeSitterSexp,
+    AstJson,
+    DiagnosticsJson,
+    PlainText,
+    Unknown,
+}
+
 /// A test corpus section with metadata and source code
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Section {
     /// Stable unique key, e.g., "regex.pos.001"
     pub id: String,
+    /// Identifier source metadata.
+    pub id_source: IdSource,
+    /// Explicit identifier from `# @id:`.
+    pub explicit_id: Option<String>,
+    /// Generated fallback identifier when explicit ID is missing.
+    pub generated_id: Option<String>,
 
     /// Display title (line after "=====")
     pub title: String,
@@ -23,6 +53,8 @@ pub struct Section {
 
     /// Body text (source code of the section)
     pub body: String,
+    /// Optional expected output block parsed from text after `---`.
+    pub expected: Option<ExpectedBlock>,
 
     /// Line number where section starts (for error reporting)
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
### Motivation

- Parser sections silently synthesized IDs and discarded expected-output after a `---` separator, making linting/inventory unable to distinguish explicit vs generated IDs and losing expectations that are critical for regression fixtures.

### Description

- Added ID provenance and expected-output types: `IdSource`, `ExpectedBlock`, and `ExpectedFormat`, and extended `Section` with `id_source`, `explicit_id`, `generated_id`, and `expected` fields (see `crates/perl-corpus/src/metadata/section.rs`).
- Updated `parse_sections` to preserve whether an `# @id:` was explicit or synthesized, record generated IDs when applicable, capture the text after `---` into `ExpectedBlock`, and heuristically infer the expected format (S-exp, JSON AST/diagnostics, or plain text) (see `crates/perl-corpus/src/metadata/parser.rs`).
- Tightened linting so a generated ID now triggers a missing-explicit-id error path instead of only checking for empty effective IDs (see `crates/perl-corpus/src/lint.rs`).
- Upgraded the inventory schema to version 2 and added enforceable ID metrics (`explicit`, `generated`, `missing_explicit_ids`, `generated_ids`, `duplicate_effective_ids`, `duplicate_explicit_ids`, `id_source_breakdown`) and updated inventory computation/tests accordingly (see `crates/perl-corpus/src/inventory.rs`).
- Updated public exports and tests to align with the new fields and behavior (`crates/perl-corpus/src/metadata/mod.rs`, `crates/perl-corpus/src/meta.rs`, `crates/perl-corpus/src/lib.rs`).

### Testing

- Ran `cargo test -p perl-corpus --locked` and all tests passed (158 passed; 0 failed). 
- An attempt to run the agent-profile script `./scripts/cargo-safe test -p perl-corpus --profile agent --locked` was blocked by the environment storage policy, so the canonical agent-profile run was not completed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f986c246b08333bf6065a7abb9f02e)