### PR TITLE
feat(critic): add shadowed lexical native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -182,7 +182,9 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_unused_parameter(&qf_diag));
                     }
                     // PL104: Variable shadowing
-                    c if c == DiagnosticCode::VariableShadowing.as_str() => {
+                    c if c == DiagnosticCode::VariableShadowing.as_str()
+                        || c == "native.variables.shadowed_lexical" =>
+                    {
                         actions.extend(quick_fixes::fix_variable_shadowing(&qf_diag));
                     }
                     // PL400: Bareword filehandle
@@ -701,6 +703,35 @@ mod tests {
             edit.location.start == source.rfind("my $dup").unwrap()
                 && edit.location.end == start
                 && edit.new_text.is_empty()
+        }));
+    }
+
+    #[test]
+    fn test_native_critic_policy_alias_for_shadowed_lexical() {
+        let source = "use strict;\nuse warnings;\nmy $value = 1;\n{ my $value = 2; }\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.rfind("$value").unwrap();
+        let diagnostics = vec![Diagnostic {
+            range: (start, start + "$value".len()),
+            severity: DiagnosticSeverity::Warning,
+            code: Some("native.variables.shadowed_lexical".to_string()),
+            message: "Lexical variable '$value' shadows an outer declaration".to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|action| {
+            action.title == "Rename to '$value_inner'"
+                && action.edit.changes.iter().any(|edit| edit.new_text == "$value_inner")
+        }));
+        assert!(actions.iter().any(|action| {
+            action.title == "Rename to '$value_local'"
+                && action.edit.changes.iter().any(|edit| edit.new_text == "$value_local")
         }));
     }
 

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -15,7 +15,7 @@ pub use native::{
     CriticCategory, CriticContext, CriticFinding, CriticFix, CriticRelatedInformation, CriticRule,
     CriticSuppression, CriticSuppressionMap, CriticSuppressionScope, CriticTextEdit,
     DuplicateLexicalDeclarationRule, FixSafety, NativeCriticRegistry, RequireUseStrictRule,
-    RequireUseWarningsRule, UnusedLexicalVariableRule,
+    RequireUseWarningsRule, ShadowedLexicalVariableRule, UnusedLexicalVariableRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -238,6 +238,7 @@ impl NativeCriticRegistry {
             Box::new(RequireUseWarningsRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(DuplicateLexicalDeclarationRule),
+            Box::new(ShadowedLexicalVariableRule),
         ])
     }
 
@@ -494,6 +495,39 @@ impl CriticRule for DuplicateLexicalDeclarationRule {
     }
 }
 
+/// Native rule that reports lexical variables that shadow outer declarations.
+///
+/// This rule delegates shadowing detection to the semantic scope analyzer so
+/// native critic diagnostics reuse existing scope facts while exposing a stable
+/// native policy ID.
+pub struct ShadowedLexicalVariableRule;
+
+impl CriticRule for ShadowedLexicalVariableRule {
+    fn id(&self) -> &'static str {
+        "native.variables.shadowed_lexical"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::VariableShadowing)
+                .map(|issue| shadowed_lexical_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
 fn unused_lexical_finding(
     rule: &UnusedLexicalVariableRule,
     source: &str,
@@ -545,6 +579,31 @@ fn duplicate_lexical_finding(
     }
 }
 
+fn shadowed_lexical_finding(
+    rule: &ShadowedLexicalVariableRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+    let replacement = shadowed_lexical_name(&issue.variable_name);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Lexical variable '{}' shadows an outer declaration", issue.variable_name),
+        explanation: "Rename the inner lexical variable or use the outer variable directly to avoid confusing scope shadowing.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: format!("Rename to '{replacement}'"),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: replacement }],
+        }),
+    }
+}
+
 fn duplicate_my_fix(source: &str, variable_start: usize) -> Option<CriticFix> {
     let (start, end) = duplicate_my_span(source, variable_start)?;
 
@@ -572,6 +631,11 @@ fn duplicate_my_span(source: &str, variable_start: usize) -> Option<(usize, usiz
     }
 }
 
