### PR TITLE
docs(tooling): fix native tooling binary examples (#0000)

### DIFF
--- a/docs/specs/NATIVE_FORMATTER_CRITIC_REPLACEMENT.md
+++ b/docs/specs/NATIVE_FORMATTER_CRITIC_REPLACEMENT.md
@@ -322,8 +322,8 @@ max = 12
 Configuration import commands should be explicit and report gaps:
 
 ```bash
-perllsp config import-perltidy .perltidyrc
-perllsp config import-perlcritic .perlcriticrc
+perl-lsp config import-perltidy .perltidyrc
+perl-lsp config import-perlcritic .perlcriticrc
 ```
 
 Import output must classify every setting:


### PR DESCRIPTION
Problem: #8219 merged a docs-only native tooling contract with two command examples using the library crate name instead of the LSP server binary.
Fix: Change the configuration import examples from `perllsp` to `perl-lsp`.
Verification: `cargo xtask fmt --check`, `cargo xtask doc-claims`, and `git diff --check` pass.