### PR TITLE
feat(hir): project import directives into semantic facts (#8252)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,7 @@ dependencies = [
  "perl-position-tracking",
  "perl-pragma",
  "perl-regex",
+ "perl-semantic-facts",
  "perl-tdd-support",
  "perl-token",
  "proptest",

--- a/crates/perl-parser-core/Cargo.toml
+++ b/crates/perl-parser-core/Cargo.toml
@@ -29,6 +29,7 @@ perl-ast = { workspace = true }
 perl-ast-v2 = { workspace = true }
 perl-pragma = { workspace = true }
 perl-regex = { workspace = true }
+perl-semantic-facts = { workspace = true }
 perl-token = { workspace = true }
 # Wave D absorbed (internal modules in src/syntax/):
 #   perl-quote → src/syntax/quote.rs
@@ -55,4 +56,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true
-

--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -1,6 +1,9 @@
 //! HIR data model.
 
 use crate::SourceLocation;
+use perl_semantic_facts::{
+    AnchorId, Confidence, FileId, ImportKind, ImportSpec, ImportSymbols, Provenance, ScopeId,
+};
 
 /// Stable identifier for a HIR item within one lowered file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -465,6 +468,18 @@ pub struct CompileEnvironment {
 }
 
 impl CompileEnvironment {
+    /// Project HIR compile directives into canonical import facts.
+    ///
+    /// This is a compiler-substrate projection only. It does not inspect the
+    /// filesystem, execute Perl, or change workspace/LSP provider behavior.
+    #[must_use]
+    pub fn import_specs(&self, file_id: FileId) -> Vec<ImportSpec> {
+        self.directives
+            .iter()
+            .filter_map(|directive| import_spec_from_directive(directive, file_id))
+            .collect()
+    }
+
     /// Build module-resolution candidate facts from static module requests.
     ///
     /// The HIR layer records lexical include-root effects and module requests,
@@ -931,6 +946,293 @@ pub enum CompileConfidence {
     Medium,
     /// Low-confidence dynamic-boundary fact.
     Low,
+}
+
+fn import_spec_from_directive(directive: &CompileDirective, file_id: FileId) -> Option<ImportSpec> {
+    match directive.action {
+        CompileDirectiveAction::Use => {
+            let module = directive.module.as_deref()?;
+            if is_version_pragma(module) {
+                return None;
+            }
+            if module == "constant" {
+                return Some(classify_constant_import(directive, file_id));
+            }
+
+            let (kind, symbols, provenance, confidence) =
+                classify_import_args(&directive.args, module, directive.range);
+            Some(import_spec(
+                module.to_string(),
+                kind,
+                symbols,
+                provenance,
+                confidence,
+                directive,
+                file_id,
+            ))
+        }
+        CompileDirectiveAction::Require => {
+            let (module, kind, symbols, provenance, confidence) =
+                if let Some(module) = directive.module.as_ref() {
+                    (
+                        module.clone(),
+                        ImportKind::Require,
+                        ImportSymbols::Default,
+                        Provenance::ExactAst,
+                        Confidence::High,
+                    )
+                } else {
+                    (
+                        String::new(),
+                        ImportKind::DynamicRequire,
+                        ImportSymbols::Dynamic,
+                        Provenance::DynamicBoundary,
+                        Confidence::Low,
+                    )
+                };
+            Some(import_spec(module, kind, symbols, provenance, confidence, directive, file_id))
+        }
+        CompileDirectiveAction::No => None,
+    }
+}
+
+fn import_spec(
+    module: String,
+    kind: ImportKind,
+    symbols: ImportSymbols,
+    provenance: Provenance,
+    confidence: Confidence,
+    directive: &CompileDirective,
+    file_id: FileId,
+) -> ImportSpec {
+    ImportSpec {
+        module,
+        kind,
+        symbols,
+        provenance,
+        confidence,
+        file_id: Some(file_id),
+        anchor_id: Some(AnchorId(directive.range.start as u64)),
+        scope_id: directive.scope_id.map(|id| ScopeId(id.index() as u64)),
+        span_start_byte: Some(directive.range.start as u32),
+    }
+}
+
+fn classify_import_args(
+    args: &[String],
+    module: &str,
+    range: SourceLocation,
+) -> (ImportKind, ImportSymbols, Provenance, Confidence) {
+    if args.is_empty() {
+        let bare_len = "use ".len() + module.len() + 1;
+        let span_len = range.end.saturating_sub(range.start);
+        if span_len > bare_len {
+            return (
+                ImportKind::UseEmpty,
+                ImportSymbols::None,
+                Provenance::ExactAst,
+                Confidence::High,
+            );
+        }
+        return (ImportKind::Use, ImportSymbols::Default, Provenance::ExactAst, Confidence::High);
+    }
+
+    let mut explicit_names = Vec::new();
+    let mut tags = Vec::new();
+    let mut has_dynamic_arg = false;
+
+    for arg in args {
+        let trimmed = arg.trim();
+        if trimmed == "=>" || trimmed == "," || trimmed == "\\" {
+            continue;
+        }
+
+        if let Some(inner) = parse_qw_content(trimmed) {
+            collect_qw_import_words(inner, &mut explicit_names, &mut tags);
+            continue;
+        }
+
+        let was_quoted = is_quoted(trimmed);
+        let unquoted = unquote(trimmed);
+        if !was_quoted && looks_like_dynamic_import_arg(unquoted) {
+            has_dynamic_arg = true;
+            continue;
+        }
+
+        if let Some(tag) = unquoted.strip_prefix(':') {
+            tags.push(tag.to_string());
+            continue;
+        }
+
+        if looks_like_symbol_name(unquoted) {
+            explicit_names.push(unquoted.to_string());
+        }
+    }
+
+    if has_dynamic_arg {
+        return (
+            ImportKind::UseExplicitList,
+            ImportSymbols::Dynamic,
+            Provenance::DynamicBoundary,
+            Confidence::Low,
+        );
+    }
+
+    if !tags.is_empty() && explicit_names.is_empty() {
+        return (
+            ImportKind::UseTag,
+            ImportSymbols::Tags(tags),
+            Provenance::ExactAst,
+            Confidence::High,
+        );
+    }
+
+    if !tags.is_empty() && !explicit_names.is_empty() {
+        return (
+            ImportKind::UseExplicitList,
+            ImportSymbols::Mixed { tags, names: explicit_names },
+            Provenance::ExactAst,
+            Confidence::High,
+        );
+    }
+
+    if !explicit_names.is_empty() {
+        return (
+            ImportKind::UseExplicitList,
+            ImportSymbols::Explicit(explicit_names),
+            Provenance::ExactAst,
+            Confidence::High,
+        );
+    }
+
+    (ImportKind::UseEmpty, ImportSymbols::None, Provenance::ExactAst, Confidence::High)
+}
+
+fn classify_constant_import(directive: &CompileDirective, file_id: FileId) -> ImportSpec {
+    let mut constant_names = Vec::new();
+    let args = &directive.args;
+
+    if args.first().map(String::as_str) == Some("{") {
+        let mut index = 1;
+        while index < args.len() {
+            let token = args[index].trim();
+            if token == "}" || token == "=>" || token == "," {
+                index += 1;
+                continue;
+            }
+            if index + 1 < args.len() && args[index + 1].trim() == "=>" {
+                constant_names.push(unquote(token).to_string());
+                index += 3;
+            } else {
+                index += 1;
+            }
+        }
+    } else if let Some(inner) = args.first().and_then(|arg| parse_qw_content(arg.trim())) {
+        constant_names.extend(inner.split_whitespace().map(str::to_string));
+    } else if let Some(name) = args.first() {
+        let trimmed = unquote(name.trim());
+        if looks_like_constant_name(trimmed) {
+            constant_names.push(trimmed.to_string());
+        }
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    constant_names.retain(|name| seen.insert(name.clone()));
+
+    let symbols = if constant_names.is_empty() {
+        ImportSymbols::None
+    } else {
+        ImportSymbols::Explicit(constant_names)
+    };
+
+    import_spec(
+        "constant".to_string(),
+        ImportKind::UseConstant,
+        symbols,
+        Provenance::ExactAst,
+        Confidence::High,
+        directive,
+        file_id,
+    )
+}
+
+fn collect_qw_import_words(inner: &str, explicit_names: &mut Vec<String>, tags: &mut Vec<String>) {
+    for word in inner.split_whitespace() {
+        if let Some(tag) = word.strip_prefix(':') {
+            tags.push(tag.to_string());
+        } else {
+            explicit_names.push(word.to_string());
+        }
+    }
+}
+
+fn is_version_pragma(module: &str) -> bool {
+    if module.chars().next().is_some_and(|character| character.is_ascii_digit()) {
+        return true;
+    }
+    module.starts_with('v')
+        && module.len() > 1
+        && module[1..].chars().all(|character| character.is_ascii_digit() || character == '.')
+}
+
+fn parse_qw_content(value: &str) -> Option<&str> {
+    let rest = value.strip_prefix("qw")?.trim_start();
+    let mut chars = rest.chars();
+    let open = chars.next()?;
+    let close = match open {
+        '(' => ')',
+        '[' => ']',
+        '{' => '}',
+        '<' => '>',
+        other => other,
+    };
+    let inner_start = open.len_utf8();
+    let inner_end = rest.len().checked_sub(close.len_utf8())?;
+    if inner_start > inner_end || !rest.ends_with(close) {
+        return None;
+    }
+    Some(&rest[inner_start..inner_end])
+}
+
+fn is_quoted(value: &str) -> bool {
+    (value.starts_with('\'') && value.ends_with('\''))
+        || (value.starts_with('"') && value.ends_with('"'))
+}
+
+fn unquote(value: &str) -> &str {
+    if is_quoted(value) && value.len() >= 2 { &value[1..value.len() - 1] } else { value }
+}
+
+fn looks_like_dynamic_import_arg(value: &str) -> bool {
+    value.starts_with('$')
+        || value.starts_with('@')
+        || value.starts_with('%')
+        || value.starts_with('&')
+        || value.starts_with('*')
+}
+
+fn looks_like_symbol_name(value: &str) -> bool {
+    let value = unquote(value);
+    if value.is_empty() {
+        return false;
+    }
+    if value.starts_with(':') {
+        return true;
+    }
+    value
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+}
+
+fn looks_like_constant_name(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    value
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
 }
 
 fn module_target_to_relative_path(target: &str) -> Option<String> {

--- a/crates/perl-parser-core/tests/hir_tests.rs
+++ b/crates/perl-parser-core/tests/hir_tests.rs
@@ -3,6 +3,7 @@ use perl_parser_core::hir::{
     ScopeGraph, StashGraph, lower_ast,
 };
 use perl_parser_core::{Node, NodeKind, Parser, SourceLocation};
+use perl_semantic_facts::{FileId, ImportKind, ImportSpec, ImportSymbols, Provenance};
 
 fn lower_source(source: &str) -> HirFile {
     let mut parser = Parser::new(source);
@@ -333,6 +334,16 @@ fn render_module_resolution_candidates(
     lines.join("\n")
 }
 
+fn find_import_spec<'a>(
+    specs: &'a [ImportSpec],
+    module: &str,
+) -> Result<&'a ImportSpec, Box<dyn std::error::Error>> {
+    specs
+        .iter()
+        .find(|spec| spec.module == module)
+        .ok_or_else(|| format!("expected ImportSpec for {module}").into())
+}
+
 #[test]
 fn hir_lowers_first_slice_constructs_with_stable_metadata() -> Result<(), Box<dyn std::error::Error>>
 {
@@ -623,6 +634,124 @@ fn hir_stash_graph_records_package_slots_inheritance_and_dynamic_boundaries()
         }),
         "AUTOLOAD should emit a HIR dynamic boundary"
     );
