### PR TITLE
feat(critic): add parameter shadowing native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -189,6 +189,12 @@ impl CodeActionsProvider {
                     {
                         actions.extend(quick_fixes::fix_duplicate_parameter(&qf_diag));
                     }
+                    // PL110: Parameter shadows outer/global variable
+                    c if c == DiagnosticCode::ParameterShadowsGlobal.as_str()
+                        || c == "native.variables.parameter_shadows_global" =>
+                    {
+                        actions.extend(quick_fixes::fix_parameter_shadowing(&qf_diag));
+                    }
                     // PL104: Variable shadowing
                     c if c == DiagnosticCode::VariableShadowing.as_str()
                         || c == "native.variables.shadowed_lexical" =>
@@ -742,6 +748,39 @@ mod tests {
         assert!(actions.iter().any(|action| {
             action.title == "Rename duplicate to '$arg_2'"
                 && action.edit.changes.iter().any(|edit| edit.new_text == "$arg_2")
+        }));
+    }
+
+    #[test]
+    fn test_native_critic_policy_alias_for_parameter_shadows_global() {
+        let source = "use strict;\nuse warnings;\nmy $name = 'outer';\nsub helper($name) { return $name; }\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.find("($name").unwrap() + 1;
+        let diagnostics = vec![Diagnostic {
+            range: (start, start + "$name".len()),
+            severity: DiagnosticSeverity::Warning,
+            code: Some("native.variables.parameter_shadows_global".to_string()),
+            message: "Parameter '$name' shadows an outer declaration".to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(actions.iter().any(|action| {
+            action.title == "Rename parameter to '$p_name'"
+                && action.edit.changes.iter().any(|edit| {
+                    edit.location.start == start
+                        && edit.location.end == start + "$name".len()
+                        && edit.new_text == "$p_name"
+                })
+        }));
+        assert!(actions.iter().any(|action| {
+            action.title == "Rename parameter to '$name_param'"
+                && action.edit.changes.iter().any(|edit| edit.new_text == "$name_param")
         }));
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -686,6 +686,34 @@ pub fn fix_duplicate_parameter(diagnostic: &QuickFixDiagnostic) -> Vec<CodeActio
     ]
 }
 
+/// Fix parameter shadowing by suggesting unambiguous parameter names.
+pub fn fix_parameter_shadowing(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let Some(param_name) = diagnostic.message.split('\'').nth(1) else {
+        return Vec::new();
+    };
+    let (sigil, base_name) = split_sigil(param_name);
+
+    [
+        format!("{sigil}p_{base_name}"),
+        format!("{sigil}{base_name}_param"),
+        format!("{sigil}{base_name}_arg"),
+    ]
+    .into_iter()
+    .map(|new_name| CodeAction {
+        title: format!("Rename parameter to '{}'", new_name),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::ParameterShadowsGlobal.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                new_text: new_name,
+            }],
+        },
+        is_preferred: false,
+    })
+    .collect()
+}
+
 /// Suggest portable shebang line
 ///
 /// Detects hardcoded perl paths in shebang lines (e.g., `#!/usr/bin/perl`,

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -15,8 +15,8 @@ pub use native::{
     CriticCategory, CriticContext, CriticFinding, CriticFix, CriticRelatedInformation, CriticRule,
     CriticSuppression, CriticSuppressionMap, CriticSuppressionScope, CriticTextEdit,
     DuplicateLexicalDeclarationRule, DuplicateParameterRule, FixSafety, NativeCriticRegistry,
-    RequireUseStrictRule, RequireUseWarningsRule, ShadowedLexicalVariableRule,
-    UnusedLexicalVariableRule, UnusedParameterRule,
+    ParameterShadowsGlobalRule, RequireUseStrictRule, RequireUseWarningsRule,
+    ShadowedLexicalVariableRule, UnusedLexicalVariableRule, UnusedParameterRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -239,6 +239,7 @@ impl NativeCriticRegistry {
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
             Box::new(DuplicateParameterRule),
+            Box::new(ParameterShadowsGlobalRule),
             Box::new(DuplicateLexicalDeclarationRule),
             Box::new(ShadowedLexicalVariableRule),
         ])
@@ -530,6 +531,39 @@ impl CriticRule for DuplicateParameterRule {
     }
 }
 
