### PR TITLE
feat(critic): add duplicate parameter native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -183,6 +183,12 @@ impl CodeActionsProvider {
                     {
                         actions.extend(quick_fixes::fix_unused_parameter(&qf_diag));
                     }
+                    // PL107: Duplicate parameter
+                    c if c == DiagnosticCode::DuplicateParameter.as_str()
+                        || c == "native.variables.duplicate_parameter" =>
+                    {
+                        actions.extend(quick_fixes::fix_duplicate_parameter(&qf_diag));
+                    }
                     // PL104: Variable shadowing
                     c if c == DiagnosticCode::VariableShadowing.as_str()
                         || c == "native.variables.shadowed_lexical" =>
@@ -703,6 +709,39 @@ mod tests {
                         && edit.location.end == start + "$unused".len()
                         && edit.new_text == "_$unused"
                 })
+        }));
+    }
+
+    #[test]
+    fn test_native_critic_policy_alias_for_duplicate_parameter() {
+        let source = "use strict;\nuse warnings;\nsub helper($arg, $arg) { return $arg; }\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.find(", $arg").unwrap() + ", ".len();
+        let diagnostics = vec![Diagnostic {
+            range: (start, start + "$arg".len()),
+            severity: DiagnosticSeverity::Error,
+            code: Some("native.variables.duplicate_parameter".to_string()),
+            message: "Parameter '$arg' appears more than once in this signature".to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|action| {
+            action.title == "Remove duplicate parameter '$arg'"
+                && action.edit.changes.iter().any(|edit| {
+                    edit.location.start == start
+                        && edit.location.end == start + "$arg".len()
+                        && edit.new_text.is_empty()
+                })
+        }));
+        assert!(actions.iter().any(|action| {
+            action.title == "Rename duplicate to '$arg_2'"
+                && action.edit.changes.iter().any(|edit| edit.new_text == "$arg_2")
         }));
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -105,6 +105,12 @@ fn mark_intentionally_unused(name: &str) -> String {
     }
 }
 
+fn split_sigil(name: &str) -> (&str, &str) {
+    let bare = name.trim_start_matches(['$', '@', '%', '&', '*']);
+    let sigil_len = name.len() - bare.len();
+    (&name[..sigil_len], bare)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -642,6 +648,42 @@ pub fn fix_unused_parameter(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> 
     }
 
     actions
+}
+
+/// Fix duplicate parameter by removing or renaming the repeated binding.
+pub fn fix_duplicate_parameter(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let Some(param_name) = diagnostic.message.split('\'').nth(1) else {
+        return Vec::new();
+    };
+    let (sigil, base_name) = split_sigil(param_name);
+    let new_name = format!("{sigil}{base_name}_2");
+
+    vec![
+        CodeAction {
+            title: format!("Remove duplicate parameter '{}'", param_name),
+            kind: CodeActionKind::QuickFix,
+            diagnostics: vec![DiagnosticCode::DuplicateParameter.as_str().to_string()],
+            edit: CodeActionEdit {
+                changes: vec![TextEdit {
+                    location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                    new_text: String::new(),
+                }],
+            },
+            is_preferred: true,
+        },
+        CodeAction {
+            title: format!("Rename duplicate to '{}'", new_name),
+            kind: CodeActionKind::QuickFix,
+            diagnostics: vec![DiagnosticCode::DuplicateParameter.as_str().to_string()],
+            edit: CodeActionEdit {
+                changes: vec![TextEdit {
+                    location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                    new_text: new_name,
+                }],
+            },
+            is_preferred: false,
+        },
+    ]
 }
 
 /// Suggest portable shebang line

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -14,9 +14,9 @@ pub use built_in::{BuiltInAnalyzer, Policy};
 pub use native::{
     CriticCategory, CriticContext, CriticFinding, CriticFix, CriticRelatedInformation, CriticRule,
     CriticSuppression, CriticSuppressionMap, CriticSuppressionScope, CriticTextEdit,
-    DuplicateLexicalDeclarationRule, FixSafety, NativeCriticRegistry, RequireUseStrictRule,
-    RequireUseWarningsRule, ShadowedLexicalVariableRule, UnusedLexicalVariableRule,
-    UnusedParameterRule,
+    DuplicateLexicalDeclarationRule, DuplicateParameterRule, FixSafety, NativeCriticRegistry,
+    RequireUseStrictRule, RequireUseWarningsRule, ShadowedLexicalVariableRule,
+    UnusedLexicalVariableRule, UnusedParameterRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -238,6 +238,7 @@ impl NativeCriticRegistry {
             Box::new(RequireUseWarningsRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
+            Box::new(DuplicateParameterRule),
             Box::new(DuplicateLexicalDeclarationRule),
             Box::new(ShadowedLexicalVariableRule),
         ])
@@ -496,6 +497,39 @@ impl CriticRule for UnusedParameterRule {
     }
 }
 
