### PR TITLE
test(memory): add lifecycle policy guard (#0000)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -652,6 +652,7 @@ gates:
     required: true
     command: >-
       cargo xtask check-from-raw &&
+      cargo xtask check-memory-lifecycle-policy &&
       bash scripts/check-version-sync.sh &&
       bash scripts/check_release_history.sh &&
       bash ci/check_missing_docs.sh &&

--- a/justfile
+++ b/justfile
@@ -1380,6 +1380,7 @@ ci-policy:
     @echo "⚖️  Checking project policies..."
     just ci-check-todos
     @cargo xtask check-from-raw
+    @cargo xtask check-memory-lifecycle-policy
     just version-check
     just ci-doc-claims
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -451,6 +451,9 @@ enum Commands {
     /// Check for disallowed direct `ExitStatus::from_raw()` usage.
     CheckFromRaw,
 
+    /// Enforce retained-state lifecycle and memory receipt invariants.
+    CheckMemoryLifecyclePolicy,
+
     /// Run production security hardening checks.
     SecurityHardening,
 
@@ -2008,6 +2011,7 @@ fn main() -> Result<()> {
         }
         Commands::CheckVersionSync => check_version_sync::run(),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),
+        Commands::CheckMemoryLifecyclePolicy => ci_policy::check_memory_lifecycle(),
         Commands::SecurityHardening => hardening::security_hardening(),
         Commands::PerformanceHardening => hardening::performance_hardening(),
         Commands::ProductionGatesValidation => hardening::production_gates_validation(),

--- a/xtask/src/tasks/ci_policy.rs
+++ b/xtask/src/tasks/ci_policy.rs
@@ -10,6 +10,16 @@ const FROM_RAW_PATTERN: &str = r"\b([A-Za-z_][A-Za-z0-9_:]*::)?ExitStatus::from_
 const ALLOWED_FROM_RAW_PATTERN: &str = r"::from_raw\(\s*raw[_ ]?exit\s*\(";
 const SEARCH_ROOTS: &[&str] = &["crates", "xtask", "examples", "tests"];
 
+struct MemoryLifecycleInputs {
+    text_sync: String,
+    workspace: String,
+    runtime_mod: String,
+    streaming_tests: String,
+    memory_status: String,
+    receipt_registry: String,
+    memory_receipt_schema: String,
+}
+
 fn source_fragment(line: &str) -> &str {
     line.splitn(3, ':').nth(2).unwrap_or(line)
 }
@@ -121,6 +131,157 @@ pub fn check_from_raw() -> Result<()> {
     bail!("CI policy check found disallowed ExitStatus::from_raw() usage");
 }
 
+fn function_body<'a>(contents: &'a str, fn_name: &str) -> Option<&'a str> {
+    let fn_pos = contents.find(&format!("fn {fn_name}"))?;
+    let body_start = contents[fn_pos..].find('{')? + fn_pos;
+    let mut depth = 0usize;
+
+    for (offset, ch) in contents[body_start..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    let body_end = body_start + offset + ch.len_utf8();
+                    return Some(&contents[body_start..body_end]);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn memory_lifecycle_violations(inputs: &MemoryLifecycleInputs) -> Vec<String> {
+    let mut violations = Vec::new();
+
+    match function_body(&inputs.text_sync, "handle_did_close") {
+        Some(body) => {
+            if !body.contains("evict_open_document_session_state(uri)") {
+                violations.push(
+                    "textDocument/didClose must call evict_open_document_session_state(uri)"
+                        .to_string(),
+                );
+            }
+            if body.contains("evict_deleted_file_state") {
+                violations
+                    .push("textDocument/didClose must not call deleted-file eviction".to_string());
+            }
+        }
+        None => violations.push("could not find handle_did_close body".to_string()),
+    }
+
+    match function_body(&inputs.text_sync, "handle_did_change_with_cancellation") {
+        Some(body) => {
+            if !body.contains("for key in self.uri_key_variants(uri)") {
+                violations.push(
+                    "didChange stream-session cancellation must sweep URI variants".to_string(),
+                );
+            }
+            if body.contains("cancel_for_uri_version(uri,") || body.contains("cancel_for_uri(uri)")
+            {
+                violations.push(
+                    "didChange must not cancel stream sessions using only the raw URI".to_string(),
+                );
+            }
+        }
+        None => {
+            violations.push("could not find handle_did_change_with_cancellation body".to_string())
+        }
+    }
+
+    if !inputs.workspace.contains("FileChangeType::DELETED") {
+        violations.push("watched-file delete branch must stay explicit".to_string());
+    }
+    if !inputs.workspace.contains("self.evict_deleted_file_state(&uri)")
+        || !inputs.workspace.contains("self.evict_deleted_file_state(uri)")
+    {
+        violations.push(
+            "watched-file and explicit delete paths must use deleted-file eviction".to_string(),
+        );
+    }
+
+    for field in ["stream_sessions", "pending_index_tasks", "parse_cancel_flags"] {
+        if !inputs.runtime_mod.contains(&format!("pub {field}: usize")) {
+            violations.push(format!("MemoryStateSnapshot must retain {field} counter"));
+        }
+    }
+
+    if !inputs.streaming_tests.contains("completion_stream_cancel_storm_keeps_one_live_session") {
+        violations.push(
+            "streaming completion cancel-storm memory regression must stay present".to_string(),
+        );
+    }
+
+    for rule in [
+        "Close-only churn may retain workspace-index entries",
+        "Close+delete churn must remove file-backed workspace-index entries",
+        "tail growth and median tail slope",
+    ] {
+        if !inputs.memory_status.contains(rule) {
+            violations.push(format!("memory plateau status must document rule: {rule}"));
+        }
+    }
+
+    if !inputs.receipt_registry.contains("check = \"memory-plateau\"")
+        || !inputs
+            .receipt_registry
+            .contains("schema = \".ci/receipts/schemas/memory-plateau.schema.json\"")
+    {
+        violations.push("memory plateau receipt must stay registered".to_string());
+    }
+
+    for field in [
+        "\"check\"",
+        "\"scenario\"",
+        "\"files\"",
+        "\"changes_per_file\"",
+        "\"tail_growth_kb\"",
+        "\"median_tail_slope_kb_per_file\"",
+        "\"passed\"",
+    ] {
+        if !inputs.memory_receipt_schema.contains(field) {
+            violations.push(format!("memory plateau receipt schema must require {field}"));
+        }
+    }
+    if !inputs.memory_receipt_schema.contains("\"check\": { \"const\": \"memory-plateau\" }") {
+        violations.push("memory plateau schema must constrain check to memory-plateau".to_string());
+    }
+
+    violations
+}
+
+pub fn check_memory_lifecycle() -> Result<()> {
+    let root = project_root()?;
+    let read = |relative: &str| -> Result<String> {
+        fs::read_to_string(root.join(relative))
+            .with_context(|| format!("failed to read {relative}"))
+    };
+
+    let inputs = MemoryLifecycleInputs {
+        text_sync: read("crates/perl-lsp-rs/src/runtime/text_sync.rs")?,
+        workspace: read("crates/perl-lsp-rs/src/runtime/workspace.rs")?,
+        runtime_mod: read("crates/perl-lsp-rs/src/runtime/mod.rs")?,
+        streaming_tests: read("crates/perl-lsp-rs/tests/lsp_streaming_completion_tests.rs")?,
+        memory_status: read("docs/project/status/memory_plateau.md")?,
+        receipt_registry: read(".ci/receipts/registry.toml")?,
+        memory_receipt_schema: read(".ci/receipts/schemas/memory-plateau.schema.json")?,
+    };
+
+    let violations = memory_lifecycle_violations(&inputs);
+    if violations.is_empty() {
+        println!("Memory lifecycle policy check passed");
+        return Ok(());
+    }
+
+    for violation in violations {
+        eprintln!("::error::{violation}");
+    }
+
+    bail!("memory lifecycle policy check failed");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,5 +321,95 @@ mod tests {
             "src/lib.rs:10:    let status = std::process::ExitStatus::from_raw(raw_exit(signal));";
 
         assert!(!is_disallowed_from_raw_line(line, &disallow_re, &allowed_re));
+    }
+
+    #[test]
+    fn memory_lifecycle_policy_accepts_current_shape() {
+        let inputs = MemoryLifecycleInputs {
+            text_sync: r#"
+                fn handle_did_change_with_cancellation(&self) {
+                    for key in self.uri_key_variants(uri) {
+                        self.stream_sessions().cancel_for_uri_version(&key, version);
+                    }
+                }
+                fn handle_did_close(&self) {
+                    self.evict_open_document_session_state(uri);
+                }
+            "#
+            .to_string(),
+            workspace: r#"
+                match change_type {
+                    FileChangeType::DELETED => self.evict_deleted_file_state(&uri),
+                    _ => {}
+                }
+                self.evict_deleted_file_state(uri);
+            "#
+            .to_string(),
+            runtime_mod: r#"
+                pub struct MemoryStateSnapshot {
+                    pub stream_sessions: usize,
+                    pub pending_index_tasks: usize,
+                    pub parse_cancel_flags: usize,
+                }
+            "#
+            .to_string(),
+            streaming_tests: "fn completion_stream_cancel_storm_keeps_one_live_session() {}"
+                .to_string(),
+            memory_status: r#"
+                Close-only churn may retain workspace-index entries.
+                Close+delete churn must remove file-backed workspace-index entries.
+                The plateau gate tracks tail growth and median tail slope.
+            "#
+            .to_string(),
+            receipt_registry: r#"
+                check = "memory-plateau"
+                schema = ".ci/receipts/schemas/memory-plateau.schema.json"
+            "#
+            .to_string(),
+            memory_receipt_schema: r#"
+                {
+                  "required": [
+                    "check",
+                    "scenario",
+                    "files",
+                    "changes_per_file",
+                    "tail_growth_kb",
+                    "median_tail_slope_kb_per_file",
+                    "passed"
+                  ],
+                  "properties": {
+                    "check": { "const": "memory-plateau" }
+                  }
+                }
+            "#
+            .to_string(),
+        };
+
+        assert!(memory_lifecycle_violations(&inputs).is_empty());
+    }
+
+    #[test]
+    fn memory_lifecycle_policy_flags_close_delete_conflation() {
+        let inputs = MemoryLifecycleInputs {
+            text_sync: r#"
+                fn handle_did_change_with_cancellation(&self) {
+                    self.stream_sessions().cancel_for_uri(uri);
+                }
+                fn handle_did_close(&self) {
+                    self.evict_deleted_file_state(uri);
+                }
+            "#
+            .to_string(),
+            workspace: String::new(),
+            runtime_mod: String::new(),
+            streaming_tests: String::new(),
+            memory_status: String::new(),
+            receipt_registry: String::new(),
+            memory_receipt_schema: String::new(),
+        };
+
+        let violations = memory_lifecycle_violations(&inputs);
+        assert!(violations.iter().any(|v| v.contains("didClose must not call")));
+        assert!(violations.iter().any(|v| v.contains("raw URI")));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `cargo xtask check-memory-lifecycle-policy` as a static tripwire for retained-state lifecycle invariants.
- Checks close/delete cleanup separation, URI-variant stream-session cancellation, memory snapshot counters, cancel-storm coverage, and memory plateau receipt wiring.
- Wires the policy into `just ci-policy` and the merge-blocking `policy_checks` gate.

## Validation

- `cargo xtask fmt`
- `cargo xtask check-memory-lifecycle-policy`
- `cargo test -p xtask ci_policy -- --nocapture`
- `git diff --check`
- `cargo xtask gate-policy check`
- `just ci-policy`
- `cargo xtask gates --gate policy_checks --receipt --receipt-path target/receipts/policy_checks-memory-policy.json`
