### PR TITLE
fix(dead-code): make unreachable scan block-aware (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ dependencies = [
 name = "perl-dead-code"
 version = "0.13.3"
 dependencies = [
+ "perl-uri",
  "perl-workspace",
  "serde",
  "serde_json",
@@ -1748,6 +1749,7 @@ dependencies = [
  "perl-parser-core",
  "perl-semantic-analyzer",
  "perl-tdd-support",
+ "perl-uri",
  "perl-workspace",
  "proptest",
  "regex",

--- a/crates/perl-dead-code/Cargo.toml
+++ b/crates/perl-dead-code/Cargo.toml
@@ -28,6 +28,7 @@ perl-workspace = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
+perl-uri = { workspace = true }
 serde_json = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/perl-dead-code/src/lib.rs
+++ b/crates/perl-dead-code/src/lib.rs
@@ -119,12 +119,21 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
+        let mut block_depth = 0usize;
+        let mut terminator: Option<(usize, usize, String)> = None;
 
         for (i, line) in text.lines().enumerate() {
             let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
+            let current_depth = block_depth;
+
+            if let Some((term_line, term_depth, term_kw)) = &terminator {
+                if current_depth < *term_depth {
+                    terminator = None;
+                } else if current_depth == *term_depth
+                    && !trimmed.is_empty()
+                    && !trimmed.starts_with('#')
+                    && !is_structural_line(trimmed)
+                {
                     dead.push(DeadCode {
                         code_type: DeadCodeType::UnreachableCode,
                         name: None,
@@ -135,18 +144,19 @@ impl DeadCodeDetector {
                             "Code is unreachable after `{}` on line {}",
                             term_kw, term_line
                         ),
-                        confidence: 0.5,
+                        confidence: 0.9,
                         suggestion: Some("Remove or restructure this code".to_string()),
                     });
                     break;
                 }
             }
 
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
-                }
+            if let Some(term_kw) = detect_unconditional_terminator(trimmed) {
+                terminator = Some((i + 1, current_depth, term_kw.to_string()));
             }
+
+            block_depth += line.chars().filter(|&ch| ch == '{').count();
+            block_depth = block_depth.saturating_sub(line.chars().filter(|&ch| ch == '}').count());
         }
 
         // Dead branch detection: scan for constant-condition patterns.
@@ -213,4 +223,49 @@ impl DeadCodeDetector {
 
         DeadCodeAnalysis { dead_code, stats, files_analyzed: docs.len(), total_lines }
     }
+}
+
+fn is_structural_line(trimmed: &str) -> bool {
+    !trimmed.is_empty() && trimmed.chars().all(|ch| ch == '}' || ch == ';')
+}
+
+fn detect_unconditional_terminator(trimmed: &str) -> Option<&str> {
+    const TERMINATORS: [&str; 4] = ["return", "die", "exit", "CORE::exit"];
+
+    let first = trimmed
+        .split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '('))
+        .next()
+        .unwrap_or_default();
+    if !TERMINATORS.contains(&first) {
+        return None;
+    }
+
+    let after_terminator = &trimmed[first.len()..];
+    let remainder = match after_terminator.split_once('#') {
+        Some((before_comment, _)) => before_comment,
+        None => after_terminator,
+    }
+    .trim_start();
+    if contains_postfix_condition(remainder) {
+        return None;
+    }
+
+    Some(first)
+}
+
+fn contains_postfix_condition(remainder: &str) -> bool {
+    const CONDITIONS: [&str; 7] = ["if", "unless", "when", "while", "until", "for", "foreach"];
+    CONDITIONS.iter().any(|keyword| contains_keyword(remainder, keyword))
+}
+
+fn contains_keyword(text: &str, keyword: &str) -> bool {
+    text.match_indices(keyword).any(|(idx, _)| {
+        let before = text[..idx].chars().next_back();
+        let after = text[idx + keyword.len()..].chars().next();
+        is_keyword_boundary(before) && is_keyword_boundary(after)
+    })
+}
+
+fn is_keyword_boundary(ch: Option<char>) -> bool {
+    ch.is_none_or(|ch| !ch.is_ascii_alphanumeric() && ch != '_')
 }

--- a/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-dead-code/tests/comprehensive_unit_tests.rs
@@ -16,7 +16,8 @@ use std::path::PathBuf;
 /// Build a WorkspaceIndex containing a single Perl file.
 fn index_with_file(uri: &str, code: &str) -> Result<WorkspaceIndex, String> {
     let index = WorkspaceIndex::new();
-    index.index_file_str(uri, code)?;
+    let indexed_uri = test_uri_to_index_uri(uri)?;
+    index.index_file_str(&indexed_uri, code)?;
     Ok(index)
 }
 
