### PR TITLE
feat(critic): add unused lexical native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -122,6 +122,9 @@ impl CodeActionsProvider {
                     c if c == DiagnosticCode::UnusedVariable.as_str() => {
                         actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
                     }
+                    "native.variables.unused_lexical" => {
+                        actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
+                    }
                     // PL403: Assignment in condition
                     c if c == DiagnosticCode::AssignmentInCondition.as_str() => {
                         actions.extend(quick_fixes::fix_assignment_in_condition(
@@ -640,6 +643,32 @@ mod tests {
 
         assert!(actions.iter().any(|a| a.title == "Add 'use strict'"));
         assert!(actions.iter().any(|a| a.title == "Add 'use warnings'"));
+    }
+
+    #[test]
+    fn test_native_critic_policy_alias_for_unused_lexical() {
+        let source = "use strict;\nuse warnings;\nmy $unused = 1;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.find("$unused").unwrap();
+        let diagnostics = vec![Diagnostic {
+            range: (start, start + "$unused".len()),
+            severity: DiagnosticSeverity::Warning,
+            code: Some("native.variables.unused_lexical".to_string()),
+            message: "Lexical variable '$unused' is declared but never used".to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|a| a.title == "Remove unused variable"));
+        assert!(actions.iter().any(|a| {
+            a.title == "Rename to '$_unused'"
+                && a.edit.changes.iter().any(|edit| edit.new_text == "$_unused")
+        }));
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -76,14 +76,15 @@ pub fn fix_unused_variable(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec
 
     // Add underscore prefix to mark as intentionally unused
     if let Some(var_name) = diagnostic.message.split('\'').nth(1) {
+        let unused_name = mark_intentionally_unused(var_name);
         actions.push(CodeAction {
-            title: format!("Rename to '_{}'", var_name),
+            title: format!("Rename to '{}'", unused_name),
             kind: CodeActionKind::QuickFix,
             diagnostics: vec![DiagnosticCode::UnusedVariable.as_str().to_string()],
             edit: CodeActionEdit {
                 changes: vec![TextEdit {
                     location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
-                    new_text: format!("_{}", var_name),
+                    new_text: unused_name,
                 }],
             },
             is_preferred: false,
@@ -91,6 +92,17 @@ pub fn fix_unused_variable(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec
     }
 
     actions
+}
+
+fn mark_intentionally_unused(name: &str) -> String {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(sigil @ ('$' | '@' | '%' | '&' | '*')) => {
+            let rest = chars.as_str();
+            format!("{sigil}_{rest}")
+        }
+        _ => format!("_{name}"),
+    }
 }
 
 #[cfg(test)]

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -14,7 +14,7 @@ pub use built_in::{BuiltInAnalyzer, Policy};
 pub use native::{
     CriticCategory, CriticContext, CriticFinding, CriticFix, CriticRelatedInformation, CriticRule,
     CriticSuppression, CriticSuppressionMap, CriticSuppressionScope, CriticTextEdit, FixSafety,
-    NativeCriticRegistry, RequireUseStrictRule, RequireUseWarningsRule,
+    NativeCriticRegistry, RequireUseStrictRule, RequireUseWarningsRule, UnusedLexicalVariableRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -7,7 +7,9 @@
 
 use super::{CriticConfig, Severity, Violation, insertion_range};
 use perl_parser_core::Node;
-use perl_parser_core::position::Range;
+use perl_parser_core::position::{Position, Range};
+use perl_pragma::PragmaTracker;
+use perl_semantic_analyzer::scope_analyzer::{IssueKind, ScopeAnalyzer, ScopeIssue};
 use serde::{Deserialize, Serialize};
 
 /// Native critic rule category.
@@ -231,7 +233,11 @@ impl NativeCriticRegistry {
     /// diagnostics and receipts are deterministic.
     #[must_use]
     pub fn recommended() -> Self {
-        Self::with_rules(vec![Box::new(RequireUseStrictRule), Box::new(RequireUseWarningsRule)])
+        Self::with_rules(vec![
+            Box::new(RequireUseStrictRule),
+            Box::new(RequireUseWarningsRule),
+            Box::new(UnusedLexicalVariableRule),
+        ])
     }
 
     /// Add a rule to the registry.
@@ -422,6 +428,74 @@ impl CriticRule for RequireUseWarningsRule {
     }
 }
 
+/// Native rule that reports lexical variables declared but never read.
+///
+/// This rule delegates scope reasoning to the existing semantic analyzer so the
+/// native critic path reuses the same declaration/use facts as core diagnostics.
+pub struct UnusedLexicalVariableRule;
+
+impl CriticRule for UnusedLexicalVariableRule {
+    fn id(&self) -> &'static str {
+        "native.variables.unused_lexical"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::UnusedVariable)
+                .map(|issue| unused_lexical_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
+fn unused_lexical_finding(
+    rule: &UnusedLexicalVariableRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+    let unused_name = prefixed_unused_name(&issue.variable_name);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Lexical variable '{}' is declared but never used", issue.variable_name),
+        explanation: "Remove the lexical variable, use it, or prefix it with '_' to mark it intentionally unused.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: format!("Rename to '{unused_name}'"),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: unused_name }],
+        }),
+    }
+}
+
+fn prefixed_unused_name(name: &str) -> String {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(sigil @ ('$' | '@' | '%' | '&' | '*')) => {
+            let rest = chars.as_str();
+            format!("{sigil}_{rest}")
+        }
+        _ => format!("_{name}"),
+    }
+}
+
 fn has_use_statement(content: &str, feature: &str) -> bool {
     content.lines().any(|line| has_use_statement_line(line, feature))
 }
@@ -441,6 +515,29 @@ fn has_use_statement_line(line: &str, feature: &str) -> bool {
     module.trim_end_matches(';') == feature
 }
 
+fn range_for_byte_span(content: &str, start: usize, end: usize) -> Range {
+    let start = start.min(content.len());
+    let end = end.min(content.len()).max(start);
+    let start_position = position_for_byte_offset(content, start);
+    let end_position = position_for_byte_offset(content, end);
+
+    Range { start: start_position, end: end_position }
+}
+
+fn position_for_byte_offset(content: &str, offset: usize) -> Position {
+    let offset = offset.min(content.len());
+    let prefix = &content[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count();
+    let line_start = prefix.rfind('\n').map_or(0, |idx| idx + 1);
+    let column = content[line_start..offset].chars().count();
+
+    Position { byte: offset, line: usize_to_u32(line), column: usize_to_u32(column) }
+}
+
+fn usize_to_u32(value: usize) -> u32 {
+    value.min(u32::MAX as usize) as u32
+}
+
 /// Build an empty AST node for tests that only exercise rule contract plumbing.
 #[cfg(test)]
 fn empty_program_node() -> Node {
@@ -452,6 +549,7 @@ fn empty_program_node() -> Node {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use perl_parser::Parser;
     use perl_parser_core::position::{Position, Range};
 
     struct DummyRule;
@@ -526,6 +624,11 @@ mod tests {
 
     fn config_with_minimum_severity(severity: u8) -> CriticConfig {
         CriticConfig { severity, ..Default::default() }
+    }
+
+    fn parse_source(source: &str) -> Node {
+        let mut parser = Parser::new(source);
+        parser.parse().expect("test source should parse")
     }
 
     #[test]
@@ -742,20 +845,137 @@ mod tests {
 
     #[test]
     fn native_recommended_registry_contains_initial_policy_bundle() {
-        let ast = empty_program_node();
+        let source = "print 1;\n";
+        let ast = parse_source(source);
         let config = CriticConfig::default();
-        let ctx = CriticContext::new("my $x = 1;\n", &ast, &config);
+        let ctx = CriticContext::new(source, &ast, &config);
         let registry = NativeCriticRegistry::recommended();
 
         let findings = registry.check(&ctx);
 
         assert_eq!(
             registry.rule_ids(),
-            vec!["native.testing.require_use_strict", "native.testing.require_use_warnings"]
+            vec![
+                "native.testing.require_use_strict",
+                "native.testing.require_use_warnings",
+                "native.variables.unused_lexical"
+            ]
         );
         assert_eq!(findings.len(), 2);
         assert_eq!(findings[0].suppression_key, "native.testing.require_use_strict");
         assert_eq!(findings[1].suppression_key, "native.testing.require_use_warnings");
+    }
+
+    #[test]
+    fn native_unused_lexical_rule_reports_declared_but_unread_variable() {
+        let source = "use strict;\nuse warnings;\nmy $unused = 1;\nprint 1;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedLexicalVariableRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.variables.unused_lexical");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Lexical variable '$unused' is declared but never used");
+        assert_eq!(finding.suppression_key, "native.variables.unused_lexical");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$unused");
+
+        let fix = finding.fix.as_ref().expect("unused lexical should offer an intent marker");
+        assert_eq!(fix.title, "Rename to '$_unused'");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].range, finding.range);
+        assert_eq!(fix.edits[0].new_text, "$_unused");
+    }
+
+    #[test]
+    fn native_unused_lexical_rule_accepts_used_and_intentionally_unused_variables() {
+        let source = "use strict;\nuse warnings;\nmy $used = 1;\nmy $_ignored = 2;\nprint $used;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedLexicalVariableRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "used and underscore-prefixed variables should be accepted");
+    }
+
+    #[test]
+    fn native_unused_lexical_rule_reports_multiple_sigils() {
+        let source = "use strict;\nuse warnings;\nmy @items = (1, 2);\nmy %seen = ();\nprint 1;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedLexicalVariableRule)]);
+
+        let findings = registry.check(&ctx);
+        let names = findings
+            .iter()
+            .map(|finding| &source[finding.range.start.byte..finding.range.end.byte])
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["@items", "%seen"]);
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| finding.fix.as_ref().expect("fix").edits[0].new_text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["@_items", "%_seen"]
+        );
+    }
+
+    #[test]
+    fn native_unused_lexical_rule_composes_with_config_and_suppressions() {
+        let ast = parse_source("use strict;\nuse warnings;\nmy $unused = 1;\n");
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.variables.unused_lexical".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(
+            "use strict;\nuse warnings;\nmy $unused = 1;\n",
+            &ast,
+            &excluded_config,
+        );
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedLexicalVariableRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.variables.unused_lexical -- legacy fixture\nuse strict;\nuse warnings;\nmy $unused = 1;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_unused_lexical_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $unused = 1;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedLexicalVariableRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.variables.unused_lexical");
+        assert_eq!(
+            violations[0].description,
+            "Lexical variable '$unused' is declared but never used"
+        );
+        assert_eq!(
+            violations[0].explanation,
+            "Remove the lexical variable, use it, or prefix it with '_' to mark it intentionally unused."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -62,6 +62,7 @@ impl CodeActionsProvider {
             Some(c) if c == DiagnosticCode::UnusedVariable.as_str() || c == "unused-variable" => {
                 fixes::fix_unused_variable(self, diagnostic)
             }
+            Some("native.variables.unused_lexical") => fixes::fix_unused_variable(self, diagnostic),
             Some("native.testing.require_use_strict") => fixes::add_use_strict(diagnostic),
             Some("native.testing.require_use_warnings") => fixes::add_use_warnings(diagnostic),
             Some(c)
@@ -339,6 +340,31 @@ mod tests {
         }));
         assert!(actions.iter().any(|action| {
             action.title == "Add 'use warnings'" && action.edit.new_text == "use warnings;\n"
+        }));
+    }
+
+    #[test]
+    fn test_native_critic_unused_lexical_quick_fix() {
+        let source = "use strict;\nuse warnings;\nmy $unused = 1;\n".to_string();
+        let provider = CodeActionsProvider::new(source.clone());
+        let start = must_some(source.find("$unused"));
+        let diagnostic = make_diagnostic(
+            (start, start + "$unused".len()),
+            DiagnosticSeverity::Warning,
+            "native.variables.unused_lexical",
+            "Lexical variable '$unused' is declared but never used",
+        );
+
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert!(actions.iter().any(|action| {
+            action.title == "Remove unused variable '$unused'"
+                && action.edit.range == (source.find("my $unused").unwrap(), source.len())
+        }));
+        assert!(actions.iter().any(|action| {
+            action.title == "Rename to '$_unused' (mark as intentionally unused)"
+                && action.edit.range == diagnostic.range
+                && action.edit.new_text == "$_unused"
         }));
     }
 

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1379,6 +1379,22 @@ mod tests {
             })
             .ok_or("expected native warnings finding")?;
         assert_eq!(warnings.source.as_deref(), Some("perl-lsp-critic"));
+
+        let unused = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.variables.unused_lexical"))
+            })
+            .ok_or("expected native unused lexical finding")?;
+        assert_eq!(unused.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(unused.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(unused.message, "Lexical variable '$x' is declared but never used");
+        let data = unused.data.as_ref().ok_or("native unused lexical data should be populated")?;
+        assert_eq!(data["code"], "native.variables.unused_lexical");
+        assert_eq!(data["suppressionKey"], "native.variables.unused_lexical");
+        assert_eq!(data["fixable"], true);
         Ok(())
     }
 

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1855,6 +1855,14 @@ mod tests {
             "native critic engine should publish native warnings finding; got: {text:?}"
         );
         assert!(
+            text.contains("native.variables.unused_lexical"),
+            "native critic engine should publish native unused lexical finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Lexical variable '$x' is declared but never used"),
+            "native unused lexical finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
             text.contains("\"source\":\"perl-lsp-critic\""),
             "native critic diagnostics should use perl-lsp-critic source; got: {text:?}"
         );
@@ -1937,6 +1945,15 @@ mod tests {
                     && diag["source"].as_str() == Some("perl-lsp-critic")
             }),
             "native critic engine should add native warnings finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.variables.unused_lexical")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Lexical variable '$x' is declared but never used")
