### PR TITLE
feat(hir): add module resolution candidates (#8242)

### DIFF
--- a/crates/perl-parser-core/src/hir/mod.rs
+++ b/crates/perl-parser-core/src/hir/mod.rs
@@ -16,8 +16,9 @@ pub use model::{
     GlobSlotKind, GlobSlotSource, HirBindingId, HirFile, HirId, HirItem, HirKind, HirScopeId,
     IncRootAction, IncRootFact, IncRootKind, IndirectCallExpr, InheritanceSource, LiteralExpr,
     LiteralKind, MethodCallExpr, MethodDecl, ModuleRequest, ModuleRequestKind,
-    ModuleResolutionStatus, PackageDecl, PackageInheritanceEdge, PackageStash, PragmaEffect,
-    RecoveryConfidence, RequireDecl, ScopeFrame, ScopeGraph, ScopeKind, StashConfidence,
-    StashDynamicBoundary, StashDynamicBoundaryKind, StashGraph, StashProvenance, StorageClass,
-    SubDecl, UseDecl, VariableBinding, VariableDecl,
+    ModuleResolutionCandidate, ModuleResolutionCandidateRoot, ModuleResolutionCandidateStatus,
+    ModuleResolutionRoot, ModuleResolutionStatus, PackageDecl, PackageInheritanceEdge,
+    PackageStash, PragmaEffect, RecoveryConfidence, RequireDecl, ScopeFrame, ScopeGraph, ScopeKind,
+    StashConfidence, StashDynamicBoundary, StashDynamicBoundaryKind, StashGraph, StashProvenance,
+    StorageClass, SubDecl, UseDecl, VariableBinding, VariableDecl,
 };

--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -464,6 +464,121 @@ pub struct CompileEnvironment {
     pub dynamic_boundaries: Vec<CompileEnvironmentBoundary>,
 }
 
+impl CompileEnvironment {
+    /// Build module-resolution candidate facts from static module requests.
+    ///
+    /// The HIR layer records lexical include-root effects and module requests,
+    /// but it does not read process environment, inspect the filesystem, or
+    /// depend on the downstream `perl-module` resolver. Callers provide
+    /// configured, `PERL5LIB`, and system roots explicitly; this method combines
+    /// them with source-order lexical `use lib` roots active at each request.
+    #[must_use]
+    pub fn module_resolution_candidates(
+        &self,
+        supplied_roots: &[ModuleResolutionRoot],
+    ) -> Vec<ModuleResolutionCandidate> {
+        self.module_requests
+            .iter()
+            .enumerate()
+            .filter_map(|(request_index, request)| {
+                let target = request.target.as_ref()?;
+                let normalized_target = normalize_module_target(target);
+                let relative_path = module_target_to_relative_path(&normalized_target)?;
+                let candidate_roots =
+                    self.candidate_roots_for_request(request, &relative_path, supplied_roots);
+                let status = if candidate_roots.is_empty() {
+                    ModuleResolutionCandidateStatus::NotFound
+                } else {
+                    ModuleResolutionCandidateStatus::CandidateBuilt
+                };
+
+                Some(ModuleResolutionCandidate {
+                    request_index,
+                    directive_item: request.directive_item,
+                    request_kind: request.kind,
+                    target: normalized_target,
+                    relative_path,
+                    roots: candidate_roots,
+                    status,
+                    range: request.range,
+                    package_context: request.package_context.clone(),
+                    provenance: request.provenance,
+                    confidence: request.confidence,
+                })
+            })
+            .collect()
+    }
+
+    fn candidate_roots_for_request(
+        &self,
+        request: &ModuleRequest,
+        relative_path: &str,
+        supplied_roots: &[ModuleResolutionRoot],
+    ) -> Vec<ModuleResolutionCandidateRoot> {
+        let active_lexical_roots = self.active_lexical_roots_for_request(request);
+        active_lexical_roots
+            .iter()
+            .map(|root| ModuleResolutionRoot {
+                path: root.path.clone(),
+                kind: root.kind,
+                source: root.source.clone(),
+            })
+            .chain(supplied_roots.iter().cloned())
+            .enumerate()
+            .map(|(precedence, root)| ModuleResolutionCandidateRoot {
+                path: root.path.clone(),
+                kind: root.kind,
+                source: root.source,
+                candidate_path: join_candidate_path(&root.path, relative_path),
+                precedence,
+            })
+            .collect()
+    }
+
+    fn active_lexical_roots_for_request(&self, request: &ModuleRequest) -> Vec<ActiveLexicalRoot> {
+        let mut active = Vec::new();
+
+        for (order, root) in self.inc_roots.iter().enumerate() {
+            if root.range.start > request.range.start {
+                continue;
+            }
+            if root.kind != IncRootKind::UseLib {
+                continue;
+            }
+
+            match root.action {
+                IncRootAction::Add => {
+                    active.push(ActiveLexicalRoot {
+                        path: root.path.clone(),
+                        kind: root.kind,
+                        source: "use-lib-lexical".to_string(),
+                        range_start: root.range.start,
+                        order,
+                    });
+                }
+                IncRootAction::Remove => {
+                    active.retain(|active_root| active_root.path != root.path);
+                }
+            }
+        }
+
+        active.sort_by(|left, right| {
+            right.range_start.cmp(&left.range_start).then_with(|| left.order.cmp(&right.order))
+        });
+
+        active
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ActiveLexicalRoot {
+    path: String,
+    kind: IncRootKind,
+    source: String,
+    range_start: usize,
+    order: usize,
+}
+
 /// One compile-time directive.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -596,6 +711,26 @@ pub enum IncRootKind {
     SystemInc,
 }
 
+/// Caller-supplied include root for module-resolution candidate facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ModuleResolutionRoot {
+    /// Include root path as configured or observed by the caller.
+    pub path: String,
+    /// Root source category.
+    pub kind: IncRootKind,
+    /// Human-readable source label for diagnostics/status output.
+    pub source: String,
+}
+
+impl ModuleResolutionRoot {
+    /// Create an explicit include root for module candidate projection.
+    #[must_use]
+    pub fn new(path: impl Into<String>, kind: IncRootKind, source: impl Into<String>) -> Self {
+        Self { path: path.into(), kind, source: source.into() }
+    }
+}
+
 /// Module load request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -642,6 +777,66 @@ pub enum ModuleResolutionStatus {
     Deferred,
     /// Module target is dynamic and cannot be resolved statically.
     Dynamic,
+}
+
+/// Derived module-resolution candidate fact keyed to a HIR module request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ModuleResolutionCandidate {
+    /// Zero-based request index in [`CompileEnvironment::module_requests`].
+    pub request_index: usize,
+    /// Directive HIR item that produced this request.
+    pub directive_item: Option<HirId>,
+    /// Source shape that requested the module.
+    pub request_kind: ModuleRequestKind,
+    /// Static module target.
+    pub target: String,
+    /// Relative module path, for example `Foo/Bar.pm`.
+    pub relative_path: String,
+    /// Ordered candidate roots considered for this request.
+    pub roots: Vec<ModuleResolutionCandidateRoot>,
+    /// Resolution status for this candidate packet.
+    pub status: ModuleResolutionCandidateStatus,
+    /// Source range for the request.
+    pub range: SourceLocation,
+    /// Package context active at the request.
+    pub package_context: Option<String>,
+    /// How this fact was produced.
+    pub provenance: CompileProvenance,
+    /// Confidence in this fact.
+    pub confidence: CompileConfidence,
+}
+
+/// A single candidate root/path pair for a static module request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ModuleResolutionCandidateRoot {
+    /// Include root path as configured or observed by the caller.
+    pub path: String,
+    /// Root source category.
+    pub kind: IncRootKind,
+    /// Human-readable source label.
+    pub source: String,
+    /// Candidate module path under this root.
+    pub candidate_path: String,
+    /// Search precedence; lower values are searched first.
+    pub precedence: usize,
+}
+
+/// Static resolution state for a module candidate packet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ModuleResolutionCandidateStatus {
+    /// Candidate paths were built but not resolved against the filesystem.
+    CandidateBuilt,
+    /// Dynamic module target cannot produce candidate paths.
+    Dynamic,
+    /// Static request has no roots to search.
+    NotFound,
+    /// Downstream resolver found a matching module.
+    Resolved,
+    /// Downstream resolver exhausted its timeout budget.
+    TimedOut,
 }
 
 /// Compile-time phase block.