@@ -24,9 +25,17 @@ fn index_with_file(uri: &str, code: &str) -> Result<WorkspaceIndex, String> {
 fn index_with_files(files: &[(&str, &str)]) -> Result<WorkspaceIndex, String> {
     let index = WorkspaceIndex::new();
     for (uri, code) in files {
-        index.index_file_str(uri, code)?;
+        let indexed_uri = test_uri_to_index_uri(uri)?;
+        index.index_file_str(&indexed_uri, code)?;
     }
     Ok(index)
+}
+
+fn test_uri_to_index_uri(uri: &str) -> Result<String, String> {
+    match uri.strip_prefix("file://") {
+        Some(path) => perl_uri::fs_path_to_uri(PathBuf::from(path)),
+        None => Ok(uri.to_string()),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -242,15 +251,58 @@ fn analyze_file_only_flags_first_unreachable_line() -> Result<(), String> {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn analyze_file_return_at_end_of_sub_flags_closing_brace() -> Result<(), String> {
-    // The stub implementation is line-by-line and flags the closing brace
-    // since it is the next non-empty line after `return`
+fn analyze_file_return_at_end_of_sub_does_not_flag_closing_brace() -> Result<(), String> {
     let code = "sub foo {\n    return 42;\n}\n";
     let index = index_with_file("file:///test_end_return.pl", code)?;
     let detector = DeadCodeDetector::new(index);
 
     let results = detector.analyze_file(&PathBuf::from("/test_end_return.pl"))?;
-    assert_eq!(results.len(), 1, "closing brace after return is flagged by stub");
+    assert!(results.is_empty(), "closing brace after return should not be flagged");
+    Ok(())
+}
+
+#[test]
+fn analyze_file_conditional_return_does_not_mark_following_statement_dead() -> Result<(), String> {
+    let code = "return if $cond;\nsay \"live\";\n";
+    let index = index_with_file("file:///test_return_if.pl", code)?;
+    let detector = DeadCodeDetector::new(index);
+
+    let results = detector.analyze_file(&PathBuf::from("/test_return_if.pl"))?;
+    assert!(results.is_empty(), "postfix conditional return should not be unconditional");
+    Ok(())
+}
+
+#[test]
+fn analyze_file_conditional_return_with_value_does_not_mark_following_statement_dead()
+-> Result<(), String> {
+    let code = "return 42 if $cond;\nsay \"live\";\n";
+    let index = index_with_file("file:///test_return_value_if.pl", code)?;
+    let detector = DeadCodeDetector::new(index);
+
+    let results = detector.analyze_file(&PathBuf::from("/test_return_value_if.pl"))?;
+    assert!(results.is_empty(), "postfix conditional return value should not be unconditional");
+    Ok(())
+}
+
+#[test]
+fn analyze_file_return_prefix_inside_identifier_is_not_a_terminator() -> Result<(), String> {
+    let code = "return42();\nsay \"live\";\n";
+    let index = index_with_file("file:///test_return42.pl", code)?;
+    let detector = DeadCodeDetector::new(index);
+
+    let results = detector.analyze_file(&PathBuf::from("/test_return42.pl"))?;
+    assert!(results.is_empty(), "return42 should not match the return terminator");
+    Ok(())
+}
+
+#[test]
+fn analyze_file_unconditional_return_in_sub_still_flags_real_statement() -> Result<(), String> {
+    let code = "sub foo {\n    return 42;\n    say \"dead\";\n}\n";
+    let index = index_with_file("file:///test_dead_after_return.pl", code)?;
+    let detector = DeadCodeDetector::new(index);
+
+    let results = detector.analyze_file(&PathBuf::from("/test_dead_after_return.pl"))?;
+    assert_eq!(results.len(), 1, "statement after unconditional return should be dead");
     assert_eq!(results[0].start_line, 3);
     Ok(())
 }

--- a/crates/perl-dead-code/tests/dead_code_behavior_tests.rs
+++ b/crates/perl-dead-code/tests/dead_code_behavior_tests.rs
@@ -4,11 +4,19 @@
 
 use perl_dead_code::{DeadCodeDetector, DeadCodeType};
 use perl_workspace::workspace_index::WorkspaceIndex;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+fn test_uri_to_index_uri(uri: &str) -> Result<String, String> {
+    match uri.strip_prefix("file://") {
+        Some(path) => perl_uri::fs_path_to_uri(PathBuf::from(path)),
+        None => Ok(uri.to_string()),
+    }
+}
 
 fn detector_with_single_file(uri: &str, source: &str) -> Result<DeadCodeDetector, String> {
     let index = WorkspaceIndex::new();
-    index.index_file_str(uri, source)?;
+    let index_uri = test_uri_to_index_uri(uri)?;
+    index.index_file_str(&index_uri, source)?;
     Ok(DeadCodeDetector::new(index))
 }
 
@@ -104,8 +112,10 @@ fn scenario_nested_parenthesized_false_condition_is_detected() -> Result<(), Str
 fn scenario_workspace_analysis_aggregates_unreachable_and_dead_branch() -> Result<(), String> {
     // Given a workspace with both unreachable code and a dead branch
     let index = WorkspaceIndex::new();
-    index.index_file_str("file:///scenario_a.pl", "exit 1;\nprint 'never';\n")?;
-    index.index_file_str("file:///scenario_b.pl", "if (0) {\n    print 'dead';\n}\n")?;
+    let scenario_a_uri = test_uri_to_index_uri("file:///scenario_a.pl")?;
+    let scenario_b_uri = test_uri_to_index_uri("file:///scenario_b.pl")?;
+    index.index_file_str(&scenario_a_uri, "exit 1;\nprint 'never';\n")?;
+    index.index_file_str(&scenario_b_uri, "if (0) {\n    print 'dead';\n}\n")?;
     let detector = DeadCodeDetector::new(index);
 
     // When workspace analysis runs

--- a/crates/perl-parser/Cargo.toml
+++ b/crates/perl-parser/Cargo.toml
@@ -96,6 +96,7 @@ doc-coverage = []  # SPEC-149 documentation coverage tests
 [dev-dependencies]
 insta = { version = "1.47.2", features = ["yaml"] }
 criterion.workspace = true
+perl-uri = { workspace = true }
 regex.workspace = true
 serial_test = "3.4.0"
 tempfile.workspace = true

--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -112,12 +112,21 @@ impl DeadCodeDetector {
             .ok_or_else(|| "file not indexed".to_string())?;
 
         let mut dead = Vec::new();
-        let mut terminator: Option<(usize, String)> = None;
+        let mut block_depth = 0usize;
+        let mut terminator: Option<(usize, usize, String)> = None;
 
         for (i, line) in text.lines().enumerate() {
             let trimmed = line.trim();
-            if let Some((term_line, term_kw)) = &terminator {
-                if !trimmed.is_empty() {
+            let current_depth = block_depth;
+
+            if let Some((term_line, term_depth, term_kw)) = &terminator {
+                if current_depth < *term_depth {
+                    terminator = None;
+                } else if current_depth == *term_depth
+                    && !trimmed.is_empty()
+                    && !trimmed.starts_with('#')
+                    && !is_structural_line(trimmed)
+                {
                     dead.push(DeadCode {
                         code_type: DeadCodeType::UnreachableCode,
                         name: None,
@@ -128,18 +137,19 @@ impl DeadCodeDetector {
                             "Code is unreachable after `{}` on line {}",
                             term_kw, term_line
                         ),
-                        confidence: 0.5,
+                        confidence: 0.9,
                         suggestion: Some("Remove or restructure this code".to_string()),
                     });
                     break;
                 }
             }
 
-            if ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw)) {
-                if let Some(first_word) = trimmed.split_whitespace().next() {
-                    terminator = Some((i + 1, first_word.to_string()));
-                }
+            if let Some(term_kw) = detect_unconditional_terminator(trimmed) {
+                terminator = Some((i + 1, current_depth, term_kw.to_string()));
             }
+
+            block_depth += line.chars().filter(|&ch| ch == '{').count();
+            block_depth = block_depth.saturating_sub(line.chars().filter(|&ch| ch == '}').count());
         }
 
         // Dead branch detection: scan for constant-condition patterns.
@@ -206,6 +216,51 @@ impl DeadCodeDetector {
 
         DeadCodeAnalysis { dead_code, stats, files_analyzed: docs.len(), total_lines }
     }
+}
+
+fn is_structural_line(trimmed: &str) -> bool {
+    !trimmed.is_empty() && trimmed.chars().all(|ch| ch == '}' || ch == ';')
+}
+
+fn detect_unconditional_terminator(trimmed: &str) -> Option<&str> {
+    const TERMINATORS: [&str; 4] = ["return", "die", "exit", "CORE::exit"];
+
+    let first = trimmed
+        .split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '('))
+        .next()
+        .unwrap_or_default();
+    if !TERMINATORS.contains(&first) {
+        return None;
+    }
+
+    let after_terminator = &trimmed[first.len()..];
+    let remainder = match after_terminator.split_once('#') {
+        Some((before_comment, _)) => before_comment,
+        None => after_terminator,
+    }
+    .trim_start();
+    if contains_postfix_condition(remainder) {
+        return None;
+    }
+
+    Some(first)
+}
+
+fn contains_postfix_condition(remainder: &str) -> bool {
+    const CONDITIONS: [&str; 7] = ["if", "unless", "when", "while", "until", "for", "foreach"];
+    CONDITIONS.iter().any(|keyword| contains_keyword(remainder, keyword))
+}
+
+fn contains_keyword(text: &str, keyword: &str) -> bool {
+    text.match_indices(keyword).any(|(idx, _)| {
+        let before = text[..idx].chars().next_back();
+        let after = text[idx + keyword.len()..].chars().next();
+        is_keyword_boundary(before) && is_keyword_boundary(after)
+    })
+}
+
+fn is_keyword_boundary(ch: Option<char>) -> bool {
+    ch.is_none_or(|ch| !ch.is_ascii_alphanumeric() && ch != '_')
 }
 
 /// Returns `true` if `condition` is a trivially-false constant expression.

--- a/crates/perl-parser/tests/dead_code_detector.rs
+++ b/crates/perl-parser/tests/dead_code_detector.rs
@@ -4,12 +4,21 @@ use std::path::PathBuf;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
+fn index_file_str(index: &WorkspaceIndex, uri: &str, code: &str) -> Result<(), String> {
+    let indexed_uri = match uri.strip_prefix("file://") {
+        Some(path) => perl_uri::fs_path_to_uri(PathBuf::from(path)),
+        None => Ok(uri.to_string()),
+    }?;
+    index.index_file_str(&indexed_uri, code)
+}
+
 #[test]
 fn detects_dead_code() -> TestResult {
     let index = WorkspaceIndex::new();
-    index.index_file_str("file:///main.pl", "use A;\nA::bar();\n")?;
-    index.index_file_str("file:///A.pm", "package A;\nsub foo { return 1; }\nsub bar { 1; }\n")?;
-    index.index_file_str(
+    index_file_str(&index, "file:///main.pl", "use A;\nA::bar();\n")?;
+    index_file_str(&index, "file:///A.pm", "package A;\nsub foo { return 1; }\nsub bar { 1; }\n")?;
+    index_file_str(
+        &index,
         "file:///Unused.pm",
         "package Unused;\nsub unused { return 1; }\nreturn 1;\nprint 'hi';\n",
     )?;
@@ -35,5 +44,65 @@ fn detects_dead_code() -> TestResult {
     assert!(analysis.dead_code.iter().any(
         |d| d.code_type == DeadCodeType::UnreachableCode && d.file_path.ends_with("Unused.pm")
     ));
+    Ok(())
+}
+
+#[test]
+fn return_at_end_of_sub_does_not_flag_closing_brace() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///module.pm", "sub foo {\n    return 42;\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/module.pm"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::UnreachableCode),
+        "closing brace should not be flagged as unreachable"
+    );
+    Ok(())
+}
+
+#[test]
+fn postfix_conditional_return_is_not_unconditional_terminator() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "return 42 if $cond;\nsay 'live';\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::UnreachableCode),
+        "postfix conditional return should not produce unreachable diagnostics"
+    );
+    Ok(())
+}
+
+#[test]
+fn return_prefix_inside_identifier_is_not_a_terminator() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "return42();\nsay 'live';\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::UnreachableCode),
+        "return42 should not match the return terminator"
+    );
+    Ok(())
+}
+
+#[test]
+fn unconditional_return_still_flags_following_statement() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///module.pm", "sub foo {\n    return 42;\n    say 'dead';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/module.pm"))?;
+
+    assert!(
+        dead.iter().any(|d| d.code_type == DeadCodeType::UnreachableCode && d.start_line == 3),
+        "statement after unconditional return should remain unreachable"
+    );
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Prevent false-positive unreachable-code findings from the line-based scanner, especially closing braces after a `return`.
- Keep conditional terminators like `return if $cond` and `return 42 if $cond` from being treated as unconditional.
- Preserve real unreachable findings after unconditional `return`/`die`/`exit` statements.

### Description

- Track block depth during per-file unreachable scans so findings are only reported for later executable statements in the same block.
- Treat structural-only lines such as `}` and `;` as non-executable.
- Use token-aware terminator detection for `return`, `die`, `exit`, and `CORE::exit`, including postfix-condition guards and identifier-boundary checks so `return42` is not matched.
- Mirror the scanner change in both `perl-dead-code` and `perl-parser` compatibility surfaces.
- Add regression coverage for closing braces, postfix conditional returns, `return42`, and real statements after unconditional returns.

### Testing

- `cargo test -p perl-dead-code --locked`
- `cargo test -p perl-parser dead_code --locked`
- `cargo clippy -p perl-dead-code --all-targets --locked -- -D warnings`
- `cargo xtask fmt --check`
- `git diff --check`