### PR TITLE
ci(policy): expand crate coverage in existing risk packs (#8161)

### DIFF
--- a/policy/ci-risk-packs.toml
+++ b/policy/ci-risk-packs.toml
@@ -17,15 +17,23 @@ updated = "2026-05-07"
 # Parser risk: parser, lexer, token, AST, tree-sitter, parser-core changes.
 # -----------------------------------------------------------------------------
 [risk_pack.parser]
-description = "Parser, lexer, token, AST, tree-sitter, and parser-core changes."
+description = "Parser, lexer, token, AST, tree-sitter, parser-core, incremental parsing, line index, position tracking, POD, pragma, and regex changes."
 paths = [
   "crates/perl-parser/**",
   "crates/perl-parser-core/**",
   "crates/perl-parser-pest/**",
+  "crates/perl-parser-bench/**",
+  "crates/perl-incremental-parsing/**",
   "crates/perl-lexer/**",
   "crates/perl-token/**",
   "crates/perl-ast/**",
   "crates/perl-ast-v2/**",
+  "crates/perl-line-index/**",
+  "crates/perl-position-tracking/**",
+  "crates/perl-pod/**",
+  "crates/perl-pragma/**",
+  "crates/perl-regex/**",
+  "crates/tree-sitter-perl/**",
   "crates/tree-sitter-perl-c/**",
   "crates/tree-sitter-perl-rs/**",
 ]
@@ -37,11 +45,17 @@ labels = ["ci:parser", "ci:mutation", "ci:coverage"]
 # LSP provider risk: LSP, completion, diagnostics, navigation, code action.
 # -----------------------------------------------------------------------------
 [risk_pack.lsp_provider]
-description = "LSP provider, protocol, completion, diagnostics, navigation, and code action changes."
+description = "LSP server, providers (completion, diagnostics, navigation, refactoring), perltidy integration, dead-code analysis, and UX regression coverage changes."
 paths = [
   "crates/perl-lsp-rs/**",
   "crates/perl-lsp-rs-core/**",
+  "crates/perl-lsp-perltidy/**",
+  "crates/perl-lsp-ux-tests/**",
+  "crates/perl-diagnostics/**",
+  "crates/perl-refactoring/**",
+  "crates/perl-dead-code/**",
   "crates/perllsp/**",
+  "features.toml",
 ]
 lanes = ["pr_smoke", "merge_gate_shards", "ux_tests", "ripr_advisory"]
 deep_lanes = ["real_repo_latency", "vscode_smoke_matrix"]
@@ -51,13 +65,14 @@ labels = ["ci:ux", "ci:real-repo-latency"]
 # Workspace / index risk: module resolution, semantic facts, indexing.
 # -----------------------------------------------------------------------------
 [risk_pack.workspace_index]
-description = "Workspace, module resolution, semantic facts, indexing, and symbol resolution."
+description = "Workspace, module resolution, semantic facts, indexing, symbol resolution, and corpus changes."
 paths = [
   "crates/perl-workspace/**",
   "crates/perl-module/**",
   "crates/perl-semantic-analyzer/**",
   "crates/perl-semantic-facts/**",
   "crates/perl-symbol/**",
+  "crates/perl-corpus/**",
 ]
 lanes = ["merge_gate_shards", "lsp_memory_smoke", "windows_guardrails", "ripr_advisory"]
 deep_lanes = ["memory_plateau", "real_repo_latency"]
@@ -68,11 +83,12 @@ labels = ["ci:memory", "ci:bench"]
 # Pairs with the PR template "Retained State" checklist.
 # -----------------------------------------------------------------------------
 [risk_pack.retained_state]
-description = "Long-lived maps, caches, queues, background tasks, sessions, document lifecycle, subprocess state."
+description = "Long-lived maps, caches, queues, background tasks, sessions, document lifecycle, subprocess state, and workspace-folder lifecycle changes."
 paths = [
   "crates/perl-lsp-rs/src/runtime/**",
   "crates/perl-lsp-rs-core/**",
   "crates/perl-workspace/**",
+  "crates/perl-subprocess-runtime/**",
 ]
 keywords = [
   "cache",
@@ -95,11 +111,13 @@ labels = ["ci:memory"]
 # DAP risk
 # -----------------------------------------------------------------------------
 [risk_pack.dap]
-description = "Debug adapter protocol, breakpoints, stepping, variables, evaluate, launch/attach."
+description = "Debug adapter protocol, breakpoints, stepping, variables, evaluate, launch/attach, and DAP session lifecycle changes."
 paths = [
   "crates/perl-dap/**",
 ]
-lanes = ["merge_gate_shards", "ux_tests", "ripr_advisory"]
+# DAP retains per-session state (stack frames, variable scopes, breakpoint
+# maps); memory smoke applies to it like the LSP runtime.
+lanes = ["merge_gate_shards", "ux_tests", "lsp_memory_smoke", "ripr_advisory"]
 deep_lanes = []
 labels = ["ci:dap"]
 
@@ -216,7 +234,11 @@ paths = [
   "Cargo.toml",
   "Cargo.lock",
   "rust-toolchain.toml",
+  "rust-toolchain",
   ".cargo/**",
+  "crates/*/Cargo.toml",
+  "xtask/Cargo.toml",
+  "deny.toml",
 ]
 lanes = ["pr_smoke", "merge_gate_shards", "security_audit"]
 deep_lanes = ["release_check"]


### PR DESCRIPTION
## Summary

Closes **item 3** of #8161 (crate coverage expansion). Items 1+2 landed in #8165; item 4 (stricter validator) remains open as a separate follow-up.

Adds 14 missing crates to existing risk packs and 1 missing lane to the `dap` pack. Pure additive change; 28 insertions, 6 deletions.

## Why

Several crates were not classified into any pack on master:

- `perl-incremental-parsing`, `perl-line-index`, `perl-position-tracking`, `perl-pod`, `perl-pragma`, `perl-regex`, `perl-parser-bench` — should be in `parser`.
- `perl-lsp-perltidy`, `perl-lsp-ux-tests`, `perl-diagnostics`, `perl-refactoring`, `perl-dead-code` — should be in `lsp_provider`.
- `perl-corpus` — should be in `workspace_index`.
- `perl-subprocess-runtime` — should be in `retained_state` (it already showed up via the `subprocess` keyword, but path-based matching is more durable).

A change to e.g. `crates/perl-incremental-parsing/src/lib.rs` previously selected no pack — only default-PR lanes ran. Now it correctly routes through `parser` (`pr_smoke` + `merge_gate_shards` + `ripr_advisory`).

## What changed

**parser** — added: `perl-incremental-parsing`, `perl-line-index`, `perl-position-tracking`, `perl-pod`, `perl-pragma`, `perl-regex`, `perl-parser-bench`, parent `crates/tree-sitter-perl/**`.

**lsp_provider** — added: `perl-lsp-perltidy`, `perl-lsp-ux-tests`, `perl-diagnostics`, `perl-refactoring`, `perl-dead-code`, `features.toml`.

**workspace_index** — added: `perl-corpus`.

**retained_state** — added `perl-subprocess-runtime` to `paths`.

**dap** — added `lsp_memory_smoke` to `lanes`. DAP retains per-session state (stack frames, variable scopes, breakpoint maps) and benefits from the same memory smoke that the LSP runtime gets.

**manifest** — added `rust-toolchain` (no `.toml` extension), `crates/*/Cargo.toml`, `xtask/Cargo.toml`, `deny.toml`.

## Verification

```text
$ python3 scripts/ci/validate_risk_packs.py --strict
Risk packs in policy/ci-risk-packs.toml: 12
Lanes in policy/ci-lanes.toml: 23
All risk packs valid.
```

Spot-check confirms previously-uncovered crates now route correctly:

| Diff path                                    | Selected packs                        |
|----------------------------------------------|---------------------------------------|
| `crates/perl-incremental-parsing/src/lib.rs` | `[parser]`                            |
| `crates/perl-line-index/src/lib.rs`          | `[parser]`                            |
| `crates/perl-pod/src/lib.rs`                 | `[parser]`                            |
| `crates/perl-pragma/src/lib.rs`              | `[parser]`                            |
| `crates/perl-corpus/src/lib.rs`              | `[workspace_index]`                   |
| `crates/perl-diagnostics/src/lib.rs`         | `[lsp_provider]`                      |
| `crates/perl-refactoring/src/lib.rs`         | `[lsp_provider]`                      |
| `crates/perl-dead-code/src/lib.rs`           | `[lsp_provider]`                      |
| `crates/perl-lsp-perltidy/src/lib.rs`        | `[lsp_provider]`                      |
| `crates/perl-lsp-ux-tests/src/lib.rs`        | `[lsp_provider]`                      |
| `features.toml`                              | `[lsp_provider]`                      |
| `deny.toml`                                  | `[manifest]`                          |
| `rust-toolchain`                             | `[manifest]`                          |
| `crates/perl-subprocess-runtime/src/lib.rs`  | `[retained_state, path_security, security]` |

## CI / LEM impact

- New default PR lanes: none.
- New advisory checks: none.
- Cache behavior: unchanged.
- Branch protection: unchanged.
- Estimated LEM change: **+0 LEM** for ordinary PRs; the new coverage routes existing default-PR + per-pack lanes more precisely.

## Out of scope

**Item 4 of #8161** (stricter validator: snake_case ID enforcement, repo-relative path enforcement, no Windows backslashes, lowercase keywords, unknown-field rejection) remains open. Lower priority than crate-coverage gaps; can layer onto the existing `validate_risk_packs.py` later.

## Refs

- Issue: #8161 (closes item 3 of 4)
- Predecessor: #8165 (closed items 1 + 2)

https://claude.ai/code/session_01W9kqLbX3ropffBJmYiifDJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01W9kqLbX3ropffBJmYiifDJ)_