+            }),
+            "native critic engine should add native unused lexical finding to workspace diagnostics: {report}"
         );
         assert!(
             !diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary
- add `native.variables.unused_lexical` to the opt-in native critic recommended registry
- reuse `ScopeAnalyzer` declaration/use facts so the rule reports unused lexical variables with precise spans, stable IDs, suppressions, severity filtering, and violation-bridge output
- surface the rule through pull, push, and workspace diagnostics when `[critic].engine = "native"`
- route native unused-lexical diagnostics through existing unused-variable quick fixes, including sigil-aware underscore-prefix edits

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
  - why: keeps formatting deterministic before any other proof
  - evidence: command exited cleanly

- [x] `cargo test -p perl-lsp-rs-core native_unused --profile agent --locked -- --nocapture`
  - why: validates the new native unused lexical rule, suppressions/config, multiple sigils, and violation bridge
  - evidence: 5 tests passed

- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
  - why: native critic registry behavior changed
  - evidence: 15 tests passed

- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
  - why: native pull/push/workspace diagnostic behavior now includes unused lexical findings
  - evidence: 3 tests passed

- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
  - why: diagnostics plumbing and enrichment changed
  - evidence: 29 tests passed

- [x] `cargo test -p perl-lsp-rs native_critic_unused --profile agent --locked --lib -- --nocapture`
  - why: LSP code-action alias for native unused lexical diagnostics changed
  - evidence: 1 test passed

- [x] `cargo test -p perl-lsp-rs-core test_native_critic_policy_alias_for_unused_lexical --profile agent --locked -- --nocapture`
  - why: core code-action alias for native unused lexical diagnostics changed
  - evidence: 1 test passed

- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
  - why: touched exported core/runtime critic surfaces
  - evidence: command exited cleanly

- [x] `cargo xtask check-memory-lifecycle-policy`
  - why: memory-sensitive runtime paths changed
  - evidence: policy check passed

- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
  - why: retained-owner-sensitive Rust paths changed
  - evidence: no new retained-owner patterns found

- [x] `cargo xtask devex pr-body --base origin/master`
  - why: verifies DevEx proof routing for the changed surfaces
  - evidence: command rendered proof packet

- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
  - why: records local proof routing artifact
  - evidence: receipt written

- [x] `git diff --check`
  - why: guards final patch whitespace
  - evidence: command exited cleanly

## Notes
- Native critic remains explicit opt-in; this does not change the default legacy/external behavior.
- The rule deliberately reuses existing semantic scope analysis rather than adding another variable walker.
- The quick-fix path now handles native unused lexical diagnostics and preserves Perl sigils when prefixing with `_`.
