### PR TITLE
fix(vscode): satisfy stricter extension lint (#0000)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -82,23 +82,6 @@ export function _setLastStartupDiagnosisForTest(diagnosis: StartupErrorDiagnosis
     lastStartupDiagnosis = diagnosis;
 }
 
-type PerlCriticSettings = {
-    enabled: boolean;
-    severity: number;
-    profile: string;
-    theme: string;
-};
-
-function getPerlCriticSettings(documentUri?: vscode.Uri): PerlCriticSettings {
-    const config = vscode.workspace.getConfiguration('perl-lsp', documentUri);
-    return {
-        enabled: config.get<boolean>('perlcritic.enabled', false),
-        severity: config.get<number>('perlcritic.severity', 3),
-        profile: config.get<string>('perlcritic.profile', ''),
-        theme: config.get<string>('perlcritic.theme', ''),
-    };
-}
-
 type PerlCriticSyncSettings = {
     enabled?: boolean;
     severity?: number;
@@ -203,7 +186,7 @@ export async function syncPerlCriticConfiguration(
 
     const payload = buildPerlCriticConfiguration(getPerlCriticSyncSettings(documentUri));
     if (payload) {
-        activeClient.sendNotification('workspace/didChangeConfiguration', payload);
+        await activeClient.sendNotification('workspace/didChangeConfiguration', payload);
     }
 }
 
@@ -319,7 +302,7 @@ export async function setPerlCriticSeverity(
     await config.update('perlcritic.severity', severity, target);
     const payload = buildPerlCriticConfiguration(getPerlCriticSyncSettings(resourceUri, severity));
     if (activeClient && payload) {
-        activeClient.sendNotification('workspace/didChangeConfiguration', payload);
+        await activeClient.sendNotification('workspace/didChangeConfiguration', payload);
     }
 
     vscode.window.showInformationMessage(`PerlCritic severity set to ${severity}.`);

--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -223,7 +223,9 @@ export class OnboardingManager {
   /** Check perlcritic availability/profile when perl-lsp.perlcritic.enabled is true. */
   async checkPerlcriticSetup(): Promise<HealthCheckResult> {
     const label = 'perlcritic';
-    const perlcriticConfig = vscode.workspace.getConfiguration('perl-lsp').get<any>('perlcritic', {});
+    const perlcriticConfig = vscode.workspace
+      .getConfiguration('perl-lsp')
+      .get<{ enabled?: unknown; profile?: unknown }>('perlcritic', {});
     const enabled = Boolean(perlcriticConfig?.enabled);
     const profile =
       typeof perlcriticConfig?.profile === 'string'

--- a/vscode-extension/src/runTestAtCursor.ts
+++ b/vscode-extension/src/runTestAtCursor.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 
 export type CursorTestCommand = {
     command: string;


### PR DESCRIPTION
Problem: The merged VS Code dependency bump exposed stricter ESLint checks and left npm run lint failing on floating notification promises plus minor type warnings.\nFix: Await the configuration notifications, remove an unused PerlCritic helper, and tighten the affected type-only imports/config typing.\nVerification: npm ci; pnpm install --frozen-lockfile; npm run compile; npm run lint; cargo xtask metrics parser-accuracy --check; cargo xtask metrics ratchet-check parser_accuracy; git diff --check.