### PR TITLE
test(memory): add POD hover cache cap coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/hover/hover_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover/hover_tests.rs
@@ -1,5 +1,6 @@
 use super::LspServer;
 use perl_tdd_support::must_some;
+use serde_json::json;
 
 #[test]
 fn test_internal_pl_sv_yes_hover_from_sigiled_token() {
@@ -11,4 +12,74 @@ fn test_internal_pl_sv_yes_hover_from_sigiled_token() {
     let hover = must_some(LspServer::get_special_variable_hover("$PL_sv_yes"));
     let value = must_some(hover["contents"]["value"].as_str());
     assert!(value.contains("true scalar"), "hover should describe the shared true scalar: {value}");
+}
+
+#[test]
+fn pod_hover_cache_prunes_at_cap_and_evicts_active_document_path()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = LspServer::with_io(Box::new(std::io::empty()), Box::new(Vec::<u8>::new()));
+    let dir = tempfile::tempdir()?;
+
+    for i in 0..1025 {
+        let path = dir.path().join(format!("Cached{i}.pm"));
+        std::fs::write(
+            &path,
+            format!(
+                "package Cached{i};\n\n=head1 NAME\n\nCached{i}\n\n=head1 DESCRIPTION\n\nCached POD {i}.\n\n=cut\n\n1;\n"
+            ),
+        )?;
+
+        let hover = server.format_pod_for_hover(&path);
+        assert!(hover.contains("Cached POD"), "POD hover should parse {path:?}");
+    }
+
+    let after_prune = server.memory_state_snapshot();
+    assert!(
+        after_prune.pod_cache_entries <= 513,
+        "1025 unique POD hovers should prune to target plus current insert, got {}",
+        after_prune.pod_cache_entries
+    );
+
+    let active_path = dir.path().join("Active.pm");
+    let active_text = "package Active;\n\n=head1 NAME\n\nActive\n\n=head1 DESCRIPTION\n\nActive POD.\n\n=cut\n\n1;\n";
+    std::fs::write(&active_path, active_text)?;
+    let active_uri =
+        url::Url::from_file_path(&active_path).map_err(|_| "invalid active file path")?;
+    let active_uri = active_uri.to_string();
+
+    server.did_open(json!({
+        "textDocument": {
+            "uri": active_uri,
+            "languageId": "perl",
+            "version": 1,
+            "text": active_text
+        }
+    }))?;
+
+    let active_hover = server.format_pod_for_hover(&active_path);
+    assert!(active_hover.contains("Active POD"), "active document POD should be cached");
+    let with_active = server.memory_state_snapshot();
+    assert_eq!(
+        with_active.pod_cache_entries,
+        after_prune.pod_cache_entries + 1,
+        "active POD path should add exactly one cache entry"
+    );
+
+    server.handle_did_close(Some(json!({"textDocument": {"uri": active_uri}})))?;
+    std::fs::remove_file(&active_path)?;
+    server.handle_did_change_watched_files(Some(json!({
+        "changes": [
+            { "uri": active_uri, "type": 3 }
+        ]
+    })))?;
+
+    let after_delete = server.memory_state_snapshot();
+    assert_eq!(after_delete.documents, 0);
+    assert_eq!(after_delete.open_text_bytes, 0);
+    assert_eq!(
+        after_delete.pod_cache_entries, after_prune.pod_cache_entries,
+        "close/delete should evict the active document POD path entry"
+    );
+
+    Ok(())
 }

