### PR TITLE
ci(metrics): scaffold learned LEM estimates from actuals (#0000)

### DIFF
--- a/.ci/metrics/ci-lane-history.json
+++ b/.ci/metrics/ci-lane-history.json
@@ -1,0 +1,124 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-07T09:54:19Z",
+  "window_days": 14,
+  "min_samples_for_learned": 5,
+  "lane_count": 23,
+  "lanes": {
+    "check_all_targets": {
+      "samples": 0,
+      "static_floor": 6.0,
+      "learned": false
+    },
+    "conflict_markers": {
+      "samples": 0,
+      "static_floor": 1.0,
+      "learned": false
+    },
+    "coverage": {
+      "samples": 0,
+      "static_floor": 45.0,
+      "learned": false
+    },
+    "docs_gate": {
+      "samples": 0,
+      "static_floor": 3.0,
+      "learned": false
+    },
+    "draft_guard": {
+      "samples": 0,
+      "static_floor": 1.0,
+      "learned": false
+    },
+    "droid_auto_review": {
+      "samples": 0,
+      "static_floor": 4.0,
+      "learned": false
+    },
+    "fuzz": {
+      "samples": 0,
+      "static_floor": 60.0,
+      "learned": false
+    },
+    "lsp_memory_smoke": {
+      "samples": 0,
+      "static_floor": 8.0,
+      "learned": false
+    },
+    "memory_plateau": {
+      "samples": 0,
+      "static_floor": 35.0,
+      "learned": false
+    },
+    "merge_gate_aggregate": {
+      "samples": 0,
+      "static_floor": 1.0,
+      "learned": false
+    },
+    "merge_gate_shards": {
+      "samples": 0,
+      "static_floor": 24.0,
+      "learned": false
+    },
+    "mutation": {
+      "samples": 0,
+      "static_floor": 60.0,
+      "learned": false
+    },
+    "perl_version_matrix": {
+      "samples": 0,
+      "static_floor": 40.0,
+      "learned": false
+    },
+    "pr_plan": {
+      "samples": 0,
+      "static_floor": 1.0,
+      "learned": false
+    },
+    "pr_smoke": {
+      "samples": 0,
+      "static_floor": 4.0,
+      "learned": false
+    },
+    "preflight_latest": {
+      "samples": 0,
+      "static_floor": 1.0,
+      "learned": false
+    },
+    "real_repo_latency": {
+      "samples": 0,
+      "static_floor": 30.0,
+      "learned": false
+    },
+    "release_check": {
+      "samples": 0,
+      "static_floor": 15.0,
+      "learned": false
+    },
+    "ripr_advisory": {
+      "samples": 0,
+      "static_floor": 4.0,
+      "learned": false
+    },
+    "security_audit": {
+      "samples": 0,
+      "static_floor": 15.0,
+      "learned": false
+    },
+    "ux_tests": {
+      "samples": 0,
+      "static_floor": 8.0,
+      "learned": false
+    },
+    "vscode_smoke_matrix": {
+      "samples": 0,
+      "static_floor": 35.0,
+      "learned": false
+    },
+    "windows_guardrails": {
+      "samples": 0,
+      "static_floor": 20.0,
+      "learned": false
+    }
+  }
+}

