### PR TITLE
chore(memory): add LSP churn plateau guardrails (#0000)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -39,6 +39,11 @@ on:
         required: false
         type: boolean
         default: true
+      run_memory:
+        description: 'Run LSP memory plateau workloads'
+        required: false
+        type: boolean
+        default: true
 
 # Cancel in-flight runs on new pushes (saves minutes)
 concurrency:
@@ -254,6 +259,121 @@ jobs:
         path: |
           .ci/metrics/real_project_latency.json
         retention-days: 30
+
+  lsp-memory-plateau:
+    name: LSP Memory Plateau
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_memory != 'false') ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'ci:memory'))
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
+        with:
+          toolchain: 1.93.1
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: nightly-lsp-memory-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build perl-lsp release binary
+        run: cargo build --release -p perl-lsp-rs --bin perl-lsp --locked
+
+      - name: Run document-churn plateau workload
+        run: |
+          mkdir -p target/memory
+          N_FILES=500 \
+          N_CHANGES=10 \
+          DO_WORKSPACE_SYMBOL=0 \
+          DELETE_AFTER_CLOSE=1 \
+          BINARY=./target/release/perl-lsp \
+          python3 scripts/repro_lsp_storm.py \
+            --json-out target/memory/nightly-doc-churn.json \
+            --csv-out target/memory/nightly-doc-churn.csv \
+            --settle-seconds 3 \
+            --server-stderr target/memory/nightly-doc-churn.server.log
+          python3 scripts/assert_rss_plateau.py \
+            target/memory/nightly-doc-churn.json \
+            --summary-out target/memory/nightly-doc-churn.plateau.json
+
+      - name: Run workspace-symbol plateau workload
+        run: |
+          N_FILES=300 \
+          N_CHANGES=10 \
+          DO_WORKSPACE_SYMBOL=1 \
+          DELETE_AFTER_CLOSE=1 \
+          BINARY=./target/release/perl-lsp \
+          python3 scripts/repro_lsp_storm.py \
+            --json-out target/memory/nightly-workspace-symbol.json \
+            --csv-out target/memory/nightly-workspace-symbol.csv \
+            --settle-seconds 3 \
+            --server-stderr target/memory/nightly-workspace-symbol.server.log
+          python3 scripts/assert_rss_plateau.py \
+            target/memory/nightly-workspace-symbol.json \
+            --summary-out target/memory/nightly-workspace-symbol.plateau.json
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if not summary_path:
+              raise SystemExit(0)
+
+          rows = [
+              (
+                  "doc churn + delete",
+                  "target/memory/nightly-doc-churn.json",
+                  "target/memory/nightly-doc-churn.plateau.json",
+              ),
+              (
+                  "workspace-symbol churn + delete",
+                  "target/memory/nightly-workspace-symbol.json",
+                  "target/memory/nightly-workspace-symbol.plateau.json",
+              ),
+          ]
+
+          with open(summary_path, "a", encoding="utf-8") as fh:
+              fh.write("## LSP memory plateau\n\n")
+              fh.write("| Workload | Files | Tail growth KB | Median tail slope KB/file | Result |\n")
+              fh.write("| --- | ---: | ---: | ---: | --- |\n")
+              for label, payload_path, plateau_path in rows:
+                  payload = json.loads(Path(payload_path).read_text())
+                  plateau = json.loads(Path(plateau_path).read_text())
+                  result = "passed" if plateau["passed"] else "failed"
+                  fh.write(
+                      f"| {label} "
+                      f"| {payload['n_files']} "
+                      f"| {plateau['tail_growth_kb']} "
+                      f"| {plateau['median_tail_slope_kb_per_file']} "
+                      f"| {result} |\n"
+                  )
+          PY
+
+      - name: Upload memory plateau artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lsp-memory-plateau-${{ github.sha }}
+          path: |
+            target/memory/nightly-doc-churn.json
+            target/memory/nightly-doc-churn.csv
+            target/memory/nightly-doc-churn.plateau.json
+            target/memory/nightly-doc-churn.server.log
+            target/memory/nightly-workspace-symbol.json
+            target/memory/nightly-workspace-symbol.csv
+            target/memory/nightly-workspace-symbol.plateau.json
+            target/memory/nightly-workspace-symbol.server.log
+          if-no-files-found: warn
+          retention-days: 30
 
   test-coverage:
     name: Test Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,89 @@ jobs:
       - name: Compile all targets (catches integration-test + bench bit-rot)
         run: just check-all-targets
 
+  lsp-memory-smoke:
+    name: LSP Memory Smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [draft-pr-check, preflight-latest-check]
+    if: needs.draft-pr-check.outputs.run_ci == 'true' && needs.preflight-latest-check.outputs.is_latest == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref_name }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
+        with:
+          toolchain: 1.93.1
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: ci-lsp-memory-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build perl-lsp release binary
+        run: cargo build --release -p perl-lsp-rs --bin perl-lsp --locked
+
+      - name: Run document-churn memory smoke
+        run: |
+          mkdir -p target/memory
+          N_FILES=75 \
+          N_CHANGES=5 \
+          DO_WORKSPACE_SYMBOL=0 \
+          DELETE_AFTER_CLOSE=1 \
+          BINARY=./target/release/perl-lsp \
+          python3 scripts/repro_lsp_storm.py \
+            --json-out target/memory/pr-smoke-doc-churn.json \
+            --csv-out target/memory/pr-smoke-doc-churn.csv \
+            --settle-seconds 1 \
+            --server-stderr target/memory/pr-smoke-doc-churn.server.log
+          python3 scripts/assert_rss_plateau.py \
+            target/memory/pr-smoke-doc-churn.json \
+            --summary-out target/memory/pr-smoke-doc-churn.plateau.json \
+            --loose
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if not summary_path:
+              raise SystemExit(0)
+
+          plateau = json.loads(Path("target/memory/pr-smoke-doc-churn.plateau.json").read_text())
+          payload = json.loads(Path("target/memory/pr-smoke-doc-churn.json").read_text())
+          result = "passed" if plateau["passed"] else "failed"
+
+          with open(summary_path, "a", encoding="utf-8") as fh:
+              fh.write("## LSP memory smoke\n\n")
+              fh.write("| Workload | Files | Tail growth KB | Median tail slope KB/file | Result |\n")
+              fh.write("| --- | ---: | ---: | ---: | --- |\n")
+              fh.write(
+                  "| doc churn + delete "
+                  f"| {payload['n_files']} "
+                  f"| {plateau['tail_growth_kb']} "
+                  f"| {plateau['median_tail_slope_kb_per_file']} "
+                  f"| {result} |\n"
+              )
+          PY
+
+      - name: Upload memory smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lsp-memory-smoke-${{ github.sha }}
+          path: |
+            target/memory/pr-smoke-doc-churn.json
+            target/memory/pr-smoke-doc-churn.csv
+            target/memory/pr-smoke-doc-churn.plateau.json
+            target/memory/pr-smoke-doc-churn.server.log
+          if-no-files-found: warn
+          retention-days: 14
+
   # ── Windows Guardrails: proactive Windows regression catchers ─────────
   windows-guardrails:
     name: Windows Guardrails (${{ matrix.lane.name }})

