### PR TITLE
fix(parser): autoquote defer as fat-arrow hash key (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -549,6 +549,19 @@ impl<'a> Parser<'a> {
                 }
             }
 
+            TokenKind::Defer => {
+                // Check for autoquoting: `defer => value` (e.g. in feature.pm hash)
+                if self.is_keyword_before_fat_arrow() {
+                    let token = self.tokens.next()?;
+                    Ok(Node::new(
+                        NodeKind::Identifier { name: token.text.to_string() },
+                        SourceLocation { start: token.start, end: token.end },
+                    ))
+                } else {
+                    self.parse_defer()
+                }
+            }
+
             TokenKind::Less => {
                 // Could be diamond operator <> or <FILEHANDLE>
                 let start = self.consume_token()?.start; // consume <

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -341,6 +341,8 @@ impl<'a> Parser<'a> {
                 | TokenKind::Finally
                 | TokenKind::When
                 | TokenKind::Undef
+                // defer - Perl 5.36+ experimental block; can also be a hash key
+                | TokenKind::Defer
                 // else/elsif — handled in parse_statement_inner for orphan recovery
                 | TokenKind::Else
                 | TokenKind::Elsif

--- a/crates/perl-parser-core/tests/fix_defer_fat_arrow_key.rs
+++ b/crates/perl-parser-core/tests/fix_defer_fat_arrow_key.rs
@@ -1,0 +1,115 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+// === Fix: `defer` as a fat-arrow hash key ===
+//
+// Perl's fat-arrow (`=>`) autoquotes any bareword on its left side, including
+// reserved keywords.  `defer` (Perl 5.36+ experimental) was missing from both
+// `is_keyword_token` (statement-level autoquote gate) and `parse_primary`
+// (expression-level dispatch), causing "expected expression, found 'defer'"
+// errors in real-world code like core/feature.pm.
+//
+// Reference failing file: /usr/share/perl/5.38/feature.pm
+//   our %feature = ( ..., defer => 'feature_defer', ... );
+
+// --- Statement-level: defer as the opening key of a bare hash pair ---
+
+#[test]
+fn test_defer_fat_arrow_stmt_level() {
+    assert_clean_parse("defer => 1;");
+}
+
+#[test]
+fn test_defer_fat_arrow_in_hash_assign() {
+    assert_clean_parse("my %h = (defer => 'feature_defer');");
+}
+
+#[test]
+fn test_defer_fat_arrow_mixed_pairs() {
+    // Mirrors the actual feature.pm pattern: multiple keyword keys in one hash
+    assert_clean_parse(
+        r#"our %feature = (
+            switch  => 'feature_switch',
+            say     => 'feature_say',
+            defer   => 'feature_defer',
+            try     => 'feature_try',
+        );"#,
+    );
+}
+
+// --- Expression-level: defer as a non-first key inside a hash literal ---
+
+#[test]
+fn test_defer_fat_arrow_second_pair() {
+    // `defer` appears as a non-first key so the expression parser handles it
+    assert_clean_parse("my %h = (a => 1, defer => 2);");
+}
+
+#[test]
+fn test_defer_fat_arrow_in_hash_ref() {
+    assert_clean_parse("my $h = { defer => 1, try => 2 };");
+}
+
+#[test]
+fn test_defer_fat_arrow_in_list_context() {
+    assert_clean_parse("my @pairs = (defer => 'x', class => 'y');");
+}
+
+#[test]
+fn test_defer_fat_arrow_in_function_arg() {
+    assert_clean_parse("foo(defer => 1);");
+}
+
+// --- Regression guard: `defer { }` block must still parse as a defer block ---
+
+#[test]
+fn test_defer_block_still_works() {
+    assert_clean_parse("defer { cleanup() };");
+}
+
+#[test]
+fn test_defer_block_in_sub() {
+    assert_clean_parse("sub foo { defer { 1 } }");
+}
+
+// --- Regression: defer mixed with other keyword keys in the same hash ---
+
+#[test]
+fn test_defer_alongside_try_catch() {
+    assert_clean_parse("my %h = (defer => 1, try => 2, catch => 3, finally => 4);");
+}
+
+#[test]
+fn test_defer_alongside_control_keywords() {
+    assert_clean_parse("my %h = (if => 1, for => 2, defer => 3, while => 4);");
+}
+
+// --- Real-world pattern from feature.pm ---
+
+#[test]
+fn test_feature_pm_hash_snippet() {
+    // Directly mirrors the failing region in /usr/share/perl/5.38/feature.pm
+    assert_clean_parse(
+        r#"our %feature = (
+            switch          => 'feature_switch',
+            say             => 'feature_say',
+            state           => 'feature_state',
+            unicode_strings => 'feature_unicode',
+            unicode_eval    => 'feature_unicode_eval',
+            evalbytes       => 'feature_evalbytes',
+            current_sub     => 'feature___SUB__',
+            refaliasing     => 'feature_refaliasing',
+            postderef_qq    => 'feature_postderef',
+            signatures      => 'feature_signatures',
+            isa             => 'feature_isa',
+            indirect        => 'feature_indirect',
+            multidimensional => 'feature_multidimensional',
+            bareword_filehandles => 'feature_bareword_filehandles',
+            try             => 'feature_try',
+            defer           => 'feature_defer',
+            extra_paired_delimiters => 'feature_more_delims',
+            builtin         => 'feature_builtin',
+            class           => 'feature_class',
+        );"#,
+    );
+}


### PR DESCRIPTION
Problem: `defer` is both a Perl keyword and a valid fat-arrow hash key, but parser-core did not autoquote `defer => ...` in statement or expression context.
Fix: Add `TokenKind::Defer` to the statement keyword autoquote gate and mirror the existing `try` expression-level guard so `defer { ... }` still parses as a defer block.
Verification:
- `cargo test -p perl-parser-core --test fix_defer_fat_arrow_key --profile agent --locked`
- `cargo check -p perl-parser-core --all-targets --profile agent --locked`
- `cargo clippy -p perl-parser-core --lib --profile agent --locked -- -D warnings -A missing_docs`
- `cargo clippy -p perl-parser-core --test fix_defer_fat_arrow_key --profile agent --locked -- -D warnings -A missing_docs`
- `cargo test -p xtask --profile agent --locked parser_accuracy`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`