### PR TITLE
feat(compile): add symbolic-ref boundary facts (#8293)

### DIFF
--- a/crates/perl-parser-core/src/hir/lower.rs
+++ b/crates/perl-parser-core/src/hir/lower.rs
@@ -25,9 +25,10 @@ use super::model::{
 /// records local scope, stash, and compile-environment side graphs, but it does
 /// not change provider behavior.
 pub fn lower_ast(ast: &Node) -> HirFile {
-    let mut lowerer = Lowerer::new(ast.location);
+    let pragma_environment = CompileTimePragmaEnvironment::build(ast);
+    let mut lowerer = Lowerer::new(ast.location, pragma_environment);
     lowerer.visit(ast, RecoveryConfidence::Parsed);
-    lowerer.record_pragma_state_facts(ast);
+    lowerer.record_pragma_state_facts();
     lowerer.finish()
 }
 
@@ -38,11 +39,12 @@ struct Lowerer {
     scope_graph: ScopeGraph,
     stash_graph: StashGraph,
     compile_environment: CompileEnvironment,
+    pragma_environment: CompileTimePragmaEnvironment,
     scope_stack: Vec<HirScopeId>,
 }
 
 impl Lowerer {
-    fn new(file_range: SourceLocation) -> Self {
+    fn new(file_range: SourceLocation, pragma_environment: CompileTimePragmaEnvironment) -> Self {
         let mut scope_graph = ScopeGraph::default();
         let file_scope = HirScopeId::from_index(0);
         scope_graph.scopes.push(ScopeFrame {
@@ -60,6 +62,7 @@ impl Lowerer {
             scope_graph,
             stash_graph: StashGraph::default(),
             compile_environment: CompileEnvironment::default(),
+            pragma_environment,
             scope_stack: vec![file_scope],
         }
     }
@@ -465,6 +468,31 @@ impl Lowerer {
                     self.record_assignment_stash_effect(lhs, rhs, node.location, confidence);
                 }
                 self.visit_children(node, confidence);
+            }
+            NodeKind::Unary { op, operand } => {
+                if is_symbolic_reference_deref_op(op)
+                    && !self.strict_refs_enabled_at(node.location.start)
+                {
+                    let reason = "symbolic reference dereference is not statically known";
+                    let item_id = self.push_item(
+                        node,
+                        None,
+                        confidence,
+                        HirKind::DynamicBoundary(DynamicBoundary {
+                            kind: DynamicBoundaryKind::SymbolicReferenceDeref,
+                            reason: reason.to_string(),
+                        }),
+                        self.package_context.clone(),
+                        Some(self.current_scope()),
+                    );
+                    self.record_compile_environment_boundary(
+                        CompileEnvironmentBoundaryKind::SymbolicReferenceDeref,
+                        node.location,
+                        Some(item_id),
+                        reason,
+                    );
+                }
+                self.visit(operand, confidence);
             }
             NodeKind::Eval { block } => {
                 if !matches!(block.kind, NodeKind::Block { .. }) {
@@ -1027,9 +1055,9 @@ impl Lowerer {
         });
     }
 
-    fn record_pragma_state_facts(&mut self, ast: &Node) {
-        let environment = CompileTimePragmaEnvironment::build(ast);
-        for entry in environment.map().entries() {
+    fn record_pragma_state_facts(&mut self) {
+        let entries = self.pragma_environment.map().entries().to_vec();
+        for entry in entries {
             let range = SourceLocation::new(entry.range.start, entry.range.end);
             if self.is_dynamic_pragma_offset(range.start) {
                 continue;
@@ -1045,6 +1073,10 @@ impl Lowerer {
                 package_context,
             ));
         }
+    }
+
+    fn strict_refs_enabled_at(&self, offset: usize) -> bool {
+        self.pragma_environment.snapshot_at(offset).state().strict_refs
     }
 
     fn is_dynamic_pragma_offset(&self, offset: usize) -> bool {
@@ -1746,6 +1778,10 @@ fn is_bareword_like(value: &str) -> bool {
 
 fn contains_interpolation_marker(value: &str) -> bool {
     value.contains('$') || value.contains('@') || value.contains('%')
+}
+
+fn is_symbolic_reference_deref_op(op: &str) -> bool {
+    matches!(op, "${}" | "@{}" | "%{}" | "&{}" | "*{}")
 }
 
 fn pragma_state_fact(

--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -267,6 +267,8 @@ pub enum CompileEffectSourceKind {
     RequireDirective,
     /// Compile-time phase block.
     PhaseBlock,
+    /// Symbolic-reference dereference.
+    SymbolicReferenceDeref,
     /// Assignment expression.
     Assignment,
     /// Typeglob assignment.
@@ -726,6 +728,9 @@ fn compile_boundary_source_kind(kind: CompileEnvironmentBoundaryKind) -> Compile
         CompileEnvironmentBoundaryKind::DynamicPragmaArgs
         | CompileEnvironmentBoundaryKind::DynamicIncRoot => CompileEffectSourceKind::UseDirective,
         CompileEnvironmentBoundaryKind::PhaseBlockExecution => CompileEffectSourceKind::PhaseBlock,
+        CompileEnvironmentBoundaryKind::SymbolicReferenceDeref => {
+            CompileEffectSourceKind::SymbolicReferenceDeref
+        }
     }
 }
 
@@ -2202,6 +2207,8 @@ pub enum CompileEnvironmentBoundaryKind {
     DynamicIncRoot,
     /// Phase block contains compile-time execution that is not evaluated here.
     PhaseBlockExecution,
+    /// Symbolic-reference dereference is possible while `strict refs` is disabled.
+    SymbolicReferenceDeref,
 }
 
 /// Provenance for HIR-local compile-environment facts.
@@ -2811,4 +2818,6 @@ pub enum DynamicBoundaryKind {
     DynamicStashMutation,
     /// `AUTOLOAD` declaration introduces dynamic method dispatch.
     Autoload,
+    /// Symbolic-reference dereference whose target cannot be modeled statically.
+    SymbolicReferenceDeref,
 }

--- a/crates/perl-parser-core/tests/hir_tests.rs
+++ b/crates/perl-parser-core/tests/hir_tests.rs
@@ -1,9 +1,9 @@
 use perl_parser_core::hir::{
     COMPILE_EFFECT_MODEL_VERSION, CompileConfidence, CompileEffectFactKind, CompileEffectKind,
     CompileEffectSourceKind, CompileEnvironment, CompileEnvironmentBoundaryKind, CompileProvenance,
-    FrameworkAdapterKind, FrameworkAdapterRegistry, FrameworkExportedSymbolKind, HirFile, HirKind,
-    IncRootKind, ModuleResolutionRoot, PragmaArgumentKind, RecoveryConfidence, ScopeGraph,
-    StashGraph, lower_ast,
+    DynamicBoundaryKind, FrameworkAdapterKind, FrameworkAdapterRegistry,
+    FrameworkExportedSymbolKind, HirFile, HirKind, IncRootKind, ModuleResolutionRoot,
+    PragmaArgumentKind, RecoveryConfidence, ScopeGraph, StashGraph, lower_ast,
 };
 use perl_parser_core::{Node, NodeKind, Parser, SourceLocation};
 use perl_semantic_facts::{
@@ -1281,6 +1281,108 @@ fn hir_compile_effect_log_links_source_mutations_facts_and_boundaries()
     assert!(
         rendered.contains("EmitDynamicBoundary"),
         "rendered effect proof should expose dynamic-boundary rows"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn hir_symbolic_refs_emit_dynamic_boundaries_only_when_strict_refs_disabled()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"package Symbolic::Refs;
+use strict;
+${$strict_scalar} = 1;
+{
+    no strict 'refs';
+    ${$loose_scalar} = 1;
+    @{$loose_array} = ();
+    %{$loose_hash} = ();
+    &{$loose_code}();
+}
+${$strict_again} = 2;
+*alias = \&target;
+"#;
+    let file = lower_source(source);
+
+    let strict_scalar = source.find("${$strict_scalar}").ok_or("expected strict scalar deref")?;
+    let strict_again = source.find("${$strict_again}").ok_or("expected restored strict deref")?;
+    let loose_scalar = source.find("${$loose_scalar}").ok_or("expected loose scalar deref")?;
+    let loose_array = source.find("@{$loose_array}").ok_or("expected loose array deref")?;
+    let loose_hash = source.find("%{$loose_hash}").ok_or("expected loose hash deref")?;
+    let loose_code = source.find("&{$loose_code}").ok_or("expected loose code deref")?;
+
+    let symbolic_items = file
+        .items
+        .iter()
+        .filter_map(|item| match &item.kind {
+            HirKind::DynamicBoundary(boundary)
+                if boundary.kind == DynamicBoundaryKind::SymbolicReferenceDeref =>
+            {
+                Some((item.range.start, boundary.reason.as_str()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        symbolic_items,
+        vec![
+            (loose_scalar, "symbolic reference dereference is not statically known"),
+            (loose_array, "symbolic reference dereference is not statically known"),
+            (loose_hash, "symbolic reference dereference is not statically known"),
+            (loose_code, "symbolic reference dereference is not statically known"),
+        ],
+        "symbolic-reference HIR boundaries should follow the scoped no strict refs region"
+    );
+
+    let symbolic_boundaries = file
+        .compile_environment
+        .dynamic_boundaries
+        .iter()
+        .filter(|boundary| boundary.kind == CompileEnvironmentBoundaryKind::SymbolicReferenceDeref)
+        .collect::<Vec<_>>();
+    let boundary_starts =
+        symbolic_boundaries.iter().map(|boundary| boundary.range.start).collect::<Vec<_>>();
+    assert_eq!(boundary_starts, vec![loose_scalar, loose_array, loose_hash, loose_code]);
+    assert!(
+        symbolic_boundaries.iter().all(|boundary| {
+            boundary.provenance == CompileProvenance::DynamicBoundary
+                && boundary.confidence == CompileConfidence::Low
+                && boundary.package_context.as_deref() == Some("Symbolic::Refs")
+                && boundary.reason == "symbolic reference dereference is not statically known"
+        }),
+        "symbolic-reference facts should stay fail-closed with package context"
+    );
+    assert!(
+        !boundary_starts.contains(&strict_scalar) && !boundary_starts.contains(&strict_again),
+        "strict refs regions should not be marked as symbolic-reference boundaries"
+    );
+
+    let effects = file.compile_effects();
+    assert!(
+        effects.iter().any(|effect| {
+            effect.kind == CompileEffectKind::EmitDynamicBoundary
+                && effect.source_kind == CompileEffectSourceKind::SymbolicReferenceDeref
+                && effect.fact_kind == CompileEffectFactKind::DynamicBoundary
+                && effect.fact_name.as_deref() == Some("SymbolicReferenceDeref")
+                && effect.dynamic_reason.as_deref()
+                    == Some("symbolic reference dereference is not statically known")
+                && effect.provenance == CompileProvenance::DynamicBoundary
+                && effect.confidence == CompileConfidence::Low
+        }),
+        "compile-effect log should expose symbolic-reference boundary rows"
+    );
+    assert!(
+        effects.iter().any(|effect| {
+            effect.kind == CompileEffectKind::AssignGlobAlias
+                && effect.fact_name.as_deref() == Some("Symbolic::Refs::alias")
+        }),
+        "static typeglob aliases should remain on the existing precise path"
+    );
+    assert!(
+        !file.items.iter().any(
+            |item| matches!(&item.kind, HirKind::CallExpr(expr) if expr.name == "provider_cutover")
+        ),
+        "symbolic-reference facts must not imply live provider cutover"
     );
 
     Ok(())


### PR DESCRIPTION
Problem: Symbolic-reference dereferences under disabled `strict refs` were not represented as explicit compile dynamic-boundary facts.
Fix: Record HIR and compile-environment dynamic boundaries for `${...}`, `@{...}`, `%{...}`, `&{...}`, and `*{...}` derefs when `strict refs` is off, and expose those boundaries through the compile-effect log without changing provider behavior.
Verification: `cargo test -p perl-parser-core --test hir_tests --profile agent --locked symbolic -- --nocapture`; `cargo test -p perl-parser-core --test hir_tests --profile agent --locked -- --nocapture`; `cargo clippy -p perl-parser-core --lib --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`.

Closes #8293.
Progresses #8207.

Notes:
- No LSP provider behavior changes.
- Existing static typeglob aliases remain on the precise `AssignGlobAlias` path.
- Parser denominator remains 49 fixtures / 29 families with 0 active failure packets; parser ratchets pass.