### PR TITLE
ci: emit ci-actuals.json from gate receipts (#0000)

### DIFF
--- a/docs/ci/ci-actuals.md
+++ b/docs/ci/ci-actuals.md
@@ -1,0 +1,112 @@
+# CI Actuals
+
+`ci-actuals.json` records what each gate actually spent in CI. It is the actuals
+counterpart to [`ci-plan.json`](pr-plan.md): the plan forecasts cost; the actuals
+record what was spent. Together they let later PRs derive learned LEM estimates.
+
+> Companion: [pr-plan.md](pr-plan.md), [lem-budgeting.md](lem-budgeting.md).
+
+---
+
+## What it does
+
+`scripts/ci/emit_ci_actuals.py` walks `target/receipts/` for gate receipts produced by
+`xtask`, extracts `gate_name`, `tier`, `status`, `duration_ms`, and runner, and converts
+each receipt into a per-job actuals entry with:
+
+- `actual_minutes` = `duration_ms / 60000`
+- `actual_lem` = `actual_minutes × runner_multiplier`
+- `estimated_lem` = `policy/ci-lanes.toml`'s `base_lem` for the matching lane id
+- `delta_lem` = `actual_lem − estimated_lem`
+
+It writes `target/ci/ci-actuals.json`. The schema is intentionally tolerant: missing
+`duration_ms` results in `actual_lem: null`. Receipts without a matching lane entry get
+`estimated_lem: null`. This avoids the actuals collector becoming a brittle gate.
+
+---
+
+## Wiring
+
+The script is meant to run after `xtask gates` in CI workflows:
+
+```yaml
+- name: Run gates
+  run: cargo xtask gates --receipt target/receipts/receipt.json
+
+- name: Emit CI actuals
+  if: always()
+  run: |
+    python3 scripts/ci/emit_ci_actuals.py \
+      --receipts-dir target/receipts \
+      --workflow "${GITHUB_WORKFLOW}" \
+      --sha "${GITHUB_SHA}" \
+      --pr "${{ github.event.pull_request.number || 0 }}" \
+      --json-out target/ci/ci-actuals.json
+
+- name: Upload ci-actuals
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: ci-actuals
+    path: target/ci/ci-actuals.json
+    retention-days: 30
+    if-no-files-found: warn
+```
+
+The actual workflow wiring lands in a follow-up — this PR delivers the script and docs
+without touching `.github/workflows/ci.yml` so the rollout stays low-risk.
+
+---
+
+## Output schema
+
+```json
+{
+  "schema_version": 1,
+  "repo": "perl-lsp",
+  "sha": "abc",
+  "pr": 8137,
+  "workflow": "CI",
+  "totals": {
+    "actual_lem": 25.0,
+    "estimated_lem": 36.0,
+    "delta_lem": -11.0
+  },
+  "jobs": [
+    {
+      "gate_name": "pr_smoke",
+      "tier": "pr_fast",
+      "status": "pass",
+      "runner": "ubuntu_24_04",
+      "duration_ms": 120000,
+      "actual_minutes": 2.0,
+      "actual_lem": 2.0,
+      "estimated_lem": 4.0,
+      "source_path": "target/receipts/receipt.json"
+    }
+  ]
+}
+```
+
+---
+
+## Why receipts, not workflow timestamps
+
+The repo already produces structured gate receipts via `xtask`. Reading those is more
+durable than scraping GitHub Actions timestamps from inside a job (which require either
+log parsing or extra calls to the Actions API). Receipts also distinguish "the gate
+ran" from "the job took N seconds" — the gate's own duration is a cleaner signal than
+job overhead like cache restore and toolchain setup.
+
+---
+
+## Roadmap
+
+| PR | Change |
+|---:|---|
+| 08 | This file. Python script + docs; not wired into workflows yet. |
+| 13 | Soft LEM warnings using actuals. |
+| 16 | Use percentile actuals (`p50`, `p90`, `p95`) to derive learned estimates. |
+
+The first phase is purely observational. Enforcement based on actuals comes only after
+a calibration window has accumulated.

--- a/scripts/ci/emit_ci_actuals.py
+++ b/scripts/ci/emit_ci_actuals.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Emit ci-actuals.json from gate receipts produced by xtask.
+
+Reads:
+  target/receipts/**/*.json   (or path passed via --receipts-dir)
+  policy/ci-budget.toml       (for runner multipliers)
+  policy/ci-lanes.toml        (for static base_lem floor)
+
+Writes:
+  target/ci/ci-actuals.json   (or path passed via --json-out)
+
+This is the actuals counterpart to ci-plan.json. The plan forecasts cost; the
+actuals records what was actually spent. Together they let later PRs derive
+learned LEM estimates (PR 16 in the rollout).
+
+Tolerant by design: receipts may have missing/partial fields, especially
+during the rollout window. Missing duration_ms results in a null actual_lem;
+the receipt is still recorded.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+
+
+def read_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def collect_receipts(receipts_dir: Path) -> list[dict[str, Any]]:
+    """Walk receipts_dir for *.json files, parse, and return as list."""
+    if not receipts_dir.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for path in sorted(receipts_dir.rglob("*.json")):
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        # Receipts have either a top-level `gates` array (gate-policy receipts)
+        # or are a single gate receipt themselves.
+        if isinstance(doc, dict) and isinstance(doc.get("gates"), list):
+            for gate in doc["gates"]:
+                if isinstance(gate, dict):
+                    gate.setdefault("_source_path", str(path))
+                    out.append(gate)
+        elif isinstance(doc, dict) and "gate_name" in doc:
+            doc.setdefault("_source_path", str(path))
+            out.append(doc)
+    return out
+
+
+def lane_base_lem(lane_id: str, lanes: dict[str, Any]) -> float | None:
+    lane = lanes.get(lane_id)
+    if not isinstance(lane, dict):
+        return None
+    base = lane.get("base_lem")
+    if isinstance(base, (int, float)):
+        return float(base)
+    return None
+
+
+def emit_actuals(
+    *,
+    receipts: list[dict[str, Any]],
+    multipliers: dict[str, float],
+    lanes: dict[str, Any],
+    workflow: str,
+    sha: str,
+    pr: int | None,
+    runner_default: str,
+) -> dict[str, Any]:
+    jobs: list[dict[str, Any]] = []
+    total_actual_lem = 0.0
+    total_estimated_lem = 0.0
+    for r in receipts:
+        gate_name = r.get("gate_name", "")
+        duration_ms = r.get("duration_ms")
+        runner = r.get("runner") or runner_default
+        mult = float(multipliers.get(runner, multipliers.get(runner_default, 1.0)))
+        if isinstance(duration_ms, (int, float)) and duration_ms > 0:
+            actual_minutes = float(duration_ms) / 1000.0 / 60.0
+            actual_lem = actual_minutes * mult
+            total_actual_lem += actual_lem
+        else:
+            actual_minutes = None
+            actual_lem = None
+        # Attribute against a static lane floor where the gate name maps to a
+        # known lane id. Many gate names match lane ids directly.
+        estimated_lem = lane_base_lem(gate_name, lanes)
+        if estimated_lem is not None:
+            total_estimated_lem += estimated_lem
+        jobs.append(
+            {
+                "gate_name": gate_name,
+                "tier": r.get("tier"),
+                "status": r.get("status"),
+                "runner": runner,
+                "duration_ms": duration_ms,
+                "actual_minutes": actual_minutes,
+                "actual_lem": actual_lem,
+                "estimated_lem": estimated_lem,
+                "source_path": r.get("_source_path"),
+            }
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "repo": "perl-lsp",
+        "sha": sha,
+        "pr": pr,
+        "workflow": workflow,
+        "totals": {
+            "actual_lem": total_actual_lem,
+            "estimated_lem": total_estimated_lem,
+            "delta_lem": total_actual_lem - total_estimated_lem,
+        },
+        "jobs": jobs,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--receipts-dir", type=Path, default=Path("target/receipts"))
+    p.add_argument("--budget", type=Path, default=Path("policy/ci-budget.toml"))
+    p.add_argument("--lanes", type=Path, default=Path("policy/ci-lanes.toml"))
+    p.add_argument(
+        "--json-out", type=Path, default=Path("target/ci/ci-actuals.json")
+    )
+    p.add_argument("--workflow", default=os.environ.get("GITHUB_WORKFLOW", ""))
+    p.add_argument("--sha", default=os.environ.get("GITHUB_SHA", "HEAD"))
+    p.add_argument("--pr", type=int, default=None)
+    p.add_argument(
+        "--runner-default",
+        default="ubuntu_24_04",
+        help="Runner to assume when receipts don't carry a runner field.",
+    )
+    args = p.parse_args()
+
+    multipliers = read_toml(args.budget).get("runner_multipliers", {})
+    lanes = read_toml(args.lanes).get("lane", {})
+
+    receipts = collect_receipts(args.receipts_dir)
+    actuals = emit_actuals(
+        receipts=receipts,
+        multipliers=multipliers,
+        lanes=lanes,
+        workflow=args.workflow,
+        sha=args.sha,
+        pr=args.pr,
+        runner_default=args.runner_default,
+    )
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(actuals, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        json.dumps(
+            {
+                "jobs": len(actuals["jobs"]),
+                "actual_lem": actuals["totals"]["actual_lem"],
+                "estimated_lem": actuals["totals"]["estimated_lem"],
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR 08 of the rollout. Adds the actuals collector that pairs with PR 04's PR Plan: the plan forecasts cost, the actuals records what was spent. Together they let later PRs (PR 13, PR 16) derive learned LEM estimates.

Stacked on **#8142** (PR 07 PR Plan ripr/origins).

## Changes

```
scripts/ci/emit_ci_actuals.py - receipts -> ci-actuals.json
docs/ci/ci-actuals.md         - schema + wiring + roadmap
```

## Behavior

- Walks `target/receipts/**/*.json` for xtask gate receipts (uses the existing `.ci/receipt.schema.json` shape).
- Tolerates partial/missing fields (`actual_lem: null` when `duration_ms` missing; `estimated_lem: null` when no matching lane in `ci-lanes.toml`).
- Computes `actual_lem = duration_ms/60000 * runner_multiplier` and `delta_lem = actual_lem − estimated_lem`.
- Emits totals and per-job entries.

## Smoke test

On a synthetic 3-gate fixture:
```
pr_smoke           actual=2.0 LEM   estimated=4.0   delta=-2.0
merge_gate_shards  actual=15.0 LEM  estimated=24.0  delta=-9.0
ux_tests           actual=8.0 LEM   estimated=8.0   delta=0
totals: actual=25 estimated=36 delta=-11
```

## CI cost / verification note

- [x] Cheapest relevant proof: synthetic fixture exercise.
- [x] No broad CI label needed.
- [x] Estimated LEM impact: 0 (no workflow files modified by this PR).
- [x] **Wiring is intentionally deferred** to a follow-up so this PR stays low-risk. PR 13 and PR 16 consume the output once wiring lands.
- [x] Rollback: revert this PR; only adds a script + docs.

## Stack

PR 01 → ... → PR 07 → **PR 08 (this)**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_