### PR TITLE
fix(parser): annotate regex embedded code instead of rejecting it (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/mod.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/mod.rs
@@ -3,4 +3,30 @@ impl<'a> Parser<'a> {
     fn parse_expression(&mut self) -> ParseResult<Node> {
         self.with_recursion_guard(|s| s.parse_comma())
     }
+
+    /// Validate parser-owned regex bodies while preserving Perl syntax that is
+    /// risky but valid. Embedded code is represented on the AST, and nested
+    /// quantifiers stay as non-fatal parser diagnostics.
+    fn analyze_regex_body_for_ast(&mut self, pattern: &str, start: usize) -> ParseResult<bool> {
+        let validator = crate::engine::regex_validator::RegexValidator::new();
+        let has_embedded_code = validator.find_code_execution(pattern, start).is_some();
+        let nested_quantifier = validator.find_nested_quantifier(pattern, start);
+
+        if !has_embedded_code && nested_quantifier.is_none() {
+            validator.validate(pattern, start).map_err(|error| match error {
+                crate::engine::regex_validator::RegexError::Syntax { message, offset } => {
+                    ParseError::syntax(message, offset)
+                }
+            })?;
+        }
+
+        if let Some(finding) = nested_quantifier {
+            self.record_error(ParseError::syntax(
+                "Nested quantifiers detected (possible backtracking risk)",
+                finding.offset,
+            ));
+        }
+
+        Ok(has_embedded_code)
+    }
 }

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -239,19 +239,7 @@ impl<'a> Parser<'a> {
                 let token = self.tokens.next()?;
                 let (pattern, body, modifiers) = quote_parser::extract_regex_parts(&token.text);
 
-                // Validate regex complexity and check for embedded code
-                let validator = crate::engine::regex_validator::RegexValidator::new();
-                validator.validate(&body, token.start)?;
-                // Nested quantifiers are recorded as a non-fatal diagnostic
-                // rather than a hard error to avoid false positives on valid
-                // Perl patterns like (?:/\.)+, (\w+)*, (?:pattern)+
-                if validator.detect_nested_quantifiers(&body) {
-                    self.record_error(ParseError::syntax(
-                        "Nested quantifiers detected (possible backtracking risk)",
-                        token.start,
-                    ));
-                }
-                let has_embedded_code = validator.detects_code_execution(&body);
+                let has_embedded_code = self.analyze_regex_body_for_ast(&body, token.start)?;
 
                 Ok(Node::new(
                     NodeKind::Regex { pattern, replacement: None, modifiers, has_embedded_code },
@@ -409,16 +397,7 @@ impl<'a> Parser<'a> {
                         },
                     )?;
 
-                // Validate regex complexity and check for embedded code
-                let validator = crate::engine::regex_validator::RegexValidator::new();
-                validator.validate(&pattern, token.start)?;
-                if validator.detect_nested_quantifiers(&pattern) {
-                    self.record_error(ParseError::syntax(
-                        "Nested quantifiers detected (possible backtracking risk)",
-                        token.start,
-                    ));
-                }
-                let has_embedded_code = validator.detects_code_execution(&pattern);
+                let has_embedded_code = self.analyze_regex_body_for_ast(&pattern, token.start)?;
 
                 // Substitution as a standalone expression (will be used with =~ later)
                 Ok(Node::new(

--- a/crates/perl-parser-core/src/engine/parser/expressions/quotes.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/quotes.rs
@@ -209,20 +209,7 @@ impl<'a> Parser<'a> {
             }
             "qr" => {
                 // Regular expression
-                // Validate regex complexity and check for embedded code
-                let validator = crate::engine::regex_validator::RegexValidator::new();
-                validator.validate(&content, start).map_err(|e| match e {
-                    crate::engine::regex_validator::RegexError::Syntax { message, offset } => {
-                        ParseError::syntax(message, offset)
-                    }
-                })?;
-                if validator.detect_nested_quantifiers(&content) {
-                    self.record_error(ParseError::syntax(
-                        "Nested quantifiers detected (possible backtracking risk)",
-                        start,
-                    ));
-                }
-                let has_embedded_code = validator.detects_code_execution(&content);
+                let has_embedded_code = self.analyze_regex_body_for_ast(&content, start)?;
 
                 Ok(Node::new(
                     NodeKind::Regex {
@@ -243,20 +230,7 @@ impl<'a> Parser<'a> {
             }
             "m" => {
                 // Match operator with pattern
-                // Validate regex complexity and check for embedded code
-                let validator = crate::engine::regex_validator::RegexValidator::new();
-                validator.validate(&content, start).map_err(|e| match e {
-                    crate::engine::regex_validator::RegexError::Syntax { message, offset } => {
-                        ParseError::syntax(message, offset)
-                    }
-                })?;
-                if validator.detect_nested_quantifiers(&content) {
-                    self.record_error(ParseError::syntax(
-                        "Nested quantifiers detected (possible backtracking risk)",
-                        start,
-                    ));
-                }
-                let has_embedded_code = validator.detects_code_execution(&content);
+                let has_embedded_code = self.analyze_regex_body_for_ast(&content, start)?;
 
                 let mut modifiers = String::new();
                 while let Ok(token) = self.tokens.peek() {

--- a/crates/perl-parser-core/src/engine/parser/tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/tests.rs
@@ -345,19 +345,27 @@ fn test_source_filter_detection() {
 }
 
 #[test]
-fn test_regex_code_execution_rejected() {
-    // Regex with code execution
-    let code = r#"my $re = qr/(?{ print "hi" })/;"#;
-    let mut parser = Parser::new(code);
-    let result = parser.parse();
-    assert!(result.is_ok());
-    let ast = must(result);
-    let sexp = ast.to_sexp();
-    assert!(
-        sexp.contains("Embedded code execution is not allowed in regex patterns"),
-        "Should reject regex code execution in: {}",
-        sexp
-    );
+fn test_regex_code_execution_annotated() {
+    let cases = [
+        ("qr operator", r#"my $re = qr/(?{ print "hi" })/;"#),
+        ("match operator", r#"$x =~ m/(?{ print "hi" })/;"#),
+        ("bare match", r#"$x =~ /(?{ print "hi" })/;"#),
+        ("substitution", r#"$x =~ s/(?{ print "hi" })/ok/;"#),
+    ];
+
+    for (name, code) in cases {
+        let mut parser = Parser::new(code);
+        let result = parser.parse();
+        assert!(result.is_ok(), "{name} should parse successfully: {:?}", result.err());
+        let ast = must(result);
+        let sexp = ast.to_sexp();
+        assert!(sexp.contains("(risk:code)"), "{name} should mark embedded code: {sexp}");
+        assert!(
+            !sexp.contains("Embedded code execution is not allowed in regex patterns"),
+            "{name} should not reject valid Perl embedded-code regex syntax: {sexp}"
+        );
+        assert!(!sexp.contains("ERROR"), "{name} should not recover through ERROR: {sexp}");
+    }
 
     // Safe regex
     let code_safe = r#"my $re = qr/hello/;"#;
@@ -367,6 +375,23 @@ fn test_regex_code_execution_rejected() {
     let ast_safe = must(result_safe);
     let sexp_safe = ast_safe.to_sexp();
     assert!(!sexp_safe.contains("(risk:code)"), "Should not flag safe regex in: {}", sexp_safe);
+}
+
+#[test]
+fn test_regex_code_execution_preserves_nested_quantifier_diagnostic() {
+    let code = r#"my $re = qr/(?{ print "hi" })(a+)+/;"#;
+    let mut parser = Parser::new(code);
+    let result = parser.parse();
+    assert!(result.is_ok(), "embedded-code regex should parse successfully: {:?}", result.err());
+    let ast = must(result);
+    let sexp = ast.to_sexp();
+    assert!(sexp.contains("(risk:code)"), "Should annotate embedded code: {sexp}");
+
+    let found = parser.errors().iter().any(|error| {
+        error.to_string().contains("Nested quantifiers detected")
+            || error.to_string().contains("backtracking risk")
+    });
+    assert!(found, "Should preserve nested-quantifier diagnostic: {:?}", parser.errors());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Parses Perl regex embedded-code constructs as valid syntax with an AST risk annotation instead of recovering through parser errors.

Covered forms:

- `qr/(?{ ... })/`
- `$x =~ m/(?{ ... })/`
- `$x =~ /(?{ ... })/`
- `$x =~ s/(?{ ... })/ok/`

The parser now uses one helper for regex AST analysis. Embedded code sets `has_embedded_code` / `(risk:code)`, while nested quantifiers remain non-fatal parser diagnostics, including when both risks appear in the same regex.

## Review notes

- This is runtime parser behavior, not just a test update.
- `RegexValidator::validate()` still rejects embedded code for direct validator callers; the parser intentionally uses the finder APIs because embedded code is valid Perl syntax that should remain parseable for editor features.
- No all-workspace status metrics moved: parser accuracy remains 46 fixtures / 28 families / 123 scored lines / 102 scored symbols, 0 failure packets, and 12 provider rows all `insufficient_data`.
- `cargo clippy -p perl-parser-core --tests ...` is currently blocked by pre-existing unrelated `panic!` calls in integration tests (`expected_module_name_tests.rs`, `fix_scoped_sub_declarations.rs`). The changed parser code passed `--lib` clippy.

## Verification

- `cargo test -p perl-parser-core --lib regex_code_execution --profile agent --locked`
- `cargo test -p perl-parser-core --lib test_catastrophic_backtracking_detection --profile agent --locked`
- `cargo test -p perl-parser-core --lib --profile agent --locked`
- `cargo clippy -p perl-parser-core --lib --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`
