### PR TITLE
test(parser): cover UnknownRest nodekind in corpus (#6486)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -9,7 +9,7 @@
 | <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 96.8% clean (`6871/7095`) / 20.5% salvage | Compatibility baseline; Perl `5.038002`, `48` unreadable, `36` recovery-only, `140` ERROR-node files, `0` catastrophic, baseline `2026-04-28` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) / insufficient_data salvage | Ecosystem breadth baseline; `6` unreadable, `0` recovery-only, `0` ERROR-node files, `0` catastrophic, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
-| **Project corpus** | 100.0% clean (`95/95`) | Deterministic regression baseline; `73` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `65/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
+| **Project corpus** | 100.0% clean (`96/96`) | Deterministic regression baseline; `74` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `66/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 
 ## Parser Scorecard
@@ -17,7 +17,7 @@
 | Metric | Value | Notes | Source |
 | --- | --- | --- |
 <!-- BEGIN: PARSER_NODEKIND_ROW -->
-| **Node-kind coverage** | 65/69 (94.2%) | 0 actionable never-seen; 4 recovery-only allowlisted | `corpus_audit` |
+| **Node-kind coverage** | 66/69 (95.7%) | 0 actionable never-seen; 3 recovery-only allowlisted | `corpus_audit` |
 <!-- END: PARSER_NODEKIND_ROW -->
 <!-- BEGIN: PARSER_RELIABILITY_ROW -->
 | **Reliability** | Ubuntu: 48 unread / CPAN: 6 unread / Project: 0 timeout, 0 panic, 0 unread | -- | `.ci/*-baseline.json` |

--- a/test_corpus/unknown_rest_unterminated_heredoc.pl
+++ b/test_corpus/unknown_rest_unterminated_heredoc.pl
@@ -1,0 +1,4 @@
+package Corpus::UnknownRestUnterminatedHeredoc;
+
+my $payload = <<'EOF';
+unterminated payload


### PR DESCRIPTION
Problem: Parser status still counted `UnknownRest` as an allowlisted recovery-only never-seen NodeKind even though a compact clean corpus fixture can exercise it.
Fix: Add a tiny unterminated-heredoc project-corpus fixture and regenerate parser status, moving NodeKind coverage from 65/69 to 66/69 while keeping project corpus 100% clean.
Verification: `cargo xtask corpus-audit-parse-one --path test_corpus/unknown_rest_unterminated_heredoc.pl`; `target\\debug\\perl-parse.exe -f debug test_corpus\\unknown_rest_unterminated_heredoc.pl`; `cargo test -p xtask --profile agent --locked nodekind -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask corpus-audit --corpus-path . --output target/corpus-audit-report.json --fresh --check`; `cargo xtask fmt --check`; `git diff --check`.