--- a/crates/perl-lsp-rs-core/src/performance/mod.rs
+++ b/crates/perl-lsp-rs-core/src/performance/mod.rs
@@ -76,6 +76,7 @@ impl AstCache {
     /// to bound peak memory.
     pub fn remove(&self, uri: &str) {
         self.cache.remove(uri);
+        self.cache.run_pending_tasks();
     }
 
     /// Clear expired entries.

--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -299,6 +299,26 @@ pub struct LspServer {
     >,
 }
 
+#[cfg(any(test, feature = "expose_lsp_test_api"))]
+/// Point-in-time counts for per-document memory pressure gauges.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryStateSnapshot {
+    /// Number of open documents in the LSP document store.
+    pub documents: usize,
+    /// Total bytes of source text held by open document state.
+    pub open_text_bytes: usize,
+    /// Number of cached semantic analyzer entries.
+    pub semantic_analyzer_cache: usize,
+    /// Number of per-document parse cancellation flags still retained.
+    pub parse_cancel_flags: usize,
+    /// Number of active inline-completion stream sessions.
+    pub stream_sessions: usize,
+    /// Number of background index tasks currently in flight.
+    pub pending_index_tasks: usize,
+    /// Number of cached POD documents.
+    pub pod_cache_entries: usize,
+}
+
 // SAFETY: LspServer is not auto-Send/Sync because DocumentState contains
 // ParentMap which has `*const Node` raw pointers. However, these pointers
 // are only accessed through the `documents: Arc<Mutex<...>>` field, which
