### PR TITLE
fix(parser-status): distinguish actionable NodeKind gaps (#6486)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -17,7 +17,7 @@
 | Metric | Value | Notes | Source |
 | --- | --- | --- |
 <!-- BEGIN: PARSER_NODEKIND_ROW -->
-| **Node-kind coverage** | 65/69 (94.2%) | 4 never-seen node kinds | `corpus_audit` |
+| **Node-kind coverage** | 65/69 (94.2%) | 0 actionable never-seen; 4 recovery-only allowlisted | `corpus_audit` |
 <!-- END: PARSER_NODEKIND_ROW -->
 <!-- BEGIN: PARSER_RELIABILITY_ROW -->
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |

--- a/xtask/src/tasks/corpus_audit.rs
+++ b/xtask/src/tasks/corpus_audit.rs
@@ -82,6 +82,9 @@ pub struct StatusSummary {
     pub perl_corpus_files: usize,
     pub nodekind_covered: usize,
     pub nodekind_total: usize,
+    pub nodekind_never_seen: usize,
+    pub nodekind_allowlisted_never_seen: usize,
+    pub nodekind_actionable_never_seen: usize,
     pub ga_covered: usize,
     pub ga_total: usize,
 }
@@ -131,6 +134,9 @@ pub fn compute_status_summary(corpus_path: &Path, timeout: Duration) -> Result<S
         perl_corpus_files,
         nodekind_covered: nodekind_stats.covered_count,
         nodekind_total: nodekind_stats.total_count,
+        nodekind_never_seen: nodekind_stats.never_seen.len(),
+        nodekind_allowlisted_never_seen: nodekind_stats.allowlisted_never_seen.len(),
+        nodekind_actionable_never_seen: nodekind_stats.actionable_never_seen.len(),
         ga_covered: ga_coverage.covered_count,
         ga_total: ga_coverage.total_count,
     })

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -160,6 +160,27 @@ fn format_perf_metric_row(name: &str, metric: Option<&ParserPerfMetric>) -> Stri
     )
 }
 
+fn format_nodekind_gap_note(summary: &super::super::corpus_audit::StatusSummary) -> String {
+    match (
+        summary.nodekind_actionable_never_seen,
+        summary.nodekind_allowlisted_never_seen,
+        summary.nodekind_never_seen,
+    ) {
+        (0, 0, 0) => "0 never-seen node kinds".to_string(),
+        (0, allowlisted, _) => {
+            format!("0 actionable never-seen; {allowlisted} recovery-only allowlisted")
+        }
+        (actionable, 0, total) => {
+            format!("{actionable} actionable never-seen; {total} total never-seen")
+        }
+        (actionable, allowlisted, total) => {
+            format!(
+                "{actionable} actionable never-seen; {allowlisted} recovery-only allowlisted; {total} total never-seen"
+            )
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Generator
 // ---------------------------------------------------------------------------
@@ -234,10 +255,10 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
             } else {
                 100.0 * summary.nodekind_covered as f64 / summary.nodekind_total as f64
             };
-            let never_seen = summary.nodekind_total.saturating_sub(summary.nodekind_covered);
+            let gap_note = format_nodekind_gap_note(summary);
             format!(
-                "| **Node-kind coverage** | {}/{} ({:.1}%) | {} never-seen node kinds | `corpus_audit` |",
-                summary.nodekind_covered, summary.nodekind_total, pct, never_seen,
+                "| **Node-kind coverage** | {}/{} ({:.1}%) | {} | `corpus_audit` |",
+                summary.nodekind_covered, summary.nodekind_total, pct, gap_note,
             )
         },
     );

--- a/xtask/src/tasks/update_status/parser/tests.rs
+++ b/xtask/src/tasks/update_status/parser/tests.rs
@@ -95,6 +95,9 @@ fn test_parser_nodekind_row_renders() -> Result<()> {
         perl_corpus_files: 22,
         nodekind_covered: 65,
         nodekind_total: 69,
+        nodekind_never_seen: 4,
+        nodekind_allowlisted_never_seen: 4,
+        nodekind_actionable_never_seen: 0,
         ga_covered: 12,
         ga_total: 12,
     };
@@ -113,13 +116,48 @@ fn test_parser_nodekind_row_renders() -> Result<()> {
     let result = generate_parser_status(&metrics, template)?;
     assert!(result.contains("65/69"), "nodekind row missing 65/69");
     assert!(result.contains("94.2"), "nodekind row missing 94.2%");
-    assert!(result.contains("4 never-seen"), "nodekind row missing never-seen count");
+    assert!(result.contains("0 actionable never-seen"), "nodekind row missing actionable count");
+    assert!(result.contains("4 recovery-only allowlisted"), "nodekind row missing allowlist count");
     assert!(
         result.contains("insufficient_data"),
         "strict-clean no-receipt row should report insufficient_data"
     );
     assert!(!result.contains("10/10"), "strict-clean no-receipt row must not show 10/10");
     Ok(())
+}
+
+#[test]
+fn test_nodekind_gap_note_distinguishes_actionable_and_allowlisted() {
+    let mut summary = super::super::super::corpus_audit::StatusSummary {
+        total_files: 91,
+        ok_files: 91,
+        error_files: 0,
+        timeout_files: 0,
+        panic_files: 0,
+        test_corpus_files: 69,
+        perl_corpus_files: 22,
+        nodekind_covered: 65,
+        nodekind_total: 69,
+        nodekind_never_seen: 4,
+        nodekind_allowlisted_never_seen: 4,
+        nodekind_actionable_never_seen: 0,
+        ga_covered: 12,
+        ga_total: 12,
+    };
+
+    assert_eq!(
+        format_nodekind_gap_note(&summary),
+        "0 actionable never-seen; 4 recovery-only allowlisted"
+    );
+
+    summary.nodekind_never_seen = 3;
+    summary.nodekind_allowlisted_never_seen = 1;
+    summary.nodekind_actionable_never_seen = 2;
+
+    assert_eq!(
+        format_nodekind_gap_note(&summary),
+        "2 actionable never-seen; 1 recovery-only allowlisted; 3 total never-seen"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Problem: Parser status reported 65/69 NodeKinds with "4 never-seen node kinds" even though the audit already classifies those missing names as recovery-only allowlisted kinds with no actionable gaps.
Fix: Carry actionable/allowlisted never-seen counts into the parser status summary and render the NodeKind row as "0 actionable never-seen; 4 recovery-only allowlisted".
Verification:
- `cargo test -p xtask --profile agent --locked nodekind -- --nocapture` passes
- `cargo check -p xtask --all-targets --profile agent --locked` passes
- `cargo xtask metrics parser-accuracy --check` passes: 49 fixtures / 29 families
- `cargo xtask update-status --only parser --check` passes
- `cargo xtask metrics ratchet-check parser_accuracy` passes
- `cargo xtask fmt --check` passes
- `git diff --check` passes

Known unrelated local debt:
- `cargo test -p xtask --profile agent --locked update_status -- --nocapture` fails on pre-existing `update_status/mod.rs` LOC and token variant tests.
- `cargo clippy -p xtask --all-targets --profile agent --locked -- -D warnings -A missing_docs` fails on pre-existing xtask test/bin lint debt outside this lane.