--- a/docs/ci/learned-estimates.md
+++ b/docs/ci/learned-estimates.md
@@ -1,0 +1,155 @@
+# Learned LEM Estimates
+
+PR 16 of the rollout. The aggregator + consumer scripts that turn observed
+`ci-actuals.json` artifacts into per-lane percentile estimates the PR Plan
+can consume in place of the static `base_lem` floors.
+
+> Companion: [pr-plan.md](pr-plan.md), [ci-actuals.md](ci-actuals.md),
+> [lem-budgeting.md](lem-budgeting.md).
+
+This is **scaffolding**: the scripts run on zero data today (they emit a
+valid empty history) and start producing meaningful estimates only after
+`ci-actuals.json` artifacts have accumulated.
+
+---
+
+## Pieces
+
+| File | Role |
+|---|---|
+| `scripts/ci/aggregate_lane_history.py` | Walks `target/ci/actuals/` for `ci-actuals.json`; computes per-lane `samples`, `p50`, `p90`, `p95`. Emits `.ci/metrics/ci-lane-history.json`. |
+| `scripts/ci/learned_estimate.py` | Reads the history file; given a lane id, returns the learned estimate, p90 warning threshold, and p95 hard-planning threshold. Falls back to the static floor when fewer than `MIN_SAMPLES_FOR_LEARNED` samples exist. |
+| `.ci/metrics/ci-lane-history.json` | Output of the aggregator. Tracked in git so the planner can read it without an extra CI step. |
+
+---
+
+## Estimate model
+
+```text
+estimate     = max(static_floor, p50_recent_actual * 1.15)
+warning      = p90_recent_actual
+hard_planning = p95_recent_actual
+```
+
+The 15% safety margin on top of `p50` absorbs ordinary CI noise without
+over-budgeting. The `static_floor` clamp guards against runaway optimism
+when `p50` lags real cost — e.g. when a lane has a fast-path that
+dominates samples but occasionally hits a slow path that the floor still
+captures.
+
+`MIN_SAMPLES_FOR_LEARNED = 5` per lane: until the lane has at least that
+many samples in the rolling window, the planner keeps using the static
+floor and the consumer returns `learned: false`.
+
+---
+
+## Window
+
+Default 14 days. Set with `--window-days N`. The aggregator filters by
+file `mtime` rather than embedded timestamps so receipts older than the
+window simply drop off without explicit pruning.
+
+---
+
+## Output schema
+
+`.ci/metrics/ci-lane-history.json`:
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-07T09:53:20Z",
+  "window_days": 14,
+  "min_samples_for_learned": 5,
+  "lane_count": 23,
+  "lanes": {
+    "pr_smoke": {
+      "samples": 6,
+      "static_floor": 4.0,
+      "learned": true,
+      "p50": 2.4,
+      "p90": 3.2,
+      "p95": 3.3,
+      "min": 1.4,
+      "max": 3.4,
+      "mean": 2.4
+    },
+    "mutation": {
+      "samples": 0,
+      "static_floor": 60.0,
+      "learned": false
+    }
+  }
+}
+```
+
+---
+
+## Consumer output
+
+```bash
+python3 scripts/ci/learned_estimate.py --lane pr_smoke
+```
+
+```json
+{
+  "lane": "pr_smoke",
+  "learned": true,
+  "estimate": 4.0,
+  "estimate_source": "static_floor (higher than learned)",
+  "static_floor": 4.0,
+  "p50": 2.4,
+  "p90_warning": 3.2,
+  "p95_hard_planning": 3.3,
+  "samples": 6
+}
+```
+
+When history is missing or the lane has too few samples:
+
+```json
+{
+  "lane": "mutation",
+  "learned": false,
+  "estimate": 60.0,
+  "static_floor": 60.0,
+  "samples": 0,
+  "reason": "only 0 samples; need 5 to learn"
+}
+```
+
+---
+
+## Wiring (deferred)
+
+The PR Plan workflow does **not** consume this in PR 16. The minimal
+end-to-end story requires:
+
+1. PR 16 (this PR) — aggregator + consumer scripts. ✓
+2. CI workflow change to upload `ci-actuals.json` artifacts to a
+   discoverable location. (PR 08's
+   [`scripts/ci/emit_ci_actuals.py`](../../scripts/ci/emit_ci_actuals.py)
+   produces the right files; the wiring step is intentionally deferred.)
+3. A scheduled job that downloads recent actuals artifacts and runs
+   `aggregate_lane_history.py` to update `.ci/metrics/ci-lane-history.json`.
+4. The PR Plan reads the history when present and the consumer reports
+   `learned: true`; otherwise it uses the static floor (current behavior).
+
+Step 1 is delivered by this PR. Steps 2–4 land as follow-ups once the
+PR 08 wiring is decided.
+
+---
+
+## Manual run (for review / debugging)
+
+```bash
+# Run aggregator on a directory of synthetic actuals.
+mkdir -p /tmp/actuals
+echo '{"jobs":[{"gate_name":"pr_smoke","actual_lem":2.1}]}' > /tmp/actuals/run-1.json
+echo '{"jobs":[{"gate_name":"pr_smoke","actual_lem":1.9}]}' > /tmp/actuals/run-2.json
+python3 scripts/ci/aggregate_lane_history.py \
+  --actuals-dir /tmp/actuals --output /tmp/hist.json
+
+# Query.
+python3 scripts/ci/learned_estimate.py --history /tmp/hist.json --lane pr_smoke
+```

--- a/scripts/ci/aggregate_lane_history.py
+++ b/scripts/ci/aggregate_lane_history.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Aggregate ci-actuals.json artifacts into a per-lane percentile history.
+
+Inputs (one or more):
+  --actuals-dir DIR      Walk DIR for ci-actuals.json files (default: target/ci/actuals/).
+  --window-days N        Only consider receipts newer than N days (default: 14).
+  --output PATH          Write history JSON here (default: .ci/metrics/ci-lane-history.json).
+  --static-lanes PATH    policy/ci-lanes.toml for static_floor reference.
+
+Output: .ci/metrics/ci-lane-history.json with per-lane sample counts and
+p50/p90/p95. PR 13's planner can consume this to derive learned estimates
+once enough samples accumulate.
+
+Schema is intentionally tolerant: lanes with fewer than MIN_SAMPLES
+samples are still recorded but flagged with `learned: false` so the
+planner falls back to the static floor.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+import time
+import tomllib
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+MIN_SAMPLES_FOR_LEARNED = 5
+
+
+def percentile(values: list[float], p: float) -> float:
+    """Linear-interpolation percentile, p in [0, 100]."""
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    sorted_vals = sorted(values)
+    k = (len(sorted_vals) - 1) * (p / 100.0)
+    lo = int(math.floor(k))
+    hi = int(math.ceil(k))
+    if lo == hi:
+        return sorted_vals[lo]
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (k - lo)
+
+
+def collect_actuals(
+    *, actuals_dir: Path, window_days: int
+) -> dict[str, list[float]]:
+    """Walk actuals_dir for ci-actuals.json files, return per-lane LEM samples."""
+    samples: dict[str, list[float]] = {}
+    if not actuals_dir.exists():
+        return samples
+
+    cutoff = time.time() - window_days * 86400
+    for path in sorted(actuals_dir.rglob("*.json")):
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < cutoff:
+            continue
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(doc, dict):
+            continue
+        for job in doc.get("jobs", []):
+            if not isinstance(job, dict):
+                continue
+            lane_id = job.get("gate_name") or job.get("lane_id")
+            actual = job.get("actual_lem")
+            if not lane_id or not isinstance(actual, (int, float)):
+                continue
+            samples.setdefault(lane_id, []).append(float(actual))
+    return samples
+
+
+def static_floors(lanes_toml: Path) -> dict[str, float]:
+    if not lanes_toml.exists():
+        return {}
+    doc = tomllib.loads(lanes_toml.read_text(encoding="utf-8"))
+    out: dict[str, float] = {}
+    for lane_id, lane in doc.get("lane", {}).items():
+        base = lane.get("base_lem")
+        if isinstance(base, (int, float)):
+            out[lane_id] = float(base)
+    return out
+
+
+def build_history(
+    *, samples: dict[str, list[float]], floors: dict[str, float], window_days: int
+) -> dict[str, Any]:
+    lanes_out: dict[str, Any] = {}
+    # Include every lane known to policy, even when samples are empty: planner
+    # readers can iterate the full keyspace without checking presence.
+    for lane_id in sorted(set(samples.keys()) | set(floors.keys())):
+        s = samples.get(lane_id, [])
+        floor = floors.get(lane_id)
+        learned = len(s) >= MIN_SAMPLES_FOR_LEARNED
+        entry: dict[str, Any] = {
+            "samples": len(s),
+            "static_floor": floor,
+            "learned": learned,
+        }
+        if s:
+            entry.update(
+                {
+                    "p50": percentile(s, 50),
+                    "p90": percentile(s, 90),
+                    "p95": percentile(s, 95),
+                    "min": min(s),
+                    "max": max(s),
+                    "mean": statistics.fmean(s),
+                }
+            )
+        lanes_out[lane_id] = entry
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "window_days": window_days,
+        "min_samples_for_learned": MIN_SAMPLES_FOR_LEARNED,
+        "lane_count": len(lanes_out),
+        "lanes": lanes_out,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--actuals-dir", type=Path, default=Path("target/ci/actuals"),
+        help="Directory to walk for ci-actuals.json artifacts.",
+    )
+    p.add_argument("--window-days", type=int, default=14)
+    p.add_argument(
+        "--output", type=Path,
+        default=Path(".ci/metrics/ci-lane-history.json"),
+    )
+    p.add_argument(
+        "--static-lanes", type=Path, default=Path("policy/ci-lanes.toml")
+    )
+    args = p.parse_args()
+
+    samples = collect_actuals(
+        actuals_dir=args.actuals_dir, window_days=args.window_days
+    )
+    floors = static_floors(args.static_lanes)
+    history = build_history(
+        samples=samples, floors=floors, window_days=args.window_days
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(history, indent=2) + "\n", encoding="utf-8"
+    )
+
+    learned = sum(1 for entry in history["lanes"].values() if entry["learned"])
+    print(
+        json.dumps(
+            {
+                "lanes": history["lane_count"],
+                "learned": learned,
+                "window_days": args.window_days,
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/learned_estimate.py
+++ b/scripts/ci/learned_estimate.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Read a lane's learned LEM estimate from .ci/metrics/ci-lane-history.json.
+
+Used by the PR Plan workflow once ci-actuals.json artifacts have accumulated
+enough samples per lane (>= MIN_SAMPLES_FOR_LEARNED in
+aggregate_lane_history.py).
+
+Estimate model:
+  estimate = max(static_floor, p50_recent_actual * 1.15)
+  warning  = p90_recent_actual
+  hard_planning = p95_recent_actual
+
+If the history is missing or the lane has too few samples, fall back to the
+static floor and report `learned: false`.
+
+Output is JSON on stdout so the caller can pipe into jq.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def estimate_for(lane_id: str, history: dict[str, Any]) -> dict[str, Any]:
+    lane = (history.get("lanes") or {}).get(lane_id)
+    if not isinstance(lane, dict):
+        return {
+            "lane": lane_id,
+            "learned": False,
+            "estimate": None,
+            "static_floor": None,
+            "samples": 0,
+            "reason": "no history entry for this lane",
+        }
+    floor = lane.get("static_floor")
+    if not lane.get("learned"):
+        return {
+            "lane": lane_id,
+            "learned": False,
+            "estimate": floor,
+            "static_floor": floor,
+            "samples": lane.get("samples", 0),
+            "reason": (
+                f"only {lane.get('samples', 0)} samples; need "
+                f"{history.get('min_samples_for_learned', 5)} to learn"
+            ),
+        }
+    p50 = lane.get("p50")
+    p90 = lane.get("p90")
+    p95 = lane.get("p95")
+    if p50 is None:
+        return {
+            "lane": lane_id,
+            "learned": False,
+            "estimate": floor,
+            "static_floor": floor,
+            "samples": lane.get("samples", 0),
+            "reason": "history missing p50",
+        }
+    learned_estimate = p50 * 1.15
+    if floor is not None and floor > learned_estimate:
+        # Static floor is higher than learned p50*1.15; respect the floor.
+        # This guards against runaway optimism when p50 lags real cost.
+        chosen = floor
+        chosen_source = "static_floor (higher than learned)"
+    else:
+        chosen = learned_estimate
+        chosen_source = "p50 * 1.15"
+    return {
+        "lane": lane_id,
+        "learned": True,
+        "estimate": chosen,
+        "estimate_source": chosen_source,
+        "static_floor": floor,
+        "p50": p50,
+        "p90_warning": p90,
+        "p95_hard_planning": p95,
+        "samples": lane.get("samples", 0),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--history",
+        type=Path,
+        default=Path(".ci/metrics/ci-lane-history.json"),
+    )
+    p.add_argument("--lane", required=True, help="Lane id to query.")
+    args = p.parse_args()
+
+    if not args.history.exists():
+        print(
+            json.dumps(
+                {
+                    "lane": args.lane,
+                    "learned": False,
+                    "estimate": None,
+                    "samples": 0,
+                    "reason": f"history file {args.history} not present",
+                }
+            )
+        )
+        return 0
+
+    try:
+        history = json.loads(args.history.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        print(json.dumps({"lane": args.lane, "learned": False, "error": str(e)}))
+        return 0
+
+    print(json.dumps(estimate_for(args.lane, history)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR 16 of the rollout. Adds the aggregator + consumer that turn observed `ci-actuals.json` artifacts into per-lane percentile estimates. **Scaffolding** — runs cleanly on zero data today and starts producing meaningful estimates only after actuals accumulate.

## Estimate model

```text
estimate     = max(static_floor, p50_recent_actual * 1.15)
warning      = p90_recent_actual
hard_planning = p95_recent_actual
```

Min samples for learned = 5 per lane. Window: 14 days (mtime-based).

## Adds

```
scripts/ci/aggregate_lane_history.py - actuals -> per-lane p50/p90/p95
scripts/ci/learned_estimate.py       - lane id -> learned estimate
.ci/metrics/ci-lane-history.json     - initial empty history (23 lanes)
docs/ci/learned-estimates.md         - estimate model + usage
```

## Smoke tests

- Empty actuals dir → 23 lanes, 0 learned, all static floor.
- 6 synthetic samples on `pr_smoke` → `learned: true, p50=2.4, p90=3.2, p95=3.3`. Static floor (4.0) is higher, so consumer returns `static_floor (higher than learned)`.

## Wiring is intentionally deferred

This PR delivers steps 1 of the 4-step calibration pipeline:

1. ✓ Aggregator + consumer scripts (this PR).
2. CI workflow change to upload `ci-actuals.json` artifacts to a discoverable location.
3. Scheduled job to download recent actuals + run aggregator.
4. PR Plan reads history when present.

Steps 2-4 land as follow-ups so this PR stays low-risk.

## CI cost / verification note

- [x] Cheapest relevant proof: aggregator + consumer self-tests on synthetic data.
- [x] No workflow files modified.
- [x] Estimated LEM impact: 0.
- [x] Rollback: revert.

## Stack

Master → **PR 16 (this)**. Independent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_