### PR TITLE
docs(roadmap): wire compiler-backed LSP tracking (#8191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The v0.13 architecture collapsed the old microcrate graph into a smaller publish
 | Troubleshooting | [docs/how-to/TROUBLESHOOTING.md](docs/how-to/TROUBLESHOOTING.md) |
 | Project status and metrics | [docs/project/status/index.md](docs/project/status/index.md) |
 | Roadmap | [docs/project/ROADMAP.md](docs/project/ROADMAP.md) |
+| Compiler-backed LSP roadmap | [docs/project/COMPILER_BACKED_LSP_ROADMAP.md](docs/project/COMPILER_BACKED_LSP_ROADMAP.md) |
 | Release history | [RELEASE_HISTORY.md](RELEASE_HISTORY.md) |
 | Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | Agent workflow | [AGENTS.md](AGENTS.md) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,7 @@ project docs when you need exact release facts, receipts, or milestone detail.
 
 - Active milestone plan: [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
 - Current truth and receipts: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md)
+- Compiler-backed LSP build-out: [docs/project/COMPILER_BACKED_LSP_ROADMAP.md](docs/project/COMPILER_BACKED_LSP_ROADMAP.md)
 - Published release tracking: [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
 
 ## Now (post-v0.12.3 ship / pre-announcement cleanup)

--- a/docs/project/COMPILER_BACKED_LSP_ROADMAP.md
+++ b/docs/project/COMPILER_BACKED_LSP_ROADMAP.md
@@ -143,7 +143,7 @@ and link the verification receipt there.
 | Framework adapters | [#8195](https://github.com/EffortlessMetrics/perl-lsp/issues/8195) | Adapter registry and one generated-member family | HIR, stash, imports | Framework fixtures with provenance |
 | Compile-time effects | [#3394](https://github.com/EffortlessMetrics/perl-lsp/issues/3394) plus future child issues from [#8191](https://github.com/EffortlessMetrics/perl-lsp/issues/8191) | Effect log and dynamic-boundary packets | HIR, scope, stash, imports | Effect fixtures and dynamic-boundary proof |
 | Tooling IR / PIR | [#8196](https://github.com/EffortlessMetrics/perl-lsp/issues/8196) | PIR data model with context, no provider cutover | HIR, scope, stash | PIR lowering fixtures |
-| Differential oracle | [#4389](https://github.com/EffortlessMetrics/perl-lsp/issues/4389) | Real-Perl conformance runner for proof lanes only | Fact schema and sandbox policy | Structured agreement receipt |
+| Differential oracle | [#8199](https://github.com/EffortlessMetrics/perl-lsp/issues/8199) ([#4389](https://github.com/EffortlessMetrics/perl-lsp/issues/4389) background) | Real-Perl conformance runner for proof lanes only | Fact schema and sandbox policy | Structured agreement receipt |
 | Provider cutover | [#8197](https://github.com/EffortlessMetrics/perl-lsp/issues/8197) | Fact-source tracing before behavior changes | Semantic scorecards, shadow compare | Provider-impact fixtures |
 
 ## Immediate PR Sequence

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -15,6 +15,7 @@
 | Quality metrics | [status/quality.md](status/quality.md) |
 | Semantic capability dashboard | [status/semantic_capability_dashboard.md](status/semantic_capability_dashboard.md) |
 | Editor UX planning scaffold | [status/editor_ux.json](status/editor_ux.json) |
+| Compiler-backed LSP roadmap | [COMPILER_BACKED_LSP_ROADMAP.md](COMPILER_BACKED_LSP_ROADMAP.md) |
 | Release readiness & blockers | [status/release.md](status/release.md) |
 | Verification protocol | [protocols/verification.md](protocols/verification.md) |
 | Planning & roadmap | [ROADMAP.md](ROADMAP.md) |

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -43,6 +43,7 @@
 - Keep all three parser corpus lanes current: Ubuntu system Perl, the cached CPAN top 1000 install, and the repo-owned corpus audit
 - Fold internal torture and edge-case suites into routine verification receipts
 - Resume parser, corpus, semantic, and DAP hardening after the release-channel receipts are closed
+- Track the post-parser semantic build-out through the [compiler-backed LSP roadmap](../COMPILER_BACKED_LSP_ROADMAP.md), keeping generated metrics in subsystem files rather than duplicating them here
 
 **Later**
 - DAP preview hardening (deeper live variables/evaluate, shim packaging, cross-editor native receipts)


### PR DESCRIPTION
Problem: The compiler-backed LSP roadmap exists, but it was not linked from the main docs surfaces and the differential proof lane still pointed at older sandbox research as canonical.
Fix: Link the roadmap from README/current status/status index/root roadmap, file EffortlessMetrics/perl-lsp-swarm#2732 for the real-Perl differential proof lane, and point the roadmap at EffortlessMetrics/perl-lsp-swarm#2732 while keeping EffortlessMetrics/perl-lsp-swarm#2942 as background.
Verification: `cargo xtask fmt --check` passes; `git diff --check` passes.
