### PR TITLE
feat(format): expand simple native inverse control layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -711,7 +711,9 @@ fn format_simple_control_block_tokens(
     }
     let keyword = match tokens[0].kind {
         TokenKind::If => "if",
+        TokenKind::Unless => "unless",
         TokenKind::While => "while",
+        TokenKind::Until => "until",
         _ => return None,
     };
     if tokens[1].kind != TokenKind::LeftParen {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_unless.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_unless.expected.pl
@@ -1,0 +1,4 @@
+unless ($ok) {
+    my $x = 1;
+    return $x;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_unless.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_unless.pl
@@ -1,0 +1,1 @@
+unless($ok){my$x=1;return$x;}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_until.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_until.expected.pl
@@ -1,0 +1,3 @@
+until ($done) {
+    return 1;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_until.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_until.pl
@@ -1,0 +1,1 @@
+until($done){return 1;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -180,6 +180,30 @@ fn native_formatter_uses_configured_indent_for_simple_while_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_unless_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "unless($ok){my$x=1;return$x;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "unless ($ok) {\n    my $x = 1;\n    return $x;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_expands_simple_until_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "until($done){return 1;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "until ($done) {\n    return 1;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_range_formatter_formats_selected_simple_subroutine_line() {
     let formatter = NativeFormatter::new();
     let source = "my$x=1;\nsub answer{our@y;return@y;}\n";
@@ -222,4 +246,19 @@ fn native_range_formatter_formats_selected_simple_while_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "while ($ok) {\n    return $x;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_unless_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nunless($ok){return$x;}\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 22));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my$x=1;\nunless ($ok) {\n    return $x;\n}\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "unless ($ok) {\n    return $x;\n}");
 }


### PR DESCRIPTION
## Summary

Adds the next small native formatter control-flow slice: simple one-line `unless (...) { ... }` and `until (...) { ... }` blocks now use the same safe control-block layout path as `if` and `while`. This keeps the formatter native-first progress narrow, parse-gated, and receipt-backed.

## Scope

- Extends the safe control-block formatter to `unless` and `until`.
- Reuses existing condition and block-body restrictions.
- Adds document-formatting, range-formatting, and fixture coverage.
- Extends native formatter receipts from 9 to 11 fixtures with idempotence and parse-preservation coverage.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_layout_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`native formatter fixtures: 11/11 passed`)
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

Receipt:
- `target/receipts/format/native-format-fixtures.json`
- `target/receipts/format/native-format-idempotence.json`
- `target/receipts/format/native-format-parse-preservation.json`
