### PR TITLE
ci(ripr): add advisory static exposure analysis (#0000)

### DIFF
--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -1,0 +1,96 @@
+# ripr — static RIPR exposure analysis (advisory)
+#
+# Adds mutation-testing-lite oracle-gap detection at static-analysis prices.
+# Advisory in this rollout PR (PR 06). PR 18 introduces narrow soft-gating
+# for high-confidence new oracle gaps with `ripr` / `ripr-waive` / `full-ci`
+# / `ci-budget-ack` labels.
+#
+# See docs/ci/ripr.md.
+
+name: ripr
+
+on:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - 'crates/**'
+      - 'xtask/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'ripr.toml'
+      - 'policy/ripr-suppressions.toml'
+      - '.github/workflows/ripr.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ripr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  ripr:
+    name: ripr static exposure
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+    # Advisory only in this PR. Failures do not block.
+    continue-on-error: true
+    if: github.event.pull_request.draft != true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Toolchain (rust-toolchain.toml pins 1.93.1)
+        run: rustc --version
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+          shared-key: ripr-${{ hashFiles('Cargo.lock') }}
+          save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+
+      - name: Install ripr
+        run: cargo install ripr --locked
+
+      - name: Run ripr (doctor)
+        run: ripr doctor
+
+      - name: Run ripr (JSON report)
+        run: |
+          mkdir -p target/ripr
+          ripr check --base "origin/${{ github.base_ref || 'master' }}" --json \
+            > target/ripr/ripr.json || true
+
+      - name: Run ripr (GitHub annotations)
+        run: |
+          ripr check --base "origin/${{ github.base_ref || 'master' }}" \
+            --format github || true
+
+      - name: Run ripr (SARIF)
+        run: |
+          ripr check --base "origin/${{ github.base_ref || 'master' }}" \
+            --format sarif > target/ripr/ripr.sarif || true
+
+      - name: Summarize ripr findings
+        if: always()
+        run: |
+          if [ -f target/ripr/ripr.json ]; then
+            python3 scripts/ci/ripr_summary.py \
+              --report target/ripr/ripr.json \
+              --summary "$GITHUB_STEP_SUMMARY" || true
+          fi
+
+      - name: Upload ripr report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ripr-report
+          path: target/ripr/
+          retention-days: 14
+          if-no-files-found: warn

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -1,0 +1,108 @@
+# ripr — Static Oracle-Gap Detection
+
+`ripr` adds **mutation-testing-lite oracle-gap detection at static-analysis prices**. It
+sits between coverage and runtime mutation testing on the verification ladder: more
+oracle-aware than coverage, far cheaper than mutation testing.
+
+> Companion: [verification-ladder.md](verification-ladder.md),
+> [labels.md](labels.md), [`policy/ripr-suppressions.toml`](../../policy/ripr-suppressions.toml).
+> Workflow: [`.github/workflows/ripr.yml`](../../.github/workflows/ripr.yml).
+
+---
+
+## What ripr does
+
+For each changed Rust function, ripr asks the mutation-testing-shaped question
+**statically**: is the changed behavior exposed to a meaningful test discriminator?
+
+It does **not**:
+
+- Run mutants.
+- Emit `killed` / `survived` counts.
+- Replace mutation testing.
+
+When reporting `ripr` findings, use ripr's own classifications:
+
+| Classification | Meaning |
+|---|---|
+| `exposed` | reachable + nearby discriminating test |
+| `weakly_exposed` | reachable, weakly-discriminating test only |
+| `reachable_unrevealed` | reachable, no discriminating test found |
+| `no_static_path` | analysis could not find a reachable path |
+| `infection_unknown` | could not classify infection |
+| `propagation_unknown` | could not classify propagation |
+| `static_unknown` | analysis bottomed out |
+
+Do **not** translate these into `killed` / `survived`. They mean something different.
+
+---
+
+## When it runs
+
+- Every PR that touches `crates/**`, `xtask/**`, `Cargo.toml`, `Cargo.lock`, or `ripr.toml`.
+- Skipped on docs-only PRs.
+- Manual via `workflow_dispatch`.
+- Forced via the `ripr` label (PR 07 wires this through PR Plan).
+
+---
+
+## Behavior
+
+- `continue-on-error: true` — does **not** block merges.
+- Uploads `target/ripr/ripr.json` and `target/ripr/ripr.sarif`.
+- Posts a per-PR step summary via `scripts/ci/ripr_summary.py`.
+
+---
+
+## Suppressions
+
+Suppressions live in [`policy/ripr-suppressions.toml`](../../policy/ripr-suppressions.toml).
+Each suppression requires:
+
+- `id` — stable identifier
+- `kind` — e.g. `generated_or_non_production_surface`
+- `paths` and/or `classification` — what to suppress
+- `owner` — accountable person/team
+- `reason` — why this is suppressed
+- `created`, `review_after`, `expires` — dates
+
+The suppression file is read by `ripr.toml`'s `[suppressions] path` setting.
+
+---
+
+## Promotion path
+
+| PR | What happens |
+|---:|---|
+| 06 | Advisory only — this PR. |
+| 18 | Narrow soft-gate for new high-confidence findings on production Rust diffs. Acknowledged via `ripr-waive` / `full-ci` / `ci-budget-ack` labels. |
+
+The soft-gate at PR 18 only fires when:
+
+- Classification is `reachable_unrevealed` or `weakly_exposed`.
+- Production Rust changed and no nearby test changed.
+- Finding is not in `policy/ripr-suppressions.toml`.
+- Confidence is high.
+
+ripr is **never** used as proof; it is used as a **prompt**.
+
+---
+
+## Toolchain
+
+`rust-toolchain.toml` pins `1.93.1`, which satisfies `ripr`'s `>= 1.93` MSRV. The workflow
+uses the toolchain pinned in the repo and installs `ripr` via `cargo install ripr --locked`.
+
+---
+
+## Running locally
+
+```bash
+cargo install ripr --locked
+ripr doctor
+ripr check --base origin/master
+ripr check --base origin/master --json > target/ripr/ripr.json
+python3 scripts/ci/ripr_summary.py \
+    --report target/ripr/ripr.json \
+    --summary /dev/stdout
+```

--- a/ripr.toml
+++ b/ripr.toml
@@ -1,0 +1,37 @@
+# ripr configuration
+#
+# Static RIPR exposure analysis for changed Rust behavior.
+# Reads policy/ripr-suppressions.toml for suppressions.
+#
+# See docs/ci/ripr.md for the perl-lsp framing. ripr is mutation-testing-lite
+# at static-analysis prices; it does not run mutants and does not replace
+# mutation testing.
+
+schema_version = 1
+
+[analysis]
+# Diff mode: analyze only changed code relative to the merge base.
+mode = "diff"
+
+[policy]
+# Advisory only in this rollout PR. PR 18 introduces narrow soft-gating for
+# high-confidence new oracle gaps.
+fail_on = []
+
+[report]
+max_related_tests = 8
+include_context = true
+
+[severity]
+# Use ripr's own classifications. Do NOT use mutation-runtime words
+# (killed/survived) when reporting these.
+exposed = "notice"
+weakly_exposed = "warning"
+reachable_unrevealed = "warning"
+no_static_path = "notice"
+infection_unknown = "notice"
+propagation_unknown = "notice"
+static_unknown = "notice"
+
+[suppressions]
+path = "policy/ripr-suppressions.toml"

--- a/scripts/ci/ripr_summary.py
+++ b/scripts/ci/ripr_summary.py
@@ -88,18 +88,28 @@ def render(findings: list[dict[str, Any]]) -> str:
             f.get("location", ""),
         )
 
