### PR TITLE
feat(critic): add unused parameter native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -178,7 +178,9 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_parse_error(&self.source, &qf_diag, c));
                     }
                     // PL108: Unused parameter
-                    c if c == DiagnosticCode::UnusedParameter.as_str() => {
+                    c if c == DiagnosticCode::UnusedParameter.as_str()
+                        || c == "native.variables.unused_parameter" =>
+                    {
                         actions.extend(quick_fixes::fix_unused_parameter(&qf_diag));
                     }
                     // PL104: Variable shadowing
@@ -672,6 +674,35 @@ mod tests {
         assert!(actions.iter().any(|a| {
             a.title == "Rename to '$_unused'"
                 && a.edit.changes.iter().any(|edit| edit.new_text == "$_unused")
+        }));
+    }
+
+    #[test]
+    fn test_native_critic_policy_alias_for_unused_parameter() {
+        let source = "use strict;\nuse warnings;\nsub helper($used, $unused) { return $used; }\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.find("$unused").unwrap();
+        let diagnostics = vec![Diagnostic {
+            range: (start, start + "$unused".len()),
+            severity: DiagnosticSeverity::Warning,
+            code: Some("native.variables.unused_parameter".to_string()),
+            message: "Parameter '$unused' is never used".to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|action| {
+            action.title == "Rename to '_$unused'"
+                && action.edit.changes.iter().any(|edit| {
+                    edit.location.start == start
+                        && edit.location.end == start + "$unused".len()
+                        && edit.new_text == "_$unused"
+                })
         }));
     }
 

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -16,6 +16,7 @@ pub use native::{
     CriticSuppression, CriticSuppressionMap, CriticSuppressionScope, CriticTextEdit,
     DuplicateLexicalDeclarationRule, FixSafety, NativeCriticRegistry, RequireUseStrictRule,
     RequireUseWarningsRule, ShadowedLexicalVariableRule, UnusedLexicalVariableRule,
+    UnusedParameterRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -237,6 +237,7 @@ impl NativeCriticRegistry {
             Box::new(RequireUseStrictRule),
             Box::new(RequireUseWarningsRule),
             Box::new(UnusedLexicalVariableRule),
+            Box::new(UnusedParameterRule),
             Box::new(DuplicateLexicalDeclarationRule),
             Box::new(ShadowedLexicalVariableRule),
         ])
@@ -462,6 +463,39 @@ impl CriticRule for UnusedLexicalVariableRule {
     }
 }
 
