### PR TITLE
feat(critic): bridge native findings to violations (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -5,7 +5,7 @@
 //! subprocess-backed Perl::Critic adapter and built-in fallback so callers can
 //! migrate rule-by-rule without changing runtime behavior in one large step.
 
-use super::{CriticConfig, Severity};
+use super::{CriticConfig, Severity, Violation};
 use perl_parser_core::Node;
 use perl_parser_core::position::Range;
 use serde::{Deserialize, Serialize};
@@ -92,6 +92,25 @@ pub struct CriticFinding {
     pub related: Vec<CriticRelatedInformation>,
     /// Optional fix.
     pub fix: Option<CriticFix>,
+}
+
+impl CriticFinding {
+    /// Convert this native finding into the existing violation shape.
+    ///
+    /// This is the bridge that lets native rules flow through current LSP,
+    /// execute-command, and diagnostic consumers while those consumers still
+    /// expect `Violation` values.
+    #[must_use]
+    pub fn to_violation(&self, file: impl Into<String>) -> Violation {
+        Violation {
+            policy: self.rule_id.clone(),
+            description: self.message.clone(),
+            explanation: self.explanation.clone(),
+            severity: self.severity,
+            range: self.range,
+            file: file.into(),
+        }
+    }
 }
 
 /// Native critic rule context.
@@ -223,5 +242,32 @@ mod tests {
         assert_eq!(value["category"], "style");
         assert_eq!(value["fix"]["safety"], "safe");
         assert_eq!(value["fix"]["edits"][0]["new_text"], "x");
+    }
+
+    #[test]
+    fn native_critic_finding_converts_to_legacy_violation_shape() {
+        let finding = CriticFinding {
+            rule_id: "native.variables.unused_lexical".to_string(),
+            category: CriticCategory::Semantic,
+            severity: Severity::Stern,
+            range: Range {
+                start: Position { byte: 10, line: 1, column: 4 },
+                end: Position { byte: 12, line: 1, column: 6 },
+            },
+            message: "unused lexical variable".to_string(),
+            explanation: "remove or use the lexical variable".to_string(),
+            suppression_key: "native.variables.unused_lexical".to_string(),
+            related: Vec::new(),
+            fix: None,
+        };
+
+        let violation = finding.to_violation("lib/App.pm");
+
+        assert_eq!(violation.policy, "native.variables.unused_lexical");
+        assert_eq!(violation.description, "unused lexical variable");
+        assert_eq!(violation.explanation, "remove or use the lexical variable");
+        assert_eq!(violation.severity, Severity::Stern);
+        assert_eq!(violation.range, finding.range);
+        assert_eq!(violation.file, "lib/App.pm");
     }
 }


### PR DESCRIPTION
## Summary

- add a `CriticFinding::to_violation` bridge for native critic findings
- preserve rule ID, message, explanation, severity, range, and file in the existing `Violation` shape
- add focused coverage so native rules can later flow through current diagnostic/execute-command consumers without a large rewrite

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed locally

- [x] `cargo xtask check-memory-lifecycle-policy`
  - why: memory-sensitive lifecycle, cache, or retained-state surfaces changed
  - evidence: command passed locally

- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
  - why: a Rust file in a retained-owner-sensitive path changed
  - evidence: no new retained-owner patterns found

- [x] `git diff --check`
  - why: guards against whitespace errors in the final patch
  - evidence: command exited cleanly

Additional focused proof:
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core --profile agent -- -D warnings -A missing_docs`

Receipt:
- `target/devex/local-proof.json`

## Notes

This is a compatibility bridge only. It does not change runtime diagnostics, external perlcritic behavior, LSP output, or rule defaults.