+
+    Ok(())
+}
+
+#[test]
+fn hir_compile_environment_projects_import_specs_from_directives()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file = lower_source(
+        "package Import::Demo;\n\
+         use Foo;\n\
+         use Empty ();\n\
+         use Explicit qw(alpha beta);\n\
+         use Brackets qw[one two];\n\
+         use Braces qw{:all delta};\n\
+         use Tags qw(:all gamma);\n\
+         use constant PI => 3;\n\
+         use Runtime @names;\n\
+         use CodeImport &handler;\n\
+         use GlobImport *slot;\n\
+         require Foo::Bar;\n\
+         require $runtime;\n",
+    );
+
+    let specs = file.compile_environment.import_specs(FileId(7));
+    let foo = find_import_spec(&specs, "Foo")?;
+    assert_eq!(foo.kind, ImportKind::Use);
+    assert_eq!(foo.symbols, ImportSymbols::Default);
+    assert_eq!(foo.provenance, Provenance::ExactAst);
+    assert_eq!(foo.file_id, Some(FileId(7)));
+    assert!(foo.scope_id.is_some(), "HIR import facts should preserve scope context");
+    assert!(foo.span_start_byte.is_some(), "HIR import facts should preserve directive order");
+
+    let empty = find_import_spec(&specs, "Empty")?;
+    assert_eq!(empty.kind, ImportKind::UseEmpty);
+    assert_eq!(empty.symbols, ImportSymbols::None);
+
+    let explicit = find_import_spec(&specs, "Explicit")?;
+    assert_eq!(explicit.kind, ImportKind::UseExplicitList);
+    assert_eq!(
+        explicit.symbols,
+        ImportSymbols::Explicit(vec!["alpha".to_string(), "beta".to_string()])
+    );
+
+    let brackets = find_import_spec(&specs, "Brackets")?;
+    assert_eq!(brackets.kind, ImportKind::UseExplicitList);
+    assert_eq!(
+        brackets.symbols,
+        ImportSymbols::Explicit(vec!["one".to_string(), "two".to_string()])
+    );
+
+    let braces = find_import_spec(&specs, "Braces")?;
+    assert_eq!(braces.kind, ImportKind::UseExplicitList);
+    assert_eq!(
+        braces.symbols,
+        ImportSymbols::Mixed { tags: vec!["all".to_string()], names: vec!["delta".to_string()] }
+    );
+
+    let tags = find_import_spec(&specs, "Tags")?;
+    assert_eq!(tags.kind, ImportKind::UseExplicitList);
+    assert_eq!(
+        tags.symbols,
+        ImportSymbols::Mixed { tags: vec!["all".to_string()], names: vec!["gamma".to_string()] }
+    );
+
+    let constant = find_import_spec(&specs, "constant")?;
+    assert_eq!(constant.kind, ImportKind::UseConstant);
+    assert_eq!(constant.symbols, ImportSymbols::Explicit(vec!["PI".to_string()]));
+
+    let runtime = find_import_spec(&specs, "Runtime")?;
+    assert_eq!(runtime.kind, ImportKind::UseExplicitList);
+    assert_eq!(runtime.symbols, ImportSymbols::Dynamic);
+    assert_eq!(runtime.provenance, Provenance::DynamicBoundary);
+
+    let code_import = find_import_spec(&specs, "CodeImport")?;
+    assert_eq!(code_import.symbols, ImportSymbols::Dynamic);
+    assert_eq!(code_import.provenance, Provenance::DynamicBoundary);
+
+    let glob_import = find_import_spec(&specs, "GlobImport")?;
+    assert_eq!(glob_import.symbols, ImportSymbols::Dynamic);
+    assert_eq!(glob_import.provenance, Provenance::DynamicBoundary);
+
+    let require = find_import_spec(&specs, "Foo::Bar")?;
+    assert_eq!(require.kind, ImportKind::Require);
+    assert_eq!(require.symbols, ImportSymbols::Default);
+
+    let dynamic_require = specs
+        .iter()
+        .find(|spec| spec.kind == ImportKind::DynamicRequire)
+        .ok_or("expected dynamic require ImportSpec")?;
+    assert_eq!(dynamic_require.module, "");
+    assert_eq!(dynamic_require.symbols, ImportSymbols::Dynamic);
+    assert_eq!(dynamic_require.provenance, Provenance::DynamicBoundary);
+
+    let starts = specs
+        .iter()
+        .map(|spec| spec.span_start_byte.ok_or("expected span_start_byte"))
+        .collect::<Result<Vec<_>, _>>()?;
+    assert!(
+        starts.windows(2).all(|window| window[0] <= window[1]),
+        "import facts must keep source order"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_compile_environment_skips_version_and_no_directives_for_import_specs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let file = lower_source(
+        "use 5.036;\n\
+         no strict 'refs';\n\
+         use Real::Module;\n",
+    );
+
+    let specs = file.compile_environment.import_specs(FileId(11));
+    assert_eq!(specs.len(), 1);
+    assert_eq!(specs[0].module, "Real::Module");
+    assert_eq!(specs[0].kind, ImportKind::Use);
 
     Ok(())
 }


### PR DESCRIPTION
Problem: HIR compile-environment facts record `use` / `require` directives, but there was no canonical `ImportSpec` projection for the compiler-backed path.
Fix: add an opt-in `CompileEnvironment::import_specs(file_id)` projection that reuses `perl-semantic-facts` import types, preserves anchors/scope/order, and keeps dynamic import args / dynamic require fail-closed. No provider cutover.
Verification: `cargo test -p perl-parser-core --test hir_tests --profile agent --locked import -- --nocapture` passes; `cargo xtask semantic-scorecard --check` passes; `cargo xtask semantic-shadow-compare --check` passes; `cargo check -p perl-parser-core --all-targets --profile agent --locked` passes; `cargo clippy -p perl-parser-core --lib --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo xtask fmt --check` passes; `git diff --check` passes.

Note: an exploratory full `cargo test -p perl-parser-core --profile agent --locked` still fails in existing unrelated `fix_subst_squote_delimiter` parser tests for substitution replacement parsing; this PR does not touch that parser lane.