### PR TITLE
fix(diagnostics): resolve test compile regression in codeDescription mapping (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -671,7 +671,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: code_description_from_lsp_code(code.as_ref()),
+            code_description: code_description_for_code_str(code_str),
             source: Some("perl-lsp".to_string()),
             message,
             related_information,
@@ -754,7 +754,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: code_description_from_lsp_code(code.as_ref()),
+            code_description: code_description_for_code_str(code_str),
             source: diagnostic_source(code_for_source.as_ref()),
             message,
             related_information,
@@ -831,7 +831,7 @@ impl PullDiagnosticsProvider {
             range,
             severity,
             code,
-            code_description: code_description_from_lsp_code(code.as_ref()),
+            code_description: code_description_for_code_str(code_str),
             source: diagnostic_source(code_for_source.as_ref()),
             message,
             related_information: None,
@@ -908,20 +908,13 @@ impl PullDiagnosticsProvider {
             range,
             severity: Some(to_lsp_severity(parse_error_severity(error))),
             code: Some(NumberOrString::String(code_str.to_string())),
-            code_description: code_description_from_lsp_code(code.as_ref()),
+            code_description: code_description_for_code_str(code_str),
             source: Some("perl-lsp".to_string()),
             message,
             related_information: to_lsp_related_information(uri, text, &[]),
             tags: None,
             data,
         }
-    }
-}
-
-fn code_description_from_lsp_code(code: Option<&NumberOrString>) -> Option<CodeDescription> {
-    match code {
-        Some(NumberOrString::String(code_str)) => code_description_for_code_str(code_str),
-        _ => None,
     }
 }
 


### PR DESCRIPTION
### Motivation

- A follow-up review found the parse-error diagnostic conversion passed a `DiagnosticCode` reference into a helper that expected `Option<&NumberOrString>`, causing test compilation failures for `perl-lsp-rs` test builds.

### Description

- Use the string-based helper `code_description_for_code_str(code_str)` at all pull-diagnostic conversion sites (AST path, context-aware path, internal diagnostic path, and parse-error fallback) so `code_description` is derived from the diagnostic code string.
- Remove the now-unused `code_description_from_lsp_code` helper to avoid dead/ambiguous code paths.
- Changes were applied in `crates/perl-lsp-rs/src/features/diagnostics/pull.rs` and do not alter existing `source`, `message`, `tags`, or `data` behavior while restoring `codeDescription.href` population when a known PL code exists.

### Testing

- Ran formatter with `./scripts/cargo-safe xtask fmt`, which succeeded.
- Attempted targeted unit tests with `./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked --lib -- diagnostics`, but the run was blocked in this environment by a storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c4477ac88333b7c8eed3b9a20ba6)