### PR TITLE
test(devex): lock local proof receipt contract (#0000)

### DIFF
--- a/docs/devex/ripr-dogfood/devex-receipt-contract-20260507.md
+++ b/docs/devex/ripr-dogfood/devex-receipt-contract-20260507.md
@@ -1,0 +1,47 @@
+# ripr dogfood note: DevEx receipt contract PR
+
+## Target
+
+- Repo: perl-lsp
+- Area: xtask DevEx local proof receipt contract
+- PR: EffortlessMetrics/perl-lsp#8213
+- Commit range: origin/master..working tree
+
+## ripr run
+
+- before: `target/ripr/dogfood/devex-receipt-contract/before.repo-exposure.json`
+- after: `target/ripr/dogfood/devex-receipt-contract/after.repo-exposure.json`
+- outcome: `target/ripr/dogfood/devex-receipt-contract/outcome.md`
+- agent brief after: `target/ripr/dogfood/devex-receipt-contract/agent-brief.after.json`
+- agent verify: `target/ripr/dogfood/devex-receipt-contract/agent-verify.json`
+- agent receipt: `target/ripr/dogfood/devex-receipt-contract/agent-receipt.json`
+
+## What ripr found correctly
+
+- `ripr check` completed and produced comparable before/after snapshots for
+  the receipt-contract test slice.
+- `ripr outcome` made the no-movement result explicit: changed `0`,
+  improved `0`, resolved `0`, unchanged `115926`.
+- `ripr agent verify` produced an advisory before/after summary from the saved
+  snapshots.
+
+## What ripr missed
+
+- The focused test locks the JSON handoff contract for `DevexReceipt`,
+  including top-level fields, proof command object fields, surfaces, hints,
+  worktree cleanliness, and generated timestamp.
+- The agent artifacts did not surface the receipt serializer or contract test
+  as a useful DevEx seam.
+- Because verify had no changed receipt seam, `ripr agent receipt` had to be
+  exercised against an unrelated unchanged seam.
+
+## What was noisy
+
+- This repeated the output/serialization oracle gap already captured in
+  EffortlessMetrics/ripr#511, so no duplicate upstream issue was opened.
+- The before/after repo-exposure JSON files remained about 365 MB each for a
+  small test-only diff.
+
+## Upstream ripr issues opened
+
+- No new issue; tracked by EffortlessMetrics/ripr#511.

--- a/xtask/src/tasks/devex_plan.rs
+++ b/xtask/src/tasks/devex_plan.rs
@@ -754,6 +754,14 @@ mod tests {
         commands.iter().map(|proof| proof.command.clone()).collect()
     }
 
+    fn assert_object_keys(object: &serde_json::Map<String, serde_json::Value>, expected: &[&str]) {
+        let mut actual = object.keys().map(String::as_str).collect::<Vec<_>>();
+        let mut expected = expected.to_vec();
+        actual.sort_unstable();
+        expected.sort_unstable();
+        assert_eq!(actual, expected);
+    }
+
     fn plan_for(files: &[&str]) -> Plan {
         build_plan("origin/master".to_string(), "abcdef1234567890".to_string(), strings(files))
     }
@@ -1125,6 +1133,91 @@ Agent-safe hints:
   "generated_at": "2026-05-07T12:00:00Z"
 }"#
         );
