### PR TITLE
feat(format): expand simple native conditional layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -591,7 +591,9 @@ fn range_includes_line(range: TextRange, line: u32) -> bool {
 }
 
 fn format_simple_line(line: &str, config: &FormatConfig) -> Option<String> {
-    format_simple_subroutine_line(line, config).or_else(|| format_simple_lexical_line(line))
+    format_simple_if_line(line, config)
+        .or_else(|| format_simple_subroutine_line(line, config))
+        .or_else(|| format_simple_lexical_line(line))
 }
 
 fn format_simple_lexical_line(line: &str) -> Option<String> {
@@ -636,6 +638,26 @@ fn format_simple_subroutine_line(line: &str, config: &FormatConfig) -> Option<St
     Some(formatted)
 }
 
+fn format_simple_if_line(line: &str, config: &FormatConfig) -> Option<String> {
+    let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
+    let (indent, body) = line.split_at(indent_len);
+    if body.is_empty() || body.contains('#') {
+        return None;
+    }
+
+    let mut stream = perl_parser_core::TokenStream::new(body);
+    let mut tokens = Vec::new();
+    loop {
+        let token = stream.next().ok()?;
+        if token.kind == perl_parser_core::TokenKind::Eof {
+            break;
+        }
+        tokens.push(token);
+    }
+
+    format_simple_if_tokens(&tokens, indent, config)
+}
+
 fn format_simple_subroutine_tokens(
     tokens: &[perl_parser_core::Token],
     indent: &str,
@@ -658,6 +680,51 @@ fn format_simple_subroutine_tokens(
     let statements = format_simple_statement_block(body_tokens)?;
     let body_indent = format!("{indent}{}", indent_unit(config));
     let mut formatted = format!("{indent}sub {} {{", tokens[1].text);
+
+    if statements.is_empty() {
+        formatted.push('\n');
+        formatted.push_str(indent);
+        formatted.push('}');
+        return Some(formatted);
+    }
+
+    for statement in statements {
+        formatted.push('\n');
+        formatted.push_str(&body_indent);
+        formatted.push_str(&statement);
+    }
+    formatted.push('\n');
+    formatted.push_str(indent);
+    formatted.push('}');
+    Some(formatted)
+}
+
+fn format_simple_if_tokens(
+    tokens: &[perl_parser_core::Token],
+    indent: &str,
+    config: &FormatConfig,
+) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.len() < 6 {
+        return None;
+    }
+    if tokens[0].kind != TokenKind::If || tokens[1].kind != TokenKind::LeftParen {
+        return None;
+    }
+
+    let (condition, next_index) = format_simple_condition_tokens(tokens, 2)?;
+    if tokens.get(next_index)?.kind != TokenKind::RightParen
+        || tokens.get(next_index + 1)?.kind != TokenKind::LeftBrace
+        || tokens.last()?.kind != TokenKind::RightBrace
+    {
+        return None;
+    }
+
+    let body_tokens = &tokens[next_index + 2..tokens.len() - 1];
+    let statements = format_simple_statement_block(body_tokens)?;
+    let body_indent = format!("{indent}{}", indent_unit(config));
+    let mut formatted = format!("{indent}if ({condition}) {{");
 
     if statements.is_empty() {
         formatted.push('\n');
@@ -780,6 +847,19 @@ fn format_simple_return_tokens(tokens: &[perl_parser_core::Token]) -> Option<Str
     }
 
     None
+}
+
+fn format_simple_condition_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+) -> Option<(String, usize)> {
+    if let Some((variable, next_index)) = format_variable_tokens(tokens, start) {
+        return Some((variable, next_index));
+    }
+
+    let token = tokens.get(start)?;
+    let value = simple_value_text(token)?;
+    Some((value.to_string(), start + 1))
 }
 
 fn indent_unit(config: &FormatConfig) -> String {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/indented_if.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/indented_if.expected.pl
@@ -1,0 +1,3 @@
+  if ($ok) {
+      return 1;
+  }

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/indented_if.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/indented_if.pl
@@ -1,0 +1,1 @@
+  if($ok){return 1;}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if.expected.pl
@@ -1,0 +1,4 @@
+if ($ok) {
+    my $x = 1;
+    return $x;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if.pl
@@ -1,0 +1,1 @@
+if($ok){my$x=1;return$x;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -134,6 +134,29 @@ fn native_formatter_uses_configured_indent_for_simple_subroutine_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_if_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "if($ok){my$x=1;return$x;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "if ($ok) {\n    my $x = 1;\n    return $x;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_uses_configured_indent_for_simple_if_blocks() {
+    let formatter = NativeFormatter::new();
+    let config = FormatConfig { indent_width: 2, ..FormatConfig::default() };
+    let source = "  if($ok){return 1;}\n";
+
+    let result = formatter.format_document(source, &config);
+
+    assert_eq!(result.formatted, "  if ($ok) {\n    return 1;\n  }\n");
+}
+
+#[test]
 fn native_range_formatter_formats_selected_simple_subroutine_line() {
     let formatter = NativeFormatter::new();
     let source = "my$x=1;\nsub answer{our@y;return@y;}\n";
@@ -146,4 +169,19 @@ fn native_range_formatter_formats_selected_simple_subroutine_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "sub answer {\n    our @y;\n    return @y;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_if_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nif($ok){return$x;}\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 18));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my$x=1;\nif ($ok) {\n    return $x;\n}\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "if ($ok) {\n    return $x;\n}");
 }


### PR DESCRIPTION
## Summary

Adds the next narrow native formatter syntax slice: simple one-line `if (...) { ... }` blocks now expand into stable multi-line layout when the condition and body stay inside the existing safe subset. The formatter remains token-based and parse-gated, keeps comments/POD/heredocs/DATA sections out of scope, and applies the same behavior through range formatting.

## Scope

- Formats simple top-level `if` blocks with scalar/simple literal conditions.
- Reuses existing safe statements inside the block body: lexical declarations and simple `return` statements.
- Adds full-document, configured-indent, range-formatting, and fixture coverage.
- Extends native formatter receipts from 5 to 7 fixtures with idempotence and parse-preservation coverage.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_layout_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`native formatter fixtures: 7/7 passed`)
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

Receipt:
- `target/receipts/format/native-format-fixtures.json`
- `target/receipts/format/native-format-idempotence.json`
- `target/receipts/format/native-format-parse-preservation.json`
