### PR TITLE
refactor(format): render simple blocks through native IR (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -701,24 +701,13 @@ fn format_simple_subroutine_tokens(
     let body_tokens = &tokens[3..tokens.len() - 1];
     let statements = format_simple_statement_block(body_tokens)?;
     let body_indent = format!("{indent}{}", indent_unit(config));
-    let mut formatted = format!("{indent}sub {} {{", tokens[1].text);
-
-    if statements.is_empty() {
-        formatted.push('\n');
-        formatted.push_str(indent);
-        formatted.push('}');
-        return Some(formatted);
-    }
-
-    for statement in statements {
-        formatted.push('\n');
-        formatted.push_str(&body_indent);
-        formatted.push_str(&statement);
-    }
-    formatted.push('\n');
-    formatted.push_str(indent);
-    formatted.push('}');
-    Some(formatted)
+    Some(render_simple_block_doc(
+        format!("{indent}sub {} {{", tokens[1].text),
+        &statements,
+        indent,
+        &body_indent,
+        config,
+    ))
 }
 
 fn format_simple_control_block_tokens(
@@ -763,42 +752,55 @@ fn format_simple_control_block_tokens(
     }
 
     let body_indent = format!("{indent}{}", indent_unit(config));
-    let mut formatted = format!("{indent}{keyword} ({condition}) {{");
-
-    if statements.is_empty() {
-        formatted.push('\n');
-        formatted.push_str(indent);
-        formatted.push('}');
-    } else {
-        for statement in statements {
-            formatted.push('\n');
-            formatted.push_str(&body_indent);
-            formatted.push_str(&statement);
-        }
-        formatted.push('\n');
-        formatted.push_str(indent);
-        formatted.push('}');
-    }
+    let mut formatted = render_simple_block_doc(
+        format!("{indent}{keyword} ({condition}) {{"),
+        &statements,
+        indent,
+        &body_indent,
+        config,
+    );
 
     if let Some(else_statements) = else_statements {
-        formatted.push_str(" else {");
-        if else_statements.is_empty() {
-            formatted.push('\n');
-            formatted.push_str(indent);
-            formatted.push('}');
-            return Some(formatted);
-        }
-
-        for statement in else_statements {
-            formatted.push('\n');
-            formatted.push_str(&body_indent);
-            formatted.push_str(&statement);
-        }
-        formatted.push('\n');
-        formatted.push_str(indent);
-        formatted.push('}');
+        formatted.push_str(&render_simple_else_doc(&else_statements, indent, &body_indent, config));
     }
     Some(formatted)
+}
+
+fn render_simple_block_doc(
+    header: String,
+    statements: &[String],
+    indent: &str,
+    body_indent: &str,
+    config: &FormatConfig,
+) -> String {
+    let mut parts = vec![FormatDoc::text(header)];
+    push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
+    FormatDoc::group(parts).render(config)
+}
+
+fn render_simple_else_doc(
+    statements: &[String],
+    indent: &str,
+    body_indent: &str,
+    config: &FormatConfig,
+) -> String {
+    let mut parts = vec![FormatDoc::text(" else {")];
+    push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
+    FormatDoc::group(parts).render(config)
+}
+
+fn push_simple_block_body_docs(
+    parts: &mut Vec<FormatDoc>,
+    statements: &[String],
+    indent: &str,
+    body_indent: &str,
+) {
+    for statement in statements {
+        parts.push(FormatDoc::HardLine);
+        parts.push(FormatDoc::text(format!("{body_indent}{statement}")));
+    }
+    parts.push(FormatDoc::HardLine);
+    parts.push(FormatDoc::text(format!("{indent}}}")));
 }
 
 fn format_simple_else_branch(


### PR DESCRIPTION
## Summary

- routes existing native formatter simple sub/control block expansion through `FormatDoc`
- keeps the current safe subset and expected output unchanged
- leaves syntax coverage, parser gates, LSP behavior, and formatter defaults unchanged

## Why

The native formatter already has a document IR, but simple block expansion still built multiline strings directly. This moves the current block layout onto the IR path before adding more list/hash/method-call syntax, so future formatting slices compose through the same renderer instead of growing more ad hoc string assembly.

## Scope

This is a refactor only:

- no new formatting syntax coverage
- no new RSS or CI gates
- no runtime/config/default behavior changes
- no changes to external `perltidy` compatibility mode

## Proof packet

Changed surfaces:
- native formatter runtime
- retained-owner-sensitive Rust path, by DevEx classification

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy format_doc --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check`
- [x] `cargo test -p perl-lsp-rs-core formatting --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
- `target/receipts/format/native-format-fixtures.json`
- `target/receipts/format/native-format-idempotence.json`
- `target/receipts/format/native-format-parse-preservation.json`