+/// Native rule that reports subroutine parameters declared but never read.
+///
+/// This rule delegates parameter-use reasoning to the semantic scope analyzer
+/// so native critic diagnostics reuse the same signature facts as existing
+/// PL108 diagnostics.
+pub struct UnusedParameterRule;
+
+impl CriticRule for UnusedParameterRule {
+    fn id(&self) -> &'static str {
+        "native.variables.unused_parameter"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::UnusedParameter)
+                .map(|issue| unused_parameter_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
 /// Native rule that reports lexical variables declared more than once in a scope.
 ///
 /// This rule delegates redeclaration detection to the semantic scope analyzer so
@@ -543,6 +577,32 @@ fn unused_lexical_finding(
         range,
         message: format!("Lexical variable '{}' is declared but never used", issue.variable_name),
         explanation: "Remove the lexical variable, use it, or prefix it with '_' to mark it intentionally unused.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: format!("Rename to '{unused_name}'"),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: unused_name }],
+        }),
+    }
+}
+
+fn unused_parameter_finding(
+    rule: &UnusedParameterRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+    let unused_name = prefixed_unused_name(&issue.variable_name);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Parameter '{}' is never used", issue.variable_name),
+        explanation: "Use the parameter or prefix it with '_' to mark it intentionally unused."
+            .to_string(),
         suppression_key: rule.id().to_string(),
         related: Vec::new(),
         fix: Some(CriticFix {
@@ -1016,6 +1076,7 @@ mod tests {
                 "native.testing.require_use_strict",
                 "native.testing.require_use_warnings",
                 "native.variables.unused_lexical",
+                "native.variables.unused_parameter",
                 "native.variables.duplicate_lexical",
                 "native.variables.shadowed_lexical"
             ]
@@ -1132,6 +1193,88 @@ mod tests {
         assert_eq!(
             violations[0].explanation,
             "Remove the lexical variable, use it, or prefix it with '_' to mark it intentionally unused."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_unused_parameter_rule_reports_unread_signature_parameter() {
+        let source = "use strict;\nuse warnings;\nsub helper($used, $unused) { return $used; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedParameterRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.variables.unused_parameter");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Parameter '$unused' is never used");
+        assert_eq!(finding.suppression_key, "native.variables.unused_parameter");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$unused");
+
+        let fix = finding.fix.as_ref().expect("unused parameter should offer an intent marker");
+        assert_eq!(fix.title, "Rename to '$_unused'");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].range, finding.range);
+        assert_eq!(fix.edits[0].new_text, "$_unused");
+    }
+
+    #[test]
+    fn native_unused_parameter_rule_accepts_used_and_intentionally_unused_parameters() {
+        let source = "use strict;\nuse warnings;\nsub helper($used, $_ignored) { return $used; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedParameterRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "used and underscore-prefixed parameters should be accepted");
+    }
+
+    #[test]
+    fn native_unused_parameter_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nsub helper($used, $unused) { return $used; }\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.variables.unused_parameter".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedParameterRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.variables.unused_parameter -- fixture\nuse strict;\nuse warnings;\nsub helper($used, $unused) { return $used; }\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_unused_parameter_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nsub helper($used, $unused) { return $used; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnusedParameterRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.variables.unused_parameter");
+        assert_eq!(violations[0].description, "Parameter '$unused' is never used");
+        assert_eq!(
+            violations[0].explanation,
+            "Use the parameter or prefix it with '_' to mark it intentionally unused."
         );
         assert_eq!(violations[0].severity, Severity::Stern);
         assert_eq!(violations[0].file, "lib/App.pm");

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -91,7 +91,11 @@ impl CodeActionsProvider {
             {
                 fixes::fix_parameter_shadowing(diagnostic)
             }
-            Some(c) if c == DiagnosticCode::UnusedParameter.as_str() || c == "unused-parameter" => {
+            Some(c)
+                if c == DiagnosticCode::UnusedParameter.as_str()
+                    || c == "unused-parameter"
+                    || c == "native.variables.unused_parameter" =>
+            {
                 fixes::fix_unused_parameter(diagnostic)
             }
             Some(c)
@@ -587,6 +591,24 @@ mod tests {
         assert_eq!(actions.len(), 1);
         assert!(actions[0].title.contains("$_self"));
         assert!(actions[0].title.contains("mark as intentionally unused"));
+    }
+
+    #[test]
+    fn test_native_critic_unused_parameter_quick_fix() {
+        let diagnostic = make_diagnostic(
+            (20, 27),
+            DiagnosticSeverity::Warning,
+            "native.variables.unused_parameter",
+            "Parameter '$unused' is never used",
+        );
+
+        let provider = CodeActionsProvider::new(String::new());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Rename to '$_unused' (mark as intentionally unused)");
+        assert_eq!(actions[0].edit.range, (20, 27));
+        assert_eq!(actions[0].edit.new_text, "$_unused");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1348,7 +1348,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nprint $x + $shadow;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nprint $x + $shadow;\n",
             None,
             &context,
             None,
@@ -1394,6 +1394,25 @@ mod tests {
         let data = unused.data.as_ref().ok_or("native unused lexical data should be populated")?;
         assert_eq!(data["code"], "native.variables.unused_lexical");
         assert_eq!(data["suppressionKey"], "native.variables.unused_lexical");
+        assert_eq!(data["fixable"], true);
+
+        let unused_parameter = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.variables.unused_parameter"))
+            })
+            .ok_or("expected native unused parameter finding")?;
+        assert_eq!(unused_parameter.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(unused_parameter.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(unused_parameter.message, "Parameter '$unused_param' is never used");
+        let data = unused_parameter
+            .data
+            .as_ref()
+            .ok_or("native unused parameter data should be populated")?;
+        assert_eq!(data["code"], "native.variables.unused_parameter");
+        assert_eq!(data["suppressionKey"], "native.variables.unused_parameter");
         assert_eq!(data["fixable"], true);
 
         let duplicate = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1835,7 +1835,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nprint $x + $shadow;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nprint $x + $shadow;\n"
                 }
             })))
             .unwrap();
@@ -1861,6 +1861,14 @@ mod tests {
         assert!(
             text.contains("Lexical variable '$unused' is declared but never used"),
             "native unused lexical finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.variables.unused_parameter"),
+            "native critic engine should publish native unused parameter finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Parameter '$unused_param' is never used"),
+            "native unused parameter finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.variables.duplicate_lexical"),
@@ -1930,7 +1938,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nprint $x + $shadow;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nprint $x + $shadow;\n"
             }
         })))?;
 
@@ -1970,6 +1978,14 @@ mod tests {
                         == Some("Lexical variable '$unused' is declared but never used")
             }),
             "native critic engine should add native unused lexical finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.variables.unused_parameter")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str() == Some("Parameter '$unused_param' is never used")
+            }),
+            "native critic engine should add native unused parameter finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.variables.unused_parameter` for unread subroutine signature parameters.

The rule stays narrow and reuses the existing semantic `ScopeAnalyzer` `UnusedParameter` facts. Native critic remains explicit opt-in; legacy critic behavior and defaults are unchanged.

## Coverage

- registers `UnusedParameterRule` in `NativeCriticRegistry::recommended()`
- supports config filtering and suppression filtering through the existing registry path
- maps through the legacy violation bridge
- surfaces through pull, push, and workspace diagnostics under `[critic].engine = "native"`
- aliases native diagnostics into existing unused-parameter quick fixes in core and LSP code-action providers

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_unused_parameter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core test_native_critic_policy_alias_for_unused_parameter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_unused_parameter --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
