### PR TITLE
feat(format): add native formatter parse gate (#0000)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ version = "0.13.4"
 name = "perl-lsp-perltidy"
 version = "0.13.4"
 dependencies = [
+ "perl-parser-core",
  "perl-subprocess-runtime",
  "perl-tdd-support",
  "serde",

--- a/crates/perl-lsp-perltidy/Cargo.toml
+++ b/crates/perl-lsp-perltidy/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["development-tools", "text-editors"]
 doctest = false
 
 [dependencies]
+perl-parser-core = { workspace = true }
 perl-subprocess-runtime = { workspace = true }
 serde = { workspace = true }
 

--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -20,7 +20,7 @@ pub mod native;
 
 pub use native::{
     FinalNewline, FormatConfig, FormatDiagnostic, FormatDiagnosticSeverity, FormatDoc,
-    FormatResult, FormatterMode, PerlFormatter, TextEdit, TextPosition, TextRange,
+    FormatResult, FormatterMode, NativeFormatter, PerlFormatter, TextEdit, TextPosition, TextRange,
 };
 
 /// Configuration for perltidy.

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -7,6 +7,9 @@
 
 use serde::{Deserialize, Serialize};
 
+const PARSE_ERROR_CODE: &str = "native.format.parse_error";
+const LITERAL_PRESERVE_CODE: &str = "native.format.literal_preserve_region";
+
 /// Native formatter document tree.
 ///
 /// This is the small, lossless-friendly formatting IR from the replacement
@@ -396,6 +399,172 @@ pub trait PerlFormatter {
     fn format_range(&self, source: &str, range: TextRange, config: &FormatConfig) -> FormatResult;
 }
 
+/// Parse-gated Rust-native Perl formatter.
+///
+/// This initial engine deliberately performs no syntax layout rewrites. It is
+/// the safety boundary that future native formatter passes should compose with:
+/// source must parse cleanly before any native formatting edit is allowed.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NativeFormatter;
+
+impl NativeFormatter {
+    /// Create a parse-gated native formatter.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn validate_clean_parse(source: &str) -> Result<(), FormatDiagnostic> {
+        if let Some(kind) = literal_preserve_region(source) {
+            return Err(FormatDiagnostic::new(
+                LITERAL_PRESERVE_CODE,
+                FormatDiagnosticSeverity::Warning,
+                None,
+                format!("native formatting skipped because {kind} preservation is not enabled yet"),
+            ));
+        }
+
+        let mut parser = perl_parser_core::Parser::new(source);
+        let output = parser.parse_with_recovery();
+
+        if output.terminated_early {
+            return Err(FormatDiagnostic::new(
+                PARSE_ERROR_CODE,
+                FormatDiagnosticSeverity::Warning,
+                None,
+                "native formatting skipped because parsing terminated early",
+            ));
+        }
+
+        if let Some(error) = output.diagnostics.first() {
+            return Err(FormatDiagnostic::new(
+                PARSE_ERROR_CODE,
+                FormatDiagnosticSeverity::Warning,
+                error.location().map(|offset| TextRange::at_byte_offset(source, offset)),
+                format!(
+                    "native formatting skipped because the source does not parse cleanly: {error}"
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn apply_final_newline(source: &str, config: &FormatConfig) -> String {
+        match config.final_newline {
+            FinalNewline::Preserve => source.to_string(),
+            FinalNewline::Insert => {
+                let trimmed = source.trim_end_matches(['\n', '\r']);
+                format!("{trimmed}\n")
+            }
+            FinalNewline::Trim => source.trim_end_matches(['\n', '\r']).to_string(),
+        }
+    }
+}
+
+impl PerlFormatter for NativeFormatter {
+    fn format_document(&self, source: &str, config: &FormatConfig) -> FormatResult {
+        if matches!(config.mode, FormatterMode::Off) {
+            return FormatResult::unchanged(source);
+        }
+
+        if let Err(diagnostic) = Self::validate_clean_parse(source) {
+            let mut result = FormatResult::unchanged(source);
+            result.diagnostics.push(diagnostic);
+            return result;
+        }
+
+        FormatResult::replace_document(source, Self::apply_final_newline(source, config))
+    }
+
+    fn format_range(&self, source: &str, _range: TextRange, config: &FormatConfig) -> FormatResult {
+        if matches!(config.mode, FormatterMode::Off) {
+            return FormatResult::unchanged(source);
+        }
+
+        if let Err(diagnostic) = Self::validate_clean_parse(source) {
+            let mut result = FormatResult::unchanged(source);
+            result.diagnostics.push(diagnostic);
+            return result;
+        }
+
+        FormatResult::unchanged(source)
+    }
+}
+
 fn utf16_len(s: &str) -> usize {
     s.chars().map(|ch| if ch as u32 >= 0x10000 { 2 } else { 1 }).sum()
+}
+
+fn literal_preserve_region(source: &str) -> Option<&'static str> {
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if is_pod_start(trimmed) {
+            return Some("POD");
+        }
+        if matches!(trimmed, "__DATA__" | "__END__") {
+            return Some("DATA section");
+        }
+        if contains_likely_heredoc_start(line) {
+            return Some("heredoc");
+        }
+    }
+    None
+}
+
+fn is_pod_start(trimmed_line: &str) -> bool {
+    matches!(
+        trimmed_line.split_whitespace().next(),
+        Some(
+            "=pod"
+                | "=head1"
+                | "=head2"
+                | "=head3"
+                | "=head4"
+                | "=over"
+                | "=item"
+                | "=back"
+                | "=begin"
+                | "=end"
+                | "=for"
+                | "=encoding"
+                | "=cut"
+        )
+    )
+}
+
+fn contains_likely_heredoc_start(line: &str) -> bool {
+    let Some((_, after_marker)) = line.split_once("<<") else {
+        return false;
+    };
+    if after_marker.starts_with('<') {
+        return false;
+    }
+
+    let after_indent = after_marker.trim_start();
+    let marker = after_indent.strip_prefix('~').unwrap_or(after_indent).trim_start();
+    let marker = marker.strip_prefix(['\'', '"', '`']).unwrap_or(marker);
+    marker.chars().next().is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+}
+
+impl TextRange {
+    fn at_byte_offset(source: &str, offset: usize) -> Self {
+        let clamped = offset.min(source.len());
+        let mut line = 0_u32;
+        let mut line_start = 0_usize;
+
+        for (idx, ch) in source.char_indices() {
+            if idx >= clamped {
+                break;
+            }
+            if ch == '\n' {
+                line += 1;
+                line_start = idx + ch.len_utf8();
+            }
+        }
+
+        let character = utf16_len(&source[line_start..clamped]) as u32;
+        let position = TextPosition::new(line, character);
+        Self::new(position, position)
+    }
 }

--- a/crates/perl-lsp-perltidy/tests/native_formatter_parse_gate_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_parse_gate_tests.rs
@@ -1,0 +1,140 @@
+use perl_lsp_perltidy::{
+    FinalNewline, FormatConfig, FormatterMode, NativeFormatter, PerlFormatter, TextPosition,
+    TextRange,
+};
+
+#[test]
+fn native_formatter_leaves_clean_source_unchanged_before_layout_passes_exist() {
+    let formatter = NativeFormatter::new();
+    let source = "my $x = 1;\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert!(result.edits.is_empty());
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_can_apply_final_newline_policy_after_clean_parse() {
+    let formatter = NativeFormatter::new();
+    let insert = FormatConfig { final_newline: FinalNewline::Insert, ..FormatConfig::default() };
+    let trim = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let inserted = formatter.format_document("my $x = 1;", &insert);
+    let trimmed = formatter.format_document("my $x = 1;\n\n", &trim);
+
+    assert!(inserted.changed);
+    assert_eq!(inserted.formatted, "my $x = 1;\n");
+    assert!(trimmed.changed);
+    assert_eq!(trimmed.formatted, "my $x = 1;");
+}
+
+#[test]
+fn native_formatter_skips_edits_when_source_has_parse_diagnostics() {
+    let formatter = NativeFormatter::new();
+    let source = "my $x = ;\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert!(result.edits.is_empty());
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].code, "native.format.parse_error");
+    assert!(result.diagnostics[0].message.contains("does not parse cleanly"));
+}
+
+#[test]
+fn native_formatter_reports_utf16_parse_error_range() {
+    let formatter = NativeFormatter::new();
+    let source = "my $face = \"😀\";\nmy $x = ;\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert_eq!(result.diagnostics.len(), 1);
+    assert!(result.diagnostics[0].range.is_some());
+}
+
+#[test]
+fn native_formatter_refuses_pod_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "=pod\n\n=head1 NAME\n\n=cut\n\nmy $x = 1;\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("POD"));
+}
+
+#[test]
+fn native_formatter_refuses_heredoc_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "print <<'EOF';\nraw { text }\nEOF\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("heredoc"));
+}
+
+#[test]
+fn native_formatter_refuses_data_section_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "my $x = 1;\n__DATA__\nraw\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("DATA section"));
+}
+
+#[test]
+fn native_formatter_does_not_treat_bitshift_as_heredoc() {
+    let formatter = NativeFormatter::new();
+    let source = "my $x = 1 << 2;";
+    let config = FormatConfig { final_newline: FinalNewline::Insert, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my $x = 1 << 2;\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_range_formatter_is_parse_gated_but_does_not_rewrite_yet() {
+    let formatter = NativeFormatter::new();
+    let source = "my $x = 1;\nmy $y = 2;\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 10));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert!(result.edits.is_empty());
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_off_mode_never_parses_or_edits() {
+    let formatter = NativeFormatter::new();
+    let config = FormatConfig { mode: FormatterMode::Off, ..FormatConfig::default() };
+    let source = "my $x = ;\n";
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert!(result.diagnostics.is_empty());
+}


### PR DESCRIPTION
## Summary

Adds the first executable Rust-native formatter engine behind the formatter contract. `NativeFormatter` is intentionally parse-gated and layout-no-op for now: it validates source with `perl-parser-core` before allowing any native edit, supports final-newline policy after a clean parse, and leaves range formatting unchanged until real range layout passes land.

This keeps the native formatter path conservative while giving future formatter passes a safety boundary: invalid or recovered Perl source produces a structured `native.format.parse_error` diagnostic and no edits. Literal-preserve regions that need dedicated handling (`POD`, heredocs, `__DATA__` / `__END__`) also produce `native.format.literal_preserve_region` and no edits, so even final-newline policy does not touch them yet.

## Changes

- Add `perl-parser-core` as a formatter-crate dependency.
- Export `NativeFormatter` from `perl-lsp-perltidy`.
- Implement `PerlFormatter` for `NativeFormatter` with clean-parse validation.
- Add literal-preserve gating for POD, heredoc, and data/end sections.
- Add focused parse-gate tests for clean no-op formatting, final-newline policy, parse-error no-edit behavior, literal-preserve no-edit behavior, range gating, UTF-16 diagnostic range presence, and off mode.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- release_version
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_parse_gate_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked --lib -p perl-lsp-perltidy -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `just version-check`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

Known local validation note:
- `just release-check` currently fails in `cargo xtask ci-audit-workflows` because `policy-validators.yml:validate` is reported as an ungated PR job. This branch does not touch workflows; treating that as an existing CI/policy cleanup issue, not a formatter regression.