### PR TITLE
feat(critic): wire native engine into pull diagnostics (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -18,6 +18,16 @@ mod native_build_hints;
 pub use native_build_hints::{NativeBuildHints, detect_native_build_hints};
 pub use perl_lsp_perltidy::FormatterMode;
 
+/// Critic diagnostic engine used for LSP policy diagnostics.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CriticEngine {
+    /// Existing built-in/external Perl::Critic-compatible path.
+    #[default]
+    Legacy,
+    /// Rust-native critic rule registry.
+    Native,
+}
+
 /// Server configuration
 ///
 /// Runtime configuration for the LSP server features including inlay hints
@@ -73,6 +83,9 @@ pub struct ServerConfig {
     ///
     /// When `Some`, passes `--theme=<expr>` to perlcritic.
     pub perlcritic_theme: Option<String>,
+
+    /// Critic engine used for LSP policy diagnostics.
+    pub critic_engine: CriticEngine,
 
     /// Whether LSP formatting is enabled.
     ///
@@ -207,6 +220,7 @@ impl Default for ServerConfig {
             perlcritic_severity: 3,
             perlcritic_profile: None,
             perlcritic_theme: None,
+            critic_engine: CriticEngine::Legacy,
             perltidy_enabled: true,
             formatting_engine: FormatterMode::Native,
             perltidy_profile: None,
@@ -284,6 +298,13 @@ impl ServerConfig {
                 let theme = theme.trim();
                 self.perlcritic_theme = (!theme.is_empty()).then(|| theme.to_string());
             }
+        }
+
+        if let Some(critic) = settings.get("critic")
+            && let Some(engine) = critic.get("engine").and_then(|v| v.as_str())
+            && let Some(engine) = parse_critic_engine(engine)
+        {
+            self.critic_engine = engine;
         }
 
         if let Some(formatting) = settings.get("formatting") {
@@ -385,6 +406,14 @@ fn parse_formatter_mode(value: &str) -> Option<FormatterMode> {
         "compat" | "perltidy-compat" => Some(FormatterMode::Compat),
         "external-legacy" | "external-perltidy" | "perltidy" => Some(FormatterMode::ExternalLegacy),
         "off" | "disabled" | "none" => Some(FormatterMode::Off),
+        _ => None,
+    }
+}
+
+fn parse_critic_engine(value: &str) -> Option<CriticEngine> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "legacy" | "external" | "perlcritic" => Some(CriticEngine::Legacy),
+        "native" => Some(CriticEngine::Native),
         _ => None,
     }
 }
@@ -674,6 +703,8 @@ pub struct ProjectConfig {
     pub ai_completion: ProjectAiCompletionConfig,
     /// `[formatting]` section: native formatter and legacy adapter configuration.
     pub formatting: ProjectFormattingConfig,
+    /// `[critic]` section: native critic and legacy adapter configuration.
+    pub critic: ProjectCriticConfig,
 }
 
 /// `[perl]` section of `.perl-lsp.toml`.
@@ -704,6 +735,14 @@ pub struct ProjectDiagnosticsConfig {
     pub perlcritic: Option<bool>,
     /// Minimum perlcritic severity (1-5). Maps to `ServerConfig.perlcritic_severity`.
     pub perlcritic_severity: Option<u8>,
+}
+
+/// `[critic]` section of `.perl-lsp.toml`.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(default)]
+pub struct ProjectCriticConfig {
+    /// Critic engine (`legacy`, `perlcritic`, or `native`).
+    pub engine: Option<String>,
 }
 
 /// `[features]` section of `.perl-lsp.toml`.
@@ -875,6 +914,11 @@ impl ProjectConfig {
         {
             config.formatting_engine = mode;
         }
+        if let Some(ref engine) = self.critic.engine
+            && let Some(engine) = parse_critic_engine(engine)
+        {
+            config.critic_engine = engine;
+        }
         if let Some(ref profile) = self.formatting.perltidy_profile {
             config.perltidy_profile = Some(profile.clone());
         }
@@ -979,6 +1023,9 @@ enabled = true
 engine = "external-perltidy"
 perltidy_maximum_line_length = 100
 perltidy_extra_args = ["-noll"]
+
+[critic]
+engine = "native"
 "#,
         )?;
 
