### PR TITLE
fix(parser): handle braced deref and no-paren calls (#0000)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1451,21 +1451,7 @@ impl<'a> PerlLexer<'a> {
                         // EXCEPT for globs - *{$glob} should be parsed as one token
                         // Also check for empty braces or EOF - in these cases we should split the tokens
                         if sigil != '*'
-                            && (matches!(
-                                self.current_char(),
-                                Some(
-                                    '$' | '@'
-                                        | '%'
-                                        | '*'
-                                        | '&'
-                                        | '['
-                                        | ' '
-                                        | '\t'
-                                        | '\n'
-                                        | '\r'
-                                        | '}'
-                                )
-                            ) || self.current_char().is_none())
+                            && !self.current_char().is_some_and(is_perl_identifier_start)
                         {
                             // This is a dereference or empty/invalid brace, backtrack
                             self.position = start + 1; // Just past the sigil

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -858,8 +858,45 @@ impl<'a> Parser<'a> {
                         }
                         _ => {
                             // Could be an operator like 'or', 'and', etc.
-                            // We need to continue parsing the expression
-                            self.parse_word_or_expr(expr)?
+                            // Also detect no-paren function calls inside parens:
+                            //   (func KEY => VALUE or ...)
+                            // When the first element is a bare identifier and the
+                            // next tokens are IDENT => , the identifier is a
+                            // function being called with fat-comma arguments.
+                            let is_no_paren_call =
+                                matches!(&expr.kind, NodeKind::Identifier { .. })
+                                    && self.peek_kind() == Some(TokenKind::Identifier)
+                                    && self.tokens
+                                        .peek_second()
+                                        .ok()
+                                        .map(|t| t.kind)
+                                        == Some(TokenKind::FatArrow);
+                            if is_no_paren_call {
+                                let NodeKind::Identifier { name } = &expr.kind else {
+                                    return self.parse_word_or_expr(expr);
+                                };
+                                let name = name.clone();
+                                let call_start = expr.location.start;
+                                let first_arg = self.parse_assignment_or_declaration()?;
+                                let args_node =
+                                    self.collect_comma_fat_arrow_continuation(first_arg)?;
+                                let args = match args_node.kind {
+                                    NodeKind::ArrayLiteral { elements } => elements,
+                                    NodeKind::HashLiteral { pairs } => pairs
+                                        .into_iter()
+                                        .flat_map(|(k, v)| [k, v])
+                                        .collect(),
+                                    _ => vec![args_node],
+                                };
+                                let call_end = self.previous_position();
+                                let call = Node::new(
+                                    NodeKind::FunctionCall { name, args },
+                                    SourceLocation { start: call_start, end: call_end },
+                                );
+                                self.parse_word_or_expr(call)?
+                            } else {
+                                self.parse_word_or_expr(expr)?
+                            }
                         }
                     }
                 };

