### PR TITLE
feat(critic): add duplicate lexical native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -221,7 +221,9 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_missing_package_declaration(&self.source));
                     }
                     // PL105: Variable redeclaration (duplicate my)
-                    c if c == DiagnosticCode::VariableRedeclaration.as_str() => {
+                    c if c == DiagnosticCode::VariableRedeclaration.as_str()
+                        || c == "native.variables.duplicate_lexical" =>
+                    {
                         actions.extend(quick_fixes::fix_variable_redeclaration(
                             &self.source,
                             &qf_diag,
@@ -668,6 +670,37 @@ mod tests {
         assert!(actions.iter().any(|a| {
             a.title == "Rename to '$_unused'"
                 && a.edit.changes.iter().any(|edit| edit.new_text == "$_unused")
+        }));
+    }
+
+    #[test]
+    fn test_native_critic_policy_alias_for_duplicate_lexical() {
+        let source = "use strict;\nuse warnings;\nmy $dup = 1;\nmy $dup = 2;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.rfind("$dup").unwrap();
+        let diagnostics = vec![Diagnostic {
+            range: (start, start + "$dup".len()),
+            severity: DiagnosticSeverity::Error,
+            code: Some("native.variables.duplicate_lexical".to_string()),
+            message: "Lexical variable '$dup' is declared more than once in the same scope"
+                .to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        let action = actions
+            .iter()
+            .find(|action| action.title == "Remove duplicate 'my' declaration")
+            .expect("native duplicate lexical should reuse duplicate-my fix");
+        assert!(action.edit.changes.iter().any(|edit| {
+            edit.location.start == source.rfind("my $dup").unwrap()
+                && edit.location.end == start
+                && edit.new_text.is_empty()
         }));
     }
 

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -13,8 +13,9 @@ pub use analyzer::{CriticAnalyzer, hash_content};
 pub use built_in::{BuiltInAnalyzer, Policy};
 pub use native::{
     CriticCategory, CriticContext, CriticFinding, CriticFix, CriticRelatedInformation, CriticRule,
-    CriticSuppression, CriticSuppressionMap, CriticSuppressionScope, CriticTextEdit, FixSafety,
-    NativeCriticRegistry, RequireUseStrictRule, RequireUseWarningsRule, UnusedLexicalVariableRule,
+    CriticSuppression, CriticSuppressionMap, CriticSuppressionScope, CriticTextEdit,
+    DuplicateLexicalDeclarationRule, FixSafety, NativeCriticRegistry, RequireUseStrictRule,
+    RequireUseWarningsRule, UnusedLexicalVariableRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -237,6 +237,7 @@ impl NativeCriticRegistry {
             Box::new(RequireUseStrictRule),
             Box::new(RequireUseWarningsRule),
             Box::new(UnusedLexicalVariableRule),
+            Box::new(DuplicateLexicalDeclarationRule),
         ])
     }
 
@@ -460,6 +461,39 @@ impl CriticRule for UnusedLexicalVariableRule {
     }
 }
 
+/// Native rule that reports lexical variables declared more than once in a scope.
+///
+/// This rule delegates redeclaration detection to the semantic scope analyzer so
+/// native critic diagnostics reuse the same binding facts as existing PL105
+/// diagnostics while exposing a stable native policy ID.
+pub struct DuplicateLexicalDeclarationRule;
+
+impl CriticRule for DuplicateLexicalDeclarationRule {
+    fn id(&self) -> &'static str {
+        "native.variables.duplicate_lexical"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Gentle
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::VariableRedeclaration)
+                .map(|issue| duplicate_lexical_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
 fn unused_lexical_finding(
     rule: &UnusedLexicalVariableRule,
     source: &str,
@@ -482,6 +516,59 @@ fn unused_lexical_finding(
             safety: FixSafety::Suggested,
             edits: vec![CriticTextEdit { range, new_text: unused_name }],
         }),
+    }
+}
+
+fn duplicate_lexical_finding(
+    rule: &DuplicateLexicalDeclarationRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+    let fix = duplicate_my_fix(source, issue.range.0);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!(
+            "Lexical variable '{}' is declared more than once in the same scope",
+            issue.variable_name
+        ),
+        explanation:
+            "Remove the duplicate lexical declarator or assign to the existing lexical variable."
+                .to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix,
+    }
+}
+
+fn duplicate_my_fix(source: &str, variable_start: usize) -> Option<CriticFix> {
+    let (start, end) = duplicate_my_span(source, variable_start)?;
+
+    Some(CriticFix {
+        title: "Remove duplicate 'my' declaration".to_string(),
+        safety: FixSafety::Safe,
+        edits: vec![CriticTextEdit {
+            range: range_for_byte_span(source, start, end),
+            new_text: String::new(),
+        }],
+    })
+}
+
+fn duplicate_my_span(source: &str, variable_start: usize) -> Option<(usize, usize)> {
+    let variable_start = variable_start.min(source.len());
+    let line_start = source[..variable_start].rfind('\n').map_or(0, |pos| pos + 1);
+    let before_var = &source[line_start..variable_start];
+    let my_offset = before_var.rfind("my ")?;
+
+    if before_var[my_offset + 3..].chars().all(char::is_whitespace) {
+        let start = line_start + my_offset;
+        Some((start, start + 3))
+    } else {
+        None
     }
 }
 
@@ -858,7 +945,8 @@ mod tests {
             vec![
                 "native.testing.require_use_strict",
                 "native.testing.require_use_warnings",
-                "native.variables.unused_lexical"
+                "native.variables.unused_lexical",
+                "native.variables.duplicate_lexical"
             ]
         );
         assert_eq!(findings.len(), 2);
@@ -975,6 +1063,98 @@ mod tests {
             "Remove the lexical variable, use it, or prefix it with '_' to mark it intentionally unused."
         );
         assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_duplicate_lexical_rule_reports_same_scope_redeclaration() {
+        let source = "use strict;\nuse warnings;\nmy $dup = 1;\nmy $dup = 2;\nprint $dup;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(DuplicateLexicalDeclarationRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.variables.duplicate_lexical");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Gentle);
+        assert_eq!(
+            finding.message,
+            "Lexical variable '$dup' is declared more than once in the same scope"
+        );
+        assert_eq!(finding.suppression_key, "native.variables.duplicate_lexical");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$dup");
+
+        let fix = finding.fix.as_ref().expect("duplicate my should offer a safe fix");
+        assert_eq!(fix.title, "Remove duplicate 'my' declaration");
+        assert_eq!(fix.safety, FixSafety::Safe);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(&source[fix.edits[0].range.start.byte..fix.edits[0].range.end.byte], "my ");
+        assert_eq!(fix.edits[0].new_text, "");
+    }
+
+    #[test]
+    fn native_duplicate_lexical_rule_accepts_nested_shadowing() {
+        let source = "use strict;\nuse warnings;\nmy $value = 1;\n{ my $value = 2; print $value; }\nprint $value;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(DuplicateLexicalDeclarationRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "nested lexical shadowing is not same-scope duplication");
+    }
+
+    #[test]
+    fn native_duplicate_lexical_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $dup = 1;\nmy $dup = 2;\nprint $dup;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.variables.duplicate_lexical".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(DuplicateLexicalDeclarationRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no perl-lsp-critic native.variables.duplicate_lexical -- fixture\nuse strict;\nuse warnings;\nmy $dup = 1;\nmy $dup = 2;\nprint $dup;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_duplicate_lexical_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $dup = 1;\nmy $dup = 2;\nprint $dup;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(DuplicateLexicalDeclarationRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.variables.duplicate_lexical");
+        assert_eq!(
+            violations[0].description,
+            "Lexical variable '$dup' is declared more than once in the same scope"
+        );
+        assert_eq!(
+            violations[0].explanation,
+            "Remove the duplicate lexical declarator or assign to the existing lexical variable."
+        );
+        assert_eq!(violations[0].severity, Severity::Gentle);
         assert_eq!(violations[0].file, "lib/App.pm");
     }
 

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -130,8 +130,29 @@ pub(super) fn fix_variable_redeclaration(
             CodeActionKind::QuickFix,
             TextEdit { range: (range.0, range.0 + 3), new_text: String::new() },
         )]
