### PR TITLE
ci(pr-plan): add soft LEM warnings and hard-ceiling guard (#0000)

### DIFF
--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -46,6 +46,10 @@ jobs:
           python-version: "3.12"
 
       - name: Compute PR Plan
+        # continue-on-error so the artifact upload step still runs even when
+        # the budget guard returns exit 2 (over hard ceiling, no override).
+        continue-on-error: true
+        id: plan
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -70,3 +74,15 @@ jobs:
           path: target/ci/ci-plan.json
           retention-days: 14
           if-no-files-found: warn
+
+      - name: Budget guard (hard ceiling)
+        # Re-surface a non-zero exit from the planner so over-ceiling PRs that
+        # don't have a `full-ci` or `ci-budget-override` label visibly fail.
+        # Sub-125-LEM PRs and acknowledged over-ceiling PRs pass.
+        if: always() && steps.plan.outcome == 'failure'
+        run: |
+          echo "::error::PR Plan returned a non-success exit code; see the step summary."
+          # Fail this job so the budget guard is visible. The PR Plan workflow
+          # is not a required check, so this never blocks merges — it only
+          # surfaces budget overruns to the contributor.
+          exit 1

--- a/docs/ci/lem-budgeting.md
+++ b/docs/ci/lem-budgeting.md
@@ -83,16 +83,17 @@ Three phases:
 
 ## Soft warnings, hard guard
 
-After PR 13:
+| Estimated LEM | Band | Behavior |
+|---:|---|---|
+| 0–35 | `default` | green summary |
+| 36–75 | `elevated` | warning |
+| 76–125 | `high` | warning; recommends `ci-budget-ack` (acknowledged silently if `ci-budget-ack` or `full-ci` is set) |
+| >125 | `over_ceiling` | **PR Plan job fails** unless `ci-budget-override` or `full-ci` is set |
 
-| Estimated LEM | Behavior |
-|---:|---|
-| 0–35 | green summary |
-| 36–75 | warning |
-| 76–125 | high warning, suggest `ci-budget-ack` |
-| >125 | fails unless `full-ci` or `ci-budget-override` |
-
-Sub-125-LEM PRs never hard-fail on cost.
+Sub-125-LEM PRs never hard-fail on cost. The PR Plan workflow itself is not a required
+check, so even a budget-guard failure does not block merges — it only surfaces the
+overrun visibly to the contributor and to anyone reviewing the PR. PR-merge enforcement
+of LEM is intentionally **not** part of this rollout.
 
 ---
 

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -364,22 +364,42 @@ def main() -> int:
 
     warnings: list[str] = []
     band = band_for(estimated_lem, budget)
+    label_set = {l.lower() for l in labels}
+    has_ack = "ci-budget-ack" in label_set or "full-ci" in label_set
+    has_override = "ci-budget-override" in label_set or "full-ci" in label_set
+
+    over_ceiling_failure = False
     if band == "elevated":
         warnings.append(
             f"Estimated LEM {estimated_lem:.1f} is in the *elevated* band "
-            f"(>{budget.get('default_limit_lem', 35)}). Consider whether all selected lanes are needed."
+            f"(>{budget.get('default_limit_lem', 35)}). Consider whether all "
+            "selected lanes are needed."
         )
     elif band == "high":
-        warnings.append(
-            f"Estimated LEM {estimated_lem:.1f} is in the *high* band. "
-            "Consider applying `ci-budget-ack`."
-        )
+        if has_ack:
+            warnings.append(
+                f"Estimated LEM {estimated_lem:.1f} is in the *high* band; "
+                "acknowledged via `ci-budget-ack` (or `full-ci`)."
+            )
+        else:
+            warnings.append(
+                f"Estimated LEM {estimated_lem:.1f} is in the *high* band. "
+                "Apply `ci-budget-ack` if this spend is intentional."
+            )
     elif band == "over_ceiling":
-        if not any(lbl in {"full-ci", "ci-budget-override"} for lbl in labels):
+        if has_override:
             warnings.append(
                 f"Estimated LEM {estimated_lem:.1f} exceeds hard ceiling "
-                f"({budget.get('hard_limit_lem', 125)}). PR Plan is advisory in this rollout PR; "
-                "PR 13 will fail without `full-ci` or `ci-budget-override`."
+                f"({budget.get('hard_limit_lem', 125)}); explicitly overridden "
+                "via `ci-budget-override` (or `full-ci`)."
+            )
+        else:
+            over_ceiling_failure = True
+            warnings.append(
+                f"::error::Estimated LEM {estimated_lem:.1f} exceeds hard "
+                f"ceiling ({budget.get('hard_limit_lem', 125)}). Apply "
+                "`ci-budget-override` or `full-ci` to acknowledge, or trim "
+                "selected lanes."
             )
 
     plan: dict[str, Any] = {
@@ -408,6 +428,12 @@ def main() -> int:
             "skipped_lanes": skipped_lanes,
         },
         "warnings": warnings,
+        "guard": {
+            "hard_ceiling_exceeded": band == "over_ceiling",
+            "override_present": has_override,
+            "ack_present": has_ack,
+            "failed": over_ceiling_failure,
+        },
     }
 
     args.json_out.parent.mkdir(parents=True, exist_ok=True)
@@ -420,6 +446,8 @@ def main() -> int:
             f.write(render_summary(plan))
 
     print(json.dumps({"estimated_lem": estimated_lem, "band": band, "lanes": len(selected_lanes)}))
+    if over_ceiling_failure:
+        return 2  # distinct from generic error so workflow can branch on it
     return 0
 
 


### PR DESCRIPTION
## Summary

PR 13 of the rollout. Adds soft warnings tuned per LEM band and a hard-ceiling guard at 125 LEM that requires explicit `ci-budget-override` or `full-ci` to pass.

Stacked on **#8144** (PR 09 gate-lane mapping).

## Behavior

| Band | LEM | Without ack/override | With `ci-budget-ack` | With `ci-budget-override` or `full-ci` |
|---|---:|---|---|---|
| `default` | 0–35 | green | n/a | n/a |
| `elevated` | 36–75 | warning | n/a | n/a |
| `high` | 76–125 | warning, recommends ack | acknowledged note | n/a |
| `over_ceiling` | >125 | **fails (exit 2)** | n/a | passes with override note |

The PR Plan workflow itself is not a required check, so even a budget-guard failure does not block merges — it only surfaces the overrun visibly to the contributor and to anyone reviewing the PR. **Merge-time enforcement of LEM is intentionally not part of this rollout.**

## Workflow integration

`pr-plan.yml` is updated with `continue-on-error: true` on the planner step (so the artifact still uploads) plus a separate `Budget guard (hard ceiling)` step that re-surfaces the planner exit code as a job failure when over-ceiling and no override.

## ci-plan.json changes

New `guard` block:
```json
"guard": {
  "hard_ceiling_exceeded": false,
  "override_present": false,
  "ack_present": false,
  "failed": false
}
```

## Smoke tests

```
78 LEM (high), no label                  -> exit 0, warning
183 LEM (over_ceiling), [ci:coverage]    -> exit 2, error
353 LEM (over_ceiling), [full-ci]        -> exit 0, override note
```

## CI cost / verification note

- [x] Cheapest relevant proof: planner exit-code smoke tests + YAML parse.
- [x] No broad CI label needed.
- [x] **Failure mode caught:** PR accidentally requesting >125 LEM without acknowledgement.
- [x] Estimated LEM impact: 0 (planner enhancement; PR Plan workflow remains 1 LEM).
- [x] Rollback: revert this PR.

## Stack

PR 01 → ... → PR 09 → **PR 13 (this)**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_