### PR TITLE
docs(policy): define Rust-first file policy (#0000)

### DIFF
--- a/docs/ci/perl-lsp-ci-policy-rollout.md
+++ b/docs/ci/perl-lsp-ci-policy-rollout.md
@@ -1,0 +1,285 @@
+# perl-lsp File-Policy Rollout
+
+This is the multi-PR rollout that builds the file-policy stack described in
+[FILE_POLICY.md](../policy/FILE_POLICY.md), [NON_RUST_POLICY.md](../policy/NON_RUST_POLICY.md),
+and [POLICY_ALLOWLISTS.md](../policy/POLICY_ALLOWLISTS.md).
+
+This is a **separate sequence** from the [CI economics rollout](perl-lsp-rollout-plan.md).
+The CI economics work answers "how much does verification cost?" The file
+policy work answers "what files belong in this repo, and who owns them?"
+The two stacks compose: the CI economics gate runs the file-policy gate
+as one of its pr-fast checks.
+
+## Order
+
+| PR | Name | Purpose | Mode introduced |
+|---:|---|---|---|
+| 01 | File-policy doctrine | Document `FILE_POLICY.md`, `NON_RUST_POLICY.md`, `POLICY_ALLOWLISTS.md`, this rollout. | n/a |
+| 02 | Non-Rust TOML ledger | Add `policy/non-rust-allowlist.toml` and `policy/non-rust-debt.toml`. | n/a |
+| 03 | `non-rust inventory` | `cargo xtask non-rust inventory` emits Markdown + JSON. | n/a |
+| 04 | `check-file-policy` | `cargo xtask check-file-policy` enforces the allowlist. | advisory |
+| 05 | `non-rust propose` | `cargo xtask non-rust propose` generates entries for unallowlisted files. | n/a |
+| 06 | Generated / executable / dependency policies | Companion ledgers and checkers. | advisory |
+| 07 | Process / network policies | Risky-behavior ledgers and checkers. | advisory |
+| 08 | Workflow surface policy | `policy/workflow-allowlist.toml` + `check-workflow-surfaces`. | advisory |
+| 09 | Unified policy report | `cargo xtask policy-report` aggregates the seven ledgers. | n/a |
+| 10 | Wire into `.ci/gate-policy.yaml` | Add a `file_policy` gate emitting receipts. | promote to `blocking-allowlist` for owned ledgers |
+| 11 | Strict-mode promotion | Promote `check-file-policy`, `check-generated`, `check-executable-files`, `check-dependency-surfaces`, `check-workflow-surfaces` to `blocking-strict`. | `blocking-strict` |
+
+## Sequencing constraints
+
+- **PR 02 must land before PR 04.** The checker reads the ledger.
+- **PR 03 may land in parallel with PR 04** — inventory does not require
+  the checker.
+- **PR 05 depends on PR 04.** The proposer needs the checker's "what's
+  unallowlisted" output.
+- **PR 06, 07, 08 may land in any order after PR 04**, but each adds its
+  own ledger and checker.
+- **PR 09 depends on PR 06, 07, 08.** The unified report aggregates
+  them.
+- **PR 10 depends on PR 09.** The gate runs the unified report.
+- **PR 11 depends on PR 10** plus a calibration window of clean baseline
+  receipts.
+
+## What each PR includes
+
+### PR 01 — File-policy doctrine (this PR)
+
+```text
+docs/policy/FILE_POLICY.md
+docs/policy/NON_RUST_POLICY.md
+docs/policy/POLICY_ALLOWLISTS.md
+docs/ci/perl-lsp-ci-policy-rollout.md
+```
+
+No code, no policy TOML, no checker. Doctrine before mechanics.
+
+### PR 02 — Non-Rust TOML ledger
+
+```text
+policy/non-rust-allowlist.toml
+policy/non-rust-debt.toml
+docs/policy/NON_RUST_INVENTORY.md   # initial seed; PR 03 generates the live one
+```
+
+Acceptance:
+
+```bash
+python3 - <<'PY'
+import pathlib, tomllib
+for p in pathlib.Path("policy").glob("*non-rust*.toml"):
+    tomllib.loads(p.read_text())
+PY
+```
+
+### PR 03 — `cargo xtask non-rust inventory`
+
+```text
+xtask/src/tasks/file_policy.rs
+xtask/src/tasks/mod.rs
+xtask/src/main.rs
+docs/policy/NON_RUST_INVENTORY.md
+```
+
+Outputs:
+
+```text
+target/policy/non-rust-inventory.md
+target/policy/non-rust-inventory.json
+```
+
+Acceptance:
+
+```bash
+cargo check -p xtask --locked
+cargo xtask non-rust inventory
+test -f target/policy/non-rust-inventory.md
+```
+
+### PR 04 — `cargo xtask check-file-policy`
+
+```text
+xtask/src/tasks/file_policy.rs        # extended
+xtask/tests/file_policy.rs
+docs/policy/POLICY_ALLOWLISTS.md      # mark advisory mode active
+```
+
+Modes: `advisory` (default), `blocking-allowlist`, `blocking-strict`.
+
+Acceptance:
+
+```bash
+cargo check -p xtask --locked
+cargo test -p xtask file_policy
+cargo xtask check-file-policy --mode advisory
+```
+
+### PR 05 — `cargo xtask non-rust propose`
+
+```text
+xtask/src/tasks/file_policy.rs        # extended
+xtask/tests/file_policy_propose.rs
+```
+
+Outputs:
+
+```text
+target/policy/non-rust-proposed-allowlist.toml
+target/policy/non-rust-proposal.md
+```
+
+Critical guarantee: **never mutates `policy/non-rust-allowlist.toml`**.
+
+### PR 06 — Generated / executable / dependency policies
+
+```text
+policy/generated-allowlist.toml
+policy/executable-allowlist.toml
+policy/dependency-surface-allowlist.toml
+xtask/src/tasks/generated_policy.rs
+xtask/src/tasks/executable_policy.rs
+xtask/src/tasks/dependency_surface_policy.rs
+xtask/tests/generated_policy.rs
+xtask/tests/executable_policy.rs
+xtask/tests/dependency_surface_policy.rs
+```
+
+Each checker introduces in `advisory` mode.
+
+### PR 07 — Process / network policies
+
+```text
+policy/process-allowlist.toml
+policy/network-allowlist.toml
+xtask/src/tasks/process_policy.rs
+xtask/src/tasks/network_policy.rs
+xtask/tests/process_policy.rs
+xtask/tests/network_policy.rs
+```
+
+Search patterns include both Rust forms (`Command`, `reqwest`, `TcpStream`)
+and script/workflow forms (`subprocess`, `curl`, `npm install`).
+
+### PR 08 — Workflow surface policy
+
+```text
+policy/workflow-allowlist.toml
+xtask/src/tasks/workflow_surface_policy.rs
+xtask/tests/workflow_surface_policy.rs
+docs/ci/workflow-policy.md
+```
+
+Pairs with the existing `cargo xtask workflow-trigger-lint` and
+`workflow-policy-lint`. The new checker covers ownership and required-or-not
+status; the existing lints cover triggers and required-checks composition.
+
+### PR 09 — Unified policy report
+
+```text
+xtask/src/tasks/policy_report.rs
+xtask/tests/policy_report.rs
+docs/policy/POLICY_REPORT.md
+```
+
+Outputs:
+
+```text
+target/policy/policy-report.md
+target/policy/policy-report.json
+```
+
+Sections: non-Rust files / generated / executable / dependency surfaces /
+workflow surfaces / process / network / expired / stale reviews / unused /
+broad globs / debt.
+
+### PR 10 — Wire into `.ci/gate-policy.yaml`
+
+```text
+.ci/gate-policy.yaml
+.github/workflows/ci.yml
+docs/project/CI.md
+docs/policy/POLICY_ALLOWLISTS.md     # mode promotion
+```
+
+The new gate runs:
+
+```bash
+cargo xtask check-file-policy            --mode blocking-allowlist
+cargo xtask check-generated              --mode blocking-allowlist
+cargo xtask check-executable-files       --mode blocking-allowlist
+cargo xtask check-dependency-surfaces    --mode blocking-allowlist
+cargo xtask check-workflow-surfaces      --mode blocking-allowlist
+cargo xtask check-process-policy         --mode advisory
+cargo xtask check-network-policy         --mode advisory
+cargo xtask policy-report
+```
+
+Receipt path: `target/receipts/file-policy.json`. Receipt schema follows
+the existing `.ci/receipt.schema.json`.
+
+### PR 11 — Strict-mode promotion
+
+```text
+.ci/gate-policy.yaml
+docs/policy/POLICY_ALLOWLISTS.md
+```
+
+Promotes the well-baselined ledgers to `blocking-strict`. Process and
+network are typically last (the noisiest) and may stay at
+`blocking-allowlist` for longer.
+
+## Definition of done
+
+The rollout is complete when **all** of the following are true:
+
+- `policy/non-rust-allowlist.toml` exists and covers every tracked
+  non-Rust file. `cargo xtask check-file-policy --mode blocking-strict`
+  passes on master.
+- `policy/non-rust-debt.toml` is empty or every entry has an owner and a
+  near-term `review_after`.
+- `cargo xtask non-rust inventory` emits Markdown + JSON inventory.
+- `cargo xtask non-rust propose` emits proposed TOML without mutating
+  the active ledger.
+- `policy/generated-allowlist.toml`,
+  `policy/executable-allowlist.toml`,
+  `policy/dependency-surface-allowlist.toml`, and
+  `policy/workflow-allowlist.toml` exist and are at least
+  `blocking-allowlist`.
+- `policy/process-allowlist.toml` and `policy/network-allowlist.toml`
+  exist and are at least `blocking-allowlist`.
+- `cargo xtask policy-report` emits Markdown + JSON.
+- `.ci/gate-policy.yaml` declares a `file_policy` gate that produces a
+  receipt.
+- CI uploads policy receipts.
+- Broad globs are justified.
+- Expired entries fail the gate.
+- Unused entries fail strict mode.
+- New non-Rust files cannot land anonymously.
+
+## Out of scope
+
+This rollout does **not**:
+
+- Replace the strict panic-family Clippy lints.
+- Replace the existing `xtask check-lint-policy`, workflow-trigger lint,
+  or workflow-policy lint.
+- Replace gate receipts or the `.ci/gate-policy.yaml` model.
+- Migrate `scripts/**` to `xtask` automatically. Migration is
+  per-script, owner-driven, and tracked through individual entries with
+  `expires` dates.
+- Cover content correctness — see `cargo xtask markdown-links`,
+  `cargo xtask validate-receipts`, and per-crate test suites.
+
+## Rollout principles
+
+- **Doctrine before mechanics.** PR 01 lands the rule. PRs 02+ implement it.
+- **Advisory before blocking.** Every checker introduces at `advisory`.
+  Promotions go through their own PR.
+- **Companions narrow broad globs.** `docs/**` is allowed because the
+  executable, generated, process, and network ledgers cover the risky
+  drift.
+- **No silencing.** Allowlist entries are receipts, not waivers.
+- **Owner over individual.** `owner = "release/ci"` not
+  `owner = "@steven"`. Areas outlast people.
+- **Receipt over rule.** The TOML ledger is the durable artifact;
+  any command-line output is regenerable.

--- a/docs/policy/FILE_POLICY.md
+++ b/docs/policy/FILE_POLICY.md
@@ -1,0 +1,178 @@
+# File Policy
+
+> Rust by default. Non-Rust by receipt. Risky behavior by companion policy.
+
+This is the doctrine that governs which files are allowed in `perl-lsp` and how.
+The mechanics — TOML ledgers, `xtask` checkers, CI receipts — come in later
+PRs of [the file-policy rollout](../ci/perl-lsp-ci-policy-rollout.md). This
+document is the rule the mechanics enforce.
+
+## The rule
+
+Three lines:
+
+1. **Rust and `cargo xtask` are the default construction material** for repo
+   automation, policy checks, test orchestration, release checks, fixture
+   runners, and production logic.
+2. **Non-Rust files are allowed when they are a real product, platform,
+   fixture, documentation, generated, or integration surface.** Markdown docs,
+   GitHub Actions YAML, Perl source fixtures, the VS Code extension, the
+   tree-sitter C bindings, and `Cargo.lock` are all legitimate.
+3. **They are not allowed anonymously.** Every non-Rust surface needs an
+   explicit allowlist entry with owner, reason, surface classification, and
+   coverage.
+
+## Why
+
+`perl-lsp` already has the right substrate — Rust 2024 with strict
+panic-family lints, an `xtask` crate that owns CI receipts and policy lints,
+and a gate-receipt model where every CI step produces a structured artifact.
+What it has been missing is the layer that says *which* file kinds may exist
+in the tree and *who* is on the hook when they regress.
+
+Three failure modes this policy prevents:
+
+- **Anonymous shell scripts** that nobody owns, nobody tests, and that quietly
+  carry credentials, network access, or process spawning logic.
+- **Drift from the receipt model** — a Python helper added "temporarily" and
+  never migrated to `xtask`, so its behavior is invisible to gate receipts.
+- **Broad globs without justification** — `**/*.sh` covered by nothing,
+  reviewed by no one, expiring never.
+
+The rule does not say "no scripts" or "no Python." It says: if a non-Rust
+file exists, the repo holds a receipt explaining who owns it, why it must be
+non-Rust, and what test or check covers it.
+
+## What counts as "non-Rust"
+
+For policy purposes, a file is **Rust** if it is one of:
+
+- `*.rs` source files,
+- `Cargo.toml` / `Cargo.lock` / `rust-toolchain*` manifests,
+- `target/**` build artifacts (gitignored, never tracked).
+
+Everything else is non-Rust and needs an allowlist receipt:
+
+| Class                 | Examples                                                             |
+| --------------------- | -------------------------------------------------------------------- |
+| Documentation         | `docs/**`, `*.md`, `README*`, `CHANGELOG*`, `RELEASE_HISTORY*`       |
+| CI / config           | `.github/workflows/*.yml`, `.ci/**`, `policy/*.toml`, `deny.toml`    |
+| Perl fixtures         | `**/*.pl`, `**/*.pm`, `**/*.t`, `test_corpus/**`                     |
+| Editor extensions     | `vscode-extension/**`, `editors/vscode/**`                           |
+| Native parser bindings| `crates/tree-sitter-perl-c/**`                                       |
+| CI / release scripts  | `scripts/**` (legacy compatibility helpers; migrating to `xtask`)    |
+| Generated artifacts   | `Cargo.lock`, status pages under `docs/project/status/**`            |
+| Assets                | images, icons, web assets                                            |
+
+Each class lands in `policy/non-rust-allowlist.toml` with its own entry. The
+[non-Rust policy doc](NON_RUST_POLICY.md) details the schema and review
+cadence.
+
+## What "allowed by receipt" means
+
+Every entry in `policy/non-rust-allowlist.toml` is a **receipt**, not an
+escape hatch. A receipt has:
+
+| Field            | Required? | Meaning                                                                  |
+| ---------------- | :-------: | ------------------------------------------------------------------------ |
+| `id`             |    yes    | Stable identifier for the entry. Cited by the policy report and CI logs. |
+| `glob` / `path`  |    yes    | The matcher. Repo-relative, no leading `./`, no Windows backslashes.     |
+| `kind`           |    yes    | Category (`documentation`, `language_fixture`, `editor_extension`, …).   |
+| `language`       |    yes    | Primary language (`markdown`, `yaml`, `perl`, `typescript`, …).          |
+| `surface`        |    yes    | Where this lives in product terms (`docs`, `parser`, `editor`, `ci`, …). |
+| `classification` |    yes    | `production` / `test` / `tooling` / `config` / `documentation`.          |
+| `owner`          |    yes    | Team / area on the hook for regressions.                                 |
+| `reason`         |    yes    | Why this surface must be non-Rust.                                       |
+| `covered_by`     |    yes    | Tests / checks / lints that catch regressions.                           |
+| `created`        |    yes    | Date the entry was added (`YYYY-MM-DD`).                                 |
+| `review_after`   |    yes    | When the entry should be re-justified.                                   |
+| `expires`        |    no     | Required for **temporary** exceptions; absent means durable.             |
+| `broad_glob_reason` | conditional | Required when the matcher covers a broad tree (e.g., `docs/**`). |
+| `retired`        |    no     | Set to `true` when the entry is intentionally unused but kept for history. |
+
+The checker fails when any required field is missing, when a broad glob has
+no `broad_glob_reason`, or when an entry has expired.
+
+## Companion policies
+
+The non-Rust allowlist answers **where non-Rust may exist**. It does not
+answer:
+
+- whether a generated file is intentional (`Cargo.lock` is; an accidental
+  `report.json` is not),
+- whether a tracked file is executable on disk (a stray `+x` on a fixture
+  is a smell),
+- whether a new package manager appeared (`package.json`, `pyproject.toml`,
+  `Gemfile`),
+- whether a workflow surface is intentional and required,
+- whether code spawns subprocesses,
+- whether code reaches the network.
+
+Those are tracked by **companion policies**:
+
+| Policy                  | Ledger                                       | Question it answers              |
+| ----------------------- | -------------------------------------------- | -------------------------------- |
+| Generated allowlist     | `policy/generated-allowlist.toml`            | Which generated files belong?    |
+| Executable allowlist    | `policy/executable-allowlist.toml`           | Which tracked files are `+x`?    |
+| Dependency surface      | `policy/dependency-surface-allowlist.toml`   | Which dep manifests exist?       |
+| Workflow surface        | `policy/workflow-allowlist.toml`             | Which CI workflows exist, who owns them, are they required? |
+| Process allowlist       | `policy/process-allowlist.toml`              | Where may we spawn subprocesses? |
+| Network allowlist       | `policy/network-allowlist.toml`              | Where may we contact the network? |
+
+Companion policies are *narrower* than the file allowlist on purpose. A
+broad `docs/**` allowlist entry is fine. A broad "subprocesses anywhere"
+allowance is not.
+
+See [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) for the full set.
+
+## Three modes
+
+Every checker has three modes. Promotion only happens after the baseline is
+clean.
+
+| Mode                 | Behavior                                              |
+| -------------------- | ----------------------------------------------------- |
+| `advisory`           | Write the report; never fail.                         |
+| `blocking-allowlist` | Fail unallowlisted files, expired entries, malformed entries, missing required fields. |
+| `blocking-strict`    | Also fail stale `review_after` dates, unused entries, and unjustified broad globs. |
+
+The rollout introduces each policy at `advisory`, lets the inventory settle,
+then promotes once owners are assigned and noise is gone. Strict mode is
+reserved for policies whose baseline is fully owned.
+
+## Anti-patterns
+
+Reviewers and agents should reject these patterns:
+
+- **Adding `**/*` globs to silence the checker.** A broad glob without a
+  `broad_glob_reason` and a narrow companion policy is a silent waiver.
+- **Setting `owner = "TODO"` and merging.** Proposed entries from
+  `cargo xtask non-rust propose` ship with `TODO` markers as a **prompt**,
+  not an answer. Reviewers must replace them.
+- **Adding a script "for now."** If `scripts/<helper>.sh` is the right
+  answer for the next 90 days, write the entry with `expires` set 90 days
+  out. If it is the right answer forever, migrate it to `xtask` first.
+- **Disabling the gate.** Mode promotions go through PR review;
+  demotions do too. The gate is not a knob individual contributors flip.
+
+## Relationship to existing infrastructure
+
+This policy does **not** replace:
+
+- Strict panic-family Clippy lints in the workspace `Cargo.toml`.
+- The existing `xtask check-lint-policy` for Clippy ledger drift.
+- The existing workflow-trigger lint and required-checks policy.
+- Gate receipts and the `.ci/gate-policy.yaml` model.
+
+It **extends** the existing policy stack with a layer that asks "is this
+file even supposed to be in this repo, and who is on the hook for it?"
+before any Clippy lint or workflow lint runs.
+
+## Roadmap
+
+- [Rollout plan](../ci/perl-lsp-ci-policy-rollout.md) — the 11 PRs that
+  build out this policy.
+- [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) — every ledger and what it
+  covers.
+- [NON_RUST_POLICY.md](NON_RUST_POLICY.md) — the non-Rust allowlist in
+  detail: schema, examples, common rejections.

--- a/docs/policy/NON_RUST_POLICY.md
+++ b/docs/policy/NON_RUST_POLICY.md
@@ -1,0 +1,243 @@
+# Non-Rust File Policy
+
+The doctrine is in [FILE_POLICY.md](FILE_POLICY.md). This document is the
+operational detail for the **non-Rust allowlist** — the primary ledger that
+declares which non-Rust files are permitted in `perl-lsp` and on what terms.
+
+## Source of truth
+
+```text
+policy/non-rust-allowlist.toml   # the active allowlist
+policy/non-rust-debt.toml        # uncertain entries pending classification
+docs/policy/NON_RUST_INVENTORY.md  # generated inventory (PR 3)
+```
+
+Reader / writer:
+
+```text
+cargo xtask non-rust inventory   # emit Markdown + JSON inventory
+cargo xtask non-rust propose     # propose entries for unallowlisted files
+cargo xtask check-file-policy    # enforce the allowlist
+```
+
+## Schema
+
+Every entry under `[[allow]]` carries the following fields. The [file-policy
+checker](POLICY_ALLOWLISTS.md) enforces these.
+
+```toml
+[[allow]]
+id              = "non-rust-<short-stable-id>"
+glob            = "<repo-relative glob>"   # or `path = "<exact-path>"`
+kind            = "<category>"
+language        = "<primary language>"
+surface         = "<product/repo surface>"
+classification  = "<production|test|tooling|config|documentation>"
+owner           = "<team-or-area>"
+reason          = "<why this must be non-Rust>"
+covered_by      = ["<test/check/lint that catches regressions>", ...]
+created         = "YYYY-MM-DD"
+review_after    = "YYYY-MM-DD"
+expires         = "YYYY-MM-DD"        # optional; required for temporary entries
+broad_glob_reason = "..."             # required when the matcher is broad
+retired         = false               # optional; true keeps the receipt for history
+```
+
+### Field semantics
+
+- **`glob` vs `path`.** Use `path` for an exact file. Use `glob` for a tree
+  or extension. A glob entry must include `**`, `*`, or `?` to be considered
+  a glob; otherwise the checker treats it as a typo.
+- **`kind`.** A short category. The current vocabulary:
+  `documentation`, `language_fixture`, `editor_extension`,
+  `native_parser_binding`, `ci_declarative`, `ci_policy_config`,
+  `ci_tooling`, `release_metadata`, `asset`, `config`, `generated`. Add a
+  new `kind` only when an existing one is misleading.
+- **`language`.** The dominant language. `mixed` is allowed for trees that
+  legitimately span languages (e.g., `scripts/**`).
+- **`surface`.** Where this lives in product terms — `docs`, `parser`,
+  `editor`, `ci`, `tooling`, `release`. Used to group the policy report.
+- **`classification`.** The blast radius if this surface breaks.
+  `production` (ships to users), `test` (parser/LSP fixtures),
+  `tooling` (developer / CI helpers), `config` (declarative settings),
+  `documentation` (prose).
+- **`owner`.** Stable identifier — `parser`, `editor/vscode`, `release/ci`,
+  `runtime/subprocess`, `docs`. Avoid individual usernames.
+- **`reason`.** One sentence answering "why is this not Rust?"
+- **`covered_by`.** Concrete commands or check names that catch regressions
+  on this surface. The checker requires at least one entry for any
+  `production`, `test`, or `tooling` classification.
+- **`review_after`.** A date the next maintainer should re-justify the
+  entry. Default cadence: 30 days for new entries, 90–180 days for stable
+  entries.
+- **`expires`.** Required when `kind` describes something temporary
+  (compatibility wrapper, migration shim). Absence implies durable.
+- **`broad_glob_reason`.** Required when the glob covers a broad tree —
+  e.g., `docs/**`, `scripts/**`, `.ci/**`. Explains why the breadth is
+  acceptable and points at the companion policies that cover risky drift.
+- **`retired`.** When set `true`, the entry is kept as a historical
+  receipt but no longer matches files. The strict-mode checker still
+  flags retired entries that have any matching files.
+
+## Worked examples
+
+### Documentation tree
+
+```toml
+[[allow]]
+id = "non-rust-docs"
+glob = "docs/**"
+kind = "documentation"
+language = "markdown"
+surface = "docs"
+classification = "documentation"
+owner = "docs"
+reason = "Project documentation, release notes, implementation plans, status pages, and policy prose."
+covered_by = [
+  "cargo xtask check-file-policy",
+  "cargo xtask markdown-links",
+]
+broad_glob_reason = "Docs are intentionally tree-shaped and non-executable; executable/process/network/generated checks cover risky drift."
+created = "2026-05-07"
+review_after = "2026-08-07"
+```
+
+This is acceptable because `docs/**` is broad but the companion policies
+narrow the risk:
+
+- The executable allowlist forbids `+x` files in `docs/**`.
+- The process and network allowlists forbid `Command::new` / network calls
+  outside of `crates/perl-subprocess-runtime` and `xtask`.
+- The generated allowlist names the specific status pages.
+
+### Perl fixture
+
+```toml
+[[allow]]
+id = "non-rust-perl-fixtures"
+glob = "**/*.pl"
+kind = "language_fixture"
+language = "perl"
+surface = "fixtures"
+classification = "test"
+owner = "parser/lsp-fixtures"
+reason = "Perl source files are first-class parser, semantic-analysis, LSP, DAP, and corpus fixtures."
+covered_by = [
+  "cargo test --workspace",
+  "cargo xtask parser-corpus-sweep --enforce --receipt",
+]
+created = "2026-05-07"
+review_after = "2026-11-07"
+```
+
+`**/*.pl` is broad, but Perl source files **are the corpus the LSP parses**.
+The receipt makes that explicit.
+
+### Editor extension
+
+```toml
+[[allow]]
+id = "non-rust-vscode-extension"
+glob = "vscode-extension/**"
+kind = "editor_extension"
+language = "typescript"
+surface = "editor"
+classification = "production"
+owner = "editor/vscode"
+reason = "VS Code extension client, packaging, and managed-binary behavior require the VS Code extension ecosystem."
+covered_by = [
+  "vscode-managed-binary-smoke",
+  "vscode-published-extension-smoke",
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+```
+
+Production surface, owned by `editor/vscode`, covered by two real CI smokes.
+
+### Temporary helper
+
+```toml
+[[allow]]
+id = "non-rust-release-compat-wrapper"
+path = "scripts/release-compat-wrapper.sh"
+kind = "release_tooling"
+language = "shell"
+surface = "release"
+classification = "tooling"
+owner = "release/ci"
+reason = "Bridges CI to a release tool that does not yet have an xtask command."
+covered_by = ["cargo xtask check-executable-files"]
+created = "2026-05-07"
+review_after = "2026-06-07"
+expires = "2026-08-07"
+```
+
+`expires` is set because the answer here is "migrate to `xtask`," not "keep
+forever." The checker rejects entries past their expiry date.
+
+## Common rejections
+
+Reviewers should reject:
+
+- **Glob has no matchers.** `glob = "scripts/release.sh"` is a typo —
+  use `path` for exact files.
+- **`covered_by = []`** for a `production` / `test` / `tooling` entry.
+  Documentation entries may legitimately have an empty cover list.
+- **`broad_glob_reason` missing** for any glob whose first segment is `**`,
+  whose second segment is `**`, or whose tree includes more than one
+  language family.
+- **`owner = "TODO"`** in the active allowlist. `TODO` is allowed in
+  proposals (`cargo xtask non-rust propose`) and in
+  `policy/non-rust-debt.toml`, but not in the active ledger.
+- **`reason` that is a tautology.** "This is markdown because it is
+  markdown" is not a reason. The reason should explain why this surface
+  exists at all.
+- **Adding the same path under two `id`s.** Duplicate matchers without an
+  explicit override break the proposal command.
+
+## Lifecycle
+
+```text
+proposed (target/policy/non-rust-proposed-allowlist.toml, generated)
+   ↓ owner classifies, edits, fills TODOs
+debt (policy/non-rust-debt.toml, time-boxed)
+   ↓ owner agrees on permanent shape
+active (policy/non-rust-allowlist.toml)
+   ↓ surface goes away
+retired (active, retired = true, kept as receipt)
+   ↓ historical retention threshold
+removed (deleted from active)
+```
+
+Most entries skip the `debt` step and go straight from `proposed` to
+`active`. The debt ledger exists for cases where ownership is genuinely
+ambiguous and a maintainer wants a tracked place for the question.
+
+## Cadence
+
+| Trigger                                          | Action                                        |
+| ------------------------------------------------ | --------------------------------------------- |
+| New non-Rust file in PR                          | `cargo xtask check-file-policy` fails; author runs `cargo xtask non-rust propose` and adds an entry. |
+| `review_after` date passes                       | Strict mode flags; owner re-justifies, advances date, or removes the entry. |
+| `expires` date passes                            | Hard fail in any blocking mode. Owner removes or replaces the entry. |
+| Surface goes away                                | Owner sets `retired = true`. Strict mode flags any remaining matches. |
+| Allowlist drift detected on master               | Tooling-debt scout files an issue; check-file-policy bumped to strict for that surface. |
+
+## What this policy does *not* do
+
+- It does not gate Clippy lint exceptions — that is `policy/clippy-debt.toml`.
+- It does not gate workflow-trigger linting — that is the existing
+  workflow-trigger policy.
+- It does not gate `Cargo.lock` reproducibility — that is
+  `cargo check --locked --workspace`.
+- It does not enforce *content* — only *existence*. A `docs/foo.md`
+  matching the docs allowlist is permitted; whether the prose is correct
+  is a review concern, not a policy one.
+
+## See also
+
+- [FILE_POLICY.md](FILE_POLICY.md) — the overarching doctrine.
+- [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) — every ledger.
+- [Rollout plan](../ci/perl-lsp-ci-policy-rollout.md) — the 11-PR sequence.

--- a/docs/policy/POLICY_ALLOWLISTS.md
+++ b/docs/policy/POLICY_ALLOWLISTS.md
@@ -1,0 +1,312 @@
+# Policy Allowlists
+
+`perl-lsp` runs a layered policy stack. Each layer is a TOML ledger plus an
+`xtask` checker plus a CI receipt. The doctrine is in
+[FILE_POLICY.md](FILE_POLICY.md). This document is the catalog: what each
+ledger covers, where the checker lives, and how the layers compose.
+
+## Why layered
+
+A single broad allowlist would force trade-offs that hurt safety. The
+non-Rust allowlist may legitimately include `docs/**` and `scripts/**` —
+broad globs in the file dimension. But a broad allowance for **subprocess
+spawning** or **network access** is never legitimate, even in `scripts/**`.
+
+The layers separate those concerns:
+
+```text
+non-rust       → which files may exist?
+generated      → which generated artifacts belong?
+executable     → which tracked files are +x?
+dependency     → which dependency-manager manifests exist?
+workflow       → which CI workflows exist, owned by whom?
+process        → where may we spawn subprocesses?
+network        → where may we contact the network?
+```
+
+A file in `scripts/**` may be allowed by the non-Rust ledger and **still
+fail** the executable, process, or network ledger. That is the point: a
+broad file-existence allowance is constrained by narrow risky-behavior
+allowances.
+
+## The seven ledgers
+
+| Ledger                                   | xtask command                              | Question                                                  | Default mode |
+| ---------------------------------------- | ------------------------------------------ | --------------------------------------------------------- | ------------ |
+| `policy/non-rust-allowlist.toml`         | `cargo xtask check-file-policy`            | Which non-Rust files are permitted?                       | advisory → blocking-allowlist |
+| `policy/generated-allowlist.toml`        | `cargo xtask check-generated`              | Which generated artifacts belong in the tree?             | advisory → blocking-allowlist |
+| `policy/executable-allowlist.toml`       | `cargo xtask check-executable-files`       | Which tracked files may carry the `+x` bit?               | advisory → blocking-allowlist |
+| `policy/dependency-surface-allowlist.toml` | `cargo xtask check-dependency-surfaces`    | Which dependency-manager manifests are permitted?         | advisory → blocking-allowlist |
+| `policy/workflow-allowlist.toml`         | `cargo xtask check-workflow-surfaces`      | Which `.github/workflows/*.yml` exist, owned by whom?     | advisory → blocking-allowlist |
+| `policy/process-allowlist.toml`          | `cargo xtask check-process-policy`         | Where in the codebase may we spawn subprocesses?          | advisory → blocking-allowlist |
+| `policy/network-allowlist.toml`          | `cargo xtask check-network-policy`         | Where may we contact the network?                         | advisory → blocking-allowlist |
+
+A unified report aggregates the seven:
+
+```bash
+cargo xtask policy-report
+# emits target/policy/policy-report.md and policy-report.json
+```
+
+## Common schema
+
+Every ledger shares this preamble:
+
+```toml
+schema_version = 1
+policy = "<ledger-name>"
+owner = "EffortlessMetrics"
+status = "advisory"   # or "active"
+updated = "YYYY-MM-DD"
+```
+
+Every entry under `[[allow]]` shares this minimum:
+
+```toml
+[[allow]]
+id          = "<ledger-prefix>-<short-id>"
+owner       = "<team-or-area>"
+reason      = "<why this exception exists>"
+created     = "YYYY-MM-DD"
+review_after = "YYYY-MM-DD"
+covered_by  = ["<command-or-check>", ...]
+```
+
+Layer-specific fields extend this base.
+
+## Per-ledger detail
+
+### `policy/non-rust-allowlist.toml`
+
+Detailed in [NON_RUST_POLICY.md](NON_RUST_POLICY.md). The primary ledger:
+which non-Rust files exist and on what terms. Adds `glob`/`path`, `kind`,
+`language`, `surface`, `classification`, optional `expires` and
+`broad_glob_reason`.
+
+### `policy/generated-allowlist.toml`
+
+Lists files that are **deliberately generated** and committed. Each entry
+declares the generator and the regeneration command.
+
+```toml
+[[allow]]
+id = "generated-cargo-lock"
+path = "Cargo.lock"
+kind = "lockfile"
+generated_by = "cargo"
+regenerate = "cargo update --workspace"
+owner = "rust/dependencies"
+reason = "Workspace lockfile pins dependency graph for reproducible CI and release builds."
+covered_by = [
+  "cargo check --locked --workspace",
+  "cargo xtask check-generated",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+```
+
+The strict-mode checker fails when:
+
+- A tracked file matches no entry but contains generator markers
+  (`# AUTO-GENERATED`, `# Do not edit`, etc.).
+- A `regenerate` command is missing for `kind = "lockfile"` /
+  `kind = "status_page"` entries.
+
+### `policy/executable-allowlist.toml`
+
+Tracks files with the `+x` bit set in the index. Default state should be
+**near-empty**. A `+x` shell script in `scripts/**` requires its own entry.
+
+```toml
+[[allow]]
+id = "executable-release-helper"
+path = "scripts/release-helper.sh"
+kind = "release_tooling"
+owner = "release/ci"
+reason = "Temporary release compatibility wrapper; migrate to cargo xtask."
+covered_by = ["cargo xtask check-executable-files"]
+created = "2026-05-07"
+review_after = "2026-06-07"
+expires = "2026-08-07"
+```
+
+The checker walks `git ls-files --eol`-style output (or `git
+ls-files --stage` and inspects mode bits) to find `+x` files and rejects
+any not in the allowlist.
+
+### `policy/dependency-surface-allowlist.toml`
+
+Catches the appearance of new package-manager manifests. The default
+allowed set is small: root `Cargo.toml`, per-crate `Cargo.toml`, the VS
+Code `package.json`. Anything else (a stray `pyproject.toml`, `Gemfile`,
+`go.mod`) fails until receipted.
+
+```toml
+[[allow]]
+id = "dependency-vscode-package-json"
+path = "vscode-extension/package.json"
+kind = "node_manifest"
+owner = "editor/vscode"
+reason = "VS Code extension packaging requires Node package metadata."
+covered_by = [
+  "vscode-managed-binary-smoke",
+  "cargo xtask check-dependency-surfaces",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+```
+
+Strict mode also flags entries whose corresponding manifest file is no
+longer present (drift in the other direction).
+
+### `policy/workflow-allowlist.toml`
+
+Catalogs every `.github/workflows/*.yml` with intent, ownership, and
+required-or-not status. Pairs with the existing workflow-trigger lint and
+required-checks policy under `.ci/policies/`.
+
+```toml
+[[allow]]
+id = "workflow-ci"
+path = ".github/workflows/ci.yml"
+kind = "required_pr_gate"
+owner = "release/ci"
+reason = "Primary merge-blocking CI workflow with PR-fast, merge-gate shards, UX, memory, Windows, and aggregate status."
+required = true
+covered_by = [
+  "cargo xtask workflow-trigger-lint",
+  "cargo xtask workflow-policy-lint",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+```
+
+Adds rules:
+
+- Every workflow must have an entry.
+- `required = true` workflows must appear in
+  `.ci/policies/required-checks.toml`.
+- Workflows with `pull_request:` triggers must declare an `intent`.
+- Label-triggered workflows must name the labels.
+- Broad `pull_request: types: [...]` triggers without scope need a
+  `broad_trigger_reason`.
+
+### `policy/process-allowlist.toml`
+
+Constrains where the codebase may spawn subprocesses. The pattern set
+includes `Command::new`, `tokio::process::Command`, `std::process::Command`,
+`spawn`, and shell forms (`exec`, `system`, `subprocess.run`).
+
+```toml
+[[allow]]
+id = "process-subprocess-runtime"
+path = "crates/perl-subprocess-runtime/src/**"
+pattern = "Command"
+owner = "runtime/subprocess"
+reason = "Subprocess runtime is the explicit boundary for external Perl/tool execution."
+covered_by = [
+  "cargo test -p perl-subprocess-runtime",
+  "cargo xtask check-process-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+```
+
+The checker greps the source tree (Rust, shell, Python, TypeScript) for
+process-spawning patterns and fails when a match exists outside the
+allowlisted path/pattern combinations.
+
+### `policy/network-allowlist.toml`
+
+Constrains where the codebase may contact the network. Patterns include
+`reqwest`, `ureq`, `TcpStream`, `UdpSocket`, `curl`, `wget`,
+`Invoke-WebRequest`, `npm install`, `pip install`, `cargo install`.
+
+```toml
+[[allow]]
+id = "network-release-publish"
+path = "xtask/src/**"
+pattern = "crates.io"
+owner = "release/ci"
+reason = "Release automation may contact crates.io only during explicit release/publish flows."
+allowed_in = ["release", "workflow_dispatch"]
+covered_by = ["cargo xtask check-network-policy"]
+created = "2026-05-07"
+review_after = "2026-08-07"
+```
+
+`allowed_in` is a list of GitHub Actions event names where the call is
+permitted. The CI receipt cross-references the workflow event when
+deciding whether to fail.
+
+## Modes and promotion
+
+Every checker accepts `--mode advisory|blocking-allowlist|blocking-strict`.
+The rollout strategy is:
+
+1. **Land at `advisory`.** Inventory the surface, generate the report,
+   let owners assign themselves.
+2. **Promote to `blocking-allowlist`.** Unallowlisted, expired, or
+   malformed entries fail the gate. Stale `review_after` and unused
+   entries are still warnings.
+3. **Promote to `blocking-strict`.** Stale reviews fail. Unused entries
+   fail. Broad globs without `broad_glob_reason` fail.
+
+Each promotion is its own PR with the commit message `policy(<ledger>):
+promote to <mode>`.
+
+## Composition rules
+
+- **A file allowed by `non-rust` may still fail `executable`,
+  `dependency`, `workflow`, `process`, or `network`.** That is intentional.
+- **A file rejected by `non-rust` does not run the other ledgers.** The
+  non-Rust ledger is the first gate; if a file shouldn't exist, no other
+  policy needs to consider it.
+- **`generated` and `non-rust` overlap.** A generated `Cargo.lock` is
+  Rust by language but generated by `cargo`; both ledgers list it.
+  Removing one entry without the other is an error.
+- **Companion ledgers reference each other in `covered_by`.** A `docs/**`
+  entry in `non-rust` lists `cargo xtask check-executable-files` in its
+  `covered_by` to make the composition explicit in the receipt.
+
+## Per-PR enforcement
+
+The full policy gate is one CI step:
+
+```bash
+cargo xtask check-file-policy            --mode blocking-allowlist
+cargo xtask check-generated              --mode blocking-allowlist
+cargo xtask check-executable-files       --mode blocking-allowlist
+cargo xtask check-dependency-surfaces    --mode blocking-allowlist
+cargo xtask check-workflow-surfaces      --mode blocking-allowlist
+cargo xtask check-process-policy         --mode advisory
+cargo xtask check-network-policy         --mode advisory
+cargo xtask policy-report
+```
+
+It writes `target/receipts/file-policy.json` and the unified policy report
+under `target/policy/`. The CI lane is wired into `.ci/gate-policy.yaml`
+in PR 10 of the [rollout](../ci/perl-lsp-ci-policy-rollout.md).
+
+## Anti-corruption rules
+
+- **Never edit `target/policy/non-rust-proposed-allowlist.toml` and rename
+  it.** The proposal exists for review; the active ledger is curated.
+  Direct moves bypass the review gate.
+- **Never set `mode = "advisory"` on a checker that was previously
+  `blocking-allowlist` without a PR titled `policy(<ledger>): demote`
+  and a maintainer review.**
+- **Never delete an entry to "fix" a failing check.** If the surface is
+  no longer present, set `retired = true` so the receipt is preserved.
+  If the surface is still present and policy is wrong, fix the policy
+  with a separate PR.
+- **Never silence the gate by adding `**/*` to a non-Rust allowlist
+  glob.** That is the textbook anti-pattern this stack exists to prevent.
+
+## See also
+
+- [FILE_POLICY.md](FILE_POLICY.md) — the doctrine.
+- [NON_RUST_POLICY.md](NON_RUST_POLICY.md) — the primary ledger in
+  detail.
+- [Rollout plan](../ci/perl-lsp-ci-policy-rollout.md) — the 11-PR
+  sequence that implements this catalog.


### PR DESCRIPTION
## Summary

PR 1 of the perl-lsp **file-policy rollout**. Doctrine only — no code, no
TOML ledger, no checker. Lands the rule before the mechanics that enforce
it.

This is a **separate sequence** from the [CI economics rollout](docs/ci/perl-lsp-rollout-plan.md).
The two stacks compose: the file-policy gate (PR 10 of this sequence) runs
as one of the pr-fast checks alongside the existing CI economics gates.

## The rule

```text
Rust and cargo xtask are the default construction material for repo
automation, policy checks, test orchestration, release checks, fixture
runners, and production logic.

Non-Rust files are allowed when they are a real product, platform,
fixture, documentation, generated, or integration surface.

They are not allowed anonymously.

Every non-Rust surface needs:
  path or glob,
  kind,
  owner,
  reason,
  surface,
  classification,
  covered_by,
  review date,
  expiry when temporary.
```

## What changed

Four documentation files, no code:

- **`docs/policy/FILE_POLICY.md`** — overarching doctrine: the rule, why,
  what counts as non-Rust, what "allowed by receipt" means, the seven
  companion policies, three modes (advisory → blocking-allowlist →
  blocking-strict), anti-patterns, relationship to existing infrastructure.
- **`docs/policy/NON_RUST_POLICY.md`** — operational detail for the
  primary ledger: schema field-by-field, worked examples (docs tree, Perl
  fixture, editor extension, temporary helper), common rejections,
  lifecycle, cadence, what this policy does *not* do.
- **`docs/policy/POLICY_ALLOWLISTS.md`** — catalog of all seven ledgers
  (non-rust, generated, executable, dependency-surface, workflow, process,
  network), common schema, per-ledger detail, modes and promotion,
  composition rules, per-PR enforcement command, anti-corruption rules.
- **`docs/ci/perl-lsp-ci-policy-rollout.md`** — the 11-PR sequence with
  files-per-PR, sequencing constraints, definition of done, out of scope.

## Why this is a separate sequence

The CI economics rollout answers "how much does verification cost?" The
file-policy rollout answers "what files belong in this repo, and who
owns them?" Both compose at the gate-receipt layer but are otherwise
orthogonal:

- CI economics: `policy/ci-budget.toml`, `policy/ci-lanes.toml`,
  `policy/ci-risk-packs.toml`, PR Plan, ripr advisory, LEM actuals.
- File policy: `policy/non-rust-allowlist.toml`,
  `policy/generated-allowlist.toml`,
  `policy/executable-allowlist.toml`,
  `policy/dependency-surface-allowlist.toml`,
  `policy/workflow-allowlist.toml`,
  `policy/process-allowlist.toml`,
  `policy/network-allowlist.toml`,
  `cargo xtask check-file-policy`, `policy-report`.

Mixing them in one rollout would have made review and ratchet impossible.

## Layered companion policies (key insight)

The non-Rust allowlist may legitimately include broad globs like `docs/**`
and `scripts/**`. A broad allowance for **subprocess spawning** or
**network access** is never legitimate. The seven ledgers separate those
concerns:

```text
non-rust       → which files may exist?
generated      → which generated artifacts belong?
executable     → which tracked files are +x?
dependency     → which dependency-manager manifests exist?
workflow       → which CI workflows exist, owned by whom?
process        → where may we spawn subprocesses?
network        → where may we contact the network?
```

A file in `scripts/**` may be allowed by `non-rust` and **still fail**
`executable`, `process`, or `network`. A broad file-existence allowance
is constrained by narrow risky-behavior allowances.

## CI / LEM impact

- New default PR lanes: none.
- New advisory checks: none.
- Cache behavior: unchanged.
- Branch protection: unchanged.
- Estimated LEM change for ordinary PRs: **+0 LEM** (docs only).

## Verification

- [x] All four files render as Markdown.
- [x] Cross-links between the four docs and to existing rollout docs are
      consistent.
- [x] No workflow, gate, or policy behavior changes.
- [x] No `policy/*.toml` files added — that is PR 2.
- [x] No `xtask` code added — that is PR 3+.

## Out of scope

This PR is **doctrine only**. The mechanics — TOML ledgers, `xtask`
checkers, CI receipts, and gate wiring — come in PRs 2–11 of
[the rollout sequence](docs/ci/perl-lsp-ci-policy-rollout.md).

## Roadmap

| PR | Name |
|---:|---|
| 01 | **This PR** — file-policy doctrine |
| 02 | Non-Rust TOML ledger |
| 03 | `cargo xtask non-rust inventory` |
| 04 | `cargo xtask check-file-policy` (advisory) |
| 05 | `cargo xtask non-rust propose` |
| 06 | Generated / executable / dependency policies |
| 07 | Process / network policies |
| 08 | Workflow surface policy |
| 09 | Unified policy report |
| 10 | Wire into `.ci/gate-policy.yaml`, promote to blocking-allowlist |
| 11 | Strict-mode promotion |

https://claude.ai/code/session_01W9kqLbX3ropffBJmYiifDJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01W9kqLbX3ropffBJmYiifDJ)_