### PR TITLE
feat(format): add simple list literal layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -999,6 +999,10 @@ fn format_simple_atom_tokens(
         return Some((call, next_index));
     }
 
+    if let Some((list, next_index)) = format_simple_list_tokens(tokens, start) {
+        return Some((list, next_index));
+    }
+
     let token = tokens.get(start)?;
     let value = simple_value_text(token)?;
     Some((value.to_string(), start + 1))
@@ -1034,6 +1038,50 @@ fn format_simple_call_tokens(
             _ => return None,
         }
     }
+}
+
+fn format_simple_list_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+) -> Option<(String, usize)> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.get(start)?.kind != TokenKind::LeftParen {
+        return None;
+    }
+
+    let mut items = Vec::new();
+    let mut index = start + 1;
+    if tokens.get(index)?.kind == TokenKind::RightParen {
+        return Some(("()".to_string(), index + 1));
+    }
+
+    loop {
+        let (item, next_index) = format_simple_atom_tokens(tokens, index)?;
+        items.push(item);
+        index = next_index;
+
+        match tokens.get(index)?.kind {
+            TokenKind::Comma => index += 1,
+            TokenKind::RightParen => {
+                return Some((render_simple_list_doc(&items), index + 1));
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn render_simple_list_doc(items: &[String]) -> String {
+    let mut parts = vec![FormatDoc::text("(")];
+    for (index, item) in items.iter().enumerate() {
+        if index > 0 {
+            parts.push(FormatDoc::text(","));
+            parts.push(FormatDoc::Space);
+        }
+        parts.push(FormatDoc::text(item));
+    }
+    parts.push(FormatDoc::text(")"));
+    FormatDoc::group(parts).render(&FormatConfig::default())
 }
 
 fn simple_binary_operator_text(token: &perl_parser_core::Token) -> Option<&str> {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_list_literals.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_list_literals.expected.pl
@@ -1,0 +1,3 @@
+my @xs = (1, 2, $y);
+$x = (foo(1), bar($y));
+return ($x, 3);

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_list_literals.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_list_literals.pl
@@ -1,0 +1,3 @@
+my@xs=(1,2,$y);
+$x=(foo(1),bar($y));
+return($x,3);

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -61,6 +61,21 @@ fn native_formatter_formats_simple_call_expressions() {
 }
 
 #[test]
+fn native_formatter_formats_simple_list_literals() {
+    let formatter = NativeFormatter::new();
+    let source = "my@xs=(1,2,$y);\n$x=(foo(1),bar($y));\nreturn($x,3);\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my @xs = (1, 2, $y);\n$x = (foo(1), bar($y));\nreturn ($x, 3);\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";
@@ -174,6 +189,21 @@ fn native_range_formatter_formats_selected_simple_call_expression_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "my $x = foo($y, 1);");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_list_literal_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my@xs=(1,2,$y);\nreturn($x,3);\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 13));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my@xs=(1,2,$y);\nreturn ($x, 3);\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "return ($x, 3);");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- adds conservative native formatting for simple parenthesized list literals
- supports simple list literals in lexical declarations, assignments, returns, and nested simple call arguments
- adds unit/range coverage plus a native-format fixture receipt case

## Scope

This keeps the formatter safe-subset boundary narrow:

- list elements must already be simple atoms or nested simple calls/lists
- no hash constructors, trailing-comma policy, wrapping, comments, POD, heredocs, or regex rewriting
- no formatter default/config/runtime changes
- external `perltidy` compatibility mode is unchanged

## Proof packet

Changed surfaces:
- native formatter runtime
- retained-owner-sensitive Rust path, by DevEx classification

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_formats_simple_list_literals --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_list_literal_line --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check`
- [x] `cargo test -p perl-lsp-rs-core formatting --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
- `target/receipts/format/native-format-fixtures.json`
- `target/receipts/format/native-format-idempotence.json`
- `target/receipts/format/native-format-parse-preservation.json`
