### PR TITLE
chore(memory): register LSP churn memory receipts (#0000)

### DIFF
--- a/.ci/metrics/baselines/memory_plateau.json
+++ b/.ci/metrics/baselines/memory_plateau.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "kind": "memory_plateau_baseline",
+  "source": {
+    "workflow": "CI (Nightly)",
+    "run_id": "25444427692",
+    "commit": "e58ab60848bae119c182740c482948de0fd357c4",
+    "captured_at": "2026-05-06T15:24:03Z"
+  },
+  "scenarios": [
+    {
+      "scenario": "lsp_doc_churn_delete",
+      "files": 500,
+      "changes_per_file": 10,
+      "workspace_symbol": false,
+      "delete_after_close": true,
+      "tail_growth_kb": 152,
+      "tail_growth_pct": 0.995,
+      "median_tail_slope_kb_per_file": 0.69,
+      "samples": 52,
+      "passed": true
+    },
+    {
+      "scenario": "lsp_workspace_symbol_churn_delete",
+      "files": 300,
+      "changes_per_file": 10,
+      "workspace_symbol": true,
+      "delete_after_close": true,
+      "tail_growth_kb": 872,
+      "tail_growth_pct": 5.951,
+      "median_tail_slope_kb_per_file": 4.764,
+      "samples": 32,
+      "passed": true
+    },
+    {
+      "scenario": "workspace_index_remove_reindex_cycle",
+      "source": "cargo test -p perl-workspace --features memory-profiling --test memory_leak_regression",
+      "tracked_tests": [
+        "remove_all_returns_index_to_empty_baseline",
+        "repeated_index_remove_cycles_do_not_accumulate",
+        "cycle_footprint_matches_single_shot_footprint",
+        "find_definition_does_not_grow_symbols_on_miss",
+        "bytes_per_symbol_stays_under_threshold_at_500_files"
+      ],
+      "passed": true
+    }
+  ]
+}

--- a/.ci/receipts/registry.toml
+++ b/.ci/receipts/registry.toml
@@ -23,6 +23,13 @@ producer = "cargo xtask merge-ready emit"
 required_fields = ["head_sha", "base_sha", "gate_graph_version", "verdict"]
 
 [[receipt]]
+check = "memory-plateau"
+schema = ".ci/receipts/schemas/memory-plateau.schema.json"
+description = "Captures LSP memory plateau workload summaries for trend comparison."
+producer = "cargo xtask metrics memory"
+required_fields = ["kind", "scenario", "files", "changes_per_file", "tail_growth_kb", "median_tail_slope_kb_per_file", "passed", "commit"]
+
+[[receipt]]
 check = "fmt"
 schema = ".ci/receipts/schemas/fmt.schema.json"
 description = "Rustfmt gate receipt for explicit formatting outcomes."

--- a/.ci/receipts/schemas/memory-plateau.schema.json
+++ b/.ci/receipts/schemas/memory-plateau.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp/.ci/receipts/schemas/memory-plateau.schema.json",
+  "title": "Memory Plateau Receipt",
+  "allOf": [
+    { "$ref": "./common-gate-receipt.schema.json" },
+    {
+      "type": "object",
+      "required": [
+        "check",
+        "kind",
+        "scenario",
+        "files",
+        "changes_per_file",
+        "tail_growth_kb",
+        "median_tail_slope_kb_per_file",
+        "passed",
+        "commit"
+      ],
+      "properties": {
+        "check": { "const": "memory-plateau" },
+        "kind": { "const": "memory_plateau" },
+        "scenario": { "type": "string", "minLength": 1 },
+        "files": { "type": "integer", "minimum": 1 },
+        "changes_per_file": { "type": "integer", "minimum": 0 },
+        "workspace_symbol": { "type": "boolean" },
+        "delete_after_close": { "type": "boolean" },
+        "settle_seconds": { "type": "number", "minimum": 0 },
+        "tail_growth_kb": { "type": "integer" },
+        "tail_growth_pct": { "type": "number" },
+        "median_tail_slope_kb_per_file": { "type": "number" },
+        "samples": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "boolean" },
+        "commit": { "type": ["string", "null"] },
+        "generated_at": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  ]
+}

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -300,9 +300,27 @@ jobs:
             --csv-out target/memory/nightly-doc-churn.csv \
             --settle-seconds 3 \
             --server-stderr target/memory/nightly-doc-churn.server.log
