### PR TITLE
feat(hir): add crate-local lowering baseline (#8192)

### DIFF
--- a/crates/perl-parser-core/src/hir/lower.rs
+++ b/crates/perl-parser-core/src/hir/lower.rs
@@ -1,0 +1,167 @@
+//! AST-to-HIR lowering.
+
+use crate::{Node, NodeKind, SourceLocation};
+
+use super::model::{
+    AstAnchor, HirFile, HirId, HirItem, HirKind, MethodDecl, PackageDecl, RecoveryConfidence,
+    RequireDecl, SubDecl, UseDecl,
+};
+
+/// Lower a parser AST into first-slice HIR items.
+///
+/// This is intentionally conservative: it emits only package, subroutine,
+/// method, use, and require items, and it does not perform scope, stash, import,
+/// or provider behavior changes.
+pub fn lower_ast(ast: &Node) -> HirFile {
+    let mut lowerer = Lowerer::default();
+    lowerer.visit(ast, RecoveryConfidence::Parsed);
+    lowerer.finish()
+}
+
+#[derive(Default)]
+struct Lowerer {
+    items: Vec<HirItem>,
+    next_id: u32,
+    package_context: Option<String>,
+}
+
+impl Lowerer {
+    fn finish(self) -> HirFile {
+        HirFile { items: self.items }
+    }
+
+    fn visit(&mut self, node: &Node, confidence: RecoveryConfidence) {
+        match &node.kind {
+            NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                for statement in statements {
+                    self.visit(statement, confidence);
+                }
+            }
+            NodeKind::Package { name, name_span, block } => {
+                self.push_item(
+                    node,
+                    Some(*name_span),
+                    confidence,
+                    HirKind::PackageDecl(PackageDecl {
+                        name: name.clone(),
+                        name_range: *name_span,
+                        has_block: block.is_some(),
+                    }),
+                    Some(name.clone()),
+                );
+
+                if let Some(block) = block {
+                    let previous_package = self.package_context.replace(name.clone());
+                    self.visit(block, confidence);
+                    self.package_context = previous_package;
+                } else {
+                    self.package_context = Some(name.clone());
+                }
+            }
+            NodeKind::Subroutine { name, name_span, prototype, signature, attributes, .. } => {
+                self.push_item(
+                    node,
+                    *name_span,
+                    confidence,
+                    HirKind::SubDecl(SubDecl {
+                        name: name.clone(),
+                        name_range: *name_span,
+                        has_prototype: prototype.is_some(),
+                        has_signature: signature.is_some(),
+                        attribute_count: attributes.len(),
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::Method { name, signature, attributes, .. } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::MethodDecl(MethodDecl {
+                        name: name.clone(),
+                        has_signature: signature.is_some(),
+                        attribute_count: attributes.len(),
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::Use { module, args, has_filter_risk } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::UseDecl(UseDecl {
+                        module: module.clone(),
+                        args: args.clone(),
+                        has_filter_risk: *has_filter_risk,
+                    }),
+                    self.package_context.clone(),
+                );
+            }
+            NodeKind::FunctionCall { name, args } if name == "require" => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::RequireDecl(RequireDecl {
+                        target: require_target(args.first()),
+                        arg_count: args.len(),
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::Error { partial: Some(partial), .. } => {
+                self.visit(partial, RecoveryConfidence::Recovered);
+            }
+            NodeKind::Error { partial: None, .. }
+            | NodeKind::MissingExpression
+            | NodeKind::MissingStatement
+            | NodeKind::MissingIdentifier
+            | NodeKind::MissingBlock
+            | NodeKind::UnknownRest => {}
+            _ => self.visit_children(node, confidence),
+        }
+    }
+
+    fn visit_children(&mut self, node: &Node, confidence: RecoveryConfidence) {
+        node.for_each_child(|child| self.visit(child, confidence));
+    }
+
+    fn push_item(
+        &mut self,
+        node: &Node,
+        name_range: Option<SourceLocation>,
+        recovery_confidence: RecoveryConfidence,
+        kind: HirKind,
+        package_context: Option<String>,
+    ) {
+        let id = HirId::from_index(self.next_id);
+        self.next_id += 1;
+        self.items.push(HirItem {
+            id,
+            kind,
+            range: node.location,
+            anchor: AstAnchor {
+                node_kind: node.kind.kind_name(),
+                range: node.location,
+                name_range,
+            },
+            recovery_confidence,
+            package_context,
+            scope_context: None,
+        });
+    }
+}
+
+fn require_target(argument: Option<&Node>) -> Option<String> {
+    match argument.map(|node| &node.kind) {
+        Some(NodeKind::Identifier { name })
+        | Some(NodeKind::String { value: name, .. })
+        | Some(NodeKind::Typeglob { name }) => Some(name.clone()),
+        _ => None,
+    }
+}

--- a/crates/perl-parser-core/src/hir/mod.rs
+++ b/crates/perl-parser-core/src/hir/mod.rs
@@ -1,0 +1,14 @@
+//! High-level IR lowered from the parser AST.
+//!
+//! HIR is the first compiler-substrate layer above raw parser nodes. It keeps
+//! stable language constructs, parser anchors, source ranges, and conservative
+//! context placeholders without changing LSP provider behavior.
+
+mod lower;
+mod model;
+
+pub use lower::lower_ast;
+pub use model::{
+    AstAnchor, HirFile, HirId, HirItem, HirKind, MethodDecl, PackageDecl, RecoveryConfidence,
+    RequireDecl, SubDecl, UseDecl,
+};

--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -1,0 +1,164 @@
+//! HIR data model.
+
+use crate::SourceLocation;
+
+/// Stable identifier for a HIR item within one lowered file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[non_exhaustive]
+pub struct HirId {
+    index: u32,
+}
+
+impl HirId {
+    /// Create an identifier from a zero-based lowering index.
+    #[inline]
+    pub const fn from_index(index: u32) -> Self {
+        Self { index }
+    }
+
+    /// Return the zero-based lowering index.
+    #[inline]
+    pub const fn index(self) -> u32 {
+        self.index
+    }
+}
+
+/// Parser AST location that produced a HIR item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AstAnchor {
+    /// Parser AST node kind name.
+    pub node_kind: &'static str,
+    /// Full AST node source range.
+    pub range: SourceLocation,
+    /// Precise name range when the AST exposes one.
+    pub name_range: Option<SourceLocation>,
+}
+
+/// Recovery quality for a lowered HIR item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum RecoveryConfidence {
+    /// Lowered from a normally parsed AST node.
+    Parsed,
+    /// Lowered from a parser recovery wrapper with a partial valid tree.
+    Recovered,
+    /// Lowered from a partially known or placeholder AST shape.
+    Partial,
+    /// Lowering could not classify recovery confidence yet.
+    Unknown,
+}
+
+/// HIR for one parsed file.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct HirFile {
+    /// Items lowered in stable depth-first source order.
+    pub items: Vec<HirItem>,
+}
+
+impl HirFile {
+    /// Return true when no HIR items were lowered.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+/// One lowered HIR item with common metadata required by compiler layers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct HirItem {
+    /// Stable item id for this file.
+    pub id: HirId,
+    /// Lowered language construct.
+    pub kind: HirKind,
+    /// Source range for the construct.
+    pub range: SourceLocation,
+    /// Parser AST anchor for this item.
+    pub anchor: AstAnchor,
+    /// Recovery quality inherited from parser recovery.
+    pub recovery_confidence: RecoveryConfidence,
+    /// Package context known at lowering time.
+    pub package_context: Option<String>,
+    /// Scope context placeholder for later scope-graph work.
+    pub scope_context: Option<HirId>,
+}
+
+/// First-slice HIR constructs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HirKind {
+    /// `package Foo;` or block package declaration.
+    PackageDecl(PackageDecl),
+    /// `sub foo { ... }` declaration.
+    SubDecl(SubDecl),
+    /// `method foo { ... }` declaration.
+    MethodDecl(MethodDecl),
+    /// `use Module ...;` declaration.
+    UseDecl(UseDecl),
+    /// `require Module;` call recognized as a compile-time declaration shape.
+    RequireDecl(RequireDecl),
+}
+
+/// Package declaration HIR payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PackageDecl {
+    /// Package name.
+    pub name: String,
+    /// Precise package-name source range.
+    pub name_range: SourceLocation,
+    /// Whether this declaration owns an inline block.
+    pub has_block: bool,
+}
+
+/// Subroutine declaration HIR payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SubDecl {
+    /// Subroutine name, absent for anonymous subs.
+    pub name: Option<String>,
+    /// Precise subroutine-name source range when available.
+    pub name_range: Option<SourceLocation>,
+    /// Whether the declaration has a prototype.
+    pub has_prototype: bool,
+    /// Whether the declaration has a signature.
+    pub has_signature: bool,
+    /// Number of parsed attributes.
+    pub attribute_count: usize,
+}
+
+/// Method declaration HIR payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MethodDecl {
+    /// Method name.
+    pub name: String,
+    /// Whether the declaration has a signature.
+    pub has_signature: bool,
+    /// Number of parsed attributes.
+    pub attribute_count: usize,
+}
+
+/// Use declaration HIR payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct UseDecl {
+    /// Module or pragma name.
+    pub module: String,
+    /// Parsed import arguments.
+    pub args: Vec<String>,
+    /// Whether the parser classified the module as a source-filter risk.
+    pub has_filter_risk: bool,
+}
+
+/// Require declaration HIR payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RequireDecl {
+    /// Statically recognized require target when available.
+    pub target: Option<String>,
+    /// Number of parser arguments on the underlying function call.
+    pub arg_count: usize,
+}

