### PR TITLE
feat(format): add native format document IR (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/README.md
+++ b/crates/perl-lsp-perltidy/README.md
@@ -8,6 +8,7 @@ replacement lane.
 ## Features
 
 - `PerlFormatter` trait and native `FormatResult` / edit / diagnostic model
+- `FormatDoc` document IR for deterministic native pretty-printing
 - `PerlTidyConfig` for serializable formatter configuration
 - `PerlTidyFormatter` for subprocess-backed formatting with memoized results
 - `BuiltInFormatter` fallback for environments without `perltidy`

--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 pub mod native;
 
 pub use native::{
-    FinalNewline, FormatConfig, FormatDiagnostic, FormatDiagnosticSeverity, FormatResult,
-    FormatterMode, PerlFormatter, TextEdit, TextPosition, TextRange,
+    FinalNewline, FormatConfig, FormatDiagnostic, FormatDiagnosticSeverity, FormatDoc,
+    FormatResult, FormatterMode, PerlFormatter, TextEdit, TextPosition, TextRange,
 };
 
 /// Configuration for perltidy.

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -7,6 +7,153 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Native formatter document tree.
+///
+/// This is the small, lossless-friendly formatting IR from the replacement
+/// contract. It is deliberately independent of Perl syntax for now; later
+/// parser-facing formatter passes should lower CST/AST fragments into this
+/// tree and then render it deterministically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FormatDoc {
+    /// Literal text that may be laid out with surrounding IR.
+    Text(String),
+    /// One ordinary space.
+    Space,
+    /// A newline at the current indentation level.
+    Line,
+    /// A line break that becomes a space when its containing group fits.
+    SoftLine,
+    /// A newline that cannot be flattened.
+    HardLine,
+    /// A layout group that may render flat or broken.
+    Group(Vec<FormatDoc>),
+    /// A nested document rendered one indentation level deeper when broken.
+    Indent(Vec<FormatDoc>),
+    /// Render one branch when broken and another branch when flat.
+    IfBreak {
+        /// Document to render when the containing group breaks.
+        broken: Box<FormatDoc>,
+        /// Document to render when the containing group fits flat.
+        flat: Box<FormatDoc>,
+    },
+    /// Literal source text that must be preserved byte-for-byte.
+    LiteralPreserve(String),
+}
+
+impl FormatDoc {
+    /// Create literal text.
+    #[must_use]
+    pub fn text(value: impl Into<String>) -> Self {
+        Self::Text(value.into())
+    }
+
+    /// Create a layout group.
+    #[must_use]
+    pub fn group(parts: impl Into<Vec<FormatDoc>>) -> Self {
+        Self::Group(parts.into())
+    }
+
+    /// Create an indented document.
+    #[must_use]
+    pub fn indent(parts: impl Into<Vec<FormatDoc>>) -> Self {
+        Self::Indent(parts.into())
+    }
+
+    /// Create an if-break choice.
+    #[must_use]
+    pub fn if_break(broken: FormatDoc, flat: FormatDoc) -> Self {
+        Self::IfBreak { broken: Box::new(broken), flat: Box::new(flat) }
+    }
+
+    /// Create a literal-preserve region.
+    #[must_use]
+    pub fn literal_preserve(value: impl Into<String>) -> Self {
+        Self::LiteralPreserve(value.into())
+    }
+
+    /// Render this document using the native formatter configuration.
+    #[must_use]
+    pub fn render(&self, config: &FormatConfig) -> String {
+        let mut renderer = DocRenderer::new(config);
+        renderer.render_doc(self, 0, false, false);
+        renderer.output
+    }
+
+    fn flat_width(&self) -> Option<usize> {
+        match self {
+            Self::Text(text) | Self::LiteralPreserve(text) => {
+                (!text.contains('\n')).then_some(text.chars().count())
+            }
+            Self::Space | Self::SoftLine => Some(1),
+            Self::Line | Self::HardLine => None,
+            Self::Group(parts) | Self::Indent(parts) => {
+                parts.iter().try_fold(0_usize, |sum, doc| doc.flat_width().map(|width| sum + width))
+            }
+            Self::IfBreak { flat, .. } => flat.flat_width(),
+        }
+    }
+}
+
+struct DocRenderer<'a> {
+    config: &'a FormatConfig,
+    output: String,
+    column: usize,
+}
+
+impl<'a> DocRenderer<'a> {
+    fn new(config: &'a FormatConfig) -> Self {
+        Self { config, output: String::new(), column: 0 }
+    }
+
+    fn render_doc(&mut self, doc: &FormatDoc, indent_level: usize, flat: bool, broken: bool) {
+        match doc {
+            FormatDoc::Text(text) | FormatDoc::LiteralPreserve(text) => self.push_text(text),
+            FormatDoc::Space => self.push_text(" "),
+            FormatDoc::Line | FormatDoc::HardLine => self.push_line(indent_level),
+            FormatDoc::SoftLine if flat => self.push_text(" "),
+            FormatDoc::SoftLine => self.push_line(indent_level),
+            FormatDoc::Group(parts) => {
+                let fits = doc
+                    .flat_width()
+                    .is_some_and(|width| self.column + width <= self.config.line_width as usize);
+                for part in parts {
+                    self.render_doc(part, indent_level, fits, !fits);
+                }
+            }
+            FormatDoc::Indent(parts) => {
+                for part in parts {
+                    self.render_doc(part, indent_level + 1, flat, broken);
+                }
+            }
+            FormatDoc::IfBreak { broken: broken_doc, flat: flat_doc } => {
+                let selected = if broken { broken_doc } else { flat_doc };
+                self.render_doc(selected, indent_level, flat, broken);
+            }
+        }
+    }
+
+    fn push_text(&mut self, text: &str) {
+        self.output.push_str(text);
+        if let Some((_, tail)) = text.rsplit_once('\n') {
+            self.column = tail.chars().count();
+        } else {
+            self.column += text.chars().count();
+        }
+    }
+
+    fn push_line(&mut self, indent_level: usize) {
+        self.output.push('\n');
+        let indent = if self.config.use_tabs {
+            "\t".repeat(indent_level)
+        } else {
+            " ".repeat(indent_level * self.config.indent_width as usize)
+        };
+        self.output.push_str(&indent);
+        self.column = indent.chars().count();
+    }
+}
+
 /// Native formatter operating mode.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/crates/perl-lsp-perltidy/tests/native_doc_ir_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_doc_ir_tests.rs