+          set +e
           python3 scripts/assert_rss_plateau.py \
             target/memory/nightly-doc-churn.json \
             --summary-out target/memory/nightly-doc-churn.plateau.json
+          PLATEAU_STATUS=$?
+          set -e
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) RECEIPT_EVENT=pull_request ;;
+            merge_group) RECEIPT_EVENT=merge_group ;;
+            *) RECEIPT_EVENT=push ;;
+          esac
+          cargo xtask metrics memory \
+            --workload-json target/memory/nightly-doc-churn.json \
+            --plateau-json target/memory/nightly-doc-churn.plateau.json \
+            --scenario lsp_doc_churn_delete \
+            --receipt target/memory/receipts/nightly-doc-churn.receipt.json \
+            --commit "$GITHUB_SHA" \
+            --event "$RECEIPT_EVENT" \
+            --markdown >> "$GITHUB_STEP_SUMMARY"
+          cargo xtask gate-receipts validate target/memory/receipts/nightly-doc-churn.receipt.json
+          exit "$PLATEAU_STATUS"
 
       - name: Run workspace-symbol plateau workload
         run: |
@@ -316,9 +334,26 @@ jobs:
             --csv-out target/memory/nightly-workspace-symbol.csv \
             --settle-seconds 3 \
             --server-stderr target/memory/nightly-workspace-symbol.server.log
+          set +e
           python3 scripts/assert_rss_plateau.py \
             target/memory/nightly-workspace-symbol.json \
             --summary-out target/memory/nightly-workspace-symbol.plateau.json
+          PLATEAU_STATUS=$?
+          set -e
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) RECEIPT_EVENT=pull_request ;;
+            merge_group) RECEIPT_EVENT=merge_group ;;
+            *) RECEIPT_EVENT=push ;;
+          esac
+          cargo xtask metrics memory \
+            --workload-json target/memory/nightly-workspace-symbol.json \
+            --plateau-json target/memory/nightly-workspace-symbol.plateau.json \
+            --scenario lsp_workspace_symbol_churn_delete \
+            --receipt target/memory/receipts/nightly-workspace-symbol.receipt.json \
+            --commit "$GITHUB_SHA" \
+            --event "$RECEIPT_EVENT" \
+            --markdown >> "$GITHUB_STEP_SUMMARY"
+          cargo xtask gate-receipts validate target/memory/receipts/nightly-workspace-symbol.receipt.json
           python3 - <<'PY'
           import json
           import os
@@ -357,6 +392,7 @@ jobs:
                       f"| {result} |\n"
                   )
           PY
+          exit "$PLATEAU_STATUS"
 
       - name: Upload memory plateau artifacts
         if: always()
@@ -368,10 +404,12 @@ jobs:
             target/memory/nightly-doc-churn.csv
             target/memory/nightly-doc-churn.plateau.json
             target/memory/nightly-doc-churn.server.log
+            target/memory/receipts/nightly-doc-churn.receipt.json
             target/memory/nightly-workspace-symbol.json
             target/memory/nightly-workspace-symbol.csv
             target/memory/nightly-workspace-symbol.plateau.json
             target/memory/nightly-workspace-symbol.server.log
+            target/memory/receipts/nightly-workspace-symbol.receipt.json
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,10 +642,27 @@ jobs:
             --csv-out target/memory/pr-smoke-doc-churn.csv \
             --settle-seconds 1 \
             --server-stderr target/memory/pr-smoke-doc-churn.server.log
+          set +e
           python3 scripts/assert_rss_plateau.py \
             target/memory/pr-smoke-doc-churn.json \
             --summary-out target/memory/pr-smoke-doc-churn.plateau.json \
             --loose