--- a/crates/perl-parser-core/src/lib.rs
+++ b/crates/perl-parser-core/src/lib.rs
@@ -89,6 +89,8 @@
 pub use perl_lexer::builtins;
 /// Parser engine components and supporting utilities.
 pub mod engine;
+/// Normalized high-level constructs lowered from the parser AST.
+pub mod hir;
 /// Syntax-level types absorbed from Wave D satellite crates.
 pub mod syntax;
 /// Token stream and trivia utilities for the parser.

--- a/crates/perl-parser-core/tests/hir_tests.rs
+++ b/crates/perl-parser-core/tests/hir_tests.rs
@@ -1,0 +1,126 @@
+use perl_parser_core::hir::{HirFile, HirKind, RecoveryConfidence, lower_ast};
+use perl_parser_core::{Node, NodeKind, Parser, SourceLocation};
+
+fn lower_source(source: &str) -> HirFile {
+    let mut parser = Parser::new(source);
+    let output = parser.parse_with_recovery();
+    lower_ast(&output.ast)
+}
+
+fn render_hir(file: &HirFile) -> String {
+    file.items.iter().map(render_item).collect::<Vec<_>>().join("\n")
+}
+
+fn render_item(item: &perl_parser_core::hir::HirItem) -> String {
+    let package = item.package_context.as_deref().unwrap_or("<none>");
+    let scope =
+        item.scope_context.map(|id| id.index().to_string()).unwrap_or_else(|| "<none>".to_string());
+    let name_anchor = if item.anchor.name_range.is_some() { "name" } else { "node" };
+    let kind = match &item.kind {
+        HirKind::PackageDecl(decl) => format!("PackageDecl {}", decl.name),
+        HirKind::SubDecl(decl) => {
+            let name = decl.name.as_deref().unwrap_or("<anonymous>");
+            format!(
+                "SubDecl {name} proto={} sig={} attrs={}",
+                decl.has_prototype, decl.has_signature, decl.attribute_count
+            )
+        }
+        HirKind::MethodDecl(decl) => format!(
+            "MethodDecl {} sig={} attrs={}",
+            decl.name, decl.has_signature, decl.attribute_count
+        ),
+        HirKind::UseDecl(decl) => format!(
+            "UseDecl {} args={} filter={}",
+            decl.module,
+            decl.args.join(","),
+            decl.has_filter_risk
+        ),
+        HirKind::RequireDecl(decl) => {
+            let target = decl.target.as_deref().unwrap_or("<dynamic>");
+            format!("RequireDecl {target} args={}", decl.arg_count)
+        }
+        _ => "UnknownFutureHirKind".to_string(),
+    };
+    format!(
+        "{} {kind} pkg={package} recovery={:?} anchor={} via={name_anchor} scope={scope}",
+        item.id.index(),
+        item.recovery_confidence,
+        item.anchor.node_kind
+    )
+}
+
+#[test]
+fn hir_lowers_first_slice_constructs_with_stable_metadata() -> Result<(), Box<dyn std::error::Error>>
+{
+    let file = lower_source(
+        "package My::Module;\n\
+         use List::Util qw(sum);\n\
+         require Other::Module;\n\
+         sub greet ($) :lvalue { 1; }\n\
+         method run { 1; }\n",
+    );
+
+    assert_eq!(
+        render_hir(&file),
+        "0 PackageDecl My::Module pkg=My::Module recovery=Parsed anchor=Package via=name scope=<none>\n\
+         1 UseDecl List::Util args=qw(sum) filter=false pkg=My::Module recovery=Parsed anchor=Use via=node scope=<none>\n\
+         2 RequireDecl Other::Module args=1 pkg=My::Module recovery=Parsed anchor=FunctionCall via=node scope=<none>\n\
+         3 SubDecl greet proto=true sig=false attrs=1 pkg=My::Module recovery=Parsed anchor=Subroutine via=name scope=<none>\n\
+         4 MethodDecl run sig=false attrs=0 pkg=My::Module recovery=Parsed anchor=Method via=node scope=<none>"
+    );
+
+    for (index, item) in file.items.iter().enumerate() {
+        assert_eq!(item.id.index(), index as u32);
+        assert!(item.range.end >= item.range.start, "HIR item range should be ordered: {:?}", item);
+        assert_eq!(item.range, item.anchor.range);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn hir_marks_items_lowered_from_error_partials_as_recovered()
+-> Result<(), Box<dyn std::error::Error>> {
+    let loc = SourceLocation { start: 0, end: 12 };
+    let partial = Node::new(
+        NodeKind::Subroutine {
+            name: Some("broken".to_string()),
+            name_span: Some(SourceLocation { start: 4, end: 10 }),
+            prototype: None,
+            signature: None,
+            attributes: Vec::new(),
+            body: Box::new(Node::new(
+                NodeKind::MissingBlock,
+                SourceLocation { start: 11, end: 11 },
+            )),
+        },
+        loc,
+    );
+    let ast = Node::new(
+        NodeKind::Program {
+            statements: vec![Node::new(
+                NodeKind::Error {
+                    message: "missing block".to_string(),
+                    expected: Vec::new(),
+                    found: None,
+                    partial: Some(Box::new(partial)),
+                },
+                loc,
+            )],
+        },
+        loc,
+    );
+
+    let file = lower_ast(&ast);
+    let Some(item) = file.items.first() else {
+        return Err("expected recovered HIR item".into());
+    };
+
+    assert_eq!(item.recovery_confidence, RecoveryConfidence::Recovered);
+    assert_eq!(
+        render_hir(&file),
+        "0 SubDecl broken proto=false sig=false attrs=0 pkg=<none> recovery=Recovered anchor=Subroutine via=name scope=<none>"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Problem: Compiler semantics need a normalized HIR layer instead of building directly on raw parser nodes.
Fix: Add a crate-local perl-parser-core HIR model/lowerer for package, sub, method, use, and require constructs with stable ids, ranges, parser anchors, recovery confidence, package context, and scope placeholders; no provider cutover.
Verification: `cargo test -p perl-parser-core --test hir_tests --profile agent --locked`; `cargo test -p perl-parser-core --profile agent --locked hir`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --test hir_tests --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`. Full `cargo clippy -p perl-parser-core --all-targets --profile agent --locked -- -D warnings -A missing_docs` is blocked on current `origin/master` by `panic!` in `crates/perl-parser-core/tests/fix_scoped_sub_declarations.rs`.