### PR TITLE
ci: wire learned-estimate consumer into PR Plan + rollout summary (#0000)

### DIFF
--- a/docs/ci/learned-estimates.md
+++ b/docs/ci/learned-estimates.md
@@ -120,23 +120,27 @@ When history is missing or the lane has too few samples:
 
 ---
 
-## Wiring (deferred)
+## Wiring status
 
-The PR Plan workflow does **not** consume this in PR 16. The minimal
-end-to-end story requires:
+The minimal end-to-end story:
 
-1. PR 16 (this PR) — aggregator + consumer scripts. ✓
+1. ✓ Aggregator + consumer scripts (PR 16).
 2. CI workflow change to upload `ci-actuals.json` artifacts to a
-   discoverable location. (PR 08's
+   discoverable location. **Pending.** PR 08's
    [`scripts/ci/emit_ci_actuals.py`](../../scripts/ci/emit_ci_actuals.py)
-   produces the right files; the wiring step is intentionally deferred.)
+   produces the right files; what's missing is a step in `ci.yml` (or a
+   sibling) that runs it after `cargo xtask gates` and uploads the JSON.
 3. A scheduled job that downloads recent actuals artifacts and runs
-   `aggregate_lane_history.py` to update `.ci/metrics/ci-lane-history.json`.
-4. The PR Plan reads the history when present and the consumer reports
-   `learned: true`; otherwise it uses the static floor (current behavior).
+   `aggregate_lane_history.py` to update
+   `.ci/metrics/ci-lane-history.json`. **Pending.**
+4. ✓ PR Plan reads the history when present (delivered alongside the
+   rollout finalize PR). When the consumer reports `learned: true`, the
+   planner substitutes `p50 × 1.15` (clamped to the static floor); it
+   falls back to the static floor otherwise.
 
-Step 1 is delivered by this PR. Steps 2–4 land as follow-ups once the
-PR 08 wiring is decided.
+Steps 2 and 3 land as follow-ups once the upload location is decided
+(artifact retention vs. committing back to the repo). The planner is
+ready for either path.
 
 ---
 

--- a/docs/ci/perl-lsp-rollout-plan.md
+++ b/docs/ci/perl-lsp-rollout-plan.md
@@ -11,28 +11,30 @@ replace the conveyor — it adds the missing economics layer.
 
 ---
 
-## Order
+## Order and status
 
-| PR | Name | Purpose |
-|---:|---|---|
-| 01 | CI economics docs | Encode verification economics doctrine and contributor framing. |
-| 02 | Policy TOML ledgers | Map every CI item to intent, cost, trigger, owner. |
-| 03 | CI inventory | Inventory current workflows; flag duplicates and gaps. |
-| 04 | PR Plan advisory | Emit per-PR LEM estimate and selected lanes. |
-| 05 | Cache save-only-master | Stop PR cache write churn. |
-| 06 | `ripr` advisory | Add static oracle-gap signal. |
-| 07 | PR Plan: `ripr` + LEM wiring | Make planner aware of `ripr` and risk packs. |
-| 08 | `ci-actuals` | Convert receipts into cost telemetry. |
-| 09 | LEM in gate policy | Cross-reference `.ci/gate-policy.yaml` with lane economics. |
-| 10 | Risk-pack routing metadata | Parser/LSP/workspace/DAP/security/memory risk packs. |
-| 11 | Workflow policy lint | Lint workflows against `policy/ci-lane-whitelist.toml`. |
-| 12 | `xtask ci plan` | Move PR Plan from Python to Rust. |
-| 13 | Soft LEM warnings | Warn above 35 / 75 LEM, hard guard above 125. |
-| 14 | External AI review tuning | Make Droid review advisory and LEM-visible. |
-| 15 | UX ownership clarification | Resolve `ci.yml` UX vs `ux-regression-gate.yml` overlap. |
-| 16 | Learned estimate scaffolding | Use observed actuals for LEM estimates. |
-| 17 | Conditional lane cleanup | Tune Windows / memory / UX / external review after actuals. |
-| 18 | `ripr` soft-gate promotion | Require acknowledgement for high-confidence new gaps. |
+| PR | Name | Purpose | Status |
+|---:|---|---|---|
+| 01 | CI economics docs | Encode verification economics doctrine and contributor framing. | landed |
+| 02 | Policy TOML ledgers | Map every CI item to intent, cost, trigger, owner. | landed |
+| 03 | CI inventory | Inventory current workflows; flag duplicates and gaps. | landed |
+| 04 | PR Plan advisory | Emit per-PR LEM estimate and selected lanes. | landed |
+| 05 | Cache save-only-master | Stop PR cache write churn. | landed |
+| 06 | `ripr` advisory | Add static oracle-gap signal. | landed |
+| 07 | PR Plan: `ripr` + LEM wiring | Make planner aware of `ripr` and risk packs. | landed |
+| 08 | `ci-actuals` | Convert receipts into cost telemetry. | landed (upload wiring deferred) |
+| 09 | LEM in gate policy | Cross-reference `.ci/gate-policy.yaml` with lane economics. | landed |
+| 10 | Risk-pack routing metadata | Parser/LSP/workspace/DAP/security/memory risk packs. | landed |
+| 11 | Workflow policy lint | Lint workflows against `policy/ci-lane-whitelist.toml`. | landed |
+| 12 | `xtask ci plan` | Move PR Plan from Python to Rust. | deferred |
+| 13 | Soft LEM warnings | Warn above 35 / 75 LEM, hard guard above 125. | landed |
+| 14 | External AI review tuning | Make Droid review advisory and LEM-visible. | landed |
+| 15 | UX ownership clarification | Resolve `ci.yml` UX vs `ux-regression-gate.yml` overlap. | landed |
+| 16 | Learned estimate scaffolding | Use observed actuals for LEM estimates. | landed |
+| 17 | Conditional lane cleanup | Tune Windows / memory / UX / external review after actuals. | data-gated |
+| 18 | `ripr` soft-gate promotion | Require acknowledgement for high-confidence new gaps. | data-gated |
+
+End-of-rollout retrospective: [`rollout-summary.md`](rollout-summary.md).
 
 ---
 