+/// Native rule that reports subroutine parameters repeated in one signature.
+///
+/// This rule delegates duplicate-parameter detection to the semantic scope
+/// analyzer so native critic diagnostics reuse existing signature facts while
+/// exposing a stable native policy ID.
+pub struct DuplicateParameterRule;
+
+impl CriticRule for DuplicateParameterRule {
+    fn id(&self) -> &'static str {
+        "native.variables.duplicate_parameter"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Gentle
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::DuplicateParameter)
+                .map(|issue| duplicate_parameter_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
 /// Native rule that reports lexical variables declared more than once in a scope.
 ///
 /// This rule delegates redeclaration detection to the semantic scope analyzer so
@@ -613,6 +647,36 @@ fn unused_parameter_finding(
     }
 }
 
+fn duplicate_parameter_finding(
+    rule: &DuplicateParameterRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+    let replacement = numbered_duplicate_name(&issue.variable_name);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!(
+            "Parameter '{}' appears more than once in this signature",
+            issue.variable_name
+        ),
+        explanation:
+            "Remove the duplicate parameter or rename it so every signature binding is unique."
+                .to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: format!("Rename duplicate parameter to '{replacement}'"),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: replacement }],
+        }),
+    }
+}
+
 fn duplicate_lexical_finding(
     rule: &DuplicateLexicalDeclarationRule,
     source: &str,
@@ -694,6 +758,11 @@ fn duplicate_my_span(source: &str, variable_start: usize) -> Option<(usize, usiz
 fn shadowed_lexical_name(name: &str) -> String {
     let (sigil, base_name) = split_sigil(name);
     format!("{sigil}inner_{base_name}")
+}
+
+fn numbered_duplicate_name(name: &str) -> String {
+    let (sigil, base_name) = split_sigil(name);
+    format!("{sigil}{base_name}_2")
 }
 
 fn prefixed_unused_name(name: &str) -> String {
@@ -1077,6 +1146,7 @@ mod tests {
                 "native.testing.require_use_warnings",
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",
+                "native.variables.duplicate_parameter",
                 "native.variables.duplicate_lexical",
                 "native.variables.shadowed_lexical"
             ]
@@ -1277,6 +1347,92 @@ mod tests {
             "Use the parameter or prefix it with '_' to mark it intentionally unused."
         );
         assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_duplicate_parameter_rule_reports_repeated_signature_parameter() {
+        let source = "use strict;\nuse warnings;\nsub helper($arg, $arg) { return $arg; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DuplicateParameterRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.variables.duplicate_parameter");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Gentle);
+        assert_eq!(finding.message, "Parameter '$arg' appears more than once in this signature");
+        assert_eq!(finding.suppression_key, "native.variables.duplicate_parameter");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$arg");
+
+        let fix = finding.fix.as_ref().expect("duplicate parameter should offer rename");
+        assert_eq!(fix.title, "Rename duplicate parameter to '$arg_2'");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].range, finding.range);
+        assert_eq!(fix.edits[0].new_text, "$arg_2");
+    }
+
+    #[test]
+    fn native_duplicate_parameter_rule_accepts_unique_parameters() {
+        let source =
+            "use strict;\nuse warnings;\nsub helper($left, $right) { return $left + $right; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DuplicateParameterRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "unique parameters should be accepted");
+    }
+
+    #[test]
+    fn native_duplicate_parameter_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nsub helper($arg, $arg) { return $arg; }\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.variables.duplicate_parameter".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DuplicateParameterRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no perl-lsp-critic native.variables.duplicate_parameter -- fixture\nuse strict;\nuse warnings;\nsub helper($arg, $arg) { return $arg; }\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_duplicate_parameter_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nsub helper($arg, $arg) { return $arg; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DuplicateParameterRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.variables.duplicate_parameter");
+        assert_eq!(
+            violations[0].description,
+            "Parameter '$arg' appears more than once in this signature"
+        );
+        assert_eq!(
+            violations[0].explanation,
+            "Remove the duplicate parameter or rename it so every signature binding is unique."
+        );
+        assert_eq!(violations[0].severity, Severity::Gentle);
         assert_eq!(violations[0].file, "lib/App.pm");
     }
 

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -81,7 +81,8 @@ impl CodeActionsProvider {
             }
             Some(c)
                 if c == DiagnosticCode::DuplicateParameter.as_str()