@@ -429,6 +449,165 @@ impl LspServer {
     /// Access the stream session manager for progressive inline completion.
     pub(crate) fn stream_sessions(&self) -> &stream_session::StreamSessionManager {
         &self.stream_session_manager
+    }
+
+    fn uri_key_variants(&self, uri: &str) -> Vec<String> {
+        fn push_unique(keys: &mut Vec<String>, key: String) {
+            if !keys.iter().any(|existing| existing == &key) {
+                keys.push(key);
+            }
+        }
+
+        fn push_windows_drive_case_variant(keys: &mut Vec<String>, key: &str) {
+            for prefix in ["file:///", "file://localhost/"] {
+                let prefix_len = prefix.len();
+                let bytes = key.as_bytes();
+                if bytes.len() <= prefix_len + 2
+                    || !key.starts_with(prefix)
+                    || bytes[prefix_len + 1] != b':'
+                    || bytes[prefix_len + 2] != b'/'
+                    || !bytes[prefix_len].is_ascii_alphabetic()
+                {
+                    continue;
+                }
+
+                let current = char::from(bytes[prefix_len]);
+                let toggled = if current.is_ascii_lowercase() {
+                    current.to_ascii_uppercase()
+                } else {
+                    current.to_ascii_lowercase()
+                };
+                let mut variant = key.to_string();
+                variant.replace_range(prefix_len..=prefix_len, &toggled.to_string());
+                push_unique(keys, variant);
+            }
+        }
+
+        let mut uri_keys = Vec::new();
+        push_unique(&mut uri_keys, uri.to_string());
+        push_unique(&mut uri_keys, self.normalize_uri_key(uri));
+
+        if let Some(path) = source_path_from_uri(uri) {
+            if let Ok(file_url) = url::Url::from_file_path(&path) {
+                let file_uri = file_url.to_string();
+                push_unique(&mut uri_keys, file_uri.clone());
+                push_unique(&mut uri_keys, self.normalize_uri_key(&file_uri));
+            }
+        }
+
+        for key in uri_keys.clone() {
+            push_windows_drive_case_variant(&mut uri_keys, &key);
+        }
+
+        uri_keys
+    }
+
+    /// Evict open-document session state for a URI without deleting workspace
+    /// index entries for the file on disk.
+    ///
+    /// `textDocument/didClose` means the editor closed its buffer; it does not
+    /// mean the source file was deleted from the workspace. Sweep both raw and
+    /// normalized keys so URI spelling differences do not retain per-document
+    /// caches after close.
+    pub(crate) fn evict_open_document_session_state(&self, uri: &str) {
+        let uri_keys = self.uri_key_variants(uri);
+
+        for key in &uri_keys {
+            self.stream_sessions().cancel_for_uri(key);
+            self.ast_cache.remove(key);
+            self.clear_document_symbols(key);
+        }
+
+        {
+            let mut cache = self.semantic_analyzer_cache.lock();
+            cache.retain(|(cached_uri, _), _| !uri_keys.iter().any(|key| key == cached_uri));
+        }
+
+        {
+            let mut documents = self.documents.lock();
+            for key in &uri_keys {
+                if let Some(doc) = documents.remove(key) {
+                    doc.generation.store(u32::MAX, Ordering::Release);
+                }
+            }
+        }
+
+        {
+            let mut flags = self.parse_cancel_flags.lock();
+            for key in &uri_keys {
+                if let Some(flag) = flags.remove(key) {
+                    flag.store(true, Ordering::Release);
+                }
+            }
+        }
+
+        for key in &uri_keys {
+            if let Some(path) = source_path_from_uri(key) {
+                self.pod_cache.lock().remove(&path);
+
+                #[cfg(not(target_arch = "wasm32"))]
+                self.pull_diagnostics_orchestrator.invalidate_file_cache(&path);
+            }
+        }
+    }
+
+    /// Evict all state for a file that no longer exists in the workspace.
+    pub(crate) fn evict_deleted_file_state(&self, uri: &str) {
+        let uri_keys = self.uri_key_variants(uri);
+        #[cfg(feature = "workspace")]
+        if let Some(coordinator) = self.coordinator() {
+            for key in &uri_keys {
+                coordinator.index().remove_file(key);
+            }
+        }
+
+        self.evict_open_document_session_state(uri);
+    }
+
+    /// Evict open-document state and workspace index state for a removed folder.
+    pub(crate) fn evict_workspace_folder_state(&self, folder_uri: &str) {
+        let folder_keys = self.uri_key_variants(folder_uri);
+        let docs_to_evict = {
+            let documents = self.documents.lock();
+            documents
+                .keys()
+                .filter(|doc_uri| {
+                    folder_keys.iter().any(|folder_key| doc_uri.starts_with(folder_key))
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+
+        for doc_uri in docs_to_evict {
+            tracing::debug!(uri = %doc_uri, "Evicting document from removed workspace");
+            self.evict_open_document_session_state(&doc_uri);
+        }
+
+        #[cfg(feature = "workspace")]
+        if let Some(coordinator) = self.coordinator() {
+            for folder_key in &folder_keys {
+                coordinator.index().remove_folder(folder_key);
+            }
+        }
+    }
+
+    /// Capture test/debug counters for retained per-document state.
+    #[cfg(any(test, feature = "expose_lsp_test_api"))]
+    pub fn memory_state_snapshot(&self) -> MemoryStateSnapshot {
+        let documents = self.documents.lock();
+        let open_text_bytes = documents.values().map(|doc| doc.text.len()).sum();
+        let document_count = documents.len();
+        drop(documents);
+
+        MemoryStateSnapshot {
+            documents: document_count,
+            open_text_bytes,
+            semantic_analyzer_cache: self.semantic_analyzer_cache.lock().len(),
+            parse_cancel_flags: self.parse_cancel_flags.lock().len(),
+            stream_sessions: self.stream_sessions().len(),
+            pending_index_tasks: self.pending_index_task_count.load(Ordering::SeqCst),
+            pod_cache_entries: self.pod_cache.lock().len(),
+        }
     }
 
     // =========================================================================

--- a/crates/perl-lsp-rs/src/runtime/stream_session.rs
+++ b/crates/perl-lsp-rs/src/runtime/stream_session.rs
@@ -130,7 +130,7 @@ impl StreamSessionManager {
     /// Number of sessions currently held by the manager.
     ///
     /// Test-only; production code observes manager state through cancellation.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "expose_lsp_test_api"))]
     pub fn len(&self) -> usize {
         self.sessions.lock().unwrap_or_else(|e| e.into_inner()).len()
     }

--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -28,7 +28,7 @@ impl LspServer {
         self.symbol_index.lock().replace_document_symbols(uri, symbols);
     }
 
-    fn clear_document_symbols(&self, uri: &str) {
+    pub(crate) fn clear_document_symbols(&self, uri: &str) {
         self.symbol_index.lock().remove_document(uri);
     }
 
@@ -271,6 +271,7 @@ impl LspServer {
 
             // Store document state with normalized URI
             let normalized_uri = self.normalize_uri_key(uri);
+            let generation = Arc::new(AtomicU32::new(0));
 
             // Initialize incremental document from the already-parsed text (didOpen).
             // code_slice is applied here to match what the full parser sees.
@@ -311,7 +312,7 @@ impl LspServer {
                     parse_errors: errors,
                     parent_map,
                     line_starts,
-                    generation: Arc::new(AtomicU32::new(0)),
+                    generation: Arc::clone(&generation),
                     degradation_tier,
                     #[cfg(feature = "incremental")]
                     incremental_doc,
@@ -333,10 +334,20 @@ impl LspServer {
                         let coordinator_clone = Arc::clone(coordinator);
                         let text_owned = text.to_string();
                         let uri_owned = uri.to_string();
+                        let generation = Arc::clone(&generation);
                         let task_counter = Arc::clone(&self.pending_index_task_count);
                         task_counter.fetch_add(1, Ordering::SeqCst);
 
                         let task = move || {
+                            if generation.load(Ordering::Acquire) != 0 {
+                                tracing::debug!(
+                                    uri = %uri_owned,
+                                    "Skipping stale background index task after document close/change"
+                                );
+                                coordinator_clone.notify_parse_complete(&uri_owned);
+                                task_counter.fetch_sub(1, Ordering::SeqCst);
+                                return;
+                            }
                             match workspace_index.index_file(url, text_owned) {
                                 Ok(()) => {
                                     if matches!(
@@ -889,6 +900,7 @@ impl LspServer {
                     }
                 }
 
+                let generation_for_index_task = doc_state.generation.clone();
                 documents.insert(normalized_uri.clone(), doc_state);
 
                 // Must drop the lock before calling publish_diagnostics
@@ -911,10 +923,22 @@ impl LspServer {
                             let coordinator_clone = Arc::clone(coordinator);
                             let doc_content = text.clone();
                             let uri_owned = uri.to_string();
+                            let expected_generation = next_gen;
+                            let generation = Arc::clone(&generation_for_index_task);
                             let task_counter = Arc::clone(&self.pending_index_task_count);
                             task_counter.fetch_add(1, Ordering::SeqCst);
 
                             let task = move || {
+                                if generation.load(Ordering::Acquire) != expected_generation {
+                                    tracing::debug!(
+                                        uri = %uri_owned,
+                                        expected_generation,
+                                        "Skipping stale background index task after document close/change"
+                                    );
+                                    coordinator_clone.notify_parse_complete(&uri_owned);
+                                    task_counter.fetch_sub(1, Ordering::SeqCst);
+                                    return;
+                                }
                                 if let Err(e) = workspace_index.index_file(url, doc_content) {
                                     tracing::warn!("Failed to index file {}: {}", uri_owned, e);
                                 }
@@ -969,42 +993,8 @@ impl LspServer {
                 .pointer("/textDocument/uri")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| invalid_params("Missing required parameter: textDocument.uri"))?;
-            let normalized_uri = self.normalize_uri_key(uri);
 
             tracing::debug!("Document closed: {}", uri);
-
-            // Cancel any active streaming inline completion sessions for this URI.
-            self.stream_sessions().cancel_for_uri(uri);
-
-            // Invalidate the SemanticAnalyzer cache for this URI on close.
-            {
-                let mut cache = self.semantic_analyzer_cache.lock();
-                cache.retain(|(cached_uri, _), _| cached_uri != &normalized_uri);
-            }
-
-            // Evict the cached AST so the (potentially large) Arc<Node> drops
-            // immediately rather than surviving until the moka TTL fires. Cover
-            // both normalized and raw URI keys to handle any normalization
-            // mismatches with `put` callers.
-            self.ast_cache.remove(&normalized_uri);
-            if normalized_uri != uri {
-                self.ast_cache.remove(uri);
-            }
-
-            // Evict the per-path POD cache entry for the closing document so
-            // the parsed POD structure is freed alongside the document. The
-            // pod_cache is keyed by filesystem path (not URI) and otherwise
-            // grows monotonically across a session.
-            //
-            // The same path is reused to invalidate the pull-diagnostics cache
-            // entry below, avoiding a second URI-to-path conversion.
-            if let Some(path) = source_path_from_uri(uri) {
-                self.pod_cache.lock().remove(&path);
-
-                // Evict cached pull-diagnostic results for the closing document.
-                #[cfg(not(target_arch = "wasm32"))]
-                self.pull_diagnostics_orchestrator.invalidate_file_cache(&path);
-            }
 
             // Notify coordinator of pending change to track cleanup work
             #[cfg(feature = "workspace")]
@@ -1012,30 +1002,7 @@ impl LspServer {
                 coordinator.notify_change(uri);
             }
 
-            // Remove from documents
-            let mut documents = self.documents.lock();
-            documents.remove(&normalized_uri).or_else(|| documents.remove(uri));
-
-            // Cancel any in-progress parse and clean up the cancellation flag.
-            {
-                let mut flags = self.parse_cancel_flags.lock();
-                if let Some(flag) = flags.remove(&normalized_uri) {
-                    flag.store(true, Ordering::Release);
-                }
-                // Also try raw URI in case normalize produced a different key.
-                if let Some(flag) = flags.remove(uri) {
-                    flag.store(true, Ordering::Release);
-                }
-            }
-
-            // Clear from workspace index
-            // Note: Mutation operation - use coordinator.index() directly
-            #[cfg(feature = "workspace")]
-            if let Some(coordinator) = self.coordinator() {
-                coordinator.index().clear_file(uri);
-            }
-
-            self.clear_document_symbols(uri);
+            self.evict_open_document_session_state(uri);
 
             // Notify coordinator that cleanup is complete
             #[cfg(feature = "workspace")]
@@ -1893,6 +1860,117 @@ mod tests {
             !server.parse_cancel_flags.lock().contains_key(uri),
             "did_close must remove the URI entry from parse_cancel_flags"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_did_close_zeroes_memory_state_snapshot() -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///test_close_memory_snapshot.pl";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": "package Close::Snapshot;\nsub target { 1 }\n1;\n"
+            }
+        }))?;
+        let _token = server.new_parse_token(uri);
+        server.stream_sessions().start_session(crate::runtime::stream_session::SessionKey {
+            uri: uri.to_string(),
+            document_version: 1,
+            line: 0,
+            character: 0,
+        });
+
+        let before = server.memory_state_snapshot();
+        assert_eq!(before.documents, 1);
+        assert!(before.open_text_bytes > 0);
+        assert_eq!(before.parse_cancel_flags, 1);
+        assert_eq!(before.stream_sessions, 1);
+
+        server.handle_did_close(Some(json!({"textDocument": {"uri": uri}})))?;
+
+        let after = server.memory_state_snapshot();
+        assert_eq!(after.documents, 0);
+        assert_eq!(after.open_text_bytes, 0);
+        assert_eq!(after.parse_cancel_flags, 0);
+        assert_eq!(after.stream_sessions, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_did_close_after_change_storm_drains_background_index_tasks()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let runtime = tokio::runtime::Runtime::new()?;
+        runtime.block_on(async {
+            let server = LspServer::new();
+            let uri = "file:///test_close_change_storm.pl";
+
+            server.did_open(json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": "package Close::Storm;\nsub target { 1 }\n1;\n"
+                }
+            }))?;
+
+            for version in 2..30 {
+                server.handle_did_change(Some(json!({
+                    "textDocument": { "uri": uri, "version": version },
+                    "contentChanges": [{
+                        "text": format!(
+                            "package Close::Storm;\nsub target {{ {} }}\n1;\n",
+                            version
+                        )
+                    }]
+                })))?;
+            }
+
+            let _token = server.new_parse_token(uri);
+            server.stream_sessions().start_session(crate::runtime::stream_session::SessionKey {
+                uri: uri.to_string(),
+                document_version: 29,
+                line: 0,
+                character: 0,
+            });
+            server.handle_did_close(Some(json!({"textDocument": {"uri": uri}})))?;
+            #[cfg(feature = "workspace")]
+            if let Some(workspace_index) = server.workspace_index() {
+                workspace_index.remove_file(uri);
+            }
+
+            for _ in 0..100 {
+                if server.pending_index_task_count.load(Ordering::SeqCst) == 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+
+            let after = server.memory_state_snapshot();
+            assert_eq!(after.pending_index_tasks, 0, "background indexing tasks must drain");
+            assert_eq!(after.documents, 0, "didClose must remove open document state");
+            assert_eq!(after.open_text_bytes, 0, "didClose must drop open document text");
+            assert_eq!(after.parse_cancel_flags, 0, "didClose must remove parse-cancel flags");
+            assert_eq!(after.stream_sessions, 0, "didClose must remove stream sessions");
+            #[cfg(feature = "workspace")]
+            if let Some(workspace_index) = server.workspace_index() {
+                assert!(
+                    workspace_index.file_symbols(uri).is_empty(),
+                    "stale background indexing must not repopulate workspace symbols after close"
+                );
+                assert!(
+                    workspace_index.document_store().get(uri).is_none(),
+                    "stale background indexing must not repopulate document store after close"
+                );
+            }
+
+            Ok::<(), Box<dyn std::error::Error>>(())
+        })?;
 
         Ok(())
     }

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -782,53 +782,7 @@ impl LspServer {
                         coordinator.notify_change(&uri);
                     }
 
-                    // Remove from index
-                    #[cfg(feature = "workspace")]
-                    if let Some(coordinator) = self.coordinator() {
-                        coordinator.index().remove_file(&uri);
-                    }
-
-                    // Remove from document store under both raw and normalized
-                    // URI keys. didOpen stores documents under
-                    // `normalize_uri_key(uri)`, but the watcher payload may use
-                    // a non-canonical form (`file://localhost/...`, Windows
-                    // drive-letter casing, percent-encoding variants). Without
-                    // the normalized lookup the document leaks into the
-                    // session's open-doc map indefinitely.
-                    let normalized_uri = self.normalize_uri_key(&uri);
-                    {
-                        let mut documents = self.documents.lock();
-                        documents.remove(&uri);
-                        if normalized_uri != uri {
-                            documents.remove(&normalized_uri);
-                        }
-                    }
-
-                    // Cancel stream sessions and clear parse-cancel flags for
-                    // both URI forms so per-file state does not survive the
-                    // delete event.
-                    self.stream_sessions().cancel_for_uri(&uri);
-                    if normalized_uri != uri {
-                        self.stream_sessions().cancel_for_uri(&normalized_uri);
-                    }
-                    {
-                        use std::sync::atomic::Ordering;
-                        let mut flags = self.parse_cancel_flags.lock();
-                        if let Some(flag) = flags.remove(&uri) {
-                            flag.store(true, Ordering::Release);
-                        }
-                        if normalized_uri != uri {
-                            if let Some(flag) = flags.remove(&normalized_uri) {
-                                flag.store(true, Ordering::Release);
-                            }
-                        }
-                    }
-
-                    // Evict the cached AST under both URI forms.
-                    self.ast_cache.remove(&uri);
-                    if normalized_uri != uri {
-                        self.ast_cache.remove(&normalized_uri);
-                    }
+                    self.evict_deleted_file_state(&uri);
 
                     tracing::debug!(uri, "Removed deleted file from index");
 
@@ -1128,19 +1082,14 @@ impl LspServer {
 
                     tracing::debug!(uri, "File deleted");
 
-                    // Remove from workspace index
-                    // Note: Mutation operation - use coordinator with lifecycle tracking
                     #[cfg(feature = "workspace")]
                     if let Some(coordinator) = self.coordinator() {
                         coordinator.notify_change(uri);
-                        coordinator.index().remove_file(uri);
-                        coordinator.notify_parse_complete(uri);
                     }
-
-                    // Remove from document store
-                    {
-                        let mut documents = self.documents.lock();
-                        documents.remove(uri);
+                    self.evict_deleted_file_state(uri);
+                    #[cfg(feature = "workspace")]
+                    if let Some(coordinator) = self.coordinator() {
+                        coordinator.notify_parse_complete(uri);
                     }
                 }
 
@@ -1443,19 +1392,7 @@ impl LspServer {
 
                     for uri in &change.removed {
                         tracing::debug!(uri, "Removed workspace folder");
-
-                        // Also remove documents from the removed workspace
-                        let mut documents = self.documents.lock();
-                        let docs_to_remove: Vec<String> = documents
-                            .keys()
-                            .filter(|doc_uri| doc_uri.starts_with(uri))
-                            .cloned()
-                            .collect();
-
-                        for doc_uri in docs_to_remove {
-                            tracing::debug!(uri = %doc_uri, "Removing document from removed workspace");
-                            documents.remove(&doc_uri);
-                        }
+                        self.evict_workspace_folder_state(uri);
                     }
 
                     // Retain only folders that are not in the removed list
@@ -1476,10 +1413,8 @@ impl LspServer {
                     if let Some(coordinator) = self.coordinator() {
                         coordinator.index().set_workspace_folders(self.workspace_folder_uris());
 
-                        // Remove files from removed folders
-                        for removed_uri in &change.removed {
-                            coordinator.index().remove_folder(removed_uri);
-                        }
+                        // Removed folders were evicted above before folder
+                        // membership was updated.
                     }
                 }
 
@@ -2158,6 +2093,168 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(server.pending_workspace_configuration_requests.lock().is_empty());
+    }
+
+    #[cfg(feature = "workspace")]
+    #[test]
+    fn watched_file_deleted_clears_raw_and_normalized_uri_state()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("delete_variant.pm");
+        let source = "package Delete::Variant;\nsub gone { 1 }\n1;\n";
+        std::fs::write(&path, source)?;
+        let normalized_uri = url::Url::from_file_path(&path).map_err(|_| "invalid file path")?;
+        let normalized_uri = normalized_uri.to_string();
+        let file_path_part = normalized_uri.strip_prefix("file:///").ok_or("expected file URI")?;
+        let raw_uri = format!("file://localhost/{file_path_part}");
+
+        assert_ne!(raw_uri, normalized_uri);
+        assert_eq!(server.normalize_uri_key(&raw_uri), server.normalize_uri_key(&normalized_uri));
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": normalized_uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": source
+            }
+        }))?;
+        let in_flight_token = server.new_parse_token(&normalized_uri);
+        server.stream_sessions().start_session(crate::runtime::stream_session::SessionKey {
+            uri: normalized_uri.clone(),
+            document_version: 1,
+            line: 0,
+            character: 0,
+        });
+        if let Some(coordinator) = server.coordinator() {
+            coordinator
+                .index()
+                .index_file(url::Url::parse(&normalized_uri)?, source.to_string())?;
+            assert!(!coordinator.index().file_symbols(&normalized_uri).is_empty());
+            assert!(coordinator.index().document_store().get(&normalized_uri).is_some());
+        }
+
+        server.handle_did_change_watched_files(Some(json!({
+            "changes": [
+                { "uri": raw_uri, "type": 3 }
+            ]
+        })))?;
+
+        assert!(in_flight_token.load(std::sync::atomic::Ordering::Relaxed));
+        let after = server.memory_state_snapshot();
+        assert_eq!(after.documents, 0);
+        assert_eq!(after.open_text_bytes, 0);
+        assert_eq!(after.parse_cancel_flags, 0);
+        assert_eq!(after.stream_sessions, 0);
+        if let Some(coordinator) = server.coordinator() {
+            assert!(coordinator.index().file_symbols(&normalized_uri).is_empty());
+            assert!(coordinator.index().file_symbols(&raw_uri).is_empty());
+            assert!(coordinator.index().document_store().get(&normalized_uri).is_none());
+            assert!(coordinator.index().document_store().get(&raw_uri).is_none());
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "workspace")]
+    #[test]
+    fn workspace_folder_removal_evicts_open_docs_under_root()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let dir = tempfile::tempdir()?;
+        let removed_root = dir.path().join("removed");
+        let kept_root = dir.path().join("kept");
+        std::fs::create_dir_all(&removed_root)?;
+        std::fs::create_dir_all(&kept_root)?;
+
+        let removed_path = removed_root.join("inside.pm");
+        let kept_path = kept_root.join("outside.pm");
+        let removed_source = "package Removed::Inside;\nsub inside { 1 }\n1;\n";
+        let kept_source = "package Kept::Outside;\nsub outside { 1 }\n1;\n";
+        std::fs::write(&removed_path, removed_source)?;
+        std::fs::write(&kept_path, kept_source)?;
+
+        let removed_folder_uri =
+            url::Url::from_directory_path(&removed_root).map_err(|_| "invalid removed root")?;
+        let kept_folder_uri =
+            url::Url::from_directory_path(&kept_root).map_err(|_| "invalid kept root")?;
+        let removed_uri = url::Url::from_file_path(&removed_path)
+            .map_err(|_| "invalid removed path")?
+            .to_string();
+        let kept_uri =
+            url::Url::from_file_path(&kept_path).map_err(|_| "invalid kept path")?.to_string();
+
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(
+                removed_folder_uri.to_string(),
+            ),
+        );
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(
+                kept_folder_uri.to_string(),
+            ),
+        );
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": removed_uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": removed_source
+            }
+        }))?;
+        server.did_open(json!({
+            "textDocument": {
+                "uri": kept_uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": kept_source
+            }
+        }))?;
+        let removed_token = server.new_parse_token(&removed_uri);
+        let kept_token = server.new_parse_token(&kept_uri);
+        server.stream_sessions().start_session(crate::runtime::stream_session::SessionKey {
+            uri: removed_uri.clone(),
+            document_version: 1,
+            line: 0,
+            character: 0,
+        });
+        server.stream_sessions().start_session(crate::runtime::stream_session::SessionKey {
+            uri: kept_uri.clone(),
+            document_version: 1,
+            line: 0,
+            character: 0,
+        });
+
+        server.handle_did_change_workspace_folders(Some(json!({
+            "event": {
+                "added": [],
+                "removed": [
+                    { "uri": removed_folder_uri.to_string(), "name": "removed" }
+                ]
+            }
+        })))?;
+
+        assert!(removed_token.load(std::sync::atomic::Ordering::Relaxed));
+        assert!(!kept_token.load(std::sync::atomic::Ordering::Relaxed));
+        {
+            let documents = server.documents.lock();
+            assert!(!documents.contains_key(&server.normalize_uri_key(&removed_uri)));
+            assert!(documents.contains_key(&server.normalize_uri_key(&kept_uri)));
+        }
+        assert!(!server.parse_cancel_flags.lock().contains_key(&removed_uri));
+        assert!(server.parse_cancel_flags.lock().contains_key(&kept_uri));
+        assert_eq!(server.stream_sessions().len(), 1);
+        assert!(
+            server
+                .workspace_folders
+                .lock()
+                .iter()
+                .all(|folder| { folder.uri != removed_folder_uri.to_string() })
+        );
+
+        Ok(())
     }
 
     #[cfg(feature = "workspace")]

