### PR TITLE
fix(dead-code): avoid structural-line unreachable false positives (#0000)

### DIFF
--- a/crates/perl-dead-code/src/lib.rs
+++ b/crates/perl-dead-code/src/lib.rs
@@ -119,34 +119,46 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
+        let mut block_depth: i32 = 0;
+        let mut terminator: Option<(usize, String, i32)> = None;
 
         for (i, line) in text.lines().enumerate() {
             let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
+            let line_number = i + 1;
+
+            let open_count = line.chars().filter(|&ch| ch == '{').count() as i32;
+            let close_count = line.chars().filter(|&ch| ch == '}').count() as i32;
+
+            if let Some((term_line, term_kw, term_depth)) = &terminator {
+                if block_depth < *term_depth {
+                    terminator = None;
+                } else if block_depth == *term_depth
+                    && !trimmed.is_empty()
+                    && !trimmed.starts_with('#')
+                    && !is_structural_only(trimmed)
+                {
                     dead.push(DeadCode {
                         code_type: DeadCodeType::UnreachableCode,
                         name: None,
                         file_path: file_path.to_path_buf(),
-                        start_line: i + 1,
-                        end_line: i + 1,
+                        start_line: line_number,
+                        end_line: line_number,
                         reason: format!(
                             "Code is unreachable after `{}` on line {}",
                             term_kw, term_line
                         ),
-                        confidence: 0.5,
+                        confidence: 0.9,
                         suggestion: Some("Remove or restructure this code".to_string()),
                     });
-                    break;
+                    terminator = None;
                 }
             }
 
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
-                }
+            if let Some(term_kw) = unconditional_terminator_keyword(trimmed) {
+                terminator = Some((line_number, term_kw.to_string(), block_depth));
             }
+
+            block_depth += open_count - close_count;
         }
 
         // Dead branch detection: scan for constant-condition patterns.

