### PR TITLE
refactor(hover): extract receiver package resolver (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -358,20 +358,8 @@ impl LspServer {
                     // Resolve receiver to a package name.
                     // `$self`, `$this`, `$class` map to current_package; bare identifiers
                     // starting with uppercase are treated as package names.
-                    let bare_receiver =
-                        raw_receiver.trim_start_matches(['$', '@', '%']).to_string();
-                    let receiver_pkg = if bare_receiver == "self"
-                        || bare_receiver == "this"
-                        || bare_receiver == "class"
-                    {
-                        crate::declaration::current_package_at(ast, offset).to_string()
-                    } else if bare_receiver.starts_with(|c: char| c.is_uppercase()) {
-                        bare_receiver
-                    } else {
-                        // Variable receiver whose type we cannot statically resolve here.
-                        // Phase 2 will not be called; fall through to token hover.
-                        String::new()
-                    };
+                    let receiver_pkg =
+                        Self::resolve_receiver_package_name(ast, offset, &raw_receiver);
 
                     if !receiver_pkg.is_empty() {
                         // Try in-file ancestors first (no workspace lock needed)
@@ -529,6 +517,21 @@ impl LspServer {
         }
 
         HoverExtracted::None
+    }
+
+    fn resolve_receiver_package_name(ast: &Node, offset: usize, raw_receiver: &str) -> String {
+        let bare_receiver = raw_receiver.trim_start_matches(['$', '@', '%']);
+        if bare_receiver == "self" || bare_receiver == "this" || bare_receiver == "class" {
+            return crate::declaration::current_package_at(ast, offset).to_string();
+        }
+
+        if bare_receiver.starts_with(|ch: char| ch.is_uppercase()) {
+            return bare_receiver.to_string();
+        }
+
+        // Variable receiver whose type we cannot statically resolve here.
+        // Phase 2 will not be called; fall through to token hover.
+        String::new()
     }
 
     /// Build a scope context string for a variable hover card.


### PR DESCRIPTION
Problem: Inherited-method hover had inline receiver-to-package normalization mixed into the main hover extraction path.
Fix: Extract that normalization into `resolve_receiver_package_name` without changing the `$self`/`$this`/`$class`, bare package, or unresolved variable receiver behavior.
Verification: `cargo test -p perl-lsp-rs --test lsp_hover_tests hover_shows_inherited_method_from_parent_class --profile agent --locked`; `cargo check -p perl-lsp-rs --all-targets --profile agent --locked`; `cargo clippy -p perl-lsp-rs --lib --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check --package perl-lsp-rs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `git diff --check`.

Note: broad `cargo test -p perl-lsp-rs hover --profile agent --locked` still hits the existing special-block hover failures (`BEGIN`/`END`/`INIT`/`CHECK`/`UNITCHECK`), and the same `block_shows` failures reproduce on unmodified `origin/master`.