### PR TITLE
test(ux): add BDD coverage for signature help, code lens, folding range (#0000)

### DIFF
--- a/.ci/metrics/editor_ux.json
+++ b/.ci/metrics/editor_ux.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "measured_at": "2026-04-30T20:54:03.456684600+00:00",
+  "measured_at": "2026-05-06T01:52:15.573099+00:00",
   "subsystem": "editor_ux",
   "top_line": {
     "workflow_pass_rate": {
@@ -1300,10 +1300,145 @@
           "insufficient data"
         ]
       }
+    },
+    {
+      "id": "signature_help_core",
+      "scenario": "ux_scenario_25_signature_help.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "code_lens_core",
+      "scenario": "ux_scenario_26_code_lens.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
+    },
+    {
+      "id": "folding_range_core",
+      "scenario": "ux_scenario_27_folding_range.rs",
+      "subsystem_owner": "editor_intelligence",
+      "pass_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "stability_rate": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "assumptions": [
+          "insufficient data"
+        ]
+      },
+      "p95_time_to_first_useful_result_ms": {
+        "state": "insufficient_data",
+        "value": null,
+        "kind": "measured",
+        "basis": [
+          "no receipts"
+        ],
+        "coverage": "receipts_included",
+        "confidence": "low",
+        "method": "p95",
+        "assumptions": [
+          "insufficient data"
+        ]
+      }
     }
   ],
   "provenance": {
-    "fixture_matrix": "H:\\Code\\Rust2\\perl-lsp\\crates\\perl-lsp-ux-tests\\fixtures\\editor_ux_fixture_matrix.json",
+    "fixture_matrix": "H:\\Code\\Rust\\perl-lsp\\crates\\perl-lsp-ux-tests\\fixtures\\editor_ux_fixture_matrix.json",
     "harness": "crates/perl-lsp-ux-tests",
     "tiers": []
   }

--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -721,6 +721,84 @@
         "manual_editor_smoke",
         "issue_burndown_regression_guard"
       ]
+    },
+    {
+      "id": "signature_help_core",
+      "scenario_file": "ux_scenario_25_signature_help.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "component": "signature_help",
+      "instrumentation": {
+        "run_receipt": false,
+        "first_useful_result": false,
+        "protocol_goldens": false
+      },
+      "user_journey": "request signature help at Perl builtin call sites",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "builtin signatureHelp requests do not return JSON-RPC errors",
+        "non-null builtin signatureHelp responses have valid signature labels",
+        "repeated builtin signatureHelp requests do not crash the server"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke"
+      ]
+    },
+    {
+      "id": "code_lens_core",
+      "scenario_file": "ux_scenario_26_code_lens.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "component": "code_lens",
+      "instrumentation": {
+        "run_receipt": false,
+        "first_useful_result": false,
+        "protocol_goldens": false
+      },
+      "user_journey": "request and resolve code lenses for Perl modules and test files",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "codeLens requests return arrays or null without JSON-RPC errors",
+        "returned lenses contain valid ranges",
+        "codeLens resolve requests do not crash the server"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke"
+      ]
+    },
+    {
+      "id": "folding_range_core",
+      "scenario_file": "ux_scenario_27_folding_range.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "component": "folding_range",
+      "instrumentation": {
+        "run_receipt": false,
+        "first_useful_result": false,
+        "protocol_goldens": false
+      },
+      "user_journey": "request folding ranges for nested Perl blocks and small edge-case files",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate"
+      ],
+      "expected_outcomes": [
+        "foldingRange requests do not return JSON-RPC errors",
+        "folding ranges include valid start and end line fields when present",
+        "multi-block files produce at least one fold"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke"
+      ]
     }
   ]
 }

--- a/crates/perl-lsp-ux-tests/src/taxonomy.rs
+++ b/crates/perl-lsp-ux-tests/src/taxonomy.rs
@@ -81,6 +81,9 @@ pub enum UxComponent {
     Rename,
     Hover,
     GotoDefinition,
+    SignatureHelp,
+    CodeLens,
+    FoldingRange,
     Infra,
     AiCompletion,
 }
@@ -223,6 +226,9 @@ mod tests {
             UxComponent::Rename,
             UxComponent::Hover,
             UxComponent::GotoDefinition,
+            UxComponent::SignatureHelp,
+            UxComponent::CodeLens,
+            UxComponent::FoldingRange,
             UxComponent::Infra,
             UxComponent::AiCompletion,
         ];