--- a/docs/ci/pr-plan.md
+++ b/docs/ci/pr-plan.md
@@ -91,10 +91,16 @@ cat target/ci/ci-plan.json | jq .budget
 
 ## Roadmap
 
-| PR | Change |
-|---:|---|
-| 04 | This file. Python prototype, advisory only. |
-| 07 | Wire `ripr` selection and risk-pack outputs visible in summary. |
-| 12 | Replace prototype with `cargo xtask ci plan`. |
-| 13 | Add hard-ceiling guard above 125 LEM. |
-| 16 | Use historical actuals to derive learned estimates. |
+| PR | Change | Status |
+|---:|---|---|
+| 04 | Python prototype, advisory only. | landed |
+| 07 | Lane origins + paths-filter + ripr summary section. | landed |
+| 12 | Replace prototype with `cargo xtask ci plan`. | deferred |
+| 13 | Hard-ceiling guard above 125 LEM. | landed |
+| 16 | Aggregator + consumer scripts; PR Plan reads `.ci/metrics/ci-lane-history.json` when present. | landed |
+
+The planner now consumes learned LEM estimates whenever the history file has
+`learned: true` for a lane (≥ 5 samples in the rolling window). Sampled lanes
+substitute `p50 × 1.15` (clamped to the static floor) for the static `base_lem`,
+and the plan's `learned` block reports `lanes_using_learned` and
+`delta_lem_vs_static`.