+    } else if let Some(my_range) = find_duplicate_my_span(provider.source(), range.0) {
+        vec![diagnostic_action(
+            diagnostic,
+            "Remove redundant 'my'",
+            CodeActionKind::QuickFix,
+            TextEdit { range: my_range, new_text: String::new() },
+        )]
     } else {
         Vec::new()
+    }
+}
+
+fn find_duplicate_my_span(source: &str, variable_start: usize) -> Option<(usize, usize)> {
+    let variable_start = variable_start.min(source.len());
+    let line_start = source[..variable_start].rfind('\n').map_or(0, |pos| pos + 1);
+    let before_var = &source[line_start..variable_start];
+    let my_offset = before_var.rfind("my ")?;
+
+    if before_var[my_offset + 3..].chars().all(char::is_whitespace) {
+        let start = line_start + my_offset;
+        Some((start, start + 3))
+    } else {
+        None
     }
 }
 

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -72,7 +72,8 @@ impl CodeActionsProvider {
             }
             Some(c)
                 if c == DiagnosticCode::VariableRedeclaration.as_str()
-                    || c == "variable-redeclaration" =>
+                    || c == "variable-redeclaration"
+                    || c == "native.variables.duplicate_lexical" =>
             {
                 fixes::fix_variable_redeclaration(self, diagnostic)
             }
