### PR TITLE
ci(xtask): add advisory lane-whitelist check to workflow-policy-lint (#0000)

### DIFF
--- a/docs/ci/workflow-policy-lint.md
+++ b/docs/ci/workflow-policy-lint.md
@@ -1,0 +1,91 @@
+# Workflow Policy Lint
+
+`cargo xtask workflow-policy-lint` validates every workflow under
+`.github/workflows/` against a set of policy rules. It is the existing
+mechanism for catching unsafe `pull_request_target` patterns, write-all
+permissions, blanket cancel-in-progress, and similar foot-guns.
+
+PR 11 of the CI economics rollout extends the linter with an opt-in
+**lane-whitelist** check.
+
+> Companion: [policy-ledgers.md](policy-ledgers.md), [perl-lsp-rollout-plan.md](perl-lsp-rollout-plan.md).
+
+---
+
+## Existing rules (errors unless noted)
+
+| Code | Meaning |
+|---|---|
+| `PR_TARGET_CHECKOUT_HEAD` | `pull_request_target` workflow checks out PR head (unsafe) |
+| `WRITE_ALL_PERMISSIONS` | `permissions: write-all` declared |
+| `PR_CONTENTS_WRITE` | `pull_request` workflow requests `contents: write` (not allowlisted) |
+| `UNTRUSTED_PR_SECRETS` | Untrusted PR code path consumes `secrets.*` |
+| `REQUIRED_STYLE_MISSING_MERGE_GROUP` | Required-style workflow missing `merge_group` trigger |
+| `REQUIRED_STYLE_SELF_FILTERED` | Required-style workflow path-filters itself |
+| `BLANKET_CANCEL_IN_PROGRESS` | `cancel-in-progress` not gated for master/merge_group truth runs |
+| `LABEL_EVENT_CANCELS_PR_RUN` | `pull_request labeled`/`unlabeled` workflow cancels in-progress runs |
+| `UNPINNED_ACTION` | Third-party action not pinned to a commit SHA (warning) |
+
+---
+
+## New: `LANE_WHITELIST_MISSING` (advisory)
+
+```bash
+cargo xtask workflow-policy-lint --check-lane-whitelist
+```
+
+For each workflow under `.github/workflows/*.yml`, the linter checks whether
+[`policy/ci-lane-whitelist.toml`](../../policy/ci-lane-whitelist.toml) has at
+least one `[[lane]]` entry whose `workflow` field matches that file.
+
+If neither a whitelist entry nor an `ALLOWLIST_WORKFLOW_LANE_MISSING`
+allowlist entry covers the workflow, the linter emits a **warning** with
+code `LANE_WHITELIST_MISSING`.
+
+The check is **advisory only** — warnings, not errors. The `passed` status
+in the receipt is unaffected. Promotion to error level is intentionally
+deferred until the whitelist has stabilized.
+
+### Allowlist
+
+`ALLOWLIST_WORKFLOW_LANE_MISSING` in
+[`xtask/src/tasks/workflow_policy_lint.rs`](../../xtask/src/tasks/workflow_policy_lint.rs)
+covers release/utility workflows that are not part of the per-PR economics
+map. Initial entries:
+
+- Release/publish: `release.yml`, `publish-*.yml`, `docker-publish.yml`,
+  `*-bump.yml`, `release-orchestration.yml`, `post-publish-smoke.yml`,
+  `vscode-published-extension-smoke.yml`
+- Post-merge utilities: `post-merge-corpus-ratchet.yml`,
+  `post-merge-status.yml`, `docs-deploy.yml`
+- Schedule-only / housekeeping: `tokmd.yml`, `merge-ready-reconciler.yml`,
+  `triage-issues.yml`, `version-bump.yml`, `ci-gate-self-tests.yml`,
+  `workflow-trigger-lint.yml`
+
+To add a new workflow that should be exempt, add a constant entry there and
+explain the reason in the commit message.
+
+---
+
+## When to enable in CI
+
+The lane-whitelist check is currently invoked only when explicitly passed
+the flag. To enable it on PRs, add to `.github/workflows/workflow-policy.yml`:
+
+```yaml
+- name: Run workflow policy lint
+  run: cargo xtask workflow-policy-lint --check-lane-whitelist --receipt target/receipts/workflow-policy.json
+```
+
+Recommended approach: leave advisory-only first, observe the warning rate
+on real PRs, then promote to error once the whitelist + allowlist are
+stable.
+
+---
+
+## Output
+
+Warnings appear as `::warning::` annotations in the GitHub workflow log.
+The receipt JSON includes them in `issues[]` with `level: "warning"`,
+`code: "LANE_WHITELIST_MISSING"`. The `passed` field of the receipt is
+unaffected by warning-level issues.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -374,6 +374,12 @@ enum Commands {
         /// Lint a single workflow fixture instead of repository workflows.
         #[arg(long)]
         fixture: Option<PathBuf>,
+
+        /// Also validate that every workflow has a `[[lane]]` entry in
+        /// policy/ci-lane-whitelist.toml. Advisory (warning-level) until the
+        /// whitelist has stabilized — see docs/ci/perl-lsp-rollout-plan.md PR 11.
+        #[arg(long)]
+        check_lane_whitelist: bool,
     },
 
     /// Measure CI lane runtimes and emit timing artifacts.
@@ -2017,10 +2023,11 @@ fn main() -> Result<()> {
         }
         Commands::TestEdgeCases { bench, coverage, test } => edge_cases::run(bench, coverage, test),
         Commands::CiAuditWorkflows => ci_audit_workflows::run(),
-        Commands::WorkflowPolicyLint { receipt, fixture } => {
+        Commands::WorkflowPolicyLint { receipt, fixture, check_lane_whitelist } => {
             workflow_policy_lint::run(workflow_policy_lint::WorkflowPolicyLintConfig {
                 receipt,
                 fixture,
+                check_lane_whitelist,
             })
         }
         Commands::CiMeasure => ci_measure::run(),

--- a/xtask/src/tasks/workflow_policy_lint.rs
+++ b/xtask/src/tasks/workflow_policy_lint.rs
@@ -1,6 +1,7 @@
 use color_eyre::eyre::{Context, Result, bail};
 use serde::Serialize;
 use serde_yaml_ng::{Mapping, Value};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -10,10 +11,44 @@ const ALLOWLIST_PR_CONTENTS_WRITE: &[&str] = &["ci.yml", "ci-nightly.yml"];
 const POLICY_WARN_UNPINNED_ACTIONS: bool = true;
 const ALLOWLIST_BLANKET_CANCEL_IN_PROGRESS: &[&str] = &["docs-deploy.yml", "post-merge-status.yml"];
 
+/// Workflow files that intentionally have no `policy/ci-lane-whitelist.toml`
+/// entry. Add an entry here only when there's a documented reason — e.g. a
+/// release/publish workflow that's release-time-only and not part of
+/// per-PR economics.
+const ALLOWLIST_WORKFLOW_LANE_MISSING: &[&str] = &[
+    // Release / publish workflows: out of scope for the per-PR economics map.
+    "brew-bump.yml",
+    "chocolatey-bump.yml",
+    "docker-publish.yml",
+    "docs-deploy.yml",
+    "post-merge-corpus-ratchet.yml",
+    "post-merge-status.yml",
+    "post-publish-smoke.yml",
+    "publish-crates.yml",
+    "publish-extension.yml",
+    "publish-dry-run.yml",
+    "release-orchestration.yml",
+    "release.yml",
+    "scoop-bump.yml",
+    "tokmd.yml",
+    "version-bump.yml",
+    "vscode-published-extension-smoke.yml",
+    "winget-bump.yml",
+    // Schedule/utility workflows tracked separately from the lane economics.
+    "ci-gate-self-tests.yml",
+    "merge-ready-reconciler.yml",
+    "triage-issues.yml",
+    "workflow-trigger-lint.yml",
+];
+
 #[derive(Debug, Clone)]
 pub struct WorkflowPolicyLintConfig {
     pub receipt: Option<PathBuf>,
     pub fixture: Option<PathBuf>,
+    /// Run the per-workflow lane-whitelist check against
+    /// `policy/ci-lane-whitelist.toml`. Advisory (warning-level) until the
+    /// whitelist has stabilized.
+    pub check_lane_whitelist: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -55,6 +90,10 @@ pub fn run(config: WorkflowPolicyLintConfig) -> Result<()> {
                 }
                 lint_workflow_file(&path, false, &mut issues)?;
             }
+        }
+
+        if config.check_lane_whitelist {
+            check_lane_whitelist(&root, &mut issues)?;
         }
     }
 
