### PR TITLE
fix(memory): plug seven session-creep leaks across LSP server, workspace index, caches, and stream sessions (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -68,6 +68,16 @@ impl AstCache {
         self.cache.insert(uri, CachedAst { ast, content_hash });
     }
 
+    /// Evict the cached AST for a single URI.
+    ///
+    /// Called on `textDocument/didClose` so the (potentially large) `Arc<Node>`
+    /// is dropped immediately rather than surviving until the TTL fires. With
+    /// rapid open/close churn over a session the TTL alone is not sufficient
+    /// to bound peak memory.
+    pub fn remove(&self, uri: &str) {
+        self.cache.remove(uri);
+    }
+
     /// Clear expired entries.
     ///
     /// Moka handles expiration automatically, but this method is kept for API compatibility.
@@ -275,8 +285,43 @@ pub mod parallel {
 
 #[cfg(test)]
 mod tests {
+    use super::AstCache;
     use super::IncrementalParser;
     use super::parallel::process_files_parallel;
+    use perl_parser_core::{Node, NodeKind, SourceLocation};
+    use std::sync::Arc;
+
+    fn dummy_ast() -> Arc<Node> {
+        Arc::new(Node::new(
+            NodeKind::Number { value: "0".to_string() },
+            SourceLocation { start: 0, end: 1 },
+        ))
+    }
+
+    #[test]
+    fn ast_cache_remove_evicts_entry_immediately() {
+        let cache = AstCache::new(16, 3600);
+        let uri = "file:///mem/leak.pl".to_string();
+        let content = "0";
+
+        cache.put(uri.clone(), content, dummy_ast());
+        assert!(cache.get(&uri, content).is_some(), "put then get must hit");
+
+        cache.remove(&uri);
+        cache.cleanup(); // flush moka pending tasks so entry_count is exact
+
+        assert!(
+            cache.get(&uri, content).is_none(),
+            "after remove, get must miss (regression: didClose left ASTs alive until TTL)"
+        );
+    }
+
+    #[test]
+    fn ast_cache_remove_unknown_uri_is_noop() {
+        let cache = AstCache::new(4, 60);
+        cache.remove("file:///never-cached.pl");
+        // Must not panic; nothing else to assert.
+    }
 
     #[test]
     fn process_files_parallel_preserves_input_order() {

--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -1233,11 +1233,33 @@ impl LspServer {
     /// Uses a per-path cache to avoid re-parsing on every hover request.
     /// Returns an empty string if no POD is found or the file cannot be read.
     fn format_pod_for_hover(&self, path: &Path) -> String {
+        // Soft cap on pod_cache size. The cache is keyed by filesystem path
+        // (not the open document), so it accumulates entries for every module
+        // ever hovered during the session — the open/close lifecycle does not
+        // shrink it. Without this cap a session that hovers many modules grows
+        // unboundedly. When the cap is reached we drain to half capacity using
+        // an arbitrary-victim policy (HashMap iteration order); precision is
+        // unimportant — re-extracting POD is cheap.
+        const POD_CACHE_SOFT_CAP: usize = 1024;
+        const POD_CACHE_PRUNE_TARGET: usize = 512;
+
         let pod = {
             let mut cache = self.pod_cache.lock();
             if let Some(cached) = cache.get(path) {
                 cached.clone()
             } else {
+                if cache.len() >= POD_CACHE_SOFT_CAP {
+                    let drop_count = cache.len().saturating_sub(POD_CACHE_PRUNE_TARGET);
+                    let mut dropped = 0usize;
+                    cache.retain(|_, _| {
+                        if dropped < drop_count {
+                            dropped += 1;
+                            false
+                        } else {
+                            true
+                        }
+                    });
+                }
                 let doc = perl_pod::extract_pod_from_file(path).unwrap_or_default();
                 cache.insert(path.to_path_buf(), doc.clone());
                 doc

--- a/crates/perl-lsp-rs/src/runtime/stream_session.rs
+++ b/crates/perl-lsp-rs/src/runtime/stream_session.rs
@@ -95,25 +95,44 @@ impl StreamSessionManager {
         session
     }
 
-    /// Cancel all sessions for a given URI (on didChange/didClose).
+    /// Cancel and remove all sessions for a given URI (on didChange/didClose).
+    ///
+    /// Cancelled sessions are evicted from the manager immediately rather than
+    /// left behind for `cleanup()` — there is no production caller of cleanup,
+    /// so without eviction here the HashMap grows monotonically as the user
+    /// edits (one stale entry per request position/version).
     pub fn cancel_for_uri(&self, uri: &str) {
-        let sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
-        for (key, session) in sessions.iter() {
+        let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        sessions.retain(|key, session| {
             if key.uri == uri {
                 session.cancel();
+                false
+            } else {
+                true
             }
-        }
+        });
     }
 
-    /// Cancel all sessions for a given URI where the document version is older
-    /// than the supplied version (on document version change).
+    /// Cancel and remove all sessions for a given URI where the document
+    /// version is older than the supplied version (on document version change).
     pub fn cancel_for_uri_version(&self, uri: &str, version: i64) {
-        let sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
-        for (key, session) in sessions.iter() {
+        let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        sessions.retain(|key, session| {
             if key.uri == uri && key.document_version < version {
                 session.cancel();
+                false
+            } else {
+                true
             }
-        }
+        });
+    }
+
+    /// Number of sessions currently held by the manager.
+    ///
+    /// Test-only; production code observes manager state through cancellation.
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.sessions.lock().unwrap_or_else(|e| e.into_inner()).len()
     }
 
     /// Remove completed/cancelled sessions (housekeeping).
@@ -172,6 +191,51 @@ mod tests {
         mgr.cancel_for_uri("file:///a.pl");
         assert!(s1.is_cancelled());
         assert!(!s2.is_cancelled());
+        // Cancelled sessions must also be evicted from the manager — this is
+        // the regression guard for the leak fixed alongside this test.
+        assert_eq!(mgr.len(), 1, "cancelled session for a.pl must be evicted");
+    }
+
+    #[test]
+    fn cancel_for_uri_evicts_many_stale_sessions() {
+        let mgr = StreamSessionManager::new();
+        for i in 0..200 {
+            mgr.start_session(SessionKey {
+                uri: "file:///hot.pl".into(),
+                document_version: i,
+                line: i as u64,
+                character: 0,
+            });
+        }
+        assert_eq!(mgr.len(), 200);
+        mgr.cancel_for_uri("file:///hot.pl");
+        assert_eq!(
+            mgr.len(),
+            0,
+            "cancel_for_uri must drain the manager for the matching URI \
+             (regression: cancellation flagged but never removed)"
+        );
+    }
+
+    #[test]
+    fn cancel_for_uri_version_evicts_older() {
+        let mgr = StreamSessionManager::new();
+        let s_old = mgr.start_session(SessionKey {
+            uri: "file:///v.pl".into(),
+            document_version: 1,
+            line: 0,
+            character: 0,
+        });
+        let s_new = mgr.start_session(SessionKey {
+            uri: "file:///v.pl".into(),
+            document_version: 5,
+            line: 1,
+            character: 0,
+        });
+        mgr.cancel_for_uri_version("file:///v.pl", 3);
+        assert!(s_old.is_cancelled());
+        assert!(!s_new.is_cancelled());
+        assert_eq!(mgr.len(), 1, "older session must be evicted, newer kept");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -982,6 +982,30 @@ impl LspServer {
                 cache.retain(|(cached_uri, _), _| cached_uri != &normalized_uri);
             }
 
+            // Evict the cached AST so the (potentially large) Arc<Node> drops
+            // immediately rather than surviving until the moka TTL fires. Cover
+            // both normalized and raw URI keys to handle any normalization
+            // mismatches with `put` callers.
+            self.ast_cache.remove(&normalized_uri);
+            if normalized_uri != uri {
+                self.ast_cache.remove(uri);
+            }
+
+            // Evict the per-path POD cache entry for the closing document so
+            // the parsed POD structure is freed alongside the document. The
+            // pod_cache is keyed by filesystem path (not URI) and otherwise
+            // grows monotonically across a session.
+            //
+            // The same path is reused to invalidate the pull-diagnostics cache
+            // entry below, avoiding a second URI-to-path conversion.
+            if let Some(path) = source_path_from_uri(uri) {
+                self.pod_cache.lock().remove(&path);
+
+                // Evict cached pull-diagnostic results for the closing document.
+                #[cfg(not(target_arch = "wasm32"))]
+                self.pull_diagnostics_orchestrator.invalidate_file_cache(&path);
+            }
+
             // Notify coordinator of pending change to track cleanup work
             #[cfg(feature = "workspace")]
             if let Some(coordinator) = self.coordinator() {

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -788,10 +788,46 @@ impl LspServer {
                         coordinator.index().remove_file(&uri);
                     }
 
-                    // Remove from document store
+                    // Remove from document store under both raw and normalized
+                    // URI keys. didOpen stores documents under
+                    // `normalize_uri_key(uri)`, but the watcher payload may use
+                    // a non-canonical form (`file://localhost/...`, Windows
+                    // drive-letter casing, percent-encoding variants). Without
+                    // the normalized lookup the document leaks into the
+                    // session's open-doc map indefinitely.
+                    let normalized_uri = self.normalize_uri_key(&uri);
                     {
                         let mut documents = self.documents.lock();
                         documents.remove(&uri);
+                        if normalized_uri != uri {
+                            documents.remove(&normalized_uri);
+                        }
+                    }
+
+                    // Cancel stream sessions and clear parse-cancel flags for
+                    // both URI forms so per-file state does not survive the
+                    // delete event.
+                    self.stream_sessions().cancel_for_uri(&uri);
+                    if normalized_uri != uri {
+                        self.stream_sessions().cancel_for_uri(&normalized_uri);
+                    }
+                    {
+                        use std::sync::atomic::Ordering;
+                        let mut flags = self.parse_cancel_flags.lock();
+                        if let Some(flag) = flags.remove(&uri) {
+                            flag.store(true, Ordering::Release);
+                        }
+                        if normalized_uri != uri {
+                            if let Some(flag) = flags.remove(&normalized_uri) {
+                                flag.store(true, Ordering::Release);
+                            }
+                        }
+                    }
+
+                    // Evict the cached AST under both URI forms.
+                    self.ast_cache.remove(&uri);
+                    if normalized_uri != uri {
+                        self.ast_cache.remove(&normalized_uri);
                     }
 
                     tracing::debug!(uri, "Removed deleted file from index");

--- a/crates/perl-workspace/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace/src/workspace/workspace_index.rs
@@ -1823,22 +1823,42 @@ impl WorkspaceIndex {
 
             // Defensive sweep: purge any remaining cache entries whose value
             // points to this file's URI.  incremental_remove_symbols already
-            // handles known symbol names; this sweep catches any entries that
-            // were inserted via the find_definition fallback path using a key
-            // that differs from both sym.name and sym.qualified_name.
-            // Use the URI stored in the file_index itself (not the caller-supplied
-            // uri_str) so the comparison is always against the exact string that
-            // was stored during indexing.
-            if let Some(indexed_uri) = file_index.symbols.first().map(|s| s.uri.as_str()) {
-                symbols.retain(|_, candidates| {
-                    candidates.retain(|candidate| candidate.location.uri.as_str() != indexed_uri);
-                    !candidates.is_empty()
-                });
+            // handles known symbol names; this sweep guarantees no stale
+            // candidates survive even when:
+            //   * the file had zero symbols (nothing for incremental_remove
+            //     to walk), or
+            //   * a symbol's stored uri differs from the canonical normalize_uri
+            //     output (URI normalization edge cases).
+            // Match against every URI spelling observed in this file index plus
+            // the canonical uri_str so raw/normalized variants are all caught.
+            let mut removed_uris = vec![uri_str.as_str()];
+            for observed_uri in file_index.symbols.iter().map(|s| s.uri.as_str()).chain(
+                file_index.references.values().flat_map(|refs| refs.iter().map(|r| r.uri.as_str())),
+            ) {
+                if !removed_uris.contains(&observed_uri) {
+                    removed_uris.push(observed_uri);
+                }
             }
+            symbols.retain(|_, candidates| {
+                candidates.retain(|candidate| {
+                    let cand_uri = candidate.location.uri.as_str();
+                    !removed_uris.contains(&cand_uri)
+                });
+                !candidates.is_empty()
+            });
 
-            // Remove from global reference index
+            // Remove from global reference index. Two-phase cleanup: first
+            // remove names this file was known to reference (cheap path), then
+            // a defensive sweep over all remaining entries to catch any that
+            // were inserted under names not present in this file's
+            // FileIndex::references map (e.g. via aggregated/global insertion
+            // paths). Empty buckets are dropped.
             let mut global_refs = self.global_references.write();
             Self::remove_file_global_refs(&mut global_refs, &file_index, &uri_str);
+            global_refs.retain(|_, locs| {
+                locs.retain(|loc| !removed_uris.contains(&loc.uri.as_str()));
+                !locs.is_empty()
+            });
         }
     }
 
@@ -2325,27 +2345,17 @@ impl WorkspaceIndex {
             return Some(location);
         }
 
+        // Fall back to a full files scan for this query. The result is intentionally
+        // NOT written back to `self.symbols`: every indexed symbol is already
+        // inserted under both qualified and bare names by `incremental_add_symbols`,
+        // so any cache miss here is for a key that does not correspond to an
+        // indexed symbol (e.g. a typo or alias). Caching such queries is unsound
+        // (entries become stale on file edits and were never tracked for cleanup
+        // in `remove_file`/`incremental_remove_symbols`) and lets the cache grow
+        // unboundedly across long sessions. Returning the resolved location
+        // directly preserves correctness without retaining state.
         let files = self.files.read();
-        let resolved = Self::find_definition_in_files(&files, symbol_name, None);
-        drop(files);
-
-        if let Some((location, _uri)) = resolved {
-            let mut symbols = self.symbols.write();
-            symbols.entry(symbol_name.to_string()).or_default().push(DefinitionCandidate {
-                location: location.clone(),
-                kind: SymbolKind::Subroutine,
-            });
-            if let Some(candidates) = symbols.get_mut(symbol_name) {
-                candidates.sort_by(|left, right| {
-                    Self::definition_candidate_sort_key(left)
-                        .cmp(&Self::definition_candidate_sort_key(right))
-                });
-                candidates.dedup();
-            }
-            return Some(location);
-        }
-
-        None
+        Self::find_definition_in_files(&files, symbol_name, None).map(|(location, _uri)| location)
     }
 
     pub(crate) fn definition_candidates(&self, symbol_name: &str) -> Vec<Location> {

--- a/crates/perl-workspace/tests/memory_leak_regression.rs
+++ b/crates/perl-workspace/tests/memory_leak_regression.rs
@@ -1,0 +1,236 @@
+//! Regression tests for memory leaks in `WorkspaceIndex`.
+//!
+//! These tests pin down the leak vectors fixed in the
+//! `claude/investigate-memory-leak-H0LGP` investigation. Each test isolates
+//! one growth path and asserts that memory accounting returns to (or stays
+//! near) baseline after the corresponding cleanup.
+//!
+//! Requires the `memory-profiling` feature so `MemorySnapshot::capture` and
+//! `DocumentStore::total_text_bytes` are available.
+
+#![cfg(feature = "memory-profiling")]
+
+use perl_workspace::workspace::memory::MemorySnapshot;
+use perl_workspace::workspace_index::WorkspaceIndex;
+use url::Url;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn module(idx: usize) -> Result<(Url, String), url::ParseError> {
+    let uri = Url::parse(&format!("file:///lib/Leak/Mod{idx}.pm"))?;
+    let src = format!(
+        r#"package Leak::Mod{idx};
+use strict;
+use warnings;
+
+sub new {{ return bless {{}}, shift }}
+sub run {{ return {idx} }}
+sub helper_{idx} {{ my ($self, $x) = @_; return $x + {idx} }}
+
+1;
+"#
+    );
+    Ok((uri, src))
+}
+
+/// After indexing N files and then removing all of them, the index must
+/// return to the empty-baseline footprint. A leak in any secondary index
+/// (`symbols`, `global_references`, semantic shards, document store) shows
+/// up as residual bytes after the remove loop.
+#[test]
+fn remove_all_returns_index_to_empty_baseline() -> TestResult {
+    let index = WorkspaceIndex::new();
+    let baseline = MemorySnapshot::capture(&index);
+    assert_eq!(baseline.total_estimated_bytes(), 0, "fresh index must be zero");
+
+    let count = 200;
+    let mut uris = Vec::with_capacity(count);
+    for i in 0..count {
+        let (uri, src) = module(i)?;
+        index.index_file(uri.clone(), src).ok();
+        uris.push(uri);
+    }
+
+    let after_index = MemorySnapshot::capture(&index);
+    assert!(
+        after_index.total_estimated_bytes() > 0,
+        "index must hold bytes after indexing {count} files"
+    );
+    assert_eq!(after_index.file_count, count, "all files indexed");
+
+    for uri in &uris {
+        index.remove_file(uri.as_str());
+    }
+
+    let after_remove = MemorySnapshot::capture(&index);
+    assert_eq!(after_remove.file_count, 0, "no files should remain");
+    assert_eq!(after_remove.symbol_count, 0, "no symbols should remain");
+    assert_eq!(
+        after_remove.symbols_bytes, 0,
+        "symbols map must be drained on full remove (regression: find_definition fallback or sweep miss)"
+    );
+    assert_eq!(
+        after_remove.global_refs_bytes, 0,
+        "global_references must be drained on full remove (regression: defensive sweep miss)"
+    );
+    assert_eq!(
+        after_remove.document_store_bytes, 0,
+        "document store must be drained on full remove"
+    );
+    // files_bytes counts the underlying HashMap keys/values; with all entries
+    // removed it must be zero. Allocator bucket capacity is not measured.
+    assert_eq!(after_remove.files_bytes, 0, "files map must be empty");
+    Ok(())
+}
+
+/// `find_definition` must NOT cache misses. Repeatedly looking up names that
+/// do not resolve should leave the `symbols` map size unchanged. Before the
+/// fix, each fallback inserted an entry that was never invalidated.
+#[test]
+fn find_definition_does_not_grow_symbols_on_miss() -> TestResult {
+    let index = WorkspaceIndex::new();
+    for i in 0..50 {
+        let (uri, src) = module(i)?;
+        index.index_file(uri, src).ok();
+    }
+    let before = MemorySnapshot::capture(&index);
+
+    // Issue 1000 lookups for names that don't exist anywhere in the index.
+    for i in 0..1000 {
+        let _ = index.find_definition(&format!("Definitely::Not::Real::sym_{i}"));
+    }
+
+    let after = MemorySnapshot::capture(&index);
+    assert_eq!(
+        after.symbols_bytes, before.symbols_bytes,
+        "find_definition cache miss must not grow the symbols map (regression: fallback insertion was reintroduced)"
+    );
+    assert_eq!(
+        after.global_refs_bytes, before.global_refs_bytes,
+        "find_definition must not grow the global_references map"
+    );
+    Ok(())
+}
+
+/// Repeated index/remove cycles for the same set of files must not accumulate
+/// memory across cycles. This catches subtle leaks where the second remove
+/// path cleans less than the first (e.g. shape-dependent sweep skips).
+#[test]
+fn repeated_index_remove_cycles_do_not_accumulate() -> TestResult {
+    let index = WorkspaceIndex::new();
+
+    // Warmup cycle to establish baseline after the first round of allocations.
+    for i in 0..40 {
+        let (uri, src) = module(i)?;
+        index.index_file(uri, src).ok();
+    }
+    for i in 0..40 {
+        let (uri, _) = module(i)?;
+        index.remove_file(uri.as_str());
+    }
+    let baseline = MemorySnapshot::capture(&index);
+    assert_eq!(baseline.symbols_bytes, 0, "warmup must drain symbols");
+    assert_eq!(baseline.global_refs_bytes, 0, "warmup must drain global_refs");
+
+    for _cycle in 0..20 {
+        for i in 0..40 {
+            let (uri, src) = module(i)?;
+            index.index_file(uri, src).ok();
+        }
+        for i in 0..40 {
+            let (uri, _) = module(i)?;
+            index.remove_file(uri.as_str());
+        }
+    }
+
+    let after = MemorySnapshot::capture(&index);
+    assert_eq!(
+        after.symbols_bytes, 0,
+        "20 index/remove cycles must leave symbols empty (regression: cycle accumulation)"
+    );
+    assert_eq!(
+        after.global_refs_bytes, 0,
+        "20 index/remove cycles must leave global_references empty"
+    );
+    assert_eq!(after.file_count, 0, "no files should remain after cycles");
+    Ok(())
+}
+
+/// Indexing the same files into two indexes — one in a single shot, one via
+/// many cycles — must produce the same memory footprint. If cycle accumulates
+/// secondary state, the cycled index will be measurably larger.
+#[test]
+fn cycle_footprint_matches_single_shot_footprint() -> TestResult {
+    let single_shot = WorkspaceIndex::new();
+    for i in 0..60 {
+        let (uri, src) = module(i)?;
+        single_shot.index_file(uri, src).ok();
+    }
+    let single = MemorySnapshot::capture(&single_shot);
+
+    let cycled = WorkspaceIndex::new();
+    for _ in 0..5 {
+        for i in 0..60 {
+            let (uri, src) = module(i)?;
+            cycled.index_file(uri, src).ok();
+        }
+        for i in 0..60 {
+            let (uri, _) = module(i)?;
+            cycled.remove_file(uri.as_str());
+        }
+    }
+    // Final indexing pass: leave the cycled index populated.
+    for i in 0..60 {
+        let (uri, src) = module(i)?;
+        cycled.index_file(uri, src).ok();
+    }
+    let cycled_snap = MemorySnapshot::capture(&cycled);
+
+    assert_eq!(
+        cycled_snap.file_count, single.file_count,
+        "file counts must match across cycled and single-shot"
+    );
+    assert_eq!(
+        cycled_snap.symbol_count, single.symbol_count,
+        "symbol counts must match across cycled and single-shot"
+    );
+    // Allow modest variance for HashMap re-allocation differences in the
+    // measured byte fields, but the cycled index must not be substantially
+    // larger than the single-shot one. A 25% upper bound catches gross leaks
+    // without flaking on benign re-allocation noise.
+    let single_total = single.total_estimated_bytes();
+    let cycled_total = cycled_snap.total_estimated_bytes();
+    let upper = single_total + single_total / 4;
+    assert!(
+        cycled_total <= upper,
+        "cycled total {cycled_total} exceeds single-shot upper bound {upper} \
+         (regression: per-cycle accumulation)"
+    );
+    Ok(())
+}
+
+/// The `bytes_per_symbol` ratio must stay within a sane envelope at moderate
+/// scale. Catches gross blow-ups (e.g. accidentally storing the full source
+/// text per symbol, or an unbounded per-key candidate cache).
+#[test]
+fn bytes_per_symbol_stays_under_threshold_at_500_files() -> TestResult {
+    let index = WorkspaceIndex::new();
+    for i in 0..500 {
+        let (uri, src) = module(i)?;
+        index.index_file(uri, src).ok();
+    }
+
+    let snap = MemorySnapshot::capture(&index);
+    assert!(snap.symbol_count >= 500, "expected at least 500 symbols");
+
+    // Current baseline measured on this corpus is well under 2_000 bytes/symbol.
+    // The threshold is loose to avoid flaking on minor refactors but tight
+    // enough to catch a 5x regression.
+    let bps = snap.bytes_per_symbol();
+    assert!(
+        bps < 5_000,
+        "bytes-per-symbol {bps} exceeded the 5_000 byte regression threshold \
+         (likely a new unbounded clone or a per-key cache without eviction)"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Problem: Long LSP sessions retained stale workspace definitions, closed-document AST/POD/diagnostic cache entries, and cancelled stream sessions beyond their useful lifetime.
Fix: Evict closed/deleted document state from AST, POD, pull-diagnostic, parse-cancel, stream-session, and workspace indexes; avoid caching `find_definition` misses; add memory-regression coverage for workspace index cleanup.
Verification: `cargo test -p perl-workspace --features memory-profiling --test memory_leak_regression --profile agent --locked`; `cargo test -p perl-lsp-rs-core --lib performance --profile agent --locked`; `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib --profile agent --locked -- --test-threads=2`; `cargo check -p perl-workspace --features memory-profiling --all-targets --profile agent --locked`; `cargo check -p perl-lsp-rs-core --all-targets --profile agent --locked`; `cargo check -p perl-lsp-rs --all-targets --profile agent --locked`; `cargo clippy -p perl-workspace --features memory-profiling --test memory_leak_regression --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-lsp-rs-core --lib --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-lsp-rs --lib --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check --package perl-workspace --package perl-lsp-rs --package perl-lsp-rs-core`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `git diff --check`.

Review notes:
- Replaced the new test-file `unwrap`/`expect` allow with `perl_tdd_support::must`.
- Extended the workspace-index defensive sweep to remove all URI spellings observed in the file index, not only the caller-normalized URI.
- Dropped an unused public `AstCache::entry_count` addition to keep the API surface narrower.