### PR TITLE
fix(dead-code): avoid brace false positives and postfix terminator matches (#0000)

### DIFF
--- a/crates/perl-dead-code/src/lib.rs
+++ b/crates/perl-dead-code/src/lib.rs
@@ -119,34 +119,43 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
+        let mut pending_terminator: Option<(usize, String, i32)> = None;
+        let mut block_depth = 0i32;
 
         for (i, line) in text.lines().enumerate() {
+            let line_number = i + 1;
             let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
+            let line_depth = block_depth;
+            let brace_delta =
+                line.chars()
+                    .fold(0i32, |acc, ch| acc + i32::from(ch == '{') - i32::from(ch == '}'));
+
+            if let Some((term_line, term_kw, term_depth)) = &pending_terminator {
+                if line_depth < *term_depth {
+                    pending_terminator = None;
+                } else if !trimmed.is_empty() && trimmed != "}" {
                     dead.push(DeadCode {
                         code_type: DeadCodeType::UnreachableCode,
                         name: None,
                         file_path: file_path.to_path_buf(),
-                        start_line: i + 1,
-                        end_line: i + 1,
+                        start_line: line_number,
+                        end_line: line_number,
                         reason: format!(
                             "Code is unreachable after `{}` on line {}",
                             term_kw, term_line
                         ),
-                        confidence: 0.5,
+                        confidence: 1.0,
                         suggestion: Some("Remove or restructure this code".to_string()),
                     });
                     break;
                 }
             }
 
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
-                }
+            if let Some(keyword) = detect_unconditional_terminator(trimmed) {
+                pending_terminator = Some((line_number, keyword.to_string(), line_depth));
             }
+
+            block_depth += brace_delta;
         }
 
         // Dead branch detection: scan for constant-condition patterns.
@@ -213,4 +222,41 @@ impl DeadCodeDetector {
 
         DeadCodeAnalysis { dead_code, stats, files_analyzed: docs.len(), total_lines }
     }
+}
+
+fn detect_unconditional_terminator(trimmed: &str) -> Option<&'static str> {
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("CORE::exit") {
+        return is_unconditional_terminator(rest).then_some("CORE::exit");
+    }
+
+    for keyword in ["return", "die", "exit"] {
+        if let Some(rest) = trimmed.strip_prefix(keyword) {
+            if is_word_boundary(rest) && is_unconditional_terminator(rest) {
+                return Some(keyword);
+            }
+        }
+    }
+
+    None
+}
+
+fn is_word_boundary(rest: &str) -> bool {
+    rest.chars()
+        .next()
+        .is_none_or(|ch| ch.is_whitespace() || matches!(ch, ';' | '(' | '{'))
+}
+
+fn is_unconditional_terminator(rest: &str) -> bool {
+    let before_comment = rest.split('#').next().unwrap_or_default().trim();
+    if before_comment.is_empty() {
+        return true;
+    }
+    !(before_comment.starts_with("if ")
+        || before_comment.starts_with("unless ")
+        || before_comment.contains(" if ")
+        || before_comment.contains(" unless "))
 }

--- a/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
@@ -242,16 +242,40 @@ fn analyze_file_only_flags_first_unreachable_line() -> Result<(), String> {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn analyze_file_return_at_end_of_sub_flags_closing_brace() -> Result<(), String> {
-    // The stub implementation is line-by-line and flags the closing brace
-    // since it is the next non-empty line after `return`
+fn analyze_file_return_at_end_of_sub_does_not_flag_closing_brace() -> Result<(), String> {
     let code = "sub foo {\n    return 42;\n}\n";
     let index = index_with_file("file:///test_end_return.pl", code)?;
     let detector = DeadCodeDetector::new(index);
 
     let results = detector.analyze_file(&PathBuf::from("/test_end_return.pl"))?;
-    assert_eq!(results.len(), 1, "closing brace after return is flagged by stub");
+    assert!(results.is_empty(), "closing brace should not be flagged as unreachable");
+    Ok(())
+}
+
+#[test]
+fn analyze_file_unconditional_return_flags_next_statement() -> Result<(), String> {
+    let code = "sub foo {\n    return 42;\n    say \"dead\";\n}\n";
+    let index = index_with_file("file:///test_dead_statement.pl", code)?;
+    let detector = DeadCodeDetector::new(index);
+
+    let results = detector.analyze_file(&PathBuf::from("/test_dead_statement.pl"))?;
+    assert_eq!(results.len(), 1, "statement after unconditional return should be dead");
     assert_eq!(results[0].start_line, 3);
+    assert_eq!(results[0].code_type, DeadCodeType::UnreachableCode);
+    Ok(())
+}
+
+#[test]
+fn analyze_file_postfix_conditional_return_is_not_unconditional() -> Result<(), String> {
+    let code = "return if $cond;\nsay \"live\";\n";
+    let index = index_with_file("file:///test_return_if.pl", code)?;
+    let detector = DeadCodeDetector::new(index);
+
+    let results = detector.analyze_file(&PathBuf::from("/test_return_if.pl"))?;
+    assert!(
+        !results.iter().any(|item| item.code_type == DeadCodeType::UnreachableCode),
+        "postfix conditional return should not trigger unreachable diagnostics"
+    );
     Ok(())
 }
 

--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -112,34 +112,43 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
+        let mut pending_terminator: Option<(usize, String, i32)> = None;
+        let mut block_depth = 0i32;
 
         for (i, line) in text.lines().enumerate() {
+            let line_number = i + 1;
             let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
+            let line_depth = block_depth;
+            let brace_delta =
+                line.chars()
+                    .fold(0i32, |acc, ch| acc + i32::from(ch == '{') - i32::from(ch == '}'));
+
+            if let Some((term_line, term_kw, term_depth)) = &pending_terminator {
+                if line_depth < *term_depth {
+                    pending_terminator = None;
+                } else if !trimmed.is_empty() && trimmed != "}" {
                     dead.push(DeadCode {
                         code_type: DeadCodeType::UnreachableCode,
                         name: None,
                         file_path: file_path.to_path_buf(),
-                        start_line: i + 1,
-                        end_line: i + 1,
+                        start_line: line_number,
+                        end_line: line_number,
                         reason: format!(
                             "Code is unreachable after `{}` on line {}",
                             term_kw, term_line
                         ),
-                        confidence: 0.5,
+                        confidence: 1.0,
                         suggestion: Some("Remove or restructure this code".to_string()),
                     });
                     break;
                 }
             }
 
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
-                }
+            if let Some(keyword) = detect_unconditional_terminator(trimmed) {
+                pending_terminator = Some((line_number, keyword.to_string(), line_depth));
             }
+
+            block_depth += brace_delta;
         }
 
         // Dead branch detection: scan for constant-condition patterns.
@@ -206,6 +215,43 @@ impl DeadCodeDetector {
 
         DeadCodeAnalysis { dead_code, stats, files_analyzed: docs.len(), total_lines }
     }
+}
+
+fn detect_unconditional_terminator(trimmed: &str) -> Option<&'static str> {
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("CORE::exit") {
+        return is_unconditional_terminator(rest).then_some("CORE::exit");
+    }
+
+    for keyword in ["return", "die", "exit"] {
+        if let Some(rest) = trimmed.strip_prefix(keyword) {
+            if is_word_boundary(rest) && is_unconditional_terminator(rest) {
+                return Some(keyword);
+            }
+        }
+    }
+
+    None
+}
+
+fn is_word_boundary(rest: &str) -> bool {
+    rest.chars()
+        .next()
+        .is_none_or(|ch| ch.is_whitespace() || matches!(ch, ';' | '(' | '{'))
+}
+
+fn is_unconditional_terminator(rest: &str) -> bool {
+    let before_comment = rest.split('#').next().unwrap_or_default().trim();
+    if before_comment.is_empty() {
+        return true;
+    }
+    !(before_comment.starts_with("if ")
+        || before_comment.starts_with("unless ")
+        || before_comment.contains(" if ")
+        || before_comment.contains(" unless "))
 }
 
 /// Returns `true` if `condition` is a trivially-false constant expression.

