### PR TITLE
ci: emit ci-actuals telemetry per gate-shard run (#8166)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,31 @@ jobs:
             --output target/test-results/gate-shard-${{ matrix.name }}-junit.xml \
             --suite-name "gate-${{ matrix.name }}"
 
+      - name: Emit CI actuals (LEM telemetry)
+        # Reads gate receipts produced above and writes target/ci/ci-actuals.json
+        # for the calibration pipeline. See docs/ci/ci-actuals.md and
+        # docs/ci/learned-estimates.md. Tolerant of missing data.
+        if: always()
+        continue-on-error: true
+        run: |
+          mkdir -p target/ci
+          python3 scripts/ci/emit_ci_actuals.py \
+            --receipts-dir target/receipts/shards \
+            --workflow "${{ github.workflow }}" \
+            --sha "${{ github.sha }}" \
+            --pr "${{ github.event.pull_request.number || 0 }}" \
+            --json-out "target/ci/ci-actuals-${{ matrix.name }}.json" || true
+
+      - name: Upload CI actuals
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-actuals-${{ matrix.name }}-${{ github.sha }}
+          path: target/ci/ci-actuals-${{ matrix.name }}.json
+          retention-days: 30
+          if-no-files-found: warn
+
       - name: Upload gate shard test results to Codecov
         if: always() && env.CODECOV_TOKEN != ''
         continue-on-error: true


### PR DESCRIPTION
## Summary

Follow-up A from EffortlessMetrics/perl-lsp-swarm#2742. Wires PR 08's `emit_ci_actuals.py` into `ci.yml`'s `merge-gate-shards` job so calibration data starts accumulating now.

## Changes

```
.github/workflows/ci.yml  +25 lines (2 new steps after JUnit conversion)
```

Two new steps per gate shard run:

1. **Emit CI actuals (LEM telemetry)** — runs `scripts/ci/emit_ci_actuals.py` against `target/receipts/shards`, writes `ci-actuals-<shard>.json`. `continue-on-error: true`; never blocks the gate.
2. **Upload CI actuals** — 30-day artifact retention, sharded by matrix name + SHA so per-PR-run files don't collide.

## Why now

PR 16's planner-side consumer is already wired (PR EffortlessMetrics/perl-lsp#8160). Once samples accumulate, learned LEM estimates become live without any further planner change. This PR is the only remaining piece for the calibration pipeline to start producing data.

## Why artifact-only

The commit-back path (write `.ci/metrics/ci-lane-history.json` from a scheduled aggregator) is a separate decision that benefits from the artifact-only path running first — we get to see what real samples look like before deciding retention/storage strategy. Artifact-only is reversible and adds no merge-gate failure surface.

## CI cost / verification note

- [x] YAML parse passes.
- [x] No required-check changes.
- [x] **Failure mode caught:** loss of LEM telemetry would blind the calibration pipeline.
- [x] Estimated LEM impact: <1 LEM per shard run (Python script + artifact upload, both bounded).
- [x] Rollback: revert.

Closes the wiring task in EffortlessMetrics/perl-lsp-swarm#2742.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_