### PR TITLE
test(devex): guard command docs against drift (#0000)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ For Codex Desktop specifically:
 
 1. Open the repository root as the workspace.
 2. Run checks through a POSIX shell (`bash`) even on Windows.
-3. Prefer `just agent-*` commands for large compile/test work.
+3. Prefer `just agent-check`, `just agent-test`, and `just agent-clippy` for large compile/test work.
 4. Use `just pr-fast` or `just ready` before handing a PR to review.
 
 ```bash
@@ -212,6 +212,7 @@ It is a quick push guard, not the full merge gate.
 | Generated status docs touched | `just status-update` then `just status-check` | Regenerates and verifies `docs/project/status/` outputs. |
 | Release/version surfaces touched | `just version-check` then `just release-check` | Verifies version sync and the release-prep gate before tagging/publishing. |
 | Need a command map | `just quick-ref` or [Commands Reference](docs/reference/COMMANDS_REFERENCE.md) | Shows the short command decision tree. |
+| DevEx docs changed | `cargo xtask check-devex-docs` | Verifies toolchain wording and documented command references stay current. |
 
 ### 5. Expand for larger changes or release prep
 

--- a/docs/contributing/FIRST_PR.md
+++ b/docs/contributing/FIRST_PR.md
@@ -178,6 +178,7 @@ If the reviewer pushes a fix directly to your branch, that is normal. Check and 
 | Parser-accuracy metrics | `just ci-metrics-ratchet-check parser_accuracy` |
 | Status docs | `just status-update` then `just status-check` |
 | Release/version prep | `just version-check` then `just release-check` |
+| DevEx docs drift | `cargo xtask check-devex-docs` |
 | Build LSP server | `cargo build -p perl-lsp-rs --release` |
 | Run all library tests | `cargo test --workspace --lib` |
 | Format | `cargo xtask fmt` |

--- a/docs/devex/ripr-dogfood/devex-docs-drift-20260507.md
+++ b/docs/devex/ripr-dogfood/devex-docs-drift-20260507.md
@@ -1,0 +1,49 @@
+# ripr dogfood note: DevEx docs drift PR
+
+## Target
+
+- Repo: perl-lsp
+- Area: xtask DevEx documentation drift guard
+- PR: EffortlessMetrics/perl-lsp#8216
+- Commit range: origin/master..working tree
+
+## ripr run
+
+- before: `target/ripr/dogfood/devex-docs-drift/before.repo-exposure.json`
+- after: `target/ripr/dogfood/devex-docs-drift/after.repo-exposure.json`
+- outcome: `target/ripr/dogfood/devex-docs-drift/outcome.md`
+- agent verify: `target/ripr/dogfood/devex-docs-drift/agent-verify.json`
+- agent receipt: `target/ripr/dogfood/devex-docs-drift/agent-receipt.json`
+
+## What ripr found correctly
+
+- `ripr check` completed and produced comparable before/after snapshots for
+  the docs-drift guard slice.
+- `ripr outcome` made the no-movement result explicit: changed `0`,
+  improved `0`, resolved `0`, unchanged `116033`.
+- `ripr agent verify` produced an advisory before/after summary from the saved
+  snapshots.
+
+## What ripr missed
+
+- The focused guard validates contributor-facing toolchain facts against
+  `rust-toolchain.toml`, including MSRV and pinned channel wording.
+- The guard validates documented `just` and `cargo xtask` references in the
+  contributor quickstart, first-PR guide, and command reference.
+- During implementation, the guard caught two real drift cases:
+  `just agent-*` was a wildcard rather than a real recipe, and
+  `cargo xtask corpus --diagnose` omitted its legacy feature requirement.
+- The agent artifacts did not surface the docs drift checker or documented
+  command-reference scan as a useful DevEx seam.
+
+## What was noisy
+
+- This is another instance of the DevEx tooling/output oracle gap already
+  tracked in EffortlessMetrics/ripr#511, so no duplicate upstream issue was
+  opened.
+- The before/after repo-exposure JSON files remained large for a small
+  docs-and-xtask diff.
+
+## Upstream ripr issues opened
+
+- No new issue; tracked by EffortlessMetrics/ripr#511.

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -92,6 +92,7 @@ perl-dap --stdio  # Standard DAP transport
 | Parser-accuracy metrics touched | `just ci-metrics-ratchet-check parser_accuracy` | Verifies parser-accuracy scorecard floors do not regress. |
 | Generated status docs touched | `just status-update` then `just status-check` | Regenerates and verifies `docs/project/status/` outputs. |
 | Release/version surfaces touched | `just version-check` then `just release-check` | Verifies version sync and the release-prep gate before tagging/publishing. |
+| DevEx docs touched | `cargo xtask check-devex-docs` | Verifies toolchain wording and documented command references stay current. |
 | Need a terminal summary | `just quick-ref` | Prints the short command decision tree. |
 
 ### Common Commands
@@ -1261,7 +1262,7 @@ See [CONTRIBUTING.md](../../CONTRIBUTING.md#release-workflow) for the full relea
 6. Run benchmarks: `cargo bench --features pure-rust`
 
 ### Debugging Parse Failures
-1. Use `cargo xtask corpus --diagnose` for detailed error info
+1. Use `cargo run -p xtask --features legacy -- corpus --diagnose` for detailed error info
 2. For Pest parser: Check parse error messages which show exact location
 3. Use `cargo xtask parse-rust file.pl --ast` to see AST structure
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -60,6 +60,9 @@ enum Commands {
         doctor: bool,
     },
 
+    /// Verify DevEx docs match the toolchain and command surface.
+    CheckDevexDocs,
+
     /// Capture a GitHub PR queue snapshot for disconnected maintainership.
     Queue {
         #[command(subcommand)]
@@ -1942,6 +1945,7 @@ fn main() -> Result<()> {
         Commands::CheckOnly => ci::check_only(),
         Commands::CheckLintPolicy => check_lint_policy::run(),
         Commands::CheckToolchain { doctor } => check_toolchain::run(doctor),
+        Commands::CheckDevexDocs => devex_docs::run(),
         Commands::Queue { command } => match command {
             QueueCommand::Snapshot { out, fixture } => queue_snapshot::run_snapshot(out, fixture),
             QueueCommand::Health { receipt, fixture } => {

--- a/xtask/src/tasks/devex_docs.rs
+++ b/xtask/src/tasks/devex_docs.rs
@@ -1,0 +1,214 @@
+//! DevEx documentation drift checks.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+use clap::CommandFactory;
+use color_eyre::eyre::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::utils::project_root;
+
+#[derive(Debug, Deserialize)]
+struct RustToolchainFile {
+    toolchain: RustToolchain,
+}
+
+#[derive(Debug, Deserialize)]
+struct RustToolchain {
+    channel: String,
+}
+
+pub fn run() -> Result<()> {
+    let root = project_root()?;
+    let report = check_devex_docs(&root)?;
+    if report.errors.is_empty() {
+        println!("DevEx docs drift check passed");
+        return Ok(());
+    }
+
+    bail!("DevEx docs drift check failed:\n{}", report.errors.join("\n"));
+}
+
+#[derive(Debug, Default)]
+struct DevexDocsReport {
+    errors: Vec<String>,
+}
+
+fn check_devex_docs(root: &Path) -> Result<DevexDocsReport> {
+    let mut report = DevexDocsReport::default();
+    check_toolchain_docs(root, &mut report)?;
+    check_documented_commands(root, &mut report)?;
+    Ok(report)
+}
+
+fn check_toolchain_docs(root: &Path, report: &mut DevexDocsReport) -> Result<()> {
+    let channel = pinned_toolchain_channel(root)?;
+    let msrv = major_minor(&channel);
+
+    let contributing = read(root, "CONTRIBUTING.md")?;
+    require_contains(report, "CONTRIBUTING.md", &contributing, &format!("MSRV {msrv}"));
+    require_contains(report, "CONTRIBUTING.md", &contributing, &format!("`{channel}`"));
+
+    let first_pr = read(root, "docs/contributing/FIRST_PR.md")?;
+    require_contains(report, "docs/contributing/FIRST_PR.md", &first_pr, &format!("MSRV {msrv}"));
+    require_contains(report, "docs/contributing/FIRST_PR.md", &first_pr, &format!("`{channel}`"));
+
+    let readme = read(root, "README.md")?;
+    require_contains(report, "README.md", &readme, &format!("MSRV-{msrv}"));
+
+    Ok(())
+}
+
+fn check_documented_commands(root: &Path, report: &mut DevexDocsReport) -> Result<()> {
+    let just_recipes = just_recipes(root)?;
+    let xtask_subcommands = xtask_subcommands();
+    for path in
+        ["CONTRIBUTING.md", "docs/reference/COMMANDS_REFERENCE.md", "docs/contributing/FIRST_PR.md"]
+    {
+        let text = read(root, path)?;
+        for command in inline_devex_commands(&text) {
+            if let Err(error) = command_exists(&command, &just_recipes, &xtask_subcommands) {
+                report.errors.push(format!("{path}: {error}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn pinned_toolchain_channel(root: &Path) -> Result<String> {
+    let raw = read(root, "rust-toolchain.toml")?;
+    let toolchain: RustToolchainFile =
+        toml::from_str(&raw).context("parsing rust-toolchain.toml")?;
+    Ok(toolchain.toolchain.channel.trim().to_string())
+}
+
+fn major_minor(channel: &str) -> String {
+    let mut parts = channel.split('.');
+    match (parts.next(), parts.next()) {
+        (Some(major), Some(minor)) => format!("{major}.{minor}"),
+        _ => channel.to_string(),
+    }
+}
+
+fn require_contains(report: &mut DevexDocsReport, path: &str, text: &str, needle: &str) {
+    if !text.contains(needle) {
+        report.errors.push(format!("{path}: missing `{needle}`"));
+    }
+}
+
+fn read(root: &Path, path: &str) -> Result<String> {
+    fs::read_to_string(root.join(path)).with_context(|| format!("reading {path}"))
+}
+
+fn just_recipes(root: &Path) -> Result<BTreeSet<String>> {
+    let justfile = read(root, "justfile")?;
+    Ok(parse_just_recipes(&justfile))
+}
+
+fn parse_just_recipes(justfile: &str) -> BTreeSet<String> {
+    justfile
+        .lines()
+        .filter_map(|line| {
+            if line.starts_with(char::is_whitespace) || line.starts_with('#') {
+                return None;
+            }
+            let (name, _) = line.split_once(':')?;
+            let name = name.split_whitespace().next()?;
+            if name.contains('=') || name.is_empty() {
+                return None;
+            }
+            Some(name.to_string())
+        })
+        .collect()
+}
+
+fn xtask_subcommands() -> BTreeSet<String> {
+    crate::Cli::command().get_subcommands().map(|command| command.get_name().to_string()).collect()
+}
+
+fn inline_devex_commands(text: &str) -> Vec<String> {
+    text.split('`')
+        .enumerate()
+        .filter_map(|(index, segment)| {
+            if index % 2 == 0 {
+                return None;
+            }
+            let command = segment.trim();
+            if command.starts_with("just ") || command.starts_with("cargo xtask ") {
+                Some(command.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn command_exists(
+    command: &str,
+    just_recipes: &BTreeSet<String>,
+    xtask_subcommands: &BTreeSet<String>,
+) -> std::result::Result<(), String> {
+    let parts = command.split_whitespace().collect::<Vec<_>>();
+    match parts.as_slice() {
+        ["just", recipe, ..] => {
+            if just_recipes.contains(*recipe) {
+                Ok(())
+            } else {
+                Err(format!("`{command}` references missing just recipe `{recipe}`"))
+            }
+        }
+        ["cargo", "xtask", subcommand, ..] => {
+            if xtask_subcommands.contains(*subcommand) {
+                Ok(())
+            } else {
+                Err(format!("`{command}` references missing cargo xtask subcommand `{subcommand}`"))
+            }
+        }
+        _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn major_minor_extracts_msrv_badge_version() {
+        assert_eq!(major_minor("1.93.1"), "1.93");
+        assert_eq!(major_minor("1.94"), "1.94");
+    }
+
+    #[test]
+    fn inline_devex_commands_extracts_just_and_xtask_references() {
+        let commands = inline_devex_commands(
+            "| Need | Command |\n|---|---|\n| Fast | `just pr-fast` |\n| Fmt | `cargo xtask fmt` |\n| Rust | `cargo test -p xtask` |\n",
+        );
+        assert_eq!(commands, vec!["just pr-fast", "cargo xtask fmt"]);
+    }
+
+    #[test]
+    fn parse_just_recipes_handles_parameterized_recipes() {
+        let recipes = parse_just_recipes(
+            r#"
+default:
+status-update subsystem="":
+    cargo xtask update-status --write
+"#,
+        );
+        assert!(recipes.contains("default"));
+        assert!(recipes.contains("status-update"));
+    }
+
+    #[test]
+    fn command_exists_rejects_stale_documented_commands() {
+        let just_recipes = BTreeSet::from(["pr-fast".to_string()]);
+        let xtask_subcommands = BTreeSet::from(["fmt".to_string()]);
+
+        assert!(command_exists("just pr-fast", &just_recipes, &xtask_subcommands).is_ok());
+        assert!(command_exists("cargo xtask fmt", &just_recipes, &xtask_subcommands).is_ok());
+        assert!(command_exists("just pr-fats", &just_recipes, &xtask_subcommands).is_err());
+        assert!(command_exists("cargo xtask fmtt", &just_recipes, &xtask_subcommands).is_err());
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -34,6 +34,7 @@ pub mod cpan_corpus;
 pub mod dead_code;
 pub mod debt_report;
 pub mod dev;
+pub mod devex_docs;
 pub mod devex_doctor;
 pub mod devex_plan;
 pub mod doc;


### PR DESCRIPTION
## Summary

Adds `cargo xtask check-devex-docs` as a local/manual DevEx docs drift guard. The check verifies:

- `CONTRIBUTING.md`, `docs/contributing/FIRST_PR.md`, and the README MSRV badge match `rust-toolchain.toml`
- documented `just` references resolve to real justfile recipes
- documented `cargo xtask` references resolve to real clap subcommands

The guard caught and fixes two drift cases while being introduced: `just agent-*` was a wildcard rather than a recipe, and `cargo xtask corpus --diagnose` omitted the required legacy-feature invocation. No CI behavior, runtime code, parser metrics, or memory policy changes.

## Proof packet

Changed surfaces:
- policy_ci
- rust_code
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed

- [x] cargo xtask check-devex-docs
  - why: validates the new DevEx docs drift guard on the current docs
  - evidence: command passed

- [x] cargo test -p xtask devex -- --nocapture
  - why: DevEx docs/planner tests changed
  - evidence: 21 DevEx-related tests passed

- [x] cargo xtask devex pr-body --base HEAD~1
  - why: validates the paste-ready proof packet still renders for this branch
  - evidence: rendered to `target/ripr/dogfood/devex-docs-drift/devex-pr-body.md`

- [x] git diff --check
  - why: guards against whitespace errors in the final patch
  - evidence: command exited cleanly

Optional proof:
- [ ] just pr-fast
- [ ] just ci-gate
- [ ] cargo xtask workflow-policy-lint
- [ ] cargo xtask workflow-trigger-lint

## ripr dogfood

- before: `target/ripr/dogfood/devex-docs-drift/before.repo-exposure.json`
- after: `target/ripr/dogfood/devex-docs-drift/after.repo-exposure.json`
- outcome: `target/ripr/dogfood/devex-docs-drift/outcome.md`
- agent verify: `target/ripr/dogfood/devex-docs-drift/agent-verify.json`
- agent receipt: `target/ripr/dogfood/devex-docs-drift/agent-receipt.json`
- outcome summary: moved `0`, improved `0`, resolved `0`, unchanged `116033`
- upstream issue: no new issue; this repeats the DevEx tooling/output oracle gap tracked by EffortlessMetrics/ripr#511
