### PR TITLE
fix(dead-code): reset unreachable spans between terminators (#0000)

### DIFF
--- a/crates/perl-dead-code/src/lib.rs
+++ b/crates/perl-dead-code/src/lib.rs
@@ -133,6 +133,25 @@ impl DeadCodeDetector {
 
             if let Some((_, _, term_depth)) = terminator {
                 if block_depth < term_depth {
+                    if let (Some((term_line, term_kw, _)), Some(start_line), Some(end_line)) =
+                        (terminator, unreachable_start, unreachable_end)
+                    {
+                        dead.push(DeadCode {
+                            code_type: DeadCodeType::UnreachableCode,
+                            name: None,
+                            file_path: file_path.to_path_buf(),
+                            start_line,
+                            end_line,
+                            reason: format!(
+                                "Code is unreachable after `{}` on line {} in the same block",
+                                term_kw, term_line
+                            ),
+                            confidence: 0.8,
+                            suggestion: Some("Remove or restructure this code".to_string()),
+                        });
+                    }
+                    unreachable_start = None;
+                    unreachable_end = None;
                     terminator = None;
                 } else if block_depth == term_depth && is_effective_code {
                     unreachable_start = Some(unreachable_start.unwrap_or(line_no));
@@ -145,6 +164,25 @@ impl DeadCodeDetector {
                 && ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw))
                 && let Some(first_word) = trimmed.split_whitespace().next()
             {
+                if let (Some((term_line, term_kw, _)), Some(start_line), Some(end_line)) =
+                    (terminator, unreachable_start, unreachable_end)
+                {
+                    dead.push(DeadCode {
+                        code_type: DeadCodeType::UnreachableCode,
+                        name: None,
+                        file_path: file_path.to_path_buf(),
+                        start_line,
+                        end_line,
+                        reason: format!(
+                            "Code is unreachable after `{}` on line {} in the same block",
+                            term_kw, term_line
+                        ),
+                        confidence: 0.8,
+                        suggestion: Some("Remove or restructure this code".to_string()),
+                    });
+                }
+                unreachable_start = None;
+                unreachable_end = None;
                 terminator = Some((line_no, first_word.to_string(), block_depth));
             }
 
@@ -174,6 +212,7 @@ impl DeadCodeDetector {
                 suggestion: Some("Remove or restructure this code".to_string()),
             });
         }
+
 
         // Dead branch detection: scan for constant-condition patterns.
         detect_dead_branches(file_path, &text, &mut dead);

--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -126,6 +126,25 @@ impl DeadCodeDetector {
 
             if let Some((_, _, term_depth)) = terminator {
                 if block_depth < term_depth {
+                    if let (Some((term_line, term_kw, _)), Some(start_line), Some(end_line)) =
+                        (terminator, unreachable_start, unreachable_end)
+                    {
+                        dead.push(DeadCode {
+                            code_type: DeadCodeType::UnreachableCode,
+                            name: None,
+                            file_path: file_path.to_path_buf(),
+                            start_line,
+                            end_line,
+                            reason: format!(
+                                "Code is unreachable after `{}` on line {} in the same block",
+                                term_kw, term_line
+                            ),
+                            confidence: 0.8,
+                            suggestion: Some("Remove or restructure this code".to_string()),
+                        });
+                    }
+                    unreachable_start = None;
+                    unreachable_end = None;
                     terminator = None;
                 } else if block_depth == term_depth && is_effective_code {
                     unreachable_start = Some(unreachable_start.unwrap_or(line_no));
@@ -138,6 +157,25 @@ impl DeadCodeDetector {
                 && ["return", "die", "exit"].iter().any(|kw| trimmed.starts_with(kw))
                 && let Some(first_word) = trimmed.split_whitespace().next()
             {
+                if let (Some((term_line, term_kw, _)), Some(start_line), Some(end_line)) =
+                    (terminator, unreachable_start, unreachable_end)
+                {
+                    dead.push(DeadCode {
+                        code_type: DeadCodeType::UnreachableCode,
+                        name: None,
+                        file_path: file_path.to_path_buf(),
+                        start_line,
+                        end_line,
+                        reason: format!(
+                            "Code is unreachable after `{}` on line {} in the same block",
+                            term_kw, term_line
+                        ),
+                        confidence: 0.8,
+                        suggestion: Some("Remove or restructure this code".to_string()),
+                    });
+                }
+                unreachable_start = None;
+                unreachable_end = None;
                 terminator = Some((line_no, first_word.to_string(), block_depth));
             }
 
@@ -167,6 +205,7 @@ impl DeadCodeDetector {
                 suggestion: Some("Remove or restructure this code".to_string()),
             });
         }
+
 
         // Dead branch detection: scan for constant-condition patterns.
         detect_dead_branches(file_path, &text, &mut dead);


### PR DESCRIPTION
### Motivation

- The block-aware unreachable-code detector could retain `unreachable_start`/`unreachable_end` after a terminator context ended or when a new terminator began, which could merge disjoint unreachable regions into a single diagnostic span and include reachable lines between them.

### Description

- Emit any accumulated unreachable `DeadCode` range and clear `unreachable_start`/`unreachable_end` when an active terminator is dropped due to leaving its block. 
- Flush and reset the current unreachable span before starting a new terminator so stale span state cannot leak into the next terminator sequence. 
- Applied the same logic to the mirrored compatibility implementation in `crates/perl-parser/src/dead_code/mod.rs` to keep behavior consistent. 
- Changes touch `crates/perl-dead-code/src/lib.rs` and `crates/perl-parser/src/dead_code/mod.rs` and preserve the prior coalescing and structural-only-line behavior.

### Testing

- Ran `cargo test -p perl-dead-code --test comprehensive_unit_tests`, which completed successfully (`47 passed; 0 failed`).
- Attempted `./scripts/cargo-safe test -p perl-dead-code --profile agent --locked` but it was blocked in this environment by storage policy (`DENY` cache usage), so it was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c44616b8833397b583f42a90ba6f)