### PR TITLE
ci(droid): make external AI review advisory (#0000)

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -1,5 +1,14 @@
 name: Droid Auto Review
 
+# External AI reviewer. Advisory: see policy/ci-lane-whitelist.toml entry
+# `droid_auto_review` and docs/ci/labels.md `ai-review`. The job runs on
+# ready_for_review credible PRs only (already filtered by `if:` below).
+#
+# The job is marked continue-on-error: true so that external-service
+# failures (rate limits, vendor outages) do not break unrelated CI signal
+# on the PR. Any review comments the action manages to post before failing
+# are still visible.
+
 on:
   pull_request:
     types: [opened, ready_for_review, reopened]
@@ -12,6 +21,9 @@ jobs:
   droid-review:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Advisory lane: do not break PR signal on external-AI-review failures.
+    # See docs/ci/perl-lsp-rollout-plan.md PR 14.
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

PR 14 of the rollout. Adds `continue-on-error: true` to the Droid Auto Review job so vendor outages, rate limits, or transient external-service failures do not break unrelated CI signal on the PR.

Stacked on **#8145** (PR 13 budget guard).

## Changes

```
.github/workflows/droid-review.yml  +12 lines (header comment + continue-on-error)
```

## Behavior

- Trigger unchanged: `opened` / `ready_for_review` / `reopened`, non-draft, same-repo only (existing `if:` clause preserved).
- Adds explanatory header comment pointing to `policy/ci-lane-whitelist.toml` `droid_auto_review` entry and `docs/ci/labels.md` `ai-review` label.
- Job-level `continue-on-error: true`. Reviewers still see any review comments the action manages to post before failing.

## Why not also tighten the trigger

The plan's optional second pass (tighten trigger to `ready_for_review` + `ai-review` label) is **not** applied here — the existing trigger is already narrow enough that further tightening would lose value without proving the failure-rate problem first. Conservative pass first.

## CI cost / verification note

- [x] Cheapest relevant proof: YAML parse + diff review.
- [x] No broad CI label needed.
- [x] **Failure mode caught:** external AI review breaking unrelated CI signal.
- [x] Estimated LEM impact: 0 (job duration unchanged).
- [x] Rollback: revert this PR.

## Stack

PR 01 → ... → PR 13 → **PR 14 (this)**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_