### PR TITLE
test(lints): add unit tests for 7 zero-coverage diagnostic lints (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/deprecated.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/deprecated.rs
@@ -85,3 +85,141 @@ pub fn check_deprecated_syntax(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn deprecated_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = Vec::new();
+        check_deprecated_syntax(&ast, &mut diags);
+        diags
+    }
+
+    fn has_code(diags: &[Diagnostic], code: &str) -> bool {
+        diags.iter().any(|d| d.code.as_deref() == Some(code))
+    }
+
+    // --- defined(@array) / defined(%hash) ---
+
+    #[test]
+    fn defined_array_is_flagged() {
+        let diags = deprecated_diags("my @arr = (1,2); if (defined @arr) { }");
+        assert!(
+            has_code(&diags, "PL500"),
+            "defined @arr should be flagged as PL500: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn defined_hash_is_flagged() {
+        let diags = deprecated_diags("my %h = (a => 1); if (defined %h) { }");
+        assert!(
+            has_code(&diags, "PL500"),
+            "defined %h should be flagged as PL500: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn defined_scalar_is_not_flagged() {
+        let diags = deprecated_diags("my $x; if (defined $x) { }");
+        assert!(
+            !has_code(&diags, "PL500"),
+            "defined $x should NOT be flagged as PL500: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn defined_string_literal_not_flagged() {
+        let diags = deprecated_diags(r#"if (defined "hello") { }"#);
+        assert!(
+            !has_code(&diags, "PL500"),
+            "defined on string literal should not be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn defined_array_diagnostic_has_deprecated_tag() {
+        let diags = deprecated_diags("my @arr = (); defined @arr;");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL500"));
+        assert!(diag.is_some(), "expected PL500 diagnostic");
+        let diag = diag.unwrap();
+        assert!(
+            diag.tags.contains(&DiagnosticTag::Deprecated),
+            "PL500 should carry the Deprecated tag"
+        );
+    }
+
+    #[test]
+    fn defined_hash_diagnostic_message_mentions_hash() {
+        let diags = deprecated_diags("my %h = (); defined %h;");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL500")).unwrap();
+        assert!(
+            diag.message.contains("%h"),
+            "message should mention the hash variable: {}", diag.message
+        );
+    }
+
+    #[test]
+    fn defined_array_diagnostic_suggestion_present() {
+        let diags = deprecated_diags("my @a = (); defined @a;");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL500")).unwrap();
+        assert!(
+            diag.suggestion.is_some(),
+            "PL500 should carry a suggestion"
+        );
+    }
+
+    // --- $[ deprecated array base ---
+
+    #[test]
+    fn array_base_variable_is_flagged() {
+        let diags = deprecated_diags("my $base = $[;");
+        assert!(
+            has_code(&diags, "PL501"),
+            "use of $[ should be flagged as PL501: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn array_base_assignment_is_flagged() {
+        let diags = deprecated_diags("$[ = 1;");
+        assert!(
+            has_code(&diags, "PL501"),
+            "assignment to $[ should be flagged as PL501: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn array_base_diagnostic_has_deprecated_tag() {
+        let diags = deprecated_diags("my $x = $[;");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL501")).unwrap();
+        assert!(
+            diag.tags.contains(&DiagnosticTag::Deprecated),
+            "PL501 should carry the Deprecated tag"
+        );
+    }
+
+    #[test]
+    fn normal_array_index_not_flagged() {
+        let diags = deprecated_diags("my @a = (1,2,3); my $x = $a[0];");
+        assert!(
+            !has_code(&diags, "PL501"),
+            "$a[0] should not be flagged as PL501: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn clean_code_no_deprecated_diagnostics() {
+        let diags = deprecated_diags(
+            "use strict;\nuse warnings;\nmy @arr = (1,2);\nif (@arr) { print 'ok'; }\n",
+        );
+        assert!(
+            !has_code(&diags, "PL500") && !has_code(&diags, "PL501"),
+            "clean code should produce no deprecated diagnostics: {diags:?}"
+        );
+    }
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/deprecated.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/deprecated.rs
@@ -90,7 +90,7 @@ pub fn check_deprecated_syntax(node: &Node, diagnostics: &mut Vec<Diagnostic>) {
 mod tests {
     use super::*;
     use perl_parser::Parser;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     fn deprecated_diags(source: &str) -> Vec<Diagnostic> {
         let ast = must(Parser::new(source).parse());
@@ -108,28 +108,19 @@ mod tests {
     #[test]
     fn defined_array_is_flagged() {
         let diags = deprecated_diags("my @arr = (1,2); if (defined @arr) { }");
-        assert!(
-            has_code(&diags, "PL500"),
-            "defined @arr should be flagged as PL500: {diags:?}"
-        );
+        assert!(has_code(&diags, "PL500"), "defined @arr should be flagged as PL500: {diags:?}");
     }
 
     #[test]
     fn defined_hash_is_flagged() {
         let diags = deprecated_diags("my %h = (a => 1); if (defined %h) { }");
-        assert!(
-            has_code(&diags, "PL500"),
-            "defined %h should be flagged as PL500: {diags:?}"
-        );
+        assert!(has_code(&diags, "PL500"), "defined %h should be flagged as PL500: {diags:?}");
     }
 
     #[test]
     fn defined_scalar_is_not_flagged() {
         let diags = deprecated_diags("my $x; if (defined $x) { }");
-        assert!(
-            !has_code(&diags, "PL500"),
-            "defined $x should NOT be flagged as PL500: {diags:?}"
-        );
+        assert!(!has_code(&diags, "PL500"), "defined $x should NOT be flagged as PL500: {diags:?}");
     }
 
     #[test]
@@ -144,9 +135,7 @@ mod tests {
     #[test]
     fn defined_array_diagnostic_has_deprecated_tag() {
         let diags = deprecated_diags("my @arr = (); defined @arr;");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL500"));
-        assert!(diag.is_some(), "expected PL500 diagnostic");
-        let diag = diag.unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL500")));
         assert!(
             diag.tags.contains(&DiagnosticTag::Deprecated),
             "PL500 should carry the Deprecated tag"
@@ -156,21 +145,19 @@ mod tests {
     #[test]
     fn defined_hash_diagnostic_message_mentions_hash() {
         let diags = deprecated_diags("my %h = (); defined %h;");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL500")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL500")));
         assert!(
             diag.message.contains("%h"),
-            "message should mention the hash variable: {}", diag.message
+            "message should mention the hash variable: {}",
+            diag.message
         );
     }
 
     #[test]
     fn defined_array_diagnostic_suggestion_present() {
         let diags = deprecated_diags("my @a = (); defined @a;");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL500")).unwrap();
-        assert!(
-            diag.suggestion.is_some(),
-            "PL500 should carry a suggestion"
-        );
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL500")));
+        assert!(diag.suggestion.is_some(), "PL500 should carry a suggestion");
     }
 
     // --- $[ deprecated array base ---
@@ -178,10 +165,7 @@ mod tests {
     #[test]
     fn array_base_variable_is_flagged() {
         let diags = deprecated_diags("my $base = $[;");
-        assert!(
-            has_code(&diags, "PL501"),
-            "use of $[ should be flagged as PL501: {diags:?}"
-        );
+        assert!(has_code(&diags, "PL501"), "use of $[ should be flagged as PL501: {diags:?}");
     }
 
     #[test]
@@ -196,7 +180,7 @@ mod tests {
     #[test]
     fn array_base_diagnostic_has_deprecated_tag() {
         let diags = deprecated_diags("my $x = $[;");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL501")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL501")));
         assert!(
             diag.tags.contains(&DiagnosticTag::Deprecated),
             "PL501 should carry the Deprecated tag"
@@ -206,10 +190,7 @@ mod tests {
     #[test]
     fn normal_array_index_not_flagged() {
         let diags = deprecated_diags("my @a = (1,2,3); my $x = $a[0];");
-        assert!(
-            !has_code(&diags, "PL501"),
-            "$a[0] should not be flagged as PL501: {diags:?}"
-        );
+        assert!(!has_code(&diags, "PL501"), "$a[0] should not be flagged as PL501: {diags:?}");
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/duplicate_hash_keys.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/duplicate_hash_keys.rs
@@ -90,7 +90,7 @@ pub fn check_duplicate_hash_keys(node: &Node, diagnostics: &mut Vec<Diagnostic>)
 mod tests {
     use super::*;
     use perl_parser::Parser;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     fn dup_key_diags(source: &str) -> Vec<Diagnostic> {
         let ast = must(Parser::new(source).parse());
@@ -106,7 +106,10 @@ mod tests {
     #[test]
     fn duplicate_string_key_is_flagged() {
         let diags = dup_key_diags(r#"my %h = (foo => 1, foo => 2);"#);
-        assert!(has_pl408(&diags), "duplicate string key 'foo' should be flagged as PL408: {diags:?}");
+        assert!(
+            has_pl408(&diags),
+            "duplicate string key 'foo' should be flagged as PL408: {diags:?}"
+        );
     }
 
     #[test]
@@ -119,7 +122,10 @@ mod tests {
     fn three_occurrences_two_diagnostics() {
         let diags = dup_key_diags(r#"my %h = (x => 1, x => 2, x => 3);"#);
         let count = diags.iter().filter(|d| d.code.as_deref() == Some("PL408")).count();
-        assert_eq!(count, 2, "three occurrences of same key should produce two PL408 diagnostics: {diags:?}");
+        assert_eq!(
+            count, 2,
+            "three occurrences of same key should produce two PL408 diagnostics: {diags:?}"
+        );
     }
 
     #[test]
@@ -137,17 +143,18 @@ mod tests {
     #[test]
     fn duplicate_message_names_the_key() {
         let diags = dup_key_diags(r#"my %h = (alpha => 1, alpha => 2);"#);
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL408")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL408")));
         assert!(
             diag.message.contains("alpha"),
-            "PL408 message should name the duplicate key: {}", diag.message
+            "PL408 message should name the duplicate key: {}",
+            diag.message
         );
     }
 
     #[test]
     fn duplicate_diagnostic_has_related_info_for_first_occurrence() {
         let diags = dup_key_diags(r#"my %h = (name => "Alice", name => "Bob");"#);
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL408")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL408")));
         assert!(
             !diag.related_information.is_empty(),
             "PL408 should include related information pointing to first occurrence"
@@ -157,7 +164,10 @@ mod tests {
     #[test]
     fn nested_hash_inner_duplicate_flagged() {
         let diags = dup_key_diags(r#"my %outer = (inner => { x => 1, x => 2 });"#);
-        assert!(has_pl408(&diags), "duplicate key inside nested hash ref should be flagged: {diags:?}");
+        assert!(
+            has_pl408(&diags),
+            "duplicate key inside nested hash ref should be flagged: {diags:?}"
+        );
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/duplicate_hash_keys.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/duplicate_hash_keys.rs
@@ -85,3 +85,90 @@ pub fn check_duplicate_hash_keys(node: &Node, diagnostics: &mut Vec<Diagnostic>)
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn dup_key_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = Vec::new();
+        check_duplicate_hash_keys(&ast, &mut diags);
+        diags
+    }
+
+    fn has_pl408(diags: &[Diagnostic]) -> bool {
+        diags.iter().any(|d| d.code.as_deref() == Some("PL408"))
+    }
+
+    #[test]
+    fn duplicate_string_key_is_flagged() {
+        let diags = dup_key_diags(r#"my %h = (foo => 1, foo => 2);"#);
+        assert!(has_pl408(&diags), "duplicate string key 'foo' should be flagged as PL408: {diags:?}");
+    }
+
+    #[test]
+    fn unique_keys_not_flagged() {
+        let diags = dup_key_diags(r#"my %h = (foo => 1, bar => 2, baz => 3);"#);
+        assert!(!has_pl408(&diags), "unique keys should not be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn three_occurrences_two_diagnostics() {
+        let diags = dup_key_diags(r#"my %h = (x => 1, x => 2, x => 3);"#);
+        let count = diags.iter().filter(|d| d.code.as_deref() == Some("PL408")).count();
+        assert_eq!(count, 2, "three occurrences of same key should produce two PL408 diagnostics: {diags:?}");
+    }
+
+    #[test]
+    fn duplicate_numeric_key_is_flagged() {
+        let diags = dup_key_diags(r#"my %h = (1 => "a", 1 => "b");"#);
+        assert!(has_pl408(&diags), "duplicate numeric key should be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn dynamic_variable_key_not_flagged() {
+        let diags = dup_key_diags(r#"my $k = "foo"; my %h = ($k => 1, $k => 2);"#);
+        assert!(!has_pl408(&diags), "dynamic variable keys should not be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn duplicate_message_names_the_key() {
+        let diags = dup_key_diags(r#"my %h = (alpha => 1, alpha => 2);"#);
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL408")).unwrap();
+        assert!(
+            diag.message.contains("alpha"),
+            "PL408 message should name the duplicate key: {}", diag.message
+        );
+    }
+
+    #[test]
+    fn duplicate_diagnostic_has_related_info_for_first_occurrence() {
+        let diags = dup_key_diags(r#"my %h = (name => "Alice", name => "Bob");"#);
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL408")).unwrap();
+        assert!(
+            !diag.related_information.is_empty(),
+            "PL408 should include related information pointing to first occurrence"
+        );
+    }
+
+    #[test]
+    fn nested_hash_inner_duplicate_flagged() {
+        let diags = dup_key_diags(r#"my %outer = (inner => { x => 1, x => 2 });"#);
+        assert!(has_pl408(&diags), "duplicate key inside nested hash ref should be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn empty_hash_not_flagged() {
+        let diags = dup_key_diags(r#"my %h = ();"#);
+        assert!(!has_pl408(&diags), "empty hash should not be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn single_pair_hash_not_flagged() {
+        let diags = dup_key_diags(r#"my %h = (key => "value");"#);
+        assert!(!has_pl408(&diags), "single-pair hash should not be flagged: {diags:?}");
+    }
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label.rs
@@ -65,3 +65,70 @@ pub fn check_goto_labels(
         });
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_semantic_analyzer::analysis::symbol::SymbolExtractor;
+    use perl_tdd_support::must;
+
+    fn goto_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let symbol_table = SymbolExtractor::new_with_source(source).extract(&ast);
+        let mut diags = Vec::new();
+        check_goto_labels(&ast, &symbol_table, &mut diags);
+        diags
+    }
+
+    fn has_pl409(diags: &[Diagnostic]) -> bool {
+        diags.iter().any(|d| d.code.as_deref() == Some("PL409"))
+    }
+
+    #[test]
+    fn goto_undefined_label_is_flagged() {
+        let diags = goto_diags("goto MISSING;");
+        assert!(has_pl409(&diags), "goto to undefined label should be flagged as PL409: {diags:?}");
+    }
+
+    #[test]
+    fn goto_defined_label_not_flagged() {
+        let diags = goto_diags("goto FOUND;\nFOUND: my $x = 1;");
+        assert!(!has_pl409(&diags), "goto to a defined label should not be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn goto_sub_reference_not_flagged() {
+        let diags = goto_diags("sub foo { }; goto &foo;");
+        assert!(!has_pl409(&diags), "goto &sub should not be flagged as PL409: {diags:?}");
+    }
+
+    #[test]
+    fn goto_variable_not_flagged() {
+        let diags = goto_diags("my $target = 'LABEL'; goto $target;");
+        assert!(!has_pl409(&diags), "goto $var should not be flagged as PL409: {diags:?}");
+    }
+
+    #[test]
+    fn diagnostic_message_names_the_label() {
+        let diags = goto_diags("goto NOWHERE;");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL409")).unwrap();
+        assert!(
+            diag.message.contains("NOWHERE"),
+            "PL409 message should name the missing label: {}", diag.message
+        );
+    }
+
+    #[test]
+    fn diagnostic_has_suggestion() {
+        let diags = goto_diags("goto PHANTOM;");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL409")).unwrap();
+        assert!(diag.suggestion.is_some(), "PL409 should carry a suggestion");
+    }
+
+    #[test]
+    fn no_goto_no_diagnostic() {
+        let diags = goto_diags("my $x = 1; print $x;");
+        assert!(!has_pl409(&diags), "code without goto should not trigger PL409: {diags:?}");
+    }
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label.rs
@@ -71,7 +71,7 @@ mod tests {
     use super::*;
     use perl_parser::Parser;
     use perl_semantic_analyzer::analysis::symbol::SymbolExtractor;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     fn goto_diags(source: &str) -> Vec<Diagnostic> {
         let ast = must(Parser::new(source).parse());
@@ -112,17 +112,18 @@ mod tests {
     #[test]
     fn diagnostic_message_names_the_label() {
         let diags = goto_diags("goto NOWHERE;");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL409")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL409")));
         assert!(
             diag.message.contains("NOWHERE"),
-            "PL409 message should name the missing label: {}", diag.message
+            "PL409 message should name the missing label: {}",
+            diag.message
         );
     }
 
     #[test]
     fn diagnostic_has_suggestion() {
         let diags = goto_diags("goto PHANTOM;");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL409")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL409")));
         assert!(diag.suggestion.is_some(), "PL409 should carry a suggestion");
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/loop_control_label.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/loop_control_label.rs
@@ -94,7 +94,7 @@ mod tests {
     use super::*;
     use perl_parser::Parser;
     use perl_semantic_analyzer::analysis::symbol::SymbolExtractor;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     fn loop_ctrl_diags(source: &str) -> Vec<Diagnostic> {
         let ast = must(Parser::new(source).parse());
@@ -113,13 +113,19 @@ mod tests {
     #[test]
     fn next_undefined_label_flagged() {
         let diags = loop_ctrl_diags("for my $i (1..10) { next OUTER; }");
-        assert!(has_pl410(&diags), "next with undefined label should be flagged as PL410: {diags:?}");
+        assert!(
+            has_pl410(&diags),
+            "next with undefined label should be flagged as PL410: {diags:?}"
+        );
     }
 
     #[test]
     fn next_defined_label_not_flagged() {
         let diags = loop_ctrl_diags("OUTER: for my $i (1..3) { for my $j (1..3) { next OUTER; } }");
-        assert!(!has_pl410(&diags), "next OUTER with defined label should not be flagged: {diags:?}");
+        assert!(
+            !has_pl410(&diags),
+            "next OUTER with defined label should not be flagged: {diags:?}"
+        );
     }
 
     #[test]
@@ -133,13 +139,19 @@ mod tests {
     #[test]
     fn last_undefined_label_flagged() {
         let diags = loop_ctrl_diags("for my $i (1..10) { last MISSING; }");
-        assert!(has_pl410(&diags), "last with undefined label should be flagged as PL410: {diags:?}");
+        assert!(
+            has_pl410(&diags),
+            "last with undefined label should be flagged as PL410: {diags:?}"
+        );
     }
 
     #[test]
     fn last_defined_label_not_flagged() {
         let diags = loop_ctrl_diags("LOOP: while (1) { last LOOP; }");
-        assert!(!has_pl410(&diags), "last LOOP with defined label should not be flagged: {diags:?}");
+        assert!(
+            !has_pl410(&diags),
+            "last LOOP with defined label should not be flagged: {diags:?}"
+        );
     }
 
     #[test]
@@ -153,13 +165,19 @@ mod tests {
     #[test]
     fn redo_undefined_label_flagged() {
         let diags = loop_ctrl_diags("for my $i (1..5) { redo NOWHERE; }");
-        assert!(has_pl410(&diags), "redo with undefined label should be flagged as PL410: {diags:?}");
+        assert!(
+            has_pl410(&diags),
+            "redo with undefined label should be flagged as PL410: {diags:?}"
+        );
     }
 
     #[test]
     fn redo_defined_label_not_flagged() {
         let diags = loop_ctrl_diags("ITER: for my $i (1..5) { redo ITER; }");
-        assert!(!has_pl410(&diags), "redo ITER with defined label should not be flagged: {diags:?}");
+        assert!(
+            !has_pl410(&diags),
+            "redo ITER with defined label should not be flagged: {diags:?}"
+        );
     }
 
     // --- message quality ---
@@ -167,7 +185,7 @@ mod tests {
     #[test]
     fn diagnostic_message_names_op_and_label() {
         let diags = loop_ctrl_diags("for my $x (1..3) { next GHOST; }");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL410")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL410")));
         assert!(diag.message.contains("next"), "message should name the op: {}", diag.message);
         assert!(diag.message.contains("GHOST"), "message should name the label: {}", diag.message);
     }
@@ -175,7 +193,7 @@ mod tests {
     #[test]
     fn diagnostic_has_suggestion() {
         let diags = loop_ctrl_diags("while (1) { last PHANTOM; }");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL410")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL410")));
         assert!(diag.suggestion.is_some(), "PL410 should carry a suggestion");
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/loop_control_label.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/loop_control_label.rs
@@ -88,3 +88,100 @@ pub fn check_loop_control_labels(
         });
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_semantic_analyzer::analysis::symbol::SymbolExtractor;
+    use perl_tdd_support::must;
+
+    fn loop_ctrl_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let symbol_table = SymbolExtractor::new_with_source(source).extract(&ast);
+        let mut diags = Vec::new();
+        check_loop_control_labels(&ast, &symbol_table, &mut diags);
+        diags
+    }
+
+    fn has_pl410(diags: &[Diagnostic]) -> bool {
+        diags.iter().any(|d| d.code.as_deref() == Some("PL410"))
+    }
+
+    // --- next LABEL ---
+
+    #[test]
+    fn next_undefined_label_flagged() {
+        let diags = loop_ctrl_diags("for my $i (1..10) { next OUTER; }");
+        assert!(has_pl410(&diags), "next with undefined label should be flagged as PL410: {diags:?}");
+    }
+
+    #[test]
+    fn next_defined_label_not_flagged() {
+        let diags = loop_ctrl_diags("OUTER: for my $i (1..3) { for my $j (1..3) { next OUTER; } }");
+        assert!(!has_pl410(&diags), "next OUTER with defined label should not be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn bare_next_not_flagged() {
+        let diags = loop_ctrl_diags("for my $i (1..10) { next; }");
+        assert!(!has_pl410(&diags), "bare next (no label) should never be flagged: {diags:?}");
+    }
+
+    // --- last LABEL ---
+
+    #[test]
+    fn last_undefined_label_flagged() {
+        let diags = loop_ctrl_diags("for my $i (1..10) { last MISSING; }");
+        assert!(has_pl410(&diags), "last with undefined label should be flagged as PL410: {diags:?}");
+    }
+
+    #[test]
+    fn last_defined_label_not_flagged() {
+        let diags = loop_ctrl_diags("LOOP: while (1) { last LOOP; }");
+        assert!(!has_pl410(&diags), "last LOOP with defined label should not be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn bare_last_not_flagged() {
+        let diags = loop_ctrl_diags("while (1) { last; }");
+        assert!(!has_pl410(&diags), "bare last (no label) should not be flagged: {diags:?}");
+    }
+
+    // --- redo LABEL ---
+
+    #[test]
+    fn redo_undefined_label_flagged() {
+        let diags = loop_ctrl_diags("for my $i (1..5) { redo NOWHERE; }");
+        assert!(has_pl410(&diags), "redo with undefined label should be flagged as PL410: {diags:?}");
+    }
+
+    #[test]
+    fn redo_defined_label_not_flagged() {
+        let diags = loop_ctrl_diags("ITER: for my $i (1..5) { redo ITER; }");
+        assert!(!has_pl410(&diags), "redo ITER with defined label should not be flagged: {diags:?}");
+    }
+
+    // --- message quality ---
+
+    #[test]
+    fn diagnostic_message_names_op_and_label() {
+        let diags = loop_ctrl_diags("for my $x (1..3) { next GHOST; }");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL410")).unwrap();
+        assert!(diag.message.contains("next"), "message should name the op: {}", diag.message);
+        assert!(diag.message.contains("GHOST"), "message should name the label: {}", diag.message);
+    }
+
+    #[test]
+    fn diagnostic_has_suggestion() {
+        let diags = loop_ctrl_diags("while (1) { last PHANTOM; }");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL410")).unwrap();
+        assert!(diag.suggestion.is_some(), "PL410 should carry a suggestion");
+    }
+
+    #[test]
+    fn clean_loops_no_diagnostic() {
+        let diags = loop_ctrl_diags("for my $i (1..10) { print $i; }");
+        assert!(!has_pl410(&diags), "clean loop code should not trigger PL410: {diags:?}");
+    }
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/package_subroutine.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/package_subroutine.rs
@@ -178,7 +178,7 @@ pub fn check_duplicate_subroutine(node: &Node, diagnostics: &mut Vec<Diagnostic>
 mod tests {
     use super::*;
     use perl_parser::Parser;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     fn missing_pkg_diags(source: &str, path: Option<&Path>) -> Vec<Diagnostic> {
         let ast = must(Parser::new(source).parse());
@@ -289,10 +289,11 @@ mod tests {
     #[test]
     fn duplicate_package_message_names_it() {
         let diags = dup_pkg_diags("package Baz;\npackage Baz;\n");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL201")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL201")));
         assert!(
             diag.message.contains("Baz"),
-            "PL201 message should name the duplicate package: {}", diag.message
+            "PL201 message should name the duplicate package: {}",
+            diag.message
         );
     }
 
@@ -318,9 +319,8 @@ mod tests {
 
     #[test]
     fn same_name_different_packages_not_flagged() {
-        let diags = dup_sub_diags(
-            "package Alpha;\nsub new { 1; }\npackage Beta;\nsub new { 2; }\n",
-        );
+        let diags =
+            dup_sub_diags("package Alpha;\nsub new { 1; }\npackage Beta;\nsub new { 2; }\n");
         assert!(
             diags.iter().all(|d| d.code.as_deref() != Some("PL300")),
             "same sub name in different packages should not be flagged: {diags:?}"
@@ -330,17 +330,18 @@ mod tests {
     #[test]
     fn duplicate_sub_message_names_it() {
         let diags = dup_sub_diags("package X;\nsub helper { 1; }\nsub helper { 2; }\n");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL300")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL300")));
         assert!(
             diag.message.contains("helper"),
-            "PL300 message should name the duplicate subroutine: {}", diag.message
+            "PL300 message should name the duplicate subroutine: {}",
+            diag.message
         );
     }
 
     #[test]
     fn duplicate_sub_has_suggestion() {
         let diags = dup_sub_diags("package X;\nsub run { 1; }\nsub run { 2; }\n");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL300")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL300")));
         assert!(diag.suggestion.is_some(), "PL300 should carry a suggestion");
     }
 }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/package_subroutine.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/package_subroutine.rs
@@ -173,3 +173,174 @@ pub fn check_duplicate_subroutine(node: &Node, diagnostics: &mut Vec<Diagnostic>
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn missing_pkg_diags(source: &str, path: Option<&Path>) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = Vec::new();
+        check_missing_package_declaration(&ast, source, path, &mut diags);
+        diags
+    }
+
+    fn dup_pkg_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = Vec::new();
+        check_duplicate_package(&ast, &mut diags);
+        diags
+    }
+
+    fn dup_sub_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = Vec::new();
+        check_duplicate_subroutine(&ast, &mut diags);
+        diags
+    }
+
+    // --- PL200: missing package declaration ---
+
+    #[test]
+    fn pm_file_without_package_flagged() {
+        let source = "sub foo { 1; }\n";
+        let path = Path::new("MyModule.pm");
+        let diags = missing_pkg_diags(source, Some(path));
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL200")),
+            "pm file without package should be flagged as PL200: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn pm_file_with_package_not_flagged() {
+        let source = "package MyModule;\nsub foo { 1; }\n";
+        let path = Path::new("MyModule.pm");
+        let diags = missing_pkg_diags(source, Some(path));
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL200")),
+            "pm file with package declaration should not be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn pl_script_without_package_not_flagged() {
+        let source = "print 'hello';\n";
+        let path = Path::new("script.pl");
+        let diags = missing_pkg_diags(source, Some(path));
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL200")),
+            "pl script without package should not be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn test_file_without_package_not_flagged() {
+        let source = "use Test::More;\nok(1);\n";
+        let path = Path::new("my_test.t");
+        let diags = missing_pkg_diags(source, Some(path));
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL200")),
+            "test .t file should not be flagged for missing package: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn shebang_file_without_package_not_flagged() {
+        let source = "#!/usr/bin/perl\nprint 'hi';\n";
+        let diags = missing_pkg_diags(source, None);
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL200")),
+            "shebang script should not be flagged for missing package: {diags:?}"
+        );
+    }
+
+    // --- PL201: duplicate package ---
+
+    #[test]
+    fn duplicate_package_is_flagged() {
+        let diags = dup_pkg_diags("package Foo;\nsub a { }\npackage Foo;\nsub b { }\n");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL201")),
+            "duplicate package declaration should be flagged as PL201: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn single_package_not_flagged() {
+        let diags = dup_pkg_diags("package Bar;\nsub x { }\n");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL201")),
+            "single package declaration should not be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn different_packages_not_flagged() {
+        let diags = dup_pkg_diags("package Foo;\nsub a { }\npackage Bar;\nsub b { }\n");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL201")),
+            "different package names should not trigger PL201: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_package_message_names_it() {
+        let diags = dup_pkg_diags("package Baz;\npackage Baz;\n");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL201")).unwrap();
+        assert!(
+            diag.message.contains("Baz"),
+            "PL201 message should name the duplicate package: {}", diag.message
+        );
+    }
+
+    // --- PL300: duplicate subroutine ---
+
+    #[test]
+    fn duplicate_sub_is_flagged() {
+        let diags = dup_sub_diags("package Pkg;\nsub process { 1; }\nsub process { 2; }\n");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL300")),
+            "duplicate subroutine should be flagged as PL300: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn unique_subs_not_flagged() {
+        let diags = dup_sub_diags("package Pkg;\nsub foo { 1; }\nsub bar { 2; }\n");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL300")),
+            "unique subroutines should not be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn same_name_different_packages_not_flagged() {
+        let diags = dup_sub_diags(
+            "package Alpha;\nsub new { 1; }\npackage Beta;\nsub new { 2; }\n",
+        );
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL300")),
+            "same sub name in different packages should not be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn duplicate_sub_message_names_it() {
+        let diags = dup_sub_diags("package X;\nsub helper { 1; }\nsub helper { 2; }\n");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL300")).unwrap();
+        assert!(
+            diag.message.contains("helper"),
+            "PL300 message should name the duplicate subroutine: {}", diag.message
+        );
+    }
+
+    #[test]
+    fn duplicate_sub_has_suggestion() {
+        let diags = dup_sub_diags("package X;\nsub run { 1; }\nsub run { 2; }\n");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL300")).unwrap();
+        assert!(diag.suggestion.is_some(), "PL300 should carry a suggestion");
+    }
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unreachable_code.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unreachable_code.rs
@@ -352,7 +352,7 @@ fn is_unconditional_exit_in_continue(node: &Node) -> bool {
 mod tests {
     use super::*;
     use perl_parser::Parser;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     fn unreachable_diags(source: &str) -> Vec<Diagnostic> {
         let ast = must(Parser::new(source).parse());
@@ -404,6 +404,15 @@ mod tests {
     }
 
     #[test]
+    fn qualified_croak_then_statement_is_flagged() {
+        let diags = unreachable_diags(r#"sub f { Carp::croak "err"; print "never"; }"#);
+        assert!(
+            has_pl406(&diags),
+            "statement after Carp::croak should be flagged as PL406: {diags:?}"
+        );
+    }
+
+    #[test]
     fn exit_then_statement_is_flagged() {
         let diags = unreachable_diags("exit 0; my $x = 1;");
         assert!(has_pl406(&diags), "statement after exit should be flagged as PL406: {diags:?}");
@@ -414,16 +423,18 @@ mod tests {
     #[test]
     fn two_statements_after_return_both_flagged() {
         let diags = unreachable_diags("sub f { return; my $a = 1; my $b = 2; }");
-        assert_eq!(count_pl406(&diags), 2, "both statements after return should be PL406: {diags:?}");
+        assert_eq!(
+            count_pl406(&diags),
+            2,
+            "both statements after return should be PL406: {diags:?}"
+        );
     }
 
     // --- nested sub reachability isolation ---
 
     #[test]
     fn return_in_inner_sub_does_not_poison_outer() {
-        let diags = unreachable_diags(
-            "sub outer { my $f = sub { return 1; }; my $x = 2; }",
-        );
+        let diags = unreachable_diags("sub outer { my $f = sub { return 1; }; my $x = 2; }");
         assert!(
             !has_pl406(&diags),
             "return inside anonymous sub should not flag outer code: {diags:?}"
@@ -432,9 +443,7 @@ mod tests {
 
     #[test]
     fn return_in_inner_sub_flags_inner_unreachable() {
-        let diags = unreachable_diags(
-            "sub outer { my $f = sub { return 1; my $dead = 99; }; }",
-        );
+        let diags = unreachable_diags("sub outer { my $f = sub { return 1; my $dead = 99; }; }");
         assert!(
             has_pl406(&diags),
             "unreachable code inside anonymous sub should be flagged: {diags:?}"
@@ -474,12 +483,21 @@ mod tests {
         assert!(has_pl406(&diags), "statement after confess should be flagged as PL406: {diags:?}");
     }
 
+    #[test]
+    fn qualified_confess_then_statement_is_flagged() {
+        let diags = unreachable_diags(r#"sub f { Carp::confess "msg"; print "dead"; }"#);
+        assert!(
+            has_pl406(&diags),
+            "statement after Carp::confess should be flagged as PL406: {diags:?}"
+        );
+    }
+
     // --- diagnostic quality ---
 
     #[test]
     fn pl406_has_unnecessary_tag() {
         let diags = unreachable_diags("sub f { return; my $x = 1; }");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL406")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL406")));
         assert!(
             diag.tags.contains(&DiagnosticTag::Unnecessary),
             "PL406 should carry the Unnecessary tag"
@@ -489,7 +507,7 @@ mod tests {
     #[test]
     fn pl406_has_suggestion() {
         let diags = unreachable_diags("sub f { return; my $x = 1; }");
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL406")).unwrap();
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL406")));
         assert!(diag.suggestion.is_some(), "PL406 should carry a suggestion");
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unreachable_code.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unreachable_code.rs
@@ -347,3 +347,155 @@ fn is_unconditional_exit_in_continue(node: &Node) -> bool {
         _ => false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn unreachable_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = Vec::new();
+        check_unreachable_code(&ast, &mut diags);
+        diags
+    }
+
+    fn has_pl406(diags: &[Diagnostic]) -> bool {
+        diags.iter().any(|d| d.code.as_deref() == Some("PL406"))
+    }
+
+    fn count_pl406(diags: &[Diagnostic]) -> usize {
+        diags.iter().filter(|d| d.code.as_deref() == Some("PL406")).count()
+    }
+
+    // --- return as exit ---
+
+    #[test]
+    fn return_then_statement_is_flagged() {
+        let diags = unreachable_diags("sub f { return 1; my $x = 2; }");
+        assert!(has_pl406(&diags), "statement after return should be flagged as PL406: {diags:?}");
+    }
+
+    #[test]
+    fn return_at_end_no_flag() {
+        let diags = unreachable_diags("sub f { my $x = 1; return $x; }");
+        assert!(!has_pl406(&diags), "return at end of sub should not flag anything: {diags:?}");
+    }
+
+    #[test]
+    fn conditional_return_does_not_flag_subsequent_code() {
+        let diags = unreachable_diags("sub f { return if $cond; my $x = 1; }");
+        assert!(!has_pl406(&diags), "return if cond should not flag subsequent code: {diags:?}");
+    }
+
+    // --- die as exit ---
+
+    #[test]
+    fn die_then_statement_is_flagged() {
+        let diags = unreachable_diags(r#"sub f { die "error"; print "never"; }"#);
+        assert!(has_pl406(&diags), "statement after die should be flagged as PL406: {diags:?}");
+    }
+
+    #[test]
+    fn croak_then_statement_is_flagged() {
+        let diags = unreachable_diags(r#"sub f { croak "err"; print "never"; }"#);
+        assert!(has_pl406(&diags), "statement after croak should be flagged as PL406: {diags:?}");
+    }
+
+    #[test]
+    fn exit_then_statement_is_flagged() {
+        let diags = unreachable_diags("exit 0; my $x = 1;");
+        assert!(has_pl406(&diags), "statement after exit should be flagged as PL406: {diags:?}");
+    }
+
+    // --- multiple unreachable statements ---
+
+    #[test]
+    fn two_statements_after_return_both_flagged() {
+        let diags = unreachable_diags("sub f { return; my $a = 1; my $b = 2; }");
+        assert_eq!(count_pl406(&diags), 2, "both statements after return should be PL406: {diags:?}");
+    }
+
+    // --- nested sub reachability isolation ---
+
+    #[test]
+    fn return_in_inner_sub_does_not_poison_outer() {
+        let diags = unreachable_diags(
+            "sub outer { my $f = sub { return 1; }; my $x = 2; }",
+        );
+        assert!(
+            !has_pl406(&diags),
+            "return inside anonymous sub should not flag outer code: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn return_in_inner_sub_flags_inner_unreachable() {
+        let diags = unreachable_diags(
+            "sub outer { my $f = sub { return 1; my $dead = 99; }; }",
+        );
+        assert!(
+            has_pl406(&diags),
+            "unreachable code inside anonymous sub should be flagged: {diags:?}"
+        );
+    }
+
+    // --- loop control exits ---
+
+    #[test]
+    fn last_in_loop_body_flags_subsequent() {
+        let diags = unreachable_diags("for my $i (1..5) { last; print $i; }");
+        assert!(has_pl406(&diags), "code after 'last' should be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn next_in_loop_body_flags_subsequent() {
+        let diags = unreachable_diags("for my $i (1..5) { next; print $i; }");
+        assert!(has_pl406(&diags), "code after 'next' should be flagged: {diags:?}");
+    }
+
+    // --- eval block: die is caught, outer code is reachable ---
+
+    #[test]
+    fn die_inside_eval_does_not_flag_after_eval() {
+        let diags = unreachable_diags(r#"eval { die "oops"; }; my $x = 1;"#);
+        assert!(
+            !has_pl406(&diags),
+            "die inside eval should not flag code after the eval block: {diags:?}"
+        );
+    }
+
+    // --- confess ---
+
+    #[test]
+    fn confess_then_statement_is_flagged() {
+        let diags = unreachable_diags(r#"sub f { confess "msg"; print "dead"; }"#);
+        assert!(has_pl406(&diags), "statement after confess should be flagged as PL406: {diags:?}");
+    }
+
+    // --- diagnostic quality ---
+
+    #[test]
+    fn pl406_has_unnecessary_tag() {
+        let diags = unreachable_diags("sub f { return; my $x = 1; }");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL406")).unwrap();
+        assert!(
+            diag.tags.contains(&DiagnosticTag::Unnecessary),
+            "PL406 should carry the Unnecessary tag"
+        );
+    }
+
+    #[test]
+    fn pl406_has_suggestion() {
+        let diags = unreachable_diags("sub f { return; my $x = 1; }");
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL406")).unwrap();
+        assert!(diag.suggestion.is_some(), "PL406 should carry a suggestion");
+    }
+
+    #[test]
+    fn clean_sub_no_pl406() {
+        let diags = unreachable_diags("sub f { my $x = 1; my $y = 2; return $x + $y; }");
+        assert!(!has_pl406(&diags), "clean sub should not trigger PL406: {diags:?}");
+    }
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unused_imports.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unused_imports.rs
@@ -221,7 +221,7 @@ fn is_module_referenced(source: &str, module: &str, use_start: usize, use_end: u
 mod tests {
     use super::*;
     use perl_parser::Parser;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     fn unused_import_diags(source: &str) -> Vec<Diagnostic> {
         let ast = must(Parser::new(source).parse());
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn used_module_not_flagged() {
-        let source = "use Scalar::Util qw(blessed);\nmy $class = blessed($obj);\n";
+        let source = "use Project::Thing;\nmy $thing = Project::Thing->new;\n";
         let diags = unused_import_diags(source);
         assert!(
             !has_unused_import(&diags),
@@ -306,7 +306,7 @@ mod tests {
 
     #[test]
     fn use_with_explicit_import_list_not_flagged() {
-        let source = "use List::Util qw(max min);\nmy $m = max(1, 2);\n";
+        let source = "use Project::Exports qw(project_value);\nmy $v = project_value();\n";
         let diags = unused_import_diags(source);
         assert!(
             !has_unused_import(&diags),
@@ -341,24 +341,22 @@ mod tests {
     fn unused_import_diagnostic_names_the_module() {
         let source = "use SomeModule::Unused;\nmy $x = 1;\n";
         let diags = unused_import_diags(source);
-        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL700"));
-        if let Some(diag) = diag {
-            assert!(
-                diag.message.contains("SomeModule::Unused"),
-                "diagnostic should name the module: {}", diag.message
-            );
-        }
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL700")));
+        assert!(
+            diag.message.contains("SomeModule::Unused"),
+            "diagnostic should name the module: {}",
+            diag.message
+        );
     }
 
     #[test]
     fn unused_import_has_unnecessary_tag() {
         let source = "use POSIX::Ghost;\nmy $x = 1;\n";
         let diags = unused_import_diags(source);
-        if let Some(diag) = diags.iter().find(|d| d.code.as_deref() == Some("PL700")) {
-            assert!(
-                diag.tags.contains(&DiagnosticTag::Unnecessary),
-                "unused-import should carry the Unnecessary tag"
-            );
-        }
+        let diag = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL700")));
+        assert!(
+            diag.tags.contains(&DiagnosticTag::Unnecessary),
+            "unused-import should carry the Unnecessary tag"
+        );
     }
 }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unused_imports.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/unused_imports.rs
@@ -216,3 +216,149 @@ fn is_module_referenced(source: &str, module: &str, use_start: usize, use_end: u
     }
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_tdd_support::must;
+
+    fn unused_import_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let mut diags = Vec::new();
+        check_unused_imports(&ast, source, &mut diags);
+        diags
+    }
+
+    fn has_unused_import(diags: &[Diagnostic]) -> bool {
+        diags.iter().any(|d| d.code.as_deref() == Some("PL700"))
+    }
+
+    // --- basic detection ---
+
+    #[test]
+    fn genuinely_unused_module_is_flagged() {
+        let source = "use POSIX::Unused;\nmy $x = 1;\n";
+        let diags = unused_import_diags(source);
+        assert!(
+            has_unused_import(&diags),
+            "unused module should produce an unused-import diagnostic: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn used_module_not_flagged() {
+        let source = "use Scalar::Util qw(blessed);\nmy $class = blessed($obj);\n";
+        let diags = unused_import_diags(source);
+        assert!(
+            !has_unused_import(&diags),
+            "module referenced in code should not be flagged: {diags:?}"
+        );
+    }
+
+    // --- pragma skip list ---
+
+    #[test]
+    fn strict_pragma_not_flagged() {
+        let source = "use strict;\nmy $x = 1;\n";
+        let diags = unused_import_diags(source);
+        assert!(!has_unused_import(&diags), "use strict should never be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn warnings_pragma_not_flagged() {
+        let source = "use warnings;\nmy $x = 1;\n";
+        let diags = unused_import_diags(source);
+        assert!(!has_unused_import(&diags), "use warnings should never be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn utf8_pragma_not_flagged() {
+        let source = "use utf8;\nmy $x = 1;\n";
+        let diags = unused_import_diags(source);
+        assert!(!has_unused_import(&diags), "use utf8 should never be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn feature_pragma_not_flagged() {
+        let source = "use feature 'say';\nsay 'hello';\n";
+        let diags = unused_import_diags(source);
+        assert!(!has_unused_import(&diags), "use feature should never be flagged: {diags:?}");
+    }
+
+    // --- implicit export skip list ---
+
+    #[test]
+    fn moose_not_flagged() {
+        let source = "use Moose;\nhas 'name' => (is => 'ro');\n";
+        let diags = unused_import_diags(source);
+        assert!(!has_unused_import(&diags), "use Moose should never be flagged: {diags:?}");
+    }
+
+    #[test]
+    fn test_more_not_flagged() {
+        let source = "use Test::More;\nok(1, 'passes');\n";
+        let diags = unused_import_diags(source);
+        assert!(!has_unused_import(&diags), "use Test::More should never be flagged: {diags:?}");
+    }
+
+    // --- explicit imports not flagged ---
+
+    #[test]
+    fn use_with_explicit_import_list_not_flagged() {
+        let source = "use List::Util qw(max min);\nmy $m = max(1, 2);\n";
+        let diags = unused_import_diags(source);
+        assert!(
+            !has_unused_import(&diags),
+            "use with explicit import list should not be flagged: {diags:?}"
+        );
+    }
+
+    // --- version declarations not flagged ---
+
+    #[test]
+    fn version_use_not_flagged() {
+        let source = "use 5.010;\nmy $x = 1;\n";
+        let diags = unused_import_diags(source);
+        assert!(!has_unused_import(&diags), "use 5.010 should not be flagged: {diags:?}");
+    }
+
+    // --- module used by qualified call ---
+
+    #[test]
+    fn module_used_by_qualified_call_not_flagged() {
+        let source = "use File::Spec;\nmy $p = File::Spec->catfile('a', 'b');\n";
+        let diags = unused_import_diags(source);
+        assert!(
+            !has_unused_import(&diags),
+            "module used via qualified call should not be flagged: {diags:?}"
+        );
+    }
+
+    // --- diagnostic quality ---
+
+    #[test]
+    fn unused_import_diagnostic_names_the_module() {
+        let source = "use SomeModule::Unused;\nmy $x = 1;\n";
+        let diags = unused_import_diags(source);
+        let diag = diags.iter().find(|d| d.code.as_deref() == Some("PL700"));
+        if let Some(diag) = diag {
+            assert!(
+                diag.message.contains("SomeModule::Unused"),
+                "diagnostic should name the module: {}", diag.message
+            );
+        }
+    }
+
+    #[test]
+    fn unused_import_has_unnecessary_tag() {
+        let source = "use POSIX::Ghost;\nmy $x = 1;\n";
+        let diags = unused_import_diags(source);
+        if let Some(diag) = diags.iter().find(|d| d.code.as_deref() == Some("PL700")) {
+            assert!(
+                diag.tags.contains(&DiagnosticTag::Unnecessary),
+                "unused-import should carry the Unnecessary tag"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Problem: Seven diagnostics lint modules lacked isolated unit coverage.

Fix: Add behavior-focused inline tests for PL500/PL501, PL408, PL409, PL410, PL406, PL200/PL201/PL300, and PL700; review follow-up replaces bare unwrap/vacuous checks with `perl_tdd_support::must_some`, non-skip-list unused-import fixtures, and qualified `Carp::croak` / `Carp::confess` PL406 coverage.

Verification: `cargo test -p perl-lsp-rs-core --lib -- lints --nocapture` passes (194 lints-filtered tests); `cargo test -p perl-lsp-rs-core --lib` passes (1377 tests); `cargo check -p perl-lsp-rs-core --all-targets --profile agent --locked`; `cargo clippy -p perl-lsp-rs-core --lib --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`.