### PR TITLE
fix(completion): gate PERL5LIB on useSystemInc opt-in for module completion (#7570)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -41,6 +41,19 @@ fn get_snippet_simple_regex() -> Option<&'static Regex> {
     SNIPPET_SIMPLE_RE.get_or_init(|| Regex::new(r"\$\d+")).as_ref().ok()
 }
 
+fn perl5lib_paths_for_completion(
+    config: &perl_lsp_rs_core::config::WorkspaceConfig,
+    perl5lib_value: Option<&str>,
+) -> Vec<String> {
+    if !config.use_system_inc {
+        return Vec::new();
+    }
+
+    perl5lib_value
+        .map(perl_lsp_rs_core::config::WorkspaceConfig::parse_perl5lib)
+        .unwrap_or_default()
+}
+
 /// Returns commit characters for a completion item based on its kind.
 /// Each string is exactly one character, per the LSP 3.x spec.
 ///
@@ -95,12 +108,17 @@ impl LspServer {
             }
         }
 
-        // Read effective include paths from the config clone (PERL5LIB + workspace paths).
+        // Read effective include paths from the config clone (workspace paths only here;
+        // PERL5LIB is gated below on use_system_inc).
         // The clone is lightweight — it does not trigger the system @INC subprocess.
         if let Some(config) = self.config_for_doc(uri) {
-            let perl5lib_paths = std::env::var("PERL5LIB")
-                .map(|v| perl_lsp_rs_core::config::WorkspaceConfig::parse_perl5lib(&v))
-                .unwrap_or_default();
+            // PERL5LIB comes from the system environment and is treated as a "system"
+            // source for completion purposes.  Only merge it into the completion roots
+            // after the user opts in via useSystemInc, matching the behaviour of the
+            // system @INC source.  Passing an empty slice omits PERL5LIB without
+            // changing anything else in effective_include_paths.
+            let perl5lib_value = std::env::var("PERL5LIB").ok();
+            let perl5lib_paths = perl5lib_paths_for_completion(&config, perl5lib_value.as_deref());
             let effective_paths = config.effective_include_paths(&perl5lib_paths);
             include_system_inc = config.use_system_inc;
 
@@ -1572,6 +1590,40 @@ mod tests {
             Some("scalar"),
             "scalar variable should have labelDetails.detail = 'scalar'"
         );
+        Ok(())
+    }
+
+    /// Verify that PERL5LIB paths are excluded from completion roots when
+    /// `use_system_inc` is disabled, and included when it is enabled.
+    #[test]
+    fn test_perl5lib_excluded_from_completion_roots_when_system_inc_disabled()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use perl_lsp_rs_core::config::WorkspaceConfig;
+        use tempfile::TempDir;
+
+        let temp = TempDir::new()?;
+        let perl5lib_dir = temp.path().join("perl5lib");
+        std::fs::create_dir_all(&perl5lib_dir)?;
+        let perl5lib_value = perl5lib_dir.to_string_lossy().to_string();
+
+        let mut config = WorkspaceConfig::default();
+        config.use_system_inc = false;
+
+        let paths_no_p5l = perl5lib_paths_for_completion(&config, Some(&perl5lib_value));
+        assert!(
+            !paths_no_p5l.iter().any(|p| p == &perl5lib_value),
+            "PERL5LIB dir must not appear in completion inputs when use_system_inc=false; \
+             got: {paths_no_p5l:?}"
+        );
+
+        config.use_system_inc = true;
+        let paths_with_p5l = perl5lib_paths_for_completion(&config, Some(&perl5lib_value));
+        assert!(
+            paths_with_p5l.iter().any(|p| p == &perl5lib_value),
+            "PERL5LIB dir must appear in completion inputs after use_system_inc=true; \
+             got: {paths_with_p5l:?}"
+        );
+
         Ok(())
     }
 }

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
@@ -978,11 +978,7 @@ fn scenario_14_include_path_missing_module_completion_consistency() {
     harness.assert_no_crash();
 }
 
-// FIXME(#7570): SystemModule appears in completion BEFORE the useSystemInc
-// opt-in when PERL5LIB is set — the PERL5LIB completion source is not gated
-// on the opt-in. Tracked in #7570; ignored to unblock master CI Gate.
 #[test]
-#[ignore = "FIXME(#7570): PERL5LIB completion not gated on useSystemInc opt-in"]
 fn scenario_14_system_inc_completion_opt_in_enabled() {
     if !binary_available() {
         eprintln!(
@@ -1016,10 +1012,6 @@ fn scenario_14_system_inc_completion_opt_in_enabled() {
     let after = harness.completion("fixture.pl", 2, 7).expect("completion after opt-in");
     let after_has_system_module = completion_has_module(&after, "SystemModule");
 
-    let defs = harness.definition("fixture.pl", 2, 4).expect("definition must not error");
-    let def_resolves = !defs.is_empty();
-    let hover_result = harness.hover("fixture.pl", 2, 4).expect("hover must not error");
-
     assert!(
         !before_has_system_module,
         "Expected SystemModule to be absent from completion before useSystemInc opt-in; labels={:?}",
@@ -1030,6 +1022,16 @@ fn scenario_14_system_inc_completion_opt_in_enabled() {
         "Expected SystemModule in completion after useSystemInc opt-in; labels={:?}",
         completion_labels(&after)
     );
+
+    harness
+        .change_file_full("fixture.pl", "use strict;\nuse warnings;\nuse SystemModule;\n")
+        .expect("didChange to completed module should succeed");
+    std::thread::sleep(Duration::from_millis(500));
+
+    let defs = harness.definition("fixture.pl", 2, 4).expect("definition must not error");
+    let def_resolves = !defs.is_empty();
+    let hover_result = harness.hover("fixture.pl", 2, 4).expect("hover must not error");
+
     assert!(
         def_resolves,
         "Expected goto-definition to resolve SystemModule after opt-in; defs={:?}",


### PR DESCRIPTION
Problem: PERL5LIB leaked into module completion roots even when users had not opted into system include discovery.

Fix: Gate PERL5LIB-fed completion roots on `workspace.useSystemInc`, while leaving module resolution's `usePerl5lib` path unchanged. The UX test now checks completion on the partial prefix, then uses the completed module spelling for goto/hover consistency.

Verification: `cargo test -p perl-lsp-rs --lib --profile agent --locked runtime::language::completion::tests`; `cargo build -p perl-lsp-rs --bin perl-lsp --profile agent --locked`; `PERL_LSP_BIN=target/agent/perl-lsp.exe cargo test -p perl-lsp-ux-tests --profile agent --locked scenario_14_system_inc_completion_opt_in_enabled -- --test-threads=1 --nocapture`; `cargo check -p perl-lsp-rs --all-targets --profile agent --locked`; `cargo clippy -p perl-lsp-rs --lib --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`.

Fixes #7570.