### PR TITLE
feat(format): add simple native range layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -465,6 +465,41 @@ impl NativeFormatter {
         formatted
     }
 
+    fn format_safe_subset_range(source: &str, range: TextRange) -> (String, Vec<TextEdit>) {
+        let mut formatted = String::with_capacity(source.len());
+        let mut edits = Vec::new();
+
+        for (line_index, line) in source.split_inclusive('\n').enumerate() {
+            let line_index = line_index as u32;
+            let (body, line_ending) = split_line_ending(line);
+            let formatted_body = if range_includes_line(range, line_index) {
+                format_simple_lexical_line(body)
+            } else {
+                None
+            };
+
+            if let Some(formatted_line) = formatted_body {
+                if formatted_line != body {
+                    edits.push(TextEdit::new(
+                        TextRange::new(
+                            TextPosition::new(line_index, 0),
+                            TextPosition::new(line_index, utf16_len(body) as u32),
+                        ),
+                        formatted_line.clone(),
+                    ));
+                    formatted.push_str(&formatted_line);
+                } else {
+                    formatted.push_str(body);
+                }
+            } else {
+                formatted.push_str(body);
+            }
+            formatted.push_str(line_ending);
+        }
+
+        (formatted, edits)
+    }
+
     fn apply_final_newline(source: &str, config: &FormatConfig) -> String {
         match config.final_newline {
             FinalNewline::Preserve => source.to_string(),
@@ -504,7 +539,7 @@ impl PerlFormatter for NativeFormatter {
         FormatResult::replace_document(source, formatted)
     }
 
-    fn format_range(&self, source: &str, _range: TextRange, config: &FormatConfig) -> FormatResult {
+    fn format_range(&self, source: &str, range: TextRange, config: &FormatConfig) -> FormatResult {
         if matches!(config.mode, FormatterMode::Off) {
             return FormatResult::unchanged(source);
         }
@@ -515,7 +550,19 @@ impl PerlFormatter for NativeFormatter {
             return result;
         }
 
-        FormatResult::unchanged(source)
+        let (formatted, edits) = Self::format_safe_subset_range(source, range);
+        if let Err(diagnostic) = Self::validate_clean_parse(&formatted) {
+            let mut result = FormatResult::unchanged(source);
+            result.diagnostics.push(FormatDiagnostic::new(
+                PARSE_PRESERVATION_CODE,
+                FormatDiagnosticSeverity::Warning,
+                diagnostic.range,
+                "native range formatting skipped because formatted output did not parse cleanly",
+            ));
+            return result;
+        }
+
+        FormatResult { formatted, changed: !edits.is_empty(), edits, diagnostics: Vec::new() }
     }
 }
 
@@ -531,6 +578,11 @@ fn split_line_ending(line: &str) -> (&str, &str) {
     } else {
         (line, "")
     }
+}
+
+fn range_includes_line(range: TextRange, line: u32) -> bool {
+    line >= range.start.line
+        && (line < range.end.line || line == range.end.line && range.end.character > 0)
 }
 
 fn format_simple_lexical_line(line: &str) -> Option<String> {

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -1,4 +1,6 @@
-use perl_lsp_perltidy::{FinalNewline, FormatConfig, NativeFormatter, PerlFormatter};
+use perl_lsp_perltidy::{
+    FinalNewline, FormatConfig, NativeFormatter, PerlFormatter, TextPosition, TextRange,
+};
 
 #[test]
 fn native_formatter_formats_simple_lexical_declarations() {
@@ -64,6 +66,37 @@ fn native_formatter_combines_simple_layout_with_final_newline_policy() {
     let result = formatter.format_document("my $x=1;", &config);
 
     assert_eq!(result.formatted, "my $x = 1;\n");
+}
+
+#[test]
+fn native_range_formatter_formats_only_selected_simple_declaration_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nmy$y=2;\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 7));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my$x=1;\nmy $y = 2;\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(
+        result.edits[0].range,
+        TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 7))
+    );
+    assert_eq!(result.edits[0].new_text, "my $y = 2;");
+}
+
+#[test]
+fn native_range_formatter_treats_end_line_at_character_zero_as_exclusive() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nmy$y=2;\n";
+    let range = TextRange::new(TextPosition::new(0, 0), TextPosition::new(1, 0));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert_eq!(result.formatted, "my $x = 1;\nmy$y=2;\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].new_text, "my $x = 1;");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Extends `NativeFormatter::format_range` to apply the same safe simple lexical declaration layout pass line-by-line within the requested LSP range. Range formatting now returns targeted line edits instead of a whole-document replacement and still validates both input and formatted output before returning edits.

## Changes

- Add range-scoped simple lexical declaration layout.
- Return per-line `TextEdit`s for changed selected lines.
- Treat an end position at character `0` as excluding that line.
- Keep final-newline policy out of range formatting.
- Add tests for selected-line formatting and exclusive end-line behavior.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_layout_tests --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_parse_gate_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked --lib -p perl-lsp-perltidy -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`