### PR TITLE
test(memory): add formatting subprocess retention smoke (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,7 @@ dependencies = [
  "perl-tdd-support",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/perl-lsp-perltidy/Cargo.toml
+++ b/crates/perl-lsp-perltidy/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 [dev-dependencies]
 perl-tdd-support = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -251,6 +251,12 @@ impl PerlTidyFormatter {
         self.cache.clear();
     }
 
+    /// Return the number of memoized formatting results.
+    #[must_use]
+    pub fn cache_len(&self) -> usize {
+        self.cache.len()
+    }
+
     /// Format a range of code.
     pub fn format_range(
         &mut self,

--- a/crates/perl-lsp-perltidy/tests/subprocess_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/subprocess_tests.rs
@@ -2,6 +2,7 @@ use perl_lsp_perltidy::{PerlTidyConfig, PerlTidyFormatter};
 use perl_subprocess_runtime::{SubprocessError, SubprocessOutput, SubprocessRuntime};
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 // --- Missing perltidy binary handling ---
 
@@ -74,4 +75,105 @@ fn get_suggestions_returns_error_when_binary_missing() {
 fn perltidy_config_default_has_timeout() {
     let config = PerlTidyConfig::default();
     assert_eq!(config.timeout_secs, 10);
+}
+
+struct TrackingRuntime {
+    active: AtomicUsize,
+    max_active: AtomicUsize,
+    invocations: AtomicUsize,
+    emitted_stdout_bytes: AtomicUsize,
+}
+
+impl TrackingRuntime {
+    fn new() -> Self {
+        Self {
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            invocations: AtomicUsize::new(0),
+            emitted_stdout_bytes: AtomicUsize::new(0),
+        }
+    }
+
+    fn active(&self) -> usize {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    fn max_active(&self) -> usize {
+        self.max_active.load(Ordering::SeqCst)
+    }
+
+    fn invocations(&self) -> usize {
+        self.invocations.load(Ordering::SeqCst)
+    }
+
+    fn emitted_stdout_bytes(&self) -> usize {
+        self.emitted_stdout_bytes.load(Ordering::SeqCst)
+    }
+}
+
+struct ActiveInvocation<'a> {
+    runtime: &'a TrackingRuntime,
+}
+
+impl<'a> ActiveInvocation<'a> {
+    fn new(runtime: &'a TrackingRuntime) -> Self {
+        let active = runtime.active.fetch_add(1, Ordering::SeqCst) + 1;
+        runtime.max_active.fetch_max(active, Ordering::SeqCst);
+        runtime.invocations.fetch_add(1, Ordering::SeqCst);
+        Self { runtime }
+    }
+}
+
+impl Drop for ActiveInvocation<'_> {
+    fn drop(&mut self) {
+        self.runtime.active.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+impl SubprocessRuntime for TrackingRuntime {
+    fn run_command(
+        &self,
+        program: &str,
+        args: &[&str],
+        stdin: Option<&[u8]>,
+    ) -> Result<SubprocessOutput, SubprocessError> {
+        let _active = ActiveInvocation::new(self);
+        assert_eq!(program, "perltidy");
+        assert!(stdin.is_none(), "format_file should not pass stdin");
+        let file_arg = args.last().ok_or_else(|| SubprocessError::new("missing file path"))?;
+        assert!(Path::new(file_arg).exists(), "format_file should pass an existing temp file");
+
+        let stdout = vec![b'x'; 16 * 1024];
+        self.emitted_stdout_bytes.fetch_add(stdout.len(), Ordering::SeqCst);
+        Ok(SubprocessOutput { stdout, stderr: Vec::new(), status_code: 0 })
+    }
+}
+
+#[test]
+fn format_file_storm_does_not_retain_subprocess_outputs_or_temp_state() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let runtime = Arc::new(TrackingRuntime::new());
+    let formatter = PerlTidyFormatter::new(PerlTidyConfig::default(), runtime.clone());
+    let mut expected_files = Vec::new();
+
+    for i in 0..64 {
+        let path = temp.path().join(format!("storm_{i}.pl"));
+        std::fs::write(&path, format!("print {i};\n")).expect("write temp Perl file");
+        formatter.format_file(&path).expect("format temp Perl file");
+        expected_files.push(path);
+    }
+
+    assert_eq!(runtime.invocations(), 64);
+    assert_eq!(runtime.active(), 0, "subprocess invocations must not remain active");
+    assert_eq!(runtime.max_active(), 1, "format_file should run synchronously per request");
+    assert_eq!(runtime.emitted_stdout_bytes(), 64 * 16 * 1024);
+    assert_eq!(formatter.cache_len(), 0, "format_file must not populate memoized format cache");
+
+    let mut remaining_files: Vec<_> = std::fs::read_dir(temp.path())
+        .expect("read tempdir")
+        .map(|entry| entry.expect("read entry").path())
+        .collect();
+    remaining_files.sort();
+    expected_files.sort();
+    assert_eq!(remaining_files, expected_files, "formatter wrapper should not create temp files");
 }

--- a/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
+++ b/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
@@ -55,7 +55,7 @@ before committing derived state.
 | `FileWatcherDebouncer` | Pending file-watcher URI queue | URI `String` | Deferred URI set during bulk filesystem operations | Expiration removes entries; `Drop` flushes pending entries on shutdown | file watcher debouncer tests; bulk watcher churn retained-state coverage; `RuntimePressureSnapshot.file_watcher_pending_uris` |
 | Read scheduler | Queued read requests and latest-sequence map | Request dedup key | Queued request payloads and cancellation tokens | Stale reads are cancelled before worker dispatch; queue drains on channel close | scheduler classification tests; add direct retained-state regression if pressure grows |
 | DAP bridge | Debug child process and session state | Debug session/process id | Child process handles, reader tasks, debugger session state | Stop, disconnect, and shutdown paths must terminate or detach process state | DAP lifecycle tests; future `dap_bridge_start_stop_loop` scenario |
-| Formatting and external tools | Perltidy/perlcritic subprocess buffers | Request scope and file path | Subprocess output buffers and temp data | Request-scoped by subprocess runtime; no session bag should retain output after completion | formatting/diagnostics tests; future subprocess churn scenario |
+| Formatting and external tools | Perltidy/perlcritic subprocess buffers | Request scope and file path | Subprocess output buffers and temp data | Request-scoped by subprocess runtime; no session bag should retain output after completion | formatting/diagnostics tests; formatting subprocess retention smoke |
 
 ## Memory Budgets
 
@@ -85,7 +85,7 @@ hard to interpret; focused scenarios make the owner obvious.
 | `file_watcher_bulk_create_change_delete` | Watcher debouncer and delete lifecycle | Unit retained-state coverage |
 | `workspace_folder_add_remove_multi_root` | Folder-scoped cleanup without cross-root eviction | Unit coverage, add process scenario if needed |
 | `dap_bridge_start_stop_loop` | Debug process/session lifecycle | Follow-up scenario |
-| `formatting_perltidy_loop` | Subprocess and output-buffer retention | Follow-up scenario |
+| `formatting_perltidy_loop` | Subprocess and output-buffer retention | Unit retained-state coverage |
 
 ## Review Checklist
 


### PR DESCRIPTION
## Summary

- add a formatting subprocess retention smoke around repeated `PerlTidyFormatter::format_file` calls on temp Perl files
- track active subprocess invocations, emitted stdout volume, cache length, and temp-dir contents to prove the wrapper does not retain request output or create temp state
- expose `PerlTidyFormatter::cache_len()` as a small retained-state counter for formatter tests
- update the retained-state inventory to mark `formatting_perltidy_loop` as unit-covered

## Scope

Unit/integration coverage only. This does not add RSS/nightly workloads or change formatter subprocess execution behavior.

## Validation

- `cargo xtask fmt`
- `cargo test -p perl-lsp-perltidy format_file_storm_does_not_retain_subprocess_outputs_or_temp_state --test subprocess_tests -- --nocapture`
- `cargo test -p perl-lsp-perltidy --test subprocess_tests -- --nocapture`
- `cargo test -p perl-lsp-perltidy -- --nocapture`
- `cargo xtask check-memory-lifecycle-policy`
- `git diff --check`