### PR TITLE
test(lints): add role/common mistake coverage (#8391)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/common_mistakes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/common_mistakes.rs
@@ -169,7 +169,7 @@ mod tests {
     use super::*;
     use perl_parser_core::parser::Parser;
     use perl_semantic_analyzer::analysis::symbol::SymbolExtractor;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     fn common_mistakes_diags(source: &str) -> Vec<Diagnostic> {
         let ast = must(Parser::new(source).parse());
@@ -203,6 +203,84 @@ mod tests {
         assert!(
             diags.iter().all(|d| d.code.as_deref() != Some("PL400")),
             "STDOUT handle should not be flagged as PL400: {diags:?}"
+        );
+    }
+
+    // --- PL403: assignment in condition ---
+
+    #[test]
+    fn assignment_in_if_condition_fires_pl403() {
+        let diags = common_mistakes_diags("my $x; if ($x = 5) { }");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL403")),
+            "assignment in `if` condition should fire PL403: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn comparison_in_if_condition_no_pl403() {
+        let diags = common_mistakes_diags("my $x = 0; if ($x == 5) { }");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL403")),
+            "comparison in `if` condition should not fire PL403: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn assignment_in_while_condition_fires_pl403() {
+        let diags = common_mistakes_diags("my $line; while ($line = 'data') { last; }");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL403")),
+            "assignment in `while` condition should fire PL403: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn string_comparison_in_if_no_pl403() {
+        let diags = common_mistakes_diags(r#"my $s = ""; if ($s eq "hello") { }"#);
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL403")),
+            "string eq comparison should not fire PL403: {diags:?}"
+        );
+    }
+
+    // --- PL404: numeric comparison with potentially undefined value ---
+
+    #[test]
+    fn numeric_compare_with_explicit_undef_fires_pl404() {
+        let diags = common_mistakes_diags("if (undef == 5) { }");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL404")),
+            "numeric comparison with `undef` should fire PL404: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn numeric_compare_with_undef_not_equal_fires_pl404() {
+        let diags = common_mistakes_diags("if (undef != 0) { }");
+        assert!(
+            diags.iter().any(|d| d.code.as_deref() == Some("PL404")),
+            "!= comparison with `undef` should fire PL404: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn numeric_compare_with_declared_scalar_no_pl404() {
+        let diags = common_mistakes_diags("my $x = 10; if ($x == 5) { }");
+        assert!(
+            diags.iter().all(|d| d.code.as_deref() != Some("PL404")),
+            "numeric compare with declared scalar should not fire PL404: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn pl403_diagnostic_suggests_double_equals() {
+        let diags = common_mistakes_diags("my $x; if ($x = 5) { }");
+        let pl403 = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL403")));
+        let suggestion = pl403.suggestion.as_deref().unwrap_or("");
+        assert!(
+            suggestion.contains("==") || suggestion.contains("eq"),
+            "PL403 suggestion should mention '==' or 'eq': {suggestion}"
         );
     }
 }

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/role_conflicts.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/role_conflicts.rs
@@ -129,3 +129,221 @@ fn format_role_list(role_names: &[String]) -> String {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser::Parser;
+    use perl_semantic_analyzer::analysis::symbol::SymbolExtractor;
+    use perl_tdd_support::{must, must_some};
+
+    fn role_conflict_diags(source: &str) -> Vec<Diagnostic> {
+        let ast = must(Parser::new(source).parse());
+        let symbol_table = SymbolExtractor::new_with_source(source).extract(&ast);
+        let mut diagnostics = Vec::new();
+        check_role_conflicts(&ast, &symbol_table, &mut diagnostics);
+        diagnostics
+    }
+
+    fn has_code(diags: &[Diagnostic], code: &str) -> bool {
+        diags.iter().any(|d| d.code.as_deref() == Some(code))
+    }
+
+    #[test]
+    fn two_roles_with_same_method_fires_pl303() {
+        let source = r#"
+package MyRole::Greet;
+use Moo::Role;
+sub greet { return "hello" }
+
+package MyRole::Welcome;
+use Moo::Role;
+sub greet { return "welcome" }
+
+package MyClass;
+use Moo;
+with 'MyRole::Greet', 'MyRole::Welcome';
+"#;
+        let diags = role_conflict_diags(source);
+        assert!(
+            has_code(&diags, "PL303"),
+            "two roles with same method should fire PL303: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn class_overriding_conflicting_method_suppresses_pl303() {
+        let source = r#"
+package MyRole::Greet;
+use Moo::Role;
+sub greet { return "hello" }
+
+package MyRole::Welcome;
+use Moo::Role;
+sub greet { return "welcome" }
+
+package MyClass;
+use Moo;
+with 'MyRole::Greet', 'MyRole::Welcome';
+sub greet { return "my custom greeting" }
+"#;
+        let diags = role_conflict_diags(source);
+        assert!(
+            !has_code(&diags, "PL303"),
+            "class providing its own `greet` should suppress PL303: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn roles_with_non_overlapping_methods_no_pl303() {
+        let source = r#"
+package MyRole::Greet;
+use Moo::Role;
+sub greet { return "hello" }
+
+package MyRole::Farewell;
+use Moo::Role;
+sub farewell { return "goodbye" }
+
+package MyClass;
+use Moo;
+with 'MyRole::Greet', 'MyRole::Farewell';
+"#;
+        let diags = role_conflict_diags(source);
+        assert!(
+            !has_code(&diags, "PL303"),
+            "non-overlapping role methods should not fire PL303: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn single_role_consumed_no_pl303() {
+        let source = r#"
+package MyRole::Greet;
+use Moo::Role;
+sub greet { return "hello" }
+
+package MyClass;
+use Moo;
+with 'MyRole::Greet';
+"#;
+        let diags = role_conflict_diags(source);
+        assert!(
+            !has_code(&diags, "PL303"),
+            "single role consumption should not fire PL303: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn three_roles_all_with_same_method_fires_pl303() {
+        let source = r#"
+package MyRole::A;
+use Moo::Role;
+sub process { return "A" }
+
+package MyRole::B;
+use Moo::Role;
+sub process { return "B" }
+
+package MyRole::C;
+use Moo::Role;
+sub process { return "C" }
+
+package MyClass;
+use Moo;
+with 'MyRole::A', 'MyRole::B', 'MyRole::C';
+"#;
+        let diags = role_conflict_diags(source);
+        assert!(
+            has_code(&diags, "PL303"),
+            "three roles with the same method should fire PL303: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn diagnostic_message_names_conflicting_method() {
+        let source = r#"
+package MyRole::A;
+use Moo::Role;
+sub run { 1 }
+
+package MyRole::B;
+use Moo::Role;
+sub run { 1 }
+
+package MyClass;
+use Moo;
+with 'MyRole::A', 'MyRole::B';
+"#;
+        let diags = role_conflict_diags(source);
+        let pl303 = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL303")));
+        let msg = &pl303.message;
+        assert!(msg.contains("run"), "message should name the conflicting method `run`: {msg}");
+    }
+
+    #[test]
+    fn class_without_any_roles_no_pl303() {
+        let source = r#"
+package MyClass;
+use Moo;
+sub greet { "hello" }
+"#;
+        let diags = role_conflict_diags(source);
+        assert!(!has_code(&diags, "PL303"), "class with no roles should not fire PL303: {diags:?}");
+    }
+
+    #[test]
+    fn plain_package_without_oo_framework_no_pl303() {
+        let source = r#"
+package MyPackage;
+sub greet { "hello" }
+"#;
+        let diags = role_conflict_diags(source);
+        assert!(
+            !has_code(&diags, "PL303"),
+            "plain package without Moo/Moose should not fire PL303: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn pl303_diagnostic_includes_suggestion() {
+        let source = r#"
+package MyRole::A;
+use Moo::Role;
+sub handle { 1 }
+
+package MyRole::B;
+use Moo::Role;
+sub handle { 1 }
+
+package MyClass;
+use Moo;
+with 'MyRole::A', 'MyRole::B';
+"#;
+        let diags = role_conflict_diags(source);
+        let pl303 = must_some(diags.iter().find(|d| d.code.as_deref() == Some("PL303")));
+        assert!(pl303.suggestion.is_some(), "PL303 should include a resolution suggestion");
+    }
+
+    #[test]
+    fn moose_role_conflict_also_fires_pl303() {
+        let source = r#"
+package MyRole::A;
+use Moose::Role;
+sub serialize { 1 }
+
+package MyRole::B;
+use Moose::Role;
+sub serialize { 1 }
+
+package MyClass;
+use Moose;
+with 'MyRole::A', 'MyRole::B';
+"#;
+        let diags = role_conflict_diags(source);
+        assert!(
+            has_code(&diags, "PL303"),
+            "Moose::Role conflict should also fire PL303: {diags:?}"
+        );
+    }
+}


### PR DESCRIPTION
Problem: PL303, PL403, and PL404 lint behavior had limited direct unit coverage.
Fix: Add focused positive/negative unit coverage for role conflicts, assignment-in-condition, and undef numeric comparisons without changing runtime lint behavior.
Verification: `cargo test -p perl-lsp-rs-core --profile agent --locked role_conflicts -- --nocapture`; `cargo test -p perl-lsp-rs-core --profile agent --locked common_mistakes -- --nocapture`; `cargo xtask fmt --check`; `git diff --check origin/master...HEAD`

Fixes #8391