--- a/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
+++ b/crates/perl-lsp-ux-tests/tests/editor_ux_fixture_matrix.rs
@@ -17,6 +17,9 @@ const VALID_COMPONENTS: &[&str] = &[
     "rename",
     "hover",
     "goto_definition",
+    "signature_help",
+    "code_lens",
+    "folding_range",
     "infra",
     "ai_completion",
 ];

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_25_signature_help.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_25_signature_help.rs
@@ -1,0 +1,155 @@
+//! Scenario 25: builtin signature-help UX coverage.
+//!
+//! This scenario locks the end-to-end `textDocument/signatureHelp` path that
+//! the current server answers reliably: Perl builtins. User-defined call-site
+//! coverage belongs in a separate runtime follow-up because that path currently
+//! times out under the real stdio harness.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::{Value, json};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+const BUILTIN_FIXTURE: &str = r#"use strict;
+use warnings;
+
+my @arr = (3, 1, 2);
+push(@arr, 4);
+my $str = join(", ", @arr);
+"#;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+fn builtin_harness() -> Result<UxHarness> {
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("builtins.pl", BUILTIN_FIXTURE))?;
+    harness.open_file("builtins.pl", BUILTIN_FIXTURE)?;
+    Ok(harness)
+}
+
+fn request_signature_help(harness: &UxHarness, line: u32, character: u32) -> Result<Value> {
+    let uri = harness.workspace.uri("builtins.pl");
+    harness.client.request(
+        "textDocument/signatureHelp",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character }
+        }),
+        REQUEST_TIMEOUT,
+    )
+}
+
+#[test]
+fn scenario_25_builtin_push_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_25: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness = builtin_harness()?;
+    let response = request_signature_help(&harness, 4, 8)?;
+
+    assert!(
+        response.get("error").is_none(),
+        "signatureHelp on builtin push MUST NOT return a JSON-RPC error: {response:?}"
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_25_builtin_join_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_25: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness = builtin_harness()?;
+    let response = request_signature_help(&harness, 5, 15)?;
+
+    assert!(
+        response.get("error").is_none(),
+        "signatureHelp on builtin join MUST NOT return a JSON-RPC error: {response:?}"
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_25_builtin_result_is_well_formed_when_present() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_25: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness = builtin_harness()?;
+    let response = request_signature_help(&harness, 5, 15)?;
+
+    assert!(
+        response.get("error").is_none(),
+        "signatureHelp on builtin join returned an error: {response:?}"
+    );
+
+    if let Some(result) = response.get("result") {
+        if !result.is_null() {
+            assert_signature_help_structure(result)?;
+        }
+    }
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_25_builtin_requests_are_idempotent() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_25: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let harness = builtin_harness()?;
+    for round in 1..=2 {
+        let response = request_signature_help(&harness, 5, 15)?;
+        assert!(
+            response.get("error").is_none(),
+            "signatureHelp round {round} MUST NOT return a JSON-RPC error: {response:?}"
+        );
+    }
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+fn assert_signature_help_structure(result: &Value) -> Result<()> {
+    let Some(signatures) = result.get("signatures") else {
+        anyhow::bail!("SignatureHelp result must have a signatures field, got: {result:?}");
+    };
+    assert!(signatures.is_array(), "SignatureHelp.signatures must be an array");
+
+    let sig_array = signatures
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("signatures is not an array: {signatures:?}"))?;
+    for (i, sig) in sig_array.iter().enumerate() {
+        assert!(
+            sig.get("label").and_then(Value::as_str).is_some(),
+            "SignatureInformation[{i}] must have a string label, got: {sig:?}"
+        );
+
+        if let Some(params) = sig.get("parameters").and_then(Value::as_array) {
+            for (j, param) in params.iter().enumerate() {
+                assert!(
+                    param.get("label").is_some(),
+                    "ParameterInformation[{i}][{j}] must have a label, got: {param:?}"
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs
@@ -1,0 +1,272 @@
+//! Scenario 26: Code lens UX coverage.
+//!
+//! Exercises `textDocument/codeLens` and `codeLens/resolve` against a typical
+//! Perl module with named subroutines, package declarations, and test helpers.
+//!
+//! Contract:
+//! - `codeLens` MUST NOT return a JSON-RPC error for any openable Perl file.
+//! - `codeLens` MUST return an array (possibly empty), never a non-array result.
+//! - Each returned CodeLens MUST have a `range` with `start` and `end` positions.
+//! - `codeLens/resolve` on any lens returned by `codeLens` MUST NOT error.
+//! - The server MUST stay stable after requesting lenses on the same file twice
+//!   (idempotency guard).
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::{Value, json};
+use std::time::Duration;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A realistic OO-style Perl module with package, several subs, and a call
+/// site and exercises the most common code-lens attachment points.
+const CODELENS_FIXTURE: &str = r#"package MyCalc;
+use strict;
+use warnings;
+
+sub new {
+    my ($class) = @_;
+    return bless {}, $class;
+}
+
+sub add {
+    my ($self, $x, $y) = @_;
+    return $x + $y;
+}
+
+sub subtract {
+    my ($self, $x, $y) = @_;
+    return $x - $y;
+}
+
+sub multiply {
+    my ($self, $x, $y) = @_;
+    return $x * $y;
+}
+
+my $calc = MyCalc->new();
+my $sum  = $calc->add(3, 4);
+print "Result: $sum\n";
+1;
+"#;
+
+/// A minimal test file so the code-lens provider can detect `Test::*` subs.
+const TEST_FIXTURE: &str = r#"use strict;
+use warnings;
+use Test::More;
+
+sub test_addition {
+    is(2 + 2, 4, 'addition works');
+}
+
+sub test_subtraction {
+    is(5 - 3, 2, 'subtraction works');
+}
+
+test_addition();
+test_subtraction();
+done_testing();
+"#;
+
+#[test]
+fn scenario_26_code_lens_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_26: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
+    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
+    let uri = harness.workspace.uri("mycalc.pl");
+
+    let response = harness.client.request(
+        "textDocument/codeLens",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(
+        response.get("error").is_none(),
+        "codeLens MUST NOT return a JSON-RPC error, got: {:?}",
+        response
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_26_code_lens_result_is_array() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_26: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
+    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
+    let uri = harness.workspace.uri("mycalc.pl");
+
+    let response = harness.client.request(
+        "textDocument/codeLens",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(response.get("error").is_none(), "codeLens returned error: {:?}", response);
+
+    let result = response.get("result").unwrap_or(&Value::Null);
+    assert!(
+        result.is_array() || result.is_null(),
+        "codeLens result MUST be an array (or null for no lenses), got: {result:?}"
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_26_code_lens_items_have_valid_ranges() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_26: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
+    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
+    let uri = harness.workspace.uri("mycalc.pl");
+
+    let response = harness.client.request(
+        "textDocument/codeLens",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(response.get("error").is_none(), "codeLens returned error: {:?}", response);
+
+    let result = response.get("result").unwrap_or(&Value::Null);
+    if let Some(lenses) = result.as_array() {
+        for (i, lens) in lenses.iter().enumerate() {
+            assert!(
+                lens.get("range").is_some(),
+                "CodeLens[{i}] MUST have a 'range' field, got: {lens:?}"
+            );
+            let Some(range) = lens.get("range") else { continue };
+            assert!(
+                range.get("start").is_some(),
+                "CodeLens[{i}].range MUST have 'start', got: {range:?}"
+            );
+            assert!(
+                range.get("end").is_some(),
+                "CodeLens[{i}].range MUST have 'end', got: {range:?}"
+            );
+        }
+    }
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_26_code_lens_is_idempotent() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_26: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
+    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
+    let uri = harness.workspace.uri("mycalc.pl");
+
+    // Two identical requests in sequence must succeed without crash.
+    for round in 1u8..=2 {
+        let response = harness.client.request(
+            "textDocument/codeLens",
+            json!({ "textDocument": { "uri": uri } }),
+            REQUEST_TIMEOUT,
+        )?;
+        assert!(
+            response.get("error").is_none(),
+            "codeLens round {round} MUST NOT return error: {:?}",
+            response
+        );
+    }
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_26_code_lens_on_test_file_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_26: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("mytest.t", TEST_FIXTURE))?;
+    harness.open_file("mytest.t", TEST_FIXTURE)?;
+    let uri = harness.workspace.uri("mytest.t");
+
+    let response = harness.client.request(
+        "textDocument/codeLens",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(
+        response.get("error").is_none(),
+        "codeLens on .t test file MUST NOT return JSON-RPC error: {:?}",
+        response
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_26_code_lens_resolve_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_26: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
+    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
+    let uri = harness.workspace.uri("mycalc.pl");
+
+    // Fetch lenses first so we can resolve the first one (if any exist).
+    let lens_response = harness.client.request(
+        "textDocument/codeLens",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+    assert!(
+        lens_response.get("error").is_none(),
+        "codeLens initial fetch returned error: {:?}",
+        lens_response
+    );
+
+    let lenses = match lens_response.get("result").and_then(Value::as_array) {
+        Some(arr) if !arr.is_empty() => arr.clone(),
+        // No lenses returned; skip resolve check (not an error).
+        _ => {
+            harness.assert_no_crash();
+            return Ok(());
+        }
+    };
+
+    let first_lens = &lenses[0];
+    let resolve_response =
+        harness.client.request("codeLens/resolve", first_lens.clone(), REQUEST_TIMEOUT)?;
+
+    assert!(
+        resolve_response.get("error").is_none(),
+        "codeLens/resolve MUST NOT return JSON-RPC error: {:?}",
+        resolve_response
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs
@@ -1,0 +1,288 @@
+//! Scenario 27: Folding range UX coverage.
+//!
+//! Exercises `textDocument/foldingRange` against Perl files with nested
+//! blocks, the primary use-case for code folding in an editor.
+//!
+//! Contract:
+//! - `foldingRange` MUST NOT return a JSON-RPC error for any valid Perl file.
+//! - If ranges are returned, each MUST have `startLine` and `endLine` integers,
+//!   with `startLine <= endLine`.
+//! - An empty file MUST return an empty array (not an error).
+//! - A file with deeply nested blocks (if/else/for/while/sub) MUST return
+//!   at least one range so the editor can offer at least one fold.
+//! - The server MUST remain stable after repeated fold requests.
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::{Value, json};
+use std::time::Duration;
+
+fn binary_available() -> bool {
+    perl_lsp_ux_tests::resolve_binary().is_ok()
+}
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Multi-block Perl file that exercises every common fold anchor:
+/// sub body, if/elsif/else, for loop, while loop, and a nested closure.
+const FOLDING_FIXTURE: &str = r#"package MyProcessor;
+use strict;
+use warnings;
+
+sub process_items {
+    my ($self, @items) = @_;
+    my @results;
+
+    for my $item (@items) {
+        if ($item > 0) {
+            push @results, $item * 2;
+        } elsif ($item == 0) {
+            push @results, 0;
+        } else {
+            push @results, -1;
+        }
+    }
+
+    return @results;
+}
+
+sub run_while_loop {
+    my ($self, $limit) = @_;
+    my $count = 0;
+    while ($count < $limit) {
+        $count++;
+    }
+    return $count;
+}
+
+sub with_closure {
+    my ($self) = @_;
+    my $adder = sub {
+        my ($x) = @_;
+        return $x + 10;
+    };
+    return $adder;
+}
+
+1;
+"#;
+
+const EMPTY_FIXTURE: &str = "";
+
+const SINGLE_LINE_FIXTURE: &str = "my $x = 42;\n";
+
+#[test]
+fn scenario_27_folding_range_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_27: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("processor.pl", FOLDING_FIXTURE))?;
+    harness.open_file("processor.pl", FOLDING_FIXTURE)?;
+    let uri = harness.workspace.uri("processor.pl");
+
+    let response = harness.client.request(
+        "textDocument/foldingRange",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(
+        response.get("error").is_none(),
+        "foldingRange MUST NOT return a JSON-RPC error, got: {:?}",
+        response
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_27_folding_range_result_is_array() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_27: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("processor.pl", FOLDING_FIXTURE))?;
+    harness.open_file("processor.pl", FOLDING_FIXTURE)?;
+    let uri = harness.workspace.uri("processor.pl");
+
+    let response = harness.client.request(
+        "textDocument/foldingRange",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(response.get("error").is_none(), "foldingRange returned error: {:?}", response);
+
+    let result = response.get("result").unwrap_or(&Value::Null);
+    assert!(
+        result.is_array() || result.is_null(),
+        "foldingRange result MUST be an array (or null), got: {result:?}"
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_27_folding_ranges_have_valid_line_fields() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_27: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("processor.pl", FOLDING_FIXTURE))?;
+    harness.open_file("processor.pl", FOLDING_FIXTURE)?;
+    let uri = harness.workspace.uri("processor.pl");
+
+    let response = harness.client.request(
+        "textDocument/foldingRange",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(response.get("error").is_none(), "foldingRange returned error: {:?}", response);
+
+    let result = response.get("result").unwrap_or(&Value::Null);
+    if let Some(ranges) = result.as_array() {
+        for (i, range) in ranges.iter().enumerate() {
+            let start_line = range.get("startLine").and_then(Value::as_u64).ok_or_else(|| {
+                anyhow::anyhow!("FoldingRange[{i}] MUST have integer 'startLine', got: {range:?}")
+            })?;
+            let end_line = range.get("endLine").and_then(Value::as_u64).ok_or_else(|| {
+                anyhow::anyhow!("FoldingRange[{i}] MUST have integer 'endLine', got: {range:?}")
+            })?;
+            assert!(
+                start_line <= end_line,
+                "FoldingRange[{i}] startLine ({start_line}) MUST be <= endLine ({end_line})"
+            );
+        }
+    }
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_27_multi_block_file_produces_at_least_one_fold() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_27: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("processor.pl", FOLDING_FIXTURE))?;
+    harness.open_file("processor.pl", FOLDING_FIXTURE)?;
+    let uri = harness.workspace.uri("processor.pl");
+
+    let response = harness.client.request(
+        "textDocument/foldingRange",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(response.get("error").is_none(), "foldingRange returned error: {:?}", response);
+
+    let result = response.get("result").unwrap_or(&Value::Null);
+    let range_count = result.as_array().map_or(0, |v| v.len());
+    assert!(
+        range_count >= 1,
+        "A file with multiple sub/if/for/while blocks MUST produce at least one folding range; got {range_count}"
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_27_empty_file_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_27: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("empty.pl", EMPTY_FIXTURE))?;
+    harness.open_file("empty.pl", EMPTY_FIXTURE)?;
+    let uri = harness.workspace.uri("empty.pl");
+
+    let response = harness.client.request(
+        "textDocument/foldingRange",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(
+        response.get("error").is_none(),
+        "foldingRange on empty file MUST NOT return JSON-RPC error: {:?}",
+        response
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_27_single_line_file_does_not_error() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_27: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("tiny.pl", SINGLE_LINE_FIXTURE))?;
+    harness.open_file("tiny.pl", SINGLE_LINE_FIXTURE)?;
+    let uri = harness.workspace.uri("tiny.pl");
+
+    let response = harness.client.request(
+        "textDocument/foldingRange",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(
+        response.get("error").is_none(),
+        "foldingRange on single-line file MUST NOT return JSON-RPC error: {:?}",
+        response
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}
+
+#[test]
+fn scenario_27_folding_range_is_idempotent() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_27: perl-lsp binary not found");
+        return Ok(());
+    }
+    let harness =
+        UxHarness::new(ScenarioConfig::default().with_file("processor.pl", FOLDING_FIXTURE))?;
+    harness.open_file("processor.pl", FOLDING_FIXTURE)?;
+    let uri = harness.workspace.uri("processor.pl");
+
+    // Request twice; both requests must succeed without crashing.
+    let first = harness.client.request(
+        "textDocument/foldingRange",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+    let second = harness.client.request(
+        "textDocument/foldingRange",
+        json!({ "textDocument": { "uri": uri } }),
+        REQUEST_TIMEOUT,
+    )?;
+
+    assert!(first.get("error").is_none(), "foldingRange first request errored: {:?}", first);
+    assert!(second.get("error").is_none(), "foldingRange second request errored: {:?}", second);
+
+    let first_count = first.get("result").and_then(Value::as_array).map_or(0, |v| v.len());
+    let second_count = second.get("result").and_then(Value::as_array).map_or(0, |v| v.len());
+
+    assert_eq!(
+        first_count, second_count,
+        "foldingRange MUST be idempotent: first={first_count}, second={second_count}"
+    );
+
+    harness.assert_no_crash();
+    Ok(())
+}

--- a/docs/project/status/editor_ux.json
+++ b/docs/project/status/editor_ux.json
@@ -4,13 +4,13 @@
       "name": "manual_editor_smoke",
       "owner": "perl-lsp-ux-tests",
       "state": "tracked",
-      "workflow_count": 26
+      "workflow_count": 29
     },
     {
       "name": "first_five_minutes_harness",
       "owner": "perl-lsp-ux-tests",
       "state": "tracked",
-      "workflow_count": 25
+      "workflow_count": 28
     },
     {
       "name": "issue_burndown_regression_guard",
@@ -21,7 +21,7 @@
   ],
   "harness": {
     "crate": "crates/perl-lsp-ux-tests",
-    "scenario_count": 27,
+    "scenario_count": 30,
     "scenario_files": [
       "crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_02_missing_perltidy.rs",
@@ -49,7 +49,10 @@
       "crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_22_template_language_mode.rs",
       "crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs",
-      "crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs"
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_25_signature_help.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs",
+      "crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs"
     ]
   },
   "integration_points": {
@@ -447,6 +450,33 @@
       "scenario": "ux_scenario_19_diagnostics_lifecycle.rs",
       "stability_rate_state": "insufficient_data",
       "subsystem_owner": "diagnostics"
+    },
+    {
+      "id": "signature_help_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_25_signature_help.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "code_lens_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_26_code_lens.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
+    },
+    {
+      "id": "folding_range_core",
+      "p95_time_to_first_useful_result_state": "insufficient_data",
+      "pass_rate_state": "insufficient_data",
+      "quarantine_age_days": null,
+      "scenario": "ux_scenario_27_folding_range.rs",
+      "stability_rate_state": "insufficient_data",
+      "subsystem_owner": "editor_intelligence"
     }
   ]
 }

--- a/docs/project/status/quality.md
+++ b/docs/project/status/quality.md
@@ -8,7 +8,7 @@
 
 <!-- BEGIN: QUALITY_METRICS_BULLETS -->
 - **Quality Metrics**: <50ms LSP response times, 931ns incremental parsing
-- **UX workflow harness**: 27 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; confidence signals (manual smoke, first-5-minutes coverage, issue-burndown regression guards) are tracked in `docs/project/status/editor_ux.json`
+- **UX workflow harness**: 30 scenario files in `perl-lsp-ux-tests`; `just ux-tests` runs the default release-confidence lane and `just ux-tests-full` adds the integration-only 10k-line large-file case; confidence signals (manual smoke, first-5-minutes coverage, issue-burndown regression guards) are tracked in `docs/project/status/editor_ux.json`
 - **Mutation testing**: mutation data pending first nightly CI run — run `just mutation-subset` locally to populate
 - **Lexer performance scorecard**: `cargo bench -p perl-lexer --bench lexer_benchmarks` writes `benchmarks/results/lexer_scorecard.json` for trend comparisons
 - **Production Status**: LSP server public alpha (`just ci-gate` passing)


### PR DESCRIPTION
## Summary

Adds end-to-end UX BDD coverage for three GA LSP features through the real `perl-lsp-ux-tests` stdio harness:

- Scenario 25: `textDocument/signatureHelp` for Perl builtin call sites.
- Scenario 26: `textDocument/codeLens` and `codeLens/resolve`.
- Scenario 27: `textDocument/foldingRange`.

This is test/status coverage only. No production LSP behavior changes are included.

## Review notes

- Signature-help coverage is intentionally builtin-only in this PR. Local review found user-defined and outside-call signature-help requests timing out under the real stdio harness, so those belong in a separate runtime follow-up instead of being hidden inside this test-only lane.
- Folding-range line validation accepts `startLine <= endLine`; the current server can return single-line ranges.
- The fixture matrix and UX taxonomy now include `signature_help`, `code_lens`, and `folding_range`, so the new scenarios are part of the real status surface.
- `.ci/metrics/editor_ux.json`, `docs/project/status/editor_ux.json`, and `docs/project/status/quality.md` reflect 30 scenario files. The new workflow rows remain `insufficient_data` because no run receipts were present.
- Parser-accuracy metrics are unchanged: 46 fixtures / 28 families / 123 scored lines / 102 scored symbols, 0 failure packets, and 12 provider rows all `insufficient_data`.

## Verification

- `cargo test -p perl-lsp-ux-tests --test ux_scenario_25_signature_help --profile agent --locked`
- `cargo test -p perl-lsp-ux-tests --test ux_scenario_26_code_lens --profile agent --locked`
- `cargo test -p perl-lsp-ux-tests --test ux_scenario_27_folding_range --profile agent --locked`
- `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked`
- `cargo test -p perl-lsp-ux-tests --profile agent --locked`
- `cargo clippy -p perl-lsp-ux-tests --tests --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`