+/// Native rule that reports subroutine parameters shadowing outer variables.
+///
+/// This rule delegates parameter shadowing detection to the semantic scope
+/// analyzer so native critic diagnostics reuse existing binding facts while
+/// exposing a stable native policy ID.
+pub struct ParameterShadowsGlobalRule;
+
+impl CriticRule for ParameterShadowsGlobalRule {
+    fn id(&self) -> &'static str {
+        "native.variables.parameter_shadows_global"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::ParameterShadowsGlobal)
+                .map(|issue| parameter_shadows_global_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
 /// Native rule that reports lexical variables declared more than once in a scope.
 ///
 /// This rule delegates redeclaration detection to the semantic scope analyzer so
@@ -677,6 +711,31 @@ fn duplicate_parameter_finding(
     }
 }
 
+fn parameter_shadows_global_finding(
+    rule: &ParameterShadowsGlobalRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+    let replacement = parameter_shadow_name(&issue.variable_name);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Parameter '{}' shadows an outer declaration", issue.variable_name),
+        explanation: "Rename the parameter or use the outer variable directly to avoid confusing scope shadowing.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: format!("Rename parameter to '{replacement}'"),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: replacement }],
+        }),
+    }
+}
+
 fn duplicate_lexical_finding(
     rule: &DuplicateLexicalDeclarationRule,
     source: &str,
@@ -763,6 +822,11 @@ fn shadowed_lexical_name(name: &str) -> String {
 fn numbered_duplicate_name(name: &str) -> String {
     let (sigil, base_name) = split_sigil(name);
     format!("{sigil}{base_name}_2")
+}
+
+fn parameter_shadow_name(name: &str) -> String {
+    let (sigil, base_name) = split_sigil(name);
+    format!("{sigil}p_{base_name}")
 }
 
 fn prefixed_unused_name(name: &str) -> String {
@@ -1147,6 +1211,7 @@ mod tests {
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",
                 "native.variables.duplicate_parameter",
+                "native.variables.parameter_shadows_global",
                 "native.variables.duplicate_lexical",
                 "native.variables.shadowed_lexical"
             ]
@@ -1433,6 +1498,89 @@ mod tests {
             "Remove the duplicate parameter or rename it so every signature binding is unique."
         );
         assert_eq!(violations[0].severity, Severity::Gentle);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_parameter_shadows_global_rule_reports_parameter_shadowing() {
+        let source = "use strict;\nuse warnings;\nmy $name = 'outer';\nsub helper($name) { return $name; }\nprint $name;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(ParameterShadowsGlobalRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.variables.parameter_shadows_global");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Parameter '$name' shadows an outer declaration");
+        assert_eq!(finding.suppression_key, "native.variables.parameter_shadows_global");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$name");
+
+        let fix = finding.fix.as_ref().expect("shadowing parameter should offer rename");
+        assert_eq!(fix.title, "Rename parameter to '$p_name'");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].range, finding.range);
+        assert_eq!(fix.edits[0].new_text, "$p_name");
+    }
+
+    #[test]
+    fn native_parameter_shadows_global_rule_accepts_unique_parameters() {
+        let source =
+            "use strict;\nuse warnings;\nmy $outer = 1;\nsub helper($inner) { return $inner; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(ParameterShadowsGlobalRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "non-shadowing parameters should be accepted");
+    }
+
+    #[test]
+    fn native_parameter_shadows_global_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $name = 'outer';\nsub helper($name) { return $name; }\nprint $name;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.variables.parameter_shadows_global".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(ParameterShadowsGlobalRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.variables.parameter_shadows_global -- fixture\nuse strict;\nuse warnings;\nmy $name = 'outer';\nsub helper($name) { return $name; }\nprint $name;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_parameter_shadows_global_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $name = 'outer';\nsub helper($name) { return $name; }\nprint $name;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(ParameterShadowsGlobalRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.variables.parameter_shadows_global");
+        assert_eq!(violations[0].description, "Parameter '$name' shadows an outer declaration");
+        assert_eq!(
+            violations[0].explanation,
+            "Rename the parameter or use the outer variable directly to avoid confusing scope shadowing."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
         assert_eq!(violations[0].file, "lib/App.pm");
     }
 

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -88,7 +88,8 @@ impl CodeActionsProvider {
             }
             Some(c)
                 if c == DiagnosticCode::ParameterShadowsGlobal.as_str()