--- a/docs/ci/rollout-summary.md
+++ b/docs/ci/rollout-summary.md
@@ -1,0 +1,188 @@
+# CI Economics Rollout — Summary
+
+End-of-rollout retrospective for the perl-lsp CI economics rollout described in
+[`perl-lsp-rollout-plan.md`](perl-lsp-rollout-plan.md).
+
+> Status: **15 of 18 plan PRs landed.** The remaining 3 are intentionally deferred
+> until calibration data accumulates.
+
+---
+
+## What landed
+
+### Doctrine and ledgers (PR 01–03, 10)
+
+- `docs/ci/cost-and-verification-policy.md`, `lem-budgeting.md`, `verification-ladder.md`,
+  `labels.md`, `perl-lsp-rollout-plan.md`, `policy-ledgers.md`, `inventory.md`,
+  `ci-lane-map.md`, `risk-packs.md`.
+- `policy/` ledgers: `ci-budget.toml`, `ci-lanes.toml`, `ci-risk-packs.toml`,
+  `ci-lane-whitelist.toml`, `ci-whitelist-exceptions.toml`, `ci-exceptions.toml`,
+  `ci-non-rust-allowlist.toml`, `ripr-suppressions.toml`.
+- PR template extended with CI cost / verification checklist.
+
+### Forecast and routing (PR 04, 07, 13)
+
+- `.github/workflows/pr-plan.yml` — advisory PR Plan workflow.
+- `scripts/ci/pr_plan.py` — Python planner with:
+  - Risk-pack routing.
+  - Lane-selection origin tracking (`default-pr`, `risk-pack:<id>`, `label:<name>`,
+    `deep-lane:full-ci`).
+  - `paths:` filter honored — lanes are skipped (visibly) when the diff doesn't match.
+  - Soft warnings per band, hard guard at 125 LEM (override via `ci-budget-override`
+    or `full-ci`).
+  - **Learned-estimate consumer** (delivered with this finalize PR): reads
+    `.ci/metrics/ci-lane-history.json` when present and substitutes learned
+    `p50 × 1.15` (clamped to static floor) for sampled lanes.
+
+### Cache hygiene (PR 05)
+
+`save-if: master-only` applied across every `Swatinem/rust-cache` invocation in
+PR-capable workflows. Cache write traffic drops to one save per master push instead of
+one per PR push.
+
+### Oracle-gap detection (PR 06)
+
+- `ripr.toml` config + `policy/ripr-suppressions.toml` ledger.
+- `.github/workflows/ripr.yml` advisory workflow (`continue-on-error: true`).
+- `scripts/ci/ripr_summary.py` — JSON → step summary with path normalization,
+  markdown pipe escaping, UTF-8 explicit encoding.
+
+### Telemetry (PR 08, 09, 16)
+
+- `scripts/ci/emit_ci_actuals.py` — receipts → `ci-actuals.json`.
+- `scripts/ci/validate_gate_lane_mapping.py` — every gate in `.ci/gate-policy.yaml`
+  maps to a lane in `policy/ci-lanes.toml` (48 / 48 mapped).
+- `scripts/ci/aggregate_lane_history.py` — actuals → per-lane p50/p90/p95.
+- `scripts/ci/learned_estimate.py` — lane id → learned estimate.
+- `.ci/metrics/ci-lane-history.json` — initial empty history (23 lanes).
+
+### Governance enforcement (PR 11)
+
+`cargo xtask workflow-policy-lint --check-lane-whitelist` — opt-in advisory check that
+every workflow has a `[[lane]]` entry in `policy/ci-lane-whitelist.toml` or is in
+`ALLOWLIST_WORKFLOW_LANE_MISSING`.
+
+### Trim / advisory (PR 14, 15)
+
+- `droid-review.yml` marked `continue-on-error: true` so external AI review failures
+  don't block unrelated CI signal.
+- UX regression lane ownership decided: `ci.yml::ux-tests` is canonical.
+  `ux-regression-gate.yml` slated for retirement after PR 17.
+
+---
+
+## Pipeline state
+
+```
+Static base_lem  →  ci-plan.json  (PR 04, 07, 13)
+                         ↓
+                      PR runs
+                         ↓
+              gate receipts (target/receipts/)
+                         ↓
+   scripts/ci/emit_ci_actuals.py  →  target/ci/ci-actuals.json   (PR 08)
+                         ↓
+   [missing wiring: upload ci-actuals.json + scheduled aggregator]
+                         ↓
+   scripts/ci/aggregate_lane_history.py  →  .ci/metrics/ci-lane-history.json   (PR 16)
+                         ↓
+   scripts/ci/learned_estimate.py  /  pr_plan.py  →  learned ci-plan.json   (this PR)
+```
+
+The wiring step in the middle is the only piece the rollout did not deliver: a CI
+workflow change to upload `ci-actuals.json` artifacts and a scheduled job to download
+recent ones and run the aggregator. PR Plan already consumes the history file when
+present; the next contributor only needs to keep the file fresh.
+
+---
+
+## What did not land (and why)
+
+### PR 12 — `xtask ci plan` (Rust port of the Python prototype)
+
+Skipped. The Python prototype works and matches the planner's expected output. A Rust
+port via `xtask` would let the planner reuse the existing `ci-scope` changed-file
+classifier, but the Python version is small, tested, and replaceable. Worth doing
+later as a code-quality improvement, not a blocker.
+
+### PR 17 — Conditional lane cleanup
+
+Cannot land without actuals. The plan's specific candidates (`lsp-memory-smoke`,
+`windows-guardrails`, `vscode-managed-binary-smoke`, security scans) require evidence
+that PR Plan's static estimates are conservative or that the lanes' failure rate
+justifies their default-PR cost. Once the calibration window closes (≥ 2 weeks of
+actuals), open a follow-up PR per candidate lane.
+
+### PR 18 — `ripr` soft-gate promotion
+
+Cannot land without `ripr` advisory data. The narrow soft-gate rule requires:
+
+- Several weeks of `ripr` findings on real diffs.
+- Confidence that high-confidence `reachable_unrevealed` / `weakly_exposed`
+  classifications correlate with real oracle gaps.
+- Suppressions ledger populated with reviewed entries.
+
+Once data is available, gate promotion lands as a one-line change in `ripr.toml`.
+
+---
+
+## Calibration milestones
+
+| When | What | Who |
+|---|---|---|
+| **Now** | All 15 PRs merged. Static estimates active. ripr advisory active. | — |
+| **+1–2 weeks** | First `ci-actuals.json` artifacts. Sample counts climbing. | follow-up: wire upload + aggregator |
+| **+2 weeks** | Diff `ci.yml::ux-tests` vs `ux-regression-gate.yml` evidence. | PR 15 action item → PR 17 |
+| **+2–4 weeks** | First lanes cross `MIN_SAMPLES_FOR_LEARNED = 5`. | PR Plan starts using learned estimates automatically |
+| **+4 weeks** | Conditional lane cleanup ready (PR 17). | open follow-up PR per candidate |
+| **+4–6 weeks** | `ripr` advisory data sufficient for soft-gate rule (PR 18). | open follow-up |
+
+---
+
+## Operational reminders
+
+- **PR Plan failure does not block merges.** The workflow is intentionally not a
+  required check; the budget guard is a visibility tool, not a merge gate.
+- **`cargo xtask workflow-policy-lint --check-lane-whitelist`** is opt-in and emits
+  warnings only. Promotion to error is deferred until the whitelist is stable.
+- **`policy/ci-whitelist-exceptions.toml`** entries expire 2026-08-07. PR 17 must
+  resolve them or extend with rationale.
+- **`policy/ripr-suppressions.toml`** entries expire 2026-08-07. Review before then
+  or remove the suppressions.
+- **`policy/ci-non-rust-allowlist.toml`** entries expire 2026-11-07.
+- **Cache save-only-master**: first master push after this rollout repopulates the
+  canonical cache. PRs from then on restore-only.
+
+---
+
+## What this rollout did not change
+
+- **Branch protection.** Required check is still `merge-gate` aggregate.
+- **Merge-gate shards.** Same gates, same tier mapping, same blocking behavior.
+- **Existing receipt schema** (`.ci/receipt.schema.json`). The actuals collector reads
+  it as-is.
+- **Existing gate definitions** in `.ci/gate-policy.yaml`. The cross-reference doc
+  records mapping but does not modify the file.
+
+---
+
+## Audit-trail PRs
+
+| # | PR | Subject |
+|---:|---|---|
+| 01 | #8134 | Verification economics doctrine |
+| 02 | #8135 | Policy TOML ledgers |
+| 03 | #8136 | CI workflow inventory |
+| 04 | #8137 | Advisory PR Plan workflow |
+| 05 | #8138 | Restore-only cache policy |
+| 06 | #8139 | `ripr` advisory |
+| 07 | #8142 | PR Plan: lane origins + paths-filter + ripr summary |
+| 08 | #8143 | `ci-actuals` from gate receipts |
+| 09 | #8144 | Gate ↔ lane economics cross-reference |
+| 10 | #8153 | Risk-pack catalog validator |
+| 11 | #8154 | `xtask` lane-whitelist check |
+| 13 | #8145 | Soft LEM warnings + 125-LEM hard ceiling |
+| 14 | #8146 | Droid review advisory |
+| 15 | #8147 | UX-regression ownership decision |
+| 16 | #8155 | Learned-LEM-estimate scaffolding |
+| **finalize** | this PR | Wire learned-estimate consumer + retrospective |

