### PR TITLE
test(devex): add routing fixture matrix (#0000)

### DIFF
--- a/docs/devex/ripr-dogfood/devex-test-gap-20260507.md
+++ b/docs/devex/ripr-dogfood/devex-test-gap-20260507.md
@@ -1,0 +1,53 @@
+# ripr dogfood note: DevEx test-gap PR 1
+
+## Target
+
+- Repo: perl-lsp
+- Area: xtask DevEx planner routing
+- PR: EffortlessMetrics/perl-lsp#8210
+- Commit range: origin/master..working tree
+
+## ripr run
+
+- before: `target/ripr/dogfood/devex/before-routing.repo-exposure.json`
+- after: `target/ripr/dogfood/devex/after-routing.repo-exposure.json`
+- outcome: `target/ripr/dogfood/devex/routing-outcome.md`
+- agent brief before: `target/ripr/dogfood/devex/agent-brief.before.json`
+- agent brief after: `target/ripr/dogfood/devex/agent-brief.after.json`
+- agent verify: `target/ripr/dogfood/devex/routing-agent-verify.json`
+- agent receipt: `target/ripr/dogfood/devex/routing-agent-receipt.json`
+
+## What ripr found correctly
+
+- `ripr check` completed on the full repo and produced comparable before/after
+  repo-exposure JSON artifacts.
+- `ripr outcome` made the no-movement result explicit: moved `0`,
+  regressed `0`, new `0`, removed `0`, unchanged `115920`.
+- `ripr agent verify` produced a machine-readable advisory summary from the
+  saved before/after snapshots.
+
+## What ripr missed
+
+- The focused test added a table-driven routing fixture matrix for
+  `xtask/src/tasks/devex_plan.rs`, but `ripr outcome` reported no improved or
+  resolved seams.
+- The agent brief and verify artifacts did not surface the DevEx routing seam
+  or the new table-driven test as a useful discriminator.
+- Because verify had no changed DevEx seam, `ripr agent receipt` could only be
+  exercised against an unrelated unchanged seam, so the receipt was not useful
+  PR evidence for this dogfood slice.
+
+## What was noisy
+
+- `ripr pilot` was useful as a smoke run, but its top recommendation targeted
+  archived heredoc parser code rather than the active DevEx changed area.
+- The requested `ripr agent status` command is not available in installed
+  `ripr` 0.4.0; the available agent surfaces are `brief`, `packet`, `verify`,
+  and `receipt`. This dogfood run used `agent brief` instead.
+- The repo-exposure artifacts are large, about 365 MB each, which makes the
+  loop heavier than the focused DevEx test itself.
+
+## Upstream ripr issues opened
+
+- EffortlessMetrics/ripr#508:
+  `dogfood(perl-lsp): table-driven DevEx routing test did not move repo exposure`

--- a/xtask/src/tasks/devex_plan.rs
+++ b/xtask/src/tasks/devex_plan.rs
@@ -748,6 +748,270 @@ mod tests {
         commands.iter().map(|proof| proof.command.clone()).collect()
     }
 
+    fn surface_strings(plan: &Plan) -> Vec<String> {
+        plan.surfaces.iter().map(|surface| surface.id().to_string()).collect()
+    }
+
+    struct DevexRoutingFixture {
+        name: &'static str,
+        files: &'static [&'static str],
+        expected_surfaces: &'static [&'static str],
+        expected_required_commands: &'static [&'static str],
+        expected_optional_commands: &'static [&'static str],
+        expected_agent_hint_snippets: &'static [&'static str],
+    }
+
+    #[test]
+    fn routing_fixture_matrix_locks_surface_and_proof_selection() {
+        let fixtures = [
+            DevexRoutingFixture {
+                name: "docs only",
+                files: &["docs/how-to/LOCAL_WATCH_MODE.md"],
+                expected_surfaces: &["docs"],
+                expected_required_commands: &["cargo xtask fmt", "git diff --check"],
+                expected_optional_commands: &["just pr-fast", "just ci-gate"],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "rust code only",
+                files: &["crates/perl-parser-core/src/lib.rs"],
+                expected_surfaces: &["rust_code"],
+                expected_required_commands: &["cargo xtask fmt", "git diff --check"],
+                expected_optional_commands: &["just pr-fast", "just ci-gate"],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "parser accuracy",
+                files: &["crates/perl-corpus/fixtures/parser_accuracy/scalar_ref.pl"],
+                expected_surfaces: &["parser_accuracy"],
+                expected_required_commands: &[
+                    "cargo xtask fmt",
+                    "just ci-metrics-ratchet-check parser_accuracy",
+                    "git diff --check",
+                ],
+                expected_optional_commands: &[
+                    "just pr-fast",
+                    "just ci-gate",
+                    "just cpan-corpus-check",
+                    "just corpus-sweep-check",
+                ],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                    "For parser-accuracy edits",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "generated status docs",
+                files: &["docs/project/status/lsp.md"],
+                expected_surfaces: &["generated_status_docs", "docs"],
+                expected_required_commands: &[
+                    "cargo xtask fmt",
+                    "just status-update",
+                    "just status-check",
+                    "git diff --check",
+                ],
+                expected_optional_commands: &["just pr-fast", "just ci-gate"],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "memory-sensitive runtime",
+                files: &["docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md"],
+                expected_surfaces: &["memory_sensitive_runtime", "docs"],
+                expected_required_commands: &[
+                    "cargo xtask fmt",
+                    "cargo xtask check-memory-lifecycle-policy",
+                    "git diff --check",
+                ],
+                expected_optional_commands: &["just pr-fast", "just ci-gate"],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                    "For memory-sensitive edits",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "retained-owner candidate",
+                files: &["crates/perl-workspace/src/workspace/workspace_index.rs"],
+                expected_surfaces: &[
+                    "memory_sensitive_runtime",
+                    "retained_owner_candidate",
+                    "rust_code",
+                ],
+                expected_required_commands: &[
+                    "cargo xtask fmt",
+                    "cargo xtask check-memory-lifecycle-policy",
+                    "cargo xtask check-memory-retained-owner-drift --base origin/master",
+                    "git diff --check",
+                ],
+                expected_optional_commands: &["just pr-fast", "just ci-gate"],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                    "For memory-sensitive edits",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "release/version surface",
+                files: &["rust-toolchain.toml"],
+                expected_surfaces: &["release_version"],
+                expected_required_commands: &[
+                    "cargo xtask fmt",
+                    "just version-check",
+                    "just release-check",
+                    "git diff --check",
+                ],
+                expected_optional_commands: &["just pr-fast", "just ci-gate"],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "policy/CI surface",
+                files: &[".github/workflows/ci.yml"],
+                expected_surfaces: &["policy_ci"],
+                expected_required_commands: &["cargo xtask fmt", "git diff --check"],
+                expected_optional_commands: &[
+                    "just pr-fast",
+                    "just ci-gate",
+                    "cargo xtask workflow-policy-lint",
+                    "cargo xtask workflow-trigger-lint",
+                ],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "xtask/devex tooling",
+                files: &["xtask/src/tasks/devex_plan.rs"],
+                expected_surfaces: &["policy_ci", "rust_code"],
+                expected_required_commands: &["cargo xtask fmt", "git diff --check"],
+                expected_optional_commands: &[
+                    "just pr-fast",
+                    "just ci-gate",
+                    "cargo xtask workflow-policy-lint",
+                    "cargo xtask workflow-trigger-lint",
+                ],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "mixed parser + status",
+                files: &["docs/project/status/parser.md"],
+                expected_surfaces: &["parser_accuracy", "generated_status_docs", "docs"],
+                expected_required_commands: &[
+                    "cargo xtask fmt",
+                    "just ci-metrics-ratchet-check parser_accuracy",
+                    "just status-update",
+                    "just status-check",
+                    "git diff --check",
+                ],
+                expected_optional_commands: &[
+                    "just pr-fast",
+                    "just ci-gate",
+                    "just cpan-corpus-check",
+                    "just corpus-sweep-check",
+                ],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                    "For parser-accuracy edits",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "mixed memory + retained owner",
+                files: &["crates/perl-lsp-rs/src/runtime/text_sync.rs"],
+                expected_surfaces: &[
+                    "memory_sensitive_runtime",
+                    "retained_owner_candidate",
+                    "rust_code",
+                ],
+                expected_required_commands: &[
+                    "cargo xtask fmt",
+                    "cargo xtask check-memory-lifecycle-policy",
+                    "cargo xtask check-memory-retained-owner-drift --base origin/master",
+                    "git diff --check",
+                ],
+                expected_optional_commands: &["just pr-fast", "just ci-gate"],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                    "For memory-sensitive edits",
+                ],
+            },
+            DevexRoutingFixture {
+                name: "mixed release + changelog",
+                files: &["CHANGELOG.md"],
+                expected_surfaces: &["release_version", "docs"],
+                expected_required_commands: &[
+                    "cargo xtask fmt",
+                    "just version-check",
+                    "just release-check",
+                    "git diff --check",
+                ],
+                expected_optional_commands: &["just pr-fast", "just ci-gate"],
+                expected_agent_hint_snippets: &[
+                    "Use `just agent-check`",
+                    "Use `just agent-pr-fast`",
+                ],
+            },
+        ];
+
+        for fixture in fixtures {
+            let plan = build_plan(
+                "origin/master".to_string(),
+                "abc123".to_string(),
+                strings(fixture.files),
+            );
+
+            assert_eq!(
+                surface_strings(&plan),
+                strings(fixture.expected_surfaces),
+                "{}: changed surfaces",
+                fixture.name
+            );
+            assert_eq!(
+                command_strings(&plan.required_commands),
+                strings(fixture.expected_required_commands),
+                "{}: required proof commands",
+                fixture.name
+            );
+            assert_eq!(
+                command_strings(&plan.optional_commands),
+                strings(fixture.expected_optional_commands),
+                "{}: optional proof commands",
+                fixture.name
+            );
+            assert_eq!(
+                plan.agent_hints.len(),
+                fixture.expected_agent_hint_snippets.len(),
+                "{}: agent hint count",
+                fixture.name
+            );
+            for snippet in fixture.expected_agent_hint_snippets {
+                assert!(
+                    plan.agent_hints.iter().any(|hint| hint.contains(snippet)),
+                    "{}: missing agent hint containing `{snippet}` in {:?}",
+                    fixture.name,
+                    plan.agent_hints
+                );
+            }
+        }
+    }
+
     #[test]
     fn plan_routes_parser_accuracy_status_memory_and_release_surfaces() {
         let plan = build_plan(


### PR DESCRIPTION
## Summary

- Add a table-driven DevEx routing fixture matrix for `xtask/src/tasks/devex_plan.rs`.
- Cover docs-only, Rust-only, parser accuracy, generated status docs, memory-sensitive runtime, retained-owner candidate, release/version, policy/CI, xtask/devex tooling, and mixed-surface changes.
- Record the first `ripr` dogfood note for the DevEx test-gap burn-down and file the upstream ripr finding.

## Proof packet

Changed surfaces:
- policy_ci
- rust_code
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command exited cleanly
- [x] cargo test -p xtask devex_plan -- --nocapture
  - why: locks the DevEx planner routing fixture matrix and existing renderer/receipt tests
  - evidence: 7 xtask DevEx tests passed
- [x] cargo xtask devex pr-body --base HEAD~1
  - why: verifies the PR proof-packet renderer still works for this branch
  - evidence: wrote `target/ripr/dogfood/devex/final-pr-body.md`
- [x] git diff --check
  - why: guards final patch whitespace
  - evidence: command exited cleanly

Optional proof:
- [ ] just pr-fast
- [ ] just ci-gate
- [ ] cargo xtask workflow-policy-lint
- [ ] cargo xtask workflow-trigger-lint

## ripr dogfood

Artifacts captured locally:
- pilot: `target/ripr/dogfood/devex/pilot/`
- before: `target/ripr/dogfood/devex/before-routing.repo-exposure.json`
- after: `target/ripr/dogfood/devex/after-routing.repo-exposure.json`
- outcome: `target/ripr/dogfood/devex/routing-outcome.md`
- agent brief before: `target/ripr/dogfood/devex/agent-brief.before.json`
- agent brief after: `target/ripr/dogfood/devex/agent-brief.after.json`
- agent verify: `target/ripr/dogfood/devex/routing-agent-verify.json`
- agent receipt: `target/ripr/dogfood/devex/routing-agent-receipt.json`

Outcome summary:
- moved: 0
- unchanged: 115920
- regressed/new/removed: 0

Dogfood finding:
- `ripr` completed the static loop, but did not surface the DevEx routing seam or recognize the new table-driven routing test as an improved discriminator.
- `ripr agent status` is not available in installed `ripr` 0.4.0, so this run used `ripr agent brief` instead.

Upstream issue opened:
- EffortlessMetrics/ripr#508: `dogfood(perl-lsp): table-driven DevEx routing test did not move repo exposure`

Receipt:
- `target/devex/local-proof.json`
