### PR TITLE
test(memory): add file watcher bulk churn coverage (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -2159,6 +2159,125 @@ mod tests {
 
     #[cfg(feature = "workspace")]
     #[test]
+    fn bulk_file_watcher_churn_drains_pressure_and_delete_state()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::runtime::file_watcher_debounce::FileWatcherDebouncer;
+        use std::sync::Arc;
+        use std::time::{Duration, Instant};
+
+        let server = LspServer::with_io(Box::new(std::io::empty()), Box::new(Vec::<u8>::new()));
+        let delivered = Arc::new(parking_lot::Mutex::new(Vec::<String>::new()));
+        let delivered_for_worker = Arc::clone(&delivered);
+        server.install_file_watcher_debouncer(FileWatcherDebouncer::with_interval(
+            Duration::from_millis(150),
+            move |uris| {
+                delivered_for_worker.lock().extend(uris);
+            },
+        ));
+
+        let dir = tempfile::tempdir()?;
+        let mut uris = Vec::new();
+        for i in 0..20 {
+            let path = dir.path().join(format!("BulkWatcher{i}.pm"));
+            let source = format!("package BulkWatcher{i};\nsub value {{ {i} }}\n1;\n");
+            std::fs::write(&path, &source)?;
+            let uri = url::Url::from_file_path(&path).map_err(|_| "invalid file path")?;
+            let uri = uri.to_string();
+
+            server.did_open(json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": source
+                }
+            }))?;
+            server.new_parse_token(&uri);
+            server.stream_sessions().start_session(crate::runtime::stream_session::SessionKey {
+                uri: uri.clone(),
+                document_version: 1,
+                line: i,
+                character: 0,
+            });
+            if let Some(coordinator) = server.coordinator() {
+                coordinator.index().index_file(url::Url::parse(&uri)?, source)?;
+                assert!(
+                    !coordinator.index().file_symbols(&uri).is_empty(),
+                    "workspace index should contain {uri} before delete"
+                );
+            }
+            uris.push(uri);
+        }
+
+        let changes = uris.iter().map(|uri| json!({ "uri": uri, "type": 2 })).collect::<Vec<_>>();
+        server.handle_did_change_watched_files(Some(json!({ "changes": changes })))?;
+
+        let mut max_pending = 0usize;
+        let pressure_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < pressure_deadline {
+            let pending = server.runtime_pressure_snapshot().file_watcher_pending_uris;
+            max_pending = max_pending.max(pending);
+            if pending == uris.len() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            max_pending > 1,
+            "bulk watched-file changes should raise file watcher pressure, max pending {max_pending}"
+        );
+
+        let drain_deadline = Instant::now() + Duration::from_secs(3);
+        while Instant::now() < drain_deadline {
+            if server.runtime_pressure_snapshot().file_watcher_pending_uris == 0
+                && delivered.lock().len() == uris.len()
+            {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(server.runtime_pressure_snapshot().file_watcher_pending_uris, 0);
+
+        let delivered_uris = delivered.lock().clone();
+        assert_eq!(delivered_uris.len(), uris.len());
+        server.handle_watched_file_batch(delivered_uris);
+
+        for uri in &uris {
+            if let Some(path) = perl_uri::uri_to_fs_path(uri) {
+                std::fs::remove_file(path)?;
+            }
+        }
+        let deletes = uris.iter().map(|uri| json!({ "uri": uri, "type": 3 })).collect::<Vec<_>>();
+        server.handle_did_change_watched_files(Some(json!({ "changes": deletes })))?;
+
+        for _ in 0..100 {
+            let pressure = server.runtime_pressure_snapshot();
+            if pressure.pending_index_tasks == 0 && pressure.file_watcher_pending_uris == 0 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let memory = server.memory_state_snapshot();
+        assert_eq!(memory.documents, 0);
+        assert_eq!(memory.open_text_bytes, 0);
+        assert_eq!(memory.parse_cancel_flags, 0);
+        assert_eq!(memory.stream_sessions, 0);
+        assert_eq!(memory.pending_index_tasks, 0);
+        assert_eq!(server.runtime_pressure_snapshot().file_watcher_pending_uris, 0);
+
+        if let Some(coordinator) = server.coordinator() {
+            for uri in &uris {
+                assert!(coordinator.index().file_symbols(uri).is_empty());
+                assert!(coordinator.index().document_store().get(uri).is_none());
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "workspace")]
+    #[test]
     fn workspace_folder_removal_evicts_open_docs_under_root()
     -> Result<(), Box<dyn std::error::Error>> {
         let server = LspServer::new();

--- a/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
+++ b/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
@@ -52,7 +52,7 @@ before committing derived state.
 | `LspServer` | Progress cancellation maps | Progress token and request id | Cancellation token bookkeeping | Progress cancel removes token and request mapping | progress cancellation tests |
 | `CancellationRegistry` | Request cancellation tokens, cleanup contexts, token cache | Request id string | Request-scoped cancellation state and cleanup closures | Dispatch finalization and `RequestCleanupGuard` remove request state | cancellation registry cleanup tests |
 | `DiagnosticDebouncer` | Pending diagnostic publish queue | URI `String` | Deferred URI set in worker thread | Expiration removes entries; `Drop` flushes pending entries on shutdown | diagnostic debouncer tests; `RuntimePressureSnapshot.diagnostic_debounce_pending_uris` |
-| `FileWatcherDebouncer` | Pending file-watcher URI queue | URI `String` | Deferred URI set during bulk filesystem operations | Expiration removes entries; `Drop` flushes pending entries on shutdown | file watcher debouncer tests; `RuntimePressureSnapshot.file_watcher_pending_uris`; future watcher churn scenario |
+| `FileWatcherDebouncer` | Pending file-watcher URI queue | URI `String` | Deferred URI set during bulk filesystem operations | Expiration removes entries; `Drop` flushes pending entries on shutdown | file watcher debouncer tests; bulk watcher churn retained-state coverage; `RuntimePressureSnapshot.file_watcher_pending_uris` |
 | Read scheduler | Queued read requests and latest-sequence map | Request dedup key | Queued request payloads and cancellation tokens | Stale reads are cancelled before worker dispatch; queue drains on channel close | scheduler classification tests; add direct retained-state regression if pressure grows |
 | DAP bridge | Debug child process and session state | Debug session/process id | Child process handles, reader tasks, debugger session state | Stop, disconnect, and shutdown paths must terminate or detach process state | DAP lifecycle tests; future `dap_bridge_start_stop_loop` scenario |
 | Formatting and external tools | Perltidy/perlcritic subprocess buffers | Request scope and file path | Subprocess output buffers and temp data | Request-scoped by subprocess runtime; no session bag should retain output after completion | formatting/diagnostics tests; future subprocess churn scenario |
@@ -82,7 +82,7 @@ hard to interpret; focused scenarios make the owner obvious.
 | `diagnostics_pull_push_churn` | Pull diagnostics, result ids, critic analyzer cache | Unit retained-state coverage |
 | `hover_pod_many_modules` | POD cache cap and path eviction | Unit retained-state coverage |
 | `completion_stream_cancel_storm` | Stream-session cancellation and removal | Unit regression coverage |
-| `file_watcher_bulk_create_change_delete` | Watcher debouncer and delete lifecycle | Follow-up scenario |
+| `file_watcher_bulk_create_change_delete` | Watcher debouncer and delete lifecycle | Unit retained-state coverage |
 | `workspace_folder_add_remove_multi_root` | Folder-scoped cleanup without cross-root eviction | Unit coverage, add process scenario if needed |
 | `dap_bridge_start_stop_loop` | Debug process/session lifecycle | Follow-up scenario |
 | `formatting_perltidy_loop` | Subprocess and output-buffer retention | Follow-up scenario |


### PR DESCRIPTION
## Summary

Add the next focused memory-control regression for file-watcher bulk churn.

## What changed

- Adds a workspace-feature test that sends a bulk `workspace/didChangeWatchedFiles` CHANGED batch through the file-watcher debouncer.
- Asserts `RuntimePressureSnapshot.file_watcher_pending_uris` rises during the debounce window and drains after delivery.
- Sends watched-file DELETE events for the same URI set and asserts document/session state, parse flags, pending index tasks, stream sessions, workspace symbols, and document-store entries are gone.
- Updates `RETAINED_STATE_INVENTORY.md` so the file-watcher churn scenario no longer points at future coverage.

## Scope

- Unit/integration retained-state coverage only.
- No RSS harness, nightly job, or release workflow changes.

## Validation

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs --features workspace bulk_file_watcher_churn_drains_pressure_and_delete_state --lib`
- [x] `cargo test -p perl-lsp-rs runtime_pressure_snapshot_reports_async_queues --lib`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `git diff --check`
