### PR TITLE
feat(format): advertise native formatter without perltidy (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/features/policy.rs
+++ b/crates/perl-lsp-rs-core/src/features/policy.rs
@@ -81,17 +81,12 @@ impl FeatureProfile {
         }
     }
 
-    /// Convert this policy into runtime `BuildFlags` that include
-    /// per-tool availability effects.
-    pub fn runtime_flags(self, has_perltidy: bool) -> BuildFlags {
-        let mut flags = self.build_flags();
-
-        // Perltidy availability gates formatting at runtime regardless of
-        // the compile-time default in the build profile.
-        flags.formatting = has_perltidy;
-        flags.range_formatting = has_perltidy;
-
-        flags
+    /// Convert this policy into runtime `BuildFlags`.
+    pub fn runtime_flags(self, _has_perltidy: bool) -> BuildFlags {
+        // Native formatting is built into the server. Perltidy availability is
+        // still detected for the external compatibility adapter, but it no
+        // longer gates whether formatting capabilities can be advertised.
+        self.build_flags()
     }
 
     /// Convert this policy into server advertised features.
@@ -248,7 +243,7 @@ mod tests {
         assert_eq!(flags, expected);
     }
 
-    // ── runtime_flags with perltidy ─────────────────────────────────
+    // ── runtime_flags with native formatting ────────────────────────
 
     #[test]
     fn runtime_flags_enables_formatting_when_perltidy_available() {
@@ -258,10 +253,13 @@ mod tests {
     }
 
     #[test]
-    fn runtime_flags_disables_formatting_without_perltidy() {
+    fn runtime_flags_keeps_formatting_enabled_without_perltidy() {
         let flags = FeatureProfile::Production.runtime_flags(false);
-        assert!(!flags.formatting, "formatting should be off without perltidy");
-        assert!(!flags.range_formatting, "range_formatting should be off without perltidy");
+        assert!(flags.formatting, "native formatting should be enabled without perltidy");
+        assert!(
+            flags.range_formatting,
+            "native range formatting should be enabled without perltidy"
+        );
     }
 
     // ── flags_for_profile / flags_for_runtime ───────────────────────
@@ -483,21 +481,24 @@ mod tests {
     }
 
     #[test]
-    fn runtime_flags_no_perltidy_disables_formatting_for_production() {
+    fn runtime_flags_no_perltidy_keeps_native_formatting_for_production() {
         let base = FeatureProfile::Production.build_flags();
         let runtime = FeatureProfile::Production.runtime_flags(false);
         assert!(base.formatting, "build_flags should enable formatting");
-        assert!(!runtime.formatting, "runtime(false) should disable formatting");
-        assert!(!runtime.range_formatting, "runtime(false) should disable range_formatting");
+        assert!(runtime.formatting, "runtime(false) should keep native formatting enabled");
+        assert!(
+            runtime.range_formatting,
+            "runtime(false) should keep native range_formatting enabled"
+        );
     }
 
     #[test]
-    fn runtime_advertised_features_without_perltidy_disables_formatting() {
+    fn runtime_advertised_features_without_perltidy_keeps_native_formatting() {
         let adv = FeatureProfile::Production.runtime_advertised_features(false);
-        assert!(!adv.formatting, "production without perltidy should not advertise formatting");
+        assert!(adv.formatting, "production without perltidy should advertise native formatting");
         assert!(
-            !adv.range_formatting,
-            "production without perltidy should not advertise range_formatting"
+            adv.range_formatting,
+            "production without perltidy should advertise native range_formatting"
         );
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
@@ -1,7 +1,10 @@
-//! Code formatting support using Perl::Tidy for Perl parsing workflow pipeline.
+//! Code formatting support for Perl parsing workflow pipeline.
 
 pub use crate::providers::formatting_types::{
     FormatPosition, FormatRange, FormatTextEdit, FormattedDocument, FormattingOptions,
+};
+use crate::tooling::perltidy::{
+    FinalNewline, FormatConfig, NativeFormatter, PerlFormatter, TextPosition, TextRange,
 };
 
 /// Re-export PerlTidyConfig from perl-lsp-perltidy for convenience.
@@ -52,7 +55,7 @@ impl FormattingError {
     }
 }
 
-/// Code formatter using perltidy.
+/// Code formatter using native formatting with an external perltidy adapter.
 pub struct FormattingProvider<R> {
     /// Subprocess runtime for executing perltidy.
     runtime: R,
@@ -90,12 +93,8 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
     ) -> Result<FormattedDocument, FormattingError> {
         let formatted = match self.run_perltidy(content, options) {
             Ok(formatted) => formatted,
-            Err(FormattingError::PerltidyNotFound(message)) => {
-                let rust_only_formatted = apply_lsp_whitespace_options(content, options);
-                if rust_only_formatted == content {
-                    return Err(FormattingError::PerltidyNotFound(message));
-                }
-                rust_only_formatted
+            Err(FormattingError::PerltidyNotFound(_)) => {
+                return Ok(native_format_document(content, options));
             }
             Err(other) => return Err(other),
         };
@@ -136,18 +135,8 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
         let text_to_format = lines[start_line..=end_line].join("\n");
         let formatted = match self.run_perltidy(&text_to_format, options) {
             Ok(formatted) => formatted,
-            Err(FormattingError::PerltidyNotFound(message)) => {
-                // `text_to_format` is a line-joined fragment (no surrounding newlines).
-                // `apply_lsp_whitespace_options` may append a trailing '\n' when
-                // `insert_final_newline` is true; strip it here so the LSP edit
-                // `new_text` does not inject an extra blank line into the document
-                // (the range replacement already sits between existing newlines).
-                let raw = apply_lsp_whitespace_options(&text_to_format, options);
-                let rust_only_formatted = raw.trim_end_matches('\n').to_string();
-                if rust_only_formatted == text_to_format {
-                    return Err(FormattingError::PerltidyNotFound(message));
-                }
-                rust_only_formatted
+            Err(FormattingError::PerltidyNotFound(_)) => {
+                return Ok(native_format_range(content, range, options));
             }
             Err(other) => return Err(other),
         };
@@ -243,6 +232,130 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
     }
 }
 
+fn native_format_document(content: &str, options: &FormattingOptions) -> FormattedDocument {
+    let config = native_format_config(options, true);
+    let result = NativeFormatter::new().format_document(content, &config);
+    if result.diagnostics.is_empty() {
+        let formatted = apply_lsp_whitespace_options(&result.formatted, options);
+        if formatted != result.formatted {
+            return FormattedDocument {
+                text: formatted.clone(),
+                edits: vec![FormatTextEdit {
+                    range: FormatRange::whole_document(content),
+                    new_text: formatted,
+                }],
+            };
+        }
+
+        return FormattedDocument {
+            text: result.formatted,
+            edits: result.edits.into_iter().map(native_edit_to_format_edit).collect(),
+        };
+    }
+
+    let formatted = apply_lsp_whitespace_options(content, options);
+    if formatted == content {
+        FormattedDocument { text: content.to_string(), edits: vec![] }
+    } else {
+        FormattedDocument {
+            text: formatted.clone(),
+            edits: vec![FormatTextEdit {
+                range: FormatRange::whole_document(content),
+                new_text: formatted,
+            }],
+        }
+    }
+}
+
+fn native_format_range(
+    content: &str,
+    range: &FormatRange,
+    options: &FormattingOptions,
+) -> FormattedDocument {
+    let native_range = TextRange::new(
+        TextPosition::new(range.start.line, range.start.character),
+        TextPosition::new(range.end.line, range.end.character),
+    );
+    let result = NativeFormatter::new().format_range(
+        content,
+        native_range,
+        &native_format_config(options, false),
+    );
+    if result.diagnostics.is_empty() {
+        if result.edits.is_empty() {
+            return whitespace_range_fallback(content, range, options);
+        }
+
+        return FormattedDocument {
+            text: result.formatted,
+            edits: result.edits.into_iter().map(native_edit_to_format_edit).collect(),
+        };
+    }
+
+    whitespace_range_fallback(content, range, options)
+}
+
+fn native_format_config(options: &FormattingOptions, allow_final_newline: bool) -> FormatConfig {
+    FormatConfig {
+        indent_width: options.tab_size,
+        use_tabs: !options.insert_spaces,
+        final_newline: if allow_final_newline {
+            if options.trim_final_newlines.unwrap_or(false) {
+                FinalNewline::Trim
+            } else if options.insert_final_newline.unwrap_or(false) {
+                FinalNewline::Insert
+            } else {
+                FinalNewline::Preserve
+            }
+        } else {
+            FinalNewline::Preserve
+        },
+        ..FormatConfig::default()
+    }
+}
+
+fn native_edit_to_format_edit(edit: crate::tooling::perltidy::TextEdit) -> FormatTextEdit {
+    FormatTextEdit {
+        range: FormatRange::new(
+            FormatPosition::new(edit.range.start.line, edit.range.start.character),
+            FormatPosition::new(edit.range.end.line, edit.range.end.character),
+        ),
+        new_text: edit.new_text,
+    }
+}
+
+fn whitespace_range_fallback(
+    content: &str,
+    range: &FormatRange,
+    options: &FormattingOptions,
+) -> FormattedDocument {
+    let lines: Vec<&str> = content.lines().collect();
+    let start_line = range.start.line as usize;
+    let end_line = (range.end.line as usize).min(lines.len().saturating_sub(1));
+
+    if start_line >= lines.len() || end_line < start_line {
+        return FormattedDocument { text: content.to_string(), edits: vec![] };
+    }
+
+    let text_to_format = lines[start_line..=end_line].join("\n");
+    let raw = apply_lsp_whitespace_options(&text_to_format, options);
+    let formatted = raw.trim_end_matches('\n').to_string();
+    if formatted == text_to_format {
+        return FormattedDocument { text: content.to_string(), edits: vec![] };
+    }
+
+    FormattedDocument {
+        text: content.to_string(),
+        edits: vec![FormatTextEdit {
+            range: FormatRange::new(
+                FormatPosition::new(start_line as u32, 0),
+                FormatPosition::new(end_line as u32, utf16_len(lines[end_line]) as u32),
+            ),
+            new_text: formatted,
+        }],
+    }
+}
+
 fn apply_lsp_whitespace_options(content: &str, options: &FormattingOptions) -> String {
     let mut output = content.to_string();
 
@@ -297,24 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn format_document_uses_rust_whitespace_fallback_when_perltidy_missing() -> Result<()> {
-        let provider = FormattingProvider::new(MissingPerltidyRuntime);
-        let options = FormattingOptions {
-            tab_size: 4,
-            insert_spaces: true,
-            trim_trailing_whitespace: Some(true),
-            insert_final_newline: Some(true),
-            trim_final_newlines: Some(true),
-        };
-
-        let formatted = provider.format_document("my $x = 1;   \n\n\n", &options)?;
-        assert_eq!(formatted.edits.len(), 1);
-        assert_eq!(formatted.edits[0].new_text, "my $x = 1;\n");
-        Ok(())
-    }
-
-    #[test]
-    fn format_document_keeps_perltidy_not_found_error_when_no_rust_fallback_changes() {
+    fn format_document_uses_native_formatter_when_perltidy_missing() -> Result<()> {
         let provider = FormattingProvider::new(MissingPerltidyRuntime);
         let options = FormattingOptions {
             tab_size: 4,
@@ -324,12 +420,48 @@ mod tests {
             trim_final_newlines: None,
         };
 
-        let result = provider.format_document("my $x = 1;\n", &options);
-        assert!(matches!(result, Err(FormattingError::PerltidyNotFound(_))));
+        let formatted = provider.format_document("my$x=1;\n", &options)?;
+        assert_eq!(formatted.edits.len(), 1);
+        assert_eq!(formatted.edits[0].new_text, "my $x = 1;\n");
+        Ok(())
     }
 
     #[test]
-    fn format_range_uses_rust_whitespace_fallback_when_perltidy_missing() -> Result<()> {
+    fn format_document_returns_empty_edits_when_native_formatter_has_no_changes() -> Result<()> {
+        let provider = FormattingProvider::new(MissingPerltidyRuntime);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: None,
+            insert_final_newline: None,
+            trim_final_newlines: None,
+        };
+
+        let result = provider.format_document("my $x = 1;\n", &options)?;
+        assert!(result.edits.is_empty());
+        assert_eq!(result.text, "my $x = 1;\n");
+        Ok(())
+    }
+
+    #[test]
+    fn format_document_falls_back_to_lsp_whitespace_when_native_declines() -> Result<()> {
+        let provider = FormattingProvider::new(MissingPerltidyRuntime);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: Some(false),
+            trim_final_newlines: None,
+        };
+
+        let formatted = provider.format_document("=pod\n\n=cut\n\nmy $x = 1;   \n", &options)?;
+        assert_eq!(formatted.edits.len(), 1);
+        assert_eq!(formatted.edits[0].new_text, "=pod\n\n=cut\n\nmy $x = 1;\n");
+        Ok(())
+    }
+
+    #[test]
+    fn format_range_uses_native_formatter_when_perltidy_missing() -> Result<()> {
         let provider = FormattingProvider::new(MissingPerltidyRuntime);
         let options = FormattingOptions {
             tab_size: 4,
@@ -342,7 +474,7 @@ mod tests {
 
         let formatted = provider.format_range(
             "line1
-my $x = 1;   
+my$x=1;
 line3
 ",
             &range,
@@ -380,7 +512,7 @@ line3
     }
 
     #[test]
-    fn format_range_keeps_perltidy_not_found_error_when_no_rust_fallback_changes() {
+    fn format_range_returns_empty_edits_when_native_formatter_has_no_changes() -> Result<()> {
         let provider = FormattingProvider::new(MissingPerltidyRuntime);
         let options = FormattingOptions {
             tab_size: 4,
@@ -396,8 +528,9 @@ line3
 ",
             &range,
             &options,
-        );
-        assert!(matches!(result, Err(FormattingError::PerltidyNotFound(_))));
+        )?;
+        assert!(result.edits.is_empty());
+        Ok(())
     }
 
     #[test]

--- a/crates/perl-lsp-rs/tests/lsp_batteries_included_test.rs
+++ b/crates/perl-lsp-rs/tests/lsp_batteries_included_test.rs
@@ -32,7 +32,7 @@ fn test_formatting_capability_advertised() -> Result<(), Box<dyn std::error::Err
 
     // Verify formatting is advertised
     if let Some(formatting_provider) = capabilities.get("documentFormattingProvider") {
-        // Formatting is conditional on perltidy availability; when present it should be a valid
+        // Formatting is provided natively; when advertised it should be a valid
         // capability payload.
         assert!(
             formatting_provider.is_boolean() || formatting_provider.is_object(),
@@ -40,7 +40,7 @@ fn test_formatting_capability_advertised() -> Result<(), Box<dyn std::error::Err
         );
     }
 
-    // Range formatting follows the same tool-availability gating as full-document formatting.
+    // Range formatting follows the same native capability shape as full-document formatting.
     if let Some(range_formatting_provider) = capabilities.get("documentRangeFormattingProvider") {
         assert!(
             range_formatting_provider.is_boolean() || range_formatting_provider.is_object(),

--- a/crates/perl-lsp-rs/tests/lsp_capabilities_contract.rs
+++ b/crates/perl-lsp-rs/tests/lsp_capabilities_contract.rs
@@ -111,8 +111,8 @@ fn test_ga_capabilities_contract() -> Result<(), Box<dyn std::error::Error>> {
         "executeCommandProvider must be advertised (implemented in v0.8.6)"
     );
 
-    // documentFormattingProvider is conditional on perltidy availability - that's OK
-    // It can be either true or null depending on environment
+    // documentFormattingProvider is native-first; capability shape is validated
+    // by the formatting-specific tests.
 
     Ok(())
 }

--- a/crates/perl-lsp-rs/tests/lsp_perltidy_test.rs
+++ b/crates/perl-lsp-rs/tests/lsp_perltidy_test.rs
@@ -81,11 +81,9 @@ fn test_pragma_code_actions() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Test that formatting provider is advertised when perltidy is available
+/// Test that formatting provider is advertised through the native formatter.
 #[test]
 fn test_formatting_provider_capability() -> Result<(), Box<dyn std::error::Error>> {
-    let has_perltidy = perl_lsp::execute_command::command_exists("perltidy");
-
     let srv = LspServer::new();
 
     let init_req = JsonRpcRequest {
@@ -104,11 +102,7 @@ fn test_formatting_provider_capability() -> Result<(), Box<dyn std::error::Error
     let has_formatting =
         result["capabilities"]["documentFormattingProvider"].as_bool().unwrap_or(false);
 
-    // Formatting should only be advertised if perltidy is available
-    assert_eq!(
-        has_formatting, has_perltidy,
-        "documentFormattingProvider should match perltidy availability"
-    );
+    assert!(has_formatting, "documentFormattingProvider should be advertised natively");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Moves formatting one step closer to native-first operation:

- formatting and range-formatting capabilities are advertised even when `perltidy` is absent
- missing external `perltidy` now falls back to the parse-gated native formatter instead of returning an install-tool error
- native fallback preserves existing LSP whitespace options and range-edit newline safety
- tests now assert formatting capability is native rather than tied to `perltidy` executable discovery

This keeps the external perltidy adapter intact for compatibility; it only removes `perltidy` as a capability prerequisite and fallback dependency.

## Proof packet

Changed surfaces:
- rust_code

Required proof:
- [x] `cargo xtask fmt`
- [x] `git diff --check`

Focused native formatting proof:
- [x] `cargo xtask native-format check`
- [x] `cargo test -p perl-lsp-rs-core providers::formatting::formatting --lib --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core features::policy --lib --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_perltidy_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_capabilities_contract --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core --lib --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo check -p perl-lsp-rs --locked`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
