### PR TITLE
fix(semantic): emit generated member facts for Moo accessors (#7952)

### DIFF
--- a/crates/perl-workspace/src/semantic/generated_member_extractor.rs
+++ b/crates/perl-workspace/src/semantic/generated_member_extractor.rs
@@ -1,0 +1,352 @@
+//! Workspace-side generated member extraction for Moo/Moose/Mouse `has`.
+//!
+//! Recognizes statically visible framework attribute declarations and emits
+//! [`EntityFact`] entries with `kind = EntityKind::GeneratedMember` anchored to
+//! the declared attribute name.
+//!
+//! # Scope
+//!
+//! Only package-level `has` calls after an order-visible `use Moo`, `use Moose`,
+//! or `use Mouse` are recognized. Plain packages without a supported framework
+//! import are skipped.
+//!
+//! # Placement note — circular dependency debt
+//!
+//! This extractor lives in `perl-workspace` rather than
+//! `perl-semantic-analyzer` because `perl-semantic-analyzer` currently depends
+//! on `perl-workspace`. Moving this producer to the semantic analyzer today
+//! would create a crate cycle. Keep this narrow until the semantic producer
+//! boundary is inverted.
+
+use crate::{Node, NodeKind};
+use perl_semantic_facts::{
+    AnchorFact, AnchorId, Confidence, EntityFact, EntityId, EntityKind, FileId, Provenance,
+};
+use std::collections::BTreeMap;
+
+/// Generated member entity plus the source anchor that proves it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GeneratedMemberFact {
+    pub(crate) entity: EntityFact,
+    pub(crate) anchor: AnchorFact,
+}
+
+#[derive(Debug, Clone, Default)]
+struct WalkCtx {
+    current_package: Option<String>,
+    accessor_framework_active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NameCandidate {
+    name: String,
+    span_start: usize,
+    span_end: usize,
+}
+
+/// Extract generated member facts from package-level framework declarations.
+pub(crate) fn extract_generated_member_facts(
+    ast: &Node,
+    file_id: FileId,
+) -> Vec<GeneratedMemberFact> {
+    let mut out = Vec::new();
+    let mut ctx = WalkCtx::default();
+    walk(ast, file_id, &mut ctx, &mut out);
+    out
+}
+
+fn walk(node: &Node, file_id: FileId, ctx: &mut WalkCtx, out: &mut Vec<GeneratedMemberFact>) {
+    match &node.kind {
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            walk_statements(statements, file_id, ctx, out);
+        }
+        NodeKind::Package { name, block, .. } => {
+            if let Some(block) = block {
+                let saved = ctx.clone();
+                ctx.current_package = Some(name.clone());
+                ctx.accessor_framework_active = false;
+                walk(block, file_id, ctx, out);
+                *ctx = saved;
+            } else {
+                ctx.current_package = Some(name.clone());
+                ctx.accessor_framework_active = false;
+            }
+        }
+        NodeKind::Use { module, .. } if is_accessor_framework_module(module) => {
+            ctx.accessor_framework_active = true;
+        }
+        NodeKind::No { module, .. } if is_accessor_framework_module(module) => {
+            ctx.accessor_framework_active = false;
+        }
+        NodeKind::ExpressionStatement { expression } => {
+            if ctx.accessor_framework_active {
+                extract_has_call(expression, file_id, ctx, out);
+            }
+        }
+        NodeKind::Subroutine { .. } | NodeKind::Method { .. } => {}
+        _ => {
+            for child in node.children() {
+                walk(child, file_id, ctx, out);
+            }
+        }
+    }
+}
+
+fn walk_statements(
+    statements: &[Node],
+    file_id: FileId,
+    ctx: &mut WalkCtx,
+    out: &mut Vec<GeneratedMemberFact>,
+) {
+    for statement in statements {
+        walk(statement, file_id, ctx, out);
+    }
+}
+
+fn extract_has_call(
+    expression: &Node,
+    file_id: FileId,
+    ctx: &WalkCtx,
+    out: &mut Vec<GeneratedMemberFact>,
+) {
+    let NodeKind::FunctionCall { name, args } = &expression.kind else {
+        return;
+    };
+    if name != "has" || args.is_empty() {
+        return;
+    }
+
+    let options_idx = args.iter().rposition(|arg| matches!(arg.kind, NodeKind::HashLiteral { .. }));
+    let Some(options_idx) = options_idx else {
+        emit_members_for_names(args, &[], file_id, ctx, out);
+        return;
+    };
+
+    let NodeKind::HashLiteral { pairs } = &args[options_idx].kind else {
+        return;
+    };
+    emit_members_for_names(&args[..options_idx], pairs, file_id, ctx, out);
+}
+
+fn emit_members_for_names(
+    name_nodes: &[Node],
+    option_pairs: &[(Node, Node)],
+    file_id: FileId,
+    ctx: &WalkCtx,
+    out: &mut Vec<GeneratedMemberFact>,
+) {
+    let package = ctx.current_package.as_deref().unwrap_or("main");
+    let options = extract_hash_options(option_pairs);
+
+    for raw_name in name_nodes.iter().flat_map(collect_name_candidates) {
+        let Some(attribute_name) = normalize_attribute_name(&raw_name.name) else {
+            continue;
+        };
+        let primary_name = options
+            .get("accessor")
+            .or_else(|| options.get("reader"))
+            .cloned()
+            .unwrap_or_else(|| attribute_name.clone());
+
+        if options.get("is").is_none_or(|mode| mode != "bare") {
+            push_member(package, &primary_name, &raw_name, file_id, out);
+        }
+
+        if let Some(writer) = options.get("writer") {
+            push_member(package, writer, &raw_name, file_id, out);
+        }
+        if let Some(predicate) =
+            option_method_name(options.get("predicate"), "has", &attribute_name)
+        {
+            push_member(package, &predicate, &raw_name, file_id, out);
+        }
+        if let Some(clearer) = option_method_name(options.get("clearer"), "clear", &attribute_name)
+        {
+            push_member(package, &clearer, &raw_name, file_id, out);
+        }
+        if let Some(builder) = option_method_name(options.get("builder"), "_build", &attribute_name)
+        {
+            push_member(package, &builder, &raw_name, file_id, out);
+        }
+    }
+}
+
+fn push_member(
+    package: &str,
+    member_name: &str,
+    source_name: &NameCandidate,
+    file_id: FileId,
+    out: &mut Vec<GeneratedMemberFact>,
+) {
+    if member_name.is_empty() {
+        return;
+    }
+    let canonical_name = format!("{package}::{member_name}");
+    if out.iter().any(|fact| {
+        fact.entity.canonical_name == canonical_name
+            && fact.anchor.span_start_byte as usize == source_name.span_start
+            && fact.anchor.span_end_byte as usize == source_name.span_end
+    }) {
+        return;
+    }
+
+    let entity_id = EntityId(stable_id(
+        "generated-member-entity",
+        file_id,
+        source_name.span_start,
+        package,
+        member_name,
+    ));
+    let anchor_id = AnchorId(stable_id(
+        "generated-member-anchor",
+        file_id,
+        source_name.span_start,
+        package,
+        member_name,
+    ));
+    let anchor = AnchorFact {
+        id: anchor_id,
+        file_id,
+        span_start_byte: source_name.span_start as u32,
+        span_end_byte: source_name.span_end as u32,
+        scope_id: None,
+        provenance: Provenance::FrameworkSynthesis,
+        confidence: Confidence::Medium,
+    };
+    let entity = EntityFact {
+        id: entity_id,
+        kind: EntityKind::GeneratedMember,
+        canonical_name,
+        anchor_id: Some(anchor_id),
+        scope_id: None,
+        provenance: Provenance::FrameworkSynthesis,
+        confidence: Confidence::Medium,
+    };
+    out.push(GeneratedMemberFact { entity, anchor });
+}
+
+fn collect_name_candidates(node: &Node) -> Vec<NameCandidate> {
+    match &node.kind {
+        NodeKind::String { value, .. } | NodeKind::Identifier { name: value } => {
+            expand_symbol_list(value)
+                .into_iter()
+                .map(|name| NameCandidate {
+                    name,
+                    span_start: node.location.start,
+                    span_end: node.location.end,
+                })
+                .collect()
+        }
+        NodeKind::ArrayLiteral { elements } => {
+            elements.iter().flat_map(collect_name_candidates).collect()
+        }
+        NodeKind::Binary { op, left, right } if op == "," => {
+            let mut names = collect_name_candidates(left);
+            names.extend(collect_name_candidates(right));
+            names
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn extract_hash_options(pairs: &[(Node, Node)]) -> BTreeMap<String, String> {
+    let mut options = BTreeMap::new();
+    for (key_node, value_node) in pairs {
+        let Some(key_name) = collect_name_candidates(key_node).into_iter().next() else {
+            continue;
+        };
+        options.insert(key_name.name, value_summary(value_node));
+    }
+    options
+}
+
+fn value_summary(node: &Node) -> String {
+    match &node.kind {
+        NodeKind::String { value, .. } => {
+            normalize_symbol_name(value).unwrap_or_else(|| value.clone())
+        }
+        NodeKind::Identifier { name } => name.clone(),
+        NodeKind::Number { value } => value.clone(),
+        _ => "expr".to_string(),
+    }
+}
+
+fn option_method_name(
+    value: Option<&String>,
+    default_prefix: &str,
+    attribute: &str,
+) -> Option<String> {
+    let value = value?;
+    if value == "1" || value == "true" {
+        return Some(format!("{default_prefix}_{attribute}"));
+    }
+    Some(value.clone())
+}
+
+fn normalize_symbol_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_matches('\'').trim_matches('"').trim();
+    if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+}
+
+fn normalize_attribute_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let without_override_prefix = trimmed.strip_prefix('+').unwrap_or(trimmed);
+    normalize_symbol_name(without_override_prefix)
+}
+
+fn expand_symbol_list(raw: &str) -> Vec<String> {
+    let raw = raw.trim();
+
+    if raw.starts_with("qw(") && raw.ends_with(')') {
+        return raw[3..raw.len() - 1]
+            .split_whitespace()
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+            .collect();
+    }
+
+    if raw.starts_with("qw") && raw.len() > 2 {
+        let open = raw.chars().nth(2).unwrap_or(' ');
+        let close = match open {
+            '(' => ')',
+            '{' => '}',
+            '[' => ']',
+            '<' => '>',
+            c => c,
+        };
+        if let (Some(start), Some(end)) = (raw.find(open), raw.rfind(close))
+            && start < end
+        {
+            return raw[start + 1..end]
+                .split_whitespace()
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+                .collect();
+        }
+    }
+
+    normalize_symbol_name(raw).into_iter().collect()
+}
+
+fn is_accessor_framework_module(module: &str) -> bool {
+    matches!(module, "Moo" | "Moo::Role" | "Moose" | "Moose::Role" | "Mouse" | "Mouse::Role")
+}
+
+fn stable_id(label: &str, file_id: FileId, anchor_start: usize, package: &str, name: &str) -> u64 {
+    const FNV_OFFSET: u64 = 14_695_981_039_346_656_037;
+    const FNV_PRIME: u64 = 1_099_511_628_211;
+
+    let mut hash = FNV_OFFSET;
+    for byte in label
+        .as_bytes()
+        .iter()
+        .chain(file_id.0.to_le_bytes().iter())
+        .chain((anchor_start as u64).to_le_bytes().iter())
+        .chain(package.as_bytes())
+        .chain(name.as_bytes())
+    {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}

--- a/crates/perl-workspace/src/semantic/mod.rs
+++ b/crates/perl-workspace/src/semantic/mod.rs
@@ -38,6 +38,9 @@ pub mod queries;
 /// Literal-eval sub extractor for dynamic boundary evidence.
 pub mod eval_sub_extractor;
 
+/// Framework generated member extractor for package-level `has` declarations.
+pub mod generated_member_extractor;
+
 /// Import-spec extractor for `ImportExportIndex` population during `index_file`.
 pub mod workspace_import_extractor;
 

--- a/crates/perl-workspace/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace/src/workspace/workspace_index.rs
@@ -2499,6 +2499,10 @@ impl WorkspaceIndex {
             crate::semantic::eval_sub_extractor::extract_eval_sub_boundaries(ast, file_id);
         let dynamic_boundaries: Vec<perl_semantic_facts::OccurrenceFact> =
             eval_sub_triples.iter().map(|(_, _, occ)| occ.clone()).collect();
+        let generated_member_facts =
+            crate::semantic::generated_member_extractor::extract_generated_member_facts(
+                ast, file_id,
+            );
 
         // Build the canonical fact shard.
         // Import specs (for `use`, `require`, `ClassName->import()`) are
@@ -2512,20 +2516,24 @@ impl WorkspaceIndex {
             &dynamic_boundaries,
         );
 
-        // Merge entity and anchor facts from eval-sub extraction into the shard.
+        // Merge entity and anchor facts from semantic producers into the shard.
         // The `build_canonical_fact_shard` function only accepts OccurrenceFact
-        // slices for dynamic_boundaries; entities and anchors must be merged
-        // manually so that the query can resolve entity names from occurrence IDs.
+        // slices for dynamic_boundaries; extra entities and anchors must be
+        // merged manually so queries can resolve those semantic facts.
         //
-        // NOTE: This post-build merge means `entities_hash` and `anchors_hash`
-        // do not reflect the eval-sub additions. Incremental replacement
-        // (`replace_fact_shard_incremental`) may miss a change if only the eval
-        // string changes — the `content_hash` (whole-file) will still catch it.
+        // NOTE: This post-build merge means `entities_hash` and `anchors_hash` do
+        // not reflect these additions. Incremental replacement
+        // (`replace_fact_shard_incremental`) may miss a change if only synthetic
+        // facts change — the `content_hash` (whole-file) will still catch it.
         // A future refactor should extend `build_canonical_fact_shard`'s API to
         // accept extra entity/anchor slices alongside `dynamic_boundaries`.
         for (entity, anchor, _) in eval_sub_triples {
             shard.entities.push(entity);
             shard.anchors.push(anchor);
+        }
+        for fact in generated_member_facts {
+            shard.entities.push(fact.entity);
+            shard.anchors.push(fact.anchor);
         }
 
         shard

--- a/crates/perl-workspace/tests/generated_member_facts.rs
+++ b/crates/perl-workspace/tests/generated_member_facts.rs
@@ -1,0 +1,74 @@
+//! Workspace fact extraction tests for framework-generated members.
+
+use perl_semantic_facts::{Confidence, EntityKind, Provenance};
+use perl_workspace::workspace::workspace_index::WorkspaceIndex;
+use std::io;
+
+#[test]
+fn moo_has_generates_member_entity_with_attribute_anchor() -> Result<(), Box<dyn std::error::Error>>
+{
+    let index = WorkspaceIndex::new();
+    let uri = "file:///generated-member.pm";
+    let source = "\
+package Accuracy::GeneratedAccessor;
+
+use Moo;
+
+has name => (is => 'ro');
+
+1;
+";
+    let expected_start =
+        source.find("name =>").ok_or_else(|| io::Error::other("missing attribute name"))?;
+    let expected_end = expected_start + "name".len();
+
+    index.index_file(url::Url::parse(uri)?, source.to_string())?;
+    let shard = index.file_fact_shard(uri).ok_or_else(|| io::Error::other("missing fact shard"))?;
+    let entity = shard
+        .entities
+        .iter()
+        .find(|entity| entity.canonical_name == "Accuracy::GeneratedAccessor::name")
+        .ok_or_else(|| io::Error::other("missing generated member entity"))?;
+
+    assert_eq!(entity.kind, EntityKind::GeneratedMember);
+    assert_eq!(entity.provenance, Provenance::FrameworkSynthesis);
+    assert_eq!(entity.confidence, Confidence::Medium);
+
+    let anchor_id =
+        entity.anchor_id.ok_or_else(|| io::Error::other("missing generated member anchor"))?;
+    let anchor = shard
+        .anchors
+        .iter()
+        .find(|anchor| anchor.id == anchor_id)
+        .ok_or_else(|| io::Error::other("missing anchor fact"))?;
+    assert_eq!(anchor.span_start_byte, expected_start as u32);
+    assert_eq!(anchor.span_end_byte, expected_end as u32);
+    assert_eq!(anchor.provenance, Provenance::FrameworkSynthesis);
+    assert_eq!(anchor.confidence, Confidence::Medium);
+
+    Ok(())
+}
+
+#[test]
+fn plain_has_without_framework_does_not_generate_member_entity()
+-> Result<(), Box<dyn std::error::Error>> {
+    let index = WorkspaceIndex::new();
+    let uri = "file:///plain-has.pm";
+    let source = "\
+package Plain::Package;
+
+has name => (is => 'ro');
+
+1;
+";
+
+    index.index_file(url::Url::parse(uri)?, source.to_string())?;
+    let shard = index.file_fact_shard(uri).ok_or_else(|| io::Error::other("missing fact shard"))?;
+
+    assert!(
+        shard.entities.iter().all(|entity| entity.kind != EntityKind::GeneratedMember),
+        "plain has without Moo/Moose/Mouse must not synthesize generated member facts"
+    );
+
+    Ok(())
+}

--- a/docs/project/status/parser_accuracy_failure_packets.json
+++ b/docs/project/status/parser_accuracy_failure_packets.json
@@ -1,31 +1,8 @@
 {
   "schema_version": 1,
-  "commit": "81de1ca6a",
+  "commit": "1db620b99",
   "cadence": "pr",
   "generated_by": "cargo xtask metrics parser-accuracy --export-status-receipts",
-  "failure_packet_count": 1,
-  "failure_packets": [
-    {
-      "id": "packet-49df877b06d09f87",
-      "failure_kind": "missing_symbol_declaration",
-      "likely_layer": "semantic_fact_extraction",
-      "fixture_id": "generated_accessor",
-      "family": "generated_accessor",
-      "metric": "symbol_decl_f1",
-      "expected": [
-        "GeneratedMember Accuracy::GeneratedAccessor::name span=\"name\""
-      ],
-      "actual": [],
-      "actual_nearest": [
-        "Package Accuracy::GeneratedAccessor span=\"Accuracy::GeneratedAccessor\"",
-        "Subroutine Accuracy::GeneratedAccessor::call_name_accessor span=\"call_name_accessor\"",
-        "Subroutine Accuracy::GeneratedAccessor::existing span=\"existing\"",
-        "Variable Accuracy::GeneratedAccessor::obj span=\"$obj\""
-      ],
-      "source_excerpt": "has name => (is => 'ro');",
-      "details": "gold symbol expectation was not present in canonical fact predictions",
-      "suggested_next_fix": "inspect fact extraction for this fixture before changing the gold expectation",
-      "suggested_next_pr": "fix(semantic): resolve parser-accuracy semantic fact packet"
-    }
-  ]
+  "failure_packet_count": 0,
+  "failure_packets": []
 }

--- a/docs/project/status/parser_accuracy_failure_worklist.md
+++ b/docs/project/status/parser_accuracy_failure_worklist.md
@@ -1,7 +1,7 @@
 # Parser-accuracy failure worklist
 
-Source: `target/metrics/parser_accuracy.json` (1 failure packets)
+Source: `target/metrics/parser_accuracy.json` (0 failure packets)
 
 | Family | Count | Likely layer | First fixture | Suggested PR |
 |---|---:|---|---|---|
-| missing_symbol_declaration | 1 | semantic_fact_extraction | `generated_accessor` | `fix(semantic): resolve parser-accuracy semantic fact packet` |
+| none | 0 | n/a | n/a | n/a |

--- a/docs/project/status/parser_accuracy_fixture_inventory.json
+++ b/docs/project/status/parser_accuracy_fixture_inventory.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "commit": "81de1ca6a",
+  "commit": "1db620b99",
   "generated_by": "cargo xtask metrics parser-accuracy --export-status-receipts",
   "fixture_count": 46,
   "family_count": 28,

--- a/docs/project/status/parser_accuracy_next.md
+++ b/docs/project/status/parser_accuracy_next.md
@@ -4,14 +4,6 @@ Source: `target/metrics/parser_accuracy.json`
 
 Denominator: 46 fixtures / 28 families; 123 scored lines; 102 scored symbols.
 
-Failure packets: 1 active.
+Failure packets: 0 active.
 
-| Field | Value |
-|---|---|
-| Pointer | `missing_symbol_declaration` |
-| Packet count | 1 |
-| Likely layer | `semantic_fact_extraction` |
-| First fixture | `generated_accessor` |
-| Suggested PR | `fix(semantic): resolve parser-accuracy semantic fact packet` |
-
-Use this pointer only after open measurement/tracking PRs are settled. If the pointed lane has already landed, regenerate this file and take the next row.
+Pointer: no active failure packets.


### PR DESCRIPTION
Problem: parser-accuracy still had one active failure packet because the workspace canonical fact shard did not emit a `GeneratedMember` entity for the Moo `has name => ...` fixture.

Fix: add a narrow workspace-side generated-member producer for order-visible Moo/Moose/Mouse `has` calls, merge those entity/anchor facts into the canonical shard, and add fail-closed workspace tests.

Measurement delta:
- Denominator unchanged: 46 fixtures / 28 families; 123 scored lines; 102 scored symbols.
- Failure packets: 1 -> 0.
- `symbol_decl_generated_accessor_f1`: 1.0.
- Provider metric rows unchanged: 12.
- Ratchet floors unchanged: `dynamic_false_precision_count=0`, `fast_path_wrong_result_count=0`.

Verification:
- `cargo test -p perl-workspace --test generated_member_facts --locked`
- `cargo xtask metrics parser-accuracy --json`
- `cargo xtask metrics parser-accuracy --export-status-receipts`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo test -p xtask status_receipts_export_failure_packets_inventory_worklist_and_pointer --locked`
- `cargo check -p perl-workspace --all-targets --locked`
- `cargo clippy -p perl-workspace --lib --locked -- -D warnings`
- `cargo clippy -p perl-workspace --test generated_member_facts --locked -- -D warnings`
- `cargo xtask fmt --check`
- `git diff --check`

Note: `cargo clippy -p perl-workspace --all-targets --locked -- -D warnings` is still blocked by unrelated pre-existing test lints in `collapse_integration_tests.rs`, `workspace_scorecard.rs`, `surface_workspace_parity.rs`, and `comprehensive_unit_tests.rs`.