### PR TITLE
chore(lint-policy): add clippy policy gate (#0000)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 [workspace.package]
 version = "0.13.3"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
 description = "Perl parser, LSP, and DAP ecosystem in Rust"
 license = "MIT OR Apache-2.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # clippy.toml
 # Keep pedantic on, but chill some noisy lints for a parser project.
 # warn-on-all-wildcard-imports = false
-msrv = "1.92"
+msrv = "1.93"
 
 # Common pedantic relaxations for parser projects
 allow-private-module-inception = true

--- a/crates/perl-ci-hygiene/Cargo.toml
+++ b/crates/perl-ci-hygiene/Cargo.toml
@@ -18,3 +18,6 @@ regex.workspace = true
 serde_json.workspace = true
 walkdir.workspace = true
 toml = "1.1.2"
+
+[lints]
+workspace = true

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -16,3 +16,6 @@ perl-workspace = { workspace = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 perl-tdd-support = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tree-sitter-perl-rs/Cargo.toml
+++ b/crates/tree-sitter-perl-rs/Cargo.toml
@@ -45,3 +45,6 @@ perl-semantic-analyzer = { workspace = true }
 perl-tdd-support = { workspace = true }
 insta = { version = "1.47.2" }
 perl-position-tracking = { workspace = true }
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,62 @@
+# Clippy Policy
+
+This workspace uses the Effortless Metrics strict Clippy policy as a governed engineering surface.
+The policy is intentionally workspace-wide: production code, tests, examples, and xtask code all inherit the same panic-free defaults.
+
+## Goals
+
+- Forbid unchecked panic-family control flow (`unwrap`, `expect`, `panic!`, `todo!`, `unimplemented!`, `unreachable!`, and `dbg!`).
+- Prevent silent failure patterns such as ignored `Result`s, ignored futures, and discarded lock guards.
+- Keep parser and protocol code safe around UTF-8 boundaries, byte indexes, string slicing, and unchecked indexing.
+- Make suppression explicit with `#[expect(..., reason = "...")]` instead of broad or silent `#[allow(...)]` carveouts.
+- Track future Rust 1.94 and 1.95 lint flips before the MSRV changes.
+
+## Source of truth
+
+The machine-readable lint ledger is [`policy/clippy-lints.toml`](../policy/clippy-lints.toml).
+It records the active workspace lints, policy posture, and planned Rust-version ratchets.
+The root [`Cargo.toml`](../Cargo.toml) must mirror every active lint in `[workspace.lints.rust]` and `[workspace.lints.clippy]`.
+
+Temporary exceptions belong in [`policy/clippy-debt.toml`](../policy/clippy-debt.toml), not in `clippy.toml` test carveouts or crate-local lint weakening.
+Debt entries must carry a lint, path, owner, reason, and expiry date.
+
+## No test carveouts
+
+Tests are part of the governed workspace surface. Do not add any of these `clippy.toml` options:
+
+- `allow-unwrap-in-tests = true`
+- `allow-expect-in-tests = true`
+- `allow-panic-in-tests = true`
+- `allow-indexing-slicing-in-tests = true`
+- `allow-dbg-in-tests = true`
+
+Prefer tests that return `Result` and use `?`, or use the repository's test helpers when an assertion needs richer diagnostics.
+
+## Suppression style
+
+Use narrow `#[expect(..., reason = "...")]` suppressions when a lint finding is intentionally retained.
+The reason should explain why the local exception is safer than changing the code now.
+Broad `#[allow(...)]` suppressions should be migrated into explicit debt or replaced with `#[expect]` as follow-up lint-policy PRs.
+
+## Parser overlay
+
+Because this workspace hosts Perl parser, lexer, semantic, LSP, and DAP code, the standard policy includes strict parser-safety rails:
+
+- `clippy::string_slice`
+- `clippy::indexing_slicing`
+- `clippy::out_of_bounds_indexing`
+- `clippy::char_indices_as_byte_indices`
+- `clippy::sliced_string_as_bytes`
+- `clippy::index_refutable_slice`
+
+These lints protect UTF-8 and source-span boundaries where byte/character confusion can produce incorrect diagnostics or edits.
+
+## Local gate
+
+Run the policy gate with:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The gate verifies the MSRV ledger, workspace lint inheritance, active/planned lint consistency, absence of Clippy test carveouts, and required debt metadata.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,8 @@
+schema = 1
+
+[[debt]]
+lint = "clippy::unwrap_used"
+path = "clippy.toml"
+owner = "lint-policy"
+reason = "Existing test suite still contains unwrap/expect-style fixture setup; remove this broad carveout after panic-free test helper migration."
+expires = "2026-07-01"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,148 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+# Active lints mirrored from Cargo.toml for this first policy PR.
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "rust-baseline"
+reason = "Workspace Rust lint baseline: unexpected_cfgs must stay governed."
+
+[[lint]]
+name = "clippy::collapsible_if"
+level = "allow"
+status = "active"
+class = "compatibility"
+reason = "Current workspace lint baseline for collapsible_if; stricter planned flips are tracked in follow-up debt."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Current workspace lint baseline for unwrap_used; stricter planned flips are tracked in follow-up debt."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Current workspace lint baseline for expect_used; stricter planned flips are tracked in follow-up debt."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Current workspace lint baseline for panic; stricter planned flips are tracked in follow-up debt."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Current workspace lint baseline for todo; stricter planned flips are tracked in follow-up debt."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Current workspace lint baseline for unimplemented; stricter planned flips are tracked in follow-up debt."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Current workspace lint baseline for dbg_macro; stricter planned flips are tracked in follow-up debt."
+
+# Planned Rust-version ratchets. These must remain planned until the workspace MSRV reaches activate_when_msrv.
+
+[[lint]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "upgrade-ratchet"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[lint]]
+name = "clippy::manual_ilog2"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "upgrade-ratchet"
+reason = "Prefer the standard integer log helper."
+
+[[lint]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "upgrade-ratchet"
+reason = "Make bit masks visually inspectable."
+
+[[lint]]
+name = "clippy::needless_type_cast"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "upgrade-ratchet"
+reason = "Avoid stale numeric type drift."
+
+[[lint]]
+name = "clippy::disallowed_fields"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade-ratchet"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[lint]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade-ratchet"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[lint]]
+name = "clippy::manual_take"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade-ratchet"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[lint]]
+name = "clippy::manual_pop_if"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade-ratchet"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[lint]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade-ratchet"
+reason = "Make durations legible without mental unit conversion."
+
+[[lint]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "upgrade-ratchet"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,4 @@
+schema_version = "0.3"
+
+# No panic-family exceptions are approved by default.
+# Entries use path + family + selector as identity; last_seen is advisory only.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,4 @@
+schema_version = "1.0"
+
+# Non-Rust source policy exceptions are managed here when the file-policy gate is enabled.
+# Each entry must include path or glob, kind, owner, reason, surface, classification, and covered_by.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Rust toolchain configuration for perl-lsp
-# MSRV: 1.92 (for OpenAI Codex compatibility)
+# MSRV: 1.93
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -64,3 +64,6 @@ legacy = ["perl-parser-pest"]
 # Building this feature requires a C toolchain and libclang to compile
 # `tree-sitter-perl-c`.
 parser-tasks = ["legacy", "tree-sitter-perl-c"]
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -48,6 +48,10 @@ enum Commands {
     /// Run format and clippy checks only (no tests)
     CheckOnly,
 
+    /// Validate workspace Clippy lint policy ledgers and inheritance.
+    #[command(name = "check-lint-policy")]
+    CheckLintPolicy,
+
     /// Verify local Rust toolchain meets the pinned MSRV in rust-toolchain.toml.
     CheckToolchain {
         /// Show a warning when rustc satisfies the minimum MSRV but differs
@@ -1820,6 +1824,7 @@ fn main() -> Result<()> {
         }
         Commands::Ci => ci::run(),
         Commands::CheckOnly => ci::check_only(),
+        Commands::CheckLintPolicy => lint_policy::run(),
         Commands::CheckToolchain { doctor } => check_toolchain::run(doctor),
         Commands::Queue { command } => match command {
             QueueCommand::Snapshot { out, fixture } => queue_snapshot::run_snapshot(out, fixture),

--- a/xtask/src/tasks/lint_policy.rs
+++ b/xtask/src/tasks/lint_policy.rs
@@ -1,0 +1,407 @@
+//! Validate the workspace Clippy policy ledger against Cargo configuration.
+
+use crate::utils::project_root;
+use chrono::{NaiveDate, Utc};
+use color_eyre::eyre::{Context, Result, bail, eyre};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml::Value;
+
+const ROOT_CARGO_TOML: &str = "Cargo.toml";
+const CLIPPY_TOML: &str = "clippy.toml";
+const CLIPPY_LINTS_TOML: &str = "policy/clippy-lints.toml";
+const CLIPPY_DEBT_TOML: &str = "policy/clippy-debt.toml";
+const FORBIDDEN_TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+#[derive(Debug, Deserialize)]
+struct LintPolicyLedger {
+    schema: u64,
+    msrv: String,
+    policy: LintPolicySettings,
+    #[serde(default)]
+    lint: Vec<LintEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintPolicySettings {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintEntry {
+    name: String,
+    level: String,
+    status: String,
+    #[serde(default)]
+    activate_when_msrv: Option<String>,
+    class: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClippyDebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+pub fn run() -> Result<()> {
+    let root = project_root()?;
+    let cargo = read_toml(root.join(ROOT_CARGO_TOML))?;
+    let ledger: LintPolicyLedger = read_toml(root.join(CLIPPY_LINTS_TOML))?;
+    let debt: ClippyDebtLedger = read_toml(root.join(CLIPPY_DEBT_TOML))?;
+
+    check_policy_header(&ledger)?;
+    check_msrv(&root, &cargo, &ledger)?;
+    check_clippy_toml(&root, &ledger, &debt)?;
+    check_workspace_lints(&cargo, &ledger)?;
+    check_workspace_members_inherit_lints(&root, &cargo)?;
+    check_debt_entries(&debt)?;
+
+    println!("lint policy check passed");
+    println!(
+        "  active lints: {}",
+        ledger.lint.iter().filter(|lint| lint.status == "active").count()
+    );
+    println!(
+        "  planned lints: {}",
+        ledger.lint.iter().filter(|lint| lint.status == "planned").count()
+    );
+    println!("  debt entries: {}", debt.debt.len());
+
+    Ok(())
+}
+
+fn read_toml<T>(path: PathBuf) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn check_policy_header(ledger: &LintPolicyLedger) -> Result<()> {
+    if ledger.schema != 1 {
+        bail!("{CLIPPY_LINTS_TOML} schema must be 1");
+    }
+    if !ledger.policy.panic_free_tests {
+        bail!("{CLIPPY_LINTS_TOML} must require panic_free_tests = true");
+    }
+    if ledger.policy.allow_test_carveouts {
+        bail!("{CLIPPY_LINTS_TOML} must forbid test carveouts");
+    }
+    if ledger.policy.suppression_style != "expect-with-reason" {
+        bail!("{CLIPPY_LINTS_TOML} must use suppression_style = \"expect-with-reason\"");
+    }
+    if ledger.policy.blanket_categories {
+        bail!("{CLIPPY_LINTS_TOML} must set blanket_categories = false");
+    }
+    Ok(())
+}
+
+fn check_msrv(root: &Path, cargo: &Value, ledger: &LintPolicyLedger) -> Result<()> {
+    let workspace_msrv = cargo
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|package| package.get("rust-version"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| eyre!("workspace.package.rust-version is missing"))?;
+    if workspace_msrv != ledger.msrv {
+        bail!(
+            "workspace.package.rust-version ({workspace_msrv}) must match {CLIPPY_LINTS_TOML} msrv ({})",
+            ledger.msrv
+        );
+    }
+
+    let toolchain_path = root.join("rust-toolchain.toml");
+    if toolchain_path.exists() {
+        let toolchain: Value = read_toml(toolchain_path)?;
+        let channel = toolchain
+            .get("toolchain")
+            .and_then(|toolchain| toolchain.get("channel"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| eyre!("rust-toolchain.toml toolchain.channel is missing"))?;
+        let channel_msrv = channel.strip_suffix(".0").unwrap_or(channel);
+        if channel_msrv != workspace_msrv {
+            bail!(
+                "rust-toolchain.toml channel ({channel}) must match workspace.package.rust-version ({workspace_msrv})"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn check_clippy_toml(
+    root: &Path,
+    ledger: &LintPolicyLedger,
+    debt: &ClippyDebtLedger,
+) -> Result<()> {
+    let path = root.join(CLIPPY_TOML);
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let clippy: Value = toml::from_str(&content).context("failed to parse clippy.toml")?;
+
+    let msrv = clippy
+        .get("msrv")
+        .and_then(Value::as_str)
+        .ok_or_else(|| eyre!("clippy.toml msrv is missing"))?;
+    if msrv != ledger.msrv {
+        bail!("clippy.toml msrv ({msrv}) must match {CLIPPY_LINTS_TOML} msrv ({})", ledger.msrv);
+    }
+
+    for carveout in FORBIDDEN_TEST_CARVEOUTS {
+        if clippy.get(*carveout).is_some()
+            || content.lines().any(|line| line.trim_start().starts_with(carveout))
+        {
+            let has_debt = debt.debt.iter().any(|entry| entry.path == CLIPPY_TOML);
+            if !has_debt {
+                bail!(
+                    "clippy.toml test carveout `{carveout}` requires explicit {CLIPPY_DEBT_TOML} debt"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_workspace_lints(cargo: &Value, ledger: &LintPolicyLedger) -> Result<()> {
+    let workspace_lints = cargo
+        .get("workspace")
+        .and_then(|workspace| workspace.get("lints"))
+        .ok_or_else(|| eyre!("[workspace.lints] is missing"))?;
+    let rust_lints = lint_table(workspace_lints, "rust")?;
+    let clippy_lints = lint_table(workspace_lints, "clippy")?;
+
+    let mut active_names = BTreeSet::new();
+    for lint in &ledger.lint {
+        validate_lint_entry(lint)?;
+        match lint.status.as_str() {
+            "active" => {
+                active_names.insert(lint.name.clone());
+                check_active_lint(lint, rust_lints, clippy_lints)?;
+            }
+            "planned" => check_planned_lint(lint, rust_lints, clippy_lints, &ledger.msrv)?,
+            other => bail!("lint {} has unsupported status `{other}`", lint.name),
+        }
+    }
+
+    for name in rust_lints.keys() {
+        let full_name = format!("rust::{name}");
+        if !active_names.contains(&full_name) {
+            bail!("active rust lint {full_name} is missing from {CLIPPY_LINTS_TOML}");
+        }
+    }
+    for name in clippy_lints.keys() {
+        let full_name = format!("clippy::{name}");
+        if !active_names.contains(&full_name) {
+            bail!("active clippy lint {full_name} is missing from {CLIPPY_LINTS_TOML}");
+        }
+    }
+
+    Ok(())
+}
+
+fn lint_table<'a>(
+    workspace_lints: &'a Value,
+    name: &str,
+) -> Result<&'a toml::map::Map<String, Value>> {
+    workspace_lints
+        .get(name)
+        .and_then(Value::as_table)
+        .ok_or_else(|| eyre!("[workspace.lints.{name}] is missing"))
+}
+
+fn validate_lint_entry(lint: &LintEntry) -> Result<()> {
+    if lint.name.trim().is_empty()
+        || lint.level.trim().is_empty()
+        || lint.class.trim().is_empty()
+        || lint.reason.trim().is_empty()
+    {
+        bail!("lint entries require name, level, class, and reason");
+    }
+    if !matches!(lint.level.as_str(), "allow" | "warn" | "deny" | "forbid") {
+        bail!("lint {} has unsupported level `{}`", lint.name, lint.level);
+    }
+    Ok(())
+}
+
+fn check_active_lint(
+    lint: &LintEntry,
+    rust_lints: &toml::map::Map<String, Value>,
+    clippy_lints: &toml::map::Map<String, Value>,
+) -> Result<()> {
+    let (family, name) = split_lint_name(&lint.name)?;
+    let table = match family {
+        "rust" => rust_lints,
+        "clippy" => clippy_lints,
+        _ => bail!("active lint {} must start with rust:: or clippy::", lint.name),
+    };
+    let actual = table
+        .get(name)
+        .ok_or_else(|| eyre!("active lint {} is missing from Cargo.toml", lint.name))?;
+    let level = lint_level(actual)
+        .ok_or_else(|| eyre!("could not read Cargo.toml level for {}", lint.name))?;
+    if level != lint.level {
+        bail!(
+            "active lint {} level is `{level}` in Cargo.toml but `{}` in {CLIPPY_LINTS_TOML}",
+            lint.name,
+            lint.level
+        );
+    }
+    Ok(())
+}
+
+fn check_planned_lint(
+    lint: &LintEntry,
+    rust_lints: &toml::map::Map<String, Value>,
+    clippy_lints: &toml::map::Map<String, Value>,
+    msrv: &str,
+) -> Result<()> {
+    let activate_when_msrv = lint
+        .activate_when_msrv
+        .as_deref()
+        .ok_or_else(|| eyre!("planned lint {} is missing activate_when_msrv", lint.name))?;
+    let (family, name) = split_lint_name(&lint.name)?;
+    if version_at_least(msrv, activate_when_msrv)? {
+        bail!(
+            "planned lint {} must be promoted because MSRV {msrv} >= {activate_when_msrv}",
+            lint.name
+        );
+    }
+    let is_active = match family {
+        "rust" => rust_lints.contains_key(name),
+        "clippy" => clippy_lints.contains_key(name),
+        _ => bail!("planned lint {} must start with rust:: or clippy::", lint.name),
+    };
+    if is_active {
+        bail!("planned lint {} is already active before MSRV {activate_when_msrv}", lint.name);
+    }
+    Ok(())
+}
+
+fn split_lint_name(name: &str) -> Result<(&str, &str)> {
+    name.split_once("::").ok_or_else(|| eyre!("lint name `{name}` must include a family prefix"))
+}
+
+fn lint_level(value: &Value) -> Option<String> {
+    value.as_str().map(ToOwned::to_owned).or_else(|| {
+        value
+            .as_table()
+            .and_then(|table| table.get("level"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+    })
+}
+
+fn version_at_least(current: &str, required: &str) -> Result<bool> {
+    let current_parts = parse_minor_version(current)?;
+    let required_parts = parse_minor_version(required)?;
+    Ok(current_parts >= required_parts)
+}
+
+fn parse_minor_version(version: &str) -> Result<(u64, u64)> {
+    let mut parts = version.split('.');
+    let major = parts
+        .next()
+        .ok_or_else(|| eyre!("version `{version}` is missing a major component"))?
+        .parse::<u64>()
+        .with_context(|| format!("version `{version}` has an invalid major component"))?;
+    let minor = parts
+        .next()
+        .ok_or_else(|| eyre!("version `{version}` is missing a minor component"))?
+        .parse::<u64>()
+        .with_context(|| format!("version `{version}` has an invalid minor component"))?;
+    Ok((major, minor))
+}
+
+fn check_workspace_members_inherit_lints(root: &Path, cargo: &Value) -> Result<()> {
+    let members = cargo
+        .get("workspace")
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(Value::as_array)
+        .ok_or_else(|| eyre!("workspace.members is missing"))?;
+
+    let mut missing = Vec::new();
+    for member in members {
+        let member_path =
+            member.as_str().ok_or_else(|| eyre!("workspace member entries must be strings"))?;
+        if member_path.contains('*') {
+            continue;
+        }
+        let manifest_path = root.join(member_path).join("Cargo.toml");
+        let member_manifest: Value = read_toml(manifest_path.clone())?;
+        let inherits = member_manifest
+            .get("lints")
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !inherits {
+            missing.push(manifest_path.display().to_string());
+        }
+    }
+
+    if !missing.is_empty() {
+        bail!("workspace members must inherit workspace lints:\n{}", missing.join("\n"));
+    }
+
+    Ok(())
+}
+
+fn check_debt_entries(debt: &ClippyDebtLedger) -> Result<()> {
+    if debt.schema != 1 {
+        bail!("{CLIPPY_DEBT_TOML} schema must be 1");
+    }
+    let today = Utc::now().date_naive();
+    let mut seen = BTreeSet::new();
+    let mut by_lint = BTreeMap::<&str, usize>::new();
+    for entry in &debt.debt {
+        if entry.lint.trim().is_empty()
+            || entry.path.trim().is_empty()
+            || entry.owner.trim().is_empty()
+            || entry.reason.trim().is_empty()
+            || entry.expires.trim().is_empty()
+        {
+            bail!(
+                "every {CLIPPY_DEBT_TOML} entry must include lint, path, owner, reason, and expires"
+            );
+        }
+        if !entry.lint.starts_with("clippy::") && !entry.lint.starts_with("rust::") {
+            bail!("debt lint `{}` must start with clippy:: or rust::", entry.lint);
+        }
+        let expires = NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d").with_context(|| {
+            format!("debt entry for {} has invalid expires date `{}`", entry.path, entry.expires)
+        })?;
+        if expires < today {
+            bail!("debt entry for {} expired on {}", entry.path, entry.expires);
+        }
+        let key = (&entry.lint, &entry.path);
+        if !seen.insert(key) {
+            bail!("duplicate debt entry for {} at {}", entry.lint, entry.path);
+        }
+        *by_lint.entry(entry.lint.as_str()).or_default() += 1;
+    }
+    Ok(())
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -58,6 +58,7 @@ pub mod inject_sha_assets;
 pub mod install_surface_check;
 pub mod intent_diff_gate;
 pub mod layer_check;
+pub mod lint_policy;
 pub mod merge_ready;
 pub mod methodology_gate;
 pub mod metrics;


### PR DESCRIPTION
### Motivation
- Create a governed, machine-readable Clippy policy for the workspace and ratchet the repo to MSRV 1.93 so lint flips and exceptions are tracked, reviewed, and gated.  
- Prevent silent test carveouts and convert ad-hoc exceptions into explicit, expiring debt and allowlists so CI can enforce policy programmatically.

### Description
- Bump workspace MSRV and toolchain to `1.93` and update `clippy.toml` `msrv` to `1.93`.  
- Add a policy ledger `policy/clippy-lints.toml` recording active workspace lints and planned Rust `1.94`/`1.95` ratchets and add `policy/clippy-debt.toml` plus placeholder allowlists `policy/no-panic-allowlist.toml` and `policy/non-rust-allowlist.toml`.  
- Add documentation `docs/CLIPPY_POLICY.md` describing goals, suppression style, no-test-carveout rule, and the ledger as the source of truth.  
- Implement `cargo xtask check-lint-policy` in `xtask/src/tasks/lint_policy.rs` and wire it into `xtask` (`xtask/src/main.rs`, `xtask/src/tasks/mod.rs`) to validate MSRV alignment, workspace lint inheritance, active/planned lint consistency, forbidden test carveouts (unless explicit debt exists), and debt metadata/expiry.  
- Ensure workspace members inherit workspace lints by adding `[lints] workspace = true` to member `Cargo.toml` files that were missing it, and add a short debt entry for the existing `allow-unwrap-in-tests` carveout in `policy/clippy-debt.toml` so the carveout is explicit and timeboxed.

### Testing
- `./scripts/cargo-safe xtask fmt` — passed.  
- `./scripts/cargo-safe xtask check-lint-policy` — passed (verified ledger, MSRV alignment, lint inheritance, planned flips, and debt entry semantics).  
- `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo +1.93.0 check -p xtask --all-targets --profile agent --locked` — passed.  
- `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo +1.93.0 clippy -p perl-token --profile agent --locked -- -D warnings -A missing_docs` — passed.  
- `./scripts/storage-doctor` and `git diff --check` were run as part of the local verification and reported no blocking issues.

Verification commands used: `cargo xtask check-lint-policy`, `./scripts/cargo-safe xtask fmt`, `cargo +1.93.0 check` and `cargo +1.93.0 clippy` (targeted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0849e7d88333b498c5aa0c881cc0)