--- a/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
@@ -242,16 +242,24 @@ fn analyze_file_only_flags_first_unreachable_line() -> Result<(), String> {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn analyze_file_return_at_end_of_sub_flags_closing_brace() -> Result<(), String> {
-    // The stub implementation is line-by-line and flags the closing brace
-    // since it is the next non-empty line after `return`
+fn analyze_file_return_at_end_of_sub_does_not_flag_closing_brace() -> Result<(), String> {
     let code = "sub foo {\n    return 42;\n}\n";
     let index = index_with_file("file:///test_end_return.pl", code)?;
     let detector = DeadCodeDetector::new(index);
 
     let results = detector.analyze_file(&PathBuf::from("/test_end_return.pl"))?;
-    assert_eq!(results.len(), 1, "closing brace after return is flagged by stub");
-    assert_eq!(results[0].start_line, 3);
+    assert!(results.is_empty(), "closing brace must not be reported as unreachable");
+    Ok(())
+}
+
+#[test]
+fn analyze_file_postfix_conditional_return_does_not_mark_following_code() -> Result<(), String> {
+    let code = "return if $cond;\nsay \"live\";\n";
+    let index = index_with_file("file:///test_postfix.pl", code)?;
+    let detector = DeadCodeDetector::new(index);
+
+    let results = detector.analyze_file(&PathBuf::from("/test_postfix.pl"))?;
+    assert!(results.is_empty(), "postfix-conditional return is not an unconditional terminator");
     Ok(())
 }
 

--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -112,34 +112,46 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
+        let mut block_depth: i32 = 0;
+        let mut terminator: Option<(usize, String, i32)> = None;
 
         for (i, line) in text.lines().enumerate() {
             let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
+            let line_number = i + 1;
+
+            let open_count = line.chars().filter(|&ch| ch == '{').count() as i32;
+            let close_count = line.chars().filter(|&ch| ch == '}').count() as i32;
+
+            if let Some((term_line, term_kw, term_depth)) = &terminator {
+                if block_depth < *term_depth {
+                    terminator = None;
+                } else if block_depth == *term_depth
+                    && !trimmed.is_empty()
+                    && !trimmed.starts_with('#')
+                    && !is_structural_only(trimmed)
+                {
                     dead.push(DeadCode {
                         code_type: DeadCodeType::UnreachableCode,
                         name: None,
                         file_path: file_path.to_path_buf(),
-                        start_line: i + 1,
-                        end_line: i + 1,
+                        start_line: line_number,
+                        end_line: line_number,
                         reason: format!(
                             "Code is unreachable after `{}` on line {}",
                             term_kw, term_line
                         ),
-                        confidence: 0.5,
+                        confidence: 0.9,
                         suggestion: Some("Remove or restructure this code".to_string()),
                     });
-                    break;
+                    terminator = None;
                 }
             }
 
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
-                }
+            if let Some(term_kw) = unconditional_terminator_keyword(trimmed) {
+                terminator = Some((line_number, term_kw.to_string(), block_depth));
             }
+
+            block_depth += open_count - close_count;
         }
 
         // Dead branch detection: scan for constant-condition patterns.
@@ -206,6 +218,39 @@ impl DeadCodeDetector {
 
         DeadCodeAnalysis { dead_code, stats, files_analyzed: docs.len(), total_lines }
     }
+}
+
+fn is_structural_only(trimmed: &str) -> bool {
+    !trimmed.is_empty() && trimmed.chars().all(|ch| matches!(ch, '{' | '}' | ';'))
+}
+
+fn unconditional_terminator_keyword(trimmed: &str) -> Option<&'static str> {
+    for keyword in ["return", "die", "exit", "CORE::exit"] {
+        let Some(rest) = trimmed.strip_prefix(keyword) else {
+            continue;
+        };
+
+        if let Some(ch) = rest.chars().next()
+            && !ch.is_whitespace()
+            && ch != ';'
+            && ch != '('
+        {
+            continue;
+        }
+
+        if has_postfix_conditional(rest) {
+            return None;
+        }
+
+        return Some(keyword);
+    }
+
+    None
+}
+
+fn has_postfix_conditional(rest: &str) -> bool {
+    let lowered = rest.to_ascii_lowercase();
+    [" if ", " unless ", " while ", " until "].iter().any(|kw| lowered.contains(kw))
 }
 
 /// Returns `true` if `condition` is a trivially-false constant expression.


### PR DESCRIPTION
### Motivation

- The existing dead-code detector used a line-prefix scan and flagged structural lines like `}` as unreachable after terminators (e.g., `return`), producing false positives.
- The detector also matched terminator keywords with a blunt `starts_with` approach and treated postfix forms like `return if $cond;` as unconditional, reducing precision.
- The change aims to make unreachable detection block-aware and token-aware enough to avoid obvious syntactic false positives while keeping the public API stable. 

### Description

- Added block-depth tracking in `analyze_file` and only mark later executable statements in the same block as unreachable, skipping structural-only lines and comments. 
- Introduced helper functions `is_structural_only`, `unconditional_terminator_keyword`, and `has_postfix_conditional` to avoid `return42` and postfix-conditional false positives and to accept `CORE::exit` as a terminator. 
- Raised confidence for unconditional unreachable findings from `0.5` to `0.9` for stronger signals. 
- Updated regression tests in `crates/perl-dead-code/tests/comprehensive_unit_tests.rs` to assert that a closing brace is not reported and added a test that a postfix-conditional `return` does not mark following code unreachable. 
- Applied the same detection logic to both `crates/perl-parser/src/dead_code/mod.rs` and the `perl-dead-code` crate wrapper to keep behavior consistent after Wave 4 absorption. 

### Testing

- Ran formatting with `./scripts/cargo-safe xtask fmt` in this environment (toolchain invoked and ran as part of the rollout). 
- Attempted `./scripts/cargo-safe test -p perl-dead-code --profile agent --locked` but it was blocked by the environment storage policy (`DENY` on cache); no full test run completed via that command. 
- Executed `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-dead-code --all-targets`, which began compilation successfully in this session but did not complete before the session handoff; new unit tests were added and are included in the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f986e042908333b1da8c8b51933901)