### PR TITLE
docs(memory): add memory regression triage template (#0000)

### DIFF
--- a/.github/ISSUE_TEMPLATE/memory_regression.yml
+++ b/.github/ISSUE_TEMPLATE/memory_regression.yml
@@ -1,0 +1,157 @@
+name: Memory Regression
+description: Report a retained-state or RSS plateau regression from memory receipts, counters, or local profiling.
+title: "[Memory] "
+labels: ["performance", "memory", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when an LSP memory guard fails or a local run shows retained state that should drain. Attach receipts before guessing at a fix.
+
+  - type: dropdown
+    id: scenario
+    attributes:
+      label: Scenario
+      description: Which memory lifecycle or subsystem exposed the regression?
+      options:
+        - lsp_doc_churn_delete
+        - lsp_workspace_symbol_churn_delete
+        - workspace_index_remove_reindex_cycle
+        - diagnostics_pull_push_churn
+        - hover_pod_many_modules
+        - completion_stream_cancel_storm
+        - file_watcher_bulk_create_change_delete
+        - workspace_folder_add_remove_multi_root
+        - formatting_perltidy_loop
+        - dap_bridge_start_stop_loop
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Commit
+      description: Commit SHA where the regression was observed.
+      placeholder: "e.g. fbd14c9bce23377ede14be837938772c34e0ce29"
+    validations:
+      required: true
+
+  - type: input
+    id: workflow-run
+    attributes:
+      label: Workflow run
+      description: Link to the failed workflow run, if available.
+      placeholder: "https://github.com/EffortlessMetrics/perl-lsp/actions/runs/..."
+
+  - type: input
+    id: artifact
+    attributes:
+      label: Artifact
+      description: Link or path to the JSON, CSV, server log, or process-tree artifact.
+      placeholder: "target/memory/doc_churn_500_delete.plateau.json"
+    validations:
+      required: true
+
+  - type: input
+    id: tail-growth-kb
+    attributes:
+      label: tail_growth_kb
+      description: Tail RSS growth from the plateau summary or receipt.
+      placeholder: "e.g. 4096"
+    validations:
+      required: true
+
+  - type: input
+    id: median-tail-slope
+    attributes:
+      label: median_tail_slope_kb_per_file
+      description: Median tail slope from the plateau summary or receipt.
+      placeholder: "e.g. 12.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: nonzero-counters
+    attributes:
+      label: Which counter stayed nonzero?
+      description: Include MemoryStateSnapshot and RuntimePressureSnapshot fields that did not drain.
+      placeholder: |
+        - documents:
+        - open_text_bytes:
+        - semantic_analyzer_cache:
+        - parse_cancel_flags:
+        - stream_sessions:
+        - pending_index_tasks:
+        - diagnostic_debounce_pending_uris:
+        - file_watcher_pending_uris:
+      render: markdown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: suspected-owner
+    attributes:
+      label: Suspected owner
+      description: Pick the state holder most likely to own the retained memory.
+      options:
+        - document/session state
+        - workspace index
+        - diagnostics cache
+        - POD cache
+        - stream sessions
+        - debouncer/task pressure
+        - subprocess or child process
+        - DAP session state
+        - unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lifecycle
+    attributes:
+      label: Lifecycle
+      description: Close-only and close+delete have intentionally different expectations.
+      options:
+        - close-only
+        - close+delete
+        - reindex
+        - query churn
+        - cancellation
+        - workspace-folder removal
+        - subprocess loop
+        - DAP start/stop
+        - unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: failure-classification
+    attributes:
+      label: Failure classification
+      description: Classify what failed before proposing a fix.
+      value: |
+        - [ ] tail growth
+        - [ ] slope
+        - [ ] missing artifact
+        - [ ] harness crash
+        - [ ] server crash
+        - [ ] counter did not drain
+        - [ ] child process retained
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: triage-notes
+    attributes:
+      label: Triage notes
+      description: Summarize the evidence and the next narrow regression to add before patching.
+      value: |
+        1. Downloaded plateau JSON/CSV/server log:
+        2. Compared MemoryStateSnapshot and RuntimePressureSnapshot:
+        3. Identified suspected owner:
+        4. Proposed failing regression test:
+      render: markdown
+    validations:
+      required: true

--- a/docs/large-workspaces/README.md
+++ b/docs/large-workspaces/README.md
@@ -12,6 +12,10 @@ Perl workspaces (5 000–10 000+ files).
 | [LSP_CHURN_REPRO.md](LSP_CHURN_REPRO.md) | Reproducing open/change/close RSS churn and checking plateau behavior |
 | [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Diagnosing slowdowns, stale symbols, index degradation |
 
+Memory plateau or retained-state regressions should be filed with the
+**Memory Regression** issue template so the report includes the receipt,
+counter, lifecycle, and suspected owner evidence needed for triage.
+
 ## Quick Reference
 
 ```bash

--- a/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
+++ b/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
@@ -115,3 +115,8 @@ When memory growth moves again:
 5. Add a failing regression before changing cleanup logic.
 6. Patch the owner or eviction boundary.
 7. Add or update a receipt so future runs classify the retained surface.
+
+Use the GitHub **Memory Regression** issue template for plateau or retained-state
+failures. The issue should name the scenario, commit, workflow run, artifact,
+tail growth, median tail slope, lifecycle, nonzero counters, and suspected
+owner before implementation begins.

--- a/docs/project/status/memory_plateau.md
+++ b/docs/project/status/memory_plateau.md
@@ -49,6 +49,15 @@ Use `--history-dir <path>` to include archived receipt directories. The command
 is evidence-only: it does not run a memory workload or participate in PR gates
 unless a workflow invokes it explicitly.
 
+## Failure Triage
+
+When a plateau gate fails, file a **Memory Regression** issue and include the
+plateau JSON/CSV/server log artifact, `tail_growth_kb`,
+`median_tail_slope_kb_per_file`, lifecycle (`close-only`, `close+delete`, or
+another named scenario), nonzero `MemoryStateSnapshot` or
+`RuntimePressureSnapshot` counters, and suspected state owner. Patch work should
+start from a narrow failing regression, not from a broad leak hunt.
+
 ## Interpretation Rules
 
 - Close-only churn may retain workspace-index entries for files that still exist.


### PR DESCRIPTION
## Summary

- add a dedicated Memory Regression issue form for retained-state and RSS plateau failures
- capture scenario, commit, workflow run, artifact, tail growth, median slope, nonzero counters, suspected owner, and lifecycle semantics
- point the memory plateau status page, retained-state inventory, and large-workspace guide at the new failure workflow

## Scope

Docs and issue-template only. No code, workflow, or memory scenario changes.

## Validation

- `cargo xtask fmt`
- `cargo xtask check-memory-lifecycle-policy`
- `python3` YAML parse smoke for `.github/ISSUE_TEMPLATE/memory_regression.yml`
- `git diff --check`