### PR TITLE
fix(diagnostics): resolve pull.rs code_description compile errors (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -629,6 +629,7 @@ impl PullDiagnosticsProvider {
         let range = lsp_range_from_offsets(text, diagnostic.range.0, diagnostic.range.1);
         let severity = Some(to_lsp_severity(diagnostic.severity));
         let code = diagnostic.code.map(NumberOrString::String);
+        let code_description = code_description_for_code(code.as_ref());
         let related_information =
             to_lsp_related_information(uri, text, &diagnostic.related_information);
 
@@ -671,7 +672,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: code_description_for_code(code.as_ref()),
+            code_description,
             source: Some("perl-lsp".to_string()),
             message,
             related_information,
@@ -691,6 +692,7 @@ impl PullDiagnosticsProvider {
         let range = lsp_range_from_offsets(text, diagnostic.range.0, diagnostic.range.1);
         let severity = Some(to_lsp_severity(diagnostic.severity));
         let code = diagnostic.code.map(NumberOrString::String);
+        let code_description = code_description_for_code(code.as_ref());
         let code_for_source = code.clone();
         let related_information =
             to_lsp_related_information(uri, text, &diagnostic.related_information);
@@ -754,7 +756,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: code_description_for_code(code.as_ref()),
+            code_description,
             source: diagnostic_source(code_for_source.as_ref()),
             message,
             related_information,
@@ -774,6 +776,7 @@ impl PullDiagnosticsProvider {
         let range = lsp_range_from_offsets(text, diagnostic.range.0, diagnostic.range.1);
         let severity = Some(to_lsp_severity(diagnostic.severity));
         let code = diagnostic.code.map(NumberOrString::String);
+        let code_description = code_description_for_code(code.as_ref());
         let code_for_source = code.clone();
         let tags = to_lsp_tags(&diagnostic.tags);
 
@@ -831,7 +834,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: code_description_for_code(code.as_ref()),
+            code_description,
             source: diagnostic_source(code_for_source.as_ref()),
             message,
             related_information: None,
@@ -882,6 +885,8 @@ impl PullDiagnosticsProvider {
 
         let code = parse_error_code(error);
         let code_str = code.as_str();
+        let lsp_code = NumberOrString::String(code_str.to_string());
+        let code_description = code_description_for_code(Some(&lsp_code));
 
         let data_obj = DiagnosticData {
             code: code_str.to_string(),
@@ -907,8 +912,8 @@ impl PullDiagnosticsProvider {
         LspDiagnostic {
             range,
             severity: Some(to_lsp_severity(parse_error_severity(error))),
-            code: Some(NumberOrString::String(code_str.to_string())),
-            code_description: code_description_for_code(code.as_ref()),
+            code: Some(lsp_code),
+            code_description,
             source: Some("perl-lsp".to_string()),
             message,
             related_information: to_lsp_related_information(uri, text, &[]),


### PR DESCRIPTION
### Motivation

- Fix compile-blocking ownership and type errors introduced while wiring `codeDescription.href` into pull diagnostics. 
- Ensure built-in diagnostic codes still produce `codeDescription` links while avoiding moves/borrows and type mismatches that break `perl-lsp-rs` compilation.

### Description

- Precompute `code_description` by calling `code_description_for_code(code.as_ref())` before moving `code` into the returned `LspDiagnostic` in `to_lsp_diagnostic`, `to_lsp_diagnostic_with_context`, and `internal_to_lsp_diagnostic` in `crates/perl-lsp-rs/src/features/diagnostics/pull.rs`.
- In the parse-error fallback, construct an LSP `NumberOrString` (`lsp_code`) from the parse error code and call `code_description_for_code(Some(&lsp_code))`, then reuse `lsp_code` for the diagnostic `code` field to avoid the previous type/borrow mismatch.
- Updated `LspDiagnostic` constructors to use the precomputed `code_description` variable instead of calling the helper inline, and kept `code`/`code_description` consistent across conversion paths.

### Testing

- Ran `./scripts/cargo-safe xtask fmt`; formatting was invoked against the workspace and progress was observed before the session ended. 
- Attempted `./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked`, but the run was blocked by the environment storage guard (`DENY: /root/.cache/devplane/perl-lsp used=48% free=31G`).
- Verified the local edit and committed the fix to prepare a follow-up PR; full automated checks could not complete in this environment due to the storage restriction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c4473a18833399c5e92f26ac749f)