### PR TITLE
feat(hir): lower variable declarations (#8192)

### DIFF
--- a/crates/perl-parser-core/src/hir/lower.rs
+++ b/crates/perl-parser-core/src/hir/lower.rs
@@ -4,14 +4,14 @@ use crate::{Node, NodeKind, SourceLocation};
 
 use super::model::{
     AstAnchor, HirFile, HirId, HirItem, HirKind, MethodDecl, PackageDecl, RecoveryConfidence,
-    RequireDecl, SubDecl, UseDecl,
+    RequireDecl, SubDecl, UseDecl, VariableBinding, VariableDecl,
 };
 
 /// Lower a parser AST into first-slice HIR items.
 ///
 /// This is intentionally conservative: it emits only package, subroutine,
-/// method, use, and require items, and it does not perform scope, stash, import,
-/// or provider behavior changes.
+/// method, use, require, and variable-declaration items, and it does not
+/// perform scope, stash, import, or provider behavior changes.
 pub fn lower_ast(ast: &Node) -> HirFile {
     let mut lowerer = Lowerer::default();
     lowerer.visit(ast, RecoveryConfidence::Parsed);
@@ -114,6 +114,44 @@ impl Lowerer {
                 );
                 self.visit_children(node, confidence);
             }
+            NodeKind::VariableDeclaration { declarator, variable, attributes, initializer } => {
+                let (variables, has_embedded_initializer) = variable_decl_bindings(variable);
+                self.push_item(
+                    node,
+                    variables.first().map(|binding| binding.range),
+                    confidence,
+                    HirKind::VariableDecl(VariableDecl {
+                        declarator: declarator.clone(),
+                        variables,
+                        attribute_count: attributes.len(),
+                        has_initializer: initializer.is_some() || has_embedded_initializer,
+                        is_list: false,
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::VariableListDeclaration {
+                declarator,
+                variables,
+                attributes,
+                initializer,
+            } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::VariableDecl(VariableDecl {
+                        declarator: declarator.clone(),
+                        variables: variables.iter().filter_map(variable_binding).collect(),
+                        attribute_count: attributes.len(),
+                        has_initializer: initializer.is_some(),
+                        is_list: true,
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
             NodeKind::Error { partial: Some(partial), .. } => {
                 self.visit(partial, RecoveryConfidence::Recovered);
             }
@@ -157,11 +195,34 @@ impl Lowerer {
     }
 }
 
+fn variable_decl_bindings(node: &Node) -> (Vec<VariableBinding>, bool) {
+    match &node.kind {
+        NodeKind::Assignment { lhs, .. } => (variable_binding(lhs).into_iter().collect(), true),
+        NodeKind::VariableWithAttributes { variable, .. } => variable_decl_bindings(variable),
+        _ => (variable_binding(node).into_iter().collect(), false),
+    }
+}
+
 fn require_target(argument: Option<&Node>) -> Option<String> {
     match argument.map(|node| &node.kind) {
         Some(NodeKind::Identifier { name })
         | Some(NodeKind::String { value: name, .. })
         | Some(NodeKind::Typeglob { name }) => Some(name.clone()),
+        _ => None,
+    }
+}
+
+fn variable_binding(node: &Node) -> Option<VariableBinding> {
+    match &node.kind {
+        NodeKind::Variable { sigil, name } => {
+            Some(VariableBinding { sigil: sigil.clone(), name: name.clone(), range: node.location })
+        }
+        NodeKind::VariableWithAttributes { variable, .. } => variable_binding(variable),
+        NodeKind::Typeglob { name } => Some(VariableBinding {
+            sigil: "*".to_string(),
+            name: name.clone(),
+            range: node.location,
+        }),
         _ => None,
     }
 }

--- a/crates/perl-parser-core/src/hir/mod.rs
+++ b/crates/perl-parser-core/src/hir/mod.rs
@@ -10,5 +10,5 @@ mod model;
 pub use lower::lower_ast;
 pub use model::{
     AstAnchor, HirFile, HirId, HirItem, HirKind, MethodDecl, PackageDecl, RecoveryConfidence,
-    RequireDecl, SubDecl, UseDecl,
+    RequireDecl, SubDecl, UseDecl, VariableBinding, VariableDecl,
 };

--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -99,6 +99,8 @@ pub enum HirKind {
     UseDecl(UseDecl),
     /// `require Module;` call recognized as a compile-time declaration shape.
     RequireDecl(RequireDecl),
+    /// `my`, `our`, `state`, or `local` variable declaration.
+    VariableDecl(VariableDecl),
 }
 
 /// Package declaration HIR payload.
@@ -161,4 +163,32 @@ pub struct RequireDecl {
     pub target: Option<String>,
     /// Number of parser arguments on the underlying function call.
     pub arg_count: usize,
+}
+
+/// Variable declaration HIR payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct VariableDecl {
+    /// Scope/storage declarator: `my`, `our`, `state`, or `local`.
+    pub declarator: String,
+    /// Variables statically visible in the declaration.
+    pub variables: Vec<VariableBinding>,
+    /// Number of parsed attributes on the declaration.
+    pub attribute_count: usize,
+    /// Whether the declaration has an initializer expression.
+    pub has_initializer: bool,
+    /// Whether this came from a list declaration.
+    pub is_list: bool,
+}
+
+/// One variable binding named by a declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct VariableBinding {
+    /// Variable sigil.
+    pub sigil: String,
+    /// Variable name without sigil.
+    pub name: String,
+    /// Source range for the variable token.
+    pub range: SourceLocation,
 }

--- a/crates/perl-parser-core/tests/hir_tests.rs
+++ b/crates/perl-parser-core/tests/hir_tests.rs
@@ -39,6 +39,22 @@ fn render_item(item: &perl_parser_core::hir::HirItem) -> String {
             let target = decl.target.as_deref().unwrap_or("<dynamic>");
             format!("RequireDecl {target} args={}", decl.arg_count)
         }
+        HirKind::VariableDecl(decl) => {
+            let variables = decl
+                .variables
+                .iter()
+                .map(|variable| format!("{}{}", variable.sigil, variable.name))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!(
+                "VariableDecl {} vars={} attrs={} init={} list={}",
+                decl.declarator,
+                variables,
+                decl.attribute_count,
+                decl.has_initializer,
+                decl.is_list
+            )
+        }
         _ => "UnknownFutureHirKind".to_string(),
     };
     format!(
@@ -74,6 +90,37 @@ fn hir_lowers_first_slice_constructs_with_stable_metadata() -> Result<(), Box<dy
         assert!(item.range.end >= item.range.start, "HIR item range should be ordered: {:?}", item);
         assert_eq!(item.range, item.anchor.range);
     }
+
+    Ok(())
+}
+
+#[test]
+fn hir_lowers_variable_declarations_without_scope_cutover() -> Result<(), Box<dyn std::error::Error>>
+{
+    let file = lower_source(
+        "package My::Module;\n\
+         my $scalar = 1;\n\
+         our @EXPORT_OK;\n\
+         state %cache;\n\
+         local $temp = undef;\n\
+         local *FH;\n\
+         my ($first, undef, @rest) = @_;\n\
+         open(my $fh, '<', $path);\n",
+    );
+
+    assert_eq!(
+        render_hir(&file),
+        "0 PackageDecl My::Module pkg=My::Module recovery=Parsed anchor=Package via=name scope=<none>\n\
+         1 VariableDecl my vars=$scalar attrs=0 init=true list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         2 VariableDecl our vars=@EXPORT_OK attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         3 VariableDecl state vars=%cache attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         4 VariableDecl local vars=$temp attrs=0 init=true list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         5 VariableDecl local vars=*FH attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         6 VariableDecl my vars=$first,@rest attrs=0 init=true list=true pkg=My::Module recovery=Parsed anchor=VariableListDeclaration via=node scope=<none>\n\
+         7 VariableDecl my vars=$fh attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>"
+    );
+
+    assert!(file.items.iter().all(|item| item.scope_context.is_none()));
 
     Ok(())
 }

--- a/docs/project/COMPILER_CAPABILITY_STATUS.md
+++ b/docs/project/COMPILER_CAPABILITY_STATUS.md
@@ -30,7 +30,7 @@ Capability states:
 | Parser measurement control plane | `live` | [#4063](https://github.com/EffortlessMetrics/perl-lsp/issues/4063), [#6484](https://github.com/EffortlessMetrics/perl-lsp/issues/6484) | `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check` |
 | Compiler build-out umbrella | `planned` | [#8191](https://github.com/EffortlessMetrics/perl-lsp/issues/8191) | Child checklist stays current |
 | Compiler capability status surface | `live` | [#8205](https://github.com/EffortlessMetrics/perl-lsp/issues/8205) | Keep this page current after each compiler-substrate PR |
-| HIR lowering | `fixture-backed` | [#8192](https://github.com/EffortlessMetrics/perl-lsp/issues/8192) | Extend lowering beyond the first package/sub/method/`use`/`require` slice to variable declarations, calls, barewords, and dynamic-boundary shells |
+| HIR lowering | `fixture-backed` | [#8192](https://github.com/EffortlessMetrics/perl-lsp/issues/8192) | Extend lowering to calls, method calls, barewords, literals, blocks, and dynamic-boundary shells |
 | Scope and pad model | `planned` | [#8193](https://github.com/EffortlessMetrics/perl-lsp/issues/8193) | Lexical binding and local reference fixtures |
 | Package and stash model | `planned` | [#8194](https://github.com/EffortlessMetrics/perl-lsp/issues/8194) | Package, glob-slot, typeglob, and inheritance fixtures |
 | Compile environment and module resolution | `planned` | [#8206](https://github.com/EffortlessMetrics/perl-lsp/issues/8206) | Pragmas, features, `@INC`, and module-resolution fixtures |


### PR DESCRIPTION
Problem: HIR lowering was fixture-backed for package/sub/method/use/require only, leaving variable declarations in the next HIR proof bucket.
Fix: Add HIR variable-declaration payloads and lowering for scalar/list `my`, `our`, `state`, and `local` declarations, including typeglobs, list placeholder filtering, nested declaration traversal, and local declarations whose initializer is embedded in the parser lvalue assignment shape. No scope graph, stash graph, import/export behavior, or provider cutover is added.
Verification: `cargo test -p perl-parser-core --test hir_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --profile agent --locked hir`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --test hir_tests --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `git diff --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`.

Known gap: full `cargo clippy -p perl-parser-core --all-targets --profile agent --locked -- -D warnings -A missing_docs` is blocked on pre-existing `panic!` / `expect()` uses in unrelated parser-core tests including `fix_async_await_3608.rs` and `expected_module_name_tests.rs`.

Parser-control deltas:
- Denominator: unchanged, 49 fixtures / 29 families; 135 scored lines; 115 scored symbols.
- Failure packets: unchanged, 0 active.
- Provider rows: unchanged; this PR has no provider cutover.
- Ratchet: unchanged; `parser_accuracy` ratchet floors pass.