### PR TITLE
feat(format): add simple hash constructor layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -1003,6 +1003,10 @@ fn format_simple_atom_tokens(
         return Some((list, next_index));
     }
 
+    if let Some((hash, next_index)) = format_simple_hash_tokens(tokens, start) {
+        return Some((hash, next_index));
+    }
+
     let token = tokens.get(start)?;
     let value = simple_value_text(token)?;
     Some((value.to_string(), start + 1))
@@ -1081,6 +1085,65 @@ fn render_simple_list_doc(items: &[String]) -> String {
         parts.push(FormatDoc::text(item));
     }
     parts.push(FormatDoc::text(")"));
+    FormatDoc::group(parts).render(&FormatConfig::default())
+}
+
+fn format_simple_hash_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+) -> Option<(String, usize)> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.get(start)?.kind != TokenKind::LeftBrace {
+        return None;
+    }
+
+    let mut pairs = Vec::new();
+    let mut index = start + 1;
+    if tokens.get(index)?.kind == TokenKind::RightBrace {
+        return Some(("{}".to_string(), index + 1));
+    }
+
+    loop {
+        let key = format_simple_hash_key_token(tokens.get(index)?)?;
+        index += 1;
+        if tokens.get(index)?.kind != TokenKind::FatArrow {
+            return None;
+        }
+        index += 1;
+
+        let (value, next_index) = format_simple_atom_tokens(tokens, index)?;
+        pairs.push((key, value));
+        index = next_index;
+
+        match tokens.get(index)?.kind {
+            TokenKind::Comma => index += 1,
+            TokenKind::RightBrace => {
+                return Some((render_simple_hash_doc(&pairs), index + 1));
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn format_simple_hash_key_token(token: &perl_parser_core::Token) -> Option<String> {
+    simple_value_text(token).map(str::to_string)
+}
+
+fn render_simple_hash_doc(pairs: &[(String, String)]) -> String {
+    let mut parts = vec![FormatDoc::text("{")];
+    for (index, (key, value)) in pairs.iter().enumerate() {
+        if index > 0 {
+            parts.push(FormatDoc::text(","));
+            parts.push(FormatDoc::Space);
+        }
+        parts.push(FormatDoc::text(key));
+        parts.push(FormatDoc::Space);
+        parts.push(FormatDoc::text("=>"));
+        parts.push(FormatDoc::Space);
+        parts.push(FormatDoc::text(value));
+    }
+    parts.push(FormatDoc::text("}"));
     FormatDoc::group(parts).render(&FormatConfig::default())
 }
 

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_hash_constructors.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_hash_constructors.expected.pl
@@ -1,0 +1,3 @@
+my $h = {foo => 1, bar => $x};
+$x = {nested => {ok => 1}, list => (1, 2)};
+return {answer => 42};

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_hash_constructors.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_hash_constructors.pl
@@ -1,0 +1,3 @@
+my$h={foo=>1,bar=>$x};
+$x={nested=>{ok=>1},list=>(1,2)};
+return{answer=>42};

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -76,6 +76,21 @@ fn native_formatter_formats_simple_list_literals() {
 }
 
 #[test]
+fn native_formatter_formats_simple_hash_constructors() {
+    let formatter = NativeFormatter::new();
+    let source = "my$h={foo=>1,bar=>$x};\n$x={nested=>{ok=>1},list=>(1,2)};\nreturn{answer=>42};\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my $h = {foo => 1, bar => $x};\n$x = {nested => {ok => 1}, list => (1, 2)};\nreturn {answer => 42};\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";
@@ -204,6 +219,21 @@ fn native_range_formatter_formats_selected_simple_list_literal_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "return ($x, 3);");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_hash_constructor_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$h={foo=>1,bar=>$x};\nreturn{answer=>42};\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 19));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my$h={foo=>1,bar=>$x};\nreturn {answer => 42};\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "return {answer => 42};");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- adds conservative native formatting for simple `{ key => value }` hash constructors
- supports simple hash constructors in declarations, assignments, returns, and nested simple list/hash/call values
- adds unit/range coverage plus a native-format fixture receipt case

## Scope

This stays inside the safe subset:

- hash keys and values must be simple token atoms or already-supported simple list/hash/call forms
- no block disambiguation expansion, multiline layout, trailing-comma policy, comments, POD, heredocs, regexes, or substitutions
- no formatter default/config/runtime behavior changes
- external `perltidy` compatibility mode is unchanged

## Proof packet

Changed surfaces:
- native formatter runtime
- retained-owner-sensitive Rust path, by DevEx classification

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_formats_simple_hash_constructors --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_hash_constructor_line --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check`
- [x] `cargo test -p perl-lsp-rs-core formatting --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
- `target/receipts/format/native-format-fixtures.json`
- `target/receipts/format/native-format-idempotence.json`
- `target/receipts/format/native-format-parse-preservation.json`