-                    || c == "parameter-shadows-global" =>
+                    || c == "parameter-shadows-global"
+                    || c == "native.variables.parameter_shadows_global" =>
             {
                 fixes::fix_parameter_shadowing(diagnostic)
             }
@@ -593,6 +594,25 @@ mod tests {
         assert_eq!(actions[0].edit.new_text, "%p_opts");
         assert_eq!(actions[1].edit.new_text, "%opts_param");
         assert_eq!(actions[2].edit.new_text, "%opts_arg");
+    }
+
+    #[test]
+    fn test_native_critic_parameter_shadows_global_quick_fix() {
+        let diagnostic = make_diagnostic(
+            (20, 25),
+            DiagnosticSeverity::Warning,
+            "native.variables.parameter_shadows_global",
+            "Parameter '$name' shadows an outer declaration",
+        );
+
+        let provider = CodeActionsProvider::new(String::new());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 3);
+        assert_eq!(actions[0].title, "Rename parameter to '$p_name'");
+        assert_eq!(actions[0].edit.new_text, "$p_name");
+        assert_eq!(actions[1].title, "Rename parameter to '$name_param'");
+        assert_eq!(actions[2].title, "Rename parameter to '$name_arg'");
     }
 
     // ── Quick-fix: unused parameter ─────────────────────────────────────

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1348,7 +1348,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nprint $x + $shadow;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param;\n",
             None,
             &context,
             None,
@@ -1435,6 +1435,28 @@ mod tests {
             .ok_or("native duplicate parameter data should be populated")?;
         assert_eq!(data["code"], "native.variables.duplicate_parameter");
         assert_eq!(data["suppressionKey"], "native.variables.duplicate_parameter");
+        assert_eq!(data["fixable"], true);
+
+        let parameter_shadow = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.variables.parameter_shadows_global"))
+            })
+            .ok_or("expected native parameter shadowing finding")?;
+        assert_eq!(parameter_shadow.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(parameter_shadow.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(
+            parameter_shadow.message,
+            "Parameter '$outer_param' shadows an outer declaration"
+        );
+        let data = parameter_shadow
+            .data
+            .as_ref()
+            .ok_or("native parameter shadowing data should be populated")?;
+        assert_eq!(data["code"], "native.variables.parameter_shadows_global");
+        assert_eq!(data["suppressionKey"], "native.variables.parameter_shadows_global");
         assert_eq!(data["fixable"], true);
 
         let duplicate = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1835,7 +1835,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nprint $x + $shadow;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param;\n"
                 }
             })))
             .unwrap();
@@ -1877,6 +1877,14 @@ mod tests {
         assert!(
             text.contains("Parameter '$dup_param' appears more than once in this signature"),
             "native duplicate parameter finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.variables.parameter_shadows_global"),
+            "native critic engine should publish native parameter shadowing finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Parameter '$outer_param' shadows an outer declaration"),
+            "native parameter shadowing finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.variables.duplicate_lexical"),
@@ -1946,7 +1954,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nprint $x + $shadow;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param;\n"
             }
         })))?;
 
@@ -2003,6 +2011,15 @@ mod tests {
                         == Some("Parameter '$dup_param' appears more than once in this signature")
             }),
             "native critic engine should add native duplicate parameter finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.variables.parameter_shadows_global")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Parameter '$outer_param' shadows an outer declaration")
+            }),
+            "native critic engine should add native parameter shadowing finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.variables.parameter_shadows_global` for subroutine parameters that shadow an outer declaration. The rule reuses the existing `ScopeAnalyzer` `ParameterShadowsGlobal` facts, so this does not add a new scope walker or change the default critic engine.

The rule is wired through the native registry, config/suppression filtering, the legacy violation bridge, pull diagnostics, push/workspace diagnostics, and both core/LSP code-action aliases for parameter-shadowing rename suggestions.

## Notes

- Native critic remains explicit opt-in.
- Legacy/default critic behavior is unchanged.
- No new formatter, memory-policy, or runtime-default behavior is included.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_parameter_shadows_global --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core test_native_critic_policy_alias_for_parameter_shadows_global --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs test_native_critic_parameter_shadows_global_quick_fix --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`