### PR TITLE
feat(memory): expose runtime pressure snapshot (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/diagnostic_debounce.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostic_debounce.rs
@@ -4,6 +4,8 @@
 //! after a configurable quiet period (default 250ms).
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -16,6 +18,8 @@ enum DebounceMsg {
 
 pub(crate) struct DiagnosticDebouncer {
     tx: std::sync::mpsc::Sender<DebounceMsg>,
+    #[allow(dead_code)] // Read by test/debug runtime pressure snapshots.
+    pending_count: Arc<AtomicUsize>,
 }
 
 impl DiagnosticDebouncer {
@@ -31,19 +35,26 @@ impl DiagnosticDebouncer {
         F: Fn(&str) + Send + 'static,
     {
         let (tx, rx) = std::sync::mpsc::channel();
+        let pending_count = Arc::new(AtomicUsize::new(0));
+        let worker_pending_count = Arc::clone(&pending_count);
         if let Err(e) = thread::Builder::new()
             .name("diag-debounce".into())
-            .spawn(move || worker_loop(rx, interval, publish_fn))
+            .spawn(move || worker_loop(rx, interval, publish_fn, worker_pending_count))
         {
             tracing::error!(error = %e, "diagnostic debounce thread spawn failed");
         }
-        Self { tx }
+        Self { tx, pending_count }
     }
 
     pub(crate) fn schedule(&self, uri: &str) {
         if let Err(e) = self.tx.send(DebounceMsg::Schedule(uri.to_string())) {
             tracing::debug!(error = %e, "diagnostic debounce: channel closed on schedule");
         }
+    }
+
+    #[allow(dead_code)] // Read by test/debug runtime pressure snapshots.
+    pub(crate) fn pending_uris(&self) -> usize {
+        self.pending_count.load(Ordering::SeqCst)
     }
 }
 
@@ -55,8 +66,12 @@ impl Drop for DiagnosticDebouncer {
     }
 }
 
-fn worker_loop<F>(rx: std::sync::mpsc::Receiver<DebounceMsg>, interval: Duration, publish_fn: F)
-where
+fn worker_loop<F>(
+    rx: std::sync::mpsc::Receiver<DebounceMsg>,
+    interval: Duration,
+    publish_fn: F,
+    pending_count: Arc<AtomicUsize>,
+) where
     F: Fn(&str) + Send + 'static,
 {
     let mut pending: HashMap<String, Instant> = HashMap::new();
@@ -64,7 +79,7 @@ where
         let timeout = earliest_timeout(&pending);
         let msg = match timeout {
             Some(dur) if dur.is_zero() => {
-                fire_expired(&mut pending, &publish_fn);
+                fire_expired(&mut pending, &publish_fn, &pending_count);
                 match rx.try_recv() {
                     Ok(m) => Some(m),
                     Err(std::sync::mpsc::TryRecvError::Empty) => continue,
@@ -74,7 +89,7 @@ where
             Some(dur) => match rx.recv_timeout(dur) {
                 Ok(m) => Some(m),
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                    fire_expired(&mut pending, &publish_fn);
+                    fire_expired(&mut pending, &publish_fn, &pending_count);
                     continue;
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
@@ -87,11 +102,13 @@ where
         match msg {
             Some(DebounceMsg::Schedule(uri)) => {
                 pending.insert(uri, Instant::now() + interval);
+                pending_count.store(pending.len(), Ordering::SeqCst);
             }
             Some(DebounceMsg::Shutdown) => {
                 for (uri, _) in pending.drain() {
                     publish_fn(&uri);
                 }
+                pending_count.store(0, Ordering::SeqCst);
                 break;
             }
             None => {}
@@ -108,8 +125,11 @@ fn earliest_timeout(pending: &HashMap<String, Instant>) -> Option<Duration> {
     Some(earliest.saturating_duration_since(now))
 }
 
-fn fire_expired<F>(pending: &mut HashMap<String, Instant>, publish_fn: &F)
-where
+fn fire_expired<F>(
+    pending: &mut HashMap<String, Instant>,
+    publish_fn: &F,
+    pending_count: &AtomicUsize,
+) where
     F: Fn(&str),
 {
     let now = Instant::now();
@@ -120,6 +140,7 @@ where
         .collect();
     for uri in expired {
         pending.remove(&uri);
+        pending_count.store(pending.len(), Ordering::SeqCst);
         publish_fn(&uri);
     }
 }
@@ -163,6 +184,23 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 0);
         thread::sleep(Duration::from_millis(80));
         assert_eq!(count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn debouncer_reports_pending_uri_pressure() {
+        let debouncer = DiagnosticDebouncer::with_interval(Duration::from_millis(80), move |_| {});
+
+        debouncer.schedule("file:///pending.pl");
+        for _ in 0..20 {
+            if debouncer.pending_uris() == 1 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(debouncer.pending_uris(), 1);
+
+        thread::sleep(Duration::from_millis(150));
+        assert_eq!(debouncer.pending_uris(), 0);
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/file_watcher_debounce.rs
+++ b/crates/perl-lsp-rs/src/runtime/file_watcher_debounce.rs
@@ -13,6 +13,8 @@
 //! a window are deduplicated (last-write wins on the deadline).
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -29,6 +31,7 @@ enum WatcherMsg {
 /// and delivers them as a single batch to the callback after a quiet period.
 pub struct FileWatcherDebouncer {
     tx: std::sync::mpsc::Sender<WatcherMsg>,
+    pending_count: Arc<AtomicUsize>,
 }
 
 impl FileWatcherDebouncer {
@@ -46,13 +49,15 @@ impl FileWatcherDebouncer {
         F: Fn(Vec<String>) + Send + 'static,
     {
         let (tx, rx) = std::sync::mpsc::channel();
+        let pending_count = Arc::new(AtomicUsize::new(0));
+        let worker_pending_count = Arc::clone(&pending_count);
         if let Err(e) = thread::Builder::new()
             .name("file-watcher-debounce".into())
-            .spawn(move || worker_loop(rx, interval, publish_fn))
+            .spawn(move || worker_loop(rx, interval, publish_fn, worker_pending_count))
         {
             tracing::error!(error = %e, "file watcher debounce thread spawn failed");
         }
-        Self { tx }
+        Self { tx, pending_count }
     }
 
     /// Schedule a URI for debounced batch delivery.
@@ -62,6 +67,11 @@ impl FileWatcherDebouncer {
         if let Err(e) = self.tx.send(WatcherMsg::Schedule(uri.to_string())) {
             tracing::debug!(error = %e, "file watcher debounce: channel closed on schedule");
         }
+    }
+
+    /// Number of unique URIs currently waiting in the debounce window.
+    pub fn pending_uris(&self) -> usize {
+        self.pending_count.load(Ordering::SeqCst)
     }
 }
 
@@ -73,8 +83,12 @@ impl Drop for FileWatcherDebouncer {
     }
 }
 
-fn worker_loop<F>(rx: std::sync::mpsc::Receiver<WatcherMsg>, interval: Duration, publish_fn: F)
-where
+fn worker_loop<F>(
+    rx: std::sync::mpsc::Receiver<WatcherMsg>,
+    interval: Duration,
+    publish_fn: F,
+    pending_count: Arc<AtomicUsize>,
+) where
     F: Fn(Vec<String>) + Send + 'static,
 {
     // pending maps uri -> deadline (last scheduled deadline wins)
@@ -83,7 +97,7 @@ where
         let timeout = earliest_timeout(&pending);
         let msg = match timeout {
             Some(dur) if dur.is_zero() => {
-                fire_expired(&mut pending, &publish_fn);
+                fire_expired(&mut pending, &publish_fn, &pending_count);
                 match rx.try_recv() {
                     Ok(m) => Some(m),
                     Err(std::sync::mpsc::TryRecvError::Empty) => continue,
@@ -93,7 +107,7 @@ where
             Some(dur) => match rx.recv_timeout(dur) {
                 Ok(m) => Some(m),
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                    fire_expired(&mut pending, &publish_fn);
+                    fire_expired(&mut pending, &publish_fn, &pending_count);
                     continue;
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
@@ -107,6 +121,7 @@ where
             Some(WatcherMsg::Schedule(uri)) => {
                 // Reset deadline on repeated schedules (last one wins)
                 pending.insert(uri, Instant::now() + interval);
+                pending_count.store(pending.len(), Ordering::SeqCst);
             }
             Some(WatcherMsg::Shutdown) => {
                 // Flush all pending URIs before exiting
@@ -114,6 +129,8 @@ where
                 if !uris.is_empty() {
                     publish_fn(uris);
                 }
+                pending.clear();
+                pending_count.store(0, Ordering::SeqCst);
                 break;
             }
             None => {}
@@ -130,8 +147,11 @@ fn earliest_timeout(pending: &HashMap<String, Instant>) -> Option<Duration> {
     Some(earliest.saturating_duration_since(now))
 }
 
-fn fire_expired<F>(pending: &mut HashMap<String, Instant>, publish_fn: &F)
-where
+fn fire_expired<F>(
+    pending: &mut HashMap<String, Instant>,
+    publish_fn: &F,
+    pending_count: &AtomicUsize,
+) where
     F: Fn(Vec<String>),
 {
     let now = Instant::now();
@@ -144,6 +164,7 @@ where
         for uri in &expired {
             pending.remove(uri);
         }
+        pending_count.store(pending.len(), Ordering::SeqCst);
         publish_fn(expired);
     }
 }
@@ -194,6 +215,24 @@ mod tests {
         // Should coalesce into a single batch call with 1 URI
         assert_eq!(call_count.load(Ordering::SeqCst), 1);
         assert_eq!(uri_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn file_watcher_debouncer_reports_pending_uri_pressure() {
+        let debouncer =
+            FileWatcherDebouncer::with_interval(Duration::from_millis(80), move |_uris| {});
+
+        debouncer.schedule("file:///pending.pl");
+        for _ in 0..20 {
+            if debouncer.pending_uris() == 1 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(debouncer.pending_uris(), 1);
+
+        thread::sleep(Duration::from_millis(150));
+        assert_eq!(debouncer.pending_uris(), 0);
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -319,6 +319,24 @@ pub struct MemoryStateSnapshot {
     pub pod_cache_entries: usize,
 }
 
+#[cfg(any(test, feature = "expose_lsp_test_api"))]
+/// Point-in-time counts for async runtime pressure gauges.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimePressureSnapshot {
+    /// Number of background index tasks currently in flight.
+    pub pending_index_tasks: usize,
+    /// Number of unique file-watcher URIs waiting in the debounce window.
+    pub file_watcher_pending_uris: usize,
+    /// Number of unique diagnostic URIs waiting in the debounce window.
+    pub diagnostic_debounce_pending_uris: usize,
+    /// Number of workspace/configuration requests waiting for client replies.
+    pub pending_workspace_configuration_requests: usize,
+    /// Number of refresh timers currently inside their debounce window.
+    pub refresh_debounce_active: usize,
+    /// Number of active inline-completion stream sessions.
+    pub active_stream_sessions: usize,
+}
+
 // SAFETY: LspServer is not auto-Send/Sync because DocumentState contains
 // ParentMap which has `*const Node` raw pointers. However, these pointers
 // are only accessed through the `documents: Arc<Mutex<...>>` field, which
@@ -607,6 +625,33 @@ impl LspServer {
             stream_sessions: self.stream_sessions().len(),
             pending_index_tasks: self.pending_index_task_count.load(Ordering::SeqCst),
             pod_cache_entries: self.pod_cache.lock().len(),
+        }
+    }
+
+    /// Capture test/debug counters for async task and debounce pressure.
+    #[cfg(any(test, feature = "expose_lsp_test_api"))]
+    pub fn runtime_pressure_snapshot(&self) -> RuntimePressureSnapshot {
+        let diagnostic_debounce_pending_uris = self
+            .diagnostic_debouncer
+            .lock()
+            .as_ref()
+            .map_or(0, diagnostic_debounce::DiagnosticDebouncer::pending_uris);
+        let file_watcher_pending_uris = self
+            .file_watcher_debouncer
+            .lock()
+            .as_ref()
+            .map_or(0, file_watcher_debounce::FileWatcherDebouncer::pending_uris);
+
+        RuntimePressureSnapshot {
+            pending_index_tasks: self.pending_index_task_count.load(Ordering::SeqCst),
+            file_watcher_pending_uris,
+            diagnostic_debounce_pending_uris,
+            pending_workspace_configuration_requests: self
+                .pending_workspace_configuration_requests
+                .lock()
+                .len(),
+            refresh_debounce_active: self.refresh_controller.debounce_active_count(),
+            active_stream_sessions: self.stream_sessions().len(),
         }
     }
 
@@ -1025,6 +1070,64 @@ mod tests {
             &folder,
             "vscode-remote://ssh-remote+dev/workspace-other/lib/Foo.pm"
         ));
+    }
+
+    #[test]
+    fn runtime_pressure_snapshot_reports_async_queues() {
+        use std::time::{Duration, Instant};
+
+        let server = LspServer::new();
+        let uri = "file:///runtime-pressure.pl";
+
+        server.install_diagnostic_debouncer(
+            diagnostic_debounce::DiagnosticDebouncer::with_interval(
+                Duration::from_secs(60),
+                |_| {},
+            ),
+        );
+        server.install_file_watcher_debouncer(
+            file_watcher_debounce::FileWatcherDebouncer::with_interval(
+                Duration::from_secs(60),
+                |_| {},
+            ),
+        );
+
+        server.publish_diagnostics_debounced(uri);
+        assert!(server.schedule_file_watcher_uri(uri));
+        server.stream_sessions().start_session(stream_session::SessionKey {
+            uri: uri.to_string(),
+            document_version: 1,
+            line: 0,
+            character: 0,
+        });
+        server.pending_workspace_configuration_requests.lock().insert(
+            1,
+            PendingWorkspaceConfigurationRequest {
+                folder_uris: vec!["file:///".to_string()],
+                includes_global_item: true,
+                created_at: Instant::now(),
+            },
+        );
+
+        let snapshot = (0..50)
+            .find_map(|_| {
+                let snapshot = server.runtime_pressure_snapshot();
+                if snapshot.diagnostic_debounce_pending_uris == 1
+                    && snapshot.file_watcher_pending_uris == 1
+                {
+                    Some(snapshot)
+                } else {
+                    std::thread::sleep(Duration::from_millis(10));
+                    None
+                }
+            })
+            .expect("debouncer workers should report pending URI pressure");
+
+        assert_eq!(snapshot.pending_index_tasks, 0);
+        assert_eq!(snapshot.diagnostic_debounce_pending_uris, 1);
+        assert_eq!(snapshot.file_watcher_pending_uris, 1);
+        assert_eq!(snapshot.pending_workspace_configuration_requests, 1);
+        assert_eq!(snapshot.active_stream_sessions, 1);
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/refresh.rs
+++ b/crates/perl-lsp-rs/src/runtime/refresh.rs
@@ -48,6 +48,11 @@ impl RefreshTimer {
     fn mark_refreshed(&mut self) {
         self.last_refresh = Some(Instant::now());
     }
+
+    #[allow(dead_code)] // Read by test/debug runtime pressure snapshots.
+    fn debounce_active(&self, debounce_duration: Duration) -> bool {
+        self.last_refresh.is_some_and(|last| last.elapsed() < debounce_duration)
+    }
 }
 
 /// Controller for debounced server→client refresh requests
@@ -268,6 +273,23 @@ impl RefreshController {
         // Trigger all refreshes
         self.refresh_all(server)
     }
+
+    /// Number of refresh timers currently inside the debounce window.
+    #[cfg(any(test, feature = "expose_lsp_test_api"))]
+    pub(crate) fn debounce_active_count(&self) -> usize {
+        let mut count = 0usize;
+        for active in [
+            self.code_lens_timer.lock().debounce_active(self.debounce_duration),
+            self.semantic_tokens_timer.lock().debounce_active(self.debounce_duration),
+            self.inlay_hint_timer.lock().debounce_active(self.debounce_duration),
+            self.inline_value_timer.lock().debounce_active(self.debounce_duration),
+            self.diagnostic_timer.lock().debounce_active(self.debounce_duration),
+            self.folding_range_timer.lock().debounce_active(self.debounce_duration),
+        ] {
+            count += usize::from(active);
+        }
+        count
+    }
 }
 
 impl Default for RefreshController {
@@ -297,6 +319,18 @@ mod tests {
         // Wait for debounce window
         std::thread::sleep(Duration::from_millis(50));
         assert!(timer.should_refresh(Duration::from_millis(25)));
+    }
+
+    #[test]
+    fn timer_reports_active_debounce_window() {
+        let mut timer = RefreshTimer::new();
+        assert!(!timer.debounce_active(Duration::from_secs(1)));
+
+        timer.mark_refreshed();
+        assert!(timer.debounce_active(Duration::from_secs(1)));
+
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(!timer.debounce_active(Duration::from_millis(25)));
     }
 
     #[test]

--- a/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
+++ b/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
@@ -51,8 +51,8 @@ before committing derived state.
 | `LspServer` | Pending workspace configuration requests | JSON-RPC request id `i64` | Request parameters and response bookkeeping | Capped to 10; response removes id; configuration and folder changes clear pending entries | workspace configuration lifecycle tests |
 | `LspServer` | Progress cancellation maps | Progress token and request id | Cancellation token bookkeeping | Progress cancel removes token and request mapping | progress cancellation tests |
 | `CancellationRegistry` | Request cancellation tokens, cleanup contexts, token cache | Request id string | Request-scoped cancellation state and cleanup closures | Dispatch finalization and `RequestCleanupGuard` remove request state | cancellation registry cleanup tests |
-| `DiagnosticDebouncer` | Pending diagnostic publish queue | URI `String` | Deferred URI set in worker thread | Expiration removes entries; `Drop` flushes pending entries on shutdown | diagnostic debouncer tests; future runtime pressure counters |
-| `FileWatcherDebouncer` | Pending file-watcher URI queue | URI `String` | Deferred URI set during bulk filesystem operations | Expiration removes entries; `Drop` flushes pending entries on shutdown | file watcher debouncer tests; future watcher churn scenario |
+| `DiagnosticDebouncer` | Pending diagnostic publish queue | URI `String` | Deferred URI set in worker thread | Expiration removes entries; `Drop` flushes pending entries on shutdown | diagnostic debouncer tests; `RuntimePressureSnapshot.diagnostic_debounce_pending_uris` |
+| `FileWatcherDebouncer` | Pending file-watcher URI queue | URI `String` | Deferred URI set during bulk filesystem operations | Expiration removes entries; `Drop` flushes pending entries on shutdown | file watcher debouncer tests; `RuntimePressureSnapshot.file_watcher_pending_uris`; future watcher churn scenario |
 | Read scheduler | Queued read requests and latest-sequence map | Request dedup key | Queued request payloads and cancellation tokens | Stale reads are cancelled before worker dispatch; queue drains on channel close | scheduler classification tests; add direct retained-state regression if pressure grows |
 | DAP bridge | Debug child process and session state | Debug session/process id | Child process handles, reader tasks, debugger session state | Stop, disconnect, and shutdown paths must terminate or detach process state | DAP lifecycle tests; future `dap_bridge_start_stop_loop` scenario |
 | Formatting and external tools | Perltidy/perlcritic subprocess buffers | Request scope and file path | Subprocess output buffers and temp data | Request-scoped by subprocess runtime; no session bag should retain output after completion | formatting/diagnostics tests; future subprocess churn scenario |
@@ -81,7 +81,7 @@ hard to interpret; focused scenarios make the owner obvious.
 | `workspace_index_reindex_same_files` | Secondary-index duplication and remove/reindex cycles | Unit regression coverage |
 | `diagnostics_pull_push_churn` | Pull diagnostics, result ids, critic analyzer cache | Follow-up scenario |
 | `hover_pod_many_modules` | POD cache cap and path eviction | Follow-up scenario |
-| `completion_stream_cancel_storm` | Stream-session cancellation and removal | Follow-up scenario |
+| `completion_stream_cancel_storm` | Stream-session cancellation and removal | Unit regression coverage |
 | `file_watcher_bulk_create_change_delete` | Watcher debouncer and delete lifecycle | Follow-up scenario |
 | `workspace_folder_add_remove_multi_root` | Folder-scoped cleanup without cross-root eviction | Unit coverage, add process scenario if needed |
 | `dap_bridge_start_stop_loop` | Debug process/session lifecycle | Follow-up scenario |

--- a/xtask/src/tasks/ci_policy.rs
+++ b/xtask/src/tasks/ci_policy.rs
@@ -234,6 +234,17 @@ fn memory_lifecycle_violations(inputs: &MemoryLifecycleInputs) -> Vec<String> {
             violations.push(format!("MemoryStateSnapshot must retain {field} counter"));
         }
     }
+    for field in [
+        "file_watcher_pending_uris",
+        "diagnostic_debounce_pending_uris",
+        "pending_workspace_configuration_requests",
+        "refresh_debounce_active",
+        "active_stream_sessions",
+    ] {
+        if !inputs.runtime_mod.contains(&format!("pub {field}: usize")) {
+            violations.push(format!("RuntimePressureSnapshot must retain {field} counter"));
+        }
+    }
 
     if !inputs.streaming_tests.contains("completion_stream_cancel_storm_keeps_one_live_session") {
         violations.push(
@@ -388,6 +399,13 @@ mod tests {
                     pub stream_sessions: usize,
                     pub pending_index_tasks: usize,
                     pub parse_cancel_flags: usize,
+                }
+                pub struct RuntimePressureSnapshot {
+                    pub file_watcher_pending_uris: usize,
+                    pub diagnostic_debounce_pending_uris: usize,
+                    pub pending_workspace_configuration_requests: usize,
+                    pub refresh_debounce_active: usize,
+                    pub active_stream_sessions: usize,
                 }
             "#
             .to_string(),


### PR DESCRIPTION
## Summary

- Adds test/debug runtime pressure counters for async memory surfaces: pending index tasks, diagnostic debounce URIs, file-watcher debounce URIs, pending workspace configuration requests, refresh debounce activity, and active stream sessions.
- Instruments the diagnostic and file-watcher debouncers with atomic pending-URI gauges without changing debounce semantics.
- Extends the memory lifecycle policy guard and retained-state inventory so these counters stay part of the memory-control surface.

## Validation

- `cargo xtask fmt`
- `cargo xtask check-memory-lifecycle-policy`
- `cargo test -p xtask ci_policy -- --nocapture`
- `cargo test -p perl-lsp-rs diagnostic_debounce --lib -- --nocapture`
- `cargo test -p perl-lsp-rs file_watcher_debounce --lib -- --nocapture`
- `cargo test -p perl-lsp-rs runtime_pressure_snapshot_reports_async_queues --lib -- --nocapture`
- `cargo test -p perl-lsp-rs timer_reports_active_debounce_window --lib -- --nocapture`
- `git diff --check`
- `cargo xtask gate-policy check`
