### PR TITLE
feat(perl-semantic-analyzer): add Class::Tiny and Class::Tiny::RW OO framework support (#3410)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/class_model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/class_model.rs
@@ -1,4 +1,4 @@
-//! Class model for Moose/Moo/Mouse/Class::Accessor intelligence.
+//! Class model for Moose/Moo/Mouse/Class::Accessor/Class::Tiny intelligence.
 //!
 //! Provides a structured representation of Perl OOP class declarations,
 //! including attributes, methods, inheritance, and role composition.
@@ -29,6 +29,8 @@ pub enum Framework {
     PlainOO,
     /// `use Role::Tiny;` (package is a role) or `use Role::Tiny::With;` (package consumes roles)
     RoleTiny,
+    /// `use Class::Tiny;` or `use Class::Tiny::RW;`
+    ClassTiny,
     /// No OO framework detected
     None,
 }
@@ -529,7 +531,10 @@ impl ClassModelBuilder {
             if let NodeKind::Use { module, args, .. } = &statements[idx].kind {
                 self.detect_mro(module, args);
                 self.detect_framework(module, args);
-                idx += 1;
+                self.extract_class_tiny_use_attrs(module, args, statements[idx].location);
+                let consumed_default_hash =
+                    self.extract_class_tiny_following_default_hash(module, statements.get(idx + 1));
+                idx += 1 + usize::from(consumed_default_hash);
                 continue;
             }
 
@@ -582,6 +587,7 @@ impl ClassModelBuilder {
             "Moo" | "Moo::Role" => Framework::Moo,
             "Mouse" | "Mouse::Role" => Framework::Mouse,
             "Role::Tiny" | "Role::Tiny::With" => Framework::RoleTiny,
+            "Class::Tiny" | "Class::Tiny::RW" => Framework::ClassTiny,
             "Class::Accessor" => Framework::ClassAccessor,
             "Object::Pad" => Framework::ObjectPad,
             "base" | "parent" => {
@@ -656,6 +662,87 @@ impl ClassModelBuilder {
                 _ => {}
             }
         }
+    }
+
+    /// Extract attributes declared inline in `use Class::Tiny ...` or `use Class::Tiny::RW ...`.
+    ///
+    /// Class::Tiny declares attributes through import arguments. Both plain
+    /// name/qw-list arguments and keys in the optional default hashref are valid
+    /// attributes, and all generate read-write accessors.
+    ///
+    /// The issue also asks for `has` compatibility. That flows through the
+    /// normal `try_extract_has` path once `ClassTiny` is set as the current framework.
+    fn extract_class_tiny_use_attrs(
+        &mut self,
+        module: &str,
+        args: &[String],
+        location: SourceLocation,
+    ) {
+        if !matches!(module, "Class::Tiny" | "Class::Tiny::RW") {
+            return;
+        }
+        let accessor_type = AccessorType::Rw;
+        for name in extract_class_tiny_attribute_names(args) {
+            self.current_attributes.push(Attribute {
+                name: name.clone(),
+                is: Some(accessor_type),
+                isa: None,
+                default: false,
+                required: false,
+                accessor_name: name,
+                location,
+                builder: None,
+                coerce: false,
+                predicate: None,
+                clearer: None,
+                trigger: false,
+            });
+        }
+    }
+
+    fn extract_class_tiny_following_default_hash(
+        &mut self,
+        module: &str,
+        statement: Option<&Node>,
+    ) -> bool {
+        if !matches!(module, "Class::Tiny" | "Class::Tiny::RW") {
+            return false;
+        }
+        let Some(statement) = statement else { return false };
+        let Some((pairs, location)) = class_tiny_default_hash_pairs(statement) else {
+            return false;
+        };
+
+        for (key_node, _) in pairs {
+            for raw_name in collect_symbol_names(key_node) {
+                let Some(attr_name) = normalize_attribute_name(&raw_name) else { continue };
+                if !is_class_tiny_attribute_name(&attr_name) {
+                    continue;
+                }
+                if let Some(existing) =
+                    self.current_attributes.iter_mut().find(|attr| attr.name == attr_name)
+                {
+                    existing.default = true;
+                    continue;
+                }
+                self.current_attributes.push(Attribute {
+                    name: attr_name.clone(),
+                    is: Some(AccessorType::Rw),
+                    isa: None,
+                    default: true,
+                    required: false,
+                    accessor_name: attr_name,
+                    location,
+                    builder: None,
+                    coerce: false,
+                    predicate: None,
+                    clearer: None,
+                    trigger: false,
+                });
+            }
+        }
+
+        true
     }
 
     /// Extract Moo/Moose `has` declarations.
@@ -1252,6 +1339,24 @@ impl ClassModelBuilder {
 
 // ---- Helper functions (parallel to SymbolExtractor's private helpers) ----
 
+fn class_tiny_default_hash_pairs(statement: &Node) -> Option<(&[(Node, Node)], SourceLocation)> {
+    let expression = match &statement.kind {
+        NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+        NodeKind::Block { statements } if statements.len() == 1 => {
+            let NodeKind::ExpressionStatement { expression } = &statements.first()?.kind else {
+                return None;
+            };
+            expression.as_ref()
+        }
+        _ => return None,
+    };
+
+    let NodeKind::HashLiteral { pairs } = &expression.kind else {
+        return None;
+    };
+    Some((pairs.as_slice(), statement.location))
+}
+
 fn collect_symbol_names(node: &Node) -> Vec<String> {
     match &node.kind {
         NodeKind::String { value, .. } => normalize_symbol_name(value).into_iter().collect(),
@@ -1481,7 +1586,7 @@ fn expand_symbol_list(raw: &str) -> Vec<String> {
 /// Plain quoted strings like `"'Parent'"` return `["Parent"]`.
 fn expand_arg_to_names(arg: &str) -> Vec<String> {
     let arg = arg.trim();
-    // qw(...) — any delimiter variant that the parser normalised to qw(...)
+    // qw(...) - any delimiter variant that the parser normalised to qw(...)
     if arg.starts_with("qw(") && arg.ends_with(')') {
         let content = &arg[3..arg.len() - 1];
         return content
@@ -1515,6 +1620,90 @@ fn expand_arg_to_names(arg: &str) -> Vec<String> {
     normalize_symbol_name(arg).into_iter().collect()
 }
 
+fn extract_class_tiny_attribute_names(args: &[String]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut seen = HashSet::new();
+    let mut idx = 0;
+
+    while idx < args.len() {
+        let token = args[idx].trim();
+        match token {
+            "" | "," | "=>" | "}" => {
+                idx += 1;
+            }
+            "+" if args.get(idx + 1).map(String::as_str) == Some("{") => {
+                idx = collect_class_tiny_hash_keys(args, idx + 1, &mut names, &mut seen);
+            }
+            "+{" | "{" => {
+                idx = collect_class_tiny_hash_keys(args, idx, &mut names, &mut seen);
+            }
+            _ => {
+                for raw_name in expand_arg_to_names(token) {
+                    push_class_tiny_attribute_name(&raw_name, &mut names, &mut seen);
+                }
+                idx += 1;
+            }
+        }
+    }
+
+    names
+}
+
+fn collect_class_tiny_hash_keys(
+    args: &[String],
+    start_idx: usize,
+    names: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) -> usize {
+    let mut idx = start_idx;
+    let mut depth = 0usize;
+
+    while idx < args.len() {
+        let token = args[idx].trim();
+        match token {
+            "+{" | "{" => {
+                depth = depth.saturating_add(1);
+                idx += 1;
+            }
+            "}" => {
+                depth = depth.saturating_sub(1);
+                idx += 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ if depth == 1 && args.get(idx + 1).map(String::as_str) == Some("=>") => {
+                push_class_tiny_attribute_name(token, names, seen);
+                idx += 2;
+            }
+            _ => {
+                idx += 1;
+            }
+        }
+    }
+
+    idx
+}
+
+fn push_class_tiny_attribute_name(
+    raw_name: &str,
+    names: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    let Some(name) = normalize_attribute_name(raw_name) else { return };
+    if !is_class_tiny_attribute_name(&name) || !seen.insert(name.clone()) {
+        return;
+    }
+    names.push(name);
+}
+
+fn is_class_tiny_attribute_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else { return false };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
 fn extract_hash_options(pairs: &[(Node, Node)]) -> HashMap<String, String> {
     let mut options = HashMap::new();
     for (key_node, value_node) in pairs {
@@ -1542,7 +1731,7 @@ fn value_summary(node: &Node) -> String {
 mod tests {
     use super::*;
     use crate::parser::Parser;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
     use std::collections::HashSet;
 
     fn build_models(code: &str) -> Vec<ClassModel> {
@@ -2573,5 +2762,177 @@ class Standalone {
             "Standalone class must have no parents, but got {:?}",
             standalone.parents
         );
+    }
+
+    // Class::Tiny tests.
+
+    #[test]
+    fn class_tiny_framework_detected() {
+        let models = build_models(
+            r#"
+package MyApp::Point;
+use Class::Tiny;
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Point"));
+        assert_eq!(model.framework, Framework::ClassTiny);
+    }
+
+    #[test]
+    fn class_tiny_rw_framework_detected() {
+        let models = build_models(
+            r#"
+package MyApp::Config;
+use Class::Tiny::RW;
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Config"));
+        assert_eq!(model.framework, Framework::ClassTiny);
+    }
+
+    #[test]
+    fn class_tiny_qw_use_attrs_extracted() {
+        let models = build_models(
+            r#"
+package MyApp::Person;
+use Class::Tiny qw(name age email);
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Person"));
+        assert_eq!(model.framework, Framework::ClassTiny);
+        assert_eq!(model.attributes.len(), 3, "expected 3 attributes from qw list");
+
+        let names: HashSet<_> = model.attributes.iter().map(|a| a.name.as_str()).collect();
+        assert!(names.contains("name"), "expected attribute 'name'");
+        assert!(names.contains("age"), "expected attribute 'age'");
+        assert!(names.contains("email"), "expected attribute 'email'");
+
+        // All qw-list attrs default to rw
+        for attr in &model.attributes {
+            assert_eq!(
+                attr.is,
+                Some(AccessorType::Rw),
+                "qw-list attribute '{}' should be rw",
+                attr.name
+            );
+        }
+    }
+
+    #[test]
+    fn class_tiny_use_attrs_include_hashref_defaults() {
+        let models = build_models(
+            r#"
+package MyApp::Employee;
+use Class::Tiny qw(name ssn), {
+    timestamp => sub { time },
+    title => 'Peon',
+};
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Employee"));
+        let names: HashSet<_> = model.attributes.iter().map(|attr| attr.name.as_str()).collect();
+        assert_eq!(model.attributes.len(), 4);
+        assert!(names.contains("name"));
+        assert!(names.contains("ssn"));
+        assert!(names.contains("timestamp"));
+        assert!(names.contains("title"));
+        assert!(!names.contains("time"));
+        assert!(!names.contains("Peon"));
+    }
+
+    #[test]
+    fn class_tiny_rw_qw_use_attrs_are_rw() {
+        let models = build_models(
+            r#"
+package MyApp::Widget;
+use Class::Tiny::RW qw(width height);
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Widget"));
+        assert_eq!(model.attributes.len(), 2);
+        for attr in &model.attributes {
+            assert_eq!(attr.is, Some(AccessorType::Rw));
+        }
+    }
+
+    #[test]
+    fn class_tiny_bare_has_declaration() {
+        // Bare `has 'name';` is kept as issue-compatible declaration syntax.
+        let models = build_models(
+            r#"
+package MyApp::Tag;
+use Class::Tiny;
+has 'label';
+has 'color';
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Tag"));
+        assert_eq!(model.attributes.len(), 2, "expected 2 attributes from bare has");
+
+        let label = must_some(model.attributes.iter().find(|a| a.name == "label"));
+        assert_eq!(label.accessor_name, "label");
+
+        let color = model.attributes.iter().find(|a| a.name == "color");
+        assert!(color.is_some(), "expected attribute 'color'");
+    }
+
+    #[test]
+    fn class_tiny_has_with_options() {
+        // `has 'name' => (is => 'ro')` should work the same as in Moo/Moose
+        let models = build_models(
+            r#"
+package MyApp::Readonly;
+use Class::Tiny;
+has 'id' => (is => 'ro');
+has 'value' => (is => 'rw');
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Readonly"));
+        assert_eq!(model.attributes.len(), 2);
+
+        let id_attr = must_some(model.attributes.iter().find(|a| a.name == "id"));
+        assert_eq!(id_attr.is, Some(AccessorType::Ro));
+
+        let value_attr = must_some(model.attributes.iter().find(|a| a.name == "value"));
+        assert_eq!(value_attr.is, Some(AccessorType::Rw));
+    }
+
+    #[test]
+    fn class_tiny_mixed_use_and_has_declarations() {
+        // Mix of qw-list and explicit has declarations
+        let models = build_models(
+            r#"
+package MyApp::Mixed;
+use Class::Tiny qw(name age);
+has 'role' => (is => 'ro');
+sub greet { }
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Mixed"));
+        assert_eq!(model.framework, Framework::ClassTiny);
+        // 2 from qw + 1 from has = 3
+        assert_eq!(model.attributes.len(), 3, "expected 3 total attributes");
+
+        let names: HashSet<_> = model.attributes.iter().map(|a| a.name.as_str()).collect();
+        assert!(names.contains("name"));
+        assert!(names.contains("age"));
+        assert!(names.contains("role"));
+
+        let role_attr = must_some(model.attributes.iter().find(|a| a.name == "role"));
+        assert_eq!(role_attr.is, Some(AccessorType::Ro), "explicit has ro should be preserved");
+
+        assert!(model.methods.iter().any(|m| m.name == "greet"), "sub greet should be tracked");
+    }
+
+    #[test]
+    fn class_tiny_has_framework_returns_true() {
+        let models = build_models(
+            r#"
+package MyApp::Tiny;
+use Class::Tiny qw(x y);
+"#,
+        );
+        let model = must_some(find_model(&models, "MyApp::Tiny"));
+        assert!(model.has_framework(), "Class::Tiny is a framework");
     }
 }

--- a/crates/perl-semantic-analyzer/src/analysis/generated_member_extractor.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/generated_member_extractor.rs
@@ -1,4 +1,4 @@
-//! Generated member extraction from Moo/Moose `has` declarations and
+//! Generated member extraction from Moo/Moose/Class::Tiny `has` declarations and
 //! `Class::Accessor` declarations.
 //!
 //! Leverages the existing [`ClassModelBuilder`] to parse `has` declarations,
@@ -71,7 +71,7 @@ impl GeneratedMemberExtractor {
 
 /// Returns `true` for frameworks that generate accessors from `has` declarations.
 fn is_accessor_framework(framework: Framework) -> bool {
-    matches!(framework, Framework::Moo | Framework::Moose | Framework::Mouse)
+    matches!(framework, Framework::Moo | Framework::Moose | Framework::Mouse | Framework::ClassTiny)
 }
 
 fn collect_has_members(model: &ClassModel, package: &str, members: &mut Vec<GeneratedMember>) {

--- a/crates/perl-semantic-analyzer/src/analysis/symbol.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/symbol.rs
@@ -349,6 +349,8 @@ pub enum FrameworkKind {
     RoleTiny,
     /// `use Role::Tiny::With;` — the package consumes roles
     RoleTinyWith,
+    /// `use Class::Tiny;` or `use Class::Tiny::RW;`
+    ClassTiny,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -467,9 +469,10 @@ impl SymbolExtractor {
                 continue;
             };
             let new_kind = match kind {
-                FrameworkKind::Moo | FrameworkKind::Moose | FrameworkKind::RoleTinyWith => {
-                    SymbolKind::Class
-                }
+                FrameworkKind::Moo
+                | FrameworkKind::Moose
+                | FrameworkKind::RoleTinyWith
+                | FrameworkKind::ClassTiny => SymbolKind::Class,
                 FrameworkKind::MooRole | FrameworkKind::MooseRole | FrameworkKind::RoleTiny => {
                     SymbolKind::Role
                 }
@@ -834,6 +837,9 @@ impl SymbolExtractor {
                 if module == "constant" {
                     self.synthesize_use_constant_symbols(args, node.location);
                 }
+                if module == "Class::Tiny" || module == "Class::Tiny::RW" {
+                    self.synthesize_class_tiny_use_attrs(args, node.location);
+                }
             }
 
             NodeKind::No { module: _, args: _, .. } => {
@@ -1084,6 +1090,12 @@ impl SymbolExtractor {
     fn visit_statement_list(&mut self, statements: &[Node]) {
         let mut idx = 0;
         while idx < statements.len() {
+            if let Some(consumed) = self.try_visit_class_tiny_use_with_default_hash(statements, idx)
+            {
+                idx += consumed;
+                continue;
+            }
+
             if let Some(consumed) = self.try_extract_framework_declarations(statements, idx) {
                 idx += consumed;
                 continue;
@@ -1092,6 +1104,32 @@ impl SymbolExtractor {
             self.visit_node(&statements[idx]);
             idx += 1;
         }
+    }
+
+    fn try_visit_class_tiny_use_with_default_hash(
+        &mut self,
+        statements: &[Node],
+        idx: usize,
+    ) -> Option<usize> {
+        let NodeKind::Use { module, .. } = &statements[idx].kind else {
+            return None;
+        };
+        if !matches!(module.as_str(), "Class::Tiny" | "Class::Tiny::RW") {
+            return None;
+        }
+
+        self.visit_node(&statements[idx]);
+
+        let Some(next_statement) = statements.get(idx + 1) else {
+            return Some(1);
+        };
+        let names = Self::class_tiny_default_hash_names(next_statement);
+        if names.is_empty() {
+            return Some(1);
+        }
+
+        self.synthesize_moo_has_attrs_with_options(&names, &[], next_statement.location);
+        Some(2)
     }
 
     /// Detect and synthesize framework declarations from statement patterns.
@@ -1106,11 +1144,15 @@ impl SymbolExtractor {
         let flags = flags.as_ref();
 
         let is_moo = flags.is_some_and(|f| f.moo);
+        let is_class_tiny = flags.is_some_and(|f| f.kind == Some(FrameworkKind::ClassTiny));
 
-        if is_moo {
+        if is_moo || is_class_tiny {
             if let Some(consumed) = self.try_extract_moo_has_declaration(statements, idx) {
                 return Some(consumed);
             }
+        }
+
+        if is_moo {
             if let Some(consumed) = self.try_extract_method_modifier(statements, idx) {
                 return Some(consumed);
             }
@@ -1222,6 +1264,7 @@ impl SymbolExtractor {
 
         // Form C: FunctionCall { name: "has", args: [name_expr, HashLiteral { ... }] }
         // Produced when the parser recognises `has 'name' => (is => 'ro', ...)` as a bare call.
+        // Also handles bare `has 'name';` (no options).
         if let NodeKind::ExpressionStatement { expression } = &first.kind
             && let NodeKind::FunctionCall { name, args } = &expression.kind
             && name == "has"
@@ -1238,6 +1281,15 @@ impl SymbolExtractor {
                         self.visit_node(first);
                         return Some(1);
                     }
+                }
+            } else {
+                // No HashLiteral in args: bare `has 'name';` with no options.
+                // Generates a combined accessor (both getter and setter).
+                let names: Vec<String> = args.iter().flat_map(Self::collect_symbol_names).collect();
+                if !names.is_empty() {
+                    self.synthesize_moo_has_attrs_with_options(&names, &[], first.location);
+                    self.visit_node(first);
+                    return Some(1);
                 }
             }
         }
@@ -1587,6 +1639,46 @@ impl SymbolExtractor {
                 attributes: metadata.clone(),
             });
         }
+    }
+
+    /// Synthesize accessor symbols for `use Class::Tiny ...` and
+    /// `use Class::Tiny::RW ...` declarations.
+    ///
+    /// Name/qw-list import arguments and default-hash keys become read-write accessors,
+    /// emitted as `Subroutine` symbols the same way `has name => (is => 'rw')` would.
+    fn synthesize_class_tiny_use_attrs(&mut self, args: &[String], location: SourceLocation) {
+        let names = extract_class_tiny_attribute_names_from_use_args(args);
+        if names.is_empty() {
+            return;
+        }
+        self.synthesize_moo_has_attrs_with_options(&names, &[], location);
+    }
+
+    fn class_tiny_default_hash_names(statement: &Node) -> Vec<String> {
+        let expression = match &statement.kind {
+            NodeKind::ExpressionStatement { expression } => expression.as_ref(),
+            NodeKind::Block { statements } if statements.len() == 1 => {
+                let Some(Node { kind: NodeKind::ExpressionStatement { expression }, .. }) =
+                    statements.first()
+                else {
+                    return Vec::new();
+                };
+                expression.as_ref()
+            }
+            _ => return Vec::new(),
+        };
+        let NodeKind::HashLiteral { pairs } = &expression.kind else {
+            return Vec::new();
+        };
+
+        let mut names = Vec::new();
+        let mut seen = HashSet::new();
+        for (key_node, _) in pairs {
+            for raw_name in Self::collect_symbol_names(key_node) {
+                push_class_tiny_attribute_name(&raw_name, &mut names, &mut seen);
+            }
+        }
+        names
     }
 
     /// Resolve the attribute-expression node used in a parsed `has` declaration pair.
@@ -2174,6 +2266,14 @@ impl SymbolExtractor {
 
         if module == "Class::Accessor" {
             self.framework_flags.entry(pkg.clone()).or_default().class_accessor = true;
+            return;
+        }
+
+        // Keep Class::Tiny in the same has-declaration extractor without enabling
+        // Moo-only roles, modifiers, or inheritance keywords.
+        if matches!(module, "Class::Tiny" | "Class::Tiny::RW") {
+            let flags = self.framework_flags.entry(pkg.clone()).or_default();
+            flags.kind = Some(FrameworkKind::ClassTiny);
             return;
         }
 
@@ -3074,6 +3174,131 @@ fn split_variable_name(full_name: &str) -> (&str, &str) {
         .next()
         .map(|(idx, ch)| (&full_name[idx..idx + ch.len_utf8()], &full_name[idx + ch.len_utf8()..]))
         .unwrap_or(("", ""))
+}
+
+fn extract_class_tiny_attribute_names_from_use_args(args: &[String]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut seen = HashSet::new();
+    let mut idx = 0;
+
+    while idx < args.len() {
+        let token = args[idx].trim();
+        match token {
+            "" | "," | "=>" | "}" => {
+                idx += 1;
+            }
+            "+" if args.get(idx + 1).map(String::as_str) == Some("{") => {
+                idx = collect_class_tiny_hash_keys(args, idx + 1, &mut names, &mut seen);
+            }
+            "+{" | "{" => {
+                idx = collect_class_tiny_hash_keys(args, idx, &mut names, &mut seen);
+            }
+            _ => {
+                for raw_name in expand_class_tiny_arg_to_names(token) {
+                    push_class_tiny_attribute_name(&raw_name, &mut names, &mut seen);
+                }
+                idx += 1;
+            }
+        }
+    }
+
+    names
+}
+
+fn collect_class_tiny_hash_keys(
+    args: &[String],
+    start_idx: usize,
+    names: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) -> usize {
+    let mut idx = start_idx;
+    let mut depth = 0usize;
+
+    while idx < args.len() {
+        let token = args[idx].trim();
+        match token {
+            "+{" | "{" => {
+                depth = depth.saturating_add(1);
+                idx += 1;
+            }
+            "}" => {
+                depth = depth.saturating_sub(1);
+                idx += 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ if depth == 1 && args.get(idx + 1).map(String::as_str) == Some("=>") => {
+                push_class_tiny_attribute_name(token, names, seen);
+                idx += 2;
+            }
+            _ => {
+                idx += 1;
+            }
+        }
+    }
+
+    idx
+}
+
+fn expand_class_tiny_arg_to_names(arg: &str) -> Vec<String> {
+    let arg = arg.trim();
+    if arg.starts_with("qw(") && arg.ends_with(')') {
+        let content = &arg[3..arg.len() - 1];
+        return content.split_whitespace().filter(|s| !s.is_empty()).map(str::to_string).collect();
+    }
+
+    if arg.starts_with("qw") && arg.len() > 2 {
+        let open = arg.chars().nth(2).unwrap_or(' ');
+        let close = match open {
+            '(' => ')',
+            '{' => '}',
+            '[' => ']',
+            '<' => '>',
+            c => c,
+        };
+        if let (Some(start), Some(end)) = (arg.find(open), arg.rfind(close))
+            && start < end
+        {
+            let content = &arg[start + 1..end];
+            return content
+                .split_whitespace()
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect();
+        }
+    }
+
+    normalize_class_tiny_attribute_name(arg).into_iter().collect()
+}
+
+fn push_class_tiny_attribute_name(
+    raw_name: &str,
+    names: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    let Some(name) = normalize_class_tiny_attribute_name(raw_name) else { return };
+    if !is_class_tiny_attribute_name(&name) || !seen.insert(name.clone()) {
+        return;
+    }
+    names.push(name);
+}
+
+fn normalize_class_tiny_attribute_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_matches('\'').trim_matches('"').trim();
+    let without_override_prefix = trimmed.strip_prefix('+').unwrap_or(trimmed);
+    if without_override_prefix.is_empty() {
+        None
+    } else {
+        Some(without_override_prefix.to_string())
+    }
+}
+
+fn is_class_tiny_attribute_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else { return false };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 /// Extract constant names from `NodeKind::Use { module: "constant", args, .. }`.

--- a/crates/perl-semantic-analyzer/tests/frameworks_class_tiny.rs
+++ b/crates/perl-semantic-analyzer/tests/frameworks_class_tiny.rs
@@ -1,0 +1,290 @@
+//! BDD integration tests for Class::Tiny framework support.
+//!
+//! Covers framework detection, qw-list attribute extraction, bare `has`
+//! declarations, and accessor symbol emission for the Class::Tiny and
+//! Class::Tiny::RW OO frameworks.
+
+use perl_semantic_analyzer::{
+    Parser,
+    analysis::class_model::{AccessorType, ClassModelBuilder, Framework},
+    symbol::{SymbolExtractor, SymbolKind, SymbolTable},
+};
+use perl_tdd_support::{must, must_some};
+
+fn build_class_models(
+    code: &str,
+) -> Vec<perl_semantic_analyzer::analysis::class_model::ClassModel> {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    ClassModelBuilder::new().build(&ast)
+}
+
+fn extract_symbols(code: &str) -> SymbolTable {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    SymbolExtractor::new_with_source(code).extract(&ast)
+}
+
+fn has_symbol(table: &SymbolTable, name: &str, kind: SymbolKind) -> bool {
+    table.symbols.get(name).is_some_and(|syms| syms.iter().any(|s| s.kind == kind))
+}
+
+// Framework detection.
+
+#[test]
+fn when_use_class_tiny_then_framework_is_class_tiny() {
+    let models = build_class_models(
+        r#"
+package Animal;
+use Class::Tiny;
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Animal"));
+    assert_eq!(model.framework, Framework::ClassTiny);
+}
+
+#[test]
+fn when_use_class_tiny_rw_then_framework_is_class_tiny() {
+    let models = build_class_models(
+        r#"
+package Config;
+use Class::Tiny::RW;
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Config"));
+    assert_eq!(model.framework, Framework::ClassTiny);
+}
+
+// Attribute extraction from use import arguments.
+
+#[test]
+fn when_class_tiny_with_qw_list_then_attrs_extracted_as_rw() {
+    let models = build_class_models(
+        r#"
+package Dog;
+use Class::Tiny qw(name breed weight);
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Dog"));
+    assert_eq!(model.attributes.len(), 3, "expected 3 attrs from qw list");
+
+    for attr in &model.attributes {
+        assert_eq!(
+            attr.is,
+            Some(AccessorType::Rw),
+            "qw-list attribute '{}' should be Rw",
+            attr.name
+        );
+        assert_eq!(attr.accessor_name, attr.name, "accessor_name should equal attr name");
+    }
+
+    let attr_names: std::collections::HashSet<_> =
+        model.attributes.iter().map(|a| a.name.as_str()).collect();
+    assert!(attr_names.contains("name"), "missing 'name'");
+    assert!(attr_names.contains("breed"), "missing 'breed'");
+    assert!(attr_names.contains("weight"), "missing 'weight'");
+}
+
+#[test]
+fn when_class_tiny_rw_with_qw_list_then_attrs_extracted_as_rw() {
+    let models = build_class_models(
+        r#"
+package Widget;
+use Class::Tiny::RW qw(width height color);
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Widget"));
+    assert_eq!(model.attributes.len(), 3);
+    for attr in &model.attributes {
+        assert_eq!(attr.is, Some(AccessorType::Rw));
+    }
+}
+
+#[test]
+fn when_class_tiny_with_no_qw_args_then_no_use_attrs() {
+    let models = build_class_models(
+        r#"
+package Minimal;
+use Class::Tiny;
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Minimal"));
+    // No attributes from the use statement.
+    assert_eq!(model.attributes.len(), 0, "bare use Class::Tiny with no args = no attrs");
+}
+
+#[test]
+fn when_class_tiny_with_default_hashref_then_keys_are_attrs() {
+    let models = build_class_models(
+        r#"
+package Employee;
+use Class::Tiny qw(name ssn), {
+  timestamp => sub { time },
+  title => 'Peon',
+};
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Employee"));
+    let attr_names: std::collections::HashSet<_> =
+        model.attributes.iter().map(|a| a.name.as_str()).collect();
+
+    assert_eq!(model.attributes.len(), 4);
+    assert!(attr_names.contains("name"));
+    assert!(attr_names.contains("ssn"));
+    assert!(attr_names.contains("timestamp"));
+    assert!(attr_names.contains("title"));
+    assert!(!attr_names.contains("time"));
+    assert!(!attr_names.contains("Peon"));
+}
+
+// Bare has declarations.
+
+#[test]
+fn when_class_tiny_bare_has_then_attr_extracted_with_no_is() {
+    let models = build_class_models(
+        r#"
+package Cat;
+use Class::Tiny;
+has 'name';
+has 'color';
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Cat"));
+    assert_eq!(model.attributes.len(), 2, "expected 2 attrs from bare has");
+
+    let name_attr = must_some(model.attributes.iter().find(|a| a.name == "name"));
+    assert_eq!(name_attr.accessor_name, "name");
+    // Bare `has 'name';` produces no explicit `is` option.
+    assert_eq!(name_attr.is, None);
+}
+
+#[test]
+fn when_class_tiny_has_with_is_ro_then_accessor_type_is_ro() {
+    let models = build_class_models(
+        r#"
+package Immutable;
+use Class::Tiny;
+has 'id' => (is => 'ro');
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Immutable"));
+    let id_attr = must_some(model.attributes.iter().find(|a| a.name == "id"));
+    assert_eq!(id_attr.is, Some(AccessorType::Ro));
+}
+
+#[test]
+fn when_class_tiny_has_with_is_rw_then_accessor_type_is_rw() {
+    let models = build_class_models(
+        r#"
+package Mutable;
+use Class::Tiny;
+has 'count' => (is => 'rw');
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Mutable"));
+    let count_attr = must_some(model.attributes.iter().find(|a| a.name == "count"));
+    assert_eq!(count_attr.is, Some(AccessorType::Rw));
+}
+
+// Mixed patterns.
+
+#[test]
+fn when_class_tiny_mixes_qw_and_has_then_all_attrs_captured() {
+    let models = build_class_models(
+        r#"
+package Employee;
+use Class::Tiny qw(name department);
+has 'salary' => (is => 'rw');
+has 'title';
+sub promote { }
+"#,
+    );
+    let model = must_some(models.iter().find(|m| m.name == "Employee"));
+    assert_eq!(model.framework, Framework::ClassTiny);
+    assert_eq!(model.attributes.len(), 4, "2 from qw + 2 from has");
+
+    let attr_names: std::collections::HashSet<_> =
+        model.attributes.iter().map(|a| a.name.as_str()).collect();
+    assert!(attr_names.contains("name"));
+    assert!(attr_names.contains("department"));
+    assert!(attr_names.contains("salary"));
+    assert!(attr_names.contains("title"));
+
+    assert!(model.methods.iter().any(|m| m.name == "promote"), "method promote expected");
+}
+
+// Symbol emission.
+
+#[test]
+fn when_class_tiny_qw_attrs_then_subroutine_symbols_emitted() {
+    let code = r#"
+package User;
+use Class::Tiny qw(name email);
+"#;
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "name", SymbolKind::Subroutine),
+        "expected accessor method symbol for 'name'"
+    );
+    assert!(
+        has_symbol(&table, "email", SymbolKind::Subroutine),
+        "expected accessor method symbol for 'email'"
+    );
+}
+
+#[test]
+fn when_class_tiny_default_hashref_then_subroutine_symbols_emitted() {
+    let code = r#"
+package User;
+use Class::Tiny qw(name), {
+  email => sub { $_[0]->_build_email },
+  status => 'active',
+};
+"#;
+    let table = extract_symbols(code);
+
+    assert!(has_symbol(&table, "name", SymbolKind::Subroutine));
+    assert!(has_symbol(&table, "email", SymbolKind::Subroutine));
+    assert!(has_symbol(&table, "status", SymbolKind::Subroutine));
+    assert!(!has_symbol(&table, "active", SymbolKind::Subroutine));
+    assert!(!has_symbol(&table, "_build_email", SymbolKind::Subroutine));
+}
+
+#[test]
+fn when_class_tiny_bare_has_then_accessor_symbol_emitted() {
+    let code = r#"
+package Shape;
+use Class::Tiny;
+has 'color';
+"#;
+    let table = extract_symbols(code);
+
+    assert!(
+        has_symbol(&table, "color", SymbolKind::Subroutine),
+        "expected accessor symbol for bare 'has color'"
+    );
+}
+
+// Isolation: other packages unaffected.
+
+#[test]
+fn when_non_class_tiny_package_uses_has_then_class_tiny_framework_not_applied() {
+    let models = build_class_models(
+        r#"
+package Moo::Thing;
+use Moo;
+has 'x' => (is => 'ro');
+
+package Plain;
+sub do_stuff { }
+"#,
+    );
+
+    let moo_model = must_some(models.iter().find(|m| m.name == "Moo::Thing"));
+    assert_eq!(moo_model.framework, Framework::Moo);
+
+    // Plain package has no framework and should not appear as ClassModel.
+    let plain = models.iter().find(|m| m.name == "Plain");
+    assert!(plain.is_none(), "plain package without framework should not produce a ClassModel");
+}


### PR DESCRIPTION
Problem: Class::Tiny packages were not recognized by the semantic analyzer, so generated accessors were missing from class models, symbols, and generated-member facts.

Fix: Add Class::Tiny/Class::Tiny::RW framework detection, synthesize read-write accessors from import args and default-hash keys, include Class::Tiny in generated-member extraction, and keep Class::Tiny limited to has/accessor handling instead of enabling Moo-only roles/modifiers.

Verification:
- `cargo test -p perl-semantic-analyzer --test frameworks_class_tiny --profile agent --locked` passes (14 tests)
- `cargo test -p perl-semantic-analyzer class_tiny --profile agent --locked` passes (9 inline + 14 integration Class::Tiny tests)
- `cargo test -p perl-semantic-analyzer --profile agent --locked` passes
- `cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked` passes
- `cargo clippy -p perl-semantic-analyzer --all-targets --profile agent --locked -- -D warnings -A missing_docs` passes
- `cargo xtask fmt --check` passes
- `cargo xtask metrics parser-accuracy --check` passes: 46 fixtures / 28 families, 123 scored lines, 102 scored symbols
- `cargo xtask metrics ratchet-check parser_accuracy` passes; all floor metrics passed
- `git diff --check` passes

Parser-accuracy receipt: failure packets remain 0; provider rows remain 12, all `insufficient_data`; no ratchet floor movement.
