### PR TITLE
docs(ci): add verification economics rollout plan (#0000)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,5 +37,12 @@ like (#0000) or (#9999) will fail CI.
 ## What's next
 <!-- Follow-up work, edge cases to address, related issues to file -->
 
+## CI cost / verification note
+<!-- See docs/ci/cost-and-verification-policy.md and docs/ci/lem-budgeting.md. -->
+- [ ] I used the cheapest relevant proof first.
+- [ ] I did not request broad CI unless this PR's risk surface needs it.
+- [ ] Any high-cost CI label (`full-ci`, `ci-budget-ack`, `ci-budget-override`) is explained in the PR body.
+- [ ] New CI work states the failure mode it catches and its estimated LEM.
+
 ## Agent
 <!-- If created by swarm: agent type, issue number, model tier -->

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -20,10 +20,11 @@ We are not reducing CI because we want less verification. We are reducing wasted
 can afford more verification where it matters.
 
 Agentic development makes code generation cheaper and faster, but verification remains
-expensive. That ratio is getting worse. At the author's current operating volume, 500+
-GitHub contributions per day is already routine from one Codex ChatGPT Pro subscription
-during the May bonus period, and 1,000 useful PRs/day is feasible with the broader local
-LLM tooling stack enabled.
+expensive. That ratio is getting worse. At high agent-driven operating volumes, 500+
+GitHub contributions per day is already routine for a single contributor with current
+LLM tooling, and 1,000 useful PRs/day is feasible with the broader local LLM tooling
+stack enabled. Even if your repo is not at that volume today, the verification system
+needs to be efficient enough to absorb agentic throughput as it grows.
 
 OpenClaw is useful as a benchmark for the pressure, not as criticism. Their published
 Blacksmith runner spend of roughly $511k maps directionally to about $20/commit since

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -1,0 +1,109 @@
+# CI Cost and Verification Policy
+
+This repository targets CI cost per ordinary PR far below common high-volume agentic
+defaults. The goal is **not** lighter verification. The goal is stronger verification per
+CI minute.
+
+> Companion docs: [lem-budgeting.md](lem-budgeting.md),
+> [verification-ladder.md](verification-ladder.md),
+> [labels.md](labels.md),
+> [perl-lsp-rollout-plan.md](perl-lsp-rollout-plan.md).
+> Anchors into the existing system: [../reference/CI_ARCHITECTURE.md](../reference/CI_ARCHITECTURE.md),
+> [`.ci/gate-policy.yaml`](../../.ci/gate-policy.yaml),
+> [`.ci/GATE_REGISTRY.toml`](../../.ci/GATE_REGISTRY.toml).
+
+---
+
+## Operating thesis
+
+We are not reducing CI because we want less verification. We are reducing wasted CI so we
+can afford more verification where it matters.
+
+Agentic development makes code generation cheaper and faster, but verification remains
+expensive. That ratio is getting worse. At the author's current operating volume, 500+
+GitHub contributions per day is already routine from one Codex ChatGPT Pro subscription
+during the May bonus period, and 1,000 useful PRs/day is feasible with the broader local
+LLM tooling stack enabled.
+
+OpenClaw is useful as a benchmark for the pressure, not as criticism. Their published
+Blacksmith runner spend of roughly $511k maps directionally to about $20/commit since
+February on Blacksmith alone. If they squash-merge PRs, commit count is a reasonable
+per-PR proxy, but the figure remains directional and excludes non-Blacksmith CI cost.
+
+We agree that agentic development needs more verification, likely more than most projects
+are doing today. The question is whether the verification system is *efficient enough to
+run continuously* at that volume.
+
+```
+Rust gives us fast compile-time and crate-local checks.
+ripr gives mutation-testing-lite value at static-analysis prices.
+LEM budgeting makes spend visible before a PR spends it.
+Risk-pack routing keeps expensive lanes tied to actual risk.
+```
+
+---
+
+## perl-lsp-specific framing
+
+`perl-lsp` already has a tiered CI conveyor: `pr_fast`, `merge_gate`, `nightly`, `release`
+(see `.ci/gate-policy.yaml`). This rollout does **not** replace it. It instruments it,
+assigns costs to lanes, adds `ripr` as a static oracle-gap signal, and uses actuals to
+tune default PR behavior over time.
+
+The relationship between artifacts:
+
+| Artifact | Role |
+|---|---|
+| `.ci/gate-policy.yaml` | What gates execute (enforcement source of truth) |
+| `.ci/GATE_REGISTRY.toml` | Gate registry for legacy/inventory mapping |
+| `policy/ci-lane-whitelist.toml` | **Why** each CI item exists, where it is allowed, who owns it |
+| `policy/ci-budget.toml` | LEM bands, runner multipliers, label conventions |
+| `policy/ci-lanes.toml` | Lane economics metadata (intent, base LEM, default-PR flag) |
+| `policy/ci-risk-packs.toml` | When extra proof is relevant |
+| `policy/ci-exceptions.toml` | Debt ledger for expensive default lanes |
+| `target/ci/ci-plan.json` | What this PR is expected to run |
+| `target/ci/ci-actuals.json` | What it actually spent |
+
+---
+
+## What a useful CI minute does
+
+A useful CI minute either:
+
+1. blocks a likely bad merge,
+2. proves a meaningful invariant,
+3. narrows a failure cause,
+4. produces durable timing, flake, cache, coverage, or compatibility signal.
+
+CI minutes spent on duplicated checks, no-op jobs, broad unrelated workflows, unnecessary
+model downloads, unnecessary OS runners, or non-blocking confirmation lanes are waste.
+
+---
+
+## Why the target is aggressive
+
+At expected repo volume, even sub-dollar PR economics matter. A `$20` verification cost
+per PR is not operationally acceptable when hundreds of PRs/day are plausible. The
+rollout target is:
+
+```text
+Default Rust PR:    < $0.50, < 35 LEM preferred
+High-risk PR:       up to $1 only with explicit label / reason
+Main / nightly:     preserve broad verification
+```
+
+See [lem-budgeting.md](lem-budgeting.md) for the LEM model and band table.
+
+---
+
+## What this rollout does not do
+
+- Does **not** weaken merge-gate shards.
+- Does **not** remove Windows guardrails or memory smoke before actuals.
+- Does **not** make `ripr` blocking.
+- Does **not** hard-enforce a 35 LEM budget before calibration.
+- Does **not** require matrix leaf checks in branch protection.
+- Does **not** treat skipped optional lanes as passed without a policy reason.
+
+The correct frame is: **more verification, better scoped, lower wasted spend, measured
+before enforced.**

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -1,0 +1,53 @@
+# CI Labels
+
+Label vocabulary for routing and budget acknowledgement. Labels are advisory until the
+PR Plan workflow lands (PR 04) and budget guard is active (PR 13). Naming aligns with
+existing `ci:*` labels already used in some workflows.
+
+> Companion: [cost-and-verification-policy.md](cost-and-verification-policy.md),
+> [lem-budgeting.md](lem-budgeting.md).
+
+---
+
+## Budget labels
+
+| Label | Meaning |
+|---|---|
+| `full-ci` | Run broad validation beyond the ordinary PR gate. Implies budget acknowledgement. |
+| `ci-budget-ack` | Acknowledge an elevated CI spend (35–125 LEM band). |
+| `ci-budget-override` | Override the hard 125 LEM ceiling. Use sparingly; always state reason in PR body. |
+
+## Lane-trigger labels
+
+| Label | Meaning |
+|---|---|
+| `ripr` | Force `ripr` static exposure analysis. |
+| `ripr-waive` | Acknowledge a `ripr` advisory finding (only after PR 18). |
+| `ci:coverage` / `coverage` | Run coverage lane. |
+| `ci:mutation` / `mutation` | Run runtime mutation testing. |
+| `ci:perl-matrix` | Run Perl version matrix lane. |
+| `ci:vscode-matrix` | Run VS Code OS matrix smoke. |
+| `ci:memory` | Run memory plateau workload. |
+| `ci:bench` / `ci:real-repo-latency` | Run real-repo latency / bench lanes. |
+| `ci:parser` | Force parser-related lanes. |
+| `ci:ux` | Force UX regression lane. |
+| `ci:dap` | Force DAP regression lanes. |
+| `ci:security` / `security-audit` | Force audit / deny / Trivy lane. |
+| `release-check` | Run release/package dry-run lanes. |
+
+## Out-of-scope labels (informational)
+
+| Label | Meaning |
+|---|---|
+| `ai-review` | Force external AI review on draft / non-credible PRs. |
+
+---
+
+## Label hygiene rules
+
+- One label per intent.
+- Adding a `ci:*` lane label without a reason in the PR body is discouraged.
+- `ci-budget-override` requires an explicit dollar/LEM reason.
+- Suppressions (e.g. `ripr-waive` on a finding) require an entry in the relevant
+  suppressions ledger (e.g. [`policy/ripr-suppressions.toml`](../../policy/ripr-suppressions.toml))
+  with `owner`, `reason`, `created`, `review_after`, `expires`.

--- a/docs/ci/lem-budgeting.md
+++ b/docs/ci/lem-budgeting.md
@@ -1,0 +1,102 @@
+# Linux-Equivalent Minutes (LEM)
+
+LEM is a normalized cost unit for CI lanes. It lets every lane and every PR be compared
+on the same axis regardless of which runner type or OS the work runs on.
+
+> See [cost-and-verification-policy.md](cost-and-verification-policy.md) for the
+> operating thesis and [verification-ladder.md](verification-ladder.md) for which lanes
+> sit at which cost band.
+
+---
+
+## Definition
+
+```text
+LEM = wall_clock_minutes × runner_multiplier
+```
+
+Runner multipliers are defined in [`policy/ci-budget.toml`](../../policy/ci-budget.toml).
+Initial values:
+
+| Runner | Multiplier |
+|---|---:|
+| `ubuntu-24.04` / `ubuntu-latest` | 1.0 |
+| `windows-latest` | 2.0 |
+| `macos-latest` | 10.0 |
+| `docker_build` | 6.0 |
+| `external_ai_review` | 4.0 |
+
+These reflect GitHub's documented per-minute billing weights for hosted runners. The
+exact rates are kept in TOML so they can be tuned without edits to docs.
+
+---
+
+## Bands
+
+Default planning bands:
+
+| Band | LEM | Meaning |
+|---|---:|---|
+| pennies | 0–12 | docs, metadata, light checks |
+| default | 13–35 | ordinary Rust PR |
+| elevated | 36–75 | risk-expanded PR |
+| high | 76–125 | explicit expensive PR |
+| over ceiling | >125 | requires `full-ci` or `ci-budget-override` |
+
+With a planning rate of `$0.008/Linux minute`:
+
+| LEM | Planning $ |
+|---:|---:|
+| 35 | ~$0.28 |
+| 75 | ~$0.60 |
+| 125 | ~$1.00 |
+
+The dollar figures are display-only; **billing truth lives in GitHub Actions usage
+reports**, not in this policy.
+
+---
+
+## Estimation strategy
+
+Three phases:
+
+1. **Static** (PR 04). Each lane declares `base_lem` in
+   [`policy/ci-lanes.toml`](../../policy/ci-lanes.toml). The PR Plan sums selected lanes.
+2. **Actuals** (PR 08). Receipts emit `target/ci/ci-actuals.json` with measured runtime
+   and runner multiplier. No enforcement.
+3. **Learned** (PR 16). Planner uses recent percentile actuals:
+
+   ```text
+   estimate     = max(static_floor, p50_recent_actual × 1.15)
+   warning      = p90_recent_actual
+   hard_planning = p95_recent_actual
+   ```
+
+   Strict enforcement of learned estimates is deferred until a calibration window has
+   accumulated.
+
+---
+
+## Soft warnings, hard guard
+
+After PR 13:
+
+| Estimated LEM | Behavior |
+|---:|---|
+| 0–35 | green summary |
+| 36–75 | warning |
+| 76–125 | high warning, suggest `ci-budget-ack` |
+| >125 | fails unless `full-ci` or `ci-budget-override` |
+
+Sub-125-LEM PRs never hard-fail on cost.
+
+---
+
+## What LEM is not
+
+- **Not a billing source.** GitHub usage and Blacksmith billing reports are authoritative.
+- **Not a per-author throttle.** It is a per-PR planning signal.
+- **Not a substitute for receipts.** Receipts (`target/receipts/`) remain the primary
+  evidence for whether a gate passed.
+
+LEM exists to make spend *visible*, not to replace the existing gate evidence layer.

--- a/docs/ci/lem-budgeting.md
+++ b/docs/ci/lem-budgeting.md
@@ -26,8 +26,12 @@ Initial values:
 | `docker_build` | 6.0 |
 | `external_ai_review` | 4.0 |
 
-These reflect GitHub's documented per-minute billing weights for hosted runners. The
-exact rates are kept in TOML so they can be tuned without edits to docs.
+For standard GitHub-hosted runners (`ubuntu-*`, `windows-*`, `macos-*`) these reflect
+GitHub's documented per-minute billing weights. For composite or specialized lanes
+(`docker_build`, `external_ai_review`, `self_hosted_gpu`) the multipliers are internal
+cost estimates rather than documented billing weights, since GitHub does not bill those
+as a single runner type. The exact rates are kept in TOML so they can be tuned without
+edits to docs.
 
 ---
 

--- a/docs/ci/perl-lsp-rollout-plan.md
+++ b/docs/ci/perl-lsp-rollout-plan.md
@@ -1,0 +1,74 @@
+# perl-lsp CI Economics Rollout Plan
+
+This is the multi-PR rollout plan for instrumenting `perl-lsp`'s existing CI conveyor
+with cost visibility, oracle-gap detection, and policy-driven routing. It does not
+replace the conveyor — it adds the missing economics layer.
+
+> Companion: [cost-and-verification-policy.md](cost-and-verification-policy.md),
+> [lem-budgeting.md](lem-budgeting.md), [verification-ladder.md](verification-ladder.md).
+> Anchors: [`.ci/gate-policy.yaml`](../../.ci/gate-policy.yaml),
+> [../reference/CI_ARCHITECTURE.md](../reference/CI_ARCHITECTURE.md).
+
+---
+
+## Order
+
+| PR | Name | Purpose |
+|---:|---|---|
+| 01 | CI economics docs | Encode verification economics doctrine and contributor framing. |
+| 02 | Policy TOML ledgers | Map every CI item to intent, cost, trigger, owner. |
+| 03 | CI inventory | Inventory current workflows; flag duplicates and gaps. |
+| 04 | PR Plan advisory | Emit per-PR LEM estimate and selected lanes. |
+| 05 | Cache save-only-master | Stop PR cache write churn. |
+| 06 | `ripr` advisory | Add static oracle-gap signal. |
+| 07 | PR Plan: `ripr` + LEM wiring | Make planner aware of `ripr` and risk packs. |
+| 08 | `ci-actuals` | Convert receipts into cost telemetry. |
+| 09 | LEM in gate policy | Cross-reference `.ci/gate-policy.yaml` with lane economics. |
+| 10 | Risk-pack routing metadata | Parser/LSP/workspace/DAP/security/memory risk packs. |
+| 11 | Workflow policy lint | Lint workflows against `policy/ci-lane-whitelist.toml`. |
+| 12 | `xtask ci plan` | Move PR Plan from Python to Rust. |
+| 13 | Soft LEM warnings | Warn above 35 / 75 LEM, hard guard above 125. |
+| 14 | External AI review tuning | Make Droid review advisory and LEM-visible. |
+| 15 | UX ownership clarification | Resolve `ci.yml` UX vs `ux-regression-gate.yml` overlap. |
+| 16 | Learned estimate scaffolding | Use observed actuals for LEM estimates. |
+| 17 | Conditional lane cleanup | Tune Windows / memory / UX / external review after actuals. |
+| 18 | `ripr` soft-gate promotion | Require acknowledgement for high-confidence new gaps. |
+
+---
+
+## Sequencing constraints
+
+- **PR 02 must land before PR 04.** PR Plan reads `policy/*.toml`.
+- **PR 04, 06, 08 are independent.** PR Plan, `ripr`, and `ci-actuals` can land in any
+  order after PR 02.
+- **PR 11 depends on PR 02.** Policy lint reads the whitelist.
+- **PR 12 depends on PR 04.** xtask version replaces the Python prototype.
+- **PR 13 depends on PR 08.** Soft warnings need a calibration window of actuals.
+- **PR 16 depends on PR 13.** Learned estimates need actuals + warnings.
+- **PR 17, 18 depend on PR 16.** Lane cleanup and `ripr` promotion need calibration.
+
+---
+
+## What this rollout will not do
+
+- Will not weaken merge-gate shards.
+- Will not remove Windows guardrails or memory smoke before actuals.
+- Will not make `ripr` blocking until PR 18.
+- Will not hard-enforce a 35 LEM budget before calibration.
+- Will not require matrix leaf checks in branch protection.
+- Will not treat skipped optional lanes as passed without a policy reason.
+
+---
+
+## Implementer handoff
+
+Every PR in the rollout must include:
+
+- Estimated LEM impact.
+- Affected workflows.
+- Whether branch protection changes (default: **no**).
+- What failure mode the lane catches.
+- What cheaper signal was considered.
+- Rollback path.
+
+Use the PR template's "CI cost / verification note" section.

--- a/docs/ci/verification-ladder.md
+++ b/docs/ci/verification-ladder.md
@@ -1,0 +1,78 @@
+# Verification Ladder
+
+Layered verification, ordered cheapest-to-most-expensive. Each rung answers a different
+proof obligation. Ordinary PRs buy the cheap rungs; main / nightly / release / labeled
+PRs buy the deep rungs.
+
+> Companion: [cost-and-verification-policy.md](cost-and-verification-policy.md),
+> [lem-budgeting.md](lem-budgeting.md), [labels.md](labels.md).
+
+---
+
+## Ladder
+
+| Layer | Default PR? | Purpose |
+|---|---:|---|
+| `cargo check` | yes | type and feature wiring |
+| `cargo fmt` | yes | mechanical consistency |
+| `cargo clippy` | yes | static policy / lint guard |
+| unit and oracle tests | yes | deterministic behavior proof |
+| UX regression smoke | yes (LSP/UX risk) | first-five-minutes user-visible behavior |
+| LSP memory smoke | yes (retained-state risk) | retained-state plateau |
+| Windows guardrails | yes (platform risk) | path / sandbox / module-separator regressions |
+| `ripr` | advisory first | static mutation-shaped oracle-gap signal |
+| bounded property tests | selective / label | input-space confidence |
+| coverage | main / `coverage` label | execution surface |
+| mutation testing | nightly / `mutation` label | runtime adequacy confirmation |
+| fuzzing | nightly | robustness |
+| OS / hardware / Docker / model checks | main / label / release | platform and integration proof |
+| release dry-run / semver | release / `release-check` label / main | publishability |
+
+---
+
+## Proof-obligation map
+
+Every CI lane should answer one row of this table. If two lanes answer the same row, one
+is a duplicate of the other and one belongs in `duplicate_of` in
+[`policy/ci-lane-whitelist.toml`](../../policy/ci-lane-whitelist.toml).
+
+| Failure mode | Cheapest lane that catches it | Deep lane |
+|---|---|---|
+| compile break | `cargo check` | all-features / all-targets |
+| formatting drift | `cargo fmt` | — |
+| lint / banned-pattern violation | `cargo clippy` | strict clippy |
+| changed behavior lacks oracle | `ripr` advisory | mutation testing |
+| unit-level regression | scoped `cargo test` | nextest workspace |
+| LSP UX regression | UX regression smoke | full UX harness + real-repo latency |
+| retained-state regression | LSP memory smoke | memory plateau |
+| Windows path / sandbox regression | Windows guardrails | platform matrix |
+| extension regression | VS Code Linux smoke | VS Code OS matrix |
+| dependency vuln | cargo audit | cargo deny / Trivy |
+| serialization break | schema fixtures | compatibility corpus |
+| public API break | public-API check | release dry-run |
+| docs break | docs gate | docs deploy |
+
+---
+
+## ripr's place on the ladder
+
+`ripr` is **mutation-testing-lite at static-analysis prices**. It does not run mutants,
+does not emit killed/survived counts, and does not replace mutation testing. It asks the
+mutation-testing-shaped question — "is the changed behavior exposed to a meaningful test
+discriminator?" — earlier and cheaper, using static analysis only.
+
+Severity vocabulary used in PR Plan summaries:
+
+```text
+exposed              — behavior change is statically reachable and has a nearby
+                       discriminating test
+weakly_exposed       — reachable, weakly-discriminating test only
+reachable_unrevealed — reachable, no discriminating test found
+no_static_path       — analysis could not find a reachable path
+infection_unknown    — could not classify infection
+propagation_unknown  — could not classify propagation
+static_unknown       — analysis bottomed out
+```
+
+Do **not** use runtime-mutation vocabulary (`killed`, `survived`) when reporting `ripr`
+results.


### PR DESCRIPTION
## Summary

PR 01 of the multi-PR CI economics rollout for `perl-lsp`. Encodes the verification economics doctrine **before** any workflow behavior changes, so future contributors and agents have the "why" behind subsequent mechanical PRs.

## Why

`perl-lsp` already has a sophisticated tiered CI conveyor (`.ci/gate-policy.yaml`: `pr_fast`, `merge_gate`, `nightly`, `release`). What's missing is a contract that makes verification *economics* explicit. Without it, future PRs will be misread as "make CI cheaper" when the actual strategy is **make verification dense enough to scale**.

The framing:

> We are not reducing CI because we want less verification.
> We are reducing wasted CI so we can afford more verification where it matters.

Includes the OpenClaw `~$20/commit` directional anchor (with squash-merge caveat) and the operating-volume reality (500+ PRs/day from one Codex Pro subscription, 1k/day with broader local LLM tooling).

## Changes

```
docs/ci/cost-and-verification-policy.md   - operating thesis
docs/ci/lem-budgeting.md                   - LEM model and bands
docs/ci/verification-ladder.md             - cheapest-to-deepest layering
docs/ci/labels.md                          - budget and lane labels
docs/ci/perl-lsp-rollout-plan.md           - 18-PR ordering and dependencies
.github/PULL_REQUEST_TEMPLATE.md           - + CI cost / verification checklist
```

## Test

Docs only. No CI behavior changes. No branch protection changes.

## Stack

This is **PR 01 of 6** in the rollout stack:

| # | Branch | What |
|---:|---|---|
| 01 | `claude/rust-ci-rollout-pr01-docs` ← *this PR* | docs anchor |
| 02 | `claude/rust-ci-rollout-pr02-policy` | policy TOML ledgers |
| 03 | `claude/rust-ci-rollout-pr03-inventory` | CI inventory |
| 04 | `claude/rust-ci-rollout-pr04-pr-plan` | advisory PR Plan workflow |
| 05 | `claude/rust-ci-rollout-pr05-cache` | restore-only cache on PRs |
| 06 | `claude/rust-ci-rollout-pr06-ripr` | `ripr` advisory |

Each branch is stacked on the previous; later PRs include the diffs of earlier ones until those are merged.

## CI cost / verification note

- [x] I used the cheapest relevant proof first.
- [x] I did not request broad CI unless this PR's risk surface needs it.
- [x] No high-cost CI label needed — docs only.
- [x] No new CI work in this PR.

Estimated LEM impact: **0** (docs only; no workflow changes).

## What I considered but didn't do

- Did not modify any workflow file. PR 01 is intentionally policy-text-only.
- Did not touch branch protection. Required-check changes are explicitly **out of scope** for this rollout; the existing `merge-gate` aggregate stays the required check.
- Did not bump MSRV. `rust-toolchain.toml` already pins 1.93.1 which satisfies `ripr` (added in PR 06).

## What's next

Merge PRs 01–03 (docs and policy) before 04–06 land. PRs 07–18 in the rollout plan extend this with actuals, learned estimates, risk-pack routing, and `ripr` soft-gate promotion — each gated on actuals from earlier PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_