### PR TITLE
docs(memory): close retained-state memory-control lane (#0000)

### DIFF
--- a/docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md
+++ b/docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md
@@ -1,0 +1,56 @@
+# Memory Control Closeout
+
+This page closes the retained-state memory incident as an operating lane. The
+fixes, counters, receipts, trend renderer, triage template, focused regression
+tests, and retained-state policy guard are now in place. New memory work should
+start from a failing receipt, a new retained owner, or an explicit subsystem
+change, not from a broad leak hunt.
+
+## Evidence Map
+
+| Surface | Evidence |
+|---------|----------|
+| Original retained-state leak | #8064 plugged session-creep paths across LSP caches, stream sessions, workspace index cleanup, and lookup miss behavior. |
+| Plateau guardrails | #8072 added LSP churn harnesses, plateau checks, lifecycle helpers, stale background-index guards, and PR/nightly memory workflows. #8074 registered structured memory plateau receipts. |
+| Runtime pressure counters | #8088 added `RuntimePressureSnapshot` counters for async pressure surfaces and extended retained-state inventory policy coverage. |
+| Diagnostics churn | #8115 added retained-state coverage for diagnostics churn after open/change/diagnostic/fix/close/delete. |
+| POD hover cache cap | #8122 locked POD cache cap/prune behavior and active document path eviction. |
+| File-watcher bulk churn | #8124 locked file-watcher debounce pressure drain and delete cleanup for document/session/index state. |
+| Trend renderer | #8126 added `cargo xtask memory-trends render` and committed `docs/project/status/memory_plateau_trends.md`. |
+| Regression issue template and triage | #8127 added the GitHub Memory Regression issue template and linked the failure triage path from memory status docs. |
+| Formatting subprocess smoke | #8130 added repeated perltidy `format_file` coverage for subprocess output, cache length, and temp-state retention. |
+| DAP start/stop smoke | #8132 added repeated DAP bridge child-process start/stop coverage and PID liveness checks. |
+| Pressure-signal inventory guard | #8141 required every retained-state inventory row to name a pressure counter or retained-process signal and extended `cargo xtask check-memory-lifecycle-policy`. |
+
+## Closeout Criteria
+
+| Criterion | Evidence |
+|-----------|----------|
+| Every retained owner has owner, key, bound, cleanup event, pressure signal, and regression surface. | `docs/large-workspaces/RETAINED_STATE_INVENTORY.md` has first-class columns for the required fields, enforced by `cargo xtask check-memory-lifecycle-policy`. |
+| Every high-risk retained-state surface has a focused scenario. | `RETAINED_STATE_INVENTORY.md` lists document churn, workspace-symbol churn, workspace index reindex, diagnostics, POD hover, stream sessions, file watcher churn, workspace-folder removal, formatting subprocess, and DAP start/stop coverage. |
+| Process-lifecycle surfaces have retained-process smoke coverage. | Formatting subprocess coverage is in #8130; DAP child-process start/stop coverage is in #8132. |
+| Memory receipts can be trended. | `cargo xtask memory-trends render` updates `docs/project/status/memory_plateau_trends.md` from plateau summaries, receipts, and committed baselines. |
+| Failure triage is documented. | `.github/ISSUE_TEMPLATE/memory_regression.yml` captures scenario, commit, artifacts, slope, counters, owner, and lifecycle; `docs/project/status/memory_plateau.md` summarizes the triage path. |
+| Policy prevents inventory drift. | `cargo xtask check-memory-lifecycle-policy` checks close/delete semantics, generation guards, memory counters, receipt registration, receipt schema fields, and retained-state inventory pressure signals. |
+| No covered memory-control item points at accidental deferred coverage. | The retained-state scenario table uses current coverage language for completed surfaces. Additional work should be tied to new retained owners or failing receipts. |
+
+## Response Path
+
+When memory behavior breaks:
+
+1. Open a Memory Regression issue from the GitHub template.
+2. Attach the plateau receipt, trend row, CSV/server log, or retained-state test output.
+3. Compare `MemoryStateSnapshot` and `RuntimePressureSnapshot`.
+4. Identify the owner from `RETAINED_STATE_INVENTORY.md`.
+5. Add or tighten a failing focused regression before patching.
+6. Patch only the owner's cleanup, bound, counter, or retained-process path.
+
+Do not add a broad RSS workload or speculative cleanup PR unless the focused
+evidence shows the existing receipt/test surface cannot isolate the owner.
+
+## Maintenance Rule
+
+Any future PR that adds or changes a long-lived map, cache, debouncer, queue,
+session, or subprocess owner must update the retained-state inventory with:
+owner, key type, byte-risk, bound or cleanup event, pressure counter or retained
+process signal, and regression test or receipt.

--- a/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
+++ b/docs/large-workspaces/RETAINED_STATE_INVENTORY.md
@@ -84,7 +84,7 @@ hard to interpret; focused scenarios make the owner obvious.
 | `hover_pod_many_modules` | POD cache cap and path eviction | Unit retained-state coverage |
 | `completion_stream_cancel_storm` | Stream-session cancellation and removal | Unit regression coverage |
 | `file_watcher_bulk_create_change_delete` | Watcher debouncer and delete lifecycle | Unit retained-state coverage |
-| `workspace_folder_add_remove_multi_root` | Folder-scoped cleanup without cross-root eviction | Unit coverage, add process scenario if needed |
+| `workspace_folder_add_remove_multi_root` | Folder-scoped cleanup without cross-root eviction | Unit coverage |
 | `dap_bridge_start_stop_loop` | Debug process/session lifecycle | Unit retained-process coverage |
 | `formatting_perltidy_loop` | Subprocess and output-buffer retention | Unit retained-state coverage |
 

--- a/docs/project/status/memory_plateau.md
+++ b/docs/project/status/memory_plateau.md
@@ -58,6 +58,12 @@ another named scenario), nonzero `MemoryStateSnapshot` or
 `RuntimePressureSnapshot` counters, and suspected state owner. Patch work should
 start from a narrow failing regression, not from a broad leak hunt.
 
