### PR TITLE
feat(critic): add native rule contract (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -5,11 +5,16 @@
 
 mod analyzer;
 mod built_in;
+mod native;
 mod quick_fix;
 mod types;
 
 pub use analyzer::{CriticAnalyzer, hash_content};
 pub use built_in::{BuiltInAnalyzer, Policy};
+pub use native::{
+    CriticCategory, CriticContext, CriticFinding, CriticFix, CriticRelatedInformation, CriticRule,
+    CriticTextEdit, FixSafety,
+};
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};
 

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -1,0 +1,227 @@
+//! Native critic rule contract.
+//!
+//! These types define the Rust-native policy diagnostic surface that future
+//! rules should target. They intentionally live beside the existing
+//! subprocess-backed Perl::Critic adapter and built-in fallback so callers can
+//! migrate rule-by-rule without changing runtime behavior in one large step.
+
+use super::{CriticConfig, Severity};
+use perl_parser_core::Node;
+use perl_parser_core::position::Range;
+use serde::{Deserialize, Serialize};
+
+/// Native critic rule category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CriticCategory {
+    /// Syntax-level policy that can be checked from tokens or AST shape.
+    Syntax,
+    /// Semantic policy that needs bindings, scopes, or inferred facts.
+    Semantic,
+    /// Workspace-aware policy that needs cross-file/module facts.
+    Workspace,
+    /// Style convention policy.
+    Style,
+    /// Maintainability or complexity policy.
+    Maintainability,
+    /// Security or unsafe-code policy.
+    Security,
+    /// Documentation or POD policy.
+    Documentation,
+}
+
+/// Safety level for an optional native critic fix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FixSafety {
+    /// Safe to apply automatically.
+    Safe,
+    /// Useful suggestion, but should require user confirmation.
+    Suggested,
+    /// Diagnostic-only guidance with no automatic edit.
+    ManualOnly,
+}
+
+/// Text edit attached to a native critic fix.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CriticTextEdit {
+    /// Range to replace.
+    pub range: Range,
+    /// Replacement text.
+    pub new_text: String,
+}
+
+/// Optional fix attached to a native critic finding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CriticFix {
+    /// Human-readable action title.
+    pub title: String,
+    /// How safe the edit is.
+    pub safety: FixSafety,
+    /// Edits needed to apply the fix.
+    pub edits: Vec<CriticTextEdit>,
+}
+
+/// Related span for richer native critic diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CriticRelatedInformation {
+    /// Related source range.
+    pub range: Range,
+    /// Explanation for the related span.
+    pub message: String,
+}
+
+/// Native critic finding emitted by a rule.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CriticFinding {
+    /// Stable native rule ID, such as `native.variables.unused_lexical`.
+    pub rule_id: String,
+    /// Rule category.
+    pub category: CriticCategory,
+    /// Finding severity.
+    pub severity: Severity,
+    /// Precise source span for the finding.
+    pub range: Range,
+    /// Short diagnostic message.
+    pub message: String,
+    /// Longer explanation shown in editor/CI details.
+    pub explanation: String,
+    /// Suppression key accepted by inline or file-level suppression handling.
+    pub suppression_key: String,
+    /// Related spans, when useful.
+    pub related: Vec<CriticRelatedInformation>,
+    /// Optional fix.
+    pub fix: Option<CriticFix>,
+}
+
+/// Native critic rule context.
+pub struct CriticContext<'a> {
+    /// Source text being analyzed.
+    pub source: &'a str,
+    /// Parsed AST for the source.
+    pub ast: &'a Node,
+    /// Critic configuration.
+    pub config: &'a CriticConfig,
+}
+
+impl<'a> CriticContext<'a> {
+    /// Build a native critic context.
+    pub fn new(source: &'a str, ast: &'a Node, config: &'a CriticConfig) -> Self {
+        Self { source, ast, config }
+    }
+}
+
+/// Native critic rule interface.
+pub trait CriticRule: Send + Sync {
+    /// Stable native rule ID.
+    fn id(&self) -> &'static str;
+
+    /// Rule category.
+    fn category(&self) -> CriticCategory;
+
+    /// Default severity before profile/config remapping.
+    fn default_severity(&self) -> Severity;
+
+    /// Check the source and append findings.
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>);
+}
+
+/// Build an empty AST node for tests that only exercise rule contract plumbing.
+#[cfg(test)]
+fn empty_program_node() -> Node {
+    use perl_parser_core::{NodeKind, SourceLocation};
+
+    Node::new(NodeKind::Program { statements: Vec::new() }, SourceLocation { start: 0, end: 0 })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perl_parser_core::position::{Position, Range};
+
+    struct DummyRule;
+
+    impl CriticRule for DummyRule {
+        fn id(&self) -> &'static str {
+            "native.test.dummy"
+        }
+
+        fn category(&self) -> CriticCategory {
+            CriticCategory::Syntax
+        }
+
+        fn default_severity(&self) -> Severity {
+            Severity::Harsh
+        }
+
+        fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+            if ctx.source.contains("dummy") {
+                out.push(CriticFinding {
+                    rule_id: self.id().to_string(),
+                    category: self.category(),
+                    severity: self.default_severity(),
+                    range: Range {
+                        start: Position { byte: 0, line: 0, column: 0 },
+                        end: Position { byte: 5, line: 0, column: 5 },
+                    },
+                    message: "dummy finding".to_string(),
+                    explanation: "dummy explanation".to_string(),
+                    suppression_key: self.id().to_string(),
+                    related: Vec::new(),
+                    fix: None,
+                });
+            }
+        }
+    }
+
+    #[test]
+    fn native_critic_rule_contract_emits_stable_finding_shape() {
+        let ast = empty_program_node();
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new("dummy", &ast, &config);
+        let mut findings = Vec::new();
+
+        DummyRule.check(&ctx, &mut findings);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "native.test.dummy");
+        assert_eq!(findings[0].suppression_key, "native.test.dummy");
+        assert_eq!(findings[0].category, CriticCategory::Syntax);
+        assert_eq!(findings[0].severity, Severity::Harsh);
+    }
+
+    #[test]
+    fn native_critic_finding_serializes_agent_friendly_fields() {
+        let finding = CriticFinding {
+            rule_id: "native.test.fixable".to_string(),
+            category: CriticCategory::Style,
+            severity: Severity::Cruel,
+            range: Range {
+                start: Position { byte: 0, line: 0, column: 0 },
+                end: Position { byte: 1, line: 0, column: 1 },
+            },
+            message: "style issue".to_string(),
+            explanation: "style explanation".to_string(),
+            suppression_key: "native.test.fixable".to_string(),
+            related: Vec::new(),
+            fix: Some(CriticFix {
+                title: "Apply style fix".to_string(),
+                safety: FixSafety::Safe,
+                edits: vec![CriticTextEdit {
+                    range: Range {
+                        start: Position { byte: 0, line: 0, column: 0 },
+                        end: Position { byte: 1, line: 0, column: 1 },
+                    },
+                    new_text: "x".to_string(),
+                }],
+            }),
+        };
+
+        let value = serde_json::to_value(&finding).expect("serialize native critic finding");
+
+        assert_eq!(value["rule_id"], "native.test.fixable");
+        assert_eq!(value["category"], "style");
+        assert_eq!(value["fix"]["safety"], "safe");
+        assert_eq!(value["fix"]["edits"][0]["new_text"], "x");
+    }
+}

