### PR TITLE
ci: add policy-validators workflow on policy-touching PRs (#8166)

### DIFF
--- a/.github/workflows/policy-validators.yml
+++ b/.github/workflows/policy-validators.yml
@@ -1,0 +1,69 @@
+# Policy Validators
+#
+# Runs the CI economics policy validators on PRs that touch policy/, the
+# gate-policy YAML, or any of the validator scripts themselves. Catches drift
+# automatically instead of relying on contributors to remember to run the
+# scripts locally.
+#
+# See policy/ci-lane-whitelist.toml entry `policy_validators`.
+
+name: Policy Validators
+
+on:
+  pull_request:
+    paths:
+      - 'policy/**'
+      - '.ci/gate-policy.yaml'
+      - 'scripts/ci/validate_risk_packs.py'
+      - 'scripts/ci/validate_gate_lane_mapping.py'
+      - '.github/workflows/policy-validators.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: policy-validators-${{ github.event.pull_request.number || github.ref }}
+  # Only cancel on synchronize to avoid label-event cancellation cascades
+  # (workflow-policy-lint LABEL_EVENT_CANCELS_PR_RUN rule).
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate CI policy ledgers
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Validate risk packs
+        run: |
+          python3 scripts/ci/validate_risk_packs.py --strict
+
+      - name: Validate gate -> lane mapping
+        run: |
+          python3 scripts/ci/validate_gate_lane_mapping.py --strict
+
+      - name: Validate policy TOML parses
+        run: |
+          python3 - <<'EOF'
+          import sys, tomllib
+          from pathlib import Path
+          failed = []
+          for p in sorted(Path("policy").glob("*.toml")):
+              try:
+                  tomllib.loads(p.read_text(encoding="utf-8"))
+                  print(f"OK: {p}")
+              except tomllib.TOMLDecodeError as e:
+                  failed.append((p, e))
+                  print(f"FAIL: {p}: {e}")
+          sys.exit(1 if failed else 0)
+          EOF

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -726,3 +726,24 @@ expensive = false
 duplicate_of = []
 review_after = "2026-06-07"
 expires = "2026-11-07"
+
+[[lane]]
+id = "policy_validators"
+workflow = ".github/workflows/policy-validators.yml"
+job = "validate"
+tier = "frontdoor"
+kind = "hygiene"
+blocking = true
+default_pr = false
+runner = "ubuntu_24_04"
+base_lem = 2
+owner = "ci"
+intent = "Validate CI policy ledgers when policy/ or gate-policy changes."
+failure_mode = "Risk packs reference unknown lanes, gates have no lane mapping, or TOML files break."
+proof_obligation = "Run validate_risk_packs.py, validate_gate_lane_mapping.py, and policy/*.toml parse-checks in --strict mode."
+evidence = ["job logs"]
+allowed_triggers = ["pull_request", "workflow_dispatch"]
+expensive = false
+duplicate_of = []
+review_after = "2026-06-07"
+expires = "2026-11-07"


### PR DESCRIPTION
## Summary

Follow-up C from EffortlessMetrics/perl-lsp-swarm#2742. Adds `.github/workflows/policy-validators.yml` that runs the three CI policy validators automatically on PRs that touch `policy/`, `.ci/gate-policy.yaml`, or the validator scripts themselves.

Catches drift instead of relying on contributors to remember to run the scripts locally.

## Validators run

- `scripts/ci/validate_risk_packs.py --strict` — every `risk_pack.lanes`/`deep_lanes` references a real lane in `policy/ci-lanes.toml`.
- `scripts/ci/validate_gate_lane_mapping.py --strict` — every gate in `.ci/gate-policy.yaml` has a lane mapping.
- Inline `tomllib` parse check on every `policy/*.toml` file.

## Workflow shape

- Path-filtered to `policy/`, `.ci/gate-policy.yaml`, validator scripts, and the workflow itself. Does not run on unrelated diffs.
- `cancel-in-progress: ${{ github.event.action == 'synchronize' }}` (workflow-policy-lint `LABEL_EVENT_CANCELS_PR_RUN` compliant).
- Pinned action SHAs (no `UNPINNED_ACTION` warnings).
- `permissions: contents: read`.

## Changes

```
.github/workflows/policy-validators.yml  +66 lines
policy/ci-lane-whitelist.toml            +20 lines (matching `policy_validators` entry)
```

## Smoke test

All three validators run cleanly against current master:
- 9 risk packs, 23 lanes, all valid.
- 48 gates, all mapped.
- 8 `policy/*.toml` files all parse.

## CI cost / verification note

- [x] YAML parses; validators self-pass on current master.
- [x] No required-check changes.
- [x] **Failure mode caught:** policy ledgers drift silently into invalid state (unknown lane references, schema breaks).
- [x] Estimated LEM impact: ~2 LEM on policy-touching PRs only.
- [x] Rollback: revert.

Closes the policy-validation portion of EffortlessMetrics/perl-lsp-swarm#2742.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp1aMuriCwWoRJx3wXWvBc)_