@@ -1,0 +1,111 @@
+use perl_lsp_perltidy::{FormatConfig, FormatDoc};
+
+#[test]
+fn format_doc_renders_flat_group_when_it_fits() {
+    let doc = FormatDoc::group(vec![
+        FormatDoc::text("my"),
+        FormatDoc::Space,
+        FormatDoc::text("$x"),
+        FormatDoc::SoftLine,
+        FormatDoc::text("="),
+        FormatDoc::Space,
+        FormatDoc::text("1;"),
+    ]);
+
+    let rendered = doc.render(&FormatConfig::default());
+
+    assert_eq!(rendered, "my $x = 1;");
+}
+
+#[test]
+fn format_doc_breaks_group_when_width_is_exceeded() {
+    let config = FormatConfig { line_width: 8, ..FormatConfig::default() };
+    let doc = FormatDoc::group(vec![
+        FormatDoc::text("my"),
+        FormatDoc::Space,
+        FormatDoc::text("$long_name"),
+        FormatDoc::SoftLine,
+        FormatDoc::text("="),
+        FormatDoc::Space,
+        FormatDoc::text("1;"),
+    ]);
+
+    let rendered = doc.render(&config);
+
+    assert_eq!(rendered, "my $long_name\n= 1;");
+}
+
+#[test]
+fn format_doc_accumulates_column_before_later_group_fit_check() {
+    let config = FormatConfig { line_width: 9, ..FormatConfig::default() };
+    let doc = FormatDoc::group(vec![
+        FormatDoc::text("my"),
+        FormatDoc::Space,
+        FormatDoc::group(vec![FormatDoc::text("$long"), FormatDoc::SoftLine, FormatDoc::text("=")]),
+    ]);
+
+    let rendered = doc.render(&config);
+
+    assert_eq!(rendered, "my $long\n=");
+}
+
+#[test]
+fn format_doc_indents_broken_nested_group() {
+    let config = FormatConfig { line_width: 12, indent_width: 2, ..FormatConfig::default() };
+    let doc = FormatDoc::group(vec![
+        FormatDoc::text("sub demo {"),
+        FormatDoc::Indent(vec![
+            FormatDoc::SoftLine,
+            FormatDoc::text("return"),
+            FormatDoc::Space,
+            FormatDoc::text("1;"),
+        ]),
+        FormatDoc::SoftLine,
+        FormatDoc::text("}"),
+    ]);
+
+    let rendered = doc.render(&config);
+
+    assert_eq!(rendered, "sub demo {\n  return 1;\n}");
+}
+
+#[test]
+fn format_doc_uses_tabs_when_configured() {
+    let config = FormatConfig { line_width: 8, use_tabs: true, ..FormatConfig::default() };
+    let doc = FormatDoc::group(vec![
+        FormatDoc::text("if ($x) {"),
+        FormatDoc::Indent(vec![FormatDoc::SoftLine, FormatDoc::text("print $x;")]),
+        FormatDoc::SoftLine,
+        FormatDoc::text("}"),
+    ]);
+
+    let rendered = doc.render(&config);
+
+    assert_eq!(rendered, "if ($x) {\n\tprint $x;\n}");
+}
+
+#[test]
+fn format_doc_if_break_selects_flat_or_broken_branch() {
+    let flat = FormatDoc::group(vec![
+        FormatDoc::text("("),
+        FormatDoc::if_break(FormatDoc::text(","), FormatDoc::text("")),
+        FormatDoc::SoftLine,
+        FormatDoc::text(")"),
+    ]);
+    let broken_config = FormatConfig { line_width: 1, ..FormatConfig::default() };
+
+    assert_eq!(flat.render(&FormatConfig::default()), "( )");
+    assert_eq!(flat.render(&broken_config), "(,\n)");
+}
+
+#[test]
+fn format_doc_literal_preserve_keeps_multiline_region() {
+    let doc = FormatDoc::group(vec![
+        FormatDoc::text("print "),
+        FormatDoc::literal_preserve("<<'EOF';\nraw { text }\nEOF"),
+    ]);
+
+    let rendered = doc.render(&FormatConfig::default());
+
+    assert_eq!(rendered, "print <<'EOF';\nraw { text }\nEOF");
+}


