### PR TITLE
chore(policy): add non-Rust allowlist ledger (#0000)

### DIFF
--- a/docs/policy/NON_RUST_INVENTORY.md
+++ b/docs/policy/NON_RUST_INVENTORY.md
@@ -1,0 +1,184 @@
+# Non-Rust File Inventory (seed)
+
+> This is the **seed** inventory written by hand at the time the
+> non-Rust allowlist was introduced. Once `cargo xtask non-rust inventory`
+> lands (PR 3 of the file-policy rollout), this document is regenerated
+> automatically and the hand-written seed should be replaced by the
+> generator's output.
+
+**Source counts** (at seed time, from `git ls-files`):
+
+```text
+8298  total tracked files
+1842  *.md (documentation)
+1451  Perl fixtures (*.pl + *.pm + *.t)
+ 239  *.json (CI metrics, schemas, fixtures)
+ 128  *.sh
+ 111  *.snap (cargo-insta snapshots)
+  79  *.yml + 12 *.yaml (CI workflows, configs)
+  69  *.toml (policy, manifests, configs)
+  46  *.ts (VS Code extension)
+  41  *.py (CI scripts)
+  14  *.h
+  14  *.svg
+  13  *.js
+   6  *.c
+```
+
+## Coverage by allowlist entry
+
+The seed allowlist (`policy/non-rust-allowlist.toml`) declares **55
+entries** covering the surface above. The intent is to reach >95% coverage
+at seed time so the eventual blocking-allowlist mode (PR 4) is tractable.
+
+### Documentation (`surface = "docs"`)
+
+| Entry id                          | Matcher                                  | Notes                                         |
+| --------------------------------- | ---------------------------------------- | --------------------------------------------- |
+| `non-rust-docs-tree`              | `docs/**`                                | All project documentation.                    |
+| `non-rust-root-governance-docs`   | `*.md`                                   | README, CHANGELOG, ROADMAP, etc.              |
+| `non-rust-license-files`          | `LICENSE-*`                              | Apache-2.0 + MIT.                             |
+| `non-rust-agent-config-files`     | `{AGENTS,AIDER,CLAUDE,CRUSH,GEMINI}.md`  | Agent-runtime project prompts.                |
+| `non-rust-perl-lsp-example-config`| `.perl-lsp.toml.example`                 | User-facing config example.                   |
+
+### CI / GitHub (`surface = "ci"`)
+
+| Entry id                    | Matcher                       | Notes                          |
+| --------------------------- | ----------------------------- | ------------------------------ |
+| `non-rust-github-workflows` | `.github/workflows/*.yml`     | Required CI conveyor.          |
+| `non-rust-github-actions`   | `.github/actions/**`          | Composite Actions.             |
+| `non-rust-github-policy`    | `.github/**`                  | Issue/PR templates, dependabot.|
+| `non-rust-ci-config`        | `.ci/**`                      | Gate policy, blockers, etc.    |
+| `non-rust-policy-ledgers`   | `policy/**`                   | TOML policy stack.             |
+| `non-rust-receipts-tree`    | `.receipts/**`                | Persisted CI receipts.         |
+| `non-rust-ops-tree`         | `.ops-perl-lsp/**`            | Swarm orchestration state.     |
+| `non-rust-trivyignore`      | `.trivyignore`                | Trivy security suppressions.   |
+
+### Perl fixtures (`surface = "fixtures"`)
+
+| Entry id                | Matcher        | Notes                                      |
+| ----------------------- | -------------- | ------------------------------------------ |
+| `non-rust-perl-fixtures`| `**/*.pl`      | 331 files; the corpus the LSP parses.      |
+| `non-rust-perl-modules` | `**/*.pm`      | 1115 files; module-resolution fixtures.    |
+| `non-rust-perl-tests`   | `**/*.t`       | Perl test files used as parser fixtures.   |
+
+### Test snapshots and regression seeds
+
+| Entry id                          | Matcher                       | Notes                          |
+| --------------------------------- | ----------------------------- | ------------------------------ |
+| `non-rust-insta-snapshots`        | `**/*.snap`                   | cargo-insta snapshots.         |
+| `non-rust-insta-pending-snapshots`| `**/*.snap.new`               | Pending review.                |
+| `non-rust-proptest-regressions`   | `**/*.proptest-regressions`   | proptest regression seeds.     |
+
+### Native parser
+
+| Entry id                       | Matcher                              | Notes                              |
+| ------------------------------ | ------------------------------------ | ---------------------------------- |
+| `non-rust-tree-sitter-c`       | `crates/tree-sitter-perl-c/**`       | C tree-sitter parser source.       |
+| `non-rust-tree-sitter-grammar` | `crates/tree-sitter-perl/**`         | Grammar / queries / corpus shared. |
+
+### Editor extension
+
+| Entry id                    | Matcher              | Notes                                 |
+| --------------------------- | -------------------- | ------------------------------------- |
+| `non-rust-vscode-extension` | `vscode-extension/**`| TypeScript client + packaging.        |
+| `non-rust-vscode-config`    | `.vscode/**`         | Workspace VS Code settings.           |
+
+### Build / release tooling
+
+| Entry id                       | Matcher / path           | Notes                                |
+| ------------------------------ | ------------------------ | ------------------------------------ |
+| `non-rust-justfile`            | `justfile`               | Repo task runner.                    |
+| `non-rust-justfiles-tree`      | `.justfiles/**`          | Modular fragments.                   |
+| `non-rust-flake-nix`           | `flake.nix`              | Nix flake for CI/dev shell.          |
+| `non-rust-flake-lock`          | `flake.lock`             | Pinned flake inputs (generated).     |
+| `non-rust-dist-workspace`      | `dist-workspace.toml`    | cargo-dist config.                   |
+| `non-rust-cliff-toml`          | `cliff.toml`             | git-cliff changelog config.          |
+| `non-rust-deny-toml`           | `deny.toml`              | cargo-deny rules.                    |
+| `non-rust-codecov-yml`         | `codecov.yml`            | Codecov reporter config.             |
+| `non-rust-ripr-toml`           | `ripr.toml`              | RIPR static-analysis config.         |
+| `non-rust-features-toml`       | `features.toml`          | LSP feature catalog.                 |
+| `non-rust-bacon-toml`          | `bacon.toml`             | Bacon developer-loop config.         |
+| `non-rust-rust-analyzer-toml`  | `rust-analyzer.toml`     | rust-analyzer workspace config.      |
+| `non-rust-clippy-toml`         | `clippy.toml`            | Workspace Clippy config.             |
+| `non-rust-cargo-config`        | `.cargo/**`              | Cargo configuration tree.            |
+| `non-rust-cargo-semver-checks` | `.cargo-semver-checks.toml` | semver-checks config.             |
+
+### Container / packaging
+
+| Entry id                    | Matcher / path        | Notes                                |
+| --------------------------- | --------------------- | ------------------------------------ |
+| `non-rust-docker-tree`      | `.docker/**`          | Dockerfiles + container scripts.     |
+| `non-rust-docker-compose`   | `docker-compose.yml`  | Compose definition.                  |
+| `non-rust-homebrew-formula` | `Formula/**`          | Homebrew formula.                    |
+
+### Scripts / installers
+
+| Entry id                     | Matcher / path | Notes                                 |
+| ---------------------------- | -------------- | ------------------------------------- |
+| `non-rust-ci-scripts-tree`   | `scripts/**`   | 128 .sh + 41 .py legacy/compat helpers. |
+| `non-rust-install-shell`     | `install.sh`   | One-line installer (Linux/macOS).     |
+| `non-rust-install-powershell`| `install.ps1`  | One-line installer (Windows).         |
+
+### Editor / IDE / agent
+
+| Entry id                   | Matcher                            | Notes                                |
+| -------------------------- | ---------------------------------- | ------------------------------------ |
+| `non-rust-claude-config`   | `.claude/**`                       | Claude Code agent config.            |
+| `non-rust-spec-tree`       | `.spec/**`                         | Spec-planner artifacts.              |
+| `non-rust-other-agents`    | `.{aider,roo,kiro,hermes,jules}/**`| Other-agent configs.                 |
+| `non-rust-aider-conf`      | `.aider.conf.yml`                  | Aider config.                        |
+
+### Repo metadata
+
+| Entry id                  | Matcher / path        | Notes                                  |
+| ------------------------- | --------------------- | -------------------------------------- |
+| `non-rust-gitignore-family` | `**/.gitignore`     | Per-tree git ignore files.             |
+| `non-rust-gitattributes`  | `.gitattributes`      | Git attributes (EOL).                  |
+| `non-rust-markdownlint`   | `.markdownlint.json`  | markdownlint config.                   |
+| `non-rust-cspell`         | `cspell.json`         | cspell dictionary.                     |
+| `non-rust-tokeignore`     | `.tokeignore`         | tokei ignore.                          |
+| `non-rust-pre-commit-hooks` | `.pre-commit-hooks.yaml` | pre-commit hook declarations.    |
+| `non-rust-config-tree`    | `.config/**`          | XDG-style per-tool config.             |
+
+## Validation
+
+```bash
+python3 scripts/policy/validate_non_rust_allowlist.py
+```
+
+Expected output:
+
+```text
+OK: validated 55 allow entries and 0 debt entries.
+```
+
+## Coverage caveats
+
+The seed allowlist is wide but not exhaustive. The Rust checker
+(`cargo xtask check-file-policy`, PR 4) will surface uncovered files via
+the `non-rust propose` command (PR 5). When that runs against the
+current repo, expect proposals for:
+
+- Top-level files not yet listed (any `.gitignore`-style metadata that
+  does not match `**/.gitignore`).
+- New crates' fixture trees if they differ from the existing patterns.
+- Any future test corpus addition (`test_corpus/<new-tree>/`).
+
+## Update cadence
+
+| Trigger                               | Action                                              |
+| ------------------------------------- | --------------------------------------------------- |
+| New crate added                       | Verify its non-Rust files are covered.              |
+| New top-level file added              | Add an allowlist entry or set the file's owner expectation. |
+| `review_after` date passes for a tree | Re-justify the entry; advance the date.             |
+| Surface goes away                     | Set `retired = true` rather than deleting the entry.|
+| `cargo xtask non-rust propose` finds  | Triage the proposal: classify into the active       |
+| unallowlisted files                   | ledger, debt ledger, or remove the file.            |
+
+## See also
+
+- [FILE_POLICY.md](FILE_POLICY.md) — the doctrine.
+- [NON_RUST_POLICY.md](NON_RUST_POLICY.md) — the schema in detail.
+- [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md) — the catalog of all seven ledgers.
+- [Rollout plan](../ci/perl-lsp-ci-policy-rollout.md) — the 11-PR sequence.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,957 @@
+# Non-Rust File Allowlist
+#
+# Source of truth for which non-Rust files are permitted in `perl-lsp`.
+# Doctrine: docs/policy/FILE_POLICY.md.
+# Schema:   docs/policy/NON_RUST_POLICY.md.
+# Catalog:  docs/policy/POLICY_ALLOWLISTS.md.
+#
+# Read by: `cargo xtask check-file-policy` (PR 4 of the file-policy rollout).
+# Written by: humans, with proposals from `cargo xtask non-rust propose`
+# (PR 5) staged in `target/policy/non-rust-proposed-allowlist.toml`.
+#
+# Mode: this ledger is `advisory` until PR 4 introduces the checker. CI
+# becomes blocking-allowlist in PR 10 of the rollout.
+
+schema_version = 1
+policy = "non-rust-allowlist"
+owner = "EffortlessMetrics"
+status = "advisory"
+updated = "2026-05-07"
+
+[defaults]
+rust_is_default = true
+xtask_is_default_for_repo_automation = true
+new_non_rust_requires_review = true
+broad_globs_require_reason = true
+coverage_required_for_production_surfaces = true
+
+# =============================================================================
+# Documentation
+# =============================================================================
+
+[[allow]]
+id = "non-rust-docs-tree"
+glob = "docs/**"
+kind = "documentation"
+language = "markdown"
+surface = "docs"
+classification = "documentation"
+owner = "docs"
+reason = "Project documentation, release notes, implementation plans, status pages, policy prose, agent guides."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Docs are intentionally tree-shaped and non-executable. The executable, generated, process, and network companion ledgers cover risky drift."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-root-governance-docs"
+glob = "*.md"
+kind = "documentation"
+language = "markdown"
+surface = "docs"
+classification = "documentation"
+owner = "docs"
+reason = "Top-level README, CHANGELOG, RELEASE_HISTORY, ROADMAP, CONTRIBUTING, SECURITY, SUPPORT, and governance docs."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Repo root markdown files are governance/documentation by convention; non-Rust by definition."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-license-files"
+glob = "LICENSE-*"
+kind = "license"
+language = "text"
+surface = "release"
+classification = "documentation"
+owner = "release/legal"
+reason = "Apache-2.0 and MIT license texts required by the dual-licensed Rust ecosystem."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-11-07"
+
+# =============================================================================
+# CI / GitHub Actions
+# =============================================================================
+
+[[allow]]
+id = "non-rust-github-workflows"
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+language = "yaml"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+covered_by = [
+  "cargo xtask workflow-trigger-lint",
+  "cargo xtask workflow-policy-lint",
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-github-actions"
+glob = ".github/actions/**"
+kind = "ci_declarative"
+language = "yaml"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "Composite GitHub Actions used by the CI conveyor."
+covered_by = [
+  "cargo xtask workflow-policy-lint",
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Composite Actions are by-convention a tree of action.yml + helper scripts; cover the entire dir."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-github-policy"
+glob = ".github/**"
+kind = "ci_declarative"
+language = "mixed"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "Issue templates, PR templates, dependabot config, CODEOWNERS, and other GitHub-platform metadata."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "GitHub-required metadata location. Workflow trigger and policy lints cover the executable subset."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-ci-config"
+glob = ".ci/**"
+kind = "ci_policy_config"
+language = "mixed"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "CI gate policy, blockers ledger, baseline metrics, receipt schemas, coverage baselines, corpus manifests, and CI receipt examples."
+covered_by = [
+  "cargo xtask gates --tier pr-fast --receipt",
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = ".ci is a governed policy/config tree. Companion workflow, dependency, process, and network checks cover risky drift."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# Policy ledgers
+# =============================================================================
+
+[[allow]]
+id = "non-rust-policy-ledgers"
+glob = "policy/**"
+kind = "ci_policy_config"
+language = "toml"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "TOML policy ledgers for CI economics, lint policy, ripr suppressions, and (this) file policy."
+covered_by = [
+  "cargo xtask check-lint-policy",
+  "cargo xtask check-file-policy",
+  "scripts/ci/validate_risk_packs.py",
+]
+broad_glob_reason = "Policy ledgers are intentionally a tree of TOML files; broad coverage is the policy stack itself."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# Perl fixtures (the corpus the LSP parses)
+# =============================================================================
+
+[[allow]]
+id = "non-rust-perl-fixtures"
+glob = "**/*.pl"
+kind = "language_fixture"
+language = "perl"
+surface = "fixtures"
+classification = "test"
+owner = "parser/lsp-fixtures"
+reason = "Perl source files are first-class parser, semantic-analysis, LSP, DAP, and corpus fixtures."
+covered_by = [
+  "cargo test --workspace",
+  "cargo xtask parser-corpus-sweep --enforce --receipt",
+]
+broad_glob_reason = "Perl source files are the corpus this LSP parses; their breadth is the product surface."
+created = "2026-05-07"
+review_after = "2026-11-07"
+
+[[allow]]
+id = "non-rust-perl-modules"
+glob = "**/*.pm"
+kind = "language_fixture"
+language = "perl"
+surface = "fixtures"
+classification = "test"
+owner = "parser/lsp-fixtures"
+reason = "Perl module files are parser, workspace, and module-resolution fixtures."
+covered_by = [
+  "cargo test --workspace",
+  "cargo xtask parser-corpus-sweep --enforce --receipt",
+]
+broad_glob_reason = "Perl modules are the corpus; their breadth is the product surface."
+created = "2026-05-07"
+review_after = "2026-11-07"
+
+[[allow]]
+id = "non-rust-perl-tests"
+glob = "**/*.t"
+kind = "language_fixture"
+language = "perl"
+surface = "fixtures"
+classification = "test"
+owner = "parser/lsp-fixtures"
+reason = "Perl `.t` test files are parser/LSP test corpus fixtures."
+covered_by = [
+  "cargo test --workspace",
+]
+broad_glob_reason = "Perl `.t` test files are corpus fixtures; they appear throughout test_corpus and crate tests."
+created = "2026-05-07"
+review_after = "2026-11-07"
+
+# =============================================================================
+# Native parser (tree-sitter)
+# =============================================================================
+
+[[allow]]
+id = "non-rust-tree-sitter-c"
+glob = "crates/tree-sitter-perl-c/**"
+kind = "native_parser_binding"
+language = "c"
+surface = "parser"
+classification = "production"
+owner = "parser/tree-sitter"
+reason = "Tree-sitter C parser source is required by the tree-sitter ecosystem; consumed by perl-tree-sitter-rs."
+covered_by = [
+  "cargo check --locked -p tree-sitter-perl-c",
+  "cargo test --locked -p tree-sitter-perl-rs",
+]
+broad_glob_reason = "tree-sitter generates a tree of C sources, headers, queries, and grammar tests; the entire crate is the artifact."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-tree-sitter-grammar"
+glob = "crates/tree-sitter-perl/**"
+kind = "native_parser_binding"
+language = "mixed"
+surface = "parser"
+classification = "production"
+owner = "parser/tree-sitter"
+reason = "Tree-sitter grammar definitions, queries, and corpus shared between the C and Rust crates."
+covered_by = [
+  "cargo test --locked -p tree-sitter-perl-rs",
+]
+broad_glob_reason = "Tree-sitter shared crate is a tree of grammar/queries/corpus by tree-sitter convention."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# VS Code extension
+# =============================================================================
+
+[[allow]]
+id = "non-rust-vscode-extension"
+glob = "vscode-extension/**"
+kind = "editor_extension"
+language = "typescript"
+surface = "editor"
+classification = "production"
+owner = "editor/vscode"
+reason = "VS Code extension client, packaging, managed-binary, and extension-host behavior require the VS Code extension ecosystem."
+covered_by = [
+  "vscode-managed-binary-smoke",
+  "vscode-published-extension-smoke",
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Editor extension is a first-class shipped artifact; TypeScript, package.json, esbuild config, and extension docs all live together."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# Build / release tooling
+# =============================================================================
+
+[[allow]]
+id = "non-rust-justfile"
+path = "justfile"
+kind = "task_runner"
+language = "just"
+surface = "tooling"
+classification = "tooling"
+owner = "release/ci"
+reason = "Repo task runner. Existing entry point for contributors; xtask migration is gradual."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-justfiles-tree"
+glob = ".justfiles/**"
+kind = "task_runner"
+language = "just"
+surface = "tooling"
+classification = "tooling"
+owner = "release/ci"
+reason = "Modular justfile fragments shared across just targets."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Modular justfile fragments live under a single tree."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-flake-nix"
+path = "flake.nix"
+kind = "build_environment"
+language = "nix"
+surface = "tooling"
+classification = "tooling"
+owner = "release/ci"
+reason = "Nix flake pins the local CI gate and developer toolchain."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-flake-lock"
+path = "flake.lock"
+kind = "lockfile"
+language = "json"
+surface = "tooling"
+classification = "config"
+owner = "release/ci"
+reason = "Nix flake lockfile pinning CI/dev-shell inputs."
+covered_by = [
+  "cargo xtask check-generated",
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-dist-workspace"
+path = "dist-workspace.toml"
+kind = "release_metadata"
+language = "toml"
+surface = "release"
+classification = "config"
+owner = "release/ci"
+reason = "cargo-dist release configuration."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-cliff-toml"
+path = "cliff.toml"
+kind = "release_metadata"
+language = "toml"
+surface = "release"
+classification = "config"
+owner = "release/ci"
+reason = "git-cliff changelog generator configuration."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-deny-toml"
+path = "deny.toml"
+kind = "security_config"
+language = "toml"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "cargo-deny advisory, license, and supply-chain rules."
+covered_by = [
+  "cargo deny check",
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-codecov-yml"
+path = "codecov.yml"
+kind = "ci_declarative"
+language = "yaml"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "Codecov reporter configuration."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-ripr-toml"
+path = "ripr.toml"
+kind = "ci_policy_config"
+language = "toml"
+surface = "ci"
+classification = "config"
+owner = "quality/ripr"
+reason = "RIPR static-analysis configuration; severity, suppressions, report shape."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-features-toml"
+path = "features.toml"
+kind = "feature_catalog"
+language = "toml"
+surface = "lsp"
+classification = "config"
+owner = "lsp/features"
+reason = "LSP feature catalog and capability declarations consumed by the LSP server."
+covered_by = [
+  "cargo test --workspace",
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-bacon-toml"
+path = "bacon.toml"
+kind = "developer_tooling"
+language = "toml"
+surface = "tooling"
+classification = "tooling"
+owner = "developer-experience"
+reason = "Bacon (bacon.rs) developer-loop runner config."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-rust-analyzer-toml"
+path = "rust-analyzer.toml"
+kind = "developer_tooling"
+language = "toml"
+surface = "tooling"
+classification = "tooling"
+owner = "developer-experience"
+reason = "rust-analyzer workspace configuration."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-clippy-toml"
+path = "clippy.toml"
+kind = "developer_tooling"
+language = "toml"
+surface = "tooling"
+classification = "config"
+owner = "developer-experience"
+reason = "Workspace Clippy lint configuration."
+covered_by = [
+  "cargo clippy --workspace",
+  "cargo xtask check-lint-policy",
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-cargo-config"
+glob = ".cargo/**"
+kind = "build_config"
+language = "toml"
+surface = "tooling"
+classification = "config"
+owner = "release/ci"
+reason = "Per-workspace cargo configuration (build flags, registries, aliases)."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = ".cargo/config.toml family lives in a single tree."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-cargo-semver-checks"
+path = ".cargo-semver-checks.toml"
+kind = "release_metadata"
+language = "toml"
+surface = "release"
+classification = "config"
+owner = "release/ci"
+reason = "cargo-semver-checks workspace configuration."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# Test fixtures and snapshots
+# =============================================================================
+
+[[allow]]
+id = "non-rust-insta-snapshots"
+glob = "**/*.snap"
+kind = "test_snapshot"
+language = "yaml"
+surface = "fixtures"
+classification = "test"
+owner = "parser/snapshots"
+reason = "cargo-insta snapshot test outputs."
+covered_by = [
+  "cargo test --workspace",
+  "cargo insta test",
+]
+broad_glob_reason = "cargo-insta writes snapshot files alongside tests across all crates; **/*.snap is the canonical match."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-insta-pending-snapshots"
+glob = "**/*.snap.new"
+kind = "test_snapshot"
+language = "yaml"
+surface = "fixtures"
+classification = "test"
+owner = "parser/snapshots"
+reason = "cargo-insta pending snapshot review files."
+covered_by = [
+  "cargo insta accept",
+]
+broad_glob_reason = "Pending snapshots co-locate with accepted ones across the tree."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-proptest-regressions"
+glob = "**/*.proptest-regressions"
+kind = "test_regression_corpus"
+language = "text"
+surface = "fixtures"
+classification = "test"
+owner = "parser/property-tests"
+reason = "proptest auto-generated regression seeds; permanent test corpus."
+covered_by = [
+  "cargo test --workspace",
+]
+broad_glob_reason = "proptest writes regression files alongside the failing test, always under crate `proptest-regressions/`."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# CI / release scripts
+# =============================================================================
+
+[[allow]]
+id = "non-rust-ci-scripts-tree"
+glob = "scripts/**"
+kind = "ci_tooling"
+language = "mixed"
+surface = "tooling"
+classification = "tooling"
+owner = "release/ci"
+reason = "Existing CI receipt conversion, memory workload, release helpers, and compatibility wrappers; migrate stable automation to xtask over time."
+covered_by = [
+  "cargo xtask gates --tier pr-fast --receipt",
+  "cargo xtask check-file-policy",
+  "cargo xtask check-executable-files",
+  "cargo xtask check-process-policy",
+  "cargo xtask check-network-policy",
+]
+broad_glob_reason = "scripts/ contains legacy and compatibility helpers being progressively migrated to xtask. The executable, process, and network companion policies constrain risky behavior."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-install-shell"
+path = "install.sh"
+kind = "release_tooling"
+language = "shell"
+surface = "release"
+classification = "tooling"
+owner = "release/ci"
+reason = "User-facing one-line installer for Linux/macOS; required by cargo-dist's installer model."
+covered_by = [
+  "cargo xtask check-executable-files",
+  "cargo xtask check-network-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-install-powershell"
+path = "install.ps1"
+kind = "release_tooling"
+language = "powershell"
+surface = "release"
+classification = "tooling"
+owner = "release/ci"
+reason = "User-facing one-line installer for Windows; required by cargo-dist's installer model."
+covered_by = [
+  "cargo xtask check-network-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# Editor / IDE / agent configuration
+# =============================================================================
+
+[[allow]]
+id = "non-rust-vscode-config"
+glob = ".vscode/**"
+kind = "editor_config"
+language = "json"
+surface = "tooling"
+classification = "tooling"
+owner = "developer-experience"
+reason = "Workspace-level VS Code settings, tasks, launch configurations."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Workspace VS Code config is a tree (settings, tasks, launch)."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-claude-config"
+glob = ".claude/**"
+kind = "agent_config"
+language = "mixed"
+surface = "tooling"
+classification = "tooling"
+owner = "developer-experience"
+reason = "Claude Code agent definitions, slash commands, hooks, and orchestration configs."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Agent runtime config is structurally a tree of agent files, prompts, and orchestrator state."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-spec-tree"
+glob = ".spec/**"
+kind = "agent_workflow"
+language = "mixed"
+surface = "tooling"
+classification = "tooling"
+owner = "developer-experience"
+reason = "Spec-planner branch artifacts (acceptance grids, checklists, context bundles) shared across agent runs."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Spec-planner artifacts are a tree (acceptance grids, checklists, context bundles)."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-other-agents"
+glob = ".{aider,roo,kiro,hermes,jules}/**"
+kind = "agent_config"
+language = "mixed"
+surface = "tooling"
+classification = "tooling"
+owner = "developer-experience"
+reason = "Other-agent configuration directories used by the swarm orchestration."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Each agent ecosystem has its own directory layout; covered together to avoid one entry per agent."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-agent-config-files"
+glob = "{AGENTS,AIDER,CLAUDE,CRUSH,GEMINI}.md"
+kind = "agent_config"
+language = "markdown"
+surface = "docs"
+classification = "documentation"
+owner = "developer-experience"
+reason = "Top-level agent guidance files (project-level prompts) read by the agent runtimes."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-aider-conf"
+path = ".aider.conf.yml"
+kind = "agent_config"
+language = "yaml"
+surface = "tooling"
+classification = "tooling"
+owner = "developer-experience"
+reason = "Aider agent project-level configuration."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# Developer / repo metadata
+# =============================================================================
+
+[[allow]]
+id = "non-rust-gitignore-family"
+glob = "**/.gitignore"
+kind = "vcs_config"
+language = "text"
+surface = "tooling"
+classification = "config"
+owner = "release/ci"
+reason = "Per-tree .gitignore files. Required by git for ignore semantics."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Per-tree .gitignore files appear under multiple subtrees; covered together."
+created = "2026-05-07"
+review_after = "2026-11-07"
+
+[[allow]]
+id = "non-rust-gitattributes"
+path = ".gitattributes"
+kind = "vcs_config"
+language = "text"
+surface = "tooling"
+classification = "config"
+owner = "release/ci"
+reason = "Git attributes for end-of-line normalization and file-type detection."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-11-07"
+
+[[allow]]
+id = "non-rust-markdownlint"
+path = ".markdownlint.json"
+kind = "linter_config"
+language = "json"
+surface = "tooling"
+classification = "config"
+owner = "docs"
+reason = "markdownlint configuration for prose CI."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-cspell"
+path = "cspell.json"
+kind = "linter_config"
+language = "json"
+surface = "tooling"
+classification = "config"
+owner = "docs"
+reason = "cspell dictionary and exclusions for prose CI."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-trivyignore"
+path = ".trivyignore"
+kind = "security_config"
+language = "text"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "Trivy security-scanner suppression list."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-tokeignore"
+path = ".tokeignore"
+kind = "tooling_config"
+language = "text"
+surface = "tooling"
+classification = "config"
+owner = "developer-experience"
+reason = "tokei (line counter) ignore patterns."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-pre-commit-hooks"
+path = ".pre-commit-hooks.yaml"
+kind = "vcs_config"
+language = "yaml"
+surface = "tooling"
+classification = "config"
+owner = "developer-experience"
+reason = "pre-commit hook declarations published by this repo for downstream consumers."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-perl-lsp-example-config"
+path = ".perl-lsp.toml.example"
+kind = "user_config_example"
+language = "toml"
+surface = "lsp"
+classification = "documentation"
+owner = "lsp/config"
+reason = "Example user-facing .perl-lsp.toml configuration; documents supported keys."
+covered_by = [
+  "cargo test --workspace",
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# Container / packaging
+# =============================================================================
+
+[[allow]]
+id = "non-rust-docker-tree"
+glob = ".docker/**"
+kind = "container_config"
+language = "mixed"
+surface = "release"
+classification = "config"
+owner = "release/ci"
+reason = "Dockerfiles and container scripts for release artifact builds."
+covered_by = [
+  "cargo xtask check-file-policy",
+  "cargo xtask check-network-policy",
+]
+broad_glob_reason = "Docker build context is a tree of Dockerfiles, scripts, and supporting files."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-docker-compose"
+path = "docker-compose.yml"
+kind = "container_config"
+language = "yaml"
+surface = "release"
+classification = "config"
+owner = "release/ci"
+reason = "Top-level compose definition for local container workflows."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-homebrew-formula"
+glob = "Formula/**"
+kind = "package_distribution"
+language = "ruby"
+surface = "release"
+classification = "production"
+owner = "release/ci"
+reason = "Homebrew formula(s) generated/maintained for macOS distribution."
+covered_by = [
+  "cargo xtask check-file-policy",
+  "cargo xtask check-network-policy",
+]
+broad_glob_reason = "Homebrew formulas live in a single Formula/ directory."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+# =============================================================================
+# Receipts / status / metrics
+# =============================================================================
+
+[[allow]]
+id = "non-rust-receipts-tree"
+glob = ".receipts/**"
+kind = "ci_receipt"
+language = "json"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "Persisted CI gate receipts referenced by status pages and review tooling."
+covered_by = [
+  "cargo xtask gate-receipts validate",
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = ".receipts/ holds CI gate receipts as a tree of JSON files."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-ops-tree"
+glob = ".ops-perl-lsp/**"
+kind = "ops_metrics"
+language = "mixed"
+surface = "ci"
+classification = "config"
+owner = "release/ci"
+reason = "Swarm orchestration metrics, queue snapshots, and per-cycle ops state."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = "Swarm ops directory holds heterogeneous operational state by design."
+created = "2026-05-07"
+review_after = "2026-08-07"
+
+[[allow]]
+id = "non-rust-config-tree"
+glob = ".config/**"
+kind = "tooling_config"
+language = "mixed"
+surface = "tooling"
+classification = "config"
+owner = "developer-experience"
+reason = "Per-repo XDG-style config (nextest profile, mdbook, etc.)."
+covered_by = [
+  "cargo xtask check-file-policy",
+]
+broad_glob_reason = ".config/ holds per-tool XDG-style config as a tree."
+created = "2026-05-07"
+review_after = "2026-08-07"

--- a/policy/non-rust-debt.toml
+++ b/policy/non-rust-debt.toml
@@ -1,0 +1,42 @@
+# Non-Rust File Debt Ledger
+#
+# Time-boxed register of non-Rust files whose ownership or justification is
+# genuinely ambiguous. Entries here are NOT allowlisted — they fail the
+# blocking-allowlist checker once it lands. Use this ledger when you want a
+# tracked place to record "we know this is here, we have not yet classified
+# it, here is the deadline."
+#
+# Policy: most newly-discovered non-Rust files should go directly into
+# `policy/non-rust-allowlist.toml` after `cargo xtask non-rust propose`.
+# This ledger is for cases that cannot be classified within a single PR.
+#
+# Doctrine: docs/policy/FILE_POLICY.md.
+# Schema:   docs/policy/NON_RUST_POLICY.md.
+
+schema_version = 1
+policy = "non-rust-debt"
+owner = "EffortlessMetrics"
+status = "active"
+updated = "2026-05-07"
+
+[defaults]
+max_debt_age_days = 30
+escalate_after_days = 14
+
+# No active debt at seed time. The non-rust-allowlist.toml seeds the known
+# surface; anything not covered there appears as an unallowlisted finding
+# in `cargo xtask check-file-policy --mode advisory` and should be
+# classified into either the allowlist or this debt register.
+#
+# Example debt entry shape:
+#
+# [[debt]]
+# id = "non-rust-debt-0001"
+# glob = "scripts/legacy-bench-runner.py"
+# kind = "unknown_non_rust_surface"
+# language = "python"
+# owner = "TODO: parser/perf?"
+# reason = "Initial inventory found this surface; classification unclear; possibly migrated to xtask in PR #NNNN."
+# created = "2026-05-07"
+# review_after = "2026-05-21"
+# expires = "2026-06-07"

--- a/scripts/policy/validate_non_rust_allowlist.py
+++ b/scripts/policy/validate_non_rust_allowlist.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Validate policy/non-rust-allowlist.toml and policy/non-rust-debt.toml.
+
+Sub-second sanity check that runs before `cargo xtask check-file-policy`
+exists (PR 4 of the file-policy rollout). Catches schema-level errors:
+
+  - TOML parses.
+  - Every [[allow]] has the required fields.
+  - `glob` and `path` are mutually exclusive on a single entry.
+  - Paths are repo-relative without leading `./` or absolute prefixes.
+  - No Windows backslashes.
+  - No duplicate ids.
+  - `created` / `review_after` / `expires` are valid YYYY-MM-DD dates.
+  - `expires` (if set) is after `created`.
+  - `review_after` is after `created`.
+  - `production` / `test` / `tooling` entries declare at least one
+    `covered_by` item.
+  - Broad globs (matching `**` at the root, or covering more than one
+    language family) declare `broad_glob_reason`.
+  - `classification` is one of the known values.
+
+This is the schema gate. The semantic gate ("this glob actually matches
+files in the repo, no tracked file is unallowlisted") lands with the Rust
+checker in PR 4.
+
+Run:
+    python3 scripts/policy/validate_non_rust_allowlist.py
+
+Exits non-zero on any violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import pathlib
+import re
+import sys
+import tomllib
+
+REQUIRED_FIELDS = (
+    "id",
+    "kind",
+    "language",
+    "surface",
+    "classification",
+    "owner",
+    "reason",
+    "covered_by",
+    "created",
+    "review_after",
+)
+OPTIONAL_FIELDS = (
+    "glob",
+    "path",
+    "expires",
+    "broad_glob_reason",
+    "retired",
+)
+KNOWN_CLASSIFICATIONS = {
+    "production",
+    "test",
+    "tooling",
+    "config",
+    "documentation",
+}
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+COVERAGE_REQUIRING_CLASSIFICATIONS = {"production", "test", "tooling"}
+
+
+def parse_date(value: str, field: str, entry_id: str, errors: list[str]) -> dt.date | None:
+    if not isinstance(value, str) or not DATE_RE.match(value):
+        errors.append(
+            f"{entry_id}: `{field}` must be a YYYY-MM-DD string, got {value!r}"
+        )
+        return None
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError:
+        errors.append(f"{entry_id}: `{field}` is not a real date: {value!r}")
+        return None
+
+
+def validate_entry(entry: dict, index: int, errors: list[str]) -> None:
+    entry_id = entry.get("id", f"<unnamed entry #{index}>")
+
+    has_glob = "glob" in entry
+    has_path = "path" in entry
+    if has_glob and has_path:
+        errors.append(f"{entry_id}: cannot set both `glob` and `path`")
+    if not has_glob and not has_path:
+        errors.append(f"{entry_id}: must set either `glob` or `path`")
+
+    matcher = entry.get("glob") or entry.get("path") or ""
+    if matcher.startswith("./") or matcher.startswith("/"):
+        errors.append(
+            f"{entry_id}: matcher `{matcher}` must be repo-relative without leading `./` or `/`"
+        )
+    if "\\" in matcher:
+        errors.append(f"{entry_id}: matcher `{matcher}` contains Windows backslashes")
+    if matcher.strip() != matcher:
+        errors.append(f"{entry_id}: matcher `{matcher}` has surrounding whitespace")
+
+    for field in REQUIRED_FIELDS:
+        if field not in entry:
+            errors.append(f"{entry_id}: missing required field `{field}`")
+
+    for field in entry:
+        if field not in REQUIRED_FIELDS + OPTIONAL_FIELDS:
+            errors.append(f"{entry_id}: unknown field `{field}`")
+
+    classification = entry.get("classification")
+    if classification and classification not in KNOWN_CLASSIFICATIONS:
+        errors.append(
+            f"{entry_id}: classification `{classification}` not in "
+            f"{sorted(KNOWN_CLASSIFICATIONS)}"
+        )
+
+    covered_by = entry.get("covered_by", [])
+    if not isinstance(covered_by, list) or any(not isinstance(c, str) for c in covered_by):
+        errors.append(f"{entry_id}: `covered_by` must be a list of strings")
+    elif (
+        classification in COVERAGE_REQUIRING_CLASSIFICATIONS
+        and len(covered_by) == 0
+    ):
+        errors.append(
+            f"{entry_id}: classification `{classification}` requires at least one `covered_by` entry"
+        )
+
+    created = parse_date(entry.get("created", ""), "created", entry_id, errors)
+    review_after = parse_date(entry.get("review_after", ""), "review_after", entry_id, errors)
+    expires_raw = entry.get("expires")
+    expires = (
+        parse_date(expires_raw, "expires", entry_id, errors)
+        if expires_raw is not None
+        else None
+    )
+
+    if created and review_after and review_after <= created:
+        errors.append(f"{entry_id}: `review_after` must be after `created`")
+    if created and expires and expires <= created:
+        errors.append(f"{entry_id}: `expires` must be after `created`")
+
+    # Broad-glob heuristic: glob starting with `**`, glob matching everything
+    # below a top-level directory (`<dir>/**`), or glob containing `*.<ext>`.
+    if has_glob:
+        is_broad = (
+            matcher.startswith("**")
+            or matcher.endswith("/**")
+            or matcher == "*.md"
+            or matcher.startswith("**/")
+        )
+        if is_broad and not entry.get("broad_glob_reason"):
+            errors.append(
+                f"{entry_id}: glob `{matcher}` is broad; declare `broad_glob_reason`"
+            )
+
+    if entry.get("retired") not in (None, True, False):
+        errors.append(f"{entry_id}: `retired` must be a boolean")
+
+
+def validate_allowlist(path: pathlib.Path, errors: list[str]) -> int:
+    try:
+        data = tomllib.loads(path.read_text())
+    except Exception as exc:
+        errors.append(f"FAIL: parse {path}: {exc}")
+        return 0
+
+    entries = data.get("allow", [])
+    if not isinstance(entries, list):
+        errors.append(f"{path}: `allow` must be a list of tables")
+        return 0
+
+    seen_ids: dict[str, int] = {}
+    seen_matchers: dict[str, str] = {}
+    for index, entry in enumerate(entries):
+        validate_entry(entry, index, errors)
+        eid = entry.get("id")
+        if isinstance(eid, str):
+            if eid in seen_ids:
+                errors.append(
+                    f"{eid}: duplicate id (also at index {seen_ids[eid]})"
+                )
+            else:
+                seen_ids[eid] = index
+
+        matcher = entry.get("glob") or entry.get("path")
+        if isinstance(matcher, str):
+            if matcher in seen_matchers:
+                errors.append(
+                    f"{eid or '<unnamed>'}: duplicate matcher `{matcher}` "
+                    f"(also used by id `{seen_matchers[matcher]}`)"
+                )
+            else:
+                seen_matchers[matcher] = eid or "<unnamed>"
+
+    return len(entries)
+
+
+def validate_debt(path: pathlib.Path, errors: list[str]) -> int:
+    try:
+        data = tomllib.loads(path.read_text())
+    except Exception as exc:
+        errors.append(f"FAIL: parse {path}: {exc}")
+        return 0
+
+    entries = data.get("debt", [])
+    if not isinstance(entries, list):
+        errors.append(f"{path}: `debt` must be a list of tables")
+        return 0
+
+    # Debt entries share most schema with allow entries, minus the
+    # `classification` strictness and `covered_by` requirement.
+    return len(entries)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allowlist",
+        type=pathlib.Path,
+        default=pathlib.Path("policy/non-rust-allowlist.toml"),
+    )
+    parser.add_argument(
+        "--debt",
+        type=pathlib.Path,
+        default=pathlib.Path("policy/non-rust-debt.toml"),
+    )
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    n_allow = validate_allowlist(args.allowlist, errors)
+    n_debt = validate_debt(args.debt, errors)
+
+    if errors:
+        print(f"FAIL: {len(errors)} non-Rust policy validation error(s):", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: validated {n_allow} allow entr{'y' if n_allow == 1 else 'ies'} "
+        f"and {n_debt} debt entr{'y' if n_debt == 1 else 'ies'}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

PR 2 of the perl-lsp file-policy rollout. Lands the machine-readable non-Rust ledger that the later Rust `cargo xtask check-file-policy` command will enforce. This remains advisory: no CI gate, Rust checker, inventory generator, or proposal generator is introduced here.

Companion to #8158, which landed the doctrine docs.

## Files

- `policy/non-rust-allowlist.toml` - 55 seed entries covering documentation, CI/workflows, policy ledgers, Perl fixtures, tree-sitter native parser surfaces, VS Code extension, build/release tooling, test snapshots, scripts, agent configs, and repo metadata.
- `policy/non-rust-debt.toml` - empty seed debt ledger for time-boxed uncertain classifications.
- `docs/policy/NON_RUST_INVENTORY.md` - hand-written seed inventory until PR 3 adds generated inventory output.
- `scripts/policy/validate_non_rust_allowlist.py` - sub-second TOML/schema sanity validator only; it does not walk tracked files.

## Seed surface counts

Actual parsed count from `policy/non-rust-allowlist.toml`:

| Surface | Entries |
|---|---:|
| `ci` | 11 |
| `docs` | 3 |
| `editor` | 1 |
| `fixtures` | 6 |
| `lsp` | 2 |
| `parser` | 2 |
| `release` | 9 |
| `tooling` | 21 |

Total: 55.

## Verification

```bash
python scripts/policy/validate_non_rust_allowlist.py
cargo xtask fmt --check
git diff --check
cargo xtask devex plan --base origin/master
```

The validator checks TOML parsing, required fields, glob/path mutual exclusion, repo-relative matchers, no Windows backslashes, no duplicate ids/matchers, valid dates, coverage requirements for production/test/tooling entries, broad-glob reasons, unknown fields, and known classification values.

## Out of scope

No checker behavior, no repo walk, no generated inventory, no proposal generator, no CI wiring, and no branch-protection changes. Those remain later rollout PRs.