+## Closeout
+
+The retained-state memory incident is closed as an active lane. The closeout
+evidence map and response playbook live in
+`docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md`.
+
 ## Interpretation Rules
 
 - Close-only churn may retain workspace-index entries for files that still exist.


### PR DESCRIPTION
## Summary

- Add `docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md` as the durable closeout map for the retained-state memory-control lane.
- Link the closeout from `docs/project/status/memory_plateau.md`.
- Remove stale deferred-coverage wording from the retained-state inventory scenario table.

No runtime behavior, RSS workload, or merge-blocking gate changes.

## Evidence Map

| Surface | Evidence |
| --- | --- |
| Original retained-state leak | #8064 |
| Plateau guardrails | #8072 / #8074 |
| Runtime pressure counters | #8088 |
| Diagnostics churn | #8115 |
| POD hover cache cap | #8122 |
| File-watcher bulk churn | #8124 |
| Trend renderer | #8126 |
| Regression issue template / triage | #8127 |
| Formatting subprocess smoke | #8130 |
| DAP start/stop smoke | #8132 |
| Pressure-signal inventory guard | #8141 |

## Validation

- `cargo xtask fmt`
- `cargo xtask check-memory-lifecycle-policy`
- `cargo test -p xtask memory_trends -- --nocapture`
- `cargo xtask memory-trends render --input-dir target/memory --output docs/project/status/memory_plateau_trends.md`
- `cargo test -p perl-lsp-rs test_diagnostics_churn_drains_retained_state_after_close_delete --lib`
- `cargo test -p perl-lsp-rs --features workspace bulk_file_watcher_churn_drains_pressure_and_delete_state --lib`
- `cargo test -p perl-lsp-rs pod_hover_cache_prunes_at_cap_and_evicts_active_document_path --lib`
- `cargo test -p perl-lsp-perltidy format_file_storm_does_not_retain_subprocess_outputs_or_temp_state --test subprocess_tests -- --nocapture`
- `cargo test -p perl-dap repeated_start_stop_cycles_do_not_leave_child_processes --lib -- --nocapture`
- `cargo test -p perl-dap --test bridge_adapter_unit_tests -- --nocapture`
- `git diff --check`

I did not run `cargo test --workspace`; this closeout is docs/proof only and should not depend on unrelated workspace flakes.