@@ -736,6 +931,40 @@ pub enum CompileConfidence {
     Medium,
     /// Low-confidence dynamic-boundary fact.
     Low,
+}
+
+fn module_target_to_relative_path(target: &str) -> Option<String> {
+    let relative_path =
+        if target.ends_with(".pm") || target.ends_with(".pl") || target.contains(['/', '\\']) {
+            target.replace('\\', "/")
+        } else {
+            let canonical = target.replace('\'', "::");
+            format!("{}.pm", canonical.replace("::", "/"))
+        };
+
+    is_safe_relative_module_path(&relative_path).then_some(relative_path)
+}
+
+fn normalize_module_target(target: &str) -> String {
+    target.trim().trim_matches('"').trim_matches('\'').to_string()
+}
+
+fn is_safe_relative_module_path(path: &str) -> bool {
+    if path.is_empty() || path.starts_with('/') || path.contains(':') {
+        return false;
+    }
+
+    path.split('/').all(|segment| !matches!(segment, "" | "." | ".."))
+}
+
+fn join_candidate_path(root: &str, relative_path: &str) -> String {
+    let normalized_root = root.replace('\\', "/");
+    let trimmed_root = normalized_root.trim_end_matches('/');
+    if trimmed_root.is_empty() {
+        relative_path.to_string()
+    } else {
+        format!("{trimmed_root}/{relative_path}")
+    }
 }
 
 /// First-slice HIR constructs.

