### PR TITLE
feat(format): add simple method call layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -991,6 +991,10 @@ fn format_simple_atom_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
 ) -> Option<(String, usize)> {
+    if let Some((method_call, next_index)) = format_simple_method_call_tokens(tokens, start) {
+        return Some((method_call, next_index));
+    }
+
     if let Some((variable, next_index)) = format_variable_tokens(tokens, start) {
         return Some((variable, next_index));
     }
@@ -1010,6 +1014,65 @@ fn format_simple_atom_tokens(
     let token = tokens.get(start)?;
     let value = simple_value_text(token)?;
     Some((value.to_string(), start + 1))
+}
+
+fn format_simple_method_call_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+) -> Option<(String, usize)> {
+    use perl_parser_core::TokenKind;
+
+    let (receiver, mut index) = format_variable_tokens(tokens, start)?;
+    if tokens.get(index)?.kind != TokenKind::Arrow {
+        return None;
+    }
+    index += 1;
+
+    let method = tokens.get(index)?;
+    if method.kind != TokenKind::Identifier || tokens.get(index + 1)?.kind != TokenKind::LeftParen {
+        return None;
+    }
+    index += 2;
+
+    let mut args = Vec::new();
+    if tokens.get(index)?.kind == TokenKind::RightParen {
+        return Some((format!("{receiver}->{}()", method.text), index + 1));
+    }
+
+    loop {
+        let (arg, next_index) = format_simple_atom_tokens(tokens, index)?;
+        args.push(arg);
+        index = next_index;
+
+        match tokens.get(index)?.kind {
+            TokenKind::Comma => index += 1,
+            TokenKind::RightParen => {
+                return Some((
+                    render_simple_method_call_doc(&receiver, method.text.as_ref(), &args),
+                    index + 1,
+                ));
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn render_simple_method_call_doc(receiver: &str, method: &str, args: &[String]) -> String {
+    let mut parts = vec![
+        FormatDoc::text(receiver),
+        FormatDoc::text("->"),
+        FormatDoc::text(method),
+        FormatDoc::text("("),
+    ];
+    for (index, arg) in args.iter().enumerate() {
+        if index > 0 {
+            parts.push(FormatDoc::text(","));
+            parts.push(FormatDoc::Space);
+        }
+        parts.push(FormatDoc::text(arg));
+    }
+    parts.push(FormatDoc::text(")"));
+    FormatDoc::group(parts).render(&FormatConfig::default())
 }
 
 fn format_simple_call_tokens(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_method_calls.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_method_calls.expected.pl
@@ -1,0 +1,3 @@
+$x = $obj->build();
+$z = $obj->empty();
+return $obj->wrap(foo(1), {ok => 1});

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_method_calls.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_method_calls.pl
@@ -1,0 +1,3 @@
+$x=$obj->build();
+$z=$obj->empty();
+return $obj->wrap(foo(1),{ok=>1});

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -91,6 +91,21 @@ fn native_formatter_formats_simple_hash_constructors() {
 }
 
 #[test]
+fn native_formatter_formats_simple_method_calls() {
+    let formatter = NativeFormatter::new();
+    let source = "$x=$obj->build();\n$z=$obj->empty();\nreturn $obj->wrap(foo(1),{ok=>1});\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "$x = $obj->build();\n$z = $obj->empty();\nreturn $obj->wrap(foo(1), {ok => 1});\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";
@@ -234,6 +249,21 @@ fn native_range_formatter_formats_selected_simple_hash_constructor_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "return {answer => 42};");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_method_call_line() {
+    let formatter = NativeFormatter::new();
+    let source = "$x=$obj->empty();\nreturn $obj->build(1,$y);\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 25));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "$x=$obj->empty();\nreturn $obj->build(1, $y);\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "return $obj->build(1, $y);");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add conservative native formatting for simple `$obj->method(...)` calls where the receiver is a variable, the method name is a plain identifier, and arguments are already supported simple atoms.
- Cover full-document and range formatting for simple method calls.
- Add a native formatter fixture so `cargo xtask native-format check` receipts include the new layout case.

## Scope

This intentionally does not add chained calls, method names that tokenize as Perl keywords, method calls on arbitrary expressions, dereference formatting, wrapping, comments/POD/heredoc behavior, or default/config/runtime changes.

## Proof packet

Changed surfaces:
- native formatter safe subset
- formatter fixtures / receipts
- LSP formatting surface
- memory-sensitive Rust path by policy routing

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_formats_simple_method_calls --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_method_call_line --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check`
- [x] `cargo test -p perl-lsp-rs-core formatting --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`