--- a/scripts/ci/pr_plan.py
+++ b/scripts/ci/pr_plan.py
@@ -220,6 +220,57 @@ def lane_lem(lane: dict[str, Any], multipliers: dict[str, float]) -> float:
     return 0.0
 
 
+def load_learned_history(path: Path) -> dict[str, Any]:
+    """Read .ci/metrics/ci-lane-history.json if present; tolerant on errors."""
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def apply_learned_estimates(
+    lanes: list[dict[str, Any]], history: dict[str, Any]
+) -> tuple[float, int]:
+    """Mutate `lanes` in place: replace `base_lem` with learned estimate where
+    available. Returns (delta_lem, learned_count) for the summary.
+
+    Estimate model (matches scripts/ci/learned_estimate.py):
+      estimate = max(static_floor, p50_recent_actual * 1.15)
+    """
+    if not history:
+        return 0.0, 0
+    by_lane: dict[str, Any] = history.get("lanes") or {}
+    delta = 0.0
+    learned_count = 0
+    for lane in lanes:
+        entry = by_lane.get(lane["id"])
+        if not isinstance(entry, dict) or not entry.get("learned"):
+            continue
+        p50 = entry.get("p50")
+        floor = entry.get("static_floor")
+        if not isinstance(p50, (int, float)):
+            continue
+        learned_estimate = float(p50) * 1.15
+        if isinstance(floor, (int, float)) and float(floor) > learned_estimate:
+            new_lem = float(floor)
+            source = "static_floor"
+        else:
+            new_lem = learned_estimate
+            source = "learned (p50 * 1.15)"
+        old_lem = lane.get("base_lem")
+        if isinstance(old_lem, (int, float)):
+            delta += new_lem - float(old_lem)
+        lane["base_lem"] = new_lem
+        lane["learned"] = True
+        lane["learned_source"] = source
+        lane["p90_warning"] = entry.get("p90")
+        lane["p95_hard_planning"] = entry.get("p95")
+        learned_count += 1
+    return delta, learned_count
+
+
 def band_for(lem: float, budget: dict[str, Any]) -> str:
     if lem <= budget.get("default_limit_lem", 35):
         return "default"
