### PR TITLE
ci(clippy): add governed lint policy gate (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/Cargo.toml
+++ b/crates/perl-ci-hygiene/Cargo.toml
@@ -18,3 +18,6 @@ regex.workspace = true
 serde_json.workspace = true
 walkdir.workspace = true
 toml = "1.1.2"
+
+[lints]
+workspace = true

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -16,3 +16,6 @@ perl-workspace = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 perl-tdd-support = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -45,3 +45,6 @@ perl-semantic-analyzer = { workspace = true }
 perl-tdd-support = { workspace = true }
 insta = { version = "1.47.2" }
 perl-position-tracking = { workspace = true }
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,53 @@
+# Clippy policy
+
+`perl-lsp` treats Clippy as a governed engineering surface, not as a local taste file. The workspace policy is recorded in three places:
+
+- `Cargo.toml` contains the active `[workspace.lints]` block inherited by member crates.
+- `policy/clippy-lints.toml` is the machine-readable ledger for active, debt, tracked, and planned Rust-version lint flips.
+- `policy/clippy-debt.toml` records temporary, expiring debt instead of weakening the global policy silently.
+
+## Workspace posture
+
+The policy applies to production code and tests. The current active Cargo lint block remains intentionally small; broader guardrail lints are tracked in `policy/clippy-lints.toml` until the relevant cleanup PRs can activate them without bundling behavior changes into the policy gate. Tests should return `Result` or use repository test helpers such as `perl_tdd_support::must` and `perl_tdd_support::must_some`.
+
+The workspace still carries Clippy's legacy test unwrap carveout in `clippy.toml`. That carveout is recorded as expiring debt in `policy/clippy-debt.toml` so this control-plane PR can add governance without also rewriting unrelated tests.
+
+The tracked lint set covers five guardrail families:
+
+1. **Panic-free code**: no unchecked `Result`/`Option` collapse, panic macros, `todo!`, `unimplemented!`, or `unreachable!` paths.
+2. **AST and UTF-8 safety**: parser and LSP boundary code must avoid unchecked string slicing, byte/character index confusion, and unchecked indexing.
+3. **Silent-failure prevention**: ignored futures, ignored `must_use` values, discarded errors, and lossy line iteration are denied.
+4. **Async, memory, numeric, and file/process footguns**: concurrency and parser correctness hazards are denied or warned according to the ledger.
+5. **Suppression governance**: broad or unexplained suppressions are rejected. Prefer narrow `#[expect(..., reason = "...")]` receipts.
+
+## Suppression style
+
+Use `#[expect]` only when the lint is correct but the local exception is intentional and reviewed:
+
+```rust
+#[expect(
+    clippy::indexing_slicing,
+    reason = "Generated parser table access is bounded by table construction invariants."
+)]
+fn generated_table_lookup(table: &[usize], index: usize) -> usize {
+    table[index]
+}
+```
+
+Do not use a silent `#[allow]`. If a lint needs repo-wide temporary treatment, add a scoped entry to `policy/clippy-debt.toml` with `lint`, `path`, `owner`, `reason`, and `expires`.
+
+## Planned Rust upgrades
+
+The ledger tracks planned Rust 1.94 and 1.95 flips before the workspace MSRV moves. `cargo xtask check-lint-policy` verifies that planned lints are present in the ledger and not activated ahead of the MSRV bump.
+
+The current workspace remains on the MSRV recorded in `Cargo.toml` and `policy/clippy-lints.toml`; the Rust 1.93 toolchain ratchet is intentionally left to a dedicated follow-up lane because toolchain changes affect CI, documentation, and release policy together.
+
+## Local check
+
+Run the policy gate before changing lint configuration:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The gate checks lint inheritance, active Cargo lint levels, tracked lint metadata, planned upgrade ledger entries, and required debt metadata.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,15 @@
+schema = 1
+
+[[debt]]
+lint = "clippy::collapsible_if"
+path = "crates/**/*.rs"
+owner = "parser"
+reason = "Existing parser and provider control-flow shapes predate the strict lint policy; clean up in behavior-preserving follow-up PRs."
+expires = "2026-07-01"
+
+[[debt]]
+lint = "clippy::unwrap_used"
+path = "clippy.toml"
+owner = "lint-policy"
+reason = "The workspace still carries Clippy's test unwrap carveout while test helper cleanup is tracked separately from this policy gate."
+expires = "2026-07-01"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,780 @@
+schema = 1
+msrv = "1.92"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = true
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+[[lint]]
+name = "clippy::collapsible_if"
+level = "allow"
+status = "debt"
+class = "style"
+reason = "Existing parser control-flow debt is tracked in policy/clippy-debt.toml until behavior-preserving cleanup lands."
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "deny"
+status = "tracked"
+class = "unsafe-memory"
+reason = "No unsafe code in production or tests without a narrow expect-with-reason receipt."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "tracked"
+class = "unsafe-memory"
+reason = "Unsafe operations must stay explicitly scoped if unsafe is ever introduced."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "tracked"
+class = "silent-failure"
+reason = "Must-use values represent work that cannot be silently discarded."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "workspace"
+reason = "Keep cfg spelling drift visible while preserving the repo-specific cfg allowlist in Cargo.toml."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Debug macros are not a reviewable diagnostics path."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "TODO execution paths are not allowed in production or tests."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Unimplemented execution paths are not allowed in production or tests."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Parser, LSP, DAP, and test code should return structured errors rather than abort execution."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "tracked"
+class = "panic"
+reason = "Unreachable markers hide parser and protocol states that should be modeled."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked Result/Option collapse in production or tests."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Expect messages are not a substitute for typed error handling or test helpers."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "tracked"
+class = "panic"
+reason = "Checked access should be explicit rather than hidden behind get().unwrap()."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "tracked"
+class = "panic"
+reason = "Result-returning code should propagate errors instead of panicking internally."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "tracked"
+class = "panic"
+reason = "Result-returning APIs promise recoverable failure, not panic paths."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "tracked"
+class = "ast-safety"
+reason = "Byte slicing UTF-8 text is unsafe for Perl parser and LSP boundary logic."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "tracked"
+class = "ast-safety"
+reason = "Indexing and slicing must be checked at parser, lexer, and protocol boundaries."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "tracked"
+class = "ast-safety"
+reason = "Out-of-bounds indexing is a correctness failure."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "tracked"
+class = "correctness"
+reason = "Telemetry and timeout math should not underflow silently."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "tracked"
+class = "ast-safety"
+reason = "Perl source offsets must not confuse character and byte positions."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "tracked"
+class = "ast-safety"
+reason = "String-byte conversion should not preserve an unchecked slice boundary."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "tracked"
+class = "ast-safety"
+reason = "Prefer slice patterns that encode parser boundary expectations."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "tracked"
+class = "silent-failure"
+reason = "Futures must be awaited, spawned, or explicitly dropped by policy."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "tracked"
+class = "silent-failure"
+reason = "Must-use values cannot be discarded with let-underscore."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "tracked"
+class = "silent-failure"
+reason = "Locks must be held by named guards with visible scope."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "tracked"
+class = "silent-failure"
+reason = "Calling ok() to discard errors hides failed work."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "tracked"
+class = "silent-failure"
+reason = "Error conversion must preserve diagnostic context."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "tracked"
+class = "panic"
+reason = "Tests should inspect results with helpers that preserve error detail."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "tracked"
+class = "silent-failure"
+reason = "Line iteration must not hide repeated IO errors."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "tracked"
+class = "async"
+reason = "Do not hold locks across await points."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "tracked"
+class = "async"
+reason = "Do not hold RefCell borrows across await points."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "tracked"
+class = "async"
+reason = "Do not hold configured invalid guard types across await points."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "tracked"
+class = "async"
+reason = "Non-Send futures should be reviewed before becoming server boundary debt."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "tracked"
+class = "async"
+reason = "Large futures should stay visible during provider review."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "tracked"
+class = "async"
+reason = "Arc should not imply cross-thread safety for non-Send/non-Sync payloads."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "tracked"
+class = "async"
+reason = "Mutex-protected sharing should use thread-safe ownership."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "tracked"
+class = "async"
+reason = "Mutable mutex access should avoid unnecessary locking."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "tracked"
+class = "async"
+reason = "Use read locks when mutation is not required."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "tracked"
+class = "unsafe-memory"
+reason = "Leaking destructors requires explicit policy review."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "tracked"
+class = "unsafe-memory"
+reason = "Forgetting non-Drop values usually signals mistaken ownership policy."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "tracked"
+class = "unsafe-memory"
+reason = "Dropping non-Drop values should not encode control flow."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "tracked"
+class = "unsafe-memory"
+reason = "Unsafe blocks need explicit safety documentation if ever introduced."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "tracked"
+class = "unsafe-memory"
+reason = "Unsafe operations should be reviewed one invariant at a time."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "tracked"
+class = "unsafe-memory"
+reason = "Packed repr must specify an ABI to avoid accidental layout assumptions."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "Floating-point comparisons should use explicit tolerance policy."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "Floating-point constant comparisons should use explicit tolerance policy."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "Float equality checks should use absolute-difference semantics."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "Lossy literals should not silently change numeric behavior."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "Sign-loss casts need explicit checked or saturating intent."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "tracked"
+class = "numeric"
+reason = "Possible wrapping casts are visible debt while parser numeric surfaces are audited."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "tracked"
+class = "numeric"
+reason = "Possible truncating casts are visible debt while parser numeric surfaces are audited."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "tracked"
+class = "numeric"
+reason = "Precision-loss casts are visible debt while metrics and parser numeric surfaces are audited."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "Invalid upcast comparisons are correctness bugs."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "Absolute-value casts must use explicit unsigned helpers."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "Enum truncation can corrupt protocol and parser states."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "tracked"
+class = "numeric"
+reason = "NaN-to-int casts need explicit handling."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "tracked"
+class = "numeric"
+reason = "Prefer standard midpoint helpers over overflow-prone formulas."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "tracked"
+class = "numeric"
+reason = "Prefer standard divisibility helpers."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "tracked"
+class = "numeric"
+reason = "Prefer standard div_ceil helpers."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "tracked"
+class = "numeric"
+reason = "Arithmetic side effects remain visible while parser numeric policies are audited."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "tracked"
+class = "file-policy"
+reason = "File open behavior must be explicit."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "tracked"
+class = "file-policy"
+reason = "Contradictory file open behavior is a bug."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "tracked"
+class = "file-policy"
+reason = "Ineffective file open flags hide intent."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "tracked"
+class = "file-policy"
+reason = "Absolute path pushes must not silently discard existing path state."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "tracked"
+class = "file-policy"
+reason = "Joining absolute paths must not silently ignore the base path."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "tracked"
+class = "file-policy"
+reason = "Interactive input parsing should make newline handling explicit."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "tracked"
+class = "file-policy"
+reason = "Process exits belong at explicit CLI boundaries."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "tracked"
+class = "api"
+reason = "Iterator-shaped APIs should preserve trait expectations."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "tracked"
+class = "api"
+reason = "Copy types should not have surprising Clone implementations."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "tracked"
+class = "api"
+reason = "Infallible conversions should use From."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "tracked"
+class = "api"
+reason = "From implementations must not fail at runtime."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "tracked"
+class = "api"
+reason = "Error facade types should implement the standard Error trait."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "tracked"
+class = "api"
+reason = "Unit errors should be replaced with structured diagnostics."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "tracked"
+class = "api"
+reason = "Large errors should remain visible for API and allocation review."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "tracked"
+class = "reviewability"
+reason = "Nested formatting obscures review and allocation behavior."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "tracked"
+class = "reviewability"
+reason = "Formatting should avoid unnecessary string allocation."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "tracked"
+class = "reviewability"
+reason = "Unused format specs hide formatting mistakes."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Path and OS-string formatting should use display when possible."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Inline format args improve reviewability."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "let-else clarifies early-return control flow."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Use standard Option-to-Result conversion helpers."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Prefix/suffix stripping should use standard checked helpers."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Use split_once when parsing two-part strings."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Use is_some_and/is_ok_and to encode variant predicates."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Use find_map for first-success searches."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Use filter_map when flattening Options from iterators."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "tracked"
+class = "reviewability"
+reason = "Match on Ok directly instead of discarding error information."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Copy values should use copied for clearer cost."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Use to_vec or collect forms that encode allocation intent."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Clone after filtering when possible."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Avoid temporary allocations when iteration can remain lazy."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Prefer direct function references when closures add no meaning."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "tracked"
+class = "reviewability"
+reason = "Prefer method references when closures add no meaning."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "tracked"
+class = "api"
+reason = "Public APIs should not have undocumented panic paths."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "tracked"
+class = "api"
+reason = "Public fallible APIs should document error behavior."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "tracked"
+class = "suppression"
+reason = "Use expect with a reason instead of silent allow attributes."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "tracked"
+class = "suppression"
+reason = "Suppressions require a reviewable reason."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "tracked"
+class = "suppression"
+reason = "Do not enable broad restriction groups without explicit lint policy."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "tracked"
+class = "suppression"
+reason = "Ignored tests need reviewable explanations."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "tracked"
+class = "suppression"
+reason = "Panic tests must state the expected panic."
+
+[[planned]]
+name = "rust::const_item_interior_mutations"
+level = "deny"
+activate_when_msrv = "1.93"
+reason = "Enable once the workspace toolchain lane moves to Rust 1.93 and confirms lint availability."
+
+[[planned]]
+name = "rust::function_casts_as_integer"
+level = "deny"
+activate_when_msrv = "1.93"
+reason = "Enable once the workspace toolchain lane moves to Rust 1.93 and confirms lint availability."
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Avoid stale numeric type drift."
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -64,3 +64,6 @@ legacy = ["perl-parser-pest"]
 # Building this feature requires a C toolchain and libclang to compile
 # `tree-sitter-perl-c`.
 parser-tasks = ["legacy", "tree-sitter-perl-c"]
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -48,6 +48,9 @@ enum Commands {
     /// Run format and clippy checks only (no tests)
     CheckOnly,
 
+    /// Verify the governed Clippy lint policy ledger and workspace inheritance.
+    CheckLintPolicy,
+
     /// Verify local Rust toolchain meets the pinned MSRV in rust-toolchain.toml.
     CheckToolchain {
         /// Show a warning when rustc satisfies the minimum MSRV but differs
@@ -1820,6 +1823,7 @@ fn main() -> Result<()> {
         }
         Commands::Ci => ci::run(),
         Commands::CheckOnly => ci::check_only(),
+        Commands::CheckLintPolicy => check_lint_policy::run(),
         Commands::CheckToolchain { doctor } => check_toolchain::run(doctor),
         Commands::Queue { command } => match command {
             QueueCommand::Snapshot { out, fixture } => queue_snapshot::run_snapshot(out, fixture),

--- a/xtask/src/tasks/check_lint_policy.rs
+++ b/xtask/src/tasks/check_lint_policy.rs
@@ -1,0 +1,474 @@
+//! Clippy lint policy coherence checks.
+
+use chrono::{Local, NaiveDate};
+use color_eyre::eyre::{Result, bail, eyre};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml::Value;
+
+const ROOT_MANIFEST: &str = "Cargo.toml";
+const CLIPPY_CONFIG: &str = "clippy.toml";
+const LINT_LEDGER: &str = "policy/clippy-lints.toml";
+const DEBT_LEDGER: &str = "policy/clippy-debt.toml";
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+const REQUIRED_PLANNED: &[&str] = &[
+    "rust::const_item_interior_mutations",
+    "rust::function_casts_as_integer",
+    "clippy::same_length_and_capacity",
+    "clippy::manual_ilog2",
+    "clippy::decimal_bitwise_operands",
+    "clippy::needless_type_cast",
+    "clippy::disallowed_fields",
+    "clippy::manual_checked_ops",
+    "clippy::manual_take",
+    "clippy::manual_pop_if",
+    "clippy::duration_suboptimal_units",
+    "clippy::unnecessary_trailing_comma",
+];
+
+#[derive(Debug, Deserialize)]
+struct LintLedger {
+    schema: u64,
+    msrv: String,
+    policy: LintPolicy,
+    #[serde(default)]
+    lint: Vec<LintEntry>,
+    #[serde(default)]
+    planned: Vec<PlannedLint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintPolicy {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    class: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlannedLint {
+    name: String,
+    level: String,
+    activate_when_msrv: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+pub fn run() -> Result<()> {
+    let root = Path::new(".");
+    let cargo = read_toml(root.join(ROOT_MANIFEST))?;
+    let lint_ledger: LintLedger = read_toml_as(root.join(LINT_LEDGER))?;
+    let debt_ledger: DebtLedger = read_toml_as(root.join(DEBT_LEDGER))?;
+
+    validate_policy_header(&lint_ledger)?;
+    validate_msrv(&cargo, &lint_ledger)?;
+    validate_workspace_lints(&cargo, &lint_ledger)?;
+    validate_workspace_members_inherit_lints(root, &cargo)?;
+    validate_clippy_config(root.join(CLIPPY_CONFIG), &lint_ledger)?;
+    validate_planned_lints(&cargo, &lint_ledger)?;
+    validate_debt_ledger(&debt_ledger)?;
+
+    println!(
+        "lint policy ok: {} lint entries, {} planned flips, {} debt entries",
+        lint_ledger.lint.len(),
+        lint_ledger.planned.len(),
+        debt_ledger.debt.len()
+    );
+    Ok(())
+}
+
+fn read_toml(path: PathBuf) -> Result<Value> {
+    let content = fs::read_to_string(&path)
+        .map_err(|err| eyre!("failed to read {}: {err}", path.display()))?;
+    toml::from_str(&content).map_err(|err| eyre!("failed to parse {}: {err}", path.display()))
+}
+
+fn read_toml_as<T>(path: PathBuf) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let content = fs::read_to_string(&path)
+        .map_err(|err| eyre!("failed to read {}: {err}", path.display()))?;
+    toml::from_str(&content).map_err(|err| eyre!("failed to parse {}: {err}", path.display()))
+}
+
+fn validate_policy_header(ledger: &LintLedger) -> Result<()> {
+    if ledger.schema != 1 {
+        bail!("{} schema must be 1", LINT_LEDGER);
+    }
+    if !ledger.policy.panic_free_tests {
+        bail!("{} must set policy.panic_free_tests = true", LINT_LEDGER);
+    }
+    if ledger.policy.suppression_style != "expect-with-reason" {
+        bail!("{} must set policy.suppression_style = \"expect-with-reason\"", LINT_LEDGER);
+    }
+    if ledger.policy.blanket_categories {
+        bail!("{} must set policy.blanket_categories = false", LINT_LEDGER);
+    }
+    Ok(())
+}
+
+fn validate_msrv(cargo: &Value, ledger: &LintLedger) -> Result<()> {
+    let msrv = value_at(cargo, &["workspace", "package", "rust-version"])?
+        .as_str()
+        .ok_or_else(|| eyre!("workspace.package.rust-version must be a string"))?;
+    if msrv != ledger.msrv {
+        bail!(
+            "workspace.package.rust-version ({msrv}) must match {LINT_LEDGER} msrv ({})",
+            ledger.msrv
+        );
+    }
+    Ok(())
+}
+
+fn validate_workspace_lints(cargo: &Value, ledger: &LintLedger) -> Result<()> {
+    let cargo_lints = collect_workspace_lints(cargo)?;
+    let mut seen = BTreeSet::new();
+    for lint in &ledger.lint {
+        validate_lint_entry(lint)?;
+        if !seen.insert(lint.name.clone()) {
+            bail!("duplicate lint ledger entry for {}", lint.name);
+        }
+        match lint.status.as_str() {
+            "active" | "debt" => {
+                let cargo_level = cargo_lints
+                    .get(&lint.name)
+                    .ok_or_else(|| eyre!("active lint {} is missing from Cargo.toml", lint.name))?;
+                if cargo_level != &lint.level {
+                    bail!(
+                        "lint {} level mismatch: Cargo.toml has {cargo_level}, ledger has {}",
+                        lint.name,
+                        lint.level
+                    );
+                }
+            }
+            "tracked" => {
+                if cargo_lints.contains_key(&lint.name) {
+                    bail!(
+                        "tracked lint {} is already active in Cargo.toml; mark it active or debt",
+                        lint.name
+                    );
+                }
+            }
+            _ => bail!("lint {} has unsupported status {}", lint.name, lint.status),
+        }
+    }
+    Ok(())
+}
+
+fn validate_lint_entry(lint: &LintEntry) -> Result<()> {
+    if lint.name.trim().is_empty() {
+        bail!("lint entry name cannot be empty");
+    }
+    if !matches!(lint.level.as_str(), "allow" | "warn" | "deny" | "forbid") {
+        bail!("lint {} has unsupported level {}", lint.name, lint.level);
+    }
+    if !matches!(lint.status.as_str(), "active" | "debt" | "tracked") {
+        bail!("lint {} must have status active, debt, or tracked", lint.name);
+    }
+    if lint.class.trim().is_empty() {
+        bail!("lint {} must have a class", lint.name);
+    }
+    if lint.reason.trim().is_empty() {
+        bail!("lint {} must have a reason", lint.name);
+    }
+    Ok(())
+}
+
+fn collect_workspace_lints(cargo: &Value) -> Result<BTreeMap<String, String>> {
+    let mut output = BTreeMap::new();
+    let workspace_lints = value_at(cargo, &["workspace", "lints"])?
+        .as_table()
+        .ok_or_else(|| eyre!("workspace.lints must be a table"))?;
+    for (tool, table) in workspace_lints {
+        let lint_table =
+            table.as_table().ok_or_else(|| eyre!("workspace.lints.{tool} must be a table"))?;
+        for (name, value) in lint_table {
+            let level = lint_level(value).ok_or_else(|| {
+                eyre!("workspace.lints.{tool}.{name} must be a string or table with level")
+            })?;
+            output.insert(format!("{tool}::{}", name.replace('-', "_")), level);
+        }
+    }
+    Ok(output)
+}
+
+fn lint_level(value: &Value) -> Option<String> {
+    if let Some(level) = value.as_str() {
+        return Some(level.to_owned());
+    }
+    value
+        .as_table()
+        .and_then(|table| table.get("level"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn validate_workspace_members_inherit_lints(root: &Path, cargo: &Value) -> Result<()> {
+    let members = value_at(cargo, &["workspace", "members"])?
+        .as_array()
+        .ok_or_else(|| eyre!("workspace.members must be an array"))?;
+    let mut missing = Vec::new();
+    for member in members {
+        let Some(member_path) = member.as_str() else {
+            bail!("workspace.members must contain only strings");
+        };
+        let manifest_path = root.join(member_path).join("Cargo.toml");
+        let manifest = read_toml(manifest_path.clone())?;
+        let inherits = value_at(&manifest, &["lints", "workspace"])
+            .and_then(|value| {
+                value.as_bool().ok_or_else(|| eyre!("[lints].workspace must be boolean"))
+            })
+            .unwrap_or(false);
+        if !inherits {
+            missing.push(manifest_path.display().to_string());
+        }
+    }
+    if !missing.is_empty() {
+        bail!("workspace members missing [lints] workspace = true: {}", missing.join(", "));
+    }
+    Ok(())
+}
+
+fn validate_clippy_config(path: PathBuf, ledger: &LintLedger) -> Result<()> {
+    let content = fs::read_to_string(&path)
+        .map_err(|err| eyre!("failed to read {}: {err}", path.display()))?;
+    if !ledger.policy.allow_test_carveouts {
+        for carveout in TEST_CARVEOUTS {
+            if !content.contains(carveout) {
+                continue;
+            }
+            bail!("{} must not contain test carveout {carveout}", path.display());
+        }
+    }
+    let config: Value = toml::from_str(&content)
+        .map_err(|err| eyre!("failed to parse {}: {err}", path.display()))?;
+    if let Some(msrv) = config.get("msrv").and_then(Value::as_str) {
+        if msrv != ledger.msrv {
+            bail!(
+                "{} msrv ({msrv}) must match {LINT_LEDGER} msrv ({})",
+                path.display(),
+                ledger.msrv
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_planned_lints(cargo: &Value, ledger: &LintLedger) -> Result<()> {
+    let cargo_lints = collect_workspace_lints(cargo)?;
+    let planned_names: BTreeSet<_> = ledger.planned.iter().map(|lint| lint.name.as_str()).collect();
+    for required in REQUIRED_PLANNED {
+        if !planned_names.contains(required) {
+            bail!("{} is missing planned lint {required}", LINT_LEDGER);
+        }
+    }
+    for planned in &ledger.planned {
+        validate_planned_lint(planned)?;
+        if compare_versions(&planned.activate_when_msrv, &ledger.msrv)? > 0
+            && cargo_lints.contains_key(&planned.name)
+        {
+            bail!(
+                "planned lint {} must not be active before MSRV {}",
+                planned.name,
+                planned.activate_when_msrv
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_planned_lint(planned: &PlannedLint) -> Result<()> {
+    if planned.name.trim().is_empty() {
+        bail!("planned lint name cannot be empty");
+    }
+    if !matches!(planned.level.as_str(), "warn" | "deny" | "forbid") {
+        bail!("planned lint {} has unsupported level {}", planned.name, planned.level);
+    }
+    if planned.activate_when_msrv.trim().is_empty() {
+        bail!("planned lint {} must have activate_when_msrv", planned.name);
+    }
+    if planned.reason.trim().is_empty() {
+        bail!("planned lint {} must have a reason", planned.name);
+    }
+    Ok(())
+}
+
+fn validate_debt_ledger(ledger: &DebtLedger) -> Result<()> {
+    if ledger.schema != 1 {
+        bail!("{} schema must be 1", DEBT_LEDGER);
+    }
+    let today = Local::now().date_naive();
+    for entry in &ledger.debt {
+        validate_debt_entry(entry, today)?;
+    }
+    Ok(())
+}
+
+fn validate_debt_entry(entry: &DebtEntry, today: NaiveDate) -> Result<()> {
+    if entry.lint.trim().is_empty() {
+        bail!("debt entry lint cannot be empty");
+    }
+    if entry.path.trim().is_empty() {
+        bail!("debt entry for {} must have a path", entry.lint);
+    }
+    if entry.owner.trim().is_empty() {
+        bail!("debt entry for {} must have an owner", entry.lint);
+    }
+    if entry.reason.trim().is_empty() {
+        bail!("debt entry for {} must have a reason", entry.lint);
+    }
+    let expires = NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d")
+        .map_err(|err| eyre!("debt entry for {} has invalid expires date: {err}", entry.lint))?;
+    if expires < today {
+        bail!("debt entry for {} expired on {expires}", entry.lint);
+    }
+    Ok(())
+}
+
+fn value_at<'a>(value: &'a Value, path: &[&str]) -> Result<&'a Value> {
+    let mut current = value;
+    for segment in path {
+        current =
+            current.get(*segment).ok_or_else(|| eyre!("missing TOML key {}", path.join(".")))?;
+    }
+    Ok(current)
+}
+
+fn compare_versions(left: &str, right: &str) -> Result<i8> {
+    let left_parts = version_parts(left)?;
+    let right_parts = version_parts(right)?;
+    for (left_part, right_part) in left_parts.iter().zip(right_parts.iter()) {
+        if left_part > right_part {
+            return Ok(1);
+        }
+        if left_part < right_part {
+            return Ok(-1);
+        }
+    }
+    Ok(0)
+}
+
+fn version_parts(version: &str) -> Result<Vec<u64>> {
+    let mut parts = Vec::new();
+    for part in version.split('.') {
+        let parsed = part
+            .parse::<u64>()
+            .map_err(|err| eyre!("invalid version component {part} in {version}: {err}"))?;
+        parts.push(parsed);
+    }
+    while parts.len() < 3 {
+        parts.push(0);
+    }
+    Ok(parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lint_entry(name: &str, status: &str) -> LintEntry {
+        LintEntry {
+            name: name.to_owned(),
+            level: "deny".to_owned(),
+            status: status.to_owned(),
+            class: "test".to_owned(),
+            reason: "test reason".to_owned(),
+        }
+    }
+
+    fn ledger_with(lint: LintEntry) -> LintLedger {
+        LintLedger {
+            schema: 1,
+            msrv: "1.92".to_owned(),
+            policy: LintPolicy {
+                panic_free_tests: true,
+                allow_test_carveouts: true,
+                suppression_style: "expect-with-reason".to_owned(),
+                blanket_categories: false,
+            },
+            lint: vec![lint],
+            planned: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn lint_entry_accepts_tracked_status() -> Result<()> {
+        validate_lint_entry(&lint_entry("clippy::indexing_slicing", "tracked"))
+    }
+
+    #[test]
+    fn lint_entry_rejects_unknown_status() -> Result<()> {
+        let result = validate_lint_entry(&lint_entry("clippy::indexing_slicing", "candidate"));
+        let Err(error) = result else {
+            bail!("candidate status should be rejected");
+        };
+        assert!(error.to_string().contains("active, debt, or tracked"));
+        Ok(())
+    }
+
+    #[test]
+    fn tracked_lints_do_not_need_cargo_entries() -> Result<()> {
+        let cargo = toml::from_str::<Value>(
+            r#"
+            [workspace.lints.clippy]
+            panic = "deny"
+            "#,
+        )?;
+        let ledger = ledger_with(lint_entry("clippy::indexing_slicing", "tracked"));
+
+        validate_workspace_lints(&cargo, &ledger)
+    }
+
+    #[test]
+    fn tracked_lints_fail_when_already_active() -> Result<()> {
+        let cargo = toml::from_str::<Value>(
+            r#"
+            [workspace.lints.clippy]
+            indexing_slicing = "deny"
+            "#,
+        )?;
+        let ledger = ledger_with(lint_entry("clippy::indexing_slicing", "tracked"));
+
+        let result = validate_workspace_lints(&cargo, &ledger);
+        let Err(error) = result else {
+            bail!("tracked active lint should fail");
+        };
+        assert!(error.to_string().contains("mark it active or debt"));
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -11,6 +11,7 @@ pub mod build;
 pub mod build_timing;
 pub mod bump_version;
 pub mod check;
+pub mod check_lint_policy;
 pub mod check_test_wiring;
 pub mod check_toolchain;
 pub mod check_version_sync;


### PR DESCRIPTION
Problem: Clippy policy was review-by-convention, with no machine-readable contract for active lint levels, planned flips, or temporary debt.

Fix: Add `cargo xtask check-lint-policy`, a Clippy policy guide, and machine-readable lint/debt ledgers. The active ledger now mirrors the current workspace lint block, broader guardrails are tracked until follow-up cleanup PRs can activate them, and the existing test unwrap carveout is recorded as expiring debt instead of being silently flipped in this lane.

Verification:
- `cargo xtask check-lint-policy`
- `cargo test -p xtask --profile agent --locked check_lint_policy`
- `cargo check -p xtask --all-targets --profile agent --locked`
- `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`

Parser accuracy contract: unchanged; 46 fixtures / 28 families, 123 scored lines, 102 scored symbols, 0 active failure packets.
