### PR TITLE
fix(diagnostics): include code descriptions in pull LSP conversion (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use lsp_types::{
-    Diagnostic as LspDiagnostic, DiagnosticRelatedInformation,
+    CodeDescription, Diagnostic as LspDiagnostic, DiagnosticRelatedInformation,
     DiagnosticSeverity as LspDiagnosticSeverity, DiagnosticTag as LspDiagnosticTag,
     DocumentDiagnosticReport, FullDocumentDiagnosticReport, Location, NumberOrString, Position,
     Range, RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport,
@@ -24,6 +24,7 @@ use perl_parser::Parser;
 use perl_parser::error::ParseError;
 use perl_parser::position::offset_to_utf16_line_col;
 use perl_parser::util::code_slice;
+use std::str::FromStr;
 
 // Import core diagnostics types from perl-lsp-providers (via parent module re-export)
 use super::{
@@ -670,7 +671,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: None,
+            code_description: lsp_code_description(code.as_ref()),
             source: Some("perl-lsp".to_string()),
             message,
             related_information,
@@ -753,7 +754,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: None,
+            code_description: lsp_code_description(code.as_ref()),
             source: diagnostic_source(code_for_source.as_ref()),
             message,
             related_information,
@@ -830,7 +831,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: None,
+            code_description: lsp_code_description(code.as_ref()),
             source: diagnostic_source(code_for_source.as_ref()),
             message,
             related_information: None,
@@ -907,7 +908,7 @@ impl PullDiagnosticsProvider {
             range,
             severity: Some(to_lsp_severity(parse_error_severity(error))),
             code: Some(NumberOrString::String(code_str.to_string())),
-            code_description: None,
+            code_description: lsp_code_description(code.as_ref()),
             source: Some("perl-lsp".to_string()),
             message,
             related_information: to_lsp_related_information(uri, text, &[]),
@@ -915,6 +916,14 @@ impl PullDiagnosticsProvider {
             data,
         }
     }
+}
+
+fn lsp_code_description(code: Option<&NumberOrString>) -> Option<CodeDescription> {
+    let NumberOrString::String(code) = code? else {
+        return None;
+    };
+    let docs_url = DiagnosticCode::parse_code(code).and_then(DiagnosticCode::documentation_url)?;
+    Uri::from_str(docs_url).ok().map(|href| CodeDescription { href })
 }
 
 fn lsp_range_from_offsets(text: &str, start: usize, end: usize) -> Range {


### PR DESCRIPTION
### Motivation

- Pull-based LSP diagnostic conversions were emitting `codeDescription: None` even when stable `PL...` codes in the catalog have documentation URLs, so users lost direct links to docs from pull diagnostics.

### Description

- Added a helper `fn lsp_code_description(code: Option<&NumberOrString>) -> Option<CodeDescription>` in `crates/perl-lsp-rs/src/features/diagnostics/pull.rs` that parses string codes via `DiagnosticCode::parse_code` and supplies a `CodeDescription.href` from `DiagnosticCode::documentation_url()` using `Uri::from_str`.
- Imported `CodeDescription` and `std::str::FromStr` and wired the helper into all pull conversion paths (`to_lsp_diagnostic`, `to_lsp_diagnostic_with_context`, `internal_to_lsp_diagnostic`, and the parse-error fallback) so `codeDescription.href` is populated when available.
- The new logic preserves existing `data`, `source`, `tags`, and message/suggestion behavior while surfacing catalog documentation links in LSP output.

### Testing

- Ran formatter with `./scripts/cargo-safe xtask fmt`, which completed successfully.
- Attempted `./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked --lib -- diagnostics`, but the test run was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp ...`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f986c8ec0c8333ac3e4f0d2abdc862)