+    def _md_safe(s: str) -> str:
+        # Normalize Windows separators and escape pipes so they don't break the
+        # markdown table.
+        return s.replace("\\", "/").replace("|", "\\|")
+
     for f in sorted(findings, key=sort_key)[:20]:
         cls = classify(f)
-        loc = f.get("location") or f.get("path") or "?"
-        if isinstance(loc, dict):
-            loc = f"{loc.get('file', '?')}:{loc.get('line', '?')}"
+        loc_raw = f.get("location") or f.get("path") or "?"
+        if isinstance(loc_raw, dict):
+            file_part = str(loc_raw.get("file", "?"))
+            line_part = loc_raw.get("line", "?")
+            loc = f"{file_part}:{line_part}"
+        else:
+            loc = str(loc_raw)
+        loc = _md_safe(loc)
         tests = f.get("related_tests") or f.get("tests") or []
         if isinstance(tests, list):
-            test_str = ", ".join(str(t) for t in tests[:3])
+            test_str = ", ".join(_md_safe(str(t)) for t in tests[:3])
             if len(tests) > 3:
                 test_str += f" (+{len(tests) - 3})"
         else:
-            test_str = str(tests)
+            test_str = _md_safe(str(tests))
         lines.append(f"| `{cls}` | {loc} | {test_str or '—'} |")
 
     lines.append("")
@@ -119,23 +129,23 @@ def main() -> int:
     p.add_argument("--summary", type=str, required=True)
     args = p.parse_args()
 
+    summary_path = Path(args.summary)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+
     if not args.report.exists() or args.report.stat().st_size == 0:
