### PR TITLE
fix(metrics): align parser-accuracy gold drift schema (#7952)

### DIFF
--- a/.ci/schemas/parser-accuracy.schema.json
+++ b/.ci/schemas/parser-accuracy.schema.json
@@ -407,9 +407,13 @@
         "duplicate_symbol_id_count",
         "missing_resolves_to_target_count",
         "changed_line_count",
+        "changed_line_sample_count",
         "changed_symbol_count",
+        "changed_symbol_sample_count",
         "removed_expectation_count",
+        "removed_expectation_sample_count",
         "added_expectation_count",
+        "added_expectation_sample_count",
         "dynamic_expectation_change_count"
       ],
       "properties": {
@@ -428,13 +432,25 @@
         "changed_line_count": {
           "$ref": "#/$defs/nonNegativeInteger"
         },
+        "changed_line_sample_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
         "changed_symbol_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "changed_symbol_sample_count": {
           "$ref": "#/$defs/nonNegativeInteger"
         },
         "removed_expectation_count": {
           "$ref": "#/$defs/nonNegativeInteger"
         },
+        "removed_expectation_sample_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
         "added_expectation_count": {
+          "$ref": "#/$defs/nonNegativeInteger"
+        },
+        "added_expectation_sample_count": {
           "$ref": "#/$defs/nonNegativeInteger"
         },
         "dynamic_expectation_change_count": {

--- a/xtask/tests/fixtures/parser-accuracy/example-artifact.json
+++ b/xtask/tests/fixtures/parser-accuracy/example-artifact.json
@@ -1618,9 +1618,13 @@
     "duplicate_symbol_id_count": 0,
     "missing_resolves_to_target_count": 0,
     "changed_line_count": 0,
+    "changed_line_sample_count": 0,
     "changed_symbol_count": 0,
+    "changed_symbol_sample_count": 0,
     "removed_expectation_count": 0,
+    "removed_expectation_sample_count": 0,
     "added_expectation_count": 0,
+    "added_expectation_sample_count": 0,
     "dynamic_expectation_change_count": 0
   },
   "metric_runtime": {


### PR DESCRIPTION
Problem: parser-accuracy gold-drift sample-count fields are emitted by the artifact but were missing from the committed schema and example artifact.

Fix: add the gold-drift sample-count fields to the schema contract and static example fixture.

Verification: `cargo test -p xtask --profile agent --locked parser_accuracy_schema -- --nocapture`; `cargo test -p xtask --profile agent --locked parser_accuracy_example_artifact_matches_schema_contract -- --nocapture`; `cargo xtask fmt --check`; `cargo check -p xtask --all-targets --profile agent --locked`; `cargo clippy -p xtask --bin xtask --profile agent --locked -- -D warnings -A missing_docs`; `git diff --check`.