### PR TITLE
test(memory): add DAP bridge start-stop retention smoke (#0000)

### DIFF
--- a/crates/perl-dap/src/bridge_adapter.rs
+++ b/crates/perl-dap/src/bridge_adapter.rs
@@ -391,6 +391,33 @@ mod tests {
         }
     }
 
+    async fn process_is_running(pid: u32) -> Result<bool> {
+        #[cfg(unix)]
+        {
+            let status = Command::new("sh")
+                .arg("-c")
+                .arg(format!("kill -0 {pid} 2>/dev/null"))
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .await?;
+            Ok(status.success())
+        }
+
+        #[cfg(windows)]
+        {
+            let output = Command::new("cmd")
+                .arg("/C")
+                .arg(format!("tasklist /FI \"PID eq {pid}\" /NH"))
+                .output()
+                .await?;
+            if !output.status.success() {
+                anyhow::bail!("tasklist failed while checking child process {pid}");
+            }
+            Ok(String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
+        }
+    }
+
     #[tokio::test]
     async fn proxy_returns_error_when_child_already_exited() -> Result<()> {
         let mut adapter = BridgeAdapter::new();
@@ -407,6 +434,35 @@ mod tests {
         let proxy_result = result?;
         assert!(proxy_result.is_err(), "proxy_messages should error for exited child");
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn repeated_start_stop_cycles_do_not_leave_child_processes() -> Result<()> {
+        let mut observed_pids = Vec::new();
+
+        for _ in 0..5 {
+            let mut adapter = BridgeAdapter::new();
+            let child = spawn_long_running_child().await?;
+            let pid = child
+                .id()
+                .ok_or_else(|| anyhow::anyhow!("spawned child should have a process id"))?;
+            observed_pids.push(pid);
+            adapter.child_process = Some(child);
+
+            let result = tokio::time::timeout(Duration::from_secs(2), adapter.shutdown()).await;
+            assert!(result.is_ok(), "shutdown should not hang for child process {pid}");
+            result??;
+
+            assert!(
+                !process_is_running(pid).await?,
+                "DAP bridge shutdown left child process {pid} running"
+            );
+        }
+
+        observed_pids.sort_unstable();
+        observed_pids.dedup();
+        assert_eq!(observed_pids.len(), 5, "each cycle should own a distinct child process");
         Ok(())
     }
 

--- a/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
+++ b/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
@@ -54,7 +54,7 @@ before committing derived state.
 | `DiagnosticDebouncer` | Pending diagnostic publish queue | URI `String` | Deferred URI set in worker thread | Expiration removes entries; `Drop` flushes pending entries on shutdown | diagnostic debouncer tests; `RuntimePressureSnapshot.diagnostic_debounce_pending_uris` |
 | `FileWatcherDebouncer` | Pending file-watcher URI queue | URI `String` | Deferred URI set during bulk filesystem operations | Expiration removes entries; `Drop` flushes pending entries on shutdown | file watcher debouncer tests; bulk watcher churn retained-state coverage; `RuntimePressureSnapshot.file_watcher_pending_uris` |
 | Read scheduler | Queued read requests and latest-sequence map | Request dedup key | Queued request payloads and cancellation tokens | Stale reads are cancelled before worker dispatch; queue drains on channel close | scheduler classification tests; add direct retained-state regression if pressure grows |
-| DAP bridge | Debug child process and session state | Debug session/process id | Child process handles, reader tasks, debugger session state | Stop, disconnect, and shutdown paths must terminate or detach process state | DAP lifecycle tests; future `dap_bridge_start_stop_loop` scenario |
+| DAP bridge | Debug child process and session state | Debug session/process id | Child process handles, reader tasks, debugger session state | Stop, disconnect, and shutdown paths must terminate or detach process state | DAP lifecycle tests; DAP bridge start/stop retention smoke |
 | Formatting and external tools | Perltidy/perlcritic subprocess buffers | Request scope and file path | Subprocess output buffers and temp data | Request-scoped by subprocess runtime; no session bag should retain output after completion | formatting/diagnostics tests; formatting subprocess retention smoke |
 
 ## Memory Budgets
@@ -84,7 +84,7 @@ hard to interpret; focused scenarios make the owner obvious.
 | `completion_stream_cancel_storm` | Stream-session cancellation and removal | Unit regression coverage |
 | `file_watcher_bulk_create_change_delete` | Watcher debouncer and delete lifecycle | Unit retained-state coverage |
 | `workspace_folder_add_remove_multi_root` | Folder-scoped cleanup without cross-root eviction | Unit coverage, add process scenario if needed |
-| `dap_bridge_start_stop_loop` | Debug process/session lifecycle | Follow-up scenario |
+| `dap_bridge_start_stop_loop` | Debug process/session lifecycle | Unit retained-process coverage |
 | `formatting_perltidy_loop` | Subprocess and output-buffer retention | Unit retained-state coverage |
 
 ## Review Checklist


### PR DESCRIPTION
## Summary

- add a DAP bridge start/stop retained-process smoke in `bridge_adapter` unit coverage
- repeatedly inject long-running child processes into `BridgeAdapter`, call shutdown, and assert each child PID is gone afterward
- update retained-state inventory to mark `dap_bridge_start_stop_loop` as unit retained-process coverage

## Scope

Unit retained-process coverage only. This does not add RSS/nightly workloads or change DAP bridge runtime behavior.

## Validation

- `cargo xtask fmt`
- `cargo test -p perl-dap repeated_start_stop_cycles_do_not_leave_child_processes --lib -- --nocapture`
- `cargo test -p perl-dap --test bridge_adapter_unit_tests -- --nocapture`
- `cargo xtask check-memory-lifecycle-policy`
- `git diff --check`