-                    || c == "duplicate-parameter" =>
+                    || c == "duplicate-parameter"
+                    || c == "native.variables.duplicate_parameter" =>
             {
                 fixes::fix_duplicate_parameter(diagnostic)
             }
@@ -535,6 +536,26 @@ mod tests {
         let actions = provider.get_actions_for_diagnostic(&diagnostic);
 
         assert_eq!(actions[1].edit.new_text, "@vals_2");
+    }
+
+    #[test]
+    fn test_native_critic_duplicate_parameter_quick_fix() {
+        let diagnostic = make_diagnostic(
+            (30, 34),
+            DiagnosticSeverity::Error,
+            "native.variables.duplicate_parameter",
+            "Parameter '$arg' appears more than once in this signature",
+        );
+
+        let provider = CodeActionsProvider::new(String::new());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].title, "Remove duplicate parameter '$arg'");
+        assert_eq!(actions[0].edit.range, (30, 34));
+        assert_eq!(actions[0].edit.new_text, "");
+        assert_eq!(actions[1].title, "Rename duplicate to '$arg_2'");
+        assert_eq!(actions[1].edit.new_text, "$arg_2");
     }
 
     // ── Quick-fix: parameter shadows global ─────────────────────────────

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1348,7 +1348,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nprint $x + $shadow;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nprint $x + $shadow;\n",
             None,
             &context,
             None,
@@ -1413,6 +1413,28 @@ mod tests {
             .ok_or("native unused parameter data should be populated")?;
         assert_eq!(data["code"], "native.variables.unused_parameter");
         assert_eq!(data["suppressionKey"], "native.variables.unused_parameter");
+        assert_eq!(data["fixable"], true);
+
+        let duplicate_parameter = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.variables.duplicate_parameter"))
+            })
+            .ok_or("expected native duplicate parameter finding")?;
+        assert_eq!(duplicate_parameter.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(duplicate_parameter.severity, Some(LspDiagnosticSeverity::ERROR));
+        assert_eq!(
+            duplicate_parameter.message,
+            "Parameter '$dup_param' appears more than once in this signature"
+        );
+        let data = duplicate_parameter
+            .data
+            .as_ref()
+            .ok_or("native duplicate parameter data should be populated")?;
+        assert_eq!(data["code"], "native.variables.duplicate_parameter");
+        assert_eq!(data["suppressionKey"], "native.variables.duplicate_parameter");
         assert_eq!(data["fixable"], true);
 
         let duplicate = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1835,7 +1835,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nprint $x + $shadow;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nprint $x + $shadow;\n"
                 }
             })))
             .unwrap();
@@ -1869,6 +1869,14 @@ mod tests {
         assert!(
             text.contains("Parameter '$unused_param' is never used"),
             "native unused parameter finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.variables.duplicate_parameter"),
+            "native critic engine should publish native duplicate parameter finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Parameter '$dup_param' appears more than once in this signature"),
+            "native duplicate parameter finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.variables.duplicate_lexical"),
@@ -1938,7 +1946,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nprint $x + $shadow;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nprint $x + $shadow;\n"
             }
         })))?;
 
@@ -1986,6 +1994,15 @@ mod tests {
                     && diag["message"].as_str() == Some("Parameter '$unused_param' is never used")
             }),
             "native critic engine should add native unused parameter finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.variables.duplicate_parameter")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Parameter '$dup_param' appears more than once in this signature")
+            }),
+            "native critic engine should add native duplicate parameter finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.variables.duplicate_parameter` for repeated subroutine signature parameters.

The rule stays narrow and reuses existing semantic `ScopeAnalyzer` `DuplicateParameter` facts. Native critic remains explicit opt-in; legacy critic behavior and defaults are unchanged.

## Coverage

- registers `DuplicateParameterRule` in `NativeCriticRegistry::recommended()`
- supports config filtering and suppression filtering through the existing registry path
- maps through the legacy violation bridge
- surfaces through pull, push, and workspace diagnostics under `[critic].engine = "native"`
- aliases native diagnostics into duplicate-parameter quick fixes in core and LSP code-action providers

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_duplicate_parameter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core test_native_critic_policy_alias_for_duplicate_parameter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs test_native_critic_duplicate_parameter_quick_fix --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
