### PR TITLE
fix(dead-code): report block-scoped unreachable ranges (#0000)

### DIFF
--- a/crates/perl-dead-code/src/lib.rs
+++ b/crates/perl-dead-code/src/lib.rs
@@ -119,40 +119,101 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
-
-        for (i, line) in text.lines().enumerate() {
-            let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
-                    dead.push(DeadCode {
-                        code_type: DeadCodeType::UnreachableCode,
-                        name: None,
-                        file_path: file_path.to_path_buf(),
-                        start_line: i + 1,
-                        end_line: i + 1,
-                        reason: format!(
-                            "Code is unreachable after `{}` on line {}",
-                            term_kw, term_line
-                        ),
-                        confidence: 0.5,
-                        suggestion: Some("Remove or restructure this code".to_string()),
-                    });
-                    break;
-                }
-            }
-
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
-                }
-            }
-        }
+        dead.extend(self.detect_unreachable_ranges(file_path, &text));
 
         // Dead branch detection: scan for constant-condition patterns.
         detect_dead_branches(file_path, &text, &mut dead);
 
         Ok(dead)
+    }
+
+    fn detect_unreachable_ranges(&self, file_path: &Path, text: &str) -> Vec<DeadCode> {
+        let mut findings = Vec::new();
+        let mut depth: i32 = 0;
+        let mut terminator: Option<(usize, String, i32)> = None;
+        let mut unreachable_start: Option<usize> = None;
+        let mut unreachable_end: Option<usize> = None;
+        let mut in_pod = false;
+
+        for (i, line) in text.lines().enumerate() {
+            let line_no = i + 1;
+            let trimmed = line.trim();
+
+            if trimmed.starts_with("=") && !trimmed.starts_with("=cut") {
+                in_pod = true;
+            }
+            if trimmed == "=cut" {
+                in_pod = false;
+                continue;
+            }
+            if in_pod {
+                continue;
+            }
+
+            let close_count = trimmed.chars().filter(|c| *c == '}').count() as i32;
+            let open_count = trimmed.chars().filter(|c| *c == '{').count() as i32;
+            let depth_before = depth;
+            depth -= close_count;
+
+            let is_comment = trimmed.starts_with('#');
+            let is_structural = trimmed.is_empty() || is_comment || trimmed == "{" || trimmed == "}";
+
+            if let Some((term_line, term_kw, term_depth)) = &terminator {
+                if depth_before < *term_depth {
+                    if let (Some(start), Some(end)) = (unreachable_start.take(), unreachable_end.take()) {
+                        findings.push(DeadCode {
+                            code_type: DeadCodeType::UnreachableCode,
+                            name: None,
+                            file_path: file_path.to_path_buf(),
+                            start_line: start,
+                            end_line: end,
+                            reason: format!("Code is unreachable after `{}` on line {}", term_kw, term_line),
+                            confidence: 0.8,
+                            suggestion: Some("Remove or restructure this code".to_string()),
+                        });
+                    }
+                    terminator = None;
+                } else if !is_structural {
+                    unreachable_start.get_or_insert(line_no);
+                    unreachable_end = Some(line_no);
+                }
+            }
+
+            if terminator.is_none() && Self::is_terminator(trimmed) {
+                if let Some(first_word) = trimmed.split_whitespace().next() {
+                    terminator = Some((line_no, first_word.trim_end_matches(';').to_string(), depth_before));
+                }
+            }
+
+            depth += open_count;
+        }
+
+        if let Some((term_line, term_kw, _)) = terminator
+            && let (Some(start), Some(end)) = (unreachable_start, unreachable_end)
+        {
+            findings.push(DeadCode {
+                code_type: DeadCodeType::UnreachableCode,
+                name: None,
+                file_path: file_path.to_path_buf(),
+                start_line: start,
+                end_line: end,
+                reason: format!("Code is unreachable after `{}` on line {}", term_kw, term_line),
+                confidence: 0.8,
+                suggestion: Some("Remove or restructure this code".to_string()),
+            });
+        }
+
+        findings
+    }
+
+    fn is_terminator(trimmed: &str) -> bool {
+        ["return", "die", "exit", "goto", "last", "next", "redo"]
+            .iter()
+            .any(|kw| {
+                trimmed == *kw
+                    || trimmed.starts_with(&format!("{kw} "))
+                    || trimmed.starts_with(&format!("{kw};"))
+            })
     }
 
     /// Analyze entire workspace for dead code

--- a/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
@@ -226,14 +226,15 @@ fn analyze_file_error_for_unindexed_file() {
 }
 
 #[test]
-fn analyze_file_only_flags_first_unreachable_line() -> Result<(), String> {
-    // The implementation breaks after the first unreachable line
+fn analyze_file_reports_full_unreachable_range() -> Result<(), String> {
     let code = "return;\nprint 1;\nprint 2;\n";
     let index = index_with_file("file:///test_multi.pl", code)?;
     let detector = DeadCodeDetector::new(index);
 
     let results = detector.analyze_file(&PathBuf::from("/test_multi.pl"))?;
-    assert_eq!(results.len(), 1, "detector should report only first unreachable line");
+    assert_eq!(results.len(), 1, "detector should aggregate one unreachable range");
+    assert_eq!(results[0].start_line, 2);
+    assert_eq!(results[0].end_line, 3);
     Ok(())
 }
 
@@ -242,16 +243,13 @@ fn analyze_file_only_flags_first_unreachable_line() -> Result<(), String> {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn analyze_file_return_at_end_of_sub_flags_closing_brace() -> Result<(), String> {
-    // The stub implementation is line-by-line and flags the closing brace
-    // since it is the next non-empty line after `return`
+fn analyze_file_return_at_end_of_sub_does_not_flag_closing_brace() -> Result<(), String> {
     let code = "sub foo {\n    return 42;\n}\n";
     let index = index_with_file("file:///test_end_return.pl", code)?;
     let detector = DeadCodeDetector::new(index);
 
     let results = detector.analyze_file(&PathBuf::from("/test_end_return.pl"))?;
-    assert_eq!(results.len(), 1, "closing brace after return is flagged by stub");
-    assert_eq!(results[0].start_line, 3);
+    assert!(results.is_empty(), "closing brace after return should not be flagged");
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation

- The existing unreachable-code detector was a line-based stub that reported only the first unreachable line and could false-positive on structural tokens like closing braces.
- This made unreachable findings noisy and unsuitable as the basis for future block- and workspace-level reachability improvements.

### Description

- Replaced the single-line stub with a block-scoped unreachable-range detector implemented as `detect_unreachable_ranges` which tracks block depth and emits one finding per contiguous unreachable range. 
- Recognizes a broader set of terminators (`return`, `die`, `exit`, `goto`, `last`, `next`, `redo`), skips POD and comment/structural lines, and avoids flagging closing-brace-only lines as unreachable. 
- Integrates the new range detector into `analyze_file` and preserves existing dead-branch detection by calling `detect_dead_branches` afterwards. 
- Updated unit tests to assert full-range reporting and to ensure a closing brace after `return` inside a `sub` is not reported.

### Testing

- Ran `cargo test -p perl-dead-code --all-targets` and all tests passed: comprehensive unit suite ran 47 tests (47 passed, 0 failed) and behavior fixtures ran 5 tests (5 passed, 0 failed). 
- The environment `./scripts/cargo-safe` invocation was not executed due to local environment storage policy and therefore was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f986d169a88333845838522f58832a)