### PR TITLE
feat(format): expand simple native else layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -723,13 +723,23 @@ fn format_simple_control_block_tokens(
     let (condition, next_index) = format_simple_condition_tokens(tokens, 2)?;
     if tokens.get(next_index)?.kind != TokenKind::RightParen
         || tokens.get(next_index + 1)?.kind != TokenKind::LeftBrace
-        || tokens.last()?.kind != TokenKind::RightBrace
     {
         return None;
     }
 
-    let body_tokens = &tokens[next_index + 2..tokens.len() - 1];
+    let body_start = next_index + 2;
+    let body_end = tokens[body_start..]
+        .iter()
+        .position(|token| token.kind == TokenKind::RightBrace)
+        .map(|offset| body_start + offset)?;
+    let body_tokens = &tokens[body_start..body_end];
     let statements = format_simple_statement_block(body_tokens)?;
+    let else_statements = format_simple_else_branch(tokens, body_end, keyword)?;
+
+    if else_statements.is_none() && body_end + 1 != tokens.len() {
+        return None;
+    }
+
     let body_indent = format!("{indent}{}", indent_unit(config));
     let mut formatted = format!("{indent}{keyword} ({condition}) {{");
 
@@ -737,18 +747,64 @@ fn format_simple_control_block_tokens(
         formatted.push('\n');
         formatted.push_str(indent);
         formatted.push('}');
-        return Some(formatted);
+    } else {
+        for statement in statements {
+            formatted.push('\n');
+            formatted.push_str(&body_indent);
+            formatted.push_str(&statement);
+        }
+        formatted.push('\n');
+        formatted.push_str(indent);
+        formatted.push('}');
     }
 
-    for statement in statements {
+    if let Some(else_statements) = else_statements {
+        formatted.push_str(" else {");
+        if else_statements.is_empty() {
+            formatted.push('\n');
+            formatted.push_str(indent);
+            formatted.push('}');
+            return Some(formatted);
+        }
+
+        for statement in else_statements {
+            formatted.push('\n');
+            formatted.push_str(&body_indent);
+            formatted.push_str(&statement);
+        }
         formatted.push('\n');
-        formatted.push_str(&body_indent);
-        formatted.push_str(&statement);
+        formatted.push_str(indent);
+        formatted.push('}');
     }
-    formatted.push('\n');
-    formatted.push_str(indent);
-    formatted.push('}');
     Some(formatted)
+}
+
+fn format_simple_else_branch(
+    tokens: &[perl_parser_core::Token],
+    body_end: usize,
+    keyword: &str,
+) -> Option<Option<Vec<String>>> {
+    use perl_parser_core::TokenKind;
+
+    let next = body_end + 1;
+    if next == tokens.len() {
+        return Some(None);
+    }
+
+    if !matches!(keyword, "if" | "unless") {
+        return None;
+    }
+    if tokens.get(next)?.kind != TokenKind::Else
+        || tokens.get(next + 1)?.kind != TokenKind::LeftBrace
+        || tokens.last()?.kind != TokenKind::RightBrace
+    {
+        return None;
+    }
+
+    let else_body_start = next + 2;
+    let else_body_tokens = &tokens[else_body_start..tokens.len() - 1];
+    let statements = format_simple_statement_block(else_body_tokens)?;
+    Some(Some(statements))
 }
 
 fn format_simple_statement_block(tokens: &[perl_parser_core::Token]) -> Option<Vec<String>> {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if_else.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if_else.expected.pl
@@ -1,0 +1,5 @@
+if ($ok) {
+    return 1;
+} else {
+    return 0;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if_else.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if_else.pl
@@ -1,0 +1,1 @@
+if($ok){return 1;}else{return 0;}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_unless_else.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_unless_else.expected.pl
@@ -1,0 +1,5 @@
+unless ($ok) {
+    return 0;
+} else {
+    return 1;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_unless_else.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_unless_else.pl
@@ -1,0 +1,1 @@
+unless($ok){return 0;}else{return 1;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -204,6 +204,30 @@ fn native_formatter_expands_simple_until_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_if_else_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "if($ok){return 1;}else{return 0;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "if ($ok) {\n    return 1;\n} else {\n    return 0;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_expands_simple_unless_else_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "unless($ok){return 0;}else{return 1;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "unless ($ok) {\n    return 0;\n} else {\n    return 1;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_range_formatter_formats_selected_simple_subroutine_line() {
     let formatter = NativeFormatter::new();
     let source = "my$x=1;\nsub answer{our@y;return@y;}\n";
@@ -261,4 +285,22 @@ fn native_range_formatter_formats_selected_simple_unless_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "unless ($ok) {\n    return $x;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_if_else_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nif($ok){return 1;}else{return 0;}\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 33));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my$x=1;\nif ($ok) {\n    return 1;\n} else {\n    return 0;\n}\n"
+    );
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "if ($ok) {\n    return 1;\n} else {\n    return 0;\n}");
 }


### PR DESCRIPTION
## Summary

Adds native formatter support for simple one-line `if (...) { ... } else { ... }` and `unless (...) { ... } else { ... }` blocks. The formatter only rewrites these when both branches stay inside the existing safe statement subset, and remains parse-gated before returning edits.

## Scope

- Parses the first safe control-block branch instead of treating the final brace as the only branch boundary.
- Allows `else` branches for `if` and `unless`; still rejects trailing tokens for loop forms.
- Adds full-document, range-formatting, and fixture coverage.
- Extends native formatter receipts from 11 to 13 fixtures with idempotence and parse-preservation coverage.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_layout_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`native formatter fixtures: 13/13 passed`)
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

Receipt:
- `target/receipts/format/native-format-fixtures.json`
- `target/receipts/format/native-format-idempotence.json`
- `target/receipts/format/native-format-parse-preservation.json`
