### PR TITLE
fix(perl-corpus): preserve corpus metadata truth (#0000)

### DIFF
--- a/crates/perl-corpus/src/inventory.rs
+++ b/crates/perl-corpus/src/inventory.rs
@@ -1,6 +1,7 @@
 use crate::files::{CorpusPaths, get_test_files_from};
 use crate::lint::KNOWN_TAGS;
 use crate::meta::Section;
+use crate::metadata::IdSource;
 use crate::parse_file;
 use anyhow::Result;
 use serde::Serialize;
@@ -28,9 +29,13 @@ pub struct CorpusInventory {
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct InventoryIds {
-    pub total: usize,
-    pub missing: usize,
-    pub duplicates: Vec<String>,
+    pub explicit: usize,
+    pub generated: usize,
+    pub missing_explicit_ids: usize,
+    pub generated_ids: Vec<String>,
+    pub duplicate_effective_ids: Vec<String>,
+    pub duplicate_explicit_ids: Vec<String>,
+    pub id_source_breakdown: BTreeMap<String, usize>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -68,7 +73,12 @@ pub fn build_inventory_from_paths(paths: &CorpusPaths) -> Result<CorpusInventory
 /// Build an inventory from explicit section data.
 pub fn inventory_from_sections(file_count: usize, sections: &[Section]) -> CorpusInventory {
     let mut id_counts: BTreeMap<&str, usize> = BTreeMap::new();
-    let mut missing_ids = 0usize;
+    let mut explicit_ids = 0usize;
+    let mut generated_ids = 0usize;
+    let mut missing_explicit_ids = 0usize;
+    let mut generated_id_values = Vec::new();
+    let mut explicit_id_counts: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut id_source_breakdown: BTreeMap<String, usize> = BTreeMap::new();
     let mut known_tags = BTreeSet::new();
     let mut unknown_tags = BTreeSet::new();
     let known_tag_set: BTreeSet<&str> = KNOWN_TAGS.iter().copied().collect();
@@ -76,10 +86,23 @@ pub fn inventory_from_sections(file_count: usize, sections: &[Section]) -> Corpu
     let mut markers = InventoryMarkers { expected_error: 0, wip: 0, parser_sensitive: 0 };
 
     for section in sections {
-        if section.id.trim().is_empty() {
-            missing_ids += 1;
-        } else {
+        if !section.id.trim().is_empty() {
             *id_counts.entry(section.id.as_str()).or_default() += 1;
+        }
+        match section.id_source {
+            IdSource::Explicit => {
+                explicit_ids += 1;
+                *id_source_breakdown.entry("explicit".to_string()).or_default() += 1;
+                if let Some(explicit_id) = section.explicit_id.as_deref() {
+                    *explicit_id_counts.entry(explicit_id).or_default() += 1;
+                }
+            }
+            IdSource::Generated => {
+                generated_ids += 1;
+                missing_explicit_ids += 1;
+                *id_source_breakdown.entry("generated".to_string()).or_default() += 1;
+                generated_id_values.push(section.id.clone());
+            }
         }
 
         for tag in &section.tags {
@@ -105,10 +128,16 @@ pub fn inventory_from_sections(file_count: usize, sections: &[Section]) -> Corpu
         }
     }
 
-    let duplicates = id_counts
+    let duplicate_effective_ids = id_counts
         .into_iter()
         .filter_map(|(id, count)| (count > 1).then_some(id.to_string()))
         .collect::<Vec<_>>();
+    let duplicate_explicit_ids = explicit_id_counts
+        .into_iter()
+        .filter_map(|(id, count)| (count > 1).then_some(id.to_string()))
+        .collect::<Vec<_>>();
+    generated_id_values.sort();
+    generated_id_values.dedup();
 
     CorpusInventory {
         schema_version: 1,
@@ -116,9 +145,13 @@ pub fn inventory_from_sections(file_count: usize, sections: &[Section]) -> Corpu
         sections: sections.len(),
         cases: sections.len(),
         ids: InventoryIds {
-            total: sections.len().saturating_sub(missing_ids),
-            missing: missing_ids,
-            duplicates,
+            explicit: explicit_ids,
+            generated: generated_ids,
+            missing_explicit_ids,
+            generated_ids: generated_id_values,
+            duplicate_effective_ids,
+            duplicate_explicit_ids,
+            id_source_breakdown,
         },
         tags: InventoryTags {
             known: known_tags.into_iter().collect(),
@@ -219,15 +252,19 @@ fn populate_fixture_coverage(gold_root: &Path, inventory: &mut CorpusInventory) 
 mod tests {
     use super::*;
 
-    fn sample_section(id: &str, tags: &[&str], flags: &[&str]) -> Section {
+    fn sample_section(id: &str, explicit: bool, tags: &[&str], flags: &[&str]) -> Section {
         Section {
             id: id.to_string(),
+            id_source: if explicit { IdSource::Explicit } else { IdSource::Generated },
+            explicit_id: explicit.then(|| id.to_string()),
+            generated_id: (!explicit).then(|| id.to_string()),
             title: "title".to_string(),
             file: "sample.txt".to_string(),
             tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
             perl: None,
             flags: flags.iter().map(|flag| (*flag).to_string()).collect(),
             body: "my $x = 1;".to_string(),
+            expected: None,
             line: Some(1),
         }
     }
@@ -235,9 +272,9 @@ mod tests {
     #[test]
     fn inventory_reports_missing_and_duplicate_ids() {
         let sections = vec![
-            sample_section("case.1", &["regex"], &[]),
-            sample_section("case.1", &["regex", "custom-tag"], &["parser-sensitive"]),
-            sample_section("", &["custom-tag"], &["wip"]),
+            sample_section("case.1", true, &["regex"], &[]),
+            sample_section("case.1", true, &["regex", "custom-tag"], &["parser-sensitive"]),
+            sample_section("sample-title-1", false, &["custom-tag"], &["wip"]),
         ];
 
         let inventory = inventory_from_sections(2, &sections);
@@ -245,9 +282,12 @@ mod tests {
         assert_eq!(inventory.schema_version, 1);
         assert_eq!(inventory.files, 2);
         assert_eq!(inventory.sections, 3);
-        assert_eq!(inventory.ids.total, 2);
-        assert_eq!(inventory.ids.missing, 1);
-        assert_eq!(inventory.ids.duplicates, vec!["case.1".to_string()]);
+        assert_eq!(inventory.ids.explicit, 2);
+        assert_eq!(inventory.ids.generated, 1);
+        assert_eq!(inventory.ids.missing_explicit_ids, 1);
+        assert_eq!(inventory.ids.generated_ids, vec!["sample-title-1".to_string()]);
+        assert_eq!(inventory.ids.duplicate_effective_ids, vec!["case.1".to_string()]);
+        assert_eq!(inventory.ids.duplicate_explicit_ids, vec!["case.1".to_string()]);
         assert_eq!(inventory.tags.known, vec!["regex".to_string()]);
         assert_eq!(inventory.tags.unknown, vec!["custom-tag".to_string()]);
         assert_eq!(inventory.markers.parser_sensitive, 1);
@@ -257,14 +297,14 @@ mod tests {
     #[test]
     fn inventory_is_deterministic() {
         let sections = vec![
-            sample_section("z.case", &["z-unknown", "regex"], &["todo"]),
-            sample_section("a.case", &["regex", "a-unknown"], &["parser-sensitive"]),
+            sample_section("z.case", true, &["z-unknown", "regex"], &["todo"]),
+            sample_section("a.case", false, &["regex", "a-unknown"], &["parser-sensitive"]),
         ];
 
         let first = inventory_from_sections(1, &sections);
         let second = inventory_from_sections(1, &sections);
         assert_eq!(first, second);
         assert_eq!(first.tags.unknown, vec!["a-unknown".to_string(), "z-unknown".to_string()]);
-        assert_eq!(first.ids.duplicates, Vec::<String>::new());
+        assert_eq!(first.ids.duplicate_effective_ids, Vec::<String>::new());
     }
 }

--- a/crates/perl-corpus/src/lint.rs
+++ b/crates/perl-corpus/src/lint.rs
@@ -1,4 +1,5 @@
 use crate::meta::Section;
+use crate::metadata::IdSource;
 use anyhow::{Result, bail};
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -297,7 +298,13 @@ pub fn check_sections(sections: &[Section], config: &LintConfig) -> LintResult {
     for section in sections {
         // Check ID format
         if section.id.is_empty() {
-            result.errors.push(format!("Missing @id in {}: {}", section.file, section.title));
+            result
+                .errors
+                .push(format!("Missing effective id in {}: {}", section.file, section.title));
+        } else if matches!(section.id_source, IdSource::Generated) {
+            result
+                .errors
+                .push(format!("Missing explicit @id in {}: {}", section.file, section.title));
         } else if !ID_RE.as_ref().is_some_and(|re| re.is_match(&section.id)) {
             result.errors.push(format!(
                 "Invalid @id format '{}' in {}: {} (must match [a-z0-9._-]+)",

--- a/crates/perl-corpus/src/metadata/mod.rs
+++ b/crates/perl-corpus/src/metadata/mod.rs
@@ -4,4 +4,4 @@ mod query;
 mod section;
 
 pub use query::{find_by_flag, find_by_tag};
-pub use section::Section;
+pub use section::{ExpectedBlock, ExpectedFormat, IdSource, Section};

--- a/crates/perl-corpus/src/metadata/parser.rs
+++ b/crates/perl-corpus/src/metadata/parser.rs
@@ -1,5 +1,5 @@
-use crate::metadata::Section;
 use crate::metadata::ids::{make_section_id, slugify_title};
+use crate::metadata::{ExpectedBlock, ExpectedFormat, IdSource, Section};
 use regex::Regex;
 use std::collections::HashMap;
 use std::path::Path;
@@ -82,13 +82,19 @@ pub fn parse_sections(text: &str, path: &Path) -> Vec<Section> {
             }
         }
 
+        let explicit_id = meta.get("id").cloned().filter(|id| !id.trim().is_empty());
         let id = make_section_id(
-            &meta.get("id").cloned().unwrap_or_default(),
+            explicit_id.as_deref().unwrap_or_default(),
             &file_stem,
             &title,
             section_index,
             &mut auto_ids,
         );
+        let (id_source, generated_id) = if explicit_id.is_some() {
+            (IdSource::Explicit, None)
+        } else {
+            (IdSource::Generated, Some(id.clone()))
+        };
         let tags = meta
             .get("tags")
             .map(|s| {
@@ -107,20 +113,73 @@ pub fn parse_sections(text: &str, path: &Path) -> Vec<Section> {
         let body_end =
             body_lines.iter().position(|line| line.trim() == "---").unwrap_or(body_lines.len());
         let body = body_lines[..body_end].join("\n").trim().to_string();
+        let expected = if body_end < body_lines.len() {
+            let raw = body_lines[body_end + 1..].join("\n").trim().to_string();
+            (!raw.is_empty()).then(|| ExpectedBlock { format: detect_expected_format(&raw), raw })
+        } else {
+            None
+        };
         let line_num = text[..start].lines().count() + 1;
         let file_name = path.file_name().unwrap_or_default();
 
         sections.push(Section {
             id,
+            id_source,
+            explicit_id,
+            generated_id,
             title,
             file: file_name.to_string_lossy().into(),
             tags,
             perl,
             flags,
             body,
+            expected,
             line: Some(line_num),
         });
     }
 
     sections
+}
+
+fn detect_expected_format(raw: &str) -> ExpectedFormat {
+    let trimmed = raw.trim();
+    if trimmed.starts_with('(') && trimmed.contains(')') {
+        return ExpectedFormat::TreeSitterSexp;
+    }
+    if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+        if trimmed.contains("\"diagnostic\"") || trimmed.contains("\"diagnostics\"") {
+            return ExpectedFormat::DiagnosticsJson;
+        }
+        return ExpectedFormat::AstJson;
+    }
+    if trimmed.is_empty() { ExpectedFormat::Unknown } else { ExpectedFormat::PlainText }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn parse_sections_tracks_explicit_and_generated_ids() {
+        let text = "=====\nExplicit\n# @id: explicit.case\nprint 1;\n=====\nGenerated\nprint 2;\n";
+        let sections = parse_sections(text, Path::new("sample.txt"));
+        assert_eq!(sections.len(), 2);
+        assert!(matches!(sections[0].id_source, IdSource::Explicit));
+        assert_eq!(sections[0].explicit_id.as_deref(), Some("explicit.case"));
+        assert!(sections[0].generated_id.is_none());
+        assert!(matches!(sections[1].id_source, IdSource::Generated));
+        assert!(sections[1].explicit_id.is_none());
+        assert_eq!(sections[1].generated_id.as_deref(), Some(sections[1].id.as_str()));
+    }
+
+    #[test]
+    fn parse_sections_preserves_expected_block() {
+        let text = "=====\nHas expected\nprint 1;\n---\n{\"diagnostics\":[]}\n";
+        let sections = parse_sections(text, Path::new("sample.txt"));
+        assert_eq!(sections.len(), 1);
+        let expected = sections[0].expected.as_ref().expect("expected block");
+        assert_eq!(expected.raw, "{\"diagnostics\":[]}");
+        assert!(matches!(expected.format, ExpectedFormat::DiagnosticsJson));
+    }
 }

--- a/crates/perl-corpus/src/metadata/section.rs
+++ b/crates/perl-corpus/src/metadata/section.rs
@@ -1,10 +1,37 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum IdSource {
+    Explicit,
+    Generated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ExpectedFormat {
+    TreeSitterSexp,
+    AstJson,
+    DiagnosticsJson,
+    PlainText,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExpectedBlock {
+    pub raw: String,
+    pub format: ExpectedFormat,
+}
+
 /// A test corpus section with metadata and source code
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Section {
     /// Stable unique key, e.g., "regex.pos.001"
     pub id: String,
+    /// Whether the section id came from `# @id:` or was synthesized.
+    pub id_source: IdSource,
+    /// Explicit `# @id:` value when present.
+    pub explicit_id: Option<String>,
+    /// Generated id value when synthesized.
+    pub generated_id: Option<String>,
 
     /// Display title (line after "=====")
     pub title: String,
@@ -23,6 +50,8 @@ pub struct Section {
 
     /// Body text (source code of the section)
     pub body: String,
+    /// Optional expected output text after `---`.
+    pub expected: Option<ExpectedBlock>,
 
     /// Line number where section starts (for error reporting)
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
### Motivation

- Section parsing previously synthesized IDs and discarded text after `---`, which made linting and inventory unable to tell explicit IDs from generated fallbacks or preserve expected outputs.
- This broke enforceable corpus gates such as `--require-explicit-id` and lost valuable expected-output fixtures used for parser/diagnostic verification. 
- Make ID provenance and expected-block data first-class so lint, inventory, and downstream ratchets can rely on corpus truth.

### Description

- Added `IdSource`, `ExpectedBlock`, and `ExpectedFormat` types and extended `Section` with `id_source`, `explicit_id`, `generated_id`, and `expected` fields to preserve provenance and expected output. (`crates/perl-corpus/src/metadata/section.rs`)
- Updated `parse_sections` to record whether an `# @id:` was explicit or generated and to retain the block after `---` as an `ExpectedBlock` with a best-effort format detector. (`crates/perl-corpus/src/metadata/parser.rs`)
- Changed lint behavior to treat generated IDs as a missing explicit `@id` error so `--require-explicit-id` can be enforced. (`crates/perl-corpus/src/lint.rs`)
- Expanded inventory reporting to include explicit vs generated counts, `missing_explicit_ids`, `generated_ids`, `duplicate_effective_ids`, `duplicate_explicit_ids`, and an `id_source_breakdown`; updated tests to match the richer schema. (`crates/perl-corpus/src/inventory.rs`)
- Re-exported new metadata types from `metadata::mod` so other crates can consume the richer section schema. (`crates/perl-corpus/src/metadata/mod.rs`)

### Testing

- Ran `cargo test -p perl-corpus`, which completed successfully: all unit and integration tests passed. 
- Ran `cargo fmt --all` and `cargo fmt --all --check`, both succeeded and code was formatted.
- Note: the preferred `./scripts/cargo-safe test -p perl-corpus --profile agent --locked` was blocked by the environment storage policy, so it was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f986c246b08333bf6065a7abb9f02e)