### PR TITLE
fix(dead-code): make unreachable detection block-aware (#0000)

### DIFF
--- a/crates/perl-dead-code/src/lib.rs
+++ b/crates/perl-dead-code/src/lib.rs
@@ -119,34 +119,60 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
+        let mut block_depth = 0_usize;
+        let mut terminator: Option<(usize, String, usize)> = None;
+        let mut unreachable_start: Option<usize> = None;
+        let mut unreachable_end: Option<usize> = None;
 
         for (i, line) in text.lines().enumerate() {
+            let line_no = i + 1;
             let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
-                    dead.push(DeadCode {
-                        code_type: DeadCodeType::UnreachableCode,
-                        name: None,
-                        file_path: file_path.to_path_buf(),
-                        start_line: i + 1,
-                        end_line: i + 1,
-                        reason: format!(
-                            "Code is unreachable after `{}` on line {}",
-                            term_kw, term_line
-                        ),
-                        confidence: 0.5,
-                        suggestion: Some("Remove or restructure this code".to_string()),
-                    });
-                    break;
+
+            let is_structural_only = trimmed.chars().all(|ch| matches!(ch, '{' | '}' | ';'));
+            let is_effective_code = !trimmed.is_empty() && !is_structural_only;
+
+            if let Some((_, _, term_depth)) = terminator {
+                if block_depth < term_depth {
+                    terminator = None;
+                } else if block_depth == term_depth && is_effective_code {
+                    unreachable_start = Some(unreachable_start.unwrap_or(line_no));
+                    unreachable_end = Some(line_no);
                 }
             }
 
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
+            if terminator.is_none()
+                && is_effective_code
+                && ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw))
+                && let Some(first_word) = trimmed.split_whitespace().next()
+            {
+                terminator = Some((line_no, first_word.to_string(), block_depth));
+            }
+
+            for ch in line.chars() {
+                match ch {
+                    '{' => block_depth += 1,
+                    '}' => block_depth = block_depth.saturating_sub(1),
+                    _ => {}
                 }
             }
+        }
+
+        if let (Some((term_line, term_kw, _)), Some(start_line), Some(end_line)) =
+            (terminator, unreachable_start, unreachable_end)
+        {
+            dead.push(DeadCode {
+                code_type: DeadCodeType::UnreachableCode,
+                name: None,
+                file_path: file_path.to_path_buf(),
+                start_line,
+                end_line,
+                reason: format!(
+                    "Code is unreachable after `{}` on line {} in the same block",
+                    term_kw, term_line
+                ),
+                confidence: 0.8,
+                suggestion: Some("Remove or restructure this code".to_string()),
+            });
         }
 
         // Dead branch detection: scan for constant-condition patterns.

--- a/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
@@ -226,14 +226,16 @@ fn analyze_file_error_for_unindexed_file() {
 }
 
 #[test]
