### PR TITLE
refactor(module): centralize effective inc root building (#8206)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
@@ -7,7 +7,7 @@ use perl_module::resolution::use_lib::{
     resolve_use_lib_paths_from_source, resolve_use_lib_paths_from_source_at_offset,
 };
 use perl_module::resolution::{
-    IncRoot, IncRootKind, ModuleUriResolution,
+    ModuleUriResolution, build_effective_inc_roots,
     resolve_module_path as resolve_workspace_module_path, resolve_module_uri_with_effective_inc,
 };
 use std::collections::HashSet;
@@ -102,67 +102,6 @@ fn resolution_root(server: &LspServer, doc_uri: Option<&str>) -> Option<PathBuf>
         workspace_folders.iter().map(|f| f.uri.clone()).collect();
     workspace_root_for_doc(&workspace_folder_uris, doc_uri)
         .or_else(|| server.root_path.lock().clone())
-}
-
-fn build_effective_inc_roots(
-    include_paths: &[String],
-    perl5lib_set: &HashSet<String>,
-    lexical_paths: &[String],
-    system_paths: &[PathBuf],
-) -> Vec<IncRoot> {
-    let mut roots = Vec::new();
-    let mut seen = HashSet::new();
-    let mut precedence = 0usize;
-
-    for path in lexical_paths {
-        let path_buf = PathBuf::from(path);
-        let kind = if path_buf.is_absolute() {
-            IncRootKind::ExternalAbsolute
-        } else {
-            IncRootKind::FileLocalLexical
-        };
-        if !seen.insert(normalized_inc_key(&path_buf)) {
-            continue;
-        }
-        roots.push(IncRoot {
-            kind,
-            path: path_buf,
-            precedence,
-            source: "use-lib-lexical".to_string(),
-        });
-        precedence += 1;
-    }
-
-    for path in include_paths {
-        let path_buf = PathBuf::from(path);
-        if !seen.insert(normalized_inc_key(&path_buf)) {
-            continue;
-        }
-        let (kind, source) = if perl5lib_set.contains(path) {
-            (IncRootKind::Perl5LibEnv, "perl5lib-env")
-        } else if path_buf.is_absolute() {
-            (IncRootKind::ExternalAbsolute, "workspace-include-paths")
-        } else {
-            (IncRootKind::WorkspaceRelative, "workspace-include-paths")
-        };
-        roots.push(IncRoot { kind, path: path_buf, precedence, source: source.to_string() });
-        precedence += 1;
-    }
-
-    for path in system_paths {
-        if !seen.insert(normalized_inc_key(path)) {
-            continue;
-        }
-        roots.push(IncRoot {
-            kind: IncRootKind::InterpreterStartup,
-            path: path.clone(),
-            precedence,
-            source: "interpreter-startup-inc".to_string(),
-        });
-        precedence += 1;
-    }
-
-    roots
 }
 
 fn append_system_inc_paths(
@@ -430,13 +369,13 @@ impl LspServer {
             Vec::new()
         };
 
-        let perl5lib_set: HashSet<String> = if config.use_perl5lib {
-            perl5lib_paths.iter().cloned().collect()
-        } else {
-            HashSet::new()
-        };
-        let effective_inc =
-            build_effective_inc_roots(&include_paths, &perl5lib_set, &lexical_paths, &system_paths);
+        let effective_inc = build_effective_inc_roots(
+            &include_paths,
+            &perl5lib_paths,
+            config.use_perl5lib,
+            &lexical_paths,
+            &system_paths,
+        );
 
         match resolve_module_uri_with_effective_inc(
             module_name,
@@ -459,6 +398,7 @@ impl LspServer {
 mod tests {
     use super::*;
     use crate::runtime::workspace_folder::WorkspaceFolderState;
+    use perl_module::resolution::IncRootKind;
     use std::fs;
 
     // --- workspace root detection warning tests ---
@@ -513,10 +453,9 @@ mod tests {
         let include_paths = vec!["lib".to_string(), "lib/".to_string(), "other".to_string()];
         let lexical_paths = vec!["lib\\".to_string()];
         let system_paths = vec![PathBuf::from("other/"), PathBuf::from("syslib")];
-        let no_perl5lib = HashSet::new();
 
         let roots =
-            build_effective_inc_roots(&include_paths, &no_perl5lib, &lexical_paths, &system_paths);
+            build_effective_inc_roots(&include_paths, &[], false, &lexical_paths, &system_paths);
         let root_paths: Vec<String> =
             roots.iter().map(|r| r.path.to_string_lossy().replace('\\', "/")).collect();
 
@@ -568,10 +507,9 @@ mod tests {
         let include_paths = vec!["dup".to_string(), "late".to_string()];
         let lexical_paths = vec!["dup".to_string()];
         let system_paths = vec![PathBuf::from("late"), PathBuf::from("sys")];
-        let no_perl5lib = HashSet::new();
 
         let roots =
-            build_effective_inc_roots(&include_paths, &no_perl5lib, &lexical_paths, &system_paths);
+            build_effective_inc_roots(&include_paths, &[], false, &lexical_paths, &system_paths);
 
         assert_eq!(roots.len(), 3);
         assert_eq!(roots[0].path, PathBuf::from("dup"));
@@ -589,8 +527,8 @@ mod tests {
     fn build_effective_inc_roots_labels_perl5lib_paths() {
         let perl5lib_path = "/home/user/perl5/lib/perl5".to_string();
         let include_paths = vec![perl5lib_path.clone(), "lib".to_string()];
-        let perl5lib_set: HashSet<String> = std::iter::once(perl5lib_path.clone()).collect();
-        let roots = build_effective_inc_roots(&include_paths, &perl5lib_set, &[], &[]);
+        let roots =
+            build_effective_inc_roots(&include_paths, &[perl5lib_path.clone()], true, &[], &[]);
 
         assert_eq!(roots.len(), 2);
         assert_eq!(roots[0].path, PathBuf::from(&perl5lib_path));
@@ -607,8 +545,8 @@ mod tests {
         // A configured path like "lib" must remain WorkspaceRelative even if
         // it coincidentally appears in $PERL5LIB.
         let include_paths = vec!["lib".to_string()];
-        let empty_perl5lib: HashSet<String> = HashSet::new();
-        let roots = build_effective_inc_roots(&include_paths, &empty_perl5lib, &[], &[]);
+        let perl5lib_paths = vec!["lib".to_string()];
+        let roots = build_effective_inc_roots(&include_paths, &perl5lib_paths, false, &[], &[]);
 
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0].kind, IncRootKind::WorkspaceRelative);

--- a/crates/perl-module/src/resolution/mod.rs
+++ b/crates/perl-module/src/resolution/mod.rs
@@ -10,6 +10,6 @@ pub mod use_lib;
 
 pub use path::resolve_module_path;
 pub use uri::{
-    IncRoot, IncRootKind, ModuleUriResolution, resolve_module_uri,
+    IncRoot, IncRootKind, ModuleUriResolution, build_effective_inc_roots, resolve_module_uri,
     resolve_module_uri_with_effective_inc,
 };

--- a/crates/perl-module/src/resolution/uri.rs
+++ b/crates/perl-module/src/resolution/uri.rs
@@ -44,6 +44,78 @@ pub struct IncRoot {
     pub source: String,
 }
 
+/// Build ordered effective include roots from lexical, configured, environment,
+/// and interpreter startup sources.
+///
+/// This centralizes the source-labeling and precedence model used by URI
+/// resolution. Callers are still responsible for computing configured include
+/// paths and deciding whether `PERL5LIB` / system `@INC` should participate.
+#[must_use]
+pub fn build_effective_inc_roots(
+    include_paths: &[String],
+    perl5lib_paths: &[String],
+    use_perl5lib: bool,
+    lexical_paths: &[String],
+    system_paths: &[PathBuf],
+) -> Vec<IncRoot> {
+    let perl5lib_set: HashSet<String> =
+        if use_perl5lib { perl5lib_paths.iter().cloned().collect() } else { HashSet::new() };
+
+    let mut roots = Vec::new();
+    let mut seen = HashSet::new();
+    let mut precedence = 0usize;
+
+    for path in lexical_paths {
+        let path_buf = PathBuf::from(path);
+        let kind = if path_buf.is_absolute() {
+            IncRootKind::ExternalAbsolute
+        } else {
+            IncRootKind::FileLocalLexical
+        };
+        if !seen.insert(normalized_inc_key(&path_buf)) {
+            continue;
+        }
+        roots.push(IncRoot {
+            kind,
+            path: path_buf,
+            precedence,
+            source: "use-lib-lexical".to_string(),
+        });
+        precedence += 1;
+    }
+
+    for path in include_paths {
+        let path_buf = PathBuf::from(path);
+        if !seen.insert(normalized_inc_key(&path_buf)) {
+            continue;
+        }
+        let (kind, source) = if perl5lib_set.contains(path) {
+            (IncRootKind::Perl5LibEnv, "perl5lib-env")
+        } else if path_buf.is_absolute() {
+            (IncRootKind::ExternalAbsolute, "workspace-include-paths")
+        } else {
+            (IncRootKind::WorkspaceRelative, "workspace-include-paths")
+        };
+        roots.push(IncRoot { kind, path: path_buf, precedence, source: source.to_string() });
+        precedence += 1;
+    }
+
+    for path in system_paths {
+        if !seen.insert(normalized_inc_key(path)) {
+            continue;
+        }
+        roots.push(IncRoot {
+            kind: IncRootKind::InterpreterStartup,
+            path: path.clone(),
+            precedence,
+            source: "interpreter-startup-inc".to_string(),
+        });
+        precedence += 1;
+    }
+
+    roots
+}
+
 /// Outcome of a module name to URI resolution attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ModuleUriResolution {
@@ -234,6 +306,11 @@ fn normalize_path_for_dedupe(path: &Path) -> PathBuf {
     if normalized.as_os_str().is_empty() { PathBuf::from(".") } else { normalized }
 }
 
+fn normalized_inc_key(path: &Path) -> String {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    if normalized == "/" { normalized } else { normalized.trim_end_matches('/').to_string() }
+}
+
 fn full_path_for_root(
     inc_root: &IncRoot,
     workspace_path: &Path,
@@ -255,5 +332,66 @@ fn full_path_for_root(
         | IncRootKind::Perl5LibEnv
         | IncRootKind::InterpreterStartup
         | IncRootKind::RuntimeDerived => Some(inc_root.path.join(relative_path)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IncRootKind, build_effective_inc_roots};
+    use std::path::PathBuf;
+
+    #[test]
+    fn effective_inc_roots_dedupes_normalized_sources() {
+        let include_paths = vec!["lib".to_string(), "lib/".to_string(), "other".to_string()];
+        let lexical_paths = vec!["lib\\".to_string()];
+        let system_paths = vec![PathBuf::from("other/"), PathBuf::from("syslib")];
+
+        let roots =
+            build_effective_inc_roots(&include_paths, &[], false, &lexical_paths, &system_paths);
+        let root_paths: Vec<String> =
+            roots.iter().map(|root| root.path.to_string_lossy().replace('\\', "/")).collect();
+
+        assert_eq!(root_paths, vec!["lib/".to_string(), "other".to_string(), "syslib".to_string()]);
+        assert_eq!(roots[0].source, "use-lib-lexical");
+        assert_eq!(roots[1].source, "workspace-include-paths");
+        assert_eq!(roots[2].source, "interpreter-startup-inc");
+    }
+
+    #[test]
+    fn effective_inc_roots_preserves_first_source_precedence() {
+        let include_paths = vec!["dup".to_string(), "late".to_string()];
+        let lexical_paths = vec!["dup".to_string()];
+        let system_paths = vec![PathBuf::from("late"), PathBuf::from("sys")];
+
+        let roots =
+            build_effective_inc_roots(&include_paths, &[], false, &lexical_paths, &system_paths);
+
+        assert_eq!(roots.len(), 3);
+        assert_eq!(roots[0].path, PathBuf::from("dup"));
+        assert_eq!(roots[0].kind, IncRootKind::FileLocalLexical);
+        assert_eq!(roots[1].path, PathBuf::from("late"));
+        assert_eq!(roots[1].kind, IncRootKind::WorkspaceRelative);
+        assert_eq!(roots[2].path, PathBuf::from("sys"));
+        assert_eq!(roots[2].kind, IncRootKind::InterpreterStartup);
+        assert_eq!(roots[0].precedence, 0);
+        assert_eq!(roots[1].precedence, 1);
+        assert_eq!(roots[2].precedence, 2);
+    }
+
+    #[test]
+    fn effective_inc_roots_labels_perl5lib_only_when_enabled() {
+        let perl5lib_path = "perl5lib".to_string();
+        let include_paths = vec![perl5lib_path.clone(), "lib".to_string()];
+
+        let enabled =
+            build_effective_inc_roots(&include_paths, &[perl5lib_path.clone()], true, &[], &[]);
+        assert_eq!(enabled[0].kind, IncRootKind::Perl5LibEnv);
+        assert_eq!(enabled[0].source, "perl5lib-env");
+        assert_eq!(enabled[1].kind, IncRootKind::WorkspaceRelative);
+
+        let disabled = build_effective_inc_roots(&include_paths, &[perl5lib_path], false, &[], &[]);
+        assert_eq!(disabled[0].kind, IncRootKind::WorkspaceRelative);
+        assert_eq!(disabled[0].source, "workspace-include-paths");
+        assert_eq!(disabled[1].kind, IncRootKind::WorkspaceRelative);
     }
 }


### PR DESCRIPTION
Problem: Compile-environment/module-resolution work needs one reusable source/provenance model for lexical, configured, PERL5LIB, and system include roots.

Fix: Move effective @INC root assembly from the LSP runtime into `perl-module`, keep the LSP runtime on the shared helper, and add crate-owned tests for precedence, dedupe, and PERL5LIB labeling. This is behavior-preserving and does not add provider cutover or new module path resolution semantics.

Verification:
- `cargo test -p perl-module --lib --profile agent --locked effective_inc_roots -- --nocapture`
- `cargo test -p perl-lsp-rs --lib --profile agent --locked build_effective_inc_roots -- --nocapture`
- `cargo check -p perl-module --all-targets --profile agent --locked`
- `cargo check -p perl-lsp-rs --lib --profile agent --locked`
- `cargo xtask fmt --check`
- `git diff --check`

Note: an earlier broad filtered `cargo test -p perl-module --profile agent --locked effective_inc_roots` run passed the matching lib tests, then Windows refused to launch an unrelated integration-test binary with `os error 740`; the final receipt uses the explicit `--lib` target.