+    }
+
+    #[test]
+    fn receipt_json_contract_keeps_agent_handoff_fields_stable() {
+        let receipt = build_receipt_payload(
+            plan_for(&[
+                "docs/project/status/parser.md",
+                "crates/perl-lsp-rs/src/runtime/text_sync.rs",
+                "CHANGELOG.md",
+            ]),
+            false,
+            "2026-05-07T12:34:56Z".to_string(),
+        )
+        .unwrap();
+
+        let value = serde_json::to_value(&receipt).expect("receipt should serialize");
+        let object = value.as_object().expect("receipt should serialize as an object");
+        assert_object_keys(
+            object,
+            &[
+                "base",
+                "head",
+                "changed_files",
+                "changed_surfaces",
+                "required_proof",
+                "optional_proof",
+                "agent_hints",
+                "worktree_clean",
+                "generated_at",
+            ],
+        );
+        assert_eq!(value["base"], "origin/master");
+        assert_eq!(value["head"], "abcdef1234567890");
+        assert_eq!(value["worktree_clean"], false);
+        assert_eq!(value["generated_at"], "2026-05-07T12:34:56Z");
+        assert_eq!(
+            value["changed_files"],
+            serde_json::json!([
+                "docs/project/status/parser.md",
+                "crates/perl-lsp-rs/src/runtime/text_sync.rs",
+                "CHANGELOG.md"
+            ])
+        );
+        assert_eq!(
+            value["changed_surfaces"],
+            serde_json::json!([
+                "parser_accuracy",
+                "generated_status_docs",
+                "memory_sensitive_runtime",
+                "retained_owner_candidate",
+                "release_version",
+                "rust_code",
+                "docs"
+            ])
+        );
+
+        let required = value["required_proof"].as_array().expect("required proof array");
+        assert!(required.len() >= 2, "required proof should not collapse to an empty contract");
+        for proof in required {
+            let proof_object = proof.as_object().expect("proof command should be an object");
+            assert_object_keys(proof_object, &["command", "why", "evidence"]);
+            assert!(proof["command"].as_str().is_some_and(|command| !command.is_empty()));
+            assert!(proof["why"].as_str().is_some_and(|why| !why.is_empty()));
+            assert!(proof["evidence"].as_str().is_some_and(|evidence| !evidence.is_empty()));
+        }
+
+        let optional = value["optional_proof"].as_array().expect("optional proof array");
+        assert!(optional.iter().any(|proof| proof["command"] == "just pr-fast"));
+        for proof in optional {
+            let proof_object = proof.as_object().expect("optional proof should be an object");
+            assert_object_keys(proof_object, &["command", "why", "evidence"]);
+        }
+
+        let hints = value["agent_hints"].as_array().expect("agent hints array");
+        assert!(
+            hints.iter().any(|hint| {
+                hint.as_str().is_some_and(|hint| hint.contains("just agent-check"))
+            })
+        );
+        assert!(hints.iter().any(|hint| {
+            hint.as_str().is_some_and(|hint| hint.contains("For memory-sensitive edits"))
+        }));
+        assert!(hints.iter().any(|hint| {
+            hint.as_str().is_some_and(|hint| hint.contains("For parser-accuracy edits"))
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a receipt JSON contract test for `DevexReceipt` agent handoff fields.
- Assert top-level receipt fields, proof command object fields, changed files/surfaces, agent hints, worktree cleanliness, and generated timestamp.
- Record the third `ripr` dogfood note and tie the repeated serialization/oracle miss to `ripr#511` instead of opening a duplicate.

## Proof packet

Changed surfaces:
- policy_ci
- rust_code
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command exited cleanly
- [x] cargo test -p xtask devex_plan -- --nocapture
  - why: locks DevEx routing, renderer goldens, and the new receipt contract test
  - evidence: 13 xtask DevEx tests passed
- [x] cargo xtask devex pr-body --base HEAD~1
  - why: verifies the PR proof-packet renderer still works for this branch
  - evidence: wrote `target/ripr/dogfood/devex-receipt-contract/final-pr-body.md`
- [x] git diff --check
  - why: guards final patch whitespace
  - evidence: command exited cleanly

Optional proof:
- [ ] just pr-fast
- [ ] just ci-gate
- [ ] cargo xtask workflow-policy-lint
- [ ] cargo xtask workflow-trigger-lint

## ripr dogfood

Artifacts captured locally:
- before: `target/ripr/dogfood/devex-receipt-contract/before.repo-exposure.json`
- after: `target/ripr/dogfood/devex-receipt-contract/after.repo-exposure.json`
- outcome: `target/ripr/dogfood/devex-receipt-contract/outcome.md`
- agent brief after: `target/ripr/dogfood/devex-receipt-contract/agent-brief.after.json`
- agent verify: `target/ripr/dogfood/devex-receipt-contract/agent-verify.json`
- agent receipt: `target/ripr/dogfood/devex-receipt-contract/agent-receipt.json`

Outcome summary:
- changed: 0
- improved: 0
- resolved: 0
- unchanged: 115926

Dogfood finding:
- This repeats the output/serialization oracle-recognition gap already tracked in EffortlessMetrics/ripr#511, so no duplicate upstream issue was opened.

Receipt:
- `target/devex/local-proof.json`
