### PR TITLE
chore(release): prepare 0.13.4 public alpha (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.4] - 2026-05-07
+
+Release notes: [v0.13.4](docs/releases/v0.13.4.md)
+
+### Fixed
+
+- **Known session-creep leaks across LSP caches** — Hover, text-sync,
+  workspace, stream-session, and workspace-index caches were retaining
+  per-session state past document close/delete lifecycle paths. Eviction is
+  now wired through, and retained-state regression tests lock the behavior.
+  (#8064)
+- **Stream sessions cancel across URI variants** — Stale inline-completion
+  stream sessions on `didChange` are cancelled even when the client mixes
+  canonical `file://` and `file://localhost` spellings for the same
+  document. Regression covers both spellings.
+- **Regex embedded code annotated, not rejected** — The parser now
+  annotates embedded code inside regex constructs instead of failing the
+  parse. (#8056)
+- **Status pipeline regeneration** — Parser-accuracy artifact is now
+  bootstrapped before regeneration (#8069) and quality counts are parsed
+  from external target dirs (#8068), so `docs/project/status/*.md`
+  reflects reality after out-of-tree CI runs.
+- **Stricter VS Code extension lint** — Cleared lint failures from the
+  upgraded TypeScript and `@types/vscode` toolchain. (#8065)
+
+### Added
+
+- **Class::Tiny and Class::Tiny::RW OO framework support** — Full
+  semantic analysis for the Class::Tiny family across both the
+  `ClassModelBuilder` and `SymbolExtractor` pipelines. `use Class::Tiny
+  qw(name email)` and bare `has 'name';` declarations now produce
+  accessor symbols so go-to-definition, hover, and workspace symbol
+  search work for Class::Tiny accessors. (#8062)
+- **LSP churn plateau guardrails** — New `memory_plateau.json` receipt,
+  nightly + PR CI gates, `scripts/repro_lsp_storm.py` reproducer, and
+  `scripts/assert_rss_plateau.py` plateau assertion. Documented in
+  `docs/large-workspaces/LSP_CHURN_REPRO.md` and a new
+  `RETAINED_STATE_INVENTORY.md` cataloguing every retained cache, its
+  owner, and its eviction rule. Runtime pressure counters expose async
+  task/debounce/session pressure, and diagnostics churn now has direct
+  retained-state coverage. (#8072, #8076, #8088, #8115)
+- **Governed clippy lint policy gate** — New CI gate enforcing the
+  `policy/clippy-lints.toml` allowlist. (#8066)
+- **Parser coverage risk map and baseline.** (#8005)
+
+### Changed
+
+- **MSRV bumped to Rust 1.93.1** — Toolchain pins, CI matrix, clippy
+  policy, `clippy.toml`, and `rust-toolchain.toml` aligned. (#7832)
+- **Decoupled `perl-semantic-analyzer` from `perl-workspace`** —
+  Removed direct coupling; analyzer no longer reaches into workspace
+  internals. (#7962)
+- **Internal refactor wave (non-user-visible)** — Hover receiver
+  package resolver extracted (#8045); execute-command test-runner
+  fallback split into helpers (#8046); completion provider
+  construction helpers extracted (#8044); call-hierarchy subroutine
+  item builder extracted (#8043); refactor-plan contract skeleton
+  added to `perl-refactoring` (#7983).
+- **Centralized VS Marketplace install badge count.** (#8049)
+- **Dependency bumps** — `actions/upload-artifact` 4 → 7 (#7914),
+  `actions/checkout` 4 → 6 (#7915), `actions/cache` 4 → 5 (#7916),
+  `@types/vscode` (#7912), TypeScript group (#7911).
+- Prepared the `v0.13.4` public-alpha patch train with workspace, crate,
+  feature catalog, and VS Code extension version surfaces aligned.
+
 ## [0.13.3] - 2026-05-03
 
 Release notes: [v0.13.3](docs/releases/v0.13.3.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**Latest Release**: 0.13.3 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
+**Latest Release**: 0.13.4 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
 
 ## Orchestration Model
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1484,14 +1484,14 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "chrono",
  "clap",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "perl-corpus"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-uri",
  "perl-workspace",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-test-must",
  "serde",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lexer"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "criterion",
  "memchr",
@@ -1602,11 +1602,11 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.13.3"
+version = "0.13.4"
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-subprocess-runtime",
  "perl-tdd-support",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs-core"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ux-tests"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-parser-core",
  "perl-tdd-support",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-bench"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-parser",
  "walkdir",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -1800,11 +1800,11 @@ dependencies = [
 
 [[package]]
 name = "perl-pod"
-version = "0.13.3"
+version = "0.13.4"
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "criterion",
  "perl-ast",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "proptest",
  "thiserror",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-facts"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "proptest",
  "serde",
@@ -1873,14 +1873,14 @@ dependencies = [
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "lsp-types",
  "perl-parser-core",
@@ -1907,18 +1907,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.13.3"
+version = "0.13.4"
 
 [[package]]
 name = "perl-token"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "criterion",
  "perl-lexer",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "perllsp"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -3169,7 +3169,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl-c"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "cc",
  "insta",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-perl-rs"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "insta",
  "perl-ast",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 rust-version = "1.93"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -212,26 +212,26 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.13.3" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.13.4" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.13.3" }
-perl-regex = { path = "crates/perl-regex", version = "0.13.3" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.13.3" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.13.3" }
-perl-ast = { path = "crates/perl-ast", version = "0.13.3" }
+perl-token = { path = "crates/perl-token", version = "0.13.4" }
+perl-regex = { path = "crates/perl-regex", version = "0.13.4" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.13.4" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.13.4" }
+perl-ast = { path = "crates/perl-ast", version = "0.13.4" }
 # Wave D absorbed (internal modules in perl-parser/src/):
 #   perl-heredoc-anti-patterns → perl-parser::heredoc_anti_patterns
 # Wave D absorbed (internal modules in perl-parser-core/src/syntax/):
 #   perl-quote, perl-heredoc, perl-error, perl-edit
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.13.3" }
-perl-symbol = { path = "crates/perl-symbol", version = "0.13.3" }
-perl-module = { path = 'crates/perl-module', version = "0.13.3" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.13.4" }
+perl-symbol = { path = "crates/perl-symbol", version = "0.13.4" }
+perl-module = { path = 'crates/perl-module', version = "0.13.4" }
 # Wave D absorbed: perl-qualified-name → perl-parser::qualified_name
-perl-line-index = { path = "crates/perl-line-index", version = "0.13.3" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.13.4" }
 # Wave D absorbed: perl-source-file → perl-parser::source_file
 # Wave D absorbed: perl-text-line → perl-parser-core::text_line
 # (perl-content-length-framing absorbed into perl-lsp-rs-core::transport::framing — Wave Final PR B)
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.13.3" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.13.4" }
 # (perl-lsp-document-highlight absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-document-links absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-performance absorbed into perl-lsp-rs-core::tooling::performance — Wave G3 step 5)
@@ -239,30 +239,30 @@ perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "
 # Wave D absorbed: perl-ast-utils → perl-parser::ast_utils
 # (perl-lsp-input-validation absorbed into perl-lsp-rs-core::runtime::input_validation — Wave G2)
 # (perl-lsp-text-utils absorbed into perl-lsp-rs-core::runtime::text_utils — Wave G2)
-perl-uri = { path = "crates/perl-uri", version = "0.13.3" }
+perl-uri = { path = "crates/perl-uri", version = "0.13.4" }
 # Wave D absorbed: perl-percentile → perl-parser::percentile
 # (perl-lsp-import-management absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-critic-parser absorbed into perl-lsp-rs-core::critic_parser — Wave G3 step 7)
 # (perl-lsp-protocol absorbed into perl-lsp-rs-core::protocol — Wave G3 step 2)
 # Wave D absorbed: perl-path-normalize → perl-parser-core::path_normalize
 # Wave D absorbed: perl-path-security → perl-parser-core::path_security
-perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.13.3" }
-perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.13.3" }
-perl-pod = { path = "crates/perl-pod", version = "0.13.3" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.13.3" }
-perl-dap = { path = "crates/perl-dap", version = "0.13.3" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.13.3" }
+perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.13.4" }
+perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.13.4" }
+perl-pod = { path = "crates/perl-pod", version = "0.13.4" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.13.4" }
+perl-dap = { path = "crates/perl-dap", version = "0.13.4" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.13.4" }
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.13.3" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.13.4" }
 # (perl-lsp-transport absorbed into perl-lsp-rs-core::transport — Wave G3 step 4)
 # (perl-lsp-tooling absorbed into perl-lsp-rs-core::tooling — Wave G3 step 6)
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.13.3" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.13.4" }
 # (perl-lsp-on-type-formatting absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting-types absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting absorbed into perl-lsp-rs-core::providers::formatting — Wave G1b)
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.13.3" }
-perl-test-must = { path = "crates/perl-test-must", version = "0.13.3" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.13.4" }
+perl-test-must = { path = "crates/perl-test-must", version = "0.13.4" }
 # (perl-lsp-diagnostics absorbed into perl-lsp-rs-core::providers::diagnostics — Wave G1b)
 # (perl-lsp-semantic-tokens absorbed into perl-lsp-rs-core::providers::semantic_tokens — Wave G1b)
 # (perl-lsp-inlay-hints absorbed into perl-lsp-rs-core::providers — Wave G1a)
@@ -286,28 +286,28 @@ perl-test-must = { path = "crates/perl-test-must", version = "0.13.3" }
 # (perl-lsp-code-actions absorbed into perl-lsp-rs-core::providers::code_actions — Wave G1b)
 # (perl-lsp-folding absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-selection-range absorbed into perl-lsp-rs-core::providers — Wave G1a)
-perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.13.3" }
+perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.13.4" }
 # Tier 3: Two-level dependencies
-perl-workspace = { path = "crates/perl-workspace", version = "0.13.3" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.13.3" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.13.3" }
+perl-workspace = { path = "crates/perl-workspace", version = "0.13.4" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.13.4" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.13.4" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.13.3" }
-perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.13.3" }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.13.4" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.13.4" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.13.3" }
-perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.13.3" }
-perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.13.3" }
+perl-parser = { path = "crates/perl-parser", version = "0.13.4" }
+perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.13.4" }
+perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.13.4" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.13.3" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.13.4" }
 
 # External dependencies
-tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.13.3" }
-tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.13.3" }
+tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.13.4" }
+tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.13.4" }
 tree-sitter = "0.26.8"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <p align="center">
   <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp"><img src="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="code coverage" /></a>
-  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.92-blue" alt="MSRV" /></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.93-blue" alt="MSRV" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
 </p>
 
@@ -40,7 +40,7 @@ These are behavioral and corpus-backed signals, not feature-inventory counts. Pr
 
 | Area | Current signal |
 |---|---:|
-| Release track | `v0.13.3` public-alpha patch |
+| Release track | `v0.13.4` public-alpha patch |
 | Published crate surface | 31 crates in `[workspace.metadata.publish.allow]` |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -14,6 +14,7 @@ Tag commit timestamps may differ from release dates.
 
 | Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
 |---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
+| [0.13.4] | `v0.13.4` | pending | pending | `pending` | [v0.13.3...v0.13.4] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | pending | pending | [v0.13.4][n-0.13.4] |
 | [0.13.3] | `v0.13.3` | [yes][gh-0.13.3] | 2026-05-03 | `06fc1443` | [v0.13.2...v0.13.3] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.3 (31 crates) | [perl-lsp-rs][vsce] | [v0.13.3][n-0.13.3] |
 | [0.13.2] | `v0.13.2` | [yes][gh-0.13.2] | 2026-05-02 | `0e9c5d78` | [v0.13.1...v0.13.2] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.2 (31 crates) | [perl-lsp-rs][vsce] | [v0.13.2][n-0.13.2] |
 | [0.13.1] | `v0.13.1` | [yes][gh-0.13.1] (prerelease) | 2026-05-01 | `6ef20484` | [v0.13.0...v0.13.1] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.1 (32 crates) | [perl-lsp-rs][vsce] | [v0.13.1][n-0.13.1] |
@@ -58,6 +59,7 @@ Tag commit timestamps may differ from release dates.
 ## Links
 
 <!-- Notes files -->
+[n-0.13.4]: docs/releases/v0.13.4.md
 [n-0.13.3]: docs/releases/v0.13.3.md
 [n-0.13.2]: docs/releases/v0.13.2.md
 [n-0.13.1]: docs/releases/v0.13.1.md
@@ -75,6 +77,7 @@ Tag commit timestamps may differ from release dates.
 [n-0.8.3]: docs/releases/v0.8.3.md
 
 <!-- Version links (to notes files) -->
+[0.13.4]: docs/releases/v0.13.4.md
 [0.13.3]: docs/releases/v0.13.3.md
 [0.13.2]: docs/releases/v0.13.2.md
 [0.13.1]: docs/releases/v0.13.1.md
@@ -92,6 +95,7 @@ Tag commit timestamps may differ from release dates.
 [0.8.3]: docs/releases/v0.8.3.md
 
 <!-- GitHub Releases -->
+[gh-0.13.4]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.4
 [gh-0.13.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.3
 [gh-0.13.2]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.2
 [gh-0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.1
@@ -105,6 +109,7 @@ Tag commit timestamps may differ from release dates.
 [gh-0.8.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3
 
 <!-- Compare ranges -->
+[v0.13.3...v0.13.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.3...v0.13.4
 [v0.13.2...v0.13.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.2...v0.13.3
 [v0.13.1...v0.13.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.1...v0.13.2
 [v0.13.0...v0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0...v0.13.1

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-module"
-version = "0.13.3"
+version = "0.13.4"
 publish = true
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -8,13 +8,13 @@
 
 ## Current Framing
 
-- Workspace version line: `v0.13.3`
-- Current release train: `v0.13.2` public-alpha patch prep, with release dispatch intentionally pending
+- Workspace version line: `v0.13.4`
+- Current release train: `v0.13.4` public-alpha patch prep, with release dispatch intentionally pending
 - Published crate surface target: 31 crates from `[workspace.metadata.publish.allow]`
 - Active work: finish release-prep verification, keep install-surface receipts wired into the runbook, and keep release language public-alpha rather than stable/GA
 - Canonical local receipt: `nix develop -c just ci-gate`
 
-Publication discipline: `v0.13.2` uses a normal SemVer package version for release channels while the human-facing product posture remains public alpha. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the cross-channel ledger, and do not dispatch the release until the prep checks pass.
+Publication discipline: `v0.13.4` uses a normal SemVer package version for release channels while the human-facing product posture remains public alpha. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the cross-channel ledger, and do not dispatch the release until the prep checks pass.
 
 ## How To Read This File
 

--- a/docs/releases/v0.13.4.md
+++ b/docs/releases/v0.13.4.md
@@ -1,0 +1,96 @@
+---
+version: "0.13.4"
+tag: "v0.13.4"
+release_date_utc: "2026-05-07"
+previous_tag: "v0.13.3"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.3...v0.13.4"
+notes_status: canonical
+release_track: public-alpha
+release_kind: patch
+channels:
+  crates_io: pending
+  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
+  open_vsx: pending
+  docker: pending
+---
+
+# v0.13.4
+
+## Summary
+
+Public-alpha patch release focused on long-session memory behavior. Several
+session-creep leaks across LSP caches are plugged, stale stream sessions are
+now cancelled across URI variants, and churn-plateau guardrails track RSS
+plateau behavior under sustained LSP workloads. Also adds Class::Tiny OO
+framework support, fixes a regex embedded-code parser regression, and bumps
+MSRV to Rust 1.93.1.
+
+## Highlights
+
+- **Plugged known session-creep leaks across LSP caches** — Hover,
+  text-sync, workspace, stream-session, and the workspace-index caches were
+  retaining per-session state that was not evicted on close/delete paths.
+  Eviction is now wired through these caches, with retained-state
+  regressions locking the behavior. (#8064)
+- **Stream sessions cancel across URI variants** — On `didChange`, stale
+  inline-completion stream sessions are cancelled even when the client
+  mixes canonical `file://` and `file://localhost` URI spellings for the
+  same document. Regression coverage locks the known URI-variant case.
+- **LSP churn plateau guardrails** — A new `memory_plateau.json` receipt
+  and CI gate (nightly + PR) check that RSS plateaus under sustained
+  didChange/completion churn, with a reproducer
+  (`scripts/repro_lsp_storm.py`) and plateau assertion
+  (`scripts/assert_rss_plateau.py`) checked into the repo. Documented in
+  `docs/large-workspaces/LSP_CHURN_REPRO.md` and a new
+  `RETAINED_STATE_INVENTORY.md` listing every retained cache, its owner,
+  and its eviction rule. Runtime pressure counters now expose async
+  surfaces such as pending index tasks, diagnostic debounce URIs,
+  file-watcher debounce URIs, refresh debounce activity, and active stream
+  sessions; diagnostics churn coverage adds the first follow-up subsystem
+  guard. (#8072, #8076, #8088, #8115)
+- **Class::Tiny / Class::Tiny::RW OO framework support** — Full semantic
+  analysis for the Class::Tiny family across both `ClassModelBuilder`
+  and `SymbolExtractor` pipelines: `use Class::Tiny qw(name email)` and
+  bare `has 'name';` declarations now produce accessor symbols, so
+  go-to-definition, hover, and workspace symbol search work for
+  Class::Tiny accessors. (#8062)
+- **Regex embedded code is annotated, not rejected** — The parser now
+  annotates embedded code inside regex constructs instead of failing the
+  parse, recovering coverage on regex-heavy modules. (#8056)
+- **MSRV bumped to Rust 1.93.1** — Toolchain pins, primary CI lanes,
+  clippy policy, and `rust-toolchain.toml` aligned. (#7832)
+- **Status pipeline fixes** — Parser-accuracy artifact bootstrap (#8069)
+  and quality-count parsing from external target dirs (#8068) so
+  regenerated `docs/project/status/*.md` files reflect reality after
+  out-of-tree CI runs.
+
+## Install / upgrade
+
+- **VS Code**: install or update the
+  [Perl Language Server](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+  extension. The managed `perllsp` binary is part of the public-alpha line.
+- **Homebrew tap**: install with `brew install effortlessmetrics/tap/perllsp`.
+  This uses the owned EffortlessMetrics tap, not Homebrew/core.
+- **Source/Binary**: download release assets or use `cargo install perllsp`
+  for the published public-alpha line.
+
+## Which file should I download?
+
+Most Linux users should choose `gnu`. Use `musl` mainly for Alpine Linux or
+musl-based containers. You do not need both GNU and musl archives.
+
+| Your system | Download suffix |
+|---|---|
+| Linux x64 / AMD64, most distributions | `x86_64-unknown-linux-gnu` |
+| Linux ARM64, most distributions | `aarch64-unknown-linux-gnu` |
+| Linux x64 / AMD64, Alpine or musl containers | `x86_64-unknown-linux-musl` |
+| Linux ARM64, Alpine or musl containers | `aarch64-unknown-linux-musl` |
+| macOS Intel | `x86_64-apple-darwin` |
+| macOS Apple Silicon | `aarch64-apple-darwin` |
+| Windows x64 | `x86_64-pc-windows-msvc` |
+
+## Links
+
+- [Compare v0.13.3...v0.13.4](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.3...v0.13.4)
+- [CHANGELOG](../../CHANGELOG.md)
+- [Release ledger](../../RELEASE_HISTORY.md)

--- a/features.toml
+++ b/features.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.13.3"
+version = "0.13.4"
 lsp_version = "3.18"
 compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 118/119 advertised
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.17",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
## Summary

Public-alpha patch release. The headline is long-session memory behavior: known retained-state/session-creep paths across LSP caches are plugged, stream sessions cancel across URI variants, runtime pressure counters are available, and churn plateau guardrails track RSS plateau behavior on long-running sessions. Also adds Class::Tiny OO framework support, fixes a regex embedded-code parser regression, and bumps MSRV to Rust 1.93.1.

## What's in this PR

Mechanical release-prep only. Every product/runtime change in the release was already merged to master before this branch; this PR prepares the 0.13.4 release surfaces:

- Bumps workspace, crate, feature catalog, VS Code extension, and doc release-track surfaces to **0.13.4** via `cargo xtask bump-version 0.13.4`.
- Adds `docs/releases/v0.13.4.md` as the canonical release notes.
- Prepends a `[0.13.4] - 2026-05-07` block to `CHANGELOG.md`.
- Updates README, roadmap, and release-history surfaces while keeping publication channels marked pending until tag/publish.

## Highlights

- Known retained-state/session-creep paths plugged across LSP caches and lifecycle cleanup. (#8064)
- LSP churn plateau guardrails, memory receipts, retained-state inventory, runtime pressure counters, and diagnostics churn coverage. (#8072, #8076, #8088, #8115)
- Class::Tiny / Class::Tiny::RW OO framework support. (#8062)
- Regex embedded code annotated instead of rejected. (#8056)
- MSRV bumped to Rust 1.93.1. (#7832)

## Verification

- [x] `cargo xtask fmt`
- [x] `cargo xtask check-version-sync` — 42 hard sites agree on 0.13.4
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `git diff --check`
- [ ] CI Gate green
- [ ] PR Smoke green
- [ ] Version sync drift gate green
- [ ] Spot-check release notes render correctly on GitHub once tagged
