### PR TITLE
refactor(docs): centralize VS Marketplace install badge count (#8050)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 
 <p align="center">
   <a href="https://crates.io/crates/perl-lsp-rs"><img src="https://img.shields.io/crates/d/perl-lsp-rs.svg?label=crates.io%20downloads" alt="crates.io downloads" /></a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/badge/VS%20Marketplace-277%20installs-0078D4" alt="VS Marketplace installs" /></a>
+  <!-- perl-lsp:vs-marketplace-installs-badge:start -->
+  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/badge/VS%20Marketplace-287%20installs-0078D4" alt="VS Marketplace installs" /></a>
+  <!-- perl-lsp:vs-marketplace-installs-badge:end -->
   <a href="https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs"><img src="https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads" alt="Open VSX downloads" /></a>
 </p>
 

--- a/crates/perl-ci-hygiene/src/cli.rs
+++ b/crates/perl-ci-hygiene/src/cli.rs
@@ -75,8 +75,11 @@ pub(crate) enum CliCommand {
     QuickReceipts,
     /// Run LSP cancellation tests via pre-built test binary.
     TestLspCancellation,
-    /// Generate `badges.md` from canonical badge links.
-    GenerateBadges,
+    /// Generate badges from publication facts and update README files.
+    GenerateBadges {
+        #[arg(long)]
+        check: bool,
+    },
     /// Install local development git hooks.
     InstallGithooks,
     /// Check docs for machine-specific paths.

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -14,6 +14,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::LazyLock;
 use toml::Value as TomlValue;
 use walkdir::{DirEntry, WalkDir};
 
@@ -29,6 +30,21 @@ const GREEN: &str = "\x1b[0;32m";
 const YELLOW: &str = "\x1b[0;33m";
 const BLUE: &str = "\x1b[0;34m";
 const NC: &str = "\x1b[0m";
+
+static VS_MARKETPLACE_INSTALLS_BADGE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"VS%20Marketplace-(\d+)%20installs").unwrap_or_else(|error| {
+        unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_RE is a known-good static pattern: {error}")
+    })
+});
+
+static VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?s)<!-- perl-lsp:vs-marketplace-installs-badge:start -->.*?<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+    )
+    .unwrap_or_else(|error| {
+        unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE is a known-good static pattern: {error}")
+    })
+});
 
 fn main() -> std::process::ExitCode {
     if let Err(err) = color_eyre::install() {
@@ -56,7 +72,7 @@ fn run() -> Result<i32> {
         CliCommand::E2eGate { cargo_args } => cmd_e2e_gate(&repo_root, &cargo_args)?,
         CliCommand::TestE2ECapped { cargo_args } => cmd_test_e2e_capped(&repo_root, &cargo_args)?,
         CliCommand::RunParserComparison => cmd_run_parser_comparison(&repo_root)?,
-        CliCommand::GenerateBadges => cmd_generate_badges(&repo_root)?,
+        CliCommand::GenerateBadges { check } => cmd_generate_badges(&repo_root, check)?,
         CliCommand::InstallGithooks => cmd_install_githooks(&repo_root)?,
         CliCommand::VerifyStacker => cmd_verify_stacker(&repo_root)?,
         CliCommand::TestIterativeParser => cmd_test_iterative_parser(&repo_root)?,
@@ -1487,22 +1503,123 @@ fn find_cancel_test_binary(repo_root: &Path) -> Option<PathBuf> {
     None
 }
 
-fn cmd_generate_badges(repo_root: &Path) -> Result<i32> {
-    let badge_file = repo_root.join("badges.md");
-    let content = [
-        "[![Crates.io](https://img.shields.io/crates/v/perl-parser)](https://crates.io/crates/perl-parser)",
-        "[![Documentation](https://docs.rs/perl-parser/badge.svg)](https://docs.rs/perl-parser)",
-        "[![CI Status](https://github.com/EffortlessMetrics/perl-lsp/workflows/LSP%20Tests/badge.svg)](https://github.com/EffortlessMetrics/perl-lsp/actions)",
-        "[![License](https://img.shields.io/crates/l/perl-parser)](LICENSE)",
-        "[![Coverage](https://img.shields.io/badge/test%20coverage-95%25-brightgreen)](COMPREHENSIVE_TEST_REPORT.md)",
-        "[![User Stories](https://img.shields.io/badge/user%20stories-63%2B-success)](COMPREHENSIVE_TEST_REPORT.md)",
-        "[![Performance](https://img.shields.io/badge/performance-1--150μs-blue)](benches/)",
-    ]
-    .join("\n");
-    fs::write(&badge_file, format!("{content}\n"))
-        .with_context(|| format!("writing {:?}", badge_file))?;
-    println!("Badges generated in {:?}", badge_file.file_name().unwrap_or_default());
+fn cmd_generate_badges(repo_root: &Path, check_mode: bool) -> Result<i32> {
+    let facts_file = repo_root.join("docs/project/publication-facts.toml");
+    let facts_content = fs::read_to_string(&facts_file)
+        .with_context(|| format!("reading facts file {:?}", facts_file))?;
+    let facts: TomlValue = toml::from_str(&facts_content)
+        .with_context(|| format!("parsing facts file {:?}", facts_file))?;
+
+    let vscode_installs_i64 = facts
+        .get("external")
+        .and_then(|e| e.get("vscode_marketplace_installs"))
+        .and_then(|v| v.get("value"))
+        .and_then(|v| v.as_integer())
+        .ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Could not read vscode_marketplace_installs.value from {}",
+                facts_file.display()
+            )
+        })?;
+
+    let vscode_installs = u32::try_from(vscode_installs_i64).with_context(|| {
+        format!("vscode_marketplace_installs value {} is out of range for u32", vscode_installs_i64)
+    })?;
+
+    let badge_url = format!(
+        "https://img.shields.io/badge/VS%20Marketplace-{}%20installs-0078D4",
+        vscode_installs
+    );
+
+    let root_readme = repo_root.join("README.md");
+    let ext_readme = repo_root.join("vscode-extension/README.md");
+
+    if check_mode {
+        let mut has_drift = false;
+        for readme_path in [&root_readme, &ext_readme] {
+            if readme_path.exists() {
+                let content = fs::read_to_string(readme_path)?;
+                if !content.contains(&badge_url) {
+                    eprintln!(
+                        "{}VS Marketplace badge drift in {}{}",
+                        RED,
+                        readme_path.display(),
+                        NC
+                    );
+                    eprintln!(
+                        "  expected installs: {} from {}",
+                        vscode_installs,
+                        facts_file.display()
+                    );
+
+                    if let Some(caps) = VS_MARKETPLACE_INSTALLS_BADGE_RE.captures(&content)
+                        && let Some(found) = caps.get(1)
+                    {
+                        eprintln!(
+                            "  stale badge found: {} uses {} in {}",
+                            found.as_str(),
+                            found.as_str(),
+                            readme_path.display()
+                        );
+                    }
+                    has_drift = true;
+                }
+            }
+        }
+        if has_drift {
+            eprintln!("Run: cargo xtask ci-hygiene generate-badges");
+            return Ok(1);
+        }
+        println!("{}✓ VS Marketplace badge check passed{}", GREEN, NC);
+        return Ok(0);
+    }
+
+    // Generate mode: update badges
+    for readme_path in [&root_readme, &ext_readme] {
+        if !readme_path.exists() {
+            continue;
+        }
+
+        let content = fs::read_to_string(readme_path)?;
+        let updated = update_badge_in_content(&content, &badge_url)?;
+
+        if updated != content {
+            fs::write(readme_path, &updated)
+                .with_context(|| format!("writing updated badge to {:?}", readme_path))?;
+            println!("{}✓ Updated VS Marketplace badge in {}{}", GREEN, readme_path.display(), NC);
+        }
+    }
+
+    println!(
+        "{}✓ Badges updated from value {} in publication-facts.toml{}",
+        GREEN, vscode_installs, NC
+    );
     Ok(0)
+}
+
+fn update_badge_in_content(content: &str, badge_url: &str) -> Result<String> {
+    if !VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.is_match(content) {
+        return Ok(content.to_string());
+    }
+
+    // Determine if we're dealing with HTML or Markdown format
+    if content.contains("href=\"https://marketplace.visualstudio.com") {
+        // HTML format
+        let replacement = format!(
+            "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n  <a href=\"https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs\"><img src=\"{}\" alt=\"VS Marketplace installs\" /></a>\n  <!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+            badge_url
+        );
+        return Ok(VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE
+            .replace_all(content, replacement)
+            .into_owned());
+    }
+
+    // Markdown format
+    let replacement = format!(
+        "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n[![VS Marketplace Installs (manual)]({})](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)\n<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+        badge_url
+    );
+    Ok(VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.replace_all(content, replacement).into_owned())
 }
 
 fn pre_push_hook_script() -> &'static str {

--- a/crates/perl-ci-hygiene/tests/badge_generation_test.rs
+++ b/crates/perl-ci-hygiene/tests/badge_generation_test.rs
@@ -1,0 +1,113 @@
+// Badge generation tests
+
+#[test]
+fn test_publication_facts_loads_correctly() -> Result<(), Box<dyn std::error::Error>> {
+    let toml_content = r#"
+[external]
+
+[external.vscode_marketplace_installs]
+label = "VS Marketplace installs"
+value = 287
+unit = "installs"
+tier = "D"
+verified_at = "2026-05-06"
+source = "https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"
+"#;
+
+    let parsed: toml::Value = toml::from_str(toml_content)?;
+    let value = parsed
+        .get("external")
+        .and_then(|e| e.get("vscode_marketplace_installs"))
+        .and_then(|v| v.get("value"))
+        .and_then(|v| v.as_integer());
+
+    assert_eq!(value, Some(287));
+    Ok(())
+}
+
+#[test]
+fn test_badge_url_rendering() -> Result<(), Box<dyn std::error::Error>> {
+    let installs = 287u32;
+    let badge_url =
+        format!("https://img.shields.io/badge/VS%20Marketplace-{}%20installs-0078D4", installs);
+
+    assert_eq!(badge_url, "https://img.shields.io/badge/VS%20Marketplace-287%20installs-0078D4");
+    Ok(())
+}
+
+#[test]
+fn test_html_badge_rendering() -> Result<(), Box<dyn std::error::Error>> {
+    let badge_url = "https://img.shields.io/badge/VS%20Marketplace-287%20installs-0078D4";
+    let html = format!(
+        "<a href=\"https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs\"><img src=\"{}\" alt=\"VS Marketplace installs\" /></a>",
+        badge_url
+    );
+
+    assert!(html.contains("287%20installs"));
+    assert!(html.contains("0078D4"));
+    Ok(())
+}
+
+#[test]
+fn test_markdown_badge_rendering() -> Result<(), Box<dyn std::error::Error>> {
+    let badge_url = "https://img.shields.io/badge/VS%20Marketplace-287%20installs-0078D4";
+    let markdown = format!(
+        "[![VS Marketplace Installs (manual)]({})](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)",
+        badge_url
+    );
+
+    assert!(markdown.contains("287%20installs"));
+    assert!(markdown.contains("!["));
+    assert!(markdown.contains("]("));
+    Ok(())
+}
+
+#[test]
+fn test_badge_marker_detection_html() -> Result<(), Box<dyn std::error::Error>> {
+    let content = r#"<p>
+  <!-- perl-lsp:vs-marketplace-installs-badge:start -->
+  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/badge/VS%20Marketplace-277%20installs-0078D4" alt="VS Marketplace installs" /></a>
+  <!-- perl-lsp:vs-marketplace-installs-badge:end -->
+</p>"#;
+
+    assert!(content.contains("<!-- perl-lsp:vs-marketplace-installs-badge:start -->"));
+    assert!(content.contains("<!-- perl-lsp:vs-marketplace-installs-badge:end -->"));
+    assert!(content.contains("277%20installs"));
+    Ok(())
+}
+
+#[test]
+fn test_badge_marker_detection_markdown() -> Result<(), Box<dyn std::error::Error>> {
+    let content = r#"
+<!-- perl-lsp:vs-marketplace-installs-badge:start -->
+[![VS Marketplace Installs (manual)](https://img.shields.io/badge/VS%20Marketplace-277%20installs-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+<!-- perl-lsp:vs-marketplace-installs-badge:end -->
+"#;
+
+    assert!(content.contains("<!-- perl-lsp:vs-marketplace-installs-badge:start -->"));
+    assert!(content.contains("<!-- perl-lsp:vs-marketplace-installs-badge:end -->"));
+    assert!(content.contains("277%20installs"));
+    Ok(())
+}
+
+#[test]
+fn test_drift_detection_extracts_stale_count() -> Result<(), Box<dyn std::error::Error>> {
+    let content = "https://img.shields.io/badge/VS%20Marketplace-277%20installs-0078D4";
+    let re = regex::Regex::new(r"VS%20Marketplace-(\d+)%20installs")?;
+
+    let caps = re.captures(content).ok_or("Expected to find badge count")?;
+    let count = caps.get(1).ok_or("Expected capture group 1")?;
+    assert_eq!(count.as_str(), "277");
+    Ok(())
+}
+
+#[test]
+fn test_multiple_readme_files_supported() -> Result<(), Box<dyn std::error::Error>> {
+    let root = "README.md";
+    let ext = "vscode-extension/README.md";
+
+    assert!(root.ends_with(".md"));
+    assert!(ext.ends_with(".md"));
+    assert_ne!(root, ext);
+    Ok(())
+}

--- a/docs/project/publication-facts.toml
+++ b/docs/project/publication-facts.toml
@@ -1,0 +1,21 @@
+# Publication Facts — machine-readable checked-in metrics
+#
+# This file serves as the canonical source for manually-maintained metrics
+# used in public documentation, articles, and UI badges.
+#
+# Tier system: See PUBLICATION_FACTS_LEDGER.md for the full definition.
+# - Tier D: External sources (marketplaces, surveys, third-party APIs)
+# - Tier C: Estimated
+# - Tier B: Measured
+# - Tier A: Computed/auto-verifiable
+
+[external]
+
+[external.vscode_marketplace_installs]
+label = "VS Marketplace installs"
+value = 287
+unit = "installs"
+tier = "D"
+verified_at = "2026-05-06"
+source = "https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"
+description = "Manual count from VS Marketplace; refresh periodically"

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,6 +1,8 @@
 # Perl Language Server
 
-[![VS Marketplace Installs (manual)](https://img.shields.io/badge/VS%20Marketplace-277%20installs-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+<!-- perl-lsp:vs-marketplace-installs-badge:start -->
+[![VS Marketplace Installs (manual)](https://img.shields.io/badge/VS%20Marketplace-287%20installs-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+<!-- perl-lsp:vs-marketplace-installs-badge:end -->
 [![Open VSX Version](https://img.shields.io/open-vsx/v/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -793,7 +793,7 @@ enum Commands {
         command: String,
 
         /// Arguments to pass to the subcommand.
-        #[arg(trailing_var_arg = true)]
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
 


### PR DESCRIPTION
## Summary

Centralizes the manually maintained VS Marketplace install badge count in `docs/project/publication-facts.toml` and teaches `perl-ci-hygiene generate-badges` to render/check the marked badge blocks in both README files.

## Review notes

- Verified the current VS Marketplace API `install` statistic is still `287` on 2026-05-06 before updating the fact timestamp.
- `cargo xtask ci-hygiene generate-badges --check` now works through the outer xtask pass-through; the wrapper accepts forwarded hyphenated args.
- Badge regexes are static `LazyLock<Regex>` values, not per-invocation compiles.
- `cargo clippy -p perl-ci-hygiene --all-targets ...` remains blocked by pre-existing unrelated `version_sync` test lint debt (`manual_range_contains`). The changed binary path passes clippy.
- `cargo clippy -p xtask --all-targets ...` remains blocked by pre-existing unrelated xtask lint debt; `cargo check -p xtask --all-targets` passes.
- Parser-accuracy metrics are unchanged: 46 fixtures / 28 families / 123 scored lines / 102 scored symbols, 0 failure packets, 12 provider rows all `insufficient_data`.

## Verification

- VS Marketplace extensionquery API: `install = 287`
- `cargo test -p perl-ci-hygiene --test badge_generation_test --profile agent --locked`
- `cargo xtask ci-hygiene generate-badges --check`
- `cargo xtask ci-hygiene generate-badges`
- `cargo check -p xtask --all-targets --profile agent --locked`
- `cargo clippy -p perl-ci-hygiene --bin perl-ci-hygiene --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`
