### PR TITLE
docs(devex): map parser accuracy and release commands (#0000)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,9 @@ It is a quick push guard, not the full merge gate.
 | Full pre-merge | `just ci-gate` or `nix develop -c just ci-gate` | Canonical local merge gate. |
 | Memory lifecycle touched | `cargo xtask check-memory-lifecycle-policy` | Enforces retained-state lifecycle and receipt policy. |
 | Retained owner added | `cargo xtask check-memory-retained-owner-drift --base origin/master` | Checks whether long-lived storage/task additions need retained-state inventory coverage. |
+| Parser-accuracy metrics touched | `just ci-metrics-ratchet-check parser_accuracy` | Verifies parser-accuracy scorecard floors do not regress. |
+| Generated status docs touched | `just status-update` then `just status-check` | Regenerates and verifies `docs/project/status/` outputs. |
+| Release/version surfaces touched | `just version-check` then `just release-check` | Verifies version sync and the release-prep gate before tagging/publishing. |
 | Need a command map | `just quick-ref` or [Commands Reference](docs/reference/COMMANDS_REFERENCE.md) | Shows the short command decision tree. |
 
 ### 5. Expand for larger changes or release prep

--- a/docs/contributing/FIRST_PR.md
+++ b/docs/contributing/FIRST_PR.md
@@ -175,6 +175,9 @@ If the reviewer pushes a fix directly to your branch, that is normal. Check and 
 | Before push | `just ready` |
 | Fast PR loop | `just pr-fast` |
 | Agent-safe compile/test | `just agent-check` / `just agent-test` |
+| Parser-accuracy metrics | `just ci-metrics-ratchet-check parser_accuracy` |
+| Status docs | `just status-update` then `just status-check` |
+| Release/version prep | `just version-check` then `just release-check` |
 | Build LSP server | `cargo build -p perl-lsp-rs --release` |
 | Run all library tests | `cargo test --workspace --lib` |
 | Format | `cargo xtask fmt` |

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -89,6 +89,9 @@ perl-dap --stdio  # Standard DAP transport
 | Full pre-merge | `just ci-gate` or `nix develop -c just ci-gate` | Canonical local merge gate. |
 | Memory touched | `cargo xtask check-memory-lifecycle-policy` | Enforces retained-state lifecycle and receipt policy. |
 | Retained owner added | `cargo xtask check-memory-retained-owner-drift --base origin/master` | Checks whether long-lived storage/task additions need retained-state inventory coverage. |
+| Parser-accuracy metrics touched | `just ci-metrics-ratchet-check parser_accuracy` | Verifies parser-accuracy scorecard floors do not regress. |
+| Generated status docs touched | `just status-update` then `just status-check` | Regenerates and verifies `docs/project/status/` outputs. |
+| Release/version surfaces touched | `just version-check` then `just release-check` | Verifies version sync and the release-prep gate before tagging/publishing. |
 | Need a terminal summary | `just quick-ref` | Prints the short command decision tree. |
 
 ### Common Commands
@@ -118,6 +121,13 @@ just pr-fast
 
 # Canonical local merge gate
 nix develop -c just ci-gate
+
+# Metrics/status/release surfaces
+just ci-metrics-ratchet-check parser_accuracy
+just status-update
+just status-check
+just version-check
+just release-check
 ```
 
 ## Build Commands


### PR DESCRIPTION
## Summary

- Add parser-accuracy ratchet routing to the contributor and commands decision tables.
- Add generated status-doc and release/version routing to the same DevEx command maps.
- Keep this docs-only: no runtime code, CI behavior, memory policy, or parser metrics changed.

## Validation

- `cargo xtask fmt`
- `just --list | rg "ci-metrics-ratchet-check|status-update|status-check|version-check|release-check|ready|devex|doctor|agent-check|agent-test|agent-clippy|agent-pr-fast|pr-fast|ci-gate"`
- `git diff --check`