-fn analyze_file_only_flags_first_unreachable_line() -> Result<(), String> {
-    // The implementation breaks after the first unreachable line
+fn analyze_file_reports_full_unreachable_range() -> Result<(), String> {
+    // Detector should coalesce contiguous unreachable statements into a range
     let code = "return;\nprint 1;\nprint 2;\n";
     let index = index_with_file("file:///test_multi.pl", code)?;
     let detector = DeadCodeDetector::new(index);
 
     let results = detector.analyze_file(&PathBuf::from("/test_multi.pl"))?;
-    assert_eq!(results.len(), 1, "detector should report only first unreachable line");
+    assert_eq!(results.len(), 1, "detector should report a single unreachable range");
+    assert_eq!(results[0].start_line, 2);
+    assert_eq!(results[0].end_line, 3);
     Ok(())
 }
 
@@ -242,16 +244,14 @@ fn analyze_file_only_flags_first_unreachable_line() -> Result<(), String> {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn analyze_file_return_at_end_of_sub_flags_closing_brace() -> Result<(), String> {
-    // The stub implementation is line-by-line and flags the closing brace
-    // since it is the next non-empty line after `return`
+fn analyze_file_return_at_end_of_sub_does_not_flag_closing_brace() -> Result<(), String> {
+    // Structural braces should not be reported as unreachable statements
     let code = "sub foo {\n    return 42;\n}\n";
     let index = index_with_file("file:///test_end_return.pl", code)?;
     let detector = DeadCodeDetector::new(index);
 
     let results = detector.analyze_file(&PathBuf::from("/test_end_return.pl"))?;
-    assert_eq!(results.len(), 1, "closing brace after return is flagged by stub");
-    assert_eq!(results[0].start_line, 3);
+    assert!(results.is_empty(), "closing brace after return should not be flagged");
     Ok(())
 }
 

--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -112,34 +112,60 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
+        let mut block_depth = 0_usize;
+        let mut terminator: Option<(usize, String, usize)> = None;
+        let mut unreachable_start: Option<usize> = None;
+        let mut unreachable_end: Option<usize> = None;
 
         for (i, line) in text.lines().enumerate() {
+            let line_no = i + 1;
             let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
-                    dead.push(DeadCode {
-                        code_type: DeadCodeType::UnreachableCode,
-                        name: None,
-                        file_path: file_path.to_path_buf(),
-                        start_line: i + 1,
-                        end_line: i + 1,
-                        reason: format!(
-                            "Code is unreachable after `{}` on line {}",
-                            term_kw, term_line
-                        ),
-                        confidence: 0.5,
-                        suggestion: Some("Remove or restructure this code".to_string()),
-                    });
-                    break;
+
+            let is_structural_only = trimmed.chars().all(|ch| matches!(ch, '{' | '}' | ';'));
+            let is_effective_code = !trimmed.is_empty() && !is_structural_only;
+
+            if let Some((_, _, term_depth)) = terminator {
+                if block_depth < term_depth {
+                    terminator = None;
+                } else if block_depth == term_depth && is_effective_code {
+                    unreachable_start = Some(unreachable_start.unwrap_or(line_no));
+                    unreachable_end = Some(line_no);
                 }
             }
 
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
+            if terminator.is_none()
+                && is_effective_code
+                && ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw))
+                && let Some(first_word) = trimmed.split_whitespace().next()
+            {
+                terminator = Some((line_no, first_word.to_string(), block_depth));
+            }
+
+            for ch in line.chars() {
+                match ch {
+                    '{' => block_depth += 1,
+                    '}' => block_depth = block_depth.saturating_sub(1),
+                    _ => {}
                 }
             }
+        }
+
+        if let (Some((term_line, term_kw, _)), Some(start_line), Some(end_line)) =
+            (terminator, unreachable_start, unreachable_end)
+        {
+            dead.push(DeadCode {
+                code_type: DeadCodeType::UnreachableCode,
+                name: None,
+                file_path: file_path.to_path_buf(),
+                start_line,
+                end_line,
+                reason: format!(
+                    "Code is unreachable after `{}` on line {} in the same block",
+                    term_kw, term_line
+                ),
+                confidence: 0.8,
+                suggestion: Some("Remove or restructure this code".to_string()),
+            });
         }
 
         // Dead branch detection: scan for constant-condition patterns.


### PR DESCRIPTION
### Motivation

- The existing unreachable-code detector was a line-based stub that flagged the first non-empty line after a terminator and could falsely report structural tokens (e.g. a closing brace) as unreachable. 
- Tests and the README expect block-scoped unreachable ranges and a more conservative behavior that will be usable as a foundation for later reachability work.

### Description

- Replace the first-line heuristic with a block-aware scan that tracks `block_depth` and records a `terminator` with its block depth so only effective code in the same block after a terminator is considered unreachable. 
- Ignore structural-only lines (lines that contain only `{`, `}`, or `;`) when deciding unreachable code, and coalesce contiguous unreachable statements into a single `DeadCode` range (`start_line`/`end_line`) with a higher confidence. 
- Apply the same change to both `crates/perl-dead-code/src/lib.rs` and the mirrored compatibility module `crates/perl-parser/src/dead_code/mod.rs`, and update tests in `crates/perl-dead-code/tests/comprehensive_unit_tests.rs` to assert full-range reporting and to avoid the closing-brace false positive.

### Testing

- Ran `cargo test -p perl-dead-code` during development which initially surfaced the existing failing expectation tied to the old stub behavior (one failing test), motivating the change. 
- After the change, ran `cargo test -p perl-dead-code --test comprehensive_unit_tests` and the suite passed (`47 passed; 0 failed`).
- Attempted the repository wrapper check `./scripts/cargo-safe test -p perl-dead-code --profile agent --locked` but it was blocked in this environment by storage policy, so it was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f986d169a88333845838522f58832a)