--- a/crates/perl-lsp-rs-core/tests/tooling_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/tooling_module_shape.rs
@@ -19,6 +19,13 @@ fn tooling_module_exposes_perl_critic_submodule() {
 }
 
 #[test]
+fn tooling_module_exposes_native_critic_contract() {
+    let _: Option<perl_critic::CriticFinding> = None;
+    let _: Option<perl_critic::CriticCategory> = None;
+    let _: Option<perl_critic::CriticFix> = None;
+}
+
+#[test]
 fn tooling_module_exposes_perltidy_submodule() {
     // Verify that perltidy submodule is accessible via tooling post-absorption.
     // NOTE(G3-API-fix): Actual type is PerlTidyFormatter, not FormattingProvider.


### PR DESCRIPTION
## Summary

- add a native critic rule contract beside the existing external Perl::Critic analyzer and built-in fallback
- define stable rule IDs, categories, findings, related spans, fix safety, serializable edits, and a `CriticRule`/`CriticContext` interface
- export the contract through `perl_lsp_rs_core::tooling::perl_critic` and lock the module shape with a focused test

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed locally

- [x] `cargo xtask check-memory-lifecycle-policy`
  - why: memory-sensitive lifecycle, cache, or retained-state surfaces changed
  - evidence: command passed locally

- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
  - why: a Rust file in a retained-owner-sensitive path changed
  - evidence: no new retained-owner patterns found

- [x] `git diff --check`
  - why: guards against whitespace errors in the final patch
  - evidence: command exited cleanly

Additional focused proof:
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core tooling_module_exposes_native_critic_contract --profile agent --locked --test tooling_module_shape -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core --profile agent -- -D warnings -A missing_docs`

Receipt:
- `target/devex/local-proof.json`

## Notes

This is contract-only. It does not change runtime diagnostics, external perlcritic behavior, LSP output, or rule defaults. The point is to give native rules a stable target shape before migrating or adding rule implementations.