+          PLATEAU_STATUS=$?
+          set -e
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) RECEIPT_EVENT=pull_request ;;
+            merge_group) RECEIPT_EVENT=merge_group ;;
+            *) RECEIPT_EVENT=push ;;
+          esac
+          cargo xtask metrics memory \
+            --workload-json target/memory/pr-smoke-doc-churn.json \
+            --plateau-json target/memory/pr-smoke-doc-churn.plateau.json \
+            --scenario lsp_doc_churn_delete_smoke \
+            --receipt target/memory/receipts/pr-smoke-doc-churn.receipt.json \
+            --commit "$GITHUB_SHA" \
+            --event "$RECEIPT_EVENT" \
+            --markdown >> "$GITHUB_STEP_SUMMARY"
+          cargo xtask gate-receipts validate target/memory/receipts/pr-smoke-doc-churn.receipt.json
           python3 - <<'PY'
           import json
           import os
@@ -671,6 +688,7 @@ jobs:
                   f"| {result} |\n"
               )
           PY
+          exit "$PLATEAU_STATUS"
 
       - name: Upload memory smoke artifacts
         if: always()
@@ -682,6 +700,7 @@ jobs:
             target/memory/pr-smoke-doc-churn.csv
             target/memory/pr-smoke-doc-churn.plateau.json
             target/memory/pr-smoke-doc-churn.server.log
+            target/memory/receipts/pr-smoke-doc-churn.receipt.json
           if-no-files-found: warn
           retention-days: 14
 

--- a/docs/large-workspaces/LSP_CHURN_REPRO.md
+++ b/docs/large-workspaces/LSP_CHURN_REPRO.md
@@ -51,6 +51,25 @@ decision as a CI artifact. Use `--settle-seconds` to control how long the
 harness waits after the last `didClose` or watched-file delete before taking
 the final RSS sample.
 
+Convert a plateau summary into a registered receipt:
+
+```bash
+cargo xtask metrics memory \
+  --workload-json target/memory/doc_churn.json \
+  --plateau-json target/memory/doc_churn.plateau.json \
+  --scenario lsp_doc_churn_delete \
+  --receipt target/memory/receipts/doc_churn.receipt.json \
+  --commit "$(git rev-parse HEAD)" \
+  --event local \
+  --markdown
+```
+
+Validate it against the receipt registry:
+
+```bash
+cargo xtask gate-receipts validate target/memory/receipts/doc_churn.receipt.json
+```
+
 CI runs this in two tiers:
 
 - PR smoke: `75` files, `5` changes, document churn only, loose plateau gate,

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -25,6 +25,7 @@
 | DAP debugger scorecard | [dap.md](dap.md) | Generator | Every DAP-touching merge |
 | Release readiness | [release.md](release.md) | Human | Ship readiness changes |
 | Workspace & indexing scorecard | [workspace.md](workspace.md) | Generator | Every workspace-touching merge |
+| Memory plateau receipts | [memory_plateau.md](memory_plateau.md) | Human | Memory guardrail or budget changes |
 | Semantic capability dashboard | [semantic_capability_dashboard.md](semantic_capability_dashboard.md) | Human | Semantic release-readiness changes |
 | Semantic UX capability dashboard | [ux_capability_dashboard.md](ux_capability_dashboard.md) | Human | UX surface readiness changes |
 | CI hardening implementation status | [ci_hardening.md](ci_hardening.md) | Human | CI hardening state changes |

