### PR TITLE
ci: add risk-pack validator and catalog doc (#0000)

### DIFF
--- a/docs/ci/risk-packs.md
+++ b/docs/ci/risk-packs.md
@@ -1,0 +1,65 @@
+# Risk Packs
+
+Risk packs route extra proof to PRs that touch known-risky surfaces. Defined in
+[`policy/ci-risk-packs.toml`](../../policy/ci-risk-packs.toml).
+
+> Companion: [pr-plan.md](pr-plan.md), [policy-ledgers.md](policy-ledgers.md).
+
+---
+
+## Catalog
+
+| Risk pack | Surface | Default lanes | Deep lanes (label-gated) |
+|---|---|---|---|
+| `parser` | parser, lexer, token, AST, tree-sitter | `pr_smoke`, `merge_gate_shards`, `ripr_advisory` | `mutation`, `fuzz`, `coverage` |
+| `lsp_provider` | LSP, completion, diagnostics, navigation | `pr_smoke`, `merge_gate_shards`, `ux_tests`, `ripr_advisory` | `real_repo_latency`, `vscode_smoke_matrix` |
+| `workspace_index` | module resolution, semantic facts, indexing | `merge_gate_shards`, `lsp_memory_smoke`, `windows_guardrails`, `ripr_advisory` | `memory_plateau`, `real_repo_latency` |
+| `retained_state` | long-lived maps, caches, queues, sessions | `lsp_memory_smoke`, `ripr_advisory` | `memory_plateau` |
+| `dap` | debug adapter, breakpoints, evaluate | `merge_gate_shards`, `ux_tests`, `ripr_advisory` | — |
+| `vscode` | extension packaging, managed binary | `docs_gate` | `vscode_smoke_matrix` |
+| `security` | sandbox, subprocess, exec, deserialization | `security_audit`, `windows_guardrails`, `ripr_advisory` | — |
+| `manifest` | Cargo.toml/lock, toolchain | `pr_smoke`, `merge_gate_shards`, `security_audit` | `release_check` |
+| `docs_only` | prose / markdown / status | `docs_gate` | — |
+
+---
+
+## How risk packs activate
+
+The PR Plan workflow walks the diff and matches each changed file against every risk
+pack's `paths` (glob) and `keywords` (substring on lowercased path). Any match selects
+the pack. Selected packs add their `lanes` to the per-PR plan and, when `full-ci` is
+labeled, also their `deep_lanes`.
+
+The `retained_state` pack additionally pairs with the PR template's *Retained State*
+checklist. If a contributor checks the retained-state boxes, they should see the
+memory smoke lane selected automatically by the planner.
+
+---
+
+## Validation
+
+```bash
+python3 scripts/ci/validate_risk_packs.py
+```
+
+Checks:
+
+- Every `lanes` / `deep_lanes` reference resolves in `policy/ci-lanes.toml`.
+- Every pack has at least one of `paths` or `keywords`.
+- Labels are strings.
+
+`--strict` exits 1 on any issue.
+
+---
+
+## Adding a new risk pack
+
+1. Add a `[risk_pack.<id>]` entry to `policy/ci-risk-packs.toml`.
+2. Set `paths` (preferred — explicit) and/or `keywords`.
+3. Set `lanes` to the default-PR lanes that should activate when the pack matches.
+4. Set `deep_lanes` to the lanes that activate only with `full-ci`.
+5. Set `labels` to label names that, when applied to a PR, force the pack on.
+6. Run `python3 scripts/ci/validate_risk_packs.py --strict`.
+7. Add a row to the catalog above.
+
+The PR Plan picks up the new pack on the next PR — no workflow edit needed.

--- a/scripts/ci/validate_risk_packs.py
+++ b/scripts/ci/validate_risk_packs.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validate risk packs in policy/ci-risk-packs.toml.
+
+Checks:
+  - Every `lanes` and `deep_lanes` entry references a real lane in
+    policy/ci-lanes.toml.
+  - Every risk pack has a non-empty `paths` or `keywords` filter.
+  - Every label referenced is a string (no nested structure mistakes).
+
+Reports issues; --strict fails on any.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--risk-packs", type=Path, default=Path("policy/ci-risk-packs.toml")
+    )
+    p.add_argument("--lanes", type=Path, default=Path("policy/ci-lanes.toml"))
+    p.add_argument("--strict", action="store_true")
+    args = p.parse_args()
+
+    risk_packs: dict[str, Any] = (
+        tomllib.loads(args.risk_packs.read_text(encoding="utf-8"))
+        .get("risk_pack", {})
+    )
+    lane_ids: set[str] = set(
+        tomllib.loads(args.lanes.read_text(encoding="utf-8"))
+        .get("lane", {})
+        .keys()
+    )
+
+    issues: list[str] = []
+    print(f"Risk packs in {args.risk_packs}: {len(risk_packs)}")
+    print(f"Lanes in {args.lanes}: {len(lane_ids)}")
+    print()
+
+    for pack_id, pack in risk_packs.items():
+        for lane in pack.get("lanes", []):
+            if lane not in lane_ids:
+                issues.append(
+                    f"{pack_id}.lanes references unknown lane '{lane}'"
+                )
+        for lane in pack.get("deep_lanes", []):
+            if lane not in lane_ids:
+                issues.append(
+                    f"{pack_id}.deep_lanes references unknown lane '{lane}'"
+                )
+        if not pack.get("paths") and not pack.get("keywords"):
+            issues.append(f"{pack_id} has neither `paths` nor `keywords`")
+        for label in pack.get("labels", []):
+            if not isinstance(label, str):
+                issues.append(f"{pack_id} has non-string label: {label!r}")
+
+    if issues:
+        print(f"Issues ({len(issues)}):")
+        for i in issues:
+            print(f"  - {i}")
+    else:
+        print("All risk packs valid.")
+
+    return 1 if args.strict and issues else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR 10 close-out. Risk packs themselves were substantively delivered as part of #PR02 (policy TOML ledgers); this PR adds the close-out validation tooling and catalog doc that PR 10 in the rollout plan documented as separate scope.

## Changes

```
scripts/ci/validate_risk_packs.py - validates risk packs against ci-lanes.toml
docs/ci/risk-packs.md              - catalog + how-to-extend
```

## Validator status

```
Risk packs in policy/ci-risk-packs.toml: 9
Lanes in policy/ci-lanes.toml: 23
All risk packs valid.
```

All 9 risk packs from the rollout plan present: `parser`, `lsp_provider`, `workspace_index`, `retained_state`, `dap`, `vscode`, `security`, `manifest`, `docs_only`.

## CI cost / verification note

- [x] No workflow files modified.
- [x] Estimated LEM impact: 0.
- [x] Rollback: revert this PR.

Closes the rollout plan PR 10 entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_