### PR TITLE
feat(format): add simple lexical list layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -875,7 +875,7 @@ fn format_simple_lexical_tokens(tokens: &[perl_parser_core::Token]) -> Option<St
         return None;
     }
 
-    let (variable, next_index) = format_variable_tokens(tokens, 1)?;
+    let (variable, next_index) = format_lexical_target_tokens(tokens, 1)?;
     let semicolon_index = tokens.len() - 1;
     if next_index == semicolon_index {
         Some(format!("{keyword} {variable};"))
@@ -884,6 +884,44 @@ fn format_simple_lexical_tokens(tokens: &[perl_parser_core::Token]) -> Option<St
         Some(format!("{keyword} {variable} = {value};"))
     } else {
         None
+    }
+}
+
+fn format_lexical_target_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+) -> Option<(String, usize)> {
+    format_variable_list_tokens(tokens, start).or_else(|| format_variable_tokens(tokens, start))
+}
+
+fn format_variable_list_tokens(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+) -> Option<(String, usize)> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.get(start)?.kind != TokenKind::LeftParen {
+        return None;
+    }
+
+    let mut variables = Vec::new();
+    let mut index = start + 1;
+    if tokens.get(index)?.kind == TokenKind::RightParen {
+        return Some(("()".to_string(), index + 1));
+    }
+
+    loop {
+        let (variable, next_index) = format_variable_tokens(tokens, index)?;
+        variables.push(variable);
+        index = next_index;
+
+        match tokens.get(index)?.kind {
+            TokenKind::Comma => index += 1,
+            TokenKind::RightParen => {
+                return Some((format!("({})", variables.join(", ")), index + 1));
+            }
+            _ => return None,
+        }
     }
 }
 

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_lexical_lists.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_lexical_lists.expected.pl
@@ -1,0 +1,3 @@
+my ($x, $y) = ($a, $b);
+our ($left, @right);
+state ($count, %seen) = seed();

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_lexical_lists.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_lexical_lists.pl
@@ -1,0 +1,3 @@
+my($x,$y)=($a,$b);
+our($left,@right);
+state($count,%seen)=seed();

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -16,6 +16,21 @@ fn native_formatter_formats_simple_lexical_declarations() {
 }
 
 #[test]
+fn native_formatter_formats_simple_lexical_declaration_lists() {
+    let formatter = NativeFormatter::new();
+    let source = "my($x,$y)=($a,$b);\nour($left,@right);\nstate($count,%seen)=seed();\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my ($x, $y) = ($a, $b);\nour ($left, @right);\nstate ($count, %seen) = seed();\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_formats_simple_binary_expressions() {
     let formatter = NativeFormatter::new();
     let source = "my$x=$y+1;\nreturn$x*2;\nif($x==2){return$y+1;}\n";
@@ -174,6 +189,21 @@ fn native_range_formatter_formats_only_selected_simple_declaration_line() {
         TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 7))
     );
     assert_eq!(result.edits[0].new_text, "my $y = 2;");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_lexical_declaration_list_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my($x,$y)=($a,$b);\nmy$z=1;\n";
+    let range = TextRange::new(TextPosition::new(0, 0), TextPosition::new(0, 18));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my ($x, $y) = ($a, $b);\nmy$z=1;\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "my ($x, $y) = ($a, $b);");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds conservative native formatting for simple parenthesized lexical declaration targets like `my($x,$y)`, `our($left,@right)`, and `state($count,%seen)`.
- Reuses the existing safe-subset expression machinery for optional RHS values, including list literals and simple calls.
- Adds document and range-formatting coverage plus a native-format fixture/expected pair.

## Scope boundaries

This slice only formats lexical declaration targets that are parenthesized lists of plain variables. It does not attempt destructuring patterns, `undef` placeholders, references, attributes, signatures, or non-lexical assignment lists.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
  - why: keeps formatting deterministic before any other proof
  - evidence: command exited cleanly

- [x] `cargo xtask check-memory-lifecycle-policy`
  - why: memory-sensitive runtime path changed
  - evidence: policy check passed

- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
  - why: retained-owner-sensitive Rust path changed
  - evidence: no new retained-owner patterns found

- [x] `git diff --check`
  - why: guards final patch whitespace
  - evidence: command exited cleanly

Focused formatter proof:
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
  - evidence: 24 layout tests and 9 parse-gate tests passed
- [x] `cargo xtask native-format check`
  - evidence: `native formatter fixtures: 23/23 passed; receipts: target/receipts/format`

Additional proof:
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`

Optional proof:
- [ ] `just pr-fast`
- [ ] `just ci-gate`

Receipt:
- `target/devex/local-proof.json`