--- a/docs/project/status/memory_plateau.md
+++ b/docs/project/status/memory_plateau.md
@@ -1,0 +1,44 @@
+# Memory Plateau Receipts
+
+> Human-owned baseline summary. Runtime receipts are generated under
+> `target/memory/receipts/` by `cargo xtask metrics memory`.
+
+## Current Baseline
+
+Source run: `CI (Nightly)` workflow dispatch `25444427692` on
+`e58ab60848bae119c182740c482948de0fd357c4`.
+
+| Scenario | Files | Changes/file | Tail growth KB | Median tail slope KB/file | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `lsp_doc_churn_delete` | 500 | 10 | 152 | 0.690 | passed |
+| `lsp_workspace_symbol_churn_delete` | 300 | 10 | 872 | 4.764 | passed |
+| `workspace_index_remove_reindex_cycle` | n/a | n/a | n/a | n/a | covered by `memory_leak_regression` |
+
+## Receipt Command
+
+```bash
+cargo xtask metrics memory \
+  --workload-json target/memory/nightly-doc-churn.json \
+  --plateau-json target/memory/nightly-doc-churn.plateau.json \
+  --scenario lsp_doc_churn_delete \
+  --receipt target/memory/receipts/nightly-doc-churn.receipt.json \
+  --commit "$GITHUB_SHA" \
+  --event push \
+  --markdown
+```
+
+The receipt is registered as `memory-plateau` in
+`.ci/receipts/registry.toml` and validates through:
+
+```bash
+cargo xtask gate-receipts validate target/memory/receipts/nightly-doc-churn.receipt.json
+```
+
+## Interpretation Rules
+
+- Close-only churn may retain workspace-index entries for files that still exist.
+- Close+delete churn must remove file-backed workspace-index entries.
+- RSS is allowed to warm up and hold allocator arenas; the plateau gate tracks
+  tail growth and median tail slope rather than exact return-to-baseline.
+- Runtime receipts are comparable evidence. Logs remain supporting artifacts,
+  not the source of trend truth.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1675,8 +1675,30 @@ enum MetricsCommand {
     WorkspaceStats,
     /// [stub] Diagnostics accuracy and latency statistics.
     DiagnosticsStats,
-    /// [stub] Hierarchical memory breakdown across LSP subsystems.
-    Memory,
+    /// Render memory plateau summaries and optional receipt JSON.
+    Memory {
+        /// Workload JSON emitted by scripts/repro_lsp_storm.py.
+        #[arg(long)]
+        workload_json: PathBuf,
+        /// Plateau summary JSON emitted by scripts/assert_rss_plateau.py.
+        #[arg(long)]
+        plateau_json: PathBuf,
+        /// Scenario id for the memory receipt.
+        #[arg(long)]
+        scenario: Option<String>,
+        /// Optional output path for the generated receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+        /// Git commit SHA attached to the receipt.
+        #[arg(long)]
+        commit: Option<String>,
+        /// Receipt event: pull_request, merge_group, push, or local.
+        #[arg(long, default_value = "local")]
+        event: String,
+        /// Render a markdown table instead of JSON to stdout.
+        #[arg(long)]
+        markdown: bool,
+    },
     /// Release-health dashboard — debt ledger + merge-gate baseline summary.
     ReleaseHealth {
         /// Number of days of history reported in the receipt window field.
@@ -2223,7 +2245,30 @@ fn main() -> Result<()> {
             }
             MetricsCommand::WorkspaceStats => metrics::workspace_stats::run(),
             MetricsCommand::DiagnosticsStats => metrics::diagnostics_stats::run(),
-            MetricsCommand::Memory => metrics::memory::run(),
+            MetricsCommand::Memory {
+                workload_json,
+                plateau_json,
+                scenario,
+                receipt,
+                commit,
+                event,
+                markdown,
+            } => {
+                let scenario = match scenario {
+                    Some(scenario) => scenario,
+                    None => metrics::memory::infer_scenario(&workload_json)
+                        .map_err(|error| eyre!(error.to_string()))?,
+                };
+                metrics::memory::run(metrics::memory::MemoryMetricsConfig {
+                    scenario,
+                    workload_json,
+                    plateau_json,
+                    receipt,
+                    commit,
+                    event,
+                    markdown,
+                })
+            }
             MetricsCommand::ReleaseHealth { days, json } => {
                 metrics::release_health::run(days, json)
             }

--- a/xtask/src/tasks/gate_receipts.rs
+++ b/xtask/src/tasks/gate_receipts.rs
@@ -196,6 +196,9 @@ fn validate_receipt(path: &Path, registry: &Registry) -> Result<ValidationResult
     if let Some(schema_path) = &schema {
         validate_schema_required_fields(&receipt, schema_path, &mut errors)?;
     }
+    if check.as_deref() == Some("memory-plateau") {
+        validate_memory_plateau_semantics(&receipt, &mut errors);
+    }
 
     Ok(ValidationResult {
         path: path.display().to_string(),
@@ -282,6 +285,76 @@ fn collect_required_fields(schema_value: &Value, required: &mut HashSet<String>)
     }
 }
 
+fn validate_memory_plateau_semantics(receipt: &Value, errors: &mut Vec<String>) {
+    require_string_eq(receipt, "kind", "memory_plateau", errors);
+    require_nonempty_string(receipt, "scenario", errors);
+    require_integer_min(receipt, "files", 1, errors);
+    require_integer_min(receipt, "changes_per_file", 0, errors);
+    require_integer(receipt, "tail_growth_kb", errors);
+    require_number(receipt, "median_tail_slope_kb_per_file", errors);
+    require_bool(receipt, "passed", errors);
+
+    if let Some(commit) = receipt.get("commit")
+        && !commit.is_string()
+        && !commit.is_null()
+    {
+        errors.push("field 'commit' must be a string or null".to_string());
+    }
+
+    if let Some(passed) = receipt.get("passed").and_then(Value::as_bool)
+        && let Some(verdict) = receipt.get("verdict").and_then(Value::as_str)
+    {
+        let expected = if passed { "pass" } else { "fail" };
+        if verdict != expected {
+            errors.push(format!("field 'verdict' must be '{expected}' when passed is {passed}"));
+        }
+    }
+}
+
+fn require_string_eq(receipt: &Value, field: &str, expected: &str, errors: &mut Vec<String>) {
+    match receipt.get(field).and_then(Value::as_str) {
+        Some(actual) if actual == expected => {}
+        Some(actual) => {
+            errors.push(format!("field '{field}' must be '{expected}', got '{actual}'"))
+        }
+        None => errors.push(format!("field '{field}' must be a string")),
+    }
+}
+
+fn require_nonempty_string(receipt: &Value, field: &str, errors: &mut Vec<String>) {
+    match receipt.get(field).and_then(Value::as_str) {
+        Some(value) if !value.is_empty() => {}
+        Some(_) => errors.push(format!("field '{field}' must not be empty")),
+        None => errors.push(format!("field '{field}' must be a string")),
+    }
+}
+
+fn require_integer(receipt: &Value, field: &str, errors: &mut Vec<String>) {
+    if receipt.get(field).and_then(Value::as_i64).is_none() {
+        errors.push(format!("field '{field}' must be an integer"));
+    }
+}
+
+fn require_integer_min(receipt: &Value, field: &str, min: i64, errors: &mut Vec<String>) {
+    match receipt.get(field).and_then(Value::as_i64) {
+        Some(value) if value >= min => {}
+        Some(value) => errors.push(format!("field '{field}' must be >= {min}, got {value}")),
+        None => errors.push(format!("field '{field}' must be an integer")),
+    }
+}
+
+fn require_number(receipt: &Value, field: &str, errors: &mut Vec<String>) {
+    if receipt.get(field).and_then(Value::as_f64).is_none() {
+        errors.push(format!("field '{field}' must be a number"));
+    }
+}
+
+fn require_bool(receipt: &Value, field: &str, errors: &mut Vec<String>) {
+    if receipt.get(field).and_then(Value::as_bool).is_none() {
+        errors.push(format!("field '{field}' must be a boolean"));
+    }
+}
+
 fn load_registry() -> Result<Registry> {
     let content = fs::read_to_string(REGISTRY_PATH)
         .with_context(|| format!("failed to read registry at {REGISTRY_PATH}"))?;
@@ -302,4 +375,64 @@ fn registry_map(registry: &Registry) -> Result<BTreeMap<String, String>> {
         }
     }
     Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_memory_receipt() -> Value {
+        json!({
+            "check": "memory-plateau",
+            "kind": "memory_plateau",
+            "schema_version": "1",
+            "event": "local",
+            "verdict": "pass",
+            "scenario": "lsp_doc_churn_delete",
+            "files": 500,
+            "changes_per_file": 10,
+            "tail_growth_kb": 152,
+            "median_tail_slope_kb_per_file": 0.69,
+            "passed": true,
+            "commit": "abc123"
+        })
+    }
+
+    #[test]
+    fn memory_plateau_semantics_accept_valid_receipt() {
+        let receipt = valid_memory_receipt();
+        let mut errors = Vec::new();
+
+        validate_memory_plateau_semantics(&receipt, &mut errors);
+
+        assert!(errors.is_empty(), "{errors:?}");
+    }
+
+    #[test]
+    fn memory_plateau_semantics_reject_malformed_receipt() {
+        let mut receipt = valid_memory_receipt();
+        receipt["kind"] = json!("wrong");
+        receipt["files"] = json!("500");
+        receipt["passed"] = json!("yes");
+        receipt["verdict"] = json!("pass");
+
+        let mut errors = Vec::new();
+        validate_memory_plateau_semantics(&receipt, &mut errors);
+
+        assert!(errors.iter().any(|error| error.contains("field 'kind'")));
+        assert!(errors.iter().any(|error| error.contains("field 'files'")));
+        assert!(errors.iter().any(|error| error.contains("field 'passed'")));
+    }
+
+    #[test]
+    fn memory_plateau_semantics_reject_verdict_mismatch() {
+        let mut receipt = valid_memory_receipt();
+        receipt["passed"] = json!(false);
+        receipt["verdict"] = json!("pass");
+
+        let mut errors = Vec::new();
+        validate_memory_plateau_semantics(&receipt, &mut errors);
+
+        assert!(errors.iter().any(|error| error.contains("verdict")));
+    }
 }

--- a/xtask/src/tasks/metrics/memory.rs
+++ b/xtask/src/tasks/metrics/memory.rs
@@ -1,9 +1,167 @@
-//! [stub] Hierarchical memory breakdown across LSP subsystems.
+//! Memory plateau receipt and summary helpers.
 
-use color_eyre::eyre::Result;
+use chrono::Utc;
+use color_eyre::eyre::{Context, Result, eyre};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Options for `cargo xtask metrics memory`.
+pub struct MemoryMetricsConfig {
+    pub scenario: String,
+    pub workload_json: PathBuf,
+    pub plateau_json: PathBuf,
+    pub receipt: Option<PathBuf>,
+    pub commit: Option<String>,
+    pub event: String,
+    pub markdown: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkloadPayload {
+    n_files: u64,
+    n_changes: u64,
+    #[serde(default)]
+    workspace_symbol: bool,
+    #[serde(default)]
+    delete_after_close: bool,
+    #[serde(default)]
+    settle_seconds: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlateauSummary {
+    samples: u64,
+    tail_growth_kb: i64,
+    tail_growth_pct: f64,
+    median_tail_slope_kb_per_file: f64,
+    passed: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct MemoryPlateauReceipt {
+    check: &'static str,
+    kind: &'static str,
+    schema_version: &'static str,
+    event: String,
+    verdict: &'static str,
+    scenario: String,
+    files: u64,
+    changes_per_file: u64,
+    workspace_symbol: bool,
+    delete_after_close: bool,
+    settle_seconds: f64,
+    tail_growth_kb: i64,
+    tail_growth_pct: f64,
+    median_tail_slope_kb_per_file: f64,
+    samples: u64,
+    passed: bool,
+    commit: Option<String>,
+    generated_at: String,
+    metrics: serde_json::Value,
+    artifacts: Vec<serde_json::Value>,
+}
 
 /// Run `cargo xtask metrics memory`.
-pub fn run() -> Result<()> {
-    println!("[stub] memory accounting not yet implemented");
+pub fn run(config: MemoryMetricsConfig) -> Result<()> {
+    let workload = read_json::<WorkloadPayload>(&config.workload_json)?;
+    let plateau = read_json::<PlateauSummary>(&config.plateau_json)?;
+
+    let receipt = MemoryPlateauReceipt {
+        check: "memory-plateau",
+        kind: "memory_plateau",
+        schema_version: "1",
+        event: config.event,
+        verdict: if plateau.passed { "pass" } else { "fail" },
+        scenario: config.scenario,
+        files: workload.n_files,
+        changes_per_file: workload.n_changes,
+        workspace_symbol: workload.workspace_symbol,
+        delete_after_close: workload.delete_after_close,
+        settle_seconds: workload.settle_seconds,
+        tail_growth_kb: plateau.tail_growth_kb,
+        tail_growth_pct: plateau.tail_growth_pct,
+        median_tail_slope_kb_per_file: plateau.median_tail_slope_kb_per_file,
+        samples: plateau.samples,
+        passed: plateau.passed,
+        commit: config.commit,
+        generated_at: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        metrics: json!({
+            "tail_growth_kb": plateau.tail_growth_kb,
+            "tail_growth_pct": plateau.tail_growth_pct,
+            "median_tail_slope_kb_per_file": plateau.median_tail_slope_kb_per_file,
+            "samples": plateau.samples,
+        }),
+        artifacts: vec![
+            json!({
+                "kind": "workload_json",
+                "path": config.workload_json,
+            }),
+            json!({
+                "kind": "plateau_summary",
+                "path": config.plateau_json,
+            }),
+        ],
+    };
+
+    if let Some(path) = &config.receipt {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+        }
+        fs::write(path, serde_json::to_string_pretty(&receipt)? + "\n")
+            .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    }
+
+    if config.markdown {
+        print_markdown(&receipt);
+    } else {
+        println!("{}", serde_json::to_string_pretty(&receipt)?);
+    }
+
     Ok(())
+}
+
+fn read_json<T>(path: &Path) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let text =
+        fs::read_to_string(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&text).wrap_err_with(|| format!("invalid JSON in {}", path.display()))
+}
+
+fn print_markdown(receipt: &MemoryPlateauReceipt) {
+    println!("## Memory plateau receipt");
+    println!();
+    println!(
+        "| Scenario | Files | Changes/file | Tail growth KB | Median tail slope KB/file | Result |"
+    );
+    println!("| --- | ---: | ---: | ---: | ---: | --- |");
+    println!(
+        "| {} | {} | {} | {} | {:.3} | {} |",
+        receipt.scenario,
+        receipt.files,
+        receipt.changes_per_file,
+        receipt.tail_growth_kb,
+        receipt.median_tail_slope_kb_per_file,
+        if receipt.passed { "passed" } else { "failed" }
+    );
+}
+
+pub fn infer_scenario(workload_json: &Path) -> Result<String> {
+    let name = workload_json
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .ok_or_else(|| eyre!("cannot infer scenario from {}", workload_json.display()))?;
+
+    match name {
+        "nightly-doc-churn" | "doc_churn_500_delete" => Ok("lsp_doc_churn_delete".to_string()),
+        "nightly-workspace-symbol" | "workspace_symbol_300_delete" => {
+            Ok("lsp_workspace_symbol_churn_delete".to_string())
+        }
+        "pr-smoke-doc-churn" => Ok("lsp_doc_churn_delete_smoke".to_string()),
+        other => Ok(other.replace('-', "_")),
+    }
 }


### PR DESCRIPTION
## Summary

Registers LSP memory plateau outputs as first-class receipts so the #8072 guardrail can be trended instead of treated as one-off logs.

## Changes
- Adds `.ci/receipts/schemas/memory-plateau.schema.json` and registers `memory-plateau` in `.ci/receipts/registry.toml`.
- Replaces the `cargo xtask metrics memory` stub with a renderer/receipt producer for churn workload JSON plus plateau summaries.
- Updates PR smoke and nightly memory workflows to emit and validate memory receipts, while preserving plateau failure exit status.
- Adds the post-#8072 master memory baseline under `.ci/metrics/baselines/memory_plateau.json` and documents the receipt command in status/churn docs.
- Adds semantic validation for `memory-plateau` receipts so malformed kind/type/verdict payloads fail validation.

## Verification
- `cargo fmt --check`
- `python3 -m py_compile scripts/repro_lsp_storm.py scripts/assert_rss_plateau.py`
- `cargo test -p xtask memory_plateau_semantics`
- `cargo check -p xtask`
- `cargo xtask gate-receipts validate target/memory/receipts/nightly-doc-churn.receipt.json`
- `cargo xtask gate-receipts validate target/memory/receipts/nightly-workspace-symbol.receipt.json`
- malformed `memory-plateau` receipt rejected by `cargo xtask gate-receipts validate /tmp/bad-memory-plateau.receipt.json`
- `cargo xtask workflow-policy-lint --receipt target/receipts/workflow-policy.json` (0 errors, 4 pre-existing unpinned-action warnings)

## Notes
This intentionally does not add the retained-state inventory/checklist work; that should remain a separate follow-up PR.