@@ -994,6 +1041,7 @@ perltidy_extra_args = ["-noll"]
         assert_eq!(config.formatting.engine.as_deref(), Some("external-perltidy"));
         assert_eq!(config.formatting.perltidy_maximum_line_length, Some(100));
         assert_eq!(config.formatting.perltidy_extra_args, vec!["-noll"]);
+        assert_eq!(config.critic.engine.as_deref(), Some("native"));
         Ok(())
     }
 
@@ -1080,6 +1128,26 @@ perltidy_extra_args = ["-noll"]
     }
 
     #[test]
+    fn server_config_accepts_native_critic_engine() {
+        let mut config = ServerConfig::default();
+        assert_eq!(config.critic_engine, CriticEngine::Legacy);
+
+        config.update_from_value(&serde_json::json!({
+            "critic": {
+                "engine": "native"
+            }
+        }));
+        assert_eq!(config.critic_engine, CriticEngine::Native);
+
+        config.update_from_value(&serde_json::json!({
+            "critic": {
+                "engine": "perlcritic"
+            }
+        }));
+        assert_eq!(config.critic_engine, CriticEngine::Legacy);
+    }
+
+    #[test]
     fn project_config_applies_formatter_engine() {
         let mut config = ServerConfig::default();
         let mut project = ProjectConfig::default();
@@ -1088,6 +1156,17 @@ perltidy_extra_args = ["-noll"]
         project.apply_to_server_config(&mut config);
 
         assert_eq!(config.formatting_engine, FormatterMode::Off);
+    }
+
+    #[test]
+    fn project_config_applies_native_critic_engine() {
+        let mut config = ServerConfig::default();
+        let mut project = ProjectConfig::default();
+        project.critic.engine = Some("native".to_string());
+
+        project.apply_to_server_config(&mut config);
+
+        assert_eq!(config.critic_engine, CriticEngine::Native);
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -18,7 +18,11 @@ use serde::{Deserialize, Serialize};
 use crate::state::DocumentState;
 use crate::util::uri::parse_uri;
 use perl_diagnostics::codes::DiagnosticCode;
+use perl_lsp_rs_core::config::CriticEngine;
 use perl_lsp_rs_core::providers::diagnostics::{parse_error_code, parse_error_severity};
+use perl_lsp_rs_core::tooling::perl_critic::{
+    CriticConfig, CriticContext, CriticFinding, NativeCriticRegistry, Severity,
+};
 use perl_module::resolution::use_lib::resolve_use_lib_paths_from_source;
 use perl_parser::Parser;
 use perl_parser::error::ParseError;
@@ -44,6 +48,8 @@ pub struct PullDiagnosticsContext {
     pub perlcritic_severity: i32,
     /// Optional perlcritic profile path
     pub perlcritic_profile: Option<String>,
+    /// Critic engine used for policy diagnostics.
+    pub critic_engine: CriticEngine,
     /// Workspace root for .perlcriticrc discovery
     pub workspace_root: Option<PathBuf>,
     /// @INC paths for module resolution
@@ -62,6 +68,7 @@ impl PullDiagnosticsContext {
             perlcritic_enabled: false,
             perlcritic_severity: 3,
             perlcritic_profile: None,
+            critic_engine: CriticEngine::Legacy,
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -77,6 +84,7 @@ impl PullDiagnosticsContext {
             perlcritic_enabled: true,
             perlcritic_severity: severity,
             perlcritic_profile: profile,
+            critic_engine: CriticEngine::Legacy,
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -94,6 +102,7 @@ impl PullDiagnosticsContext {
             perlcritic_enabled: false,
             perlcritic_severity: 3,
             perlcritic_profile: None,
+            critic_engine: CriticEngine::Legacy,
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -108,6 +117,7 @@ impl std::fmt::Debug for PullDiagnosticsContext {
             .field("perlcritic_enabled", &self.perlcritic_enabled)
             .field("perlcritic_severity", &self.perlcritic_severity)
             .field("perlcritic_profile", &self.perlcritic_profile)
+            .field("critic_engine", &self.critic_engine)
             .field("workspace_root", &self.workspace_root)
             .field("include_paths", &self.include_paths)
             .field("markup_message_support", &self.markup_message_support)
@@ -331,8 +341,7 @@ impl PullDiagnosticsProvider {
 
                 let mut diagnostics = base_diagnostics;
 
-                // Add built-in Perl::Critic policy violations
-                self.add_builtin_critic_diagnostics(uri, &ast, content, &mut diagnostics);
+                self.add_policy_critic_diagnostics(uri, &ast, content, context, &mut diagnostics);
 
                 diagnostics
             }
@@ -407,6 +416,25 @@ impl PullDiagnosticsProvider {
         effective_paths
     }
 
+    /// Add configured policy critic diagnostics.
+    fn add_policy_critic_diagnostics(
+        &self,
+        uri: &Uri,
+        ast: &std::sync::Arc<perl_parser::ast::Node>,
+        content: &str,
+        context: &PullDiagnosticsContext,
+        diagnostics: &mut Vec<LspDiagnostic>,
+    ) {
+        match context.critic_engine {
+            CriticEngine::Legacy => {
+                self.add_builtin_critic_diagnostics(uri, ast, content, diagnostics);
+            }
+            CriticEngine::Native => {
+                self.add_native_critic_diagnostics(uri, ast, content, context, diagnostics);
+            }
+        }
+    }
+
     /// Add built-in Perl::Critic policy diagnostics.
     fn add_builtin_critic_diagnostics(
         &self,
@@ -443,6 +471,60 @@ impl PullDiagnosticsProvider {
             };
 
             diagnostics.push(self.to_lsp_diagnostic(uri, content, internal_diag));
+        }
+    }
+
+    /// Add native critic policy diagnostics.
+    fn add_native_critic_diagnostics(
+        &self,
+        uri: &Uri,
+        ast: &std::sync::Arc<perl_parser::ast::Node>,
+        content: &str,
+        context: &PullDiagnosticsContext,
+        diagnostics: &mut Vec<LspDiagnostic>,
+    ) {
+        let critic_config = CriticConfig {
+            severity: context.perlcritic_severity.clamp(1, 5) as u8,
+            profile: context.perlcritic_profile.clone(),
+            ..CriticConfig::default()
+        };
+        let critic_context = CriticContext::new(content, ast.as_ref(), &critic_config);
+        let registry = NativeCriticRegistry::recommended();
+
+        for finding in registry.check(&critic_context) {
+            diagnostics.push(self.native_finding_to_lsp_diagnostic(uri, content, finding));
+        }
+    }
+
+    fn native_finding_to_lsp_diagnostic(
+        &self,
+        _uri: &Uri,
+        text: &str,
+        finding: CriticFinding,
+    ) -> LspDiagnostic {
+        let range = lsp_range_from_offsets(text, finding.range.start.byte, finding.range.end.byte);
+        let severity = Some(native_critic_severity_to_lsp(finding.severity));
+        let code = Some(NumberOrString::String(finding.rule_id.clone()));
+        let fixable = finding.fix.is_some();
+        let data = Some(serde_json::json!({
+            "code": finding.rule_id,
+            "category": format!("{:?}", finding.category),
+            "fixable": fixable,
+            "tags": [],
+            "suppressionKey": finding.suppression_key,
+            "explanation": finding.explanation,
+        }));
+
+        LspDiagnostic {
+            range,
+            severity,
+            code,
+            code_description: None,
+            source: Some("perl-lsp-critic".to_string()),
+            message: finding.message,
+            related_information: None,
+            tags: None,
+            data,
         }
     }
 
@@ -519,8 +601,13 @@ impl PullDiagnosticsProvider {
 
             let mut diagnostics = base_diagnostics;
 
-            // Add built-in Perl::Critic policy violations
-            self.add_builtin_critic_diagnostics(uri, ast, &doc_state.text, &mut diagnostics);
+            self.add_policy_critic_diagnostics(
+                uri,
+                ast,
+                &doc_state.text,
+                context,
+                &mut diagnostics,
+            );
 
             // Add dead code diagnostics from workspace-wide symbol analysis
             #[cfg(all(feature = "workspace", not(target_arch = "wasm32")))]
@@ -953,6 +1040,15 @@ fn to_lsp_severity(severity: InternalDiagnosticSeverity) -> LspDiagnosticSeverit
     }
 }
 
+fn native_critic_severity_to_lsp(severity: Severity) -> LspDiagnosticSeverity {
+    match severity {
+        Severity::Gentle => LspDiagnosticSeverity::ERROR,
+        Severity::Stern | Severity::Harsh => LspDiagnosticSeverity::WARNING,
+        Severity::Cruel => LspDiagnosticSeverity::INFORMATION,
+        Severity::Brutal => LspDiagnosticSeverity::HINT,
+    }
+}
+
 fn to_lsp_tags(tags: &[InternalDiagnosticTag]) -> Option<Vec<LspDiagnosticTag>> {
     if tags.is_empty() {
         return None;
@@ -1237,6 +1333,72 @@ mod tests {
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
         assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));
         assert!(is_fixable_diagnostic("Variables::ProhibitUnusedVariables"));
+    }
+
+    #[test]
+    fn native_critic_engine_emits_opt_in_lsp_diagnostics() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let provider = PullDiagnosticsProvider::new();
+        let uri: Uri = "file:///test.pl".parse()?;
+        let mut context = PullDiagnosticsContext::new();
+        context.critic_engine = CriticEngine::Native;
+        context.perlcritic_severity = 3;
+
+        let items = get_full_items(provider.get_document_diagnostics_with_context(
+            &uri,
+            "my $x = 1;\n",
+            None,
+            &context,
+            None,
+        ));
+
+        let strict = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.testing.require_use_strict"))
+            })
+            .ok_or("expected native strict finding")?;
+        assert_eq!(strict.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(strict.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(strict.message, "Code does not use strict");
+        let data = strict.data.as_ref().ok_or("native critic data should be populated")?;
+        assert_eq!(data["code"], "native.testing.require_use_strict");
+        assert_eq!(data["suppressionKey"], "native.testing.require_use_strict");
+        assert_eq!(data["fixable"], true);
+
+        let warnings = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.testing.require_use_warnings"))
+            })
+            .ok_or("expected native warnings finding")?;
+        assert_eq!(warnings.source.as_deref(), Some("perl-lsp-critic"));
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_critic_engine_remains_default_for_pull_diagnostics()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let provider = PullDiagnosticsProvider::new();
+        let uri: Uri = "file:///test.pl".parse()?;
+        let items =
+            get_full_items(provider.get_document_diagnostics(&uri, "my $x = 1;\n", None, None));
+
+        assert!(!items.iter().any(|diag| {
+            diag.code
+                .as_ref()
+                .is_some_and(|code| matches!(code, NumberOrString::String(value) if value.starts_with("native.")))
+        }));
+        assert!(items.iter().any(|diag| {
+            diag.code.as_ref().is_some_and(|code| {
+                matches!(code, NumberOrString::String(value) if value == "TestingAndDebugging::RequireUseStrict")
+            })
+        }));
+        Ok(())
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -94,9 +94,14 @@ impl PullDiagnosticsOrchestrator {
     /// Build context from LspServer state.
     pub fn build_context(&self, server: &LspServer, uri: &str) -> PullDiagnosticsContext {
         // Get config values
-        let (perlcritic_enabled, perlcritic_severity, perlcritic_profile) = {
+        let (perlcritic_enabled, perlcritic_severity, perlcritic_profile, critic_engine) = {
             let cfg = server.config.lock();
-            (cfg.perlcritic_enabled, cfg.perlcritic_severity, cfg.perlcritic_profile.clone())
+            (
+                cfg.perlcritic_enabled,
+                cfg.perlcritic_severity,
+                cfg.perlcritic_profile.clone(),
+                cfg.critic_engine,
+            )
         };
 
         let profile =
@@ -129,6 +134,7 @@ impl PullDiagnosticsOrchestrator {
             perlcritic_enabled,
             perlcritic_severity: perlcritic_severity.into(),
             perlcritic_profile: profile,
+            critic_engine,
             workspace_root,
             include_paths,
             markup_message_support,
@@ -149,17 +155,18 @@ impl PullDiagnosticsOrchestrator {
         use perl_lsp_rs_core::tooling::perl_critic::{CriticAnalyzer, CriticConfig};
 
         // Check config
-        let (enabled, severity, profile, theme) = {
+        let (enabled, severity, profile, theme, critic_engine) = {
             let cfg = server.config.lock();
             (
                 cfg.perlcritic_enabled,
                 cfg.perlcritic_severity,
                 cfg.perlcritic_profile.clone(),
                 cfg.perlcritic_theme.clone(),
+                cfg.critic_engine,
             )
         };
 
-        if !enabled {
+        if !enabled || critic_engine == perl_lsp_rs_core::config::CriticEngine::Native {
             return;
         }
 
@@ -1390,16 +1397,17 @@ impl LspServer {
         diagnostics: &mut Vec<InternalDiagnostic>,
     ) {
         // Check config: perlcritic must be explicitly enabled (opt-in)
-        let (enabled, severity, profile, theme) = {
+        let (enabled, severity, profile, theme, critic_engine) = {
             let cfg = self.config.lock();
             (
                 cfg.perlcritic_enabled,
                 cfg.perlcritic_severity,
                 cfg.perlcritic_profile.clone(),
                 cfg.perlcritic_theme.clone(),
+                cfg.critic_engine,
             )
         };
-        if !enabled {
+        if !enabled || critic_engine == perl_lsp_rs_core::config::CriticEngine::Native {
             return;
         }
         let profile = profile.and_then(|profile| (!profile.trim().is_empty()).then_some(profile));


### PR DESCRIPTION
## Summary

Wires the Rust-native critic registry into pull diagnostics behind an explicit opt-in engine switch:

```toml
[critic]
engine = "native"
```

Default behavior remains legacy-compatible. Existing built-in policy diagnostics continue to run by default, and the external perlcritic subprocess collector is skipped when the native engine is selected so native mode does not accidentally shell out through old `perlcritic.enabled` settings.

## What changed

- Added `CriticEngine` to server/project config, defaulting to `Legacy`.
- Parsed `critic.engine` from LSP settings and `[critic]` project config.
- Passed the critic engine into `PullDiagnosticsContext`.
- Routed pull diagnostics through either the existing built-in analyzer or `NativeCriticRegistry::recommended()`.
- Added native LSP diagnostics with stable rule IDs, source `perl-lsp-critic`, severity, byte spans, suppression key, explanation, and fixability metadata.
- Kept the legacy `Violation` bridge and native registry config filtering untouched.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
  - why: keeps formatting deterministic before any other proof
  - evidence: passed

- [x] `cargo test -p perl-lsp-rs-core critic_engine --profile agent --locked -- --nocapture`
  - why: config parsing/project config routing changed
  - evidence: passed

- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
  - why: opt-in native pull diagnostics path changed
  - evidence: passed

- [x] `cargo test -p perl-lsp-rs legacy_critic_engine --profile agent --locked --lib -- --nocapture`
  - why: default legacy pull diagnostics must remain unchanged
  - evidence: passed

- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
  - why: native critic registry/filter/suppression behavior must stay intact
  - evidence: passed

- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
  - why: touched runtime/core Rust surfaces
  - evidence: passed

- [x] `cargo xtask check-memory-lifecycle-policy`
  - why: memory-sensitive runtime surface changed
  - evidence: passed

- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
  - why: retained-owner-sensitive Rust paths changed
  - evidence: passed, no new retained-owner patterns

- [x] `cargo xtask devex pr-body --base origin/master`
  - why: records the self-routed local proof packet
  - evidence: passed

- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
  - why: emits local proof receipt for handoff
  - evidence: passed

- [x] `git diff --check`
  - why: guards against whitespace errors in the final patch
  - evidence: passed

## Out of scope

- Native critic is not default.
- `perl.runCritic` execute-command behavior is unchanged.
- No new critic rules are added.
- No formatter, parser metric, memory policy, or CI behavior changes.