-        Path(args.summary).parent.mkdir(parents=True, exist_ok=True)
-        with open(args.summary, "a") as f:
+        with open(summary_path, "a", encoding="utf-8") as f:
             f.write("# ripr (advisory)\n\nReport file empty or missing.\n")
         return 0
 
     try:
-        doc = json.loads(args.report.read_text())
+        doc = json.loads(args.report.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
-        Path(args.summary).parent.mkdir(parents=True, exist_ok=True)
-        with open(args.summary, "a") as f:
+        with open(summary_path, "a", encoding="utf-8") as f:
             f.write(f"# ripr (advisory)\n\nCould not parse report: {e}\n")
         return 0
 
     findings = collect_findings(doc)
-    Path(args.summary).parent.mkdir(parents=True, exist_ok=True)
-    with open(args.summary, "a") as f:
+    with open(summary_path, "a", encoding="utf-8") as f:
         f.write(render(findings))
     return 0
 

--- a/scripts/ci/ripr_summary.py
+++ b/scripts/ci/ripr_summary.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Render a ripr JSON report into a GitHub step summary.
+
+Defensive: tolerates schema variation between ripr versions, since this is the
+first integration. Produces a markdown table sorted by classification severity.
+Does not use runtime-mutation vocabulary (killed/survived).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Order matters: most actionable classifications first.
+SEVERITY_ORDER = [
+    "exposed",
+    "weakly_exposed",
+    "reachable_unrevealed",
+    "infection_unknown",
+    "propagation_unknown",
+    "no_static_path",
+    "static_unknown",
+]
+
+
+def collect_findings(doc: Any) -> list[dict[str, Any]]:
+    """Find a list of finding dicts in the ripr report regardless of layout."""
+    if isinstance(doc, list):
+        return [d for d in doc if isinstance(d, dict)]
+    if isinstance(doc, dict):
+        for key in ("findings", "results", "items", "report"):
+            v = doc.get(key)
+            if isinstance(v, list):
+                return [d for d in v if isinstance(d, dict)]
+    return []
+
+
+def classify(finding: dict[str, Any]) -> str:
+    for key in ("classification", "class", "category", "severity"):
+        v = finding.get(key)
+        if isinstance(v, str):
+            return v.lower()
+    return "static_unknown"
+
+
+def render(findings: list[dict[str, Any]]) -> str:
+    lines = ["# ripr (advisory)", ""]
+    if not findings:
+        lines.extend(
+            [
+                "No oracle-gap findings on the changed Rust diff.",
+                "",
+                "_ripr is advisory in this rollout. See "
+                "[`docs/ci/ripr.md`](../blob/master/docs/ci/ripr.md)._",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    counts: dict[str, int] = {}
+    for f in findings:
+        c = classify(f)
+        counts[c] = counts.get(c, 0) + 1
+
+    lines.append("## Counts")
+    lines.append("")
+    lines.append("| Classification | Count |")
+    lines.append("|---|---:|")
+    for cls in SEVERITY_ORDER:
+        if cls in counts:
+            lines.append(f"| `{cls}` | {counts[cls]} |")
+    other = {k: v for k, v in counts.items() if k not in SEVERITY_ORDER}
+    for cls, n in sorted(other.items()):
+        lines.append(f"| `{cls}` | {n} |")
+    lines.append("")
+
+    lines.append("## Top findings")
+    lines.append("")
+    lines.append("| Classification | Location | Test signal |")
+    lines.append("|---|---|---|")
+
+    def sort_key(f: dict[str, Any]) -> tuple[int, str]:
+        c = classify(f)
+        return (
+            SEVERITY_ORDER.index(c) if c in SEVERITY_ORDER else len(SEVERITY_ORDER),
+            f.get("location", ""),
+        )
+
+    for f in sorted(findings, key=sort_key)[:20]:
+        cls = classify(f)
+        loc = f.get("location") or f.get("path") or "?"
+        if isinstance(loc, dict):
+            loc = f"{loc.get('file', '?')}:{loc.get('line', '?')}"
+        tests = f.get("related_tests") or f.get("tests") or []
+        if isinstance(tests, list):
+            test_str = ", ".join(str(t) for t in tests[:3])
+            if len(tests) > 3:
+                test_str += f" (+{len(tests) - 3})"
+        else:
+            test_str = str(tests)
+        lines.append(f"| `{cls}` | {loc} | {test_str or '—'} |")
+
+    lines.append("")
+    lines.append(
+        "_ripr is **advisory** in this rollout. ripr is mutation-testing-lite at "
+        "static-analysis prices; it does **not** run mutants and does **not** replace "
+        "runtime mutation testing. See "
+        "[`docs/ci/verification-ladder.md`](../blob/master/docs/ci/verification-ladder.md) "
+        "for ripr's place on the verification ladder._"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--report", type=Path, required=True)
+    p.add_argument("--summary", type=str, required=True)
+    args = p.parse_args()
+
+    if not args.report.exists() or args.report.stat().st_size == 0:
+        Path(args.summary).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.summary, "a") as f:
+            f.write("# ripr (advisory)\n\nReport file empty or missing.\n")
+        return 0
+
+    try:
+        doc = json.loads(args.report.read_text())
+    except json.JSONDecodeError as e:
+        Path(args.summary).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.summary, "a") as f:
+            f.write(f"# ripr (advisory)\n\nCould not parse report: {e}\n")
+        return 0
+
+    findings = collect_findings(doc)
+    Path(args.summary).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.summary, "a") as f:
+        f.write(render(findings))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR 06 of the CI economics rollout. Adds `ripr` static RIPR exposure analysis as an **advisory** lane. Sits between coverage and runtime mutation testing on the verification ladder: more oracle-aware than coverage, far cheaper than mutation testing.

Stacked on **#8138** (PR 05 cache).

## Why

The PR 03 inventory flagged "changed behavior lacks oracle on PR" as a real gap. Today only nightly mutation testing covers oracle adequacy, which is too slow to be a per-PR signal. `ripr` asks the mutation-testing-shaped question **statically** at the cost of a 4-LEM job.

## What ripr does (and does not)

`ripr` does **not**:
- run mutants
- emit `killed` / `survived` counts
- replace mutation testing

It asks: is the changed behavior exposed to a meaningful test discriminator? Findings use ripr's own classifications (`exposed`, `weakly_exposed`, `reachable_unrevealed`, `no_static_path`, `infection_unknown`, `propagation_unknown`, `static_unknown`). Runtime-mutation vocabulary is forbidden in summaries — `scripts/ci/ripr_summary.py` enforces this naming.

## Changes

```
ripr.toml                            - ripr config (advisory severities)
.github/workflows/ripr.yml           - PR workflow, continue-on-error
scripts/ci/ripr_summary.py           - JSON -> step-summary renderer
docs/ci/ripr.md                      - usage, classifications, promotion path
```

Suppressions live in `policy/ripr-suppressions.toml` (added in PR 02).

## Behavior

- Triggers on PRs touching `crates/**`, `xtask/**`, `Cargo.{toml,lock}`, `ripr.toml`, `policy/ripr-suppressions.toml`, or its own workflow.
- Skips drafts and (via paths filter) docs-only PRs.
- `continue-on-error: true`. Does not block merges.
- Uploads `target/ripr/ripr.json` and `target/ripr/ripr.sarif`.
- Cache `save-if` per PR 05 policy.

## Toolchain

`rust-toolchain.toml` already pins `1.93.1`, satisfying ripr's `>= 1.93` MSRV. The workflow installs ripr via `cargo install ripr --locked`.

## Promotion path

PR 18 introduces narrow soft-gating for high-confidence new oracle gaps (only when classification is `reachable_unrevealed` or `weakly_exposed`, production Rust changed, no nearby test changed, not suppressed, high confidence). Gated PRs can acknowledge via `ripr-waive` / `full-ci` / `ci-budget-ack` labels.

## Test

- `ripr.toml` parses with `tomllib`.
- `.github/workflows/ripr.yml` parses with `yaml.safe_load`.
- `scripts/ci/ripr_summary.py` smoke-tested on `{"findings":[]}` empty input.
- `cargo install ripr --locked` is exercised by the workflow itself; first run will validate end-to-end.

## CI cost / verification note

- [x] Cheapest relevant proof: static analysis (~4 LEM) before any runtime mutation lane.
- [x] No broad CI label needed.
- [x] **Failure mode caught:** changed behavior is reachable but tests do not appear to discriminate it.
- [x] **Cheaper signal considered:** coverage misses oracle adequacy (it only measures execution surface). No cheaper signal for oracle-gap detection exists.
- [x] **Estimated LEM impact:** +4 LEM on Rust-touching PRs (advisory job; does not block).
- [x] **Rollback path:** Revert this PR. No state outside this branch (no required-check, no policy enforcement).

## Stack

PR 01 → PR 02 → PR 03 → PR 04 → PR 05 → **PR 06 (this)**.

## What I considered but didn't do

- Did not make ripr blocking. PR 18 introduces narrow soft-gating after advisory data accumulates.
- Did not add ripr to the merge-gate aggregate. The whole point is that ripr is a prompt, not proof.
- Did not bump MSRV. Already satisfied at 1.93.1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_