### PR TITLE
feat(format): expand simple native while layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -591,7 +591,7 @@ fn range_includes_line(range: TextRange, line: u32) -> bool {
 }
 
 fn format_simple_line(line: &str, config: &FormatConfig) -> Option<String> {
-    format_simple_if_line(line, config)
+    format_simple_control_block_line(line, config)
         .or_else(|| format_simple_subroutine_line(line, config))
         .or_else(|| format_simple_lexical_line(line))
 }
@@ -638,7 +638,7 @@ fn format_simple_subroutine_line(line: &str, config: &FormatConfig) -> Option<St
     Some(formatted)
 }
 
-fn format_simple_if_line(line: &str, config: &FormatConfig) -> Option<String> {
+fn format_simple_control_block_line(line: &str, config: &FormatConfig) -> Option<String> {
     let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
     let (indent, body) = line.split_at(indent_len);
     if body.is_empty() || body.contains('#') {
@@ -655,7 +655,7 @@ fn format_simple_if_line(line: &str, config: &FormatConfig) -> Option<String> {
         tokens.push(token);
     }
 
-    format_simple_if_tokens(&tokens, indent, config)
+    format_simple_control_block_tokens(&tokens, indent, config)
 }
 
 fn format_simple_subroutine_tokens(
@@ -699,7 +699,7 @@ fn format_simple_subroutine_tokens(
     Some(formatted)
 }
 
-fn format_simple_if_tokens(
+fn format_simple_control_block_tokens(
     tokens: &[perl_parser_core::Token],
     indent: &str,
     config: &FormatConfig,
@@ -709,7 +709,12 @@ fn format_simple_if_tokens(
     if tokens.len() < 6 {
         return None;
     }
-    if tokens[0].kind != TokenKind::If || tokens[1].kind != TokenKind::LeftParen {
+    let keyword = match tokens[0].kind {
+        TokenKind::If => "if",
+        TokenKind::While => "while",
+        _ => return None,
+    };
+    if tokens[1].kind != TokenKind::LeftParen {
         return None;
     }
 
@@ -724,7 +729,7 @@ fn format_simple_if_tokens(
     let body_tokens = &tokens[next_index + 2..tokens.len() - 1];
     let statements = format_simple_statement_block(body_tokens)?;
     let body_indent = format!("{indent}{}", indent_unit(config));
-    let mut formatted = format!("{indent}if ({condition}) {{");
+    let mut formatted = format!("{indent}{keyword} ({condition}) {{");
 
     if statements.is_empty() {
         formatted.push('\n');

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/indented_while.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/indented_while.expected.pl
@@ -1,0 +1,3 @@
+  while ($ok) {
+      return 1;
+  }

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/indented_while.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/indented_while.pl
@@ -1,0 +1,1 @@
+  while($ok){return 1;}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_while.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_while.expected.pl
@@ -1,0 +1,4 @@
+while ($ok) {
+    my $x = 1;
+    return $x;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_while.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_while.pl
@@ -1,0 +1,1 @@
+while($ok){my$x=1;return$x;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -157,6 +157,29 @@ fn native_formatter_uses_configured_indent_for_simple_if_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_while_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "while($ok){my$x=1;return$x;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "while ($ok) {\n    my $x = 1;\n    return $x;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_uses_configured_indent_for_simple_while_blocks() {
+    let formatter = NativeFormatter::new();
+    let config = FormatConfig { indent_width: 2, ..FormatConfig::default() };
+    let source = "  while($ok){return 1;}\n";
+
+    let result = formatter.format_document(source, &config);
+
+    assert_eq!(result.formatted, "  while ($ok) {\n    return 1;\n  }\n");
+}
+
+#[test]
 fn native_range_formatter_formats_selected_simple_subroutine_line() {
     let formatter = NativeFormatter::new();
     let source = "my$x=1;\nsub answer{our@y;return@y;}\n";
@@ -184,4 +207,19 @@ fn native_range_formatter_formats_selected_simple_if_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "if ($ok) {\n    return $x;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_while_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nwhile($ok){return$x;}\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 21));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my$x=1;\nwhile ($ok) {\n    return $x;\n}\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "while ($ok) {\n    return $x;\n}");
 }


### PR DESCRIPTION
## Summary

Adds the next narrow native formatter syntax slice: simple one-line `while (...) { ... }` blocks now share the same safe control-block formatter used by `if` layout. The formatter remains token-based and parse-gated, preserves literal-risk regions by skipping them, and supports the behavior through range formatting.

## Scope

- Generalizes the simple `if` line formatter into a small control-block formatter.
- Adds simple `while` block layout for scalar/simple literal conditions.
- Reuses existing safe block body statements: lexical declarations and simple `return` statements.
- Adds full-document, configured-indent, range-formatting, and fixture coverage.
- Extends native formatter receipts from 7 to 9 fixtures with idempotence and parse-preservation coverage.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_layout_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`native formatter fixtures: 9/9 passed`)
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

Receipt:
- `target/receipts/format/native-format-fixtures.json`
- `target/receipts/format/native-format-idempotence.json`
- `target/receipts/format/native-format-parse-preservation.json`
