### PR TITLE
feat(format): expand simple native assignment layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -676,7 +676,7 @@ fn format_simple_statement_line(line: &str) -> Option<String> {
         tokens.push(token);
     }
 
-    let formatted = format_simple_return_tokens(&tokens)?;
+    let formatted = format_simple_statement_tokens(&tokens)?;
     Some(format!("{indent}{formatted}"))
 }
 
@@ -852,7 +852,9 @@ fn format_simple_statement_block(tokens: &[perl_parser_core::Token]) -> Option<V
 }
 
 fn format_simple_statement_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
-    format_simple_lexical_tokens(tokens).or_else(|| format_simple_return_tokens(tokens))
+    format_simple_lexical_tokens(tokens)
+        .or_else(|| format_simple_return_tokens(tokens))
+        .or_else(|| format_simple_assignment_tokens(tokens))
 }
 
 fn format_simple_lexical_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
@@ -922,6 +924,23 @@ fn format_simple_return_tokens(tokens: &[perl_parser_core::Token]) -> Option<Str
 
     let value = format_simple_expression_tokens(tokens, 1, semicolon_index)?;
     Some(format!("return {value};"))
+}
+
+fn format_simple_assignment_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.last()?.kind != TokenKind::Semicolon {
+        return None;
+    }
+
+    let (variable, next_index) = format_variable_tokens(tokens, 0)?;
+    let semicolon_index = tokens.len() - 1;
+    if tokens.get(next_index)?.kind != TokenKind::Assign {
+        return None;
+    }
+
+    let value = format_simple_expression_tokens(tokens, next_index + 1, semicolon_index)?;
+    Some(format!("{variable} = {value};"))
 }
 
 fn format_simple_condition_tokens(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_assignments.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_assignments.expected.pl
@@ -1,0 +1,6 @@
+$x = 1;
+$y = $x + 2;
+sub bump {
+    $x = $x + 1;
+    return $x;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_assignments.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_assignments.pl
@@ -1,0 +1,3 @@
+$x=1;
+$y=$x+2;
+sub bump{$x=$x+1;return$x;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -31,6 +31,21 @@ fn native_formatter_formats_simple_binary_expressions() {
 }
 
 #[test]
+fn native_formatter_formats_simple_assignments() {
+    let formatter = NativeFormatter::new();
+    let source = "$x=1;\n$y=$x+2;\nsub bump{$x=$x+1;return$x;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "$x = 1;\n$y = $x + 2;\nsub bump {\n    $x = $x + 1;\n    return $x;\n}\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";
@@ -114,6 +129,21 @@ fn native_range_formatter_formats_selected_simple_binary_expression_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "my $x = $y + 1;");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_assignment_line() {
+    let formatter = NativeFormatter::new();
+    let source = "$x=1;\n$y=$x+2;\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 8));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "$x=1;\n$y = $x + 2;\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "$y = $x + 2;");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- extend the parse-gated native formatter safe subset to standalone simple assignments
- reuse the existing simple variable/expression formatter for assignment statements in top-level lines and simple block bodies
- add full-document, range-formatting, and fixture receipt coverage for simple assignment layout

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed locally

- [x] `cargo xtask check-memory-lifecycle-policy`
  - why: memory-sensitive lifecycle, cache, or retained-state surfaces changed
  - evidence: command passed locally

- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
  - why: a Rust file in a retained-owner-sensitive path changed
  - evidence: no new retained-owner patterns found

- [x] `git diff --check`
  - why: guards against whitespace errors in the final patch
  - evidence: command exited cleanly

Additional focused proof:
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_layout_tests --profile agent --locked -- --nocapture` (28/28 passed)
- [x] `cargo xtask native-format check` (15/15 fixtures passed; receipts: `target/receipts/format`)
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`

Receipt:
- `target/devex/local-proof.json`

## Notes

This keeps the native formatter conservative: it only formats simple `$var = expr;` assignment statements where the existing simple expression formatter can prove the right-hand side is a single atom or binary expression. Unsupported statements remain unchanged.