### PR TITLE
feat(compile-env): resolve HIR module candidates (#8270)

### DIFF
--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -702,6 +702,7 @@ impl CompileEnvironment {
                     relative_path,
                     roots: candidate_roots,
                     status,
+                    resolved_path: None,
                     range: request.range,
                     package_context: request.package_context.clone(),
                     provenance: request.provenance,
@@ -709,6 +710,37 @@ impl CompileEnvironment {
                 })
             })
             .collect()
+    }
+
+    /// Resolve static module candidate facts using a caller-supplied path predicate.
+    ///
+    /// This preserves the HIR layer's explicit boundary: the caller supplies
+    /// roots and the existence check, so parser-core still does not read
+    /// ambient process state or spawn Perl.
+    #[must_use]
+    pub fn resolved_module_resolution_candidates(
+        &self,
+        supplied_roots: &[ModuleResolutionRoot],
+        mut path_exists: impl FnMut(&str) -> bool,
+    ) -> Vec<ModuleResolutionCandidate> {
+        let mut candidates = self.module_resolution_candidates(supplied_roots);
+
+        for candidate in &mut candidates {
+            if candidate.status != ModuleResolutionCandidateStatus::CandidateBuilt {
+                continue;
+            }
+
+            if let Some(root) =
+                candidate.roots.iter().find(|root| path_exists(&root.candidate_path))
+            {
+                candidate.status = ModuleResolutionCandidateStatus::Resolved;
+                candidate.resolved_path = Some(root.candidate_path.clone());
+            } else {
+                candidate.status = ModuleResolutionCandidateStatus::NotFound;
+            }
+        }
+
+        candidates
     }
 
     fn candidate_roots_for_request(
@@ -999,6 +1031,8 @@ pub struct ModuleResolutionCandidate {
     pub roots: Vec<ModuleResolutionCandidateRoot>,
     /// Resolution status for this candidate packet.
     pub status: ModuleResolutionCandidateStatus,
+    /// Candidate path selected by the resolver, when a matching file exists.
+    pub resolved_path: Option<String>,
     /// Source range for the request.
     pub range: SourceLocation,
     /// Package context active at the request.

--- a/crates/perl-parser-core/tests/hir_tests.rs
+++ b/crates/perl-parser-core/tests/hir_tests.rs
@@ -6,6 +6,7 @@ use perl_parser_core::{Node, NodeKind, Parser, SourceLocation};
 use perl_semantic_facts::{
     Confidence, ExportSet, ExportTag, FileId, ImportKind, ImportSpec, ImportSymbols, Provenance,
 };
+use std::fs;
 
 fn lower_source(source: &str) -> HirFile {
     let mut parser = Parser::new(source);
@@ -319,6 +320,43 @@ fn render_module_resolution_candidates(
             candidate.request_kind,
             candidate.relative_path,
             candidate.status,
+            candidate.roots.len(),
+            package,
+            candidate.provenance,
+            candidate.confidence
+        ));
+
+        for root in candidate.roots {
+            lines.push(format!(
+                "root={} {:?} source={} candidate={} precedence={}",
+                root.path, root.kind, root.source, root.candidate_path, root.precedence
+            ));
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn render_resolved_module_resolution_candidates(
+    environment: &CompileEnvironment,
+    supplied_roots: &[ModuleResolutionRoot],
+    path_exists: impl FnMut(&str) -> bool,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push("[module-candidates]".to_string());
+
+    for candidate in environment.resolved_module_resolution_candidates(supplied_roots, path_exists)
+    {
+        let package = candidate.package_context.as_deref().unwrap_or("<none>");
+        let resolved_path = candidate.resolved_path.as_deref().unwrap_or("<none>");
+        lines.push(format!(
+            "request={} target={} kind={:?} rel={} status={:?} resolved={} roots={} pkg={} {:?} {:?}",
+            candidate.request_index,
+            candidate.target,
+            candidate.request_kind,
+            candidate.relative_path,
+            candidate.status,
+            resolved_path,
             candidate.roots.len(),
             package,
             candidate.provenance,
@@ -1035,6 +1073,107 @@ fn hir_module_resolution_candidate_facts_reject_path_traversal_targets()
     assert_eq!(
         render_module_resolution_candidates(&file.compile_environment, &supplied_roots),
         "[module-candidates]"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_module_resolution_outcomes_resolve_against_explicit_roots()
+-> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let workspace_root = dir.path().join("workspace");
+    let env_root = dir.path().join("envlib");
+    let system_root = dir.path().join("system");
+    let lexical_module = workspace_root.join("lib/Foo/Bar.pm");
+    let env_module = env_root.join("Env/Only.pm");
+
+    let lexical_parent =
+        lexical_module.parent().ok_or("expected lexical module parent directory")?;
+    fs::create_dir_all(lexical_parent)?;
+    fs::write(&lexical_module, "package Foo::Bar;\n1;\n")?;
+
+    let env_parent = env_module.parent().ok_or("expected env module parent directory")?;
+    fs::create_dir_all(env_parent)?;
+    fs::write(&env_module, "package Env::Only;\n1;\n")?;
+    fs::create_dir_all(&system_root)?;
+    let workspace_root = workspace_root.to_string_lossy().replace('\\', "/");
+    let env_root = env_root.to_string_lossy().replace('\\', "/");
+    let system_root = system_root.to_string_lossy().replace('\\', "/");
+
+    let file = lower_source(
+        "package Env::Demo;\n\
+         use lib 'lib';\n\
+         use Foo::Bar;\n\
+         require Env::Only;\n\
+         require Missing::Thing;\n\
+         require $dynamic;\n",
+    );
+    let supplied_roots = vec![
+        ModuleResolutionRoot::new(
+            workspace_root.clone(),
+            IncRootKind::Configured,
+            "workspace-include-paths",
+        ),
+        ModuleResolutionRoot::new(env_root.clone(), IncRootKind::Perl5Lib, "perl5lib-env"),
+        ModuleResolutionRoot::new(
+            system_root.clone(),
+            IncRootKind::SystemInc,
+            "interpreter-startup-inc",
+        ),
+    ];
+
+    assert_eq!(
+        render_resolved_module_resolution_candidates(
+            &file.compile_environment,
+            &supplied_roots,
+            |candidate| {
+                let path = if let Some(rest) = candidate.strip_prefix("lib/") {
+                    std::path::PathBuf::from(&workspace_root).join("lib").join(rest)
+                } else {
+                    std::path::PathBuf::from(candidate)
+                };
+                path.is_file()
+            },
+        ),
+        format!(
+            "[module-candidates]\n\
+             request=0 target=Foo::Bar kind=Use rel=Foo/Bar.pm status=Resolved resolved=lib/Foo/Bar.pm roots=4 pkg=Env::Demo ExactAst High\n\
+             root=lib UseLib source=use-lib-lexical candidate=lib/Foo/Bar.pm precedence=0\n\
+             root={workspace} Configured source=workspace-include-paths candidate={workspace}/Foo/Bar.pm precedence=1\n\
+             root={env} Perl5Lib source=perl5lib-env candidate={env}/Foo/Bar.pm precedence=2\n\
+             root={system} SystemInc source=interpreter-startup-inc candidate={system}/Foo/Bar.pm precedence=3\n\
+             request=1 target=Env::Only kind=Require rel=Env/Only.pm status=Resolved resolved={env}/Env/Only.pm roots=4 pkg=Env::Demo ExactAst High\n\
+             root=lib UseLib source=use-lib-lexical candidate=lib/Env/Only.pm precedence=0\n\
+             root={workspace} Configured source=workspace-include-paths candidate={workspace}/Env/Only.pm precedence=1\n\
+             root={env} Perl5Lib source=perl5lib-env candidate={env}/Env/Only.pm precedence=2\n\
+             root={system} SystemInc source=interpreter-startup-inc candidate={system}/Env/Only.pm precedence=3\n\
+             request=2 target=Missing::Thing kind=Require rel=Missing/Thing.pm status=NotFound resolved=<none> roots=4 pkg=Env::Demo ExactAst High\n\
+             root=lib UseLib source=use-lib-lexical candidate=lib/Missing/Thing.pm precedence=0\n\
+             root={workspace} Configured source=workspace-include-paths candidate={workspace}/Missing/Thing.pm precedence=1\n\
+             root={env} Perl5Lib source=perl5lib-env candidate={env}/Missing/Thing.pm precedence=2\n\
+             root={system} SystemInc source=interpreter-startup-inc candidate={system}/Missing/Thing.pm precedence=3",
+            workspace = workspace_root,
+            env = env_root,
+            system = system_root
+        )
+    );
+
+    assert_eq!(file.compile_environment.module_requests.len(), 4);
+    let outcome_facts =
+        file.compile_environment.resolved_module_resolution_candidates(&supplied_roots, |_| false);
+    assert!(
+        outcome_facts.iter().all(|candidate| {
+            candidate.directive_item.is_some() && candidate.range.end >= candidate.range.start
+        }),
+        "resolved/not-found outcome facts should preserve source anchors"
+    );
+    assert_eq!(
+        file.compile_environment
+            .resolved_module_resolution_candidates(&supplied_roots, |_| true)
+            .len(),
+        3,
+        "dynamic require must not produce fake resolution outcomes"
     );
 
     Ok(())


### PR DESCRIPTION
Problem: HIR module-resolution facts stopped at candidate paths and could not prove resolved vs missing outcomes against explicit include roots.
Fix: Add a caller-supplied HIR outcome projection that marks resolved/not-found candidates while preserving root provenance, source anchors, and dynamic-require fail-closed behavior.
Verification: `cargo test -p perl-parser-core --test hir_tests --profile agent --locked module -- --nocapture`; `cargo test -p perl-parser-core --test hir_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-module --lib --profile agent --locked effective_inc_roots -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --lib --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`.

Note: `cargo clippy -p perl-parser-core --tests --profile agent --locked -- -D warnings -A missing_docs` is still blocked by pre-existing unrelated test lint debt in `crates/perl-parser-core/tests/fix_scoped_sub_declarations.rs` (`panic!`).