### PR TITLE
ci(policy): expand risk-pack crate coverage (#8161)

### DIFF
--- a/docs/ci/risk-packs.md
+++ b/docs/ci/risk-packs.md
@@ -11,16 +11,16 @@ Risk packs route extra proof to PRs that touch known-risky surfaces. Defined in
 
 | Risk pack | Surface | Default lanes | Deep lanes (label-gated) |
 |---|---|---|---|
-| `parser` | parser, lexer, token, AST, tree-sitter | `pr_smoke`, `merge_gate_shards`, `ripr_advisory` | `mutation`, `fuzz`, `coverage` |
-| `lsp_provider` | LSP, completion, diagnostics, navigation | `pr_smoke`, `merge_gate_shards`, `ux_tests`, `ripr_advisory` | `real_repo_latency`, `vscode_smoke_matrix` |
-| `workspace_index` | module resolution, semantic facts, indexing | `merge_gate_shards`, `lsp_memory_smoke`, `windows_guardrails`, `ripr_advisory` | `memory_plateau`, `real_repo_latency` |
+| `parser` | parser, lexer, token, AST, tree-sitter, corpus, POD, regex, position support | `pr_smoke`, `merge_gate_shards`, `ripr_advisory` | `mutation`, `fuzz`, `coverage` |
+| `lsp_provider` | LSP, completion, diagnostics, navigation, refactoring, dead-code, formatting, UX harness | `pr_smoke`, `merge_gate_shards`, `ux_tests`, `ripr_advisory` | `real_repo_latency`, `vscode_smoke_matrix` |
+| `workspace_index` | module resolution, pragma state, semantic facts, indexing | `merge_gate_shards`, `lsp_memory_smoke`, `windows_guardrails`, `ripr_advisory` | `memory_plateau`, `real_repo_latency` |
 | `retained_state` | long-lived maps, caches, queues, sessions | `lsp_memory_smoke`, `ripr_advisory` | `memory_plateau` |
 | `dap` | debug adapter, breakpoints, evaluate | `merge_gate_shards`, `ux_tests`, `ripr_advisory` | — |
 | `vscode` | extension packaging, managed binary | `pr_smoke` | `vscode_smoke_matrix` |
 | `path_security` | URI normalization, path traversal, sandbox | `merge_gate_shards`, `windows_guardrails`, `ripr_advisory` | — |
 | `security` | sandbox, subprocess, exec, deserialization | `security_audit`, `windows_guardrails`, `ripr_advisory` | — |
 | `manifest` | Cargo.toml/lock, toolchain | `pr_smoke`, `merge_gate_shards`, `security_audit` | `release_check` |
-| `policy` | policy ledgers, gate policy, ripr config | `pr_smoke`, `merge_gate_shards` | — |
+| `policy` | policy ledgers, gate policy, CI hygiene crate, ripr config | `pr_smoke`, `merge_gate_shards` | — |
 | `workflow` | GitHub Actions, CI scripts, xtask CI tasks | `pr_smoke`, `merge_gate_shards` | — |
 | `docs_only` | prose / markdown / status | `docs_gate` | — |
 

--- a/policy/ci-risk-packs.toml
+++ b/policy/ci-risk-packs.toml
@@ -14,33 +14,51 @@ status = "advisory"
 updated = "2026-05-07"
 
 # -----------------------------------------------------------------------------
-# Parser risk: parser, lexer, token, AST, tree-sitter, parser-core changes.
+# Parser risk: parser, lexer, token, AST, tree-sitter, corpus, POD, regex,
+# source-position, and parser support changes.
 # -----------------------------------------------------------------------------
 [risk_pack.parser]
-description = "Parser, lexer, token, AST, tree-sitter, and parser-core changes."
+description = "Parser, lexer, token, AST, tree-sitter, corpus, POD, regex, source-position, and parser support changes."
 paths = [
   "crates/perl-parser/**",
   "crates/perl-parser-core/**",
+  "crates/perl-parser-bench/**",
   "crates/perl-parser-pest/**",
+  "crates/perl-incremental-parsing/**",
   "crates/perl-lexer/**",
   "crates/perl-token/**",
   "crates/perl-ast/**",
   "crates/perl-ast-v2/**",
+  "crates/perl-corpus/**",
+  "crates/perl-line-index/**",
+  "crates/perl-position-tracking/**",
+  "crates/perl-pod/**",
+  "crates/perl-regex/**",
+  "crates/perl-tdd-support/**",
+  "crates/perl-test-generators/**",
+  "crates/perl-test-must/**",
   "crates/tree-sitter-perl-c/**",
   "crates/tree-sitter-perl-rs/**",
+  "tree-sitter-perl/**",
 ]
 lanes = ["pr_smoke", "merge_gate_shards", "ripr_advisory"]
 deep_lanes = ["mutation", "fuzz", "coverage"]
 labels = ["ci:parser", "ci:mutation", "ci:coverage"]
 
 # -----------------------------------------------------------------------------
-# LSP provider risk: LSP, completion, diagnostics, navigation, code action.
+# LSP provider risk: LSP, completion, diagnostics, navigation, code action,
+# refactoring, dead-code, formatting, and UX harness changes.
 # -----------------------------------------------------------------------------
 [risk_pack.lsp_provider]
-description = "LSP provider, protocol, completion, diagnostics, navigation, and code action changes."
+description = "LSP provider, protocol, completion, diagnostics, navigation, code action, refactoring, dead-code, formatting, and UX harness changes."
 paths = [
+  "crates/perl-dead-code/**",
+  "crates/perl-diagnostics/**",
+  "crates/perl-lsp-perltidy/**",
   "crates/perl-lsp-rs/**",
   "crates/perl-lsp-rs-core/**",
+  "crates/perl-lsp-ux-tests/**",
+  "crates/perl-refactoring/**",
   "crates/perllsp/**",
 ]
 lanes = ["pr_smoke", "merge_gate_shards", "ux_tests", "ripr_advisory"]
@@ -55,6 +73,7 @@ description = "Workspace, module resolution, semantic facts, indexing, and symbo
 paths = [
   "crates/perl-workspace/**",
   "crates/perl-module/**",
+  "crates/perl-pragma/**",
   "crates/perl-semantic-analyzer/**",
   "crates/perl-semantic-facts/**",
   "crates/perl-symbol/**",
@@ -151,6 +170,7 @@ labels = ["ci:security", "security-audit"]
 [risk_pack.policy]
 description = "Changes to policy ledgers (policy/*.toml), gate policy (.ci/gate-policy.yaml), or CI economics TOMLs."
 paths = [
+  "crates/perl-ci-hygiene/**",
   "policy/**",
   ".ci/gate-policy.yaml",
   ".ci/blockers.yaml",


### PR DESCRIPTION
Problem: several parser, semantic, LSP, CI, and support crates did not match any risk-pack path, so changes in those crates could miss the intended proof lanes.
Fix: expand existing risk-pack paths and catalog wording so all crate directories map to at least one pack without adding stricter validator rules in this PR.
Verification: all 37 crate directories map to at least one risk-pack path; `python3 scripts/ci/validate_risk_packs.py --strict`; `cargo xtask devex plan --base origin/master`; `cargo xtask workflow-policy-lint --check-lane-whitelist` (passes with existing unpinned-action warnings); `cargo xtask workflow-trigger-lint`; `cargo xtask fmt`; `git diff --check`.