--- a/crates/perl-parser-core/tests/hir_tests.rs
+++ b/crates/perl-parser-core/tests/hir_tests.rs
@@ -1,5 +1,6 @@
 use perl_parser_core::hir::{
-    CompileEnvironment, HirFile, HirKind, RecoveryConfidence, ScopeGraph, StashGraph, lower_ast,
+    CompileEnvironment, HirFile, HirKind, IncRootKind, ModuleResolutionRoot, RecoveryConfidence,
+    ScopeGraph, StashGraph, lower_ast,
 };
 use perl_parser_core::{Node, NodeKind, Parser, SourceLocation};
 
@@ -294,6 +295,39 @@ fn render_compile_environment(environment: &CompileEnvironment) -> String {
             "{:?} pkg={} {:?} {:?} reason={}",
             boundary.kind, package, boundary.provenance, boundary.confidence, boundary.reason
         ));
+    }
+
+    lines.join("\n")
+}
+
+fn render_module_resolution_candidates(
+    environment: &CompileEnvironment,
+    supplied_roots: &[ModuleResolutionRoot],
+) -> String {
+    let mut lines = Vec::new();
+    lines.push("[module-candidates]".to_string());
+
+    for candidate in environment.module_resolution_candidates(supplied_roots) {
+        let package = candidate.package_context.as_deref().unwrap_or("<none>");
+        lines.push(format!(
+            "request={} target={} kind={:?} rel={} status={:?} roots={} pkg={} {:?} {:?}",
+            candidate.request_index,
+            candidate.target,
+            candidate.request_kind,
+            candidate.relative_path,
+            candidate.status,
+            candidate.roots.len(),
+            package,
+            candidate.provenance,
+            candidate.confidence
+        ));
+
+        for root in candidate.roots {
+            lines.push(format!(
+                "root={} {:?} source={} candidate={} precedence={}",
+                root.path, root.kind, root.source, root.candidate_path, root.precedence
+            ));
+        }
     }
 
     lines.join("\n")
@@ -653,6 +687,122 @@ fn hir_compile_environment_records_directives_without_provider_cutover()
             |item| matches!(&item.kind, HirKind::CallExpr(expr) if expr.name == "provider_cutover")
         ),
         "compile-environment facts must not imply live provider cutover"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_module_resolution_candidate_facts_preserve_root_sources_and_dynamic_boundaries()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file = lower_source(
+        "package Env::Demo;\n\
+         use lib 'lib';\n\
+         use Foo::Bar;\n\
+         no lib 'lib';\n\
+         require Other::Thing;\n\
+         require $dynamic;\n",
+    );
+    let supplied_roots = vec![
+        ModuleResolutionRoot::new(
+            "configured/lib",
+            IncRootKind::Configured,
+            "workspace-include-paths",
+        ),
+        ModuleResolutionRoot::new("env/lib", IncRootKind::Perl5Lib, "perl5lib-env"),
+        ModuleResolutionRoot::new(
+            "/usr/share/perl5",
+            IncRootKind::SystemInc,
+            "interpreter-startup-inc",
+        ),
+    ];
+
+    assert_eq!(
+        render_module_resolution_candidates(&file.compile_environment, &supplied_roots),
+        "[module-candidates]\n\
+         request=0 target=Foo::Bar kind=Use rel=Foo/Bar.pm status=CandidateBuilt roots=4 pkg=Env::Demo ExactAst High\n\
+           root=lib UseLib source=use-lib-lexical candidate=lib/Foo/Bar.pm precedence=0\n\
+           root=configured/lib Configured source=workspace-include-paths candidate=configured/lib/Foo/Bar.pm precedence=1\n\
+           root=env/lib Perl5Lib source=perl5lib-env candidate=env/lib/Foo/Bar.pm precedence=2\n\
+           root=/usr/share/perl5 SystemInc source=interpreter-startup-inc candidate=/usr/share/perl5/Foo/Bar.pm precedence=3\n\
+         request=1 target=Other::Thing kind=Require rel=Other/Thing.pm status=CandidateBuilt roots=3 pkg=Env::Demo ExactAst High\n\
+           root=configured/lib Configured source=workspace-include-paths candidate=configured/lib/Other/Thing.pm precedence=0\n\
+           root=env/lib Perl5Lib source=perl5lib-env candidate=env/lib/Other/Thing.pm precedence=1\n\
+           root=/usr/share/perl5 SystemInc source=interpreter-startup-inc candidate=/usr/share/perl5/Other/Thing.pm precedence=2"
+    );
+
+    assert_eq!(file.compile_environment.module_requests.len(), 3);
+    assert_eq!(
+        file.compile_environment.module_resolution_candidates(&supplied_roots).len(),
+        2,
+        "dynamic require must not produce fake candidate paths"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_module_resolution_candidate_facts_mark_static_requests_without_roots_as_not_found()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file = lower_source("use Missing::Module;\n");
+
+    assert_eq!(
+        render_module_resolution_candidates(&file.compile_environment, &[]),
+        "[module-candidates]\n\
+         request=0 target=Missing::Module kind=Use rel=Missing/Module.pm status=NotFound roots=0 pkg=<none> ExactAst High"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_module_resolution_candidate_facts_preserve_path_like_require_targets()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file = lower_source("require 'Local/Path.pm';\n");
+    let supplied_roots =
+        [ModuleResolutionRoot::new("lib", IncRootKind::Configured, "workspace-include-paths")];
+
+    assert_eq!(
+        render_module_resolution_candidates(&file.compile_environment, &supplied_roots),
+        "[module-candidates]\n\
+         request=0 target=Local/Path.pm kind=Require rel=Local/Path.pm status=CandidateBuilt roots=1 pkg=<none> ExactAst High\n\
+         root=lib Configured source=workspace-include-paths candidate=lib/Local/Path.pm precedence=0"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_module_resolution_candidate_facts_match_use_lib_precedence()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file = lower_source(
+        "use lib 'older';\n\
+         use lib qw(first second);\n\
+         use Foo::Bar;\n",
+    );
+
+    assert_eq!(
+        render_module_resolution_candidates(&file.compile_environment, &[]),
+        "[module-candidates]\n\
+         request=0 target=Foo::Bar kind=Use rel=Foo/Bar.pm status=CandidateBuilt roots=3 pkg=<none> ExactAst High\n\
+         root=first UseLib source=use-lib-lexical candidate=first/Foo/Bar.pm precedence=0\n\
+         root=second UseLib source=use-lib-lexical candidate=second/Foo/Bar.pm precedence=1\n\
+         root=older UseLib source=use-lib-lexical candidate=older/Foo/Bar.pm precedence=2"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_module_resolution_candidate_facts_reject_path_traversal_targets()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file = lower_source("require '../Secret.pm';\n");
+    let supplied_roots =
+        [ModuleResolutionRoot::new("lib", IncRootKind::Configured, "workspace-include-paths")];
+
+    assert_eq!(
+        render_module_resolution_candidates(&file.compile_environment, &supplied_roots),
+        "[module-candidates]"
     );
 
     Ok(())


### PR DESCRIPTION
Problem: HIR records module requests and include-root effects, but compiler fact lanes had no candidate-path fact surface keyed to those requests.
Fix: Add HIR-local module-resolution candidate facts built from static requests, active lexical `use lib` roots, and caller-supplied configured/PERL5LIB/system roots, while leaving dynamic `require` candidate-free and avoiding provider cutover.
Verification:
- `cargo test -p perl-parser-core --test hir_tests --profile agent --locked -- --nocapture` passes
- `cargo test -p perl-module --lib --profile agent --locked effective_inc_roots -- --nocapture` passes
- `cargo check -p perl-parser-core --all-targets --profile agent --locked` passes
- `cargo clippy -p perl-parser-core --lib --profile agent --locked -- -D warnings -A missing_docs` passes
- `cargo xtask fmt --check` passes
- `git diff --check` passes

Note: `cargo clippy -p perl-parser-core --all-targets --profile agent --locked -- -D warnings -A missing_docs` is blocked by pre-existing unrelated parser-core test lint debt (`panic`/`expect`/`assert!(false)` in older test files), so this PR used lib clippy plus all-targets check.