### PR TITLE
docs(memory): surface memory-control closeout in release docs (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ Release notes: [v0.13.4](docs/releases/v0.13.4.md)
   owner, and its eviction rule. Runtime pressure counters expose async
   task/debounce/session pressure, and diagnostics churn now has direct
   retained-state coverage. (#8072, #8076, #8088, #8115)
+- **Memory-control closeout** — Long-session retained-state memory behavior
+  is now covered by lifecycle cleanup, runtime pressure counters, plateau
+  receipts, trend rendering, focused subsystem regressions, and
+  retained-state inventory policy. This closes the known retained-state /
+  session-creep class and adds guardrails against recurrence, without
+  claiming every possible memory issue is fixed. See
+  [MEMORY_CONTROL_CLOSEOUT.md](docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md).
 - **Governed clippy lint policy gate** — New CI gate enforcing the
   `policy/clippy-lints.toml` allowlist. (#8066)
 - **Parser coverage risk map and baseline.** (#8005)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ These are behavioral and corpus-backed signals, not feature-inventory counts. Pr
 | Issue-regression UX workflows | 13 workflows tracked |
 | Workspace stale-index defects | 0 / 7 tested scenarios |
 | Multi-root workspace tests | 8 / 8 |
+| Memory-control closeout | Known retained-state/session-creep class closed with guardrails ([closeout](docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md)) |
 
 See [project status](docs/project/status/index.md), [parser status](docs/project/status/parser.md), [workspace status](docs/project/status/workspace.md), and [quality metrics](docs/project/status/quality.md) for generated details.
 

--- a/docs/releases/v0.13.4.md
+++ b/docs/releases/v0.13.4.md
@@ -48,6 +48,13 @@ MSRV to Rust 1.93.1.
   file-watcher debounce URIs, refresh debounce activity, and active stream
   sessions; diagnostics churn coverage adds the first follow-up subsystem
   guard. (#8072, #8076, #8088, #8115)
+- **Memory-control closeout surfaced** — Long-session retained-state memory
+  behavior is now covered by lifecycle cleanup, runtime pressure counters,
+  plateau receipts, trend rendering, focused subsystem regressions, and
+  retained-state inventory policy. This closes the known retained-state /
+  session-creep class and adds guardrails against recurrence; it does not
+  claim every possible memory issue is fixed. See
+  `docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md`.
 - **Class::Tiny / Class::Tiny::RW OO framework support** — Full semantic
   analysis for the Class::Tiny family across both `ClassModelBuilder`
   and `SymbolExtractor` pipelines: `use Class::Tiny qw(name email)` and
@@ -94,3 +101,4 @@ musl-based containers. You do not need both GNU and musl archives.
 - [Compare v0.13.3...v0.13.4](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.3...v0.13.4)
 - [CHANGELOG](../../CHANGELOG.md)
 - [Release ledger](../../RELEASE_HISTORY.md)
+- [Memory control closeout](../large-workspaces/MEMORY_CONTROL_CLOSEOUT.md)


### PR DESCRIPTION
## Summary

- Surface the retained-state memory-control closeout from the v0.13.4 release notes.
- Add the closeout link and careful retained-state/session-creep wording to the changelog.
- Add a README status row pointing users and maintainers at the closeout map.

No runtime behavior, workflow, gate, or test changes.

## Validation

- `cargo xtask fmt`
- `cargo xtask check-memory-lifecycle-policy`
- `git diff --check`