### PR TITLE
feat(critic): add native critic quick fixes (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -200,11 +200,13 @@ impl CodeActionsProvider {
                     | "InputOutput::RequireThreeArgOpen" => {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
-                    // Perl::Critic policies for missing strict/warnings.
-                    "TestingAndDebugging::RequireUseStrict" => {
+                    // Perl::Critic/native critic policies for missing strict/warnings.
+                    "TestingAndDebugging::RequireUseStrict"
+                    | "native.testing.require_use_strict" => {
                         actions.extend(quick_fixes::add_use_strict());
                     }
-                    "TestingAndDebugging::RequireUseWarnings" => {
+                    "TestingAndDebugging::RequireUseWarnings"
+                    | "native.testing.require_use_warnings" => {
                         actions.extend(quick_fixes::add_use_warnings());
                     }
                     // Perl::Critic policy alias for unused variables.
@@ -605,6 +607,39 @@ mod tests {
         assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
         assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
         assert!(actions.iter().any(|a| a.title.contains("Remove unused variable")));
+    }
+
+    #[test]
+    fn test_native_critic_policy_aliases_for_strict_and_warnings() {
+        let source = "print 'hello';\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![
+            Diagnostic {
+                range: (0, 0),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("native.testing.require_use_strict".to_string()),
+                message: "Code does not use strict".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+            Diagnostic {
+                range: (0, 0),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("native.testing.require_use_warnings".to_string()),
+                message: "Code does not use warnings".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            },
+        ];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
+        assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -75,6 +75,24 @@ pub(super) fn fix_unused_variable(
     actions
 }
 
+pub(super) fn add_use_strict(diagnostic: &Diagnostic) -> Vec<CodeAction> {
+    vec![diagnostic_action(
+        diagnostic,
+        "Add 'use strict'",
+        CodeActionKind::QuickFix,
+        TextEdit { range: (0, 0), new_text: "use strict;\n".to_string() },
+    )]
+}
+
+pub(super) fn add_use_warnings(diagnostic: &Diagnostic) -> Vec<CodeAction> {
+    vec![diagnostic_action(
+        diagnostic,
+        "Add 'use warnings'",
+        CodeActionKind::QuickFix,
+        TextEdit { range: (0, 0), new_text: "use warnings;\n".to_string() },
+    )]
+}
+
 pub(super) fn fix_variable_shadowing(diagnostic: &Diagnostic) -> Vec<CodeAction> {
     let Some(var_name) = source_utils::extract_quoted_value(&diagnostic.message) else {
         return Vec::new();

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -62,6 +62,8 @@ impl CodeActionsProvider {
             Some(c) if c == DiagnosticCode::UnusedVariable.as_str() || c == "unused-variable" => {
                 fixes::fix_unused_variable(self, diagnostic)
             }
+            Some("native.testing.require_use_strict") => fixes::add_use_strict(diagnostic),
+            Some("native.testing.require_use_warnings") => fixes::add_use_warnings(diagnostic),
             Some(c)
                 if c == DiagnosticCode::VariableShadowing.as_str() || c == "variable-shadowing" =>
             {
@@ -310,6 +312,34 @@ mod tests {
         let actions = provider.get_actions_for_diagnostic(&diagnostic);
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Rename to '$_unused' (mark as intentionally unused)");
+    }
+
+    #[test]
+    fn test_native_critic_strict_warnings_quick_fixes() {
+        let provider = CodeActionsProvider::new("print 'hello';\n".to_string());
+        let diagnostics = vec![
+            make_diagnostic(
+                (0, 0),
+                DiagnosticSeverity::Warning,
+                "native.testing.require_use_strict",
+                "Code does not use strict",
+            ),
+            make_diagnostic(
+                (0, 0),
+                DiagnosticSeverity::Warning,
+                "native.testing.require_use_warnings",
+                "Code does not use warnings",
+            ),
+        ];
+
+        let actions = provider.get_code_actions((0, 1), &diagnostics);
+
+        assert!(actions.iter().any(|action| {
+            action.title == "Add 'use strict'" && action.edit.new_text == "use strict;\n"
+        }));
+        assert!(actions.iter().any(|action| {
+            action.title == "Add 'use warnings'" && action.edit.new_text == "use warnings;\n"
+        }));
     }
 
     // ── Quick-fix: variable shadowing ───────────────────────────────────

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/source_utils.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/source_utils.rs
@@ -3,6 +3,13 @@
 use super::CodeActionsProvider;
 
 pub(super) fn ranges_overlap(r1: (usize, usize), r2: (usize, usize)) -> bool {
+    if r1.0 == r1.1 {
+        return r2.0 <= r1.0 && r1.0 <= r2.1;
+    }
+    if r2.0 == r2.1 {
+        return r1.0 <= r2.0 && r2.0 <= r1.1;
+    }
+
     r1.0 < r2.1 && r2.0 < r1.1
 }
 

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1111,6 +1111,8 @@ fn is_fixable_diagnostic(code: &str) -> bool {
         code,
         "TestingAndDebugging::RequireUseStrict"
             | "TestingAndDebugging::RequireUseWarnings"
+            | "native.testing.require_use_strict"
+            | "native.testing.require_use_warnings"
             | "InputOutput::ProhibitBarewordFileHandles"
             | "InputOutput::RequireBriefOpen"
             | "InputOutput::RequireThreeArgOpen"

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1626,6 +1626,8 @@ fn is_fixable_perlcritic_policy(code: &str) -> bool {
             | "InputOutput::RequireThreeArgOpen"
             | "TestingAndDebugging::RequireUseStrict"
             | "TestingAndDebugging::RequireUseWarnings"
+            | "native.testing.require_use_strict"
+            | "native.testing.require_use_warnings"
             | "Variables::ProhibitUnusedVariables"
     )
 }


### PR DESCRIPTION
## Summary

Adds quick-fix routing for the native critic strict/warnings rule IDs introduced by the opt-in native diagnostic path:

- `native.testing.require_use_strict` -> `Add 'use strict'`
- `native.testing.require_use_warnings` -> `Add 'use warnings'`

This keeps the native critic editor flow honest: diagnostics that advertise a safe fix now resolve to the same existing pragma insertion code actions as the legacy Perl::Critic aliases.

## What changed

- Routed native strict/warnings rule IDs in the core code-action provider.
- Routed native strict/warnings rule IDs in the LSP-facing code-action provider.
- Added LSP-facing quick-fix builders for file-scope strict/warnings insertion.
- Taught range filtering to include zero-width diagnostics at the requested boundary, which is required for insertion-point diagnostics.
- Added native alias tests on both code-action surfaces.
- Added native strict/warnings IDs to diagnostic fixability allowlists.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
  - why: keeps formatting deterministic before any other proof
  - evidence: passed

- [x] `cargo test -p perl-lsp-rs-core native_critic_policy_aliases --profile agent --locked -- --nocapture`
  - why: core code-action alias routing changed
  - evidence: passed

- [x] `cargo test -p perl-lsp-rs test_native_critic_strict_warnings_quick_fixes --profile agent --locked --lib -- --nocapture`
  - why: LSP-facing code-action alias routing changed
  - evidence: passed

- [x] `cargo test -p perl-lsp-rs code_actions_provider --profile agent --locked --lib -- --nocapture`
  - why: range filtering and code-action provider behavior changed
  - evidence: passed

- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
  - why: native diagnostic fixability data must stay aligned with quick-fix routing
  - evidence: passed

- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
  - why: touched runtime/core Rust surfaces
  - evidence: passed

- [x] `cargo xtask check-memory-lifecycle-policy`
  - why: memory-sensitive runtime surface changed
  - evidence: passed

- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
  - why: retained-owner-sensitive Rust paths changed
  - evidence: passed, no new retained-owner patterns

- [x] `cargo xtask devex pr-body --base origin/master`
  - why: records the self-routed local proof packet
  - evidence: passed

- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
  - why: emits local proof receipt for handoff
  - evidence: passed

- [x] `git diff --check`
  - why: guards against whitespace errors in the final patch
  - evidence: passed

## Out of scope

- Native critic remains opt-in.
- No new critic rules are added.
- `perl.runCritic` execute-command behavior is unchanged.
- No formatter, parser metric, memory policy, or CI behavior changes.
