### PR TITLE
feat(format): expand simple native expression layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -593,6 +593,7 @@ fn range_includes_line(range: TextRange, line: u32) -> bool {
 fn format_simple_line(line: &str, config: &FormatConfig) -> Option<String> {
     format_simple_control_block_line(line, config)
         .or_else(|| format_simple_subroutine_line(line, config))
+        .or_else(|| format_simple_statement_line(line))
         .or_else(|| format_simple_lexical_line(line))
 }
 
@@ -656,6 +657,27 @@ fn format_simple_control_block_line(line: &str, config: &FormatConfig) -> Option
     }
 
     format_simple_control_block_tokens(&tokens, indent, config)
+}
+
+fn format_simple_statement_line(line: &str) -> Option<String> {
+    let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
+    let (indent, body) = line.split_at(indent_len);
+    if body.is_empty() || body.contains('#') {
+        return None;
+    }
+
+    let mut stream = perl_parser_core::TokenStream::new(body);
+    let mut tokens = Vec::new();
+    loop {
+        let token = stream.next().ok()?;
+        if token.kind == perl_parser_core::TokenKind::Eof {
+            break;
+        }
+        tokens.push(token);
+    }
+
+    let formatted = format_simple_return_tokens(&tokens)?;
+    Some(format!("{indent}{formatted}"))
 }
 
 fn format_simple_subroutine_tokens(
@@ -852,8 +874,8 @@ fn format_simple_lexical_tokens(tokens: &[perl_parser_core::Token]) -> Option<St
     let semicolon_index = tokens.len() - 1;
     if next_index == semicolon_index {
         Some(format!("{keyword} {variable};"))
-    } else if next_index + 2 == semicolon_index && tokens[next_index].kind == TokenKind::Assign {
-        let value = simple_value_text(&tokens[next_index + 1])?;
+    } else if tokens[next_index].kind == TokenKind::Assign {
+        let value = format_simple_expression_tokens(tokens, next_index + 1, semicolon_index)?;
         Some(format!("{keyword} {variable} = {value};"))
     } else {
         None
@@ -898,21 +920,40 @@ fn format_simple_return_tokens(tokens: &[perl_parser_core::Token]) -> Option<Str
         return Some("return;".to_string());
     }
 
-    if let Some((variable, next_index)) = format_variable_tokens(tokens, 1)
-        && next_index == semicolon_index
-    {
-        return Some(format!("return {variable};"));
-    }
-
-    if semicolon_index == 2 {
-        let value = simple_value_text(&tokens[1])?;
-        return Some(format!("return {value};"));
-    }
-
-    None
+    let value = format_simple_expression_tokens(tokens, 1, semicolon_index)?;
+    Some(format!("return {value};"))
 }
 
 fn format_simple_condition_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+) -> Option<(String, usize)> {
+    use perl_parser_core::TokenKind;
+
+    let end = tokens[start..]
+        .iter()
+        .position(|token| token.kind == TokenKind::RightParen)
+        .map(|offset| start + offset)?;
+    let condition = format_simple_expression_tokens(tokens, start, end)?;
+    Some((condition, end))
+}
+
+fn format_simple_expression_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+    end: usize,
+) -> Option<String> {
+    let (left, next_index) = format_simple_atom_tokens(tokens, start)?;
+    if next_index == end {
+        return Some(left);
+    }
+
+    let operator = simple_binary_operator_text(tokens.get(next_index)?)?;
+    let (right, final_index) = format_simple_atom_tokens(tokens, next_index + 1)?;
+    (final_index == end).then(|| format!("{left} {operator} {right}"))
+}
+
+fn format_simple_atom_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
 ) -> Option<(String, usize)> {
@@ -923,6 +964,33 @@ fn format_simple_condition_tokens(
     let token = tokens.get(start)?;
     let value = simple_value_text(token)?;
     Some((value.to_string(), start + 1))
+}
+
+fn simple_binary_operator_text(token: &perl_parser_core::Token) -> Option<&str> {
+    use perl_parser_core::TokenKind;
+
+    matches!(
+        token.kind,
+        TokenKind::Plus
+            | TokenKind::Minus
+            | TokenKind::Star
+            | TokenKind::Percent
+            | TokenKind::Dot
+            | TokenKind::Equal
+            | TokenKind::NotEqual
+            | TokenKind::Less
+            | TokenKind::LessEqual
+            | TokenKind::Greater
+            | TokenKind::GreaterEqual
+            | TokenKind::StringCompare
+            | TokenKind::Spaceship
+            | TokenKind::And
+            | TokenKind::Or
+            | TokenKind::DefinedOr
+            | TokenKind::WordAnd
+            | TokenKind::WordOr
+    )
+    .then_some(token.text.as_ref())
 }
 
 fn indent_unit(config: &FormatConfig) -> String {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_binary_expressions.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_binary_expressions.expected.pl
@@ -1,0 +1,5 @@
+my $x = $y + 1;
+return $x * 2;
+if ($x == 2) {
+    return $y + 1;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_binary_expressions.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_binary_expressions.pl
@@ -1,0 +1,3 @@
+my$x=$y+1;
+return$x*2;
+if($x==2){return$y+1;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -16,6 +16,21 @@ fn native_formatter_formats_simple_lexical_declarations() {
 }
 
 #[test]
+fn native_formatter_formats_simple_binary_expressions() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=$y+1;\nreturn$x*2;\nif($x==2){return$y+1;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my $x = $y + 1;\nreturn $x * 2;\nif ($x == 2) {\n    return $y + 1;\n}\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";
@@ -84,6 +99,21 @@ fn native_range_formatter_formats_only_selected_simple_declaration_line() {
         TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 7))
     );
     assert_eq!(result.edits[0].new_text, "my $y = 2;");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_binary_expression_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=$y+1;\nreturn$x*2;\n";
+    let range = TextRange::new(TextPosition::new(0, 0), TextPosition::new(0, 10));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my $x = $y + 1;\nreturn$x*2;\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "my $x = $y + 1;");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds simple binary expression formatting to the native formatter safe subset. Declarations, returns, and control conditions now share a small atom/binary-expression formatter, so forms like `$x+1`, `$x*2`, and `$x==2` get stable spacing when the source still parses cleanly before and after formatting.

## Scope

- Adds a simple expression formatter for one atom or one binary operator between two simple atoms.
- Uses it for lexical assignment values, return values, and control-block conditions.
- Adds top-level simple `return` line formatting through the safe line dispatcher.
- Keeps nested expressions, calls, ternaries, regexes, and chained operators unsupported.
- Extends native formatter receipts from 13 to 14 fixtures with idempotence and parse-preservation coverage.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_layout_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`native formatter fixtures: 14/14 passed`)
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

Receipt:
- `target/receipts/format/native-format-fixtures.json`
- `target/receipts/format/native-format-idempotence.json`
- `target/receipts/format/native-format-parse-preservation.json`
