### PR TITLE
test(tree-sitter-perl-c): add 11 snapshot tests for S-expression output (#4362)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,6 +3179,7 @@ name = "tree-sitter-perl-c"
 version = "0.13.3"
 dependencies = [
  "cc",
+ "insta",
  "tree-sitter",
  "tree-sitter-language",
 ]

--- a/crates/tree-sitter-perl-c/Cargo.toml
+++ b/crates/tree-sitter-perl-c/Cargo.toml
@@ -34,6 +34,7 @@ default-target = "x86_64-unknown-linux-gnu"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
+insta = { version = "1.47.2" }
 
 [features]
 default = ["c-scanner"]

--- a/crates/tree-sitter-perl-c/tests/snapshots.rs
+++ b/crates/tree-sitter-perl-c/tests/snapshots.rs
@@ -1,0 +1,101 @@
+//! Snapshot tests for the C-backed tree-sitter Perl grammar S-expression output.
+//!
+//! These test the same 11 Perl constructs as `tree-sitter-perl-rs/tests/snapshots.rs`
+//! but capture the upstream C grammar's S-expression shape. Run
+//! `INSTA_UPDATE=always cargo test -p tree-sitter-perl-c --test snapshots`
+//! to regenerate snapshots when the upstream grammar is updated.
+//!
+//! Snapshot content intentionally differs from `tree-sitter-perl-rs` — the C grammar
+//! produces different node kinds (upstream tree-sitter grammar vs. native v3 AST).
+//! Both sets of snapshots together form the cross-backend comparison baseline.
+
+use std::error::Error;
+
+use tree_sitter_perl_c::parse_perl_code;
+
+fn sexp(code: &str) -> Result<String, Box<dyn Error>> {
+    let tree = parse_perl_code(code)?;
+    Ok(tree.root_node().to_sexp())
+}
+
+#[test]
+fn snapshot_variable_declaration() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!("variable_declaration", sexp("my $x = 42;")?);
+    Ok(())
+}
+
+#[test]
+fn snapshot_subroutine() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!("subroutine", sexp("sub foo { return $_[0] + 1; }")?);
+    Ok(())
+}
+
+#[test]
+fn snapshot_heredoc() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!("heredoc", sexp("my $text = <<END;\nhello world\nEND\n")?);
+    Ok(())
+}
+
+#[test]
+fn snapshot_regex() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!("regex", sexp(r"my $matched = ($str =~ /^\d+$/);")?);
+    Ok(())
+}
+
+#[test]
+fn snapshot_package_declaration() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!(
+        "package_declaration",
+        sexp("package My::Module;\nuse strict;\nuse warnings;")?
+    );
+    Ok(())
+}
+
+#[test]
+fn snapshot_package_with_multiple_subs() -> Result<(), Box<dyn Error>> {
+    let src = "package Animal;\n\nsub new { my ($class, %args) = @_; bless {}, $class; }\n\nsub speak { return \"...\"; }\n\nsub name { return $_[0]->{name}; }";
+    insta::assert_snapshot!("package_with_multiple_subs", sexp(src)?);
+    Ok(())
+}
+
+#[test]
+fn snapshot_nested_blocks() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!("nested_blocks", sexp("sub outer { if (1) { while (1) { last; } } }")?);
+    Ok(())
+}
+
+#[test]
+fn snapshot_complex_regex() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!(
+        "complex_regex",
+        sexp(r#"my @matches = ($text =~ /(\w+)\s+=\s+(\d+)/g);"#)?
+    );
+    Ok(())
+}
+
+#[test]
+fn snapshot_control_flow_with_postfix_condition() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!(
+        "control_flow_with_postfix_condition",
+        sexp("my $x = 3;\nprint \"odd\\n\" if $x % 2;\n")?
+    );
+    Ok(())
+}
+
+#[test]
+fn snapshot_data_structure_dereference() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!(
+        "data_structure_dereference",
+        sexp("my $name = $user->{profile}->{name} // 'unknown';")?
+    );
+    Ok(())
+}
+
+#[test]
+fn snapshot_for_loop_with_lexical_iterator() -> Result<(), Box<dyn Error>> {
+    insta::assert_snapshot!(
+        "for_loop_with_lexical_iterator",
+        sexp("for my $item (@items) { print $item, \"\\n\"; }")?
+    );
+    Ok(())
+}

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__complex_regex.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__complex_regex.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(r#\"my @matches = ($text =~ /(\\w+)\\s+=\\s+(\\d+)/g);\"#)"
+---
+(source_file (expression_statement (assignment_expression left: (variable_declaration variable: (array (varname))) right: (binary_expression left: (scalar (varname)) right: (match_regexp content: (regexp_content (escape_sequence) (escape_sequence) (escape_sequence) (escape_sequence)) modifiers: (match_regexp_modifiers))))))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__control_flow_with_postfix_condition.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__control_flow_with_postfix_condition.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(\"my $x = 3;\\nprint \\\"odd\\\\n\\\" if $x % 2;\\n\")"
+---
+(source_file (expression_statement (assignment_expression left: (variable_declaration variable: (scalar (varname))) right: (number))) (expression_statement (postfix_conditional_expression (ambiguous_function_call_expression function: (function) arguments: (interpolated_string_literal content: (string_content (escape_sequence)))) condition: (binary_expression left: (scalar (varname)) right: (number)))))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__data_structure_dereference.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__data_structure_dereference.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(\"my $name = $user->{profile}->{name} // 'unknown';\")"
+---
+(source_file (expression_statement (assignment_expression left: (variable_declaration variable: (scalar (varname))) right: (binary_expression left: (hash_element_expression (hash_element_expression (scalar (varname)) key: (autoquoted_bareword)) key: (autoquoted_bareword)) right: (string_literal content: (string_content))))))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__for_loop_with_lexical_iterator.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__for_loop_with_lexical_iterator.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(\"for my $item (@items) { print $item, \\\"\\\\n\\\"; }\")"
+---
+(source_file (for_statement variable: (scalar (varname)) list: (array (varname)) block: (block (expression_statement (ambiguous_function_call_expression function: (function) arguments: (list_expression (scalar (varname)) (interpolated_string_literal content: (string_content (escape_sequence)))))))))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__heredoc.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__heredoc.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(\"my $text = <<END;\\nhello world\\nEND\\n\")"
+---
+(source_file (expression_statement (assignment_expression left: (variable_declaration variable: (scalar (varname))) right: (heredoc_token))) (heredoc_content (heredoc_end)))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__nested_blocks.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__nested_blocks.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(\"sub outer { if (1) { while (1) { last; } } }\")"
+---
+(source_file (subroutine_declaration_statement name: (bareword) body: (block (conditional_statement condition: (number) block: (block (loop_statement condition: (number) block: (block (expression_statement (loopex_expression)))))))))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__package_declaration.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__package_declaration.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(\"package My::Module;\\nuse strict;\\nuse warnings;\")"
+---
+(source_file (package_statement name: (package)) (use_statement module: (package)) (use_statement module: (package)))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__package_with_multiple_subs.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__package_with_multiple_subs.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: sexp(src)
+---
+(source_file (package_statement name: (package)) (subroutine_declaration_statement name: (bareword) body: (block (expression_statement (assignment_expression left: (variable_declaration variables: (scalar (varname)) variables: (hash (varname))) right: (array (varname)))) (expression_statement (ambiguous_function_call_expression function: (function) arguments: (list_expression (anonymous_hash_expression) (scalar (varname))))))) (subroutine_declaration_statement name: (bareword) body: (block (expression_statement (return_expression (interpolated_string_literal content: (string_content)))))) (subroutine_declaration_statement name: (bareword) body: (block (expression_statement (return_expression (hash_element_expression (array_element_expression array: (container_variable (varname)) index: (number)) key: (autoquoted_bareword)))))))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__regex.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__regex.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(r\"my $matched = ($str =~ /^\\d+$/);\")"
+---
+(source_file (expression_statement (assignment_expression left: (variable_declaration variable: (scalar (varname))) right: (binary_expression left: (scalar (varname)) right: (match_regexp content: (regexp_content (escape_sequence)))))))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__subroutine.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__subroutine.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(\"sub foo { return $_[0] + 1; }\")"
+---
+(source_file (subroutine_declaration_statement name: (bareword) body: (block (expression_statement (return_expression (binary_expression left: (array_element_expression array: (container_variable (varname)) index: (number)) right: (number)))))))

--- a/crates/tree-sitter-perl-c/tests/snapshots/snapshots__variable_declaration.snap
+++ b/crates/tree-sitter-perl-c/tests/snapshots/snapshots__variable_declaration.snap
@@ -1,0 +1,5 @@
+---
+source: crates/tree-sitter-perl-c/tests/snapshots.rs
+expression: "sexp(\"my $x = 42;\")"
+---
+(source_file (expression_statement (assignment_expression left: (variable_declaration variable: (scalar (varname))) right: (number))))


### PR DESCRIPTION
## Summary

Closes #4362.

Adds snapshot testing infrastructure to `tree-sitter-perl-c`, covering the same 11 Perl constructs already tested in `tree-sitter-perl-rs/tests/snapshots.rs`. The C-backed grammar previously had no S-expression snapshot suite, so changes to `c-src/parser.c`, `c-src/scanner.c`, or tree-sitter runtime behavior could alter parse shape without an explicit snapshot review.

### What changed

- Add `insta = "1.47.2"` to `crates/tree-sitter-perl-c` dev-dependencies.
- Add `crates/tree-sitter-perl-c/tests/snapshots.rs` with 11 `Result`-returning snapshot tests.
- Commit 11 `.snap` files for representative Perl constructs.

### Constructs covered

`variable_declaration`, `subroutine`, `heredoc`, `regex`, `package_declaration`, `package_with_multiple_subs`, `nested_blocks`, `complex_regex`, `control_flow_with_postfix_condition`, `data_structure_dereference`, `for_loop_with_lexical_iterator`.

### Verification

- `cargo test -p tree-sitter-perl-c --test snapshots --profile agent --locked` passed: 11 snapshots.
- `cargo test -p tree-sitter-perl-c --profile agent --locked` passed.
- `cargo clippy -p tree-sitter-perl-c --tests --profile agent --locked -- -D warnings -A missing_docs` passed.
- `cargo xtask fmt --check` passed.
- `cargo xtask metrics parser-accuracy --check` passed: 46 fixtures / 28 families; 123 scored lines; 102 scored symbols; 0 active failure packets.
- `cargo xtask metrics ratchet-check parser_accuracy` passed; parser-accuracy floors unchanged.
- `git diff --check` passed.

### Accuracy-control deltas

- Denominator: unchanged at 46 fixtures / 28 families; 123 scored lines; 102 scored symbols.
- Failure packets: unchanged at 0 active.
- Provider rows: unchanged at 12, all `insufficient_data`.
- Ratchet: no floor movement; all parser-accuracy floors pass.

https://claude.ai/code/session_01GQs7ssc4h4oPocN1KXrYGB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQs7ssc4h4oPocN1KXrYGB)_