### PR TITLE
feat(hir): lower expression shells (#8192)

### DIFF
--- a/crates/perl-parser-core/src/hir/lower.rs
+++ b/crates/perl-parser-core/src/hir/lower.rs
@@ -3,14 +3,16 @@
 use crate::{Node, NodeKind, SourceLocation};
 
 use super::model::{
-    AstAnchor, HirFile, HirId, HirItem, HirKind, MethodDecl, PackageDecl, RecoveryConfidence,
-    RequireDecl, SubDecl, UseDecl, VariableBinding, VariableDecl,
+    AstAnchor, BarewordExpr, BlockShell, CallExpr, CallForm, DynamicBoundary, DynamicBoundaryKind,
+    HirFile, HirId, HirItem, HirKind, IndirectCallExpr, LiteralExpr, LiteralKind, MethodCallExpr,
+    MethodDecl, PackageDecl, RecoveryConfidence, RequireDecl, SubDecl, UseDecl, VariableBinding,
+    VariableDecl,
 };
 
 /// Lower a parser AST into first-slice HIR items.
 ///
 /// This is intentionally conservative: it emits only package, subroutine,
-/// method, use, require, and variable-declaration items, and it does not
+/// method, use, require, variable-declaration, and expression-shell items, and it does not
 /// perform scope, stash, import, or provider behavior changes.
 pub fn lower_ast(ast: &Node) -> HirFile {
     let mut lowerer = Lowerer::default();
@@ -32,7 +34,19 @@ impl Lowerer {
 
     fn visit(&mut self, node: &Node, confidence: RecoveryConfidence) {
         match &node.kind {
-            NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            NodeKind::Program { statements } => {
+                for statement in statements {
+                    self.visit(statement, confidence);
+                }
+            }
+            NodeKind::Block { statements } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::BlockShell(BlockShell { statement_count: statements.len() }),
+                    self.package_context.clone(),
+                );
                 for statement in statements {
                     self.visit(statement, confidence);
                 }
@@ -112,6 +126,180 @@ impl Lowerer {
                     }),
                     self.package_context.clone(),
                 );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::FunctionCall { name, args } => {
+                let form = if name == "->()" { CallForm::Coderef } else { CallForm::NamedFunction };
+                let arg_count = match form {
+                    CallForm::NamedFunction => args.len(),
+                    // The parser stores the dynamic callee as args[0] for coderef invocation.
+                    CallForm::Coderef => args.len().saturating_sub(1),
+                };
+                if name == "->()" {
+                    self.push_item(
+                        node,
+                        None,
+                        confidence,
+                        HirKind::DynamicBoundary(DynamicBoundary {
+                            kind: DynamicBoundaryKind::CoderefCall,
+                            reason: "coderef or dynamic callee invoked through ->()".to_string(),
+                        }),
+                        self.package_context.clone(),
+                    );
+                }
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::CallExpr(CallExpr { name: name.clone(), arg_count, form }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::MethodCall { object, method, args } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::MethodCallExpr(MethodCallExpr {
+                        method: method.clone(),
+                        arg_count: args.len(),
+                        object_kind: object.kind.kind_name(),
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::IndirectCall { method, object, args } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::IndirectCallExpr(IndirectCallExpr {
+                        method: method.clone(),
+                        arg_count: args.len(),
+                        object_kind: object.kind.kind_name(),
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::Identifier { name } => {
+                self.push_item(
+                    node,
+                    Some(node.location),
+                    confidence,
+                    HirKind::BarewordExpr(BarewordExpr { name: name.clone() }),
+                    self.package_context.clone(),
+                );
+            }
+            NodeKind::Number { value } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::LiteralExpr(LiteralExpr {
+                        kind: LiteralKind::Number,
+                        value: Some(value.clone()),
+                        interpolated: None,
+                        element_count: None,
+                        pair_count: None,
+                    }),
+                    self.package_context.clone(),
+                );
+            }
+            NodeKind::String { value, interpolated } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::LiteralExpr(LiteralExpr {
+                        kind: LiteralKind::String,
+                        value: Some(value.clone()),
+                        interpolated: Some(*interpolated),
+                        element_count: None,
+                        pair_count: None,
+                    }),
+                    self.package_context.clone(),
+                );
+            }
+            NodeKind::Undef => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::LiteralExpr(LiteralExpr {
+                        kind: LiteralKind::Undef,
+                        value: None,
+                        interpolated: None,
+                        element_count: None,
+                        pair_count: None,
+                    }),
+                    self.package_context.clone(),
+                );
+            }
+            NodeKind::ArrayLiteral { elements } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::LiteralExpr(LiteralExpr {
+                        kind: LiteralKind::Array,
+                        value: None,
+                        interpolated: None,
+                        element_count: Some(elements.len()),
+                        pair_count: None,
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::HashLiteral { pairs } => {
+                self.push_item(
+                    node,
+                    None,
+                    confidence,
+                    HirKind::LiteralExpr(LiteralExpr {
+                        kind: LiteralKind::Hash,
+                        value: None,
+                        interpolated: None,
+                        element_count: None,
+                        pair_count: Some(pairs.len()),
+                    }),
+                    self.package_context.clone(),
+                );
+                self.visit_children(node, confidence);
+            }
+            NodeKind::Eval { block } => {
+                if !matches!(block.kind, NodeKind::Block { .. }) {
+                    self.push_item(
+                        node,
+                        None,
+                        confidence,
+                        HirKind::DynamicBoundary(DynamicBoundary {
+                            kind: DynamicBoundaryKind::EvalExpression,
+                            reason: "eval body is an expression rather than a parsed block"
+                                .to_string(),
+                        }),
+                        self.package_context.clone(),
+                    );
+                }
+                self.visit_children(node, confidence);
+            }
+            NodeKind::Do { block } => {
+                if !matches!(block.kind, NodeKind::Block { .. }) {
+                    self.push_item(
+                        node,
+                        None,
+                        confidence,
+                        HirKind::DynamicBoundary(DynamicBoundary {
+                            kind: DynamicBoundaryKind::DoExpression,
+                            reason: "do body is an expression rather than a parsed block"
+                                .to_string(),
+                        }),
+                        self.package_context.clone(),
+                    );
+                }
                 self.visit_children(node, confidence);
             }
             NodeKind::VariableDeclaration { declarator, variable, attributes, initializer } => {

--- a/crates/perl-parser-core/src/hir/mod.rs
+++ b/crates/perl-parser-core/src/hir/mod.rs
@@ -9,6 +9,8 @@ mod model;
 
 pub use lower::lower_ast;
 pub use model::{
-    AstAnchor, HirFile, HirId, HirItem, HirKind, MethodDecl, PackageDecl, RecoveryConfidence,
-    RequireDecl, SubDecl, UseDecl, VariableBinding, VariableDecl,
+    AstAnchor, BarewordExpr, BlockShell, CallExpr, CallForm, DynamicBoundary, DynamicBoundaryKind,
+    HirFile, HirId, HirItem, HirKind, IndirectCallExpr, LiteralExpr, LiteralKind, MethodCallExpr,
+    MethodDecl, PackageDecl, RecoveryConfidence, RequireDecl, SubDecl, UseDecl, VariableBinding,
+    VariableDecl,
 };

--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -101,6 +101,20 @@ pub enum HirKind {
     RequireDecl(RequireDecl),
     /// `my`, `our`, `state`, or `local` variable declaration.
     VariableDecl(VariableDecl),
+    /// Function-like call expression shell.
+    CallExpr(CallExpr),
+    /// Method-call expression shell.
+    MethodCallExpr(MethodCallExpr),
+    /// Indirect-object method-call expression shell.
+    IndirectCallExpr(IndirectCallExpr),
+    /// Bareword expression shell.
+    BarewordExpr(BarewordExpr),
+    /// Literal expression shell.
+    LiteralExpr(LiteralExpr),
+    /// Block expression shell without scope construction.
+    BlockShell(BlockShell),
+    /// Unsupported or intentionally dynamic Perl boundary.
+    DynamicBoundary(DynamicBoundary),
 }
 
 /// Package declaration HIR payload.
@@ -191,4 +205,120 @@ pub struct VariableBinding {
     pub name: String,
     /// Source range for the variable token.
     pub range: SourceLocation,
+}
+
+/// Function-like call shell payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CallExpr {
+    /// Callee name, or parser sentinel for dynamic call forms.
+    pub name: String,
+    /// Number of parsed arguments.
+    pub arg_count: usize,
+    /// Parser-observed call shape.
+    pub form: CallForm,
+}
+
+/// Parser-observed call shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CallForm {
+    /// A named function call such as `foo(...)`.
+    NamedFunction,
+    /// A coderef/dynamic callee call such as `$callback->(...)`.
+    Coderef,
+}
+
+/// Method-call shell payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MethodCallExpr {
+    /// Method name.
+    pub method: String,
+    /// Number of parsed arguments.
+    pub arg_count: usize,
+    /// Parser AST kind for the receiver expression.
+    pub object_kind: &'static str,
+}
+
+/// Indirect-object call shell payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct IndirectCallExpr {
+    /// Method name.
+    pub method: String,
+    /// Number of parsed arguments.
+    pub arg_count: usize,
+    /// Parser AST kind for the receiver/class expression.
+    pub object_kind: &'static str,
+}
+
+/// Bareword expression shell payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BarewordExpr {
+    /// Bareword text as parsed.
+    pub name: String,
+}
+
+/// Literal expression shell payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct LiteralExpr {
+    /// Literal category.
+    pub kind: LiteralKind,
+    /// Preserved value for compact scalar literals.
+    pub value: Option<String>,
+    /// Whether the literal can interpolate variables.
+    pub interpolated: Option<bool>,
+    /// Element count for aggregate literals.
+    pub element_count: Option<usize>,
+    /// Pair count for hash literals.
+    pub pair_count: Option<usize>,
+}
+
+/// Literal category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum LiteralKind {
+    /// Numeric literal.
+    Number,
+    /// String literal.
+    String,
+    /// `undef`.
+    Undef,
+    /// Array/list literal.
+    Array,
+    /// Hash literal.
+    Hash,
+}
+
+/// Block shell payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BlockShell {
+    /// Number of parsed statements directly inside the block.
+    pub statement_count: usize,
+}
+
+/// Dynamic-boundary shell payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DynamicBoundary {
+    /// Boundary category.
+    pub kind: DynamicBoundaryKind,
+    /// Short human-readable reason for the boundary.
+    pub reason: String,
+}
+
+/// Dynamic-boundary category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum DynamicBoundaryKind {
+    /// Coderef/dynamic callee call through `->()`.
+    CoderefCall,
+    /// `eval` whose body is not a statically parsed block.
+    EvalExpression,
+    /// `do` whose body is not a statically parsed block.
+    DoExpression,
 }