@@ -520,6 +559,74 @@ fn is_sha_pinned(uses: &str) -> bool {
         return false;
     };
     reference.len() == 40 && reference.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+/// Validate that every workflow under `.github/workflows/` is referenced by at
+/// least one `[[lane]]` entry in `policy/ci-lane-whitelist.toml`, OR is in the
+/// `ALLOWLIST_WORKFLOW_LANE_MISSING` allowlist (release/utility workflows).
+///
+/// Issues are emitted at warning level — advisory until the whitelist has
+/// stabilized. PR 11 introduces this as advisory; promotion to error level
+/// happens only after a calibration window.
+fn check_lane_whitelist(root: &Path, issues: &mut Vec<LintIssue>) -> Result<()> {
+    let whitelist_path = root.join("policy").join("ci-lane-whitelist.toml");
+    if !whitelist_path.exists() {
+        // Whitelist not present in this repo; silently skip rather than failing.
+        return Ok(());
+    }
+
+    let whitelist_text = fs::read_to_string(&whitelist_path)
+        .with_context(|| format!("reading {}", whitelist_path.display()))?;
+    let whitelist: toml::Value = toml::from_str(&whitelist_text)
+        .with_context(|| format!("parsing {}", whitelist_path.display()))?;
+
+    // Collect workflow paths referenced by whitelist lanes.
+    let mut whitelisted_workflows: HashSet<String> = HashSet::new();
+    if let Some(lanes) = whitelist.get("lane").and_then(|v| v.as_array()) {
+        for lane in lanes {
+            if let Some(workflow) = lane.get("workflow").and_then(|v| v.as_str()) {
+                whitelisted_workflows.insert(workflow.to_string());
+            }
+        }
+    }
+
+    let workflows_dir = root.join(".github").join("workflows");
+    if !workflows_dir.exists() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(&workflows_dir)
+        .with_context(|| format!("reading {}", workflows_dir.display()))?
+    {
+        let path = entry.context("reading workflow entry")?.path();
+        let Some(ext) = path.extension().and_then(|v| v.to_str()) else {
+            continue;
+        };
+        if ext != "yml" && ext != "yaml" {
+            continue;
+        }
+        let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if ALLOWLIST_WORKFLOW_LANE_MISSING.contains(&file_name) {
+            continue;
+        }
+        let workflow_ref = format!(".github/workflows/{file_name}");
+        if !whitelisted_workflows.contains(&workflow_ref) {
+            issues.push(LintIssue {
+                level: "warning",
+                code: "LANE_WHITELIST_MISSING",
+                workflow: file_name.to_string(),
+                message: format!(
+                    "workflow has no `[[lane]]` entry in policy/ci-lane-whitelist.toml \
+                     (and is not in ALLOWLIST_WORKFLOW_LANE_MISSING). Add an entry or \
+                     allowlist with reason."
+                ),
+            });
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

PR 11 of the rollout. Extends `cargo xtask workflow-policy-lint` with an opt-in `--check-lane-whitelist` flag that validates every workflow under `.github/workflows/` has a corresponding `[[lane]]` entry in `policy/ci-lane-whitelist.toml`.

## Behavior

- **Off by default.** Existing CI invocation unchanged.
- With `--check-lane-whitelist`: emits `LANE_WHITELIST_MISSING` warnings for workflows that are neither in the whitelist nor in the `ALLOWLIST_WORKFLOW_LANE_MISSING` allowlist (release/utility workflows).
- Warnings, not errors — the receipt's `passed` field is unaffected. Promotion to error is intentionally deferred per the rollout plan.

## Allowlist

Release/publish workflows and schedule-only utilities that are not part of the per-PR economics map:
```
release.yml, publish-*.yml, docker-publish.yml, *-bump.yml,
post-merge-*.yml, docs-deploy.yml, post-publish-smoke.yml,
vscode-published-extension-smoke.yml, tokmd.yml,
merge-ready-reconciler.yml, triage-issues.yml, version-bump.yml,
ci-gate-self-tests.yml, workflow-trigger-lint.yml
```

## Smoke test

```
$ cargo xtask workflow-policy-lint --check-lane-whitelist
Workflow policy lint passed (0 error(s), 9 warning(s))
```

5 `LANE_WHITELIST_MISSING` warnings (`droid.yml`, `flake-detection.yml`, `pipeline-labels.yml`, `ux-regression-gate.yml`, `workflow-policy.yml`) — real gaps the lint surfaces; addressing them is a follow-up.

## Adds

```
xtask/src/tasks/workflow_policy_lint.rs  +73 lines (new check fn + allowlist)
xtask/src/main.rs                         +6 lines (CLI flag)
docs/ci/workflow-policy-lint.md           rule catalog + usage
```

## CI cost / verification note

- [x] Cheapest relevant proof: `cargo build -p xtask` clean; smoke test against repo workflows.
- [x] No required-check changes.
- [x] **Failure mode caught:** new workflow added without a lane economics entry.
- [x] Estimated LEM impact: ~0 (advisory check; opt-in).
- [x] Rollback: revert.

## Stack

Master → **PR 11 (this)**. Independent of the PR 07–15 chain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_