@@ -366,6 +367,26 @@ mod tests {
                 && action.edit.range == diagnostic.range
                 && action.edit.new_text == "$_unused"
         }));
+    }
+
+    #[test]
+    fn test_native_critic_duplicate_lexical_quick_fix() {
+        let source = "use strict;\nuse warnings;\nmy $dup = 1;\nmy $dup = 2;\n".to_string();
+        let provider = CodeActionsProvider::new(source.clone());
+        let start = must_some(source.rfind("$dup"));
+        let diagnostic = make_diagnostic(
+            (start, start + "$dup".len()),
+            DiagnosticSeverity::Error,
+            "native.variables.duplicate_lexical",
+            "Lexical variable '$dup' is declared more than once in the same scope",
+        );
+
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Remove redundant 'my'");
+        assert_eq!(actions[0].edit.range, (source.rfind("my $dup").unwrap(), start));
+        assert_eq!(actions[0].edit.new_text, "");
     }
 
     // ── Quick-fix: variable shadowing ───────────────────────────────────

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1348,7 +1348,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nprint $x;\n",
             None,
             &context,
             None,
@@ -1390,10 +1390,30 @@ mod tests {
             .ok_or("expected native unused lexical finding")?;
         assert_eq!(unused.source.as_deref(), Some("perl-lsp-critic"));
         assert_eq!(unused.severity, Some(LspDiagnosticSeverity::WARNING));
-        assert_eq!(unused.message, "Lexical variable '$x' is declared but never used");
+        assert_eq!(unused.message, "Lexical variable '$unused' is declared but never used");
         let data = unused.data.as_ref().ok_or("native unused lexical data should be populated")?;
         assert_eq!(data["code"], "native.variables.unused_lexical");
         assert_eq!(data["suppressionKey"], "native.variables.unused_lexical");
+        assert_eq!(data["fixable"], true);
+
+        let duplicate = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.variables.duplicate_lexical"))
+            })
+            .ok_or("expected native duplicate lexical finding")?;
+        assert_eq!(duplicate.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(duplicate.severity, Some(LspDiagnosticSeverity::ERROR));
+        assert_eq!(
+            duplicate.message,
+            "Lexical variable '$x' is declared more than once in the same scope"
+        );
+        let data =
+            duplicate.data.as_ref().ok_or("native duplicate lexical data should be populated")?;
+        assert_eq!(data["code"], "native.variables.duplicate_lexical");
+        assert_eq!(data["suppressionKey"], "native.variables.duplicate_lexical");
         assert_eq!(data["fixable"], true);
         Ok(())
     }

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1835,7 +1835,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nprint $x;\n"
                 }
             })))
             .unwrap();
@@ -1859,8 +1859,16 @@ mod tests {
             "native critic engine should publish native unused lexical finding; got: {text:?}"
         );
         assert!(
-            text.contains("Lexical variable '$x' is declared but never used"),
+            text.contains("Lexical variable '$unused' is declared but never used"),
             "native unused lexical finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.variables.duplicate_lexical"),
+            "native critic engine should publish native duplicate lexical finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Lexical variable '$x' is declared more than once in the same scope"),
+            "native duplicate lexical finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("\"source\":\"perl-lsp-critic\""),
@@ -1914,7 +1922,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nprint $x;\n"
             }
         })))?;
 
@@ -1951,9 +1959,20 @@ mod tests {
                 diag["code"].as_str() == Some("native.variables.unused_lexical")
                     && diag["source"].as_str() == Some("perl-lsp-critic")
                     && diag["message"].as_str()
-                        == Some("Lexical variable '$x' is declared but never used")
+                        == Some("Lexical variable '$unused' is declared but never used")
             }),
             "native critic engine should add native unused lexical finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.variables.duplicate_lexical")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some(
+                            "Lexical variable '$x' is declared more than once in the same scope",
+                        )
+            }),
+            "native critic engine should add native duplicate lexical finding to workspace diagnostics: {report}"
         );
         assert!(
             !diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.variables.duplicate_lexical` for same-scope lexical redeclarations. The rule reuses existing `ScopeAnalyzer` `VariableRedeclaration` facts, keeps the diagnostic span on the duplicate variable, and attaches a safe fix that removes the duplicate `my` declarator when available.

Legacy remains default. Native critic remains explicit opt-in.

## Coverage

- Registers `DuplicateLexicalDeclarationRule` in the recommended native critic bundle.
- Covers config filtering, suppression filtering, and the legacy violation bridge.
- Extends pull, push, and workspace native diagnostic tests to assert the duplicate lexical finding.
- Adds core and LSP-facing code-action aliases for `native.variables.duplicate_lexical` so the existing duplicate-`my` quick fix remains available from precise variable spans.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_duplicate --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_duplicate --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core test_native_critic_policy_alias_for_duplicate_lexical --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`