+fn shadowed_lexical_name(name: &str) -> String {
+    let (sigil, base_name) = split_sigil(name);
+    format!("{sigil}inner_{base_name}")
+}
+
 fn prefixed_unused_name(name: &str) -> String {
     let mut chars = name.chars();
     match chars.next() {
@@ -581,6 +645,12 @@ fn prefixed_unused_name(name: &str) -> String {
         }
         _ => format!("_{name}"),
     }
+}
+
+fn split_sigil(name: &str) -> (&str, &str) {
+    let bare = name.trim_start_matches(['$', '@', '%', '&', '*']);
+    let sigil_len = name.len() - bare.len();
+    (&name[..sigil_len], bare)
 }
 
 fn has_use_statement(content: &str, feature: &str) -> bool {
@@ -946,7 +1016,8 @@ mod tests {
                 "native.testing.require_use_strict",
                 "native.testing.require_use_warnings",
                 "native.variables.unused_lexical",
-                "native.variables.duplicate_lexical"
+                "native.variables.duplicate_lexical",
+                "native.variables.shadowed_lexical"
             ]
         );
         assert_eq!(findings.len(), 2);
@@ -1155,6 +1226,95 @@ mod tests {
             "Remove the duplicate lexical declarator or assign to the existing lexical variable."
         );
         assert_eq!(violations[0].severity, Severity::Gentle);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_shadowed_lexical_rule_reports_inner_shadowing() {
+        let source = "use strict;\nuse warnings;\nmy $value = 1;\n{ my $value = 2; print $value; }\nprint $value;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(ShadowedLexicalVariableRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.variables.shadowed_lexical");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Lexical variable '$value' shadows an outer declaration");
+        assert_eq!(finding.suppression_key, "native.variables.shadowed_lexical");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$value");
+
+        let fix = finding.fix.as_ref().expect("shadowed lexical should offer a rename");
+        assert_eq!(fix.title, "Rename to '$inner_value'");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].range, finding.range);
+        assert_eq!(fix.edits[0].new_text, "$inner_value");
+    }
+
+    #[test]
+    fn native_shadowed_lexical_rule_accepts_unique_nested_lexicals() {
+        let source = "use strict;\nuse warnings;\nmy $outer = 1;\n{ my $inner = 2; print $inner; }\nprint $outer;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(ShadowedLexicalVariableRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "unique nested lexicals should not be shadowing findings");
+    }
+
+    #[test]
+    fn native_shadowed_lexical_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $value = 1;\n{ my $value = 2; print $value; }\nprint $value;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.variables.shadowed_lexical".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(ShadowedLexicalVariableRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.variables.shadowed_lexical -- fixture\nuse strict;\nuse warnings;\nmy $value = 1;\n{ my $value = 2; print $value; }\nprint $value;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_shadowed_lexical_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $value = 1;\n{ my $value = 2; print $value; }\nprint $value;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(ShadowedLexicalVariableRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.variables.shadowed_lexical");
+        assert_eq!(
+            violations[0].description,
+            "Lexical variable '$value' shadows an outer declaration"
+        );
+        assert_eq!(
+            violations[0].explanation,
+            "Rename the inner lexical variable or use the outer variable directly to avoid confusing scope shadowing."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
         assert_eq!(violations[0].file, "lib/App.pm");
     }
 

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -66,7 +66,9 @@ impl CodeActionsProvider {
             Some("native.testing.require_use_strict") => fixes::add_use_strict(diagnostic),
             Some("native.testing.require_use_warnings") => fixes::add_use_warnings(diagnostic),
             Some(c)
-                if c == DiagnosticCode::VariableShadowing.as_str() || c == "variable-shadowing" =>
+                if c == DiagnosticCode::VariableShadowing.as_str()
+                    || c == "variable-shadowing"
+                    || c == "native.variables.shadowed_lexical" =>
             {
                 fixes::fix_variable_shadowing(diagnostic)
             }
@@ -407,6 +409,24 @@ mod tests {
         assert_eq!(actions[0].title, "Rename shadowing variable to '$inner_foo'");
         assert_eq!(actions[1].title, "Rename shadowing variable to '$local_foo'");
         assert_eq!(actions[2].title, "Rename shadowing variable to '$foo_2'");
+    }
+
+    #[test]
+    fn test_native_critic_shadowed_lexical_quick_fix() {
+        let diagnostic = make_diagnostic(
+            (20, 26),
+            DiagnosticSeverity::Warning,
+            "native.variables.shadowed_lexical",
+            "Lexical variable '$value' shadows an outer declaration",
+        );
+
+        let provider = CodeActionsProvider::new(String::new());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 3);
+        assert_eq!(actions[0].title, "Rename shadowing variable to '$inner_value'");
+        assert_eq!(actions[1].title, "Rename shadowing variable to '$local_value'");
+        assert_eq!(actions[2].title, "Rename shadowing variable to '$value_2'");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1348,7 +1348,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nprint $x;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nprint $x + $shadow;\n",
             None,
             &context,
             None,
@@ -1414,6 +1414,23 @@ mod tests {
             duplicate.data.as_ref().ok_or("native duplicate lexical data should be populated")?;
         assert_eq!(data["code"], "native.variables.duplicate_lexical");
         assert_eq!(data["suppressionKey"], "native.variables.duplicate_lexical");
+        assert_eq!(data["fixable"], true);
+
+        let shadowed = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.variables.shadowed_lexical"))
+            })
+            .ok_or("expected native shadowed lexical finding")?;
+        assert_eq!(shadowed.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(shadowed.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(shadowed.message, "Lexical variable '$shadow' shadows an outer declaration");
+        let data =
+            shadowed.data.as_ref().ok_or("native shadowed lexical data should be populated")?;
+        assert_eq!(data["code"], "native.variables.shadowed_lexical");
+        assert_eq!(data["suppressionKey"], "native.variables.shadowed_lexical");
         assert_eq!(data["fixable"], true);
         Ok(())
     }

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1835,7 +1835,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nprint $x;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nprint $x + $shadow;\n"
                 }
             })))
             .unwrap();