--- a/docs/large-workspaces/LSP_CHURN_REPRO.md
+++ b/docs/large-workspaces/LSP_CHURN_REPRO.md
@@ -1,0 +1,75 @@
+# LSP Churn Memory Reproduction
+
+Investigation date: 2026-05-06
+
+This harness reproduces open/change/close document churn against `perl-lsp`
+and records RSS samples as JSON or CSV. For plateau gates, run it with
+`DELETE_AFTER_CLOSE=1` so each closed file is also removed from the workspace;
+close-only churn preserves workspace index entries for files that still exist
+on disk. This is investigation and regression infrastructure: it measures
+whether process memory plateaus after warmup, not whether RSS returns exactly
+to baseline.
+
+Build the server:
+
+```bash
+cargo build --release -p perl-lsp-rs
+```
+
+Run document churn:
+
+```bash
+N_FILES=500 \
+N_CHANGES=10 \
+DO_WORKSPACE_SYMBOL=0 \
+DELETE_AFTER_CLOSE=1 \
+BINARY=./target/release/perl-lsp \
+python3 scripts/repro_lsp_storm.py \
+  --json-out target/memory/doc_churn.json \
+  --csv-out target/memory/doc_churn.csv
+
+python3 scripts/assert_rss_plateau.py target/memory/doc_churn.json
+```
+
+Run churn plus workspace-symbol pressure:
+
+```bash
+N_FILES=300 \
+N_CHANGES=10 \
+DO_WORKSPACE_SYMBOL=1 \
+DELETE_AFTER_CLOSE=1 \
+BINARY=./target/release/perl-lsp \
+python3 scripts/repro_lsp_storm.py \
+  --json-out target/memory/workspace_symbol.json \
+  --csv-out target/memory/workspace_symbol.csv
+
+python3 scripts/assert_rss_plateau.py target/memory/workspace_symbol.json
+```
+
+Use `--summary-out target/memory/<name>.plateau.json` to persist the plateau
+decision as a CI artifact. Use `--settle-seconds` to control how long the
+harness waits after the last `didClose` or watched-file delete before taking
+the final RSS sample.
+
+CI runs this in two tiers:
+
+- PR smoke: `75` files, `5` changes, document churn only, loose plateau gate,
+  artifacts retained for 14 days.
+- Nightly or `ci:memory` label: `500` files document churn plus `300` files
+  with workspace-symbol pressure, strict plateau gate, artifacts retained for
+  30 days.
+
+Acceptance should focus on shape:
+
+- RSS can rise during warmup.
+- RSS should flatten after warmup.
+- Repeated closed-file churn should not ratchet linearly by file count.
+- Workspace-symbol pressure should plateau or be materially reduced compared
+  with the pre-fix baseline.
+
+Allocator arenas and `HashMap` capacity can remain reserved, so exact return
+to initial RSS is not required.
+
+The harness is best supported on Linux and macOS. Linux uses `/proc` for RSS;
+other Unix-like systems fall back to `ps`. Windows process and URI handling is
+not part of this guard yet.

