### PR TITLE
fix(parser): pos lvalue assignment and undef placeholder in nested my() lists (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -267,6 +267,9 @@ impl<'a> Parser<'a> {
                     | "chroot"
                     | "utime"
                     | "umask"
+                    // `pos` is an lvalue-capable optional-arg builtin; `pos $s = value`
+                    // must not be treated as an indirect method call.
+                    | "pos"
             )
         {
             if let Ok(next) = self.tokens.peek_second() {
@@ -510,7 +513,19 @@ impl<'a> Parser<'a> {
             let mut variables = Vec::new();
 
             while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
-                let var = self.parse_variable()?;
+                // `undef` is valid as a throw-away placeholder in list
+                // destructuring: my ($a, undef, $b) = func();
+                // This also covers the nested form:
+                //   (my ($a, $b, undef), $c) = func();
+                let var = if self.peek_kind() == Some(TokenKind::Undef) {
+                    let undef_token = self.consume_token()?;
+                    Node::new(
+                        NodeKind::Undef,
+                        SourceLocation { start: undef_token.start, end: undef_token.end },
+                    )
+                } else {
+                    self.parse_variable()?
+                };
                 variables.push(var);
 
                 if self.peek_kind() == Some(TokenKind::Comma) {

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -625,13 +625,54 @@ impl<'a> Parser<'a> {
             .last()
             .map(|arg| arg.location.end)
             .unwrap_or_else(|| self.previous_position());
-        let expr = Node::new(
+        let mut expr = Node::new(
             NodeKind::FunctionCall {
                 name: func_name.to_string(),
                 args,
             },
             SourceLocation { start, end },
         );
+
+        // `pos` is an lvalue-capable builtin in Perl: `pos $s = value` and
+        // `pos = value` assign to the current regex-match position.  After
+        // building the call node, check for an assignment operator so the
+        // result is `Assignment { lhs: pos($s), rhs: value }` rather than
+        // leaving `= value` as an unparsed token sequence.
+        if func_name == "pos" {
+            let assign_op = match self.peek_kind() {
+                Some(TokenKind::Assign) => Some("="),
+                Some(TokenKind::PlusAssign) => Some("+="),
+                Some(TokenKind::MinusAssign) => Some("-="),
+                Some(TokenKind::StarAssign) => Some("*="),
+                Some(TokenKind::SlashAssign) => Some("/="),
+                Some(TokenKind::PercentAssign) => Some("%="),
+                Some(TokenKind::DotAssign) => Some(".="),
+                Some(TokenKind::AndAssign) => Some("&="),
+                Some(TokenKind::OrAssign) => Some("|="),
+                Some(TokenKind::XorAssign) => Some("^="),
+                Some(TokenKind::PowerAssign) => Some("**="),
+                Some(TokenKind::LeftShiftAssign) => Some("<<="),
+                Some(TokenKind::RightShiftAssign) => Some(">>="),
+                Some(TokenKind::LogicalAndAssign) => Some("&&="),
+                Some(TokenKind::LogicalOrAssign) => Some("||="),
+                Some(TokenKind::DefinedOrAssign) => Some("//="),
+                _ => None,
+            };
+            if let Some(op) = assign_op {
+                self.tokens.next()?; // consume the assignment operator
+                let rhs = self.parse_assignment()?;
+                let assign_end = rhs.location.end;
+                expr = Node::new(
+                    NodeKind::Assignment {
+                        lhs: Box::new(expr),
+                        rhs: Box::new(rhs),
+                        op: op.to_string(),
+                    },
+                    SourceLocation { start, end: assign_end },
+                );
+                return self.parse_named_unary_statement_tail(expr);
+            }
+        }
 
         if had_args {
             self.parse_named_unary_statement_tail(expr)

--- a/crates/perl-parser-core/tests/fix_my_list_undef_placeholder.rs
+++ b/crates/perl-parser-core/tests/fix_my_list_undef_placeholder.rs
@@ -1,0 +1,49 @@
+// Regression tests for `undef` as a placeholder in `my (...)` list declarations
+// inside parenthesised expression context.
+//
+// Root cause: `parse_declaration_arg` (used when `my (...)` appears inside a
+// parenthesised expression like `(my ($a, $b, undef), $c) = func()`) did not
+// allow `undef` in the variable list, unlike `parse_variable_declaration`
+// which already handled it correctly.
+//
+// Pattern from real CPAN code:
+// - Unicode/UCD.pm:2020
+//   `(my ($simple_invlist_ref, $simple_invmap_ref, undef), $default)
+//        = prop_invmap('Simple_Case_Folding');`
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_my_list_undef_in_nested_parens() {
+    // Unicode/UCD.pm:2020 - undef placeholder inside my() inside outer parens
+    let source = r#"(my ($simple_invlist_ref, $simple_invmap_ref, undef), $default) = prop_invmap('Simple_Case_Folding');"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_my_list_undef_leading() {
+    assert_clean_parse("(my (undef, $b, $c), $d) = func();");
+}
+
+#[test]
+fn test_my_list_undef_only() {
+    assert_clean_parse("(my (undef), $rest) = func();");
+}
+
+#[test]
+fn test_my_list_undef_multiple() {
+    assert_clean_parse("(my ($a, undef, $c, undef), $last) = func();");
+}
+
+#[test]
+fn test_my_list_undef_standalone_still_works() {
+    // The standalone `my (..., undef)` case was already working; regression guard
+    assert_clean_parse("my ($a, $b, undef) = func();");
+}
+
+#[test]
+fn test_outer_list_undef_item_still_works() {
+    // undef in outer list (not inside my) was already working
+    assert_clean_parse("($a, undef, $c) = func();");
+}

--- a/crates/perl-parser-core/tests/fix_pos_lvalue.rs
+++ b/crates/perl-parser-core/tests/fix_pos_lvalue.rs
@@ -1,0 +1,116 @@
+// Regression tests for `pos` used as an lvalue.
+//
+// Root causes fixed:
+// 1. `pos` was missing from the indirect-call exclusion list, so
+//    `pos $s = value` was mis-parsed as an indirect method call
+//    (method=pos, object=$s), which then failed on the `=`.
+// 2. `parse_named_unary_statement_call` did not handle assignment
+//    operators after the call node, so `pos $s = value` left `= value`
+//    unparsed even after fix 1.
+//
+// Patterns from real CPAN code:
+// - re.pm:212             `pos $s = $sav_pos - 1;`
+// - Text/Balanced.pm:228  `pos $$textref = $startpos;`
+// - Text/Balanced.pm:180  `pos = $posbug;`
+// - Unicode/UCD.pm:869    `pos $x = 0;`
+
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+use perl_parser_core::{Node, NodeKind};
+
+fn first_expression(source: &str) -> Result<Node, Box<dyn std::error::Error>> {
+    let ast = parse(source);
+    let sexp = ast.to_sexp();
+    let NodeKind::Program { mut statements } = ast.kind else {
+        return Err(format!("expected Program, got {sexp}").into());
+    };
+    if statements.len() != 1 {
+        return Err(format!("expected one statement, got {} in {sexp}", statements.len()).into());
+    }
+
+    let statement = statements.remove(0);
+    let NodeKind::ExpressionStatement { expression } = statement.kind else {
+        return Err(
+            format!("expected ExpressionStatement, got {}", statement.kind.kind_name()).into()
+        );
+    };
+
+    Ok(*expression)
+}
+
+fn assert_pos_assignment_shape(
+    source: &str,
+    expected_arg_count: usize,
+    expected_op: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let expression = first_expression(source)?;
+    let NodeKind::Assignment { lhs, rhs: _, op } = expression.kind else {
+        return Err(format!("expected Assignment, got {}", expression.kind.kind_name()).into());
+    };
+    assert_eq!(op, expected_op);
+
+    let NodeKind::FunctionCall { name, args } = lhs.kind else {
+        return Err(format!("expected pos() FunctionCall lhs, got {}", lhs.kind.kind_name()).into());
+    };
+    assert_eq!(name, "pos");
+    assert_eq!(args.len(), expected_arg_count);
+    Ok(())
+}
+
+#[test]
+fn test_pos_lvalue_assign_scalar() -> Result<(), Box<dyn std::error::Error>> {
+    // re.pm:212 and Unicode/UCD.pm:869
+    assert_pos_assignment_shape("pos $s = $sav_pos - 1;", 1, "=")
+}
+
+#[test]
+fn test_pos_lvalue_assign_zero() -> Result<(), Box<dyn std::error::Error>> {
+    assert_pos_assignment_shape("pos $x = 0;", 1, "=")
+}
+
+#[test]
+fn test_pos_lvalue_assign_deref_scalar() -> Result<(), Box<dyn std::error::Error>> {
+    // Text/Balanced.pm:228, 249, 258, 268
+    assert_pos_assignment_shape("pos $$textref = $startpos;", 1, "=")
+}
+
+#[test]
+fn test_pos_lvalue_bare_assign() -> Result<(), Box<dyn std::error::Error>> {
+    // Text/Balanced.pm:180 - pos without argument is an lvalue for $_
+    assert_pos_assignment_shape("pos = $posbug;", 0, "=")
+}
+
+#[test]
+fn test_pos_lvalue_augmented_assign() -> Result<(), Box<dyn std::error::Error>> {
+    // Augmented assignment operators also valid (e.g. pos $s += 1)
+    assert_pos_assignment_shape("pos $s += 1;", 1, "+=")
+}
+
+#[test]
+fn test_pos_lvalue_in_block() {
+    let source = r#"
+sub import {
+    while ($s =~ /(\w+)/g) {
+        my $sav_pos = pos $s;
+        my $count = $s =~ s/a//g;
+        pos $s = $sav_pos - 1;
+    }
+}
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_pos_read_only_still_works() {
+    // Read-only uses should still parse correctly
+    assert_clean_parse("my $p = pos $s;");
+    assert_clean_parse("if (pos $$textref) { return; }");
+    assert_clean_parse("warn pos $s;");
+}
+
+#[test]
+fn test_pos_no_arg_read() {
+    // pos() with no arg reads pos of $_
+    assert_clean_parse("my $p = pos;");
+    assert_clean_parse("print pos;");
+}


### PR DESCRIPTION
Problem: parser-core misparsed CPAN-style `pos` lvalue assignments and rejected `undef` placeholders in nested `my (...)` declaration lists parsed as expression arguments.
Fix: Exclude `pos` from indirect-call detection, let statement-start `pos` consume assignment operators as an lvalue call, and allow `undef` placeholders in `parse_declaration_arg` list declarations.
Verification:
- `cargo test -p perl-parser-core --test fix_pos_lvalue --test fix_my_list_undef_placeholder --profile agent --locked`
- `cargo check -p perl-parser-core --all-targets --profile agent --locked`
- `cargo clippy -p perl-parser-core --lib --profile agent --locked -- -D warnings -A missing_docs`
- `cargo clippy -p perl-parser-core --test fix_pos_lvalue --test fix_my_list_undef_placeholder --profile agent --locked -- -D warnings -A missing_docs`
- `cargo test -p xtask --profile agent --locked parser_accuracy`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`