### PR TITLE
test(devex): verify planner proof commands exist (#0000)

### DIFF
--- a/docs/devex/ripr-dogfood/devex-command-existence-20260507.md
+++ b/docs/devex/ripr-dogfood/devex-command-existence-20260507.md
@@ -1,0 +1,47 @@
+# ripr dogfood note: DevEx command existence PR
+
+## Target
+
+- Repo: perl-lsp
+- Area: xtask DevEx planner proof command validity
+- PR: EffortlessMetrics/perl-lsp#8214
+- Commit range: origin/master..working tree
+
+## ripr run
+
+- before: `target/ripr/dogfood/devex-command-existence/before.repo-exposure.json`
+- after: `target/ripr/dogfood/devex-command-existence/after.repo-exposure.json`
+- outcome: `target/ripr/dogfood/devex-command-existence/outcome.md`
+- agent verify: `target/ripr/dogfood/devex-command-existence/agent-verify.json`
+- agent receipt: `target/ripr/dogfood/devex-command-existence/agent-receipt.json`
+
+## What ripr found correctly
+
+- `ripr check` completed and produced comparable before/after snapshots for
+  the command-existence guard slice.
+- `ripr outcome` made the no-movement result explicit: changed `0`,
+  improved `0`, resolved `0`, unchanged `116033`.
+- `ripr agent verify` produced an advisory before/after summary from the saved
+  snapshots.
+
+## What ripr missed
+
+- The focused test validates every planner-emitted proof command against a
+  real local command surface: `just` recipes from the justfile, `cargo xtask`
+  subcommands from clap metadata, or the explicitly allowed `git diff --check`.
+- The test would catch a stale proof recommendation such as `just status-updat`
+  or `cargo xtask check-memory-retained-owner-drift2`.
+- The agent artifacts did not surface the command router or local-command
+  inventory as a useful DevEx seam.
+
+## What was noisy
+
+- This is another instance of the DevEx tooling/output oracle gap already
+  tracked in EffortlessMetrics/ripr#511, so no duplicate upstream issue was
+  opened.
+- The before/after repo-exposure JSON files remained large for a small
+  test-only diff.
+
+## Upstream ripr issues opened
+
+- No new issue; tracked by EffortlessMetrics/ripr#511.

--- a/xtask/src/tasks/devex_plan.rs
+++ b/xtask/src/tasks/devex_plan.rs
@@ -745,6 +745,7 @@ fn render_plan(plan: &Plan) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     fn strings(paths: &[&str]) -> Vec<String> {
         paths.iter().map(|path| path.to_string()).collect()
@@ -768,6 +769,52 @@ mod tests {
 
     fn surface_strings(plan: &Plan) -> Vec<String> {
         plan.surfaces.iter().map(|surface| surface.id().to_string()).collect()
+    }
+
+    fn just_recipes() -> BTreeSet<String> {
+        include_str!("../../../justfile")
+            .lines()
+            .filter_map(|line| {
+                if line.starts_with(char::is_whitespace) || line.starts_with('#') {
+                    return None;
+                }
+                let (name, _) = line.split_once(':')?;
+                let name = name.split_whitespace().next()?;
+                if name.contains('=') || name.is_empty() {
+                    return None;
+                }
+                Some(name.to_string())
+            })
+            .collect()
+    }
+
+    fn xtask_subcommands() -> BTreeSet<String> {
+        crate::Cli::command()
+            .get_subcommands()
+            .map(|command| command.get_name().to_string())
+            .collect()
+    }
+
+    fn assert_proof_command_resolves(command: &str) {
+        let parts = command.split_whitespace().collect::<Vec<_>>();
+        match parts.as_slice() {
+            ["just", recipe, ..] => {
+                let recipes = just_recipes();
+                assert!(
+                    recipes.contains(*recipe),
+                    "`{command}` references missing just recipe `{recipe}`"
+                );
+            }
+            ["cargo", "xtask", subcommand, ..] => {
+                let subcommands = xtask_subcommands();
+                assert!(
+                    subcommands.contains(*subcommand),
+                    "`{command}` references missing cargo xtask subcommand `{subcommand}`"
+                );
+            }
+            ["git", "diff", "--check"] => {}
+            _ => panic!("`{command}` is not a recognized DevEx proof command shape"),
+        }
     }
 
     struct DevexRoutingFixture {
@@ -1027,6 +1074,25 @@ mod tests {
                     plan.agent_hints
                 );
             }
+        }
+    }
+
+    #[test]
+    fn planner_proof_commands_resolve_to_real_local_commands() {
+        let plan = plan_for(&[
+            "docs/project/status/parser.md",
+            "crates/perl-lsp-rs/src/runtime/text_sync.rs",
+            ".github/workflows/ci.yml",
+            "CHANGELOG.md",
+        ]);
+
+        for command in plan
+            .required_commands
+            .iter()
+            .chain(plan.optional_commands.iter())
+            .map(|proof| &proof.command)
+        {
+            assert_proof_command_resolves(command);
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a focused DevEx command-existence guard so planner proof recommendations cannot drift into stale local commands. The test builds a broad DevEx plan and verifies every emitted proof command resolves to one of:

- a real `just` recipe from `justfile`,
- a real `cargo xtask` subcommand from clap metadata, or
- the explicitly allowed `git diff --check` shell command.

Also records the ripr dogfood before/after/outcome loop for this slice. No routing behavior, CI behavior, runtime code, parser metrics, or memory policy changes.

## Proof packet

Changed surfaces:
- policy_ci
- rust_code
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed

- [x] cargo test -p xtask devex_plan -- --nocapture
  - why: DevEx planner command guard changed
  - evidence: 14 DevEx tests passed, including `planner_proof_commands_resolve_to_real_local_commands`

- [x] cargo xtask devex pr-body --base HEAD~1
  - why: validates the paste-ready proof packet still renders for this branch
  - evidence: rendered to `target/ripr/dogfood/devex-command-existence/devex-pr-body.md`

- [x] git diff --check
  - why: guards against whitespace errors in the final patch
  - evidence: command exited cleanly

Optional proof:
- [ ] just pr-fast
- [ ] just ci-gate
- [ ] cargo xtask workflow-policy-lint
- [ ] cargo xtask workflow-trigger-lint

## ripr dogfood

- before: `target/ripr/dogfood/devex-command-existence/before.repo-exposure.json`
- after: `target/ripr/dogfood/devex-command-existence/after.repo-exposure.json`
- outcome: `target/ripr/dogfood/devex-command-existence/outcome.md`
- agent verify: `target/ripr/dogfood/devex-command-existence/agent-verify.json`
- agent receipt: `target/ripr/dogfood/devex-command-existence/agent-receipt.json`
- outcome summary: moved `0`, improved `0`, resolved `0`, unchanged `116033`
- upstream issue: no new issue; this repeats the DevEx tooling/output oracle gap tracked by EffortlessMetrics/ripr#511
