### PR TITLE
feat(compile-env): prove scoped pragma facts (#8280)

### DIFF
--- a/crates/perl-parser-core/src/hir/lower.rs
+++ b/crates/perl-parser-core/src/hir/lower.rs
@@ -1,6 +1,8 @@
 //! AST-to-HIR lowering.
 
 use crate::{Node, NodeKind, SourceLocation};
+use perl_pragma::{CompileTimePragmaEnvironment, PragmaSnapshot};
+use perl_semantic_facts::AnchorId;
 
 use super::model::{
     AstAnchor, BarewordExpr, Binding, BindingReference, BlockShell, CallExpr, CallForm,
@@ -11,9 +13,9 @@ use super::model::{
     HirItem, HirKind, HirScopeId, IncRootAction, IncRootFact, IncRootKind, IndirectCallExpr,
     InheritanceSource, LiteralExpr, LiteralKind, MethodCallExpr, MethodDecl, ModuleRequest,
     ModuleRequestKind, ModuleResolutionStatus, PackageDecl, PackageInheritanceEdge, PackageStash,
-    PragmaEffect, RecoveryConfidence, RequireDecl, ScopeFrame, ScopeGraph, ScopeKind,
-    StashConfidence, StashDynamicBoundary, StashDynamicBoundaryKind, StashGraph, StashProvenance,
-    StorageClass, SubDecl, UseDecl, VariableBinding, VariableDecl,
+    PragmaArgumentKind, PragmaEffect, PragmaStateFact, RecoveryConfidence, RequireDecl, ScopeFrame,
+    ScopeGraph, ScopeKind, StashConfidence, StashDynamicBoundary, StashDynamicBoundaryKind,
+    StashGraph, StashProvenance, StorageClass, SubDecl, UseDecl, VariableBinding, VariableDecl,
 };
 
 /// Lower a parser AST into first-slice HIR items.
@@ -25,6 +27,7 @@ use super::model::{
 pub fn lower_ast(ast: &Node) -> HirFile {
     let mut lowerer = Lowerer::new(ast.location);
     lowerer.visit(ast, RecoveryConfidence::Parsed);
+    lowerer.record_pragma_state_facts(ast);
     lowerer.finish()
 }
 
@@ -1000,10 +1003,21 @@ impl Lowerer {
         range: SourceLocation,
         item_id: Option<HirId>,
     ) {
+        let Some((argument_kind, args)) = static_pragma_args(pragma, args) else {
+            self.record_compile_environment_boundary(
+                CompileEnvironmentBoundaryKind::DynamicPragmaArgs,
+                range,
+                item_id,
+                "pragma arguments are not statically known",
+            );
+            return;
+        };
+
         self.compile_environment.pragma_effects.push(PragmaEffect {
             pragma: pragma.to_string(),
             enabled,
-            args: args.to_vec(),
+            args,
+            argument_kind,
             range,
             directive_item: item_id,
             scope_id: Some(self.current_scope()),
@@ -1011,6 +1025,70 @@ impl Lowerer {
             provenance: CompileProvenance::ExactAst,
             confidence: CompileConfidence::High,
         });
+    }
+
+    fn record_pragma_state_facts(&mut self, ast: &Node) {
+        let environment = CompileTimePragmaEnvironment::build(ast);
+        for entry in environment.map().entries() {
+            let range = SourceLocation::new(entry.range.start, entry.range.end);
+            if self.is_dynamic_pragma_offset(range.start) {
+                continue;
+            }
+
+            let (directive_item, scope_id, package_context) =
+                self.compile_environment_metadata_at(range.start);
+            self.compile_environment.pragma_state_facts.push(pragma_state_fact(
+                range,
+                &entry.snapshot,
+                directive_item,
+                scope_id,
+                package_context,
+            ));
+        }
+    }
+
+    fn is_dynamic_pragma_offset(&self, offset: usize) -> bool {
+        self.compile_environment.dynamic_boundaries.iter().any(|boundary| {
+            boundary.kind == CompileEnvironmentBoundaryKind::DynamicPragmaArgs
+                && boundary.range.start == offset
+        })
+    }
+
+    fn compile_environment_metadata_at(
+        &self,
+        offset: usize,
+    ) -> (Option<HirId>, Option<HirScopeId>, Option<String>) {
+        if let Some(effect) = self
+            .compile_environment
+            .pragma_effects
+            .iter()
+            .find(|effect| effect.range.start == offset)
+        {
+            return (effect.directive_item, effect.scope_id, effect.package_context.clone());
+        }
+
+        if let Some(directive) = self
+            .compile_environment
+            .directives
+            .iter()
+            .find(|directive| directive.range.start == offset)
+        {
+            return (directive.item_id, directive.scope_id, directive.package_context.clone());
+        }
+
+        if let Some(scope) = self.innermost_scope_at(offset) {
+            return (None, Some(scope.id), scope.package_context.clone());
+        }
+
+        (None, None, self.package_context.clone())
+    }
+
+    fn innermost_scope_at(&self, offset: usize) -> Option<&ScopeFrame> {
+        self.scope_graph
+            .scopes
+            .iter()
+            .filter(|scope| scope.range.start <= offset && offset <= scope.range.end)
+            .max_by_key(|scope| (scope.range.start, scope.id.index()))
     }
 
     fn record_inc_root_effects(
@@ -1668,6 +1746,89 @@ fn is_bareword_like(value: &str) -> bool {
 
 fn contains_interpolation_marker(value: &str) -> bool {
     value.contains('$') || value.contains('@') || value.contains('%')
+}
+
+fn pragma_state_fact(
+    range: SourceLocation,
+    snapshot: &PragmaSnapshot,
+    directive_item: Option<HirId>,
+    scope_id: Option<HirScopeId>,
+    package_context: Option<String>,
+) -> PragmaStateFact {
+    let state = snapshot.state();
+    PragmaStateFact {
+        range,
+        anchor_id: AnchorId(range.start as u64),
+        directive_item,
+        scope_id,
+        package_context,
+        strict_vars: state.strict_vars,
+        strict_subs: state.strict_subs,
+        strict_refs: state.strict_refs,
+        warnings: state.warnings,
+        disabled_warning_categories: state.disabled_warning_categories.clone(),
+        features: state.features.iter().map(|feature| (*feature).to_string()).collect(),
+        provenance: CompileProvenance::ExactAst,
+        confidence: CompileConfidence::High,
+    }
+}
+
+fn static_pragma_args(pragma: &str, args: &[String]) -> Option<(PragmaArgumentKind, Vec<String>)> {
+    if args.is_empty() {
+        return Some((PragmaArgumentKind::Broad, Vec::new()));
+    }
+
+    let mut normalized = Vec::new();
+    for arg in args {
+        for item in static_pragma_arg_items(arg)? {
+            if !is_valid_static_pragma_arg(pragma, &item) {
+                return None;
+            }
+            normalized.push(item);
+        }
+    }
+
+    if normalized.is_empty() { None } else { Some((PragmaArgumentKind::Categories, normalized)) }
+}
+
+fn static_pragma_arg_items(arg: &str) -> Option<Vec<String>> {
+    let trimmed = arg.trim().trim_matches(',');
+    if trimmed.is_empty() || contains_interpolation_marker(trimmed) {
+        return None;
+    }
+
+    let unquoted = trimmed.trim_matches('"').trim_matches('\'');
+    let body = if let Some(inner) =
+        unquoted.strip_prefix("qw(").and_then(|value| value.strip_suffix(')'))
+    {
+        inner
+    } else {
+        unquoted
+    };
+
+    let items = body.split_whitespace().map(clean_static_pragma_arg).collect::<Option<Vec<_>>>()?;
+    if items.is_empty() { None } else { Some(items) }
+}
+
+fn clean_static_pragma_arg(arg: &str) -> Option<String> {
+    let cleaned = arg.trim().trim_matches(',').trim_matches('"').trim_matches('\'');
+    if cleaned.is_empty() || contains_interpolation_marker(cleaned) {
+        return None;
+    }
+    if cleaned.chars().any(|ch| {
+        matches!(ch, '(' | ')' | '[' | ']' | '{' | '}' | '\\' | ';' | '=' | '>' | '<' | '&' | '*')
+    }) {
+        return None;
+    }
+    Some(cleaned.to_string())
+}
+
+fn is_valid_static_pragma_arg(pragma: &str, arg: &str) -> bool {
+    match pragma {
+        "strict" => matches!(arg, "vars" | "subs" | "refs"),
+        "warnings" | "feature" => true,
+        _ => false,
+    }
 }
 
 fn static_package_args(args: &[String]) -> Vec<String> {

--- a/crates/perl-parser-core/src/hir/mod.rs
+++ b/crates/perl-parser-core/src/hir/mod.rs
@@ -19,8 +19,8 @@ pub use model::{
     ModuleRequestKind, ModuleResolutionCacheInvalidation, ModuleResolutionCacheKey,
     ModuleResolutionCacheRootKey, ModuleResolutionCandidate, ModuleResolutionCandidatePathState,
     ModuleResolutionCandidateRoot, ModuleResolutionCandidateStatus, ModuleResolutionRoot,
-    ModuleResolutionStatus, PackageDecl, PackageInheritanceEdge, PackageStash, PragmaEffect,
-    RecoveryConfidence, RequireDecl, ScopeFrame, ScopeGraph, ScopeKind, StashConfidence,
-    StashDynamicBoundary, StashDynamicBoundaryKind, StashGraph, StashProvenance, StorageClass,
-    SubDecl, UseDecl, VariableBinding, VariableDecl,
+    ModuleResolutionStatus, PackageDecl, PackageInheritanceEdge, PackageStash, PragmaArgumentKind,
+    PragmaEffect, PragmaStateFact, RecoveryConfidence, RequireDecl, ScopeFrame, ScopeGraph,
+    ScopeKind, StashConfidence, StashDynamicBoundary, StashDynamicBoundaryKind, StashGraph,
+    StashProvenance, StorageClass, SubDecl, UseDecl, VariableBinding, VariableDecl,
 };

--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -644,6 +644,8 @@ pub struct CompileEnvironment {
     pub directives: Vec<CompileDirective>,
     /// Pragma or feature effects in stable source order.
     pub pragma_effects: Vec<PragmaEffect>,
+    /// Effective strict/warnings/feature state facts in source order.
+    pub pragma_state_facts: Vec<PragmaStateFact>,
     /// Include-root effects such as `use lib` and `no lib`.
     pub inc_roots: Vec<IncRootFact>,
     /// Static and dynamic module requests observed in the file.
@@ -655,6 +657,19 @@ pub struct CompileEnvironment {
 }
 
 impl CompileEnvironment {
+    /// Effective pragma state facts in source order.
+    #[must_use]
+    pub fn pragma_state_facts(&self) -> &[PragmaStateFact] {
+        &self.pragma_state_facts
+    }
+
+    /// Return the latest effective pragma state fact at or before `offset`.
+    #[must_use]
+    pub fn pragma_state_at(&self, offset: usize) -> Option<&PragmaStateFact> {
+        let idx = self.pragma_state_facts.partition_point(|fact| fact.range.start <= offset);
+        if idx > 0 { self.pragma_state_facts.get(idx - 1) } else { None }
+    }
+
     /// Project HIR compile directives into canonical import facts.
     ///
     /// This is a compiler-substrate projection only. It does not inspect the
@@ -881,8 +896,10 @@ pub struct PragmaEffect {
     pub pragma: String,
     /// Whether the pragma is being enabled (`use`) or disabled (`no`).
     pub enabled: bool,
-    /// Static arguments captured by the parser.
+    /// Static, normalized categories or feature names captured by the parser.
     pub args: Vec<String>,
+    /// Whether this effect applies broadly or to listed categories/features.
+    pub argument_kind: PragmaArgumentKind,
     /// Source range for the effect.
     pub range: SourceLocation,
     /// Directive that produced this effect.
@@ -895,6 +912,68 @@ pub struct PragmaEffect {
     pub provenance: CompileProvenance,
     /// Confidence in this fact.
     pub confidence: CompileConfidence,
+}
+
+/// Static pragma argument shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum PragmaArgumentKind {
+    /// No arguments were supplied, so the pragma transition applies broadly.
+    Broad,
+    /// Static category, warning, or feature names were supplied.
+    Categories,
+}
+
+/// Effective strict/warnings/feature state after a compile-time transition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PragmaStateFact {
+    /// Source range for the transition that produced this state.
+    pub range: SourceLocation,
+    /// Stable source anchor for this transition.
+    pub anchor_id: AnchorId,
+    /// Directive that produced this state, when HIR has one.
+    pub directive_item: Option<HirId>,
+    /// Scope containing this transition.
+    pub scope_id: Option<HirScopeId>,
+    /// Package context active at this transition.
+    pub package_context: Option<String>,
+    /// Effective `strict vars` state.
+    pub strict_vars: bool,
+    /// Effective `strict subs` state.
+    pub strict_subs: bool,
+    /// Effective `strict refs` state.
+    pub strict_refs: bool,
+    /// Effective global warnings state.
+    pub warnings: bool,
+    /// Warning categories explicitly disabled in this state.
+    pub disabled_warning_categories: Vec<String>,
+    /// Effective feature names in this state.
+    pub features: Vec<String>,
+    /// How this fact was produced.
+    pub provenance: CompileProvenance,
+    /// Confidence in this fact.
+    pub confidence: CompileConfidence,
+}
+
+impl PragmaStateFact {
+    /// Whether all strict categories are active in this state.
+    #[must_use]
+    pub fn strict_enabled(&self) -> bool {
+        self.strict_vars && self.strict_subs && self.strict_refs
+    }
+
+    /// Whether warnings are active for a category in this state.
+    #[must_use]
+    pub fn warning_active(&self, category: &str) -> bool {
+        self.warnings && !self.disabled_warning_categories.iter().any(|name| name == category)
+    }
+
+    /// Whether a feature is active in this state.
+    #[must_use]
+    pub fn has_feature(&self, feature: &str) -> bool {
+        self.features.iter().any(|name| name == feature)
+    }
 }
 
 /// Include-root effect.
@@ -1261,6 +1340,8 @@ pub struct CompileEnvironmentBoundary {
 pub enum CompileEnvironmentBoundaryKind {
     /// `require` target could not be determined statically.
     DynamicRequire,
+    /// Pragma or feature arguments could not be determined statically.
+    DynamicPragmaArgs,
     /// Include-root effect is dynamic or unsupported.
     DynamicIncRoot,
     /// Phase block contains compile-time execution that is not evaluated here.

--- a/crates/perl-parser-core/tests/hir_tests.rs
+++ b/crates/perl-parser-core/tests/hir_tests.rs
@@ -1,10 +1,12 @@
 use perl_parser_core::hir::{
-    CompileEnvironment, HirFile, HirKind, IncRootKind, ModuleResolutionRoot, RecoveryConfidence,
+    CompileConfidence, CompileEnvironment, CompileEnvironmentBoundaryKind, CompileProvenance,
+    HirFile, HirKind, IncRootKind, ModuleResolutionRoot, PragmaArgumentKind, RecoveryConfidence,
     ScopeGraph, StashGraph, lower_ast,
 };
 use perl_parser_core::{Node, NodeKind, Parser, SourceLocation};
 use perl_semantic_facts::{
-    Confidence, ExportSet, ExportTag, FileId, ImportKind, ImportSpec, ImportSymbols, Provenance,
+    AnchorId, Confidence, ExportSet, ExportTag, FileId, ImportKind, ImportSpec, ImportSymbols,
+    Provenance,
 };
 use std::fs;
 
@@ -249,9 +251,10 @@ fn render_compile_environment(environment: &CompileEnvironment) -> String {
     for effect in &environment.pragma_effects {
         let package = effect.package_context.as_deref().unwrap_or("<none>");
         lines.push(format!(
-            "{} enabled={} args={} pkg={} {:?} {:?}",
+            "{} enabled={} kind={:?} args={} pkg={} {:?} {:?}",
             effect.pragma,
             effect.enabled,
+            effect.argument_kind,
             effect.args.join(","),
             package,
             effect.provenance,
@@ -930,10 +933,10 @@ fn hir_compile_environment_records_directives_without_provider_cutover()
          Require <dynamic> Dynamic args= scope=1 pkg=Env::Demo ExactAst High\n\
          Require Runtime::Thing Module args= scope=3 pkg=Env::Demo ExactAst High\n\
          [pragmas]\n\
-         strict enabled=true args= pkg=Env::Demo ExactAst High\n\
-         warnings enabled=true args=qw(all) pkg=Env::Demo ExactAst High\n\
-         feature enabled=true args='signatures' pkg=Env::Demo ExactAst High\n\
-         warnings enabled=false args='once' pkg=Env::Demo ExactAst High\n\
+         strict enabled=true kind=Broad args= pkg=Env::Demo ExactAst High\n\
+         warnings enabled=true kind=Categories args=all pkg=Env::Demo ExactAst High\n\
+         feature enabled=true kind=Categories args=signatures pkg=Env::Demo ExactAst High\n\
+         warnings enabled=false kind=Categories args=once pkg=Env::Demo ExactAst High\n\
          [inc]\n\
          lib Add UseLib pkg=Env::Demo ExactAst High\n\
          t/lib Add UseLib pkg=Env::Demo ExactAst High\n\
@@ -957,6 +960,105 @@ fn hir_compile_environment_records_directives_without_provider_cutover()
             |item| matches!(&item.kind, HirKind::CallExpr(expr) if expr.name == "provider_cutover")
         ),
         "compile-environment facts must not imply live provider cutover"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_compile_environment_proves_scoped_pragma_state_facts()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = "package Env::Scoped;\n\
+         use strict;\n\
+         use warnings;\n\
+         use feature 'say';\n\
+         {\n\
+             no strict 'refs';\n\
+             no warnings 'once';\n\
+             no feature 'say';\n\
+             my $inside = 1;\n\
+         }\n\
+         my $outside = 1;\n\
+         use strict $dynamic;\n";
+    let file = lower_source(source);
+    let environment = &file.compile_environment;
+
+    let strict_offset = source.find("use strict;").ok_or("expected outer strict directive")?;
+    let no_strict_offset = source.find("no strict 'refs';").ok_or("expected no strict")?;
+    let inside_offset = source.find("my $inside").ok_or("expected inner marker")?;
+    let outside_offset = source.find("my $outside").ok_or("expected outer marker")?;
+    let dynamic_offset =
+        source.find("use strict $dynamic").ok_or("expected dynamic strict directive")?;
+
+    let strict_effect = environment
+        .pragma_effects
+        .iter()
+        .find(|effect| effect.range.start == strict_offset && effect.pragma == "strict")
+        .ok_or("expected broad strict effect")?;
+    assert_eq!(strict_effect.argument_kind, PragmaArgumentKind::Broad);
+    assert!(strict_effect.args.is_empty());
+    assert_eq!(strict_effect.provenance, CompileProvenance::ExactAst);
+    assert_eq!(strict_effect.confidence, CompileConfidence::High);
+
+    let no_strict_effect = environment
+        .pragma_effects
+        .iter()
+        .find(|effect| effect.range.start == no_strict_offset && effect.pragma == "strict")
+        .ok_or("expected category strict effect")?;
+    assert_eq!(no_strict_effect.argument_kind, PragmaArgumentKind::Categories);
+    assert_eq!(no_strict_effect.args, vec!["refs".to_string()]);
+    assert_eq!(no_strict_effect.range.start, no_strict_offset);
+    assert!(strict_effect.range.start < no_strict_effect.range.start);
+
+    let after_strict = environment
+        .pragma_state_at(strict_offset)
+        .ok_or("expected state after strict directive")?;
+    assert_eq!(after_strict.anchor_id, AnchorId(strict_offset as u64));
+    assert_eq!(after_strict.package_context.as_deref(), Some("Env::Scoped"));
+    assert!(after_strict.scope_id.is_some());
+    assert!(after_strict.strict_enabled());
+    assert_eq!(after_strict.provenance, CompileProvenance::ExactAst);
+    assert_eq!(after_strict.confidence, CompileConfidence::High);
+
+    let inside_state =
+        environment.pragma_state_at(inside_offset).ok_or("expected inner scoped pragma state")?;
+    assert!(inside_state.strict_vars);
+    assert!(inside_state.strict_subs);
+    assert!(!inside_state.strict_refs);
+    assert!(inside_state.warnings);
+    assert!(!inside_state.warning_active("once"));
+    assert!(!inside_state.has_feature("say"));
+    assert!(
+        inside_state.disabled_warning_categories.iter().any(|category| category == "once"),
+        "category-specific no warnings should be visible in the state fact"
+    );
+
+    let outside_state = environment
+        .pragma_state_at(outside_offset)
+        .ok_or("expected restored outer pragma state")?;
+    assert!(outside_state.strict_enabled());
+    assert!(outside_state.warning_active("once"));
+    assert!(outside_state.has_feature("say"));
+
+    assert!(
+        !environment.pragma_state_facts().iter().any(|fact| fact.range.start == dynamic_offset),
+        "dynamic pragma arguments must not produce a confirmed state fact"
+    );
+    let dynamic_boundary = environment
+        .dynamic_boundaries
+        .iter()
+        .find(|boundary| boundary.kind == CompileEnvironmentBoundaryKind::DynamicPragmaArgs)
+        .ok_or("expected dynamic pragma boundary")?;
+    assert_eq!(dynamic_boundary.range.start, dynamic_offset);
+    assert_eq!(dynamic_boundary.package_context.as_deref(), Some("Env::Scoped"));
+    assert_eq!(dynamic_boundary.provenance, CompileProvenance::DynamicBoundary);
+    assert_eq!(dynamic_boundary.confidence, CompileConfidence::Low);
+
+    assert!(
+        !file.items.iter().any(
+            |item| matches!(&item.kind, HirKind::CallExpr(expr) if expr.name == "provider_cutover")
+        ),
+        "compile-environment state facts must not imply live provider cutover"
     );
 
     Ok(())


### PR DESCRIPTION
Problem: HIR compile-environment facts recorded raw strict/warnings/feature directives but did not expose scoped effective state facts or fail-closed dynamic pragma arguments.
Fix: Add PragmaStateFact with anchors, scope/package context, provenance/confidence, query helpers, normalized pragma effect arguments, and DynamicPragmaArgs boundaries without provider cutover.
Verification: cargo test -p perl-parser-core --test hir_tests --profile agent --locked pragma -- --nocapture; cargo test -p perl-parser-core --test hir_tests --profile agent --locked -- --nocapture; cargo check -p perl-parser-core --all-targets --profile agent --locked; cargo clippy -p perl-parser-core --lib --profile agent --locked -- -D warnings -A missing_docs; cargo xtask fmt --check; git diff --check; cargo xtask metrics parser-accuracy --check; cargo xtask update-status --only parser --check; cargo xtask metrics ratchet-check parser_accuracy.