### PR TITLE
test(memory): lock close-only workspace index semantics (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -2029,6 +2029,57 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "workspace")]
+    #[test]
+    fn test_did_close_preserves_workspace_index_for_existing_file()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///test_close_preserves_workspace_index.pl";
+        let source = "package Close::Only;\nsub still_indexed { 1 }\n1;\n";
+
+        server.did_open(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": source
+            }
+        }))?;
+        if let Some(coordinator) = server.coordinator() {
+            coordinator.index().index_file(url::Url::parse(uri)?, source.to_string())?;
+            assert!(
+                !coordinator.index().file_symbols(uri).is_empty(),
+                "workspace index setup must hold symbols before close"
+            );
+            assert!(
+                coordinator.index().document_store().get(uri).is_some(),
+                "workspace document store setup must hold the file before close"
+            );
+        }
+
+        server.handle_did_close(Some(json!({"textDocument": {"uri": uri}})))?;
+
+        let after = server.memory_state_snapshot();
+        assert_eq!(after.documents, 0, "didClose must evict open-document state");
+        assert_eq!(after.open_text_bytes, 0, "didClose must drop open-buffer text");
+        assert!(
+            server.symbol_index.lock().search_prefix("still_").is_empty(),
+            "didClose must clear open-document symbol overlays"
+        );
+        if let Some(coordinator) = server.coordinator() {
+            assert!(
+                !coordinator.index().file_symbols(uri).is_empty(),
+                "didClose is not file deletion; workspace-backed symbols for existing files must remain"
+            );
+            assert!(
+                coordinator.index().document_store().get(uri).is_some(),
+                "didClose must not remove workspace-index document store entries for existing files"
+            );
+        }
+
+        Ok(())
+    }
+
     /// didClose must clear diagnostics using the client-provided URI string.
     ///
     /// This preserves exact URI identity for clients that key diagnostics by


### PR DESCRIPTION
## Summary
Adds a named lifecycle regression for the close-only side of the close-vs-delete memory contract.

## Changes
- `crates/perl-lsp-rs/src/runtime/text_sync.rs` adds `test_did_close_preserves_workspace_index_for_existing_file`.
- The test indexes a file into the workspace index, opens it as an LSP document, runs `didClose`, and asserts that open-document state and symbol overlays are evicted while workspace-backed symbols and document-store entries remain.

## Test
This should fail if `didClose` is accidentally routed through deleted-file cleanup or otherwise removes workspace-index state for files that still exist.

## Verification
- [x] `cargo xtask fmt` - clean
- [x] `git diff --check` - clean
- [x] `cargo test -p perl-lsp-rs --features workspace test_did_close_preserves_workspace_index_for_existing_file -- --nocapture` - pass
- [x] `cargo test -p perl-lsp-rs --features workspace watched_file_deleted_clears_raw_and_normalized_uri_state -- --nocapture` - pass
- [ ] `cargo clippy -p <crate> --tests` - not run; targeted lifecycle regression only
- [ ] `cargo test -p <crate>` - not run; targeted tests above
- [ ] This PR introduces UX-visible changes. I have verified that error messages are actionable and the UX test harness still passes. N/A

## Retained State
- [x] Owner, key type, bound, and cleanup event are documented.
- [x] Key normalization is handled.
- [x] Close-only behavior is distinct from delete/folder-removal behavior.
- [x] Delayed background work cannot repopulate stale state. N/A for this test-only assertion; #8072 covers stale background index guards.
- [x] A regression test, receipt, snapshot counter, or debug counter covers the state.

## What I considered but didn't do
Kept the PR to one negative lifecycle test. Delete/folder removal and stale background indexing already have focused coverage, so this PR only locks the missing close-only invariant.

## What's next
Add the next subsystem memory scenario, likely stream-session cancellation churn or diagnostics churn, as a separate PR.

## Agent
Codex; memory lifecycle regression follow-up.
