### PR TITLE
chore(lint-policy): add clippy policy gate (#0000)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 [workspace.package]
 version = "0.13.3"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
 description = "Perl parser, LSP, and DAP ecosystem in Rust"
 license = "MIT OR Apache-2.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # clippy.toml
 # Keep pedantic on, but chill some noisy lints for a parser project.
 # warn-on-all-wildcard-imports = false
-msrv = "1.92"
+msrv = "1.93"
 
 # Common pedantic relaxations for parser projects
 allow-private-module-inception = true
@@ -14,4 +14,3 @@ too-many-lines-threshold = 500
 # Clippy's collapsible_if is aggressive and would require many changes
 # in critical parsing paths that could introduce regressions
 disallowed-methods = []
-allow-unwrap-in-tests = true

--- a/crates/perl-ci-hygiene/Cargo.toml
+++ b/crates/perl-ci-hygiene/Cargo.toml
@@ -18,3 +18,6 @@ regex.workspace = true
 serde_json.workspace = true
 walkdir.workspace = true
 toml = "1.1.2"
+
+[lints]
+workspace = true

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -16,3 +16,6 @@ perl-workspace = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 perl-tdd-support = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -45,3 +45,6 @@ perl-semantic-analyzer = { workspace = true }
 perl-tdd-support = { workspace = true }
 insta = { version = "1.47.2" }
 perl-position-tracking = { workspace = true }
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,35 @@
+# Clippy policy
+
+`perl-lsp` treats Clippy as a governed engineering surface, not as a local taste file. The root `Cargo.toml` owns the active workspace lint baseline, while `policy/clippy-lints.toml` records active lints, staged platform-policy lints, and planned Rust 1.94 and 1.95 flips.
+
+## Invariants
+
+- The workspace MSRV is Rust 1.93 and must match `policy/clippy-lints.toml`.
+- Workspace crates inherit the root lint policy with `[lints] workspace = true`.
+- Production code and tests share the same panic-free baseline: no `unwrap`, `expect`, `panic!`, `todo!`, `unimplemented!`, `unreachable!`, or `dbg!` carveouts.
+- `clippy.toml` is reserved for repo-local thresholds and disallowed-method/type policy. It must not enable test carveouts such as `allow-unwrap-in-tests`.
+- Suppressions should use narrow `#[expect(..., reason = "...")]` receipts rather than broad `#[allow(...)]` carveouts.
+
+## Active lint families
+
+The policy ledger covers active and staged lint families:
+
+- panic-free production and tests;
+- AST, parser, UTF-8, string slicing, and index safety;
+- silent-failure prevention for ignored futures, must-use values, locks, `Result::ok`, and `map_err`;
+- async and concurrency footguns;
+- unsafe and memory-adjacent footguns;
+- numeric correctness warnings and denies;
+- file, process, and path hazards;
+- API/trait correctness; and
+- reviewability lints that reduce allocation noise and clarify control flow.
+
+## Debt and future flips
+
+Temporary exceptions belong in `policy/clippy-debt.toml` with `lint`, `path`, `owner`, `reason`, and `expires`. Staged lints are not yet active in `Cargo.toml`; they become active only after the debt ledger is retired or narrowed. Planned Rust 1.94 and 1.95 lint flips are tracked in `policy/clippy-lints.toml` before the MSRV bump so upgrades are explicit ratchets rather than surprise cleanup waves.
+
+Run the policy gate with:
+
+```bash
+cargo xtask check-lint-policy
+```

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,57 @@
+schema = 1
+
+[[debt]]
+lint = "rust::unsafe_code"
+path = "crates/perl-lsp-rs-core/src/platform.rs"
+owner = "lsp/runtime"
+reason = "Windows PATH/environment boundary still uses Rust 2024 unsafe environment mutation; migrate to command-scoped environment handling before promoting unsafe_code to forbid."
+expires = "2026-07-01"
+
+[[debt]]
+lint = "rust::unsafe_code"
+path = "crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs"
+owner = "lsp/runtime"
+reason = "Launcher tests and guards still mutate process environment; replace with scoped helpers or child-process env injection before promoting unsafe_code to forbid."
+expires = "2026-07-01"
+
+[[debt]]
+lint = "rust::unsafe_code"
+path = "crates/perl-corpus/src/files.rs"
+owner = "corpus"
+reason = "Corpus environment guard uses Rust 2024 unsafe environment mutation; replace with command-scoped environment handling before promoting unsafe_code to forbid."
+expires = "2026-07-01"
+
+[[debt]]
+lint = "rust::unsafe_code"
+path = "crates/tree-sitter-perl-c/src/lib.rs"
+owner = "parser/tree-sitter"
+reason = "Tree-sitter FFI boundary requires a reviewed unsafe carveout policy before the shared unsafe_code lint can become forbid."
+expires = "2026-07-01"
+
+[[debt]]
+lint = "rust::unsafe_code"
+path = "xtask/src/tasks/ci/context.rs"
+owner = "ci/xtask"
+reason = "CI xtask environment setup mutates process environment; replace with command-scoped environment propagation before promoting unsafe_code to forbid."
+expires = "2026-07-01"
+
+[[debt]]
+lint = "rust::unsafe_code"
+path = "xtask/src/tasks/gates.rs"
+owner = "ci/xtask"
+reason = "Gate runner mutates process environment for global policy variables; replace with child-command environment injection before promoting unsafe_code to forbid."
+expires = "2026-07-01"
+
+[[debt]]
+lint = "clippy::allow_attributes"
+path = "crates/**/*.rs"
+owner = "quality"
+reason = "Existing tests and generated-style helpers still use allow attributes; migrate to expect-with-reason receipts in follow-up PRs."
+expires = "2026-07-01"
+
+[[debt]]
+lint = "clippy::allow_attributes"
+path = "xtask/src/**/*.rs"
+owner = "quality"
+reason = "Existing xtask metrics and fixture structs still use allow attributes; migrate to expect-with-reason receipts in follow-up PRs."
+expires = "2026-07-01"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,211 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked Result/Option collapse in production or tests."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No message-only unchecked Result/Option collapse in production or tests."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Use Result, Option, or test helpers instead of panic-driven control flow."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Do not leave runtime TODO traps in production or test code."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Do not leave runtime unimplemented traps in production or test code."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Do not commit debug-print macros."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "configuration"
+reason = "Surface misspelled or undeclared conditional compilation flags."
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "forbid"
+status = "staged"
+class = "unsafe-memory"
+reason = "Target shared platform policy; existing unsafe environment and FFI debt is tracked before activation."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "staged"
+class = "unsafe-memory"
+reason = "Require explicit unsafe blocks inside any future unsafe function body once unsafe debt is retired."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "staged"
+class = "silent-failure"
+reason = "Reject silently ignored must-use results after existing debt is inventoried."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "staged"
+class = "silent-failure"
+reason = "Do not silently detach futures."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "staged"
+class = "silent-failure"
+reason = "Do not silently discard must-use values."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "staged"
+class = "silent-failure"
+reason = "Do not immediately drop synchronization guards."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "staged"
+class = "silent-failure"
+reason = "Do not hide errors by calling Result::ok without observing the value."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "staged"
+class = "silent-failure"
+reason = "Do not erase error values during mapping."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "staged"
+class = "suppression-governance"
+reason = "Move broad allow attributes to narrow expect-with-reason receipts."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "staged"
+class = "suppression-governance"
+reason = "Require explicit reasons for suppression receipts."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "staged"
+class = "parser-safety"
+reason = "Parser and LSP offsets must not assume UTF-8 byte boundaries without checked helpers."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "staged"
+class = "parser-safety"
+reason = "Parser and protocol code should prefer checked access or reviewed table abstractions."
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Avoid stale numeric type drift."
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "numeric"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "time"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,6 @@
+schema_version = "0.3"
+
+# Panic-family exceptions belong here using path + family + selector identity.
+# last_seen locations are advisory only. This workspace is moving toward an
+# empty allowlist; any future entry must include owner, classification,
+# explanation, and optional expires metadata.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,5 @@
+schema_version = "1.0"
+
+# Non-Rust programming/configuration surfaces are tracked here when a policy
+# checker needs structured ownership. Entries use path or glob plus kind,
+# owner, reason, surface, classification, covered_by, and optional expires.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Rust toolchain configuration for perl-lsp
-# MSRV: 1.92 (for OpenAI Codex compatibility)
+# MSRV: 1.93 (for OpenAI Codex compatibility)
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -64,3 +64,6 @@ legacy = ["perl-parser-pest"]
 # Building this feature requires a C toolchain and libclang to compile
 # `tree-sitter-perl-c`.
 parser-tasks = ["legacy", "tree-sitter-perl-c"]
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1070,6 +1070,9 @@ enum Commands {
     /// Check that test-bearing Rust files are reachable from their module tree.
     CheckTestWiring,
 
+    /// Verify workspace Clippy lint policy, ledger, and debt invariants.
+    CheckLintPolicy,
+
     /// Emit per-subsystem engineering-health metrics.
     Metrics {
         #[command(subcommand)]
@@ -2197,6 +2200,7 @@ fn main() -> Result<()> {
             check: args.check,
         }),
         Commands::CheckTestWiring => check_test_wiring::run(),
+        Commands::CheckLintPolicy => check_lint_policy::run(),
         Commands::Metrics { command } => match command {
             MetricsCommand::ParserStats { input, json } => metrics::parser_stats::run(input, json),
             MetricsCommand::ParserAccuracy {

--- a/xtask/src/tasks/check_lint_policy.rs
+++ b/xtask/src/tasks/check_lint_policy.rs
@@ -1,0 +1,418 @@
+use chrono::NaiveDate;
+use color_eyre::eyre::{Result, bail};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml::Value;
+use walkdir::WalkDir;
+
+const ROOT_CARGO: &str = "Cargo.toml";
+const CLIPPY_TOML: &str = "clippy.toml";
+const LINT_POLICY: &str = "policy/clippy-lints.toml";
+const LINT_DEBT: &str = "policy/clippy-debt.toml";
+const NO_PANIC_ALLOWLIST: &str = "policy/no-panic-allowlist.toml";
+const NON_RUST_ALLOWLIST: &str = "policy/non-rust-allowlist.toml";
+const REQUIRED_POLICY_MSRV: &str = "1.93";
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+#[derive(Debug, Deserialize)]
+struct ClippyPolicy {
+    schema: u64,
+    msrv: String,
+    policy: PolicyFlags,
+    #[serde(default)]
+    lint: Vec<LintEntry>,
+    #[serde(default)]
+    planned: Vec<PlannedLint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyFlags {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    class: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlannedLint {
+    name: String,
+    level: String,
+    activate_when_msrv: String,
+    class: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: Option<String>,
+    path: Option<String>,
+    owner: Option<String>,
+    reason: Option<String>,
+    expires: Option<String>,
+}
+
+pub fn run() -> Result<()> {
+    let root = Path::new(".");
+    let mut violations = Vec::new();
+
+    let cargo_text = read_to_string(ROOT_CARGO, &mut violations);
+    let policy_text = read_to_string(LINT_POLICY, &mut violations);
+    let debt_text = read_to_string(LINT_DEBT, &mut violations);
+
+    if !Path::new(NO_PANIC_ALLOWLIST).exists() {
+        violations.push(format!("missing required policy file `{NO_PANIC_ALLOWLIST}`"));
+    }
+    if !Path::new(NON_RUST_ALLOWLIST).exists() {
+        violations.push(format!("missing required policy file `{NON_RUST_ALLOWLIST}`"));
+    }
+
+    let cargo_value = parse_toml_value(ROOT_CARGO, cargo_text.as_deref(), &mut violations);
+    let policy = parse_toml::<ClippyPolicy>(LINT_POLICY, policy_text.as_deref(), &mut violations);
+    let debt = parse_toml::<DebtLedger>(LINT_DEBT, debt_text.as_deref(), &mut violations);
+
+    if let (Some(cargo), Some(policy)) = (cargo_value.as_ref(), policy.as_ref()) {
+        check_msrv(cargo, policy, &mut violations);
+        check_policy_flags(policy, &mut violations);
+        check_active_lints(cargo, policy, &mut violations);
+        check_planned_lints(cargo, policy, &mut violations);
+        check_workspace_members_inherit_lints(root, cargo, &mut violations);
+    }
+
+    check_clippy_toml(&mut violations);
+
+    if let Some(debt) = debt.as_ref() {
+        check_debt_ledger(debt, &mut violations);
+    }
+
+    if violations.is_empty() {
+        println!("lint policy OK");
+        Ok(())
+    } else {
+        for violation in &violations {
+            eprintln!("lint policy violation: {violation}");
+        }
+        bail!("lint policy check failed with {} violation(s)", violations.len())
+    }
+}
+
+fn read_to_string(path: &str, violations: &mut Vec<String>) -> Option<String> {
+    match fs::read_to_string(path) {
+        Ok(text) => Some(text),
+        Err(error) => {
+            violations.push(format!("failed to read `{path}`: {error}"));
+            None
+        }
+    }
+}
+
+fn parse_toml_value(path: &str, text: Option<&str>, violations: &mut Vec<String>) -> Option<Value> {
+    let text = text?;
+    match toml::from_str::<Value>(text) {
+        Ok(value) => Some(value),
+        Err(error) => {
+            violations.push(format!("failed to parse `{path}` as TOML: {error}"));
+            None
+        }
+    }
+}
+
+fn parse_toml<T>(path: &str, text: Option<&str>, violations: &mut Vec<String>) -> Option<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let text = text?;
+    match toml::from_str::<T>(text) {
+        Ok(value) => Some(value),
+        Err(error) => {
+            violations.push(format!("failed to parse `{path}` as TOML: {error}"));
+            None
+        }
+    }
+}
+
+fn check_msrv(cargo: &Value, policy: &ClippyPolicy, violations: &mut Vec<String>) {
+    let cargo_msrv = cargo
+        .get("workspace")
+        .and_then(Value::as_table)
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(Value::as_table)
+        .and_then(|package| package.get("rust-version"))
+        .and_then(Value::as_str);
+
+    if cargo_msrv != Some(policy.msrv.as_str()) {
+        violations.push(format!(
+            "workspace.package.rust-version must match {LINT_POLICY} msrv (Cargo.toml: {:?}, policy: {})",
+            cargo_msrv, policy.msrv
+        ));
+    }
+
+    if policy.msrv != REQUIRED_POLICY_MSRV {
+        violations.push(format!(
+            "{LINT_POLICY} msrv must stay on the shared platform MSRV {REQUIRED_POLICY_MSRV}"
+        ));
+    }
+}
+
+fn check_policy_flags(policy: &ClippyPolicy, violations: &mut Vec<String>) {
+    if policy.schema != 1 {
+        violations.push(format!("{LINT_POLICY} schema must be 1"));
+    }
+    if !policy.policy.panic_free_tests {
+        violations.push("policy.panic_free_tests must be true".to_owned());
+    }
+    if policy.policy.allow_test_carveouts {
+        violations.push("policy.allow_test_carveouts must be false".to_owned());
+    }
+    if policy.policy.suppression_style != "expect-with-reason" {
+        violations.push("policy.suppression_style must be `expect-with-reason`".to_owned());
+    }
+    if policy.policy.blanket_categories {
+        violations.push("policy.blanket_categories must be false".to_owned());
+    }
+}
+
+fn check_active_lints(cargo: &Value, policy: &ClippyPolicy, violations: &mut Vec<String>) {
+    let active_lints: Vec<&LintEntry> =
+        policy.lint.iter().filter(|lint| lint.status == "active").collect();
+    if active_lints.is_empty() {
+        violations.push(format!("{LINT_POLICY} must declare active [[lint]] entries"));
+    }
+
+    let mut seen = BTreeSet::new();
+    for lint in active_lints {
+        if !seen.insert(lint.name.as_str()) {
+            violations.push(format!("duplicate active lint `{}` in {LINT_POLICY}", lint.name));
+        }
+        if lint.class.trim().is_empty() {
+            violations.push(format!("active lint `{}` is missing class", lint.name));
+        }
+        if lint.reason.trim().is_empty() {
+            violations.push(format!("active lint `{}` is missing reason", lint.name));
+        }
+        match cargo_lint_level(cargo, &lint.name) {
+            Some(level) if level == lint.level => {}
+            Some(level) => violations.push(format!(
+                "active lint `{}` has Cargo.toml level `{level}` but policy level `{}`",
+                lint.name, lint.level
+            )),
+            None => violations.push(format!(
+                "active lint `{}` is missing from root Cargo.toml workspace lints",
+                lint.name
+            )),
+        }
+    }
+}
+
+fn check_planned_lints(cargo: &Value, policy: &ClippyPolicy, violations: &mut Vec<String>) {
+    let mut planned_versions = BTreeSet::new();
+    for planned in &policy.planned {
+        planned_versions.insert(planned.activate_when_msrv.as_str());
+        if planned.class.trim().is_empty() {
+            violations.push(format!("planned lint `{}` is missing class", planned.name));
+        }
+        if planned.reason.trim().is_empty() {
+            violations.push(format!("planned lint `{}` is missing reason", planned.name));
+        }
+        if planned.level != "deny" && planned.level != "warn" {
+            violations
+                .push(format!("planned lint `{}` must have level `deny` or `warn`", planned.name));
+        }
+        if cargo_lint_level(cargo, &planned.name).is_some() {
+            violations.push(format!(
+                "planned lint `{}` must not be active before MSRV {}",
+                planned.name, planned.activate_when_msrv
+            ));
+        }
+    }
+    for required in ["1.94", "1.95"] {
+        if !planned_versions.contains(required) {
+            violations.push(format!("{LINT_POLICY} must track planned Rust {required} lint flips"));
+        }
+    }
+}
+
+fn cargo_lint_level(cargo: &Value, lint_name: &str) -> Option<String> {
+    let (family, name) = lint_name.split_once("::")?;
+    let lints = cargo
+        .get("workspace")
+        .and_then(Value::as_table)
+        .and_then(|workspace| workspace.get("lints"))
+        .and_then(Value::as_table)
+        .and_then(|lints| lints.get(family))
+        .and_then(Value::as_table)?;
+    let value = lints.get(name)?;
+    if let Some(level) = value.as_str() {
+        return Some(level.to_owned());
+    }
+    value.as_table().and_then(|table| table.get("level")).and_then(Value::as_str).map(str::to_owned)
+}
+
+fn check_workspace_members_inherit_lints(root: &Path, cargo: &Value, violations: &mut Vec<String>) {
+    for manifest in workspace_member_manifests(root, cargo, violations) {
+        let manifest_text = match fs::read_to_string(&manifest) {
+            Ok(text) => text,
+            Err(error) => {
+                violations.push(format!("failed to read `{}`: {error}", manifest.display()));
+                continue;
+            }
+        };
+        let manifest_value = match toml::from_str::<Value>(&manifest_text) {
+            Ok(value) => value,
+            Err(error) => {
+                violations.push(format!("failed to parse `{}`: {error}", manifest.display()));
+                continue;
+            }
+        };
+        let inherits = manifest_value
+            .get("lints")
+            .and_then(Value::as_table)
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !inherits {
+            violations.push(format!(
+                "workspace member `{}` must include `[lints] workspace = true`",
+                manifest.display()
+            ));
+        }
+    }
+}
+
+fn workspace_member_manifests(
+    root: &Path,
+    cargo: &Value,
+    violations: &mut Vec<String>,
+) -> Vec<PathBuf> {
+    let Some(members) = cargo
+        .get("workspace")
+        .and_then(Value::as_table)
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(Value::as_array)
+    else {
+        violations.push("Cargo.toml missing workspace.members".to_owned());
+        return Vec::new();
+    };
+
+    let mut manifests = Vec::new();
+    for member in members {
+        let Some(member) = member.as_str() else {
+            violations.push("workspace.members contains a non-string entry".to_owned());
+            continue;
+        };
+        if member.contains('*') {
+            collect_globbed_member_manifests(root, member, violations, &mut manifests);
+        } else {
+            manifests.push(root.join(member).join("Cargo.toml"));
+        }
+    }
+    manifests
+}
+
+fn collect_globbed_member_manifests(
+    root: &Path,
+    pattern: &str,
+    violations: &mut Vec<String>,
+    manifests: &mut Vec<PathBuf>,
+) {
+    let prefix = pattern.split('*').next().unwrap_or_default();
+    let base = root.join(prefix);
+    if !base.exists() {
+        violations.push(format!("workspace member glob base `{}` does not exist", base.display()));
+        return;
+    }
+    for entry in WalkDir::new(base).max_depth(3) {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        if entry.file_name() == "Cargo.toml" {
+            manifests.push(entry.into_path());
+        }
+    }
+}
+
+fn check_clippy_toml(violations: &mut Vec<String>) {
+    let text = match fs::read_to_string(CLIPPY_TOML) {
+        Ok(text) => text,
+        Err(error) => {
+            violations.push(format!("failed to read `{CLIPPY_TOML}`: {error}"));
+            return;
+        }
+    };
+    for carveout in TEST_CARVEOUTS {
+        if text.contains(carveout) {
+            violations.push(format!("{CLIPPY_TOML} must not configure test carveout `{carveout}`"));
+        }
+    }
+    match toml::from_str::<Value>(&text) {
+        Ok(value) => {
+            let msrv = value.get("msrv").and_then(Value::as_str);
+            if msrv != Some(REQUIRED_POLICY_MSRV) {
+                violations.push(format!(
+                    "{CLIPPY_TOML} msrv must be {REQUIRED_POLICY_MSRV} (found {msrv:?})"
+                ));
+            }
+        }
+        Err(error) => violations.push(format!("failed to parse `{CLIPPY_TOML}`: {error}")),
+    }
+}
+
+fn check_debt_ledger(debt: &DebtLedger, violations: &mut Vec<String>) {
+    if debt.schema != 1 {
+        violations.push(format!("{LINT_DEBT} schema must be 1"));
+    }
+    let today = chrono::Utc::now().date_naive();
+    for (index, entry) in debt.debt.iter().enumerate() {
+        let number = index + 1;
+        check_required_field(number, "lint", entry.lint.as_deref(), violations);
+        check_required_field(number, "path", entry.path.as_deref(), violations);
+        check_required_field(number, "owner", entry.owner.as_deref(), violations);
+        check_required_field(number, "reason", entry.reason.as_deref(), violations);
+        check_required_field(number, "expires", entry.expires.as_deref(), violations);
+        if let Some(expires) = entry.expires.as_deref() {
+            match NaiveDate::parse_from_str(expires, "%Y-%m-%d") {
+                Ok(date) if date < today => {
+                    violations.push(format!("debt entry #{number} expired on {expires}"))
+                }
+                Ok(_) => {}
+                Err(error) => violations.push(format!(
+                    "debt entry #{number} has invalid expires date `{expires}`: {error}"
+                )),
+            }
+        }
+    }
+}
+
+fn check_required_field(
+    entry_number: usize,
+    field: &str,
+    value: Option<&str>,
+    violations: &mut Vec<String>,
+) {
+    if value.is_none_or(|value| value.trim().is_empty()) {
+        violations.push(format!("debt entry #{entry_number} is missing `{field}`"));
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -11,6 +11,7 @@ pub mod build;
 pub mod build_timing;
 pub mod bump_version;
 pub mod check;
+pub mod check_lint_policy;
 pub mod check_test_wiring;
 pub mod check_toolchain;
 pub mod check_version_sync;


### PR DESCRIPTION
### Motivation

- Raise workspace MSRV to `1.93` and formalize a governed Clippy policy so panic-free and suppression-governed rules are platform-wide rather than ad-hoc.  
- Provide a machine-readable ledger and debt tracking so planned Rust 1.94/1.95 flips and temporary exceptions are explicit and reviewable.  
- Prevent test carveouts and ensure workspace-wide inheritance of the lint baseline for consistent enforcement.  

### Description

- Bumped workspace `rust-version` to `1.93` and updated `rust-toolchain.toml` and `clippy.toml` MSRV to `1.93`, removing `allow-unwrap-in-tests`.  
- Added policy artifacts under `policy/`: `clippy-lints.toml` (active/staged/planned lint ledger), `clippy-debt.toml` (debt ledger), `no-panic-allowlist.toml`, and `non-rust-allowlist.toml` (allowlist placeholders).  
- Documented the governance model in `docs/CLIPPY_POLICY.md` and added example debt entries for staged `unsafe_code` and suppression migration.  
- Implemented `cargo xtask check-lint-policy` by adding `xtask/src/tasks/check_lint_policy.rs` and wiring the command into `xtask/src/main.rs` and `xtask/src/tasks/mod.rs`; the checker validates MSRV alignment, active/planned lints, workspace `[lints] workspace = true` inheritance, clippy test-carveouts, and debt entry completeness/expiry.  
- Added `[lints] workspace = true` to several member `Cargo.toml` files to ensure inheritance.  

### Testing

- Ran `./scripts/cargo-safe xtask check-lint-policy` and it passed (`lint policy OK`).  
- Ran `./scripts/cargo-safe xtask fmt` and it passed.  
- Ran `cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs` and it completed successfully for the `xtask` binary.  
- Attempt to run full agent profile `./scripts/cargo-safe check -p xtask --all-targets --profile agent --locked` was blocked by local storage guard (`DENY: /root/.cache/devplane/...`); this is an environmental/storage policy failure rather than a code error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0849e7d88333b498c5aa0c881cc0)