@@ -1869,6 +1869,14 @@ mod tests {
         assert!(
             text.contains("Lexical variable '$x' is declared more than once in the same scope"),
             "native duplicate lexical finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.variables.shadowed_lexical"),
+            "native critic engine should publish native shadowed lexical finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Lexical variable '$shadow' shadows an outer declaration"),
+            "native shadowed lexical finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("\"source\":\"perl-lsp-critic\""),
@@ -1922,7 +1930,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nprint $x;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nprint $x + $shadow;\n"
             }
         })))?;
 
@@ -1973,6 +1981,15 @@ mod tests {
                         )
             }),
             "native critic engine should add native duplicate lexical finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.variables.shadowed_lexical")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Lexical variable '$shadow' shadows an outer declaration")
+            }),
+            "native critic engine should add native shadowed lexical finding to workspace diagnostics: {report}"
         );
         assert!(
             !diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.variables.shadowed_lexical` for lexical declarations that shadow an outer declaration. The rule reuses existing `ScopeAnalyzer` `VariableShadowing` facts, keeps spans on the shadowing variable, and attaches suggested rename metadata.

Legacy remains default. Native critic remains explicit opt-in.

## Coverage

- Registers `ShadowedLexicalVariableRule` in the recommended native critic bundle.
- Covers config filtering, suppression filtering, and the legacy violation bridge.
- Extends pull, push, and workspace native diagnostic tests to assert the shadowed lexical finding alongside unused and duplicate lexical findings.
- Adds core and LSP-facing code-action aliases for `native.variables.shadowed_lexical` so existing shadowing rename suggestions remain available.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_shadowed --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_shadowed --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core test_native_critic_policy_alias_for_shadowed_lexical --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`