--- a/crates/perl-parser-core/tests/fix_proto_dollar_dollar.rs
+++ b/crates/perl-parser-core/tests/fix_proto_dollar_dollar.rs
@@ -1,0 +1,134 @@
+// Quick integration test
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_proto_double_dollar() {
+    assert_clean_parse(r#"sub foo($$) { return 1; }"#);
+}
+
+#[test]
+fn test_proto_triple_dollar() {
+    assert_clean_parse(r#"sub foo($$$) { return 1; }"#);
+}
+
+#[test]
+fn test_proto_dollar_semicolon() {
+    assert_clean_parse(r#"sub ok ($$;$) { return 1; }"#);
+}
+
+#[test]
+fn test_proto_single_dollar() {
+    assert_clean_parse(r#"sub foo ($) { return 1; }"#);
+}
+
+#[test]
+fn test_anon_sub_single_dollar_proto() {
+    assert_clean_parse(r#"my $x = sub ($) { $_[0] >= 0x20 };"#);
+}
+
+#[test]
+fn test_anon_sub_double_dollar_proto() {
+    assert_clean_parse(r#"my $x = sub ($$) { return 1; };"#);
+}
+
+#[test]
+fn test_fetch_sub_pattern() {
+    assert_clean_parse(
+        r#"
+if (defined(my $sub = _fetch_sub utf8 => 'is_utf8')) {
+    *is_utf8 = $sub;
+}
+"#,
+    );
+}
+
+#[test]
+fn test_carp_pm_is_utf8_pattern() {
+    let src = r#"
+BEGIN {
+    *is_safe_printable_codepoint =
+        1 ?
+            sub ($) {
+                my $u = shift;
+                $u >= 0x20 && $u <= 0x7e;
+            }
+        :
+            sub ($) { $_[0] >= 0x20 && $_[0] <= 0x7e }
+        ;
+}
+"#;
+    assert_clean_parse(src);
+}
+
+#[test]
+fn test_carp_sub_full_pattern() {
+    let src = r#"
+    eval(q(sub ($) {
+        my $u = utf8::native_to_unicode($_[0]);
+        $u >= 0x20 && $u <= 0x7e;
+    }))
+"#;
+    assert_clean_parse(src);
+}
+
+#[test]
+fn test_carp_pm_representative_patterns() {
+    let source = r#"
+BEGIN {
+    *is_safe_printable_codepoint =
+        sub ($) { $_[0] >= 0x20 && $_[0] <= 0x7e };
+}
+
+if (defined(my $sub = _fetch_sub utf8 => 'is_utf8')) {
+    *is_utf8 = $sub;
+}
+
+my $gv =
+    (_fetch_sub B => 'svref_2object' or return '')
+        ->($func)->GV;
+
+$mess .= sprintf ", <%s> %s %d",
+    *${+LAST_FH}{NAME},
+    ($/ eq "\n" ? "line" : "chunk"), $.;
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_method_chain_after_parens_with_or() {
+    // (_fetch_sub B => 'svref_2object' or return '') ->($func)->GV
+    let src = r#"
+my $gv =
+    (_fetch_sub B => 'svref_2object' or return '')
+        ->($func)->GV;
+"#;
+    assert_clean_parse(src);
+}
+
+#[test]
+fn test_glob_deref_with_unary_plus_key() {
+    // *${+LAST_FH}{NAME}
+    let src = r#"my $x = *${+LAST_FH}{NAME};"#;
+    assert_clean_parse(src);
+}
+
+#[test]
+fn test_braced_numeric_capture_still_parses() {
+    assert_clean_parse(r#"my $capture = ${1};"#);
+}
+
+#[test]
+fn test_braced_punctuation_special_vars_still_parse() {
+    assert_clean_parse(r#"my $errno = ${!}; my $last = ${+};"#);
+}
+
+#[test]
+fn test_sprintf_with_glob_deref() {
+    let src = r#"
+$mess .= sprintf ", <%s> %s %d",
+    *${+LAST_FH}{NAME},
+    ($/ eq "\n" ? "line" : "chunk"), $.;
+"#;
+    assert_clean_parse(src);
+}


### PR DESCRIPTION
Problem: parser-core still failed on `${+...}` glob-deref patterns and no-paren fat-comma calls inside parenthesized expressions from Carp-style code.
Fix: Let non-identifier braced scalar contents lex as dereference syntax, detect `(func KEY => VALUE or ...)` as a no-paren call inside parens, and replace non-portable/debug tests with focused regressions including braced special-variable guards.
Verification:
- `cargo test -p perl-parser-core --test fix_proto_dollar_dollar --profile agent --locked`
- `cargo test -p perl-lexer --profile agent --locked`
- `cargo check -p perl-parser-core -p perl-lexer --all-targets --profile agent --locked`
- `cargo clippy -p perl-parser-core -p perl-lexer --lib --profile agent --locked -- -D warnings -A missing_docs`
- `cargo clippy -p perl-parser-core --test fix_proto_dollar_dollar --profile agent --locked -- -D warnings -A missing_docs`
- `cargo test -p xtask --profile agent --locked parser_accuracy`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`