### PR TITLE
test(parser-core): align regex code execution expectation (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -345,7 +345,7 @@ fn test_source_filter_detection() {
 }
 
 #[test]
-fn test_regex_code_execution_detection() {
+fn test_regex_code_execution_rejected() {
     // Regex with code execution
     let code = r#"my $re = qr/(?{ print "hi" })/;"#;
     let mut parser = Parser::new(code);
@@ -353,7 +353,11 @@ fn test_regex_code_execution_detection() {
     assert!(result.is_ok());
     let ast = must(result);
     let sexp = ast.to_sexp();
-    assert!(sexp.contains("(risk:code)"), "Should detect regex code execution in: {}", sexp);
+    assert!(
+        sexp.contains("Embedded code execution is not allowed in regex patterns"),
+        "Should reject regex code execution in: {}",
+        sexp
+    );
 
     // Safe regex
     let code_safe = r#"my $re = qr/hello/;"#;


### PR DESCRIPTION
Problem: PR Smoke currently fails because a parser-core test still expects embedded regex code to produce a risk node, but RegexValidator::validate() now rejects it as a syntax error.\nFix: Update the parser-core unit test to assert the embedded-code syntax error while keeping the safe-regex negative case.\nVerification: \cargo test -p perl-parser -p perl-lexer -p perl-parser-core --lib --locked -- --test-threads=4\, \cargo xtask fmt --check\, \cargo xtask metrics parser-accuracy --check\, \cargo xtask metrics ratchet-check parser_accuracy\, and \git diff --check\ pass.