--- a/docs/large-workspaces/README.md
+++ b/docs/large-workspaces/README.md
@@ -8,6 +8,7 @@ Perl workspaces (5 000–10 000+ files).
 | [TESTING_GUIDE.md](TESTING_GUIDE.md) | Generating test workspaces, writing large-workspace tests, performance baselines |
 | [PROFILING_GUIDE.md](PROFILING_GUIDE.md) | CPU flamegraphs, heap profiling, criterion benchmarks |
 | [MEMORY_PATTERNS.md](MEMORY_PATTERNS.md) | How memory scales, cache behavior, common anti-patterns |
+| [LSP_CHURN_REPRO.md](LSP_CHURN_REPRO.md) | Reproducing open/change/close RSS churn and checking plateau behavior |
 | [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Diagnosing slowdowns, stale symbols, index degradation |
 
 ## Quick Reference

--- a/scripts/assert_rss_plateau.py
+++ b/scripts/assert_rss_plateau.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Assert that RSS samples flatten after warmup."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+
+def median_slope(points: list[tuple[int, int]]) -> float:
+    slopes: list[float] = []
+    for idx, (x1, y1) in enumerate(points):
+        for x2, y2 in points[idx + 1 :]:
+            dx = x2 - x1
+            if dx > 0:
+                slopes.append((y2 - y1) / dx)
+    return statistics.median(slopes) if slopes else 0.0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("json_file", type=Path)
+    parser.add_argument("--warmup-fraction", type=float, default=0.5)
+    parser.add_argument("--max-tail-growth-kb", type=int, default=8192)
+    parser.add_argument("--max-tail-growth-pct", type=float, default=8.0)
+    parser.add_argument("--max-slope-kb-per-file", type=float, default=2.0)
+    parser.add_argument("--summary-out", type=Path)
+    parser.add_argument("--loose", action="store_true")
+    args = parser.parse_args()
+
+    if args.loose:
+        args.max_tail_growth_kb *= 2
+        args.max_tail_growth_pct *= 2.0
+        args.max_slope_kb_per_file *= 2.0
+
+    payload = json.loads(args.json_file.read_text(encoding="utf-8"))
+    samples = [
+        sample
+        for sample in payload.get("samples", [])
+        if sample.get("phase") in {"churn", "settled"} and int(sample.get("rss_kb", 0)) > 0
+    ]
+    if len(samples) < 4:
+        raise SystemExit(f"need at least 4 RSS samples, got {len(samples)}")
+
+    start = max(0, min(len(samples) - 2, int(len(samples) * args.warmup_fraction)))
+    tail = samples[start:]
+    tail_points = [(int(s["file_index"]), int(s["rss_kb"])) for s in tail]
+    tail_rss = [rss for _, rss in tail_points]
+    tail_min = min(tail_rss)
+    tail_last = tail_rss[-1]
+    tail_growth_kb = tail_last - tail_min
+    tail_growth_pct = (tail_growth_kb / max(tail_min, 1)) * 100.0
+    slope = median_slope(tail_points)
+    material_growth_kb = max(2048, args.max_tail_growth_kb // 4)
+
+    failures: list[str] = []
+    if tail_growth_kb > args.max_tail_growth_kb and tail_growth_pct > args.max_tail_growth_pct:
+        failures.append(
+            "tail growth exceeded limits: "
+            f"{tail_growth_kb} KB ({tail_growth_pct:.2f}%)"
+        )
+    if tail_growth_kb > material_growth_kb and slope > args.max_slope_kb_per_file:
+        failures.append(
+            "tail slope exceeded limit: "
+            f"{slope:.2f} KB/file > {args.max_slope_kb_per_file:.2f} KB/file"
+        )
+
+    summary = {
+        "json_file": str(args.json_file),
+        "samples": len(samples),
+        "tail_samples": len(tail),
+        "tail_min_kb": tail_min,
+        "tail_last_kb": tail_last,
+        "tail_growth_kb": tail_growth_kb,
+        "tail_growth_pct": round(tail_growth_pct, 3),
+        "median_tail_slope_kb_per_file": round(slope, 3),
+        "material_growth_kb": material_growth_kb,
+        "passed": not failures,
+    }
+    print(json.dumps(summary, indent=2))
+    if args.summary_out:
+        args.summary_out.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_out.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    if failures:
+        raise SystemExit("; ".join(failures))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repro_lsp_storm.py
+++ b/scripts/repro_lsp_storm.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Drive perl-lsp through open/change/close churn and record RSS samples."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import queue
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from urllib.parse import quote
+
+
+def env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        raise SystemExit(f"{name} must be an integer, got {value!r}")
+
+
+def file_uri(path: Path) -> str:
+    return "file://" + quote(str(path.resolve()))
+
+
+def rss_kb(pid: int) -> int:
+    status = Path(f"/proc/{pid}/status")
+    if status.exists():
+        for line in status.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+
+    out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)], text=True)
+    return int(out.strip() or "0")
+
+
+def send_message(proc: subprocess.Popen[bytes], payload: dict) -> None:
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    assert proc.stdin is not None
+    proc.stdin.write(header + body)
+    proc.stdin.flush()
+
+
+def read_messages(proc: subprocess.Popen[bytes], out: "queue.Queue[dict]") -> None:
+    assert proc.stdout is not None
+    stream = proc.stdout
+    while True:
+        headers: dict[str, str] = {}
+        while True:
+            line = stream.readline()
+            if not line:
+                return
+            if line == b"\r\n":
+                break
+            key, _, value = line.decode("ascii", errors="replace").partition(":")
+            headers[key.lower()] = value.strip()
+        length = int(headers.get("content-length", "0"))
+        if length <= 0:
+            continue
+        raw = stream.read(length)
+        if not raw:
+            return
+        try:
+            out.put(json.loads(raw.decode("utf-8")))
+        except json.JSONDecodeError:
+            continue
+
+
+def perl_source(index: int, version: int) -> str:
+    package = f"Storm::File{index:05d}"
+    return (
+        f"package {package};\n"
+        "use strict;\n"
+        "use warnings;\n\n"
+        f"sub value_{index:05d} {{ return {index + version}; }}\n"
+        f"sub call_{index:05d} {{ return value_{index:05d}(); }}\n\n"
+        "1;\n"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--csv-out", type=Path)
+    parser.add_argument("--binary", default=os.environ.get("BINARY", "./target/release/perl-lsp"))
+    parser.add_argument("--n-files", type=int, default=env_int("N_FILES", 500))
+    parser.add_argument("--n-changes", type=int, default=env_int("N_CHANGES", 10))
+    parser.add_argument(
+        "--workspace-symbol",
+        action="store_true",
+        default=os.environ.get("DO_WORKSPACE_SYMBOL", "0") == "1",
+    )
+    parser.add_argument(
+        "--delete-after-close",
+        action="store_true",
+        default=os.environ.get("DELETE_AFTER_CLOSE", "0") == "1",
+        help="unlink each file after didClose and send a watched-file DELETED event",
+    )
+    parser.add_argument("--sample-every", type=int, default=env_int("SAMPLE_EVERY", 10))
+    parser.add_argument("--settle-seconds", type=float, default=float(os.environ.get("SETTLE_SECONDS", "1.0")))
+    parser.add_argument("--server-stderr", type=Path)
+    args = parser.parse_args()
+
+    binary = shutil.which(args.binary) or args.binary
+    server_stderr = subprocess.DEVNULL
+    stderr_handle = None
+    if args.server_stderr:
+        args.server_stderr.parent.mkdir(parents=True, exist_ok=True)
+        stderr_handle = args.server_stderr.open("wb")
+        server_stderr = stderr_handle
+
+    with tempfile.TemporaryDirectory(prefix="perl-lsp-storm-") as tmp:
+        root = Path(tmp)
+        proc = subprocess.Popen(
+            [binary, "--stdio"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=server_stderr,
+        )
+        responses: "queue.Queue[dict]" = queue.Queue()
+        reader = threading.Thread(target=read_messages, args=(proc, responses), daemon=True)
+        reader.start()
+
+        next_id = 1
+        start = time.monotonic()
+        samples: list[dict] = []
+
+        def sample(phase: str, file_index: int) -> None:
+            try:
+                rss = rss_kb(proc.pid)
+            except Exception as exc:  # pragma: no cover - platform fallback
+                print(f"rss sample failed: {exc}", file=sys.stderr)
+                rss = 0
+            row = {
+                "elapsed_s": round(time.monotonic() - start, 3),
+                "phase": phase,
+                "file_index": file_index,
+                "rss_kb": rss,
+            }
+            samples.append(row)
+            print(json.dumps(row, separators=(",", ":")), file=sys.stderr)
+
+        def request(method: str, params: dict | None = None) -> int:
+            nonlocal next_id
+            req_id = next_id
+            next_id += 1
+            send_message(proc, {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params or {}})
+            return req_id
+
+        def notify(method: str, params: dict | None = None) -> None:
+            send_message(proc, {"jsonrpc": "2.0", "method": method, "params": params or {}})
+
+        def wait_for_response(req_id: int, timeout: float = 10.0) -> dict:
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(f"timed out waiting for response id {req_id}")
+                try:
+                    message = responses.get(timeout=remaining)
+                except queue.Empty as exc:
+                    raise TimeoutError(f"timed out waiting for response id {req_id}") from exc
+                if message.get("id") == req_id:
+                    return message
+
+        try:
+            initialize_id = request(
+                "initialize",
+                {
+                    "processId": os.getpid(),
+                    "rootUri": file_uri(root),
+                    "capabilities": {
+                        "textDocument": {
+                            "synchronization": {"didSave": True},
+                            "publishDiagnostics": {"relatedInformation": True},
+                        },
+                        "workspace": {"workspaceFolders": True},
+                    },
+                    "workspaceFolders": [{"uri": file_uri(root), "name": "storm"}],
+                },
+            )
+            wait_for_response(initialize_id, timeout=10.0)
+            notify("initialized", {})
+            sample("initialized", 0)
+
+            for i in range(args.n_files):
+                path = root / f"File{i:05d}.pm"
+                text = perl_source(i, 0)
+                path.write_text(text, encoding="utf-8")
+                uri = file_uri(path)
+                notify(
+                    "textDocument/didOpen",
+                    {
+                        "textDocument": {
+                            "uri": uri,
+                            "languageId": "perl",
+                            "version": 1,
+                            "text": text,
+                        }
+                    },
+                )
+                for change in range(args.n_changes):
+                    text = perl_source(i, change + 1)
+                    notify(
+                        "textDocument/didChange",
+                        {
+                            "textDocument": {"uri": uri, "version": change + 2},
+                            "contentChanges": [{"text": text}],
+                        },
+                    )
+                if args.workspace_symbol:
+                    request("workspace/symbol", {"query": f"value_{i:05d}"})
+                notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+                if args.delete_after_close:
+                    path.unlink(missing_ok=True)
+                    notify(
+                        "workspace/didChangeWatchedFiles",
+                        {
+                            "changes": [
+                                {
+                                    "uri": uri,
+                                    "type": 3,
+                                }
+                            ]
+                        },
+                    )
+
+                if i % max(args.sample_every, 1) == 0 or i == args.n_files - 1:
+                    sample("churn", i + 1)
+
+            time.sleep(args.settle_seconds)
+            sample("settled", args.n_files)
+            shutdown_id = request("shutdown", {})
+            wait_for_response(shutdown_id, timeout=10.0)
+            notify("exit", {})
+        finally:
+            try:
+                if proc.stdin:
+                    proc.stdin.close()
+            except BrokenPipeError:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+            if stderr_handle:
+                stderr_handle.close()
+
+        result = {
+            "schema": 1,
+            "binary": str(binary),
+            "n_files": args.n_files,
+            "n_changes": args.n_changes,
+            "workspace_symbol": args.workspace_symbol,
+            "delete_after_close": args.delete_after_close,
+            "sample_every": args.sample_every,
+            "settle_seconds": args.settle_seconds,
+            "samples": samples,
+        }
+
+        if args.json_out:
+            args.json_out.parent.mkdir(parents=True, exist_ok=True)
+            args.json_out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+        if args.csv_out:
+            args.csv_out.parent.mkdir(parents=True, exist_ok=True)
+            with args.csv_out.open("w", newline="", encoding="utf-8") as fh:
+                writer = csv.DictWriter(fh, fieldnames=["elapsed_s", "phase", "file_index", "rss_kb"])
+                writer.writeheader()
+                writer.writerows(samples)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Problem: open/change/close churn can retain LSP document/session/cache state without a measured plateau guard.

Fix: add lifecycle eviction helpers, stale background-index generation guards, memory-state counters, focused lifecycle coverage, Linux/macOS RSS churn scripts, and PR/nightly memory plateau workflows. The rebased branch also pins the new workflow jobs to Rust 1.93.1 and covers Windows file-URI variants for lifecycle eviction.

Verification:
- `python -m py_compile scripts\repro_lsp_storm.py scripts\assert_rss_plateau.py`
- `cargo test -p perl-lsp-rs --profile agent --locked did_close`
- `cargo test -p perl-lsp-rs --profile agent --locked watched_file_deleted_clears_raw_and_normalized_uri_state`
- `cargo test -p perl-lsp-rs --profile agent --locked workspace_folder_removal_evicts_open_docs_under_root`
- `cargo test -p perl-lsp-rs-core --profile agent --locked ast_cache_remove_evicts_entry_immediately`
- `cargo test -p perl-lsp-rs --profile agent --locked stream_session::tests::cancel_for_uri_evicts_many_stale_sessions`
- `cargo check -p perl-lsp-rs --all-targets --profile agent --locked`
- `cargo clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs`
- `cargo build --release -p perl-lsp-rs --bin perl-lsp --locked`
- `cargo xtask workflow-policy-lint --receipt target/receipts/workflow-policy.json` passed with 0 errors and 4 pre-existing unpinned-action warnings
- `cargo xtask workflow-trigger-lint`
- `cargo xtask fmt --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `git diff --check`

Note: the RSS plateau harness is documented as Linux/macOS-oriented. Local Windows verification compiled the scripts and release binary; the PR smoke workflow exercises the RSS gate on Ubuntu.