--- a/crates/perl-parser/tests/dead_code_detector.rs
+++ b/crates/perl-parser/tests/dead_code_detector.rs
@@ -37,3 +37,33 @@ fn detects_dead_code() -> TestResult {
     ));
     Ok(())
 }
+
+#[test]
+fn return_at_end_of_sub_does_not_flag_closing_brace() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index.index_file_str("file:///module.pm", "sub foo {\n    return 42;\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/module.pm"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::UnreachableCode),
+        "closing brace should not be flagged as unreachable"
+    );
+    Ok(())
+}
+
+#[test]
+fn postfix_conditional_return_is_not_unconditional_terminator() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index.index_file_str("file:///script.pl", "return if $cond;\nsay 'live';\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::UnreachableCode),
+        "postfix conditional return should not produce unreachable diagnostics"
+    );
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Prevent spurious unreachable findings where a `}`-only line (closing brace) was flagged after a terminator like `return` by making detection block-aware. 
- Replace blunt `starts_with` matching for `return`/`die`/`exit` with token-aware logic so postfix conditionals (`return if ...`) and identifier mash-ups (`return42`) are not treated as unconditional terminators.
- Keep the absorbed and compat surfaces in sync by applying the fix to both `perl-dead-code` and the canonical `perl_parser::dead_code` surface to avoid implementation drift.

### Description

- Added block-depth tracking and `pending_terminator` (line, keyword, depth) so an unconditional terminator only marks later executable statements in the same block as unreachable, and `}`-only lines are treated as structural not executable. 
- Replaced simple `starts_with(...)` logic with `detect_unconditional_terminator`, `is_word_boundary`, and `is_unconditional_terminator` helpers that enforce word boundaries, ignore comment-only lines, recognize `CORE::exit`, and filter out postfix conditionals like `if`/`unless`.
- Increased confidence to `1.0` for syntactic unconditional-terminator cases produced by this scanner. 
- Applied identical fixes to both `crates/perl-dead-code/src/lib.rs` and `crates/perl-parser/src/dead_code/mod.rs` to maintain a single canonical implementation surface. 
- Added regression tests exercising the new behavior: do not flag closing brace after `return`, do flag a real statement after an unconditional `return`, and do not flag statements after postfix `return if ...`. Tests were added/updated in `crates/perl-dead-code/tests/comprehensive_unit_tests.rs` and `crates/perl-parser/tests/dead_code_detector.rs`.

### Testing

- Ran `cargo test -p perl-dead-code --all-targets --locked` and the `perl-dead-code` test suite passed (all new and existing tests succeeded). 
- Added unit tests covering: `return` at end-of-sub no longer flags `}`, unconditional-`return` followed by statement is reported, and postfix-conditional `return` does not count as unconditional; these tests pass for the compat crate. 
- Attempted to run the broader `perl-parser` verification and Wave 4 absorption checks in this environment but those runs were impacted by long-running compilation / file-lock contention; the change was applied to the `perl-parser` dead-code module and the corresponding tests were added, but a full `./scripts/cargo-safe test -p perl-parser` run was blocked in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f986e042908333b1da8c8b51933901)