--- a/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
+++ b/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
@@ -40,7 +40,7 @@ before committing derived state.
 | `LspServer` | `ast_cache` | URI `String` with cached content hash | Parsed ASTs for recently used documents | `AstCache::new(100, 300)` in runtime constructors; explicit `AstCache::remove` on close/delete | `ast_cache_remove_evicts_entry_immediately` |
 | `LspServer` | `semantic_analyzer_cache` | `(normalized_uri, content_hash)` | Semantic analyzer graphs and derived scope state | Invalidated on `didChange`, close, and delete; hard-clears when the cache reaches 50 entries | semantic analyzer invalidation tests in `text_sync.rs`; `MemoryStateSnapshot` |
 | `LspServer` | `parse_cancel_flags` | URI `String` | Per-document cancellation tokens and stale parse coordination | New parses cancel prior tokens; close/delete/folder cleanup trips and removes flags | `test_did_close_cancels_and_removes_flag`; snapshot tests |
-| `LspServer` | `pod_cache` | Filesystem `PathBuf` | Parsed POD hover docs | Soft cap 1024 entries, prune target 512; close/delete removes the file path entry | `MemoryStateSnapshot`; hover cache cap should be covered by future POD churn scenario |
+| `LspServer` | `pod_cache` | Filesystem `PathBuf` | Parsed POD hover docs | Soft cap 1024 entries, prune target 512; close/delete removes the file path entry | POD hover cache cap and close/delete eviction test; `MemoryStateSnapshot.pod_cache_entries` |
 | `LspServer` | Pull diagnostics file cache | Filesystem path | Diagnostic result state and external diagnostic reuse | Invalidated on text change, close, and delete through the pull diagnostics orchestrator | lifecycle snapshot tests; diagnostics churn retained-state coverage |
 | `LspServer` | Perl::Critic analyzer and warning set | Analyzer config and workspace warning keys | External analyzer cache, profile discovery, warning suppression keys | Analyzer reset on critic configuration changes; file cache invalidated on document changes and eviction | diagnostics tests; future diagnostics churn receipt |
 | `StreamSessionManager` | Inline-completion stream sessions | `SessionKey { uri, document_version, line, character }` | Streaming buffers, cancellation flags, per-request session entries | `cancel_for_uri` and `cancel_for_uri_version` cancel and remove entries immediately | stream-session eviction tests; `MemoryStateSnapshot.stream_sessions` |
@@ -80,7 +80,7 @@ hard to interpret; focused scenarios make the owner obvious.
 | `lsp_workspace_symbol_churn_delete` | Index/query pressure during document churn | Nightly receipts |
 | `workspace_index_reindex_same_files` | Secondary-index duplication and remove/reindex cycles | Unit regression coverage |
 | `diagnostics_pull_push_churn` | Pull diagnostics, result ids, critic analyzer cache | Unit retained-state coverage |
-| `hover_pod_many_modules` | POD cache cap and path eviction | Follow-up scenario |
+| `hover_pod_many_modules` | POD cache cap and path eviction | Unit retained-state coverage |
 | `completion_stream_cancel_storm` | Stream-session cancellation and removal | Unit regression coverage |
 | `file_watcher_bulk_create_change_delete` | Watcher debouncer and delete lifecycle | Follow-up scenario |
 | `workspace_folder_add_remove_multi_root` | Folder-scoped cleanup without cross-root eviction | Unit coverage, add process scenario if needed |


### PR DESCRIPTION
## Summary

Add the next focused memory-control regression for POD hover cache retention.

## What changed

- Adds a unit/integration test that primes more than 1024 unique POD file paths through `format_pod_for_hover` and asserts `MemoryStateSnapshot.pod_cache_entries` is pruned back to the cap target behavior.
- Verifies an active document POD path is evicted after `didClose` plus watched-file `DELETE` cleanup.
- Updates `RETAINED_STATE_INVENTORY.md` so `pod_cache` no longer points at future coverage.

## Scope

- Unit/integration retained-state coverage only.
- No RSS harness, nightly job, or release workflow changes.

## Validation

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs pod_hover_cache_prunes_at_cap_and_evicts_active_document_path --lib`
- [x] `cargo test -p perl-lsp-rs --features workspace pod_hover_cache_prunes_at_cap_and_evicts_active_document_path --lib`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `git diff --check`
