### PR TITLE
ci(policy): expand risk packs — vscode fix and 3 new packs (#8161)

### DIFF
--- a/docs/ci/risk-packs.md
+++ b/docs/ci/risk-packs.md
@@ -16,9 +16,12 @@ Risk packs route extra proof to PRs that touch known-risky surfaces. Defined in
 | `workspace_index` | module resolution, semantic facts, indexing | `merge_gate_shards`, `lsp_memory_smoke`, `windows_guardrails`, `ripr_advisory` | `memory_plateau`, `real_repo_latency` |
 | `retained_state` | long-lived maps, caches, queues, sessions | `lsp_memory_smoke`, `ripr_advisory` | `memory_plateau` |
 | `dap` | debug adapter, breakpoints, evaluate | `merge_gate_shards`, `ux_tests`, `ripr_advisory` | — |
-| `vscode` | extension packaging, managed binary | `docs_gate` | `vscode_smoke_matrix` |
+| `vscode` | extension packaging, managed binary | `pr_smoke` | `vscode_smoke_matrix` |
+| `path_security` | URI normalization, path traversal, sandbox | `merge_gate_shards`, `windows_guardrails`, `ripr_advisory` | — |
 | `security` | sandbox, subprocess, exec, deserialization | `security_audit`, `windows_guardrails`, `ripr_advisory` | — |
 | `manifest` | Cargo.toml/lock, toolchain | `pr_smoke`, `merge_gate_shards`, `security_audit` | `release_check` |
+| `policy` | policy ledgers, gate policy, ripr config | `pr_smoke`, `merge_gate_shards` | — |
+| `workflow` | GitHub Actions, CI scripts, xtask CI tasks | `pr_smoke`, `merge_gate_shards` | — |
 | `docs_only` | prose / markdown / status | `docs_gate` | — |
 
 ---

--- a/policy/ci-risk-packs.toml
+++ b/policy/ci-risk-packs.toml
@@ -111,9 +111,74 @@ description = "VS Code extension packaging, managed binary, extension-host behav
 paths = [
   "vscode-extension/**",
 ]
-lanes = ["docs_gate"]
+# A TypeScript change in the extension still needs the LSP binary built and
+# UX-smoke-tested; docs_gate alone is insufficient. Cross-OS smoke matrix
+# remains label-gated via deep_lanes.
+lanes = ["pr_smoke"]
 deep_lanes = ["vscode_smoke_matrix"]
 labels = ["ci:vscode-matrix"]
+
+# -----------------------------------------------------------------------------
+# Path-security risk: URI normalization, path traversal, sandbox enforcement.
+# Carved out from the broader security pack because Windows path handling and
+# sandbox fail-closed behavior are this repo's most frequent regression class —
+# split routes windows_guardrails precisely without requiring Cargo.lock to move.
+# -----------------------------------------------------------------------------
+[risk_pack.path_security]
+description = "URI normalization, path traversal, sandbox enforcement, and file-system access surface changes."
+paths = [
+  "crates/perl-uri/**",
+  "crates/perl-lsp-rs/src/runtime/**",
+  "crates/perl-subprocess-runtime/**",
+]
+keywords = [
+  "uri",
+  "sandbox",
+  "path_security",
+  "canonicalize",
+  "normalize",
+  "traversal",
+]
+lanes = ["merge_gate_shards", "windows_guardrails", "ripr_advisory"]
+deep_lanes = []
+labels = ["ci:security", "security-audit"]
+
+# -----------------------------------------------------------------------------
+# Policy risk: changes to policy ledgers, gate policy, or risk-pack TOML
+# itself. A change here can invalidate every other PR's routing, so the
+# merge gate must run.
+# -----------------------------------------------------------------------------
+[risk_pack.policy]
+description = "Changes to policy ledgers (policy/*.toml), gate policy (.ci/gate-policy.yaml), or CI economics TOMLs."
+paths = [
+  "policy/**",
+  ".ci/gate-policy.yaml",
+  ".ci/blockers.yaml",
+  ".ci/receipt.schema.json",
+  "ripr.toml",
+]
+lanes = ["pr_smoke", "merge_gate_shards"]
+deep_lanes = []
+labels = ["ci:policy"]
+
+# -----------------------------------------------------------------------------
+# Workflow risk: GitHub Actions workflows, CI scripts, and xtask CI tasks.
+# A workflow change can ripple through every other PR's gate behavior, so the
+# gate must run.
+# -----------------------------------------------------------------------------
+[risk_pack.workflow]
+description = "GitHub Actions workflows, CI scripts, and xtask CI tasks."
+paths = [
+  ".github/workflows/**",
+  ".github/actions/**",
+  "scripts/ci/**",
+  "xtask/src/tasks/ci_*",
+  "xtask/src/tasks/workflow_*",
+  "xtask/src/tasks/gate_*",
+]
+lanes = ["pr_smoke", "merge_gate_shards"]
+deep_lanes = []
+labels = ["ci:workflow"]
 
 # -----------------------------------------------------------------------------
 # Security risk: sandbox, subprocess, eval, exec, path security, deserialization.


### PR DESCRIPTION
## Summary

Closes the bug-fix + new-packs portion of #8161. Items 3 (expanded crate coverage) and 4 (stricter validator) are out of scope and remain on the issue for separate follow-ups.

Pack count: **9 → 12**.

## What changed

### Bug fix

`vscode` pack `lanes`: `docs_gate` → `pr_smoke`.

A TypeScript change in the extension still needs the LSP binary built and UX-smoke-tested. The previous routing meant a `vscode-extension/**` change skipped Rust compilation entirely. Cross-OS smoke matrix remains `vscode_smoke_matrix` under `deep_lanes`, gated by `full-ci` / `ci:vscode-matrix`.

### Three new packs

- **`path_security`** — URI normalization, path traversal, sandbox enforcement. Splits the Windows-regression-prone surface from generic `security` so `windows_guardrails` routes precisely on `crates/perl-uri/**` / `crates/perl-lsp-rs/src/runtime/**` / `crates/perl-subprocess-runtime/**` changes without requiring `Cargo.lock` to move.
- **`policy`** — `policy/**`, `.ci/gate-policy.yaml`, `.ci/blockers.yaml`, `.ci/receipt.schema.json`, `ripr.toml`. A change here can invalidate every other PR's routing, so the merge gate must run.
- **`workflow`** — `.github/workflows`, `.github/actions`, `scripts/ci`, `xtask/src/tasks/{ci,workflow,gate}_*`. A workflow change can ripple through every other PR's gate behavior.

### Catalog

`docs/ci/risk-packs.md` table updated to 12 rows.

## Verification

```text
$ python3 scripts/ci/validate_risk_packs.py --strict
Risk packs in policy/ci-risk-packs.toml: 12
Lanes in policy/ci-lanes.toml: 23
All risk packs valid.
```

Planner spot-check (script: import `pr_plan`, call `classify_areas`):

| Diff                                       | Selected packs                |
|--------------------------------------------|-------------------------------|
| `vscode-extension/src/extension.ts`        | `[vscode]`                    |
| `policy/ci-lanes.toml` + `.github/workflows/ci.yml` | `[policy, workflow]` |
| `crates/perl-uri/src/canonicalize.rs`      | `[retained_state, path_security]` |
| `crates/perl-parser/src/lib.rs`            | `[parser]`                    |
| `scripts/ci/pr_plan.py`                    | `[workflow]`                  |

## CI / LEM impact

- New default PR lanes: none.
- New advisory checks: none.
- Cache behavior: unchanged.
- Branch protection: unchanged.
- Estimated LEM change: **+0 LEM** for ordinary PRs; the new packs route existing default-PR lanes more precisely.
- Routing: `vscode-extension/**` PRs now correctly run `pr_smoke` instead of skipping Rust compilation.

## Out of scope

Items 3 and 4 of #8161 remain open:

- **#8161 item 3**: expanded crate coverage in existing packs (`perl-incremental-parsing`, `perl-line-index`, `perl-position-tracking`, `perl-corpus`, `perl-pod`, `perl-pragma`, `perl-diagnostics`, `perl-refactoring`, `perl-dead-code`, `perl-lsp-perltidy`, `perl-lsp-ux-tests`, parent `crates/tree-sitter-perl/**`).
- **#8161 item 4**: stricter validator (snake_case id check, repo-relative matcher enforcement, no Windows backslashes, lowercase-keyword check, unknown-field rejection).

Both are mechanical follow-ups; landing this bug fix + the 3 new packs first is the higher-value lever.

## Refs

- Issue: #8161
- Original (closed) PR with full implementation: #8156

https://claude.ai/code/session_01W9kqLbX3ropffBJmYiifDJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01W9kqLbX3ropffBJmYiifDJ)_