### PR DESCRIPTION
## Summary

Adds the native formatter document IR foundation described in the replacement contract:

- introduces `FormatDoc` with `Text`, `Space`, `Line`, `SoftLine`, `HardLine`, `Group`, `Indent`, `IfBreak`, and `LiteralPreserve`
- adds a deterministic renderer over `FormatConfig` with width-aware flat/broken groups, indentation, tab support, if-break branch selection, and literal-preserve handling
- keeps `FormatDoc` evolvable as a public API with `#[non_exhaustive]`
- exports `FormatDoc` from `perl-lsp-perltidy`
- adds focused IR tests for flat rendering, broken rendering, accumulated column fit checks, indentation, tabs, if-break behavior, and multiline literal preservation
- updates the formatter crate README feature list

This is still API/model groundwork only. It does not wire native formatting into LSP, change defaults, or modify the existing external perltidy adapter.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: passed locally
- [x] cargo clippy --locked --lib -p perl-lsp-perltidy -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs
  - why: matches the PR smoke scoped clippy gate for this changed surface
  - evidence: passed locally
- [x] cargo test -p perl-lsp-perltidy --test native_doc_ir_tests --profile agent --locked -- --nocapture
  - why: validates the new document IR renderer directly
  - evidence: 7 tests passed locally
- [x] cargo test -p perl-lsp-perltidy --profile agent --locked
  - why: ensures existing perltidy adapter/cache/subprocess behavior still passes with the new IR exports
  - evidence: 79 tests passed locally across config, formatting, native contract, native IR, and subprocess tests
- [x] cargo check -p perl-lsp-perltidy --all-targets --profile agent --locked
  - why: proves all formatter crate targets still compile
  - evidence: passed locally
- [x] cargo xtask check-memory-lifecycle-policy
  - why: DevEx planner routes formatter crate edits through memory-sensitive policy checks
  - evidence: passed locally
- [x] cargo xtask check-memory-retained-owner-drift --base origin/master
  - why: confirms no new retained-owner storage patterns were introduced
  - evidence: passed locally: no new retained-owner patterns found
- [x] git diff --check
  - why: guards against whitespace errors in the final patch
  - evidence: passed locally

Optional proof not run:
- `just pr-fast`
- `just ci-gate`

Known local gap:
- `cargo clippy -p perl-lsp-perltidy --all-targets --profile agent --locked -- -D warnings -A missing_docs` is blocked by pre-existing `expect()` debt in `tests/subprocess_tests.rs`; the PR smoke-scoped clippy command above passes.

## Runtime impact

None. This is a native formatting IR/model slice only; the current external perltidy adapter remains untouched.