--- a/crates/perl-parser-core/tests/hir_tests.rs
+++ b/crates/perl-parser-core/tests/hir_tests.rs
@@ -55,6 +55,41 @@ fn render_item(item: &perl_parser_core::hir::HirItem) -> String {
                 decl.is_list
             )
         }
+        HirKind::CallExpr(expr) => {
+            format!("CallExpr {} args={} form={:?}", expr.name, expr.arg_count, expr.form)
+        }
+        HirKind::MethodCallExpr(expr) => format!(
+            "MethodCallExpr {} args={} object={}",
+            expr.method, expr.arg_count, expr.object_kind
+        ),
+        HirKind::IndirectCallExpr(expr) => format!(
+            "IndirectCallExpr {} args={} object={}",
+            expr.method, expr.arg_count, expr.object_kind
+        ),
+        HirKind::BarewordExpr(expr) => format!("BarewordExpr {}", expr.name),
+        HirKind::LiteralExpr(expr) => {
+            let value = expr.value.as_deref().unwrap_or("<none>");
+            let interpolated = expr
+                .interpolated
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "<none>".to_string());
+            let element_count = expr
+                .element_count
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "<none>".to_string());
+            let pair_count = expr
+                .pair_count
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "<none>".to_string());
+            format!(
+                "LiteralExpr {:?} value={} interp={} elements={} pairs={}",
+                expr.kind, value, interpolated, element_count, pair_count
+            )
+        }
+        HirKind::BlockShell(shell) => format!("BlockShell statements={}", shell.statement_count),
+        HirKind::DynamicBoundary(boundary) => {
+            format!("DynamicBoundary {:?} reason={}", boundary.kind, boundary.reason)
+        }
         _ => "UnknownFutureHirKind".to_string(),
     };
     format!(
@@ -81,8 +116,13 @@ fn hir_lowers_first_slice_constructs_with_stable_metadata() -> Result<(), Box<dy
         "0 PackageDecl My::Module pkg=My::Module recovery=Parsed anchor=Package via=name scope=<none>\n\
          1 UseDecl List::Util args=qw(sum) filter=false pkg=My::Module recovery=Parsed anchor=Use via=node scope=<none>\n\
          2 RequireDecl Other::Module args=1 pkg=My::Module recovery=Parsed anchor=FunctionCall via=node scope=<none>\n\
-         3 SubDecl greet proto=true sig=false attrs=1 pkg=My::Module recovery=Parsed anchor=Subroutine via=name scope=<none>\n\
-         4 MethodDecl run sig=false attrs=0 pkg=My::Module recovery=Parsed anchor=Method via=node scope=<none>"
+         3 BarewordExpr Other::Module pkg=My::Module recovery=Parsed anchor=Identifier via=name scope=<none>\n\
+         4 SubDecl greet proto=true sig=false attrs=1 pkg=My::Module recovery=Parsed anchor=Subroutine via=name scope=<none>\n\
+         5 BlockShell statements=1 pkg=My::Module recovery=Parsed anchor=Block via=node scope=<none>\n\
+         6 LiteralExpr Number value=1 interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Number via=node scope=<none>\n\
+         7 MethodDecl run sig=false attrs=0 pkg=My::Module recovery=Parsed anchor=Method via=node scope=<none>\n\
+         8 BlockShell statements=1 pkg=My::Module recovery=Parsed anchor=Block via=node scope=<none>\n\
+         9 LiteralExpr Number value=1 interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Number via=node scope=<none>"
     );
 
     for (index, item) in file.items.iter().enumerate() {
@@ -112,12 +152,64 @@ fn hir_lowers_variable_declarations_without_scope_cutover() -> Result<(), Box<dy
         render_hir(&file),
         "0 PackageDecl My::Module pkg=My::Module recovery=Parsed anchor=Package via=name scope=<none>\n\
          1 VariableDecl my vars=$scalar attrs=0 init=true list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
-         2 VariableDecl our vars=@EXPORT_OK attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
-         3 VariableDecl state vars=%cache attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
-         4 VariableDecl local vars=$temp attrs=0 init=true list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
-         5 VariableDecl local vars=*FH attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
-         6 VariableDecl my vars=$first,@rest attrs=0 init=true list=true pkg=My::Module recovery=Parsed anchor=VariableListDeclaration via=node scope=<none>\n\
-         7 VariableDecl my vars=$fh attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>"
+         2 LiteralExpr Number value=1 interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Number via=node scope=<none>\n\
+         3 VariableDecl our vars=@EXPORT_OK attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         4 VariableDecl state vars=%cache attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         5 VariableDecl local vars=$temp attrs=0 init=true list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         6 LiteralExpr Undef value=<none> interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Undef via=node scope=<none>\n\
+         7 VariableDecl local vars=*FH attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         8 VariableDecl my vars=$first,@rest attrs=0 init=true list=true pkg=My::Module recovery=Parsed anchor=VariableListDeclaration via=node scope=<none>\n\
+         9 LiteralExpr Undef value=<none> interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Undef via=node scope=<none>\n\
+         10 CallExpr open args=1 form=NamedFunction pkg=My::Module recovery=Parsed anchor=FunctionCall via=node scope=<none>\n\
+         11 LiteralExpr Array value=<none> interp=<none> elements=3 pairs=<none> pkg=My::Module recovery=Parsed anchor=ArrayLiteral via=node scope=<none>\n\
+         12 VariableDecl my vars=$fh attrs=0 init=false list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         13 LiteralExpr String value='<' interp=false elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=String via=node scope=<none>"
+    );
+
+    assert!(file.items.iter().all(|item| item.scope_context.is_none()));
+
+    Ok(())
+}
+
+#[test]
+fn hir_lowers_expression_shells_without_provider_cutover() -> Result<(), Box<dyn std::error::Error>>
+{
+    let file = lower_source(
+        "package My::Module;\n\
+         helper($value, 42, \"x\");\n\
+         $self->method($value);\n\
+         new Widget 1;\n\
+         $callback->(42);\n\
+         grep { $_->ok } @items;\n\
+         eval $source;\n\
+         do $file;\n\
+         my $settings = { foo => 1, bar => \"x\" };\n",
+    );
+
+    assert_eq!(
+        render_hir(&file),
+        "0 PackageDecl My::Module pkg=My::Module recovery=Parsed anchor=Package via=name scope=<none>\n\
+         1 CallExpr helper args=3 form=NamedFunction pkg=My::Module recovery=Parsed anchor=FunctionCall via=node scope=<none>\n\
+         2 LiteralExpr Number value=42 interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Number via=node scope=<none>\n\
+         3 LiteralExpr String value=\"x\" interp=true elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=String via=node scope=<none>\n\
+         4 MethodCallExpr method args=1 object=Variable pkg=My::Module recovery=Parsed anchor=MethodCall via=node scope=<none>\n\
+         5 IndirectCallExpr new args=1 object=Identifier pkg=My::Module recovery=Parsed anchor=IndirectCall via=node scope=<none>\n\
+         6 BarewordExpr Widget pkg=My::Module recovery=Parsed anchor=Identifier via=name scope=<none>\n\
+         7 LiteralExpr Number value=1 interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Number via=node scope=<none>\n\
+         8 DynamicBoundary CoderefCall reason=coderef or dynamic callee invoked through ->() pkg=My::Module recovery=Parsed anchor=FunctionCall via=node scope=<none>\n\
+         9 CallExpr ->() args=1 form=Coderef pkg=My::Module recovery=Parsed anchor=FunctionCall via=node scope=<none>\n\
+         10 LiteralExpr Number value=42 interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Number via=node scope=<none>\n\
+         11 CallExpr grep args=2 form=NamedFunction pkg=My::Module recovery=Parsed anchor=FunctionCall via=node scope=<none>\n\
+         12 BlockShell statements=1 pkg=My::Module recovery=Parsed anchor=Block via=node scope=<none>\n\
+         13 MethodCallExpr ok args=0 object=Variable pkg=My::Module recovery=Parsed anchor=MethodCall via=node scope=<none>\n\
+         14 DynamicBoundary EvalExpression reason=eval body is an expression rather than a parsed block pkg=My::Module recovery=Parsed anchor=Eval via=node scope=<none>\n\
+         15 DynamicBoundary DoExpression reason=do body is an expression rather than a parsed block pkg=My::Module recovery=Parsed anchor=Do via=node scope=<none>\n\
+         16 VariableDecl my vars=$settings attrs=0 init=true list=false pkg=My::Module recovery=Parsed anchor=VariableDeclaration via=name scope=<none>\n\
+         17 LiteralExpr Hash value=<none> interp=<none> elements=<none> pairs=2 pkg=My::Module recovery=Parsed anchor=HashLiteral via=node scope=<none>\n\
+         18 LiteralExpr String value=foo interp=false elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=String via=node scope=<none>\n\
+         19 LiteralExpr Number value=1 interp=<none> elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=Number via=node scope=<none>\n\
+         20 LiteralExpr String value=bar interp=false elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=String via=node scope=<none>\n\
+         21 LiteralExpr String value=\"x\" interp=true elements=<none> pairs=<none> pkg=My::Module recovery=Parsed anchor=String via=node scope=<none>"
     );
 
     assert!(file.items.iter().all(|item| item.scope_context.is_none()));

--- a/docs/project/COMPILER_CAPABILITY_STATUS.md
+++ b/docs/project/COMPILER_CAPABILITY_STATUS.md
@@ -30,7 +30,7 @@ Capability states:
 | Parser measurement control plane | `live` | [#4063](https://github.com/EffortlessMetrics/perl-lsp/issues/4063), [#6484](https://github.com/EffortlessMetrics/perl-lsp/issues/6484) | `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check` |
 | Compiler build-out umbrella | `planned` | [#8191](https://github.com/EffortlessMetrics/perl-lsp/issues/8191) | Child checklist stays current |
 | Compiler capability status surface | `live` | [#8205](https://github.com/EffortlessMetrics/perl-lsp/issues/8205) | Keep this page current after each compiler-substrate PR |
-| HIR lowering | `fixture-backed` | [#8192](https://github.com/EffortlessMetrics/perl-lsp/issues/8192) | Extend lowering to calls, method calls, barewords, literals, blocks, and dynamic-boundary shells |
+| HIR lowering | `fixture-backed` | [#8192](https://github.com/EffortlessMetrics/perl-lsp/issues/8192) | Add HIR coverage metric/status proof before provider cutover |
 | Scope and pad model | `planned` | [#8193](https://github.com/EffortlessMetrics/perl-lsp/issues/8193) | Lexical binding and local reference fixtures |
 | Package and stash model | `planned` | [#8194](https://github.com/EffortlessMetrics/perl-lsp/issues/8194) | Package, glob-slot, typeglob, and inheritance fixtures |
 | Compile environment and module resolution | `planned` | [#8206](https://github.com/EffortlessMetrics/perl-lsp/issues/8206) | Pragmas, features, `@INC`, and module-resolution fixtures |


### PR DESCRIPTION
Problem: HIR lowering still stopped at declarations, leaving calls, literals, blocks, and obvious dynamic expression boundaries outside the compiler-substrate fixture surface.
Fix: Add shallow HIR expression shells for function, method, indirect calls, barewords, literals, block shells, and coderef/eval/do dynamic boundaries without scope, stash, import/export, or provider cutover.
Verification: `cargo test -p perl-parser-core --test hir_tests --profile agent --locked -- --nocapture`, `cargo test -p perl-parser-core --profile agent --locked hir`, `cargo check -p perl-parser-core --all-targets --profile agent --locked`, `cargo clippy -p perl-parser-core --test hir_tests --profile agent --locked -- -D warnings -A missing_docs`, `cargo xtask fmt --check`, `git diff --check`, `cargo xtask metrics parser-accuracy --check`, `cargo xtask update-status --only parser --check`, and `cargo xtask metrics ratchet-check parser_accuracy` pass.

Parser-control deltas: denominator unchanged at 49 fixtures / 29 families, 135 scored lines, 115 scored symbols; failure packets remain 0 active; provider rows unchanged; parser_accuracy ratchet floors pass.

Known gap: `cargo clippy -p perl-parser-core --all-targets --profile agent --locked -- -D warnings -A missing_docs` still fails on pre-existing test-only panic/expect/assertions-on-constants debt in `fix_async_await_3608.rs`, `expected_module_name_tests.rs`, and `bare_call_binding_regression_tests.rs`.