### PR TITLE
feat(format): expand simple native call expression layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -855,6 +855,7 @@ fn format_simple_statement_tokens(tokens: &[perl_parser_core::Token]) -> Option<
     format_simple_lexical_tokens(tokens)
         .or_else(|| format_simple_return_tokens(tokens))
         .or_else(|| format_simple_assignment_tokens(tokens))
+        .or_else(|| format_simple_expression_statement_tokens(tokens))
 }
 
 fn format_simple_lexical_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
@@ -943,6 +944,18 @@ fn format_simple_assignment_tokens(tokens: &[perl_parser_core::Token]) -> Option
     Some(format!("{variable} = {value};"))
 }
 
+fn format_simple_expression_statement_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.last()?.kind != TokenKind::Semicolon {
+        return None;
+    }
+
+    let semicolon_index = tokens.len() - 1;
+    let (call, next_index) = format_simple_call_tokens(tokens, 0)?;
+    (next_index == semicolon_index).then(|| format!("{call};"))
+}
+
 fn format_simple_condition_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
@@ -980,9 +993,45 @@ fn format_simple_atom_tokens(
         return Some((variable, next_index));
     }
 
+    if let Some((call, next_index)) = format_simple_call_tokens(tokens, start) {
+        return Some((call, next_index));
+    }
+
     let token = tokens.get(start)?;
     let value = simple_value_text(token)?;
     Some((value.to_string(), start + 1))
+}
+
+fn format_simple_call_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+) -> Option<(String, usize)> {
+    use perl_parser_core::TokenKind;
+
+    let name = tokens.get(start)?;
+    if name.kind != TokenKind::Identifier || tokens.get(start + 1)?.kind != TokenKind::LeftParen {
+        return None;
+    }
+
+    let mut args = Vec::new();
+    let mut index = start + 2;
+    if tokens.get(index)?.kind == TokenKind::RightParen {
+        return Some((format!("{}()", name.text), index + 1));
+    }
+
+    loop {
+        let (arg, next_index) = format_simple_atom_tokens(tokens, index)?;
+        args.push(arg);
+        index = next_index;
+
+        match tokens.get(index)?.kind {
+            TokenKind::Comma => index += 1,
+            TokenKind::RightParen => {
+                return Some((format!("{}({})", name.text, args.join(", ")), index + 1));
+            }
+            _ => return None,
+        }
+    }
 }
 
 fn simple_binary_operator_text(token: &perl_parser_core::Token) -> Option<&str> {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_call_expressions.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_call_expressions.expected.pl
@@ -1,0 +1,4 @@
+my $x = foo($y, 1);
+$z = bar();
+return baz($x, $z);
+foo($x, bar());

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_call_expressions.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_call_expressions.pl
@@ -1,0 +1,4 @@
+my$x=foo($y,1);
+$z=bar();
+return baz($x,$z);
+foo($x,bar());

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -46,6 +46,21 @@ fn native_formatter_formats_simple_assignments() {
 }
 
 #[test]
+fn native_formatter_formats_simple_call_expressions() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=foo($y,1);\n$z=bar();\nreturn baz($x,$z);\nfoo($x,bar());\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my $x = foo($y, 1);\n$z = bar();\nreturn baz($x, $z);\nfoo($x, bar());\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";
@@ -144,6 +159,21 @@ fn native_range_formatter_formats_selected_simple_assignment_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "$y = $x + 2;");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_call_expression_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=foo($y,1);\nreturn baz($x,$y);\n";
+    let range = TextRange::new(TextPosition::new(0, 0), TextPosition::new(0, 15));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my $x = foo($y, 1);\nreturn baz($x,$y);\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "my $x = foo($y, 1);");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- extend the parse-gated native formatter safe subset to simple parenthesized call expressions
- format calls in declarations, assignments, returns, and standalone call statements when arguments are simple atoms or nested simple calls
- add full-document, range-formatting, and fixture receipt coverage for call expression layout

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed locally

- [x] `cargo xtask check-memory-lifecycle-policy`
  - why: memory-sensitive lifecycle, cache, or retained-state surfaces changed
  - evidence: command passed locally

- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
  - why: a Rust file in a retained-owner-sensitive path changed
  - evidence: no new retained-owner patterns found

- [x] `git diff --check`
  - why: guards against whitespace errors in the final patch
  - evidence: command exited cleanly

Additional focused proof:
- [x] `cargo test -p perl-lsp-perltidy --test native_formatter_layout_tests --profile agent --locked -- --nocapture` (30/30 passed)
- [x] `cargo xtask native-format check` (16/16 fixtures passed; receipts: `target/receipts/format`)
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`

Receipt:
- `target/devex/local-proof.json`

## Notes

This keeps the formatter conservative: it only formats parenthesized calls where each argument is a simple atom or nested simple call. Bareword/builtin call syntax and complex argument expressions remain unchanged until they have their own preservation coverage.