@@ -330,6 +381,13 @@ def main() -> int:
     parser.add_argument(
         "--json-out", type=Path, default=Path("target/ci/ci-plan.json")
     )
+    parser.add_argument(
+        "--history",
+        type=Path,
+        default=Path(".ci/metrics/ci-lane-history.json"),
+        help="Optional learned-LEM history (PR 16). Falls back to static "
+        "base_lem when missing or sparse.",
+    )
     parser.add_argument("--summary", type=str, default=os.environ.get("GITHUB_STEP_SUMMARY"))
     args = parser.parse_args()
 
@@ -358,6 +416,12 @@ def main() -> int:
         risk_packs=risk_packs,
         lanes=lanes,
     )
+
+    # Apply learned LEM estimates from .ci/metrics/ci-lane-history.json when
+    # the file is present and the lane has enough samples. Falls back to the
+    # static base_lem when history is absent or sparse.
+    history = load_learned_history(args.history)
+    learned_delta, learned_count = apply_learned_estimates(selected_lanes, history)
 
     estimated_lem = sum(lane_lem(lane, multipliers) for lane in selected_lanes)
     rate = float(budget.get("linux_minute_rate_usd", 0.008))
@@ -433,6 +497,11 @@ def main() -> int:
             "override_present": has_override,
             "ack_present": has_ack,
             "failed": over_ceiling_failure,
+        },
+        "learned": {
+            "history_present": bool(history),
+            "lanes_using_learned": learned_count,
+            "delta_lem_vs_static": learned_delta,
         },
     }
 


### PR DESCRIPTION
## Summary

Final close-out PR for the perl-lsp CI economics rollout. Two changes:

### 1. PR Plan consumes learned LEM estimates

When `.ci/metrics/ci-lane-history.json` (PR 16) reports `learned: true` for a lane (≥ 5 samples in window), the planner substitutes `p50 × 1.15` (clamped to the static floor) for the static `base_lem`. Falls back to static when history is missing or sparse.

```
ci-plan.json now includes:
  "learned": {
    "history_present": true,
    "lanes_using_learned": 0,
    "delta_lem_vs_static": 0.0
  }
```

Smoke test on this branch: history file present but empty (no samples accumulated yet) → 0 lanes using learned, delta 0.0, falls back to static `base_lem`. Correct behavior.

### 2. Rollout retrospective

`docs/ci/rollout-summary.md` — end-of-rollout doc covering:
- What landed (15 of 18 plan PRs)
- Calibration pipeline state
- What did not land (PR 12 Rust port, PR 17/18 data-gated)
- Operational reminders (expiry dates, label semantics, branch protection unchanged)
- Audit-trail of all 16 merged PRs

Status columns added to `pr-plan.md`, `learned-estimates.md`, `perl-lsp-rollout-plan.md`.

## What this PR does NOT do

- Does **not** wire `emit_ci_actuals.py` into `ci.yml`. The upload location (artifact retention vs. commit-back to `.ci/metrics/`) is a separate decision point that lands as a follow-up.
- Does **not** change branch protection.
- Does **not** change merge-gate behavior.

The calibration pipeline is now ready end-to-end (steps 1, 4 of the 4-step model); steps 2 (upload) and 3 (scheduled aggregator) are mechanical follow-ups.

## CI cost / verification note

- [x] Cheapest relevant proof: pr_plan.py smoke-tested with empty history; output structure verified.
- [x] No required-check changes.
- [x] Estimated LEM impact: 0.
- [x] Rollback: revert this PR; planner reverts to static-only behavior.

## Stack

Master → **finalize (this)**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_