### PR TITLE
feat(critic): add assignment-in-condition native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -126,7 +126,9 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
                     }
                     // PL403: Assignment in condition
-                    c if c == DiagnosticCode::AssignmentInCondition.as_str() => {
+                    c if c == DiagnosticCode::AssignmentInCondition.as_str()
+                        || c == "native.common.assignment_in_condition" =>
+                    {
                         actions.extend(quick_fixes::fix_assignment_in_condition(
                             &self.source,
                             &qf_diag,
@@ -360,6 +362,34 @@ mod tests {
         assert!(
             actions.iter().any(|a| a.title.contains("==")),
             "Expected action to change to comparison, got: {:?}",
+            actions
+        );
+    }
+
+    #[test]
+    fn test_native_critic_policy_alias_for_assignment_in_condition() {
+        let source = "if ($x = 5) { }";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![make_diagnostic(
+            4,
+            10,
+            "native.common.assignment_in_condition",
+            "Assignment in condition - did you mean '=='?",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(
+            actions.iter().any(|a| a.title == "Change to comparison (==)"
+                && a.edit.changes.iter().any(|edit| edit.new_text == "==")),
+            "Expected native critic alias to offer comparison fix, got: {:?}",
+            actions
+        );
+        assert!(
+            actions.iter().any(|a| a.title == "Keep assignment (add parentheses)"),
+            "Expected native critic alias to offer intentional-assignment fix, got: {:?}",
             actions
         );
     }

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -12,11 +12,12 @@ mod types;
 pub use analyzer::{CriticAnalyzer, hash_content};
 pub use built_in::{BuiltInAnalyzer, Policy};
 pub use native::{
-    CriticCategory, CriticContext, CriticFinding, CriticFix, CriticRelatedInformation, CriticRule,
-    CriticSuppression, CriticSuppressionMap, CriticSuppressionScope, CriticTextEdit,
-    DuplicateLexicalDeclarationRule, DuplicateParameterRule, FixSafety, NativeCriticRegistry,
-    ParameterShadowsGlobalRule, RequireUseStrictRule, RequireUseWarningsRule,
-    ShadowedLexicalVariableRule, UnusedLexicalVariableRule, UnusedParameterRule,
+    AssignmentInConditionRule, CriticCategory, CriticContext, CriticFinding, CriticFix,
+    CriticRelatedInformation, CriticRule, CriticSuppression, CriticSuppressionMap,
+    CriticSuppressionScope, CriticTextEdit, DuplicateLexicalDeclarationRule,
+    DuplicateParameterRule, FixSafety, NativeCriticRegistry, ParameterShadowsGlobalRule,
+    RequireUseStrictRule, RequireUseWarningsRule, ShadowedLexicalVariableRule,
+    UnusedLexicalVariableRule, UnusedParameterRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -7,6 +7,7 @@
 
 use super::{CriticConfig, Severity, Violation, insertion_range};
 use perl_parser_core::Node;
+use perl_parser_core::NodeKind;
 use perl_parser_core::position::{Position, Range};
 use perl_pragma::PragmaTracker;
 use perl_semantic_analyzer::scope_analyzer::{IssueKind, ScopeAnalyzer, ScopeIssue};
@@ -236,6 +237,7 @@ impl NativeCriticRegistry {
         Self::with_rules(vec![
             Box::new(RequireUseStrictRule),
             Box::new(RequireUseWarningsRule),
+            Box::new(AssignmentInConditionRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
             Box::new(DuplicateParameterRule),
@@ -430,6 +432,31 @@ impl CriticRule for RequireUseWarningsRule {
                 edits: vec![CriticTextEdit { range, new_text: "use warnings;\n".to_string() }],
             }),
         });
+    }
+}
+
+/// Native rule that reports assignments used directly as conditions.
+///
+/// This mirrors the existing common-mistake diagnostic through the native
+/// critic contract so opt-in native critic users get stable rule IDs,
+/// suppressions, severity filtering, and fix metadata.
+pub struct AssignmentInConditionRule;
+
+impl CriticRule for AssignmentInConditionRule {
+    fn id(&self) -> &'static str {
+        "native.common.assignment_in_condition"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Syntax
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_assignment_in_condition_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -736,6 +763,36 @@ fn parameter_shadows_global_finding(
     }
 }
 
+fn assignment_in_condition_finding(
+    rule: &AssignmentInConditionRule,
+    source: &str,
+    condition: &Node,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, condition.location.start, condition.location.end);
+    let fix = assignment_comparison_fix(source, condition.location.start, condition.location.end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: "Assignment in condition - did you mean '=='?".to_string(),
+        explanation: "Assignments in conditions are usually accidental. Use '==' for numeric comparison, 'eq' for string comparison, or add parentheses if the assignment is intentional.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: vec![
+            CriticRelatedInformation {
+                range,
+                message: "Use '==' for numeric comparison or 'eq' for string comparison.".to_string(),
+            },
+            CriticRelatedInformation {
+                range,
+                message: "If the assignment is intentional, wrap it in parentheses.".to_string(),
+            },
+        ],
+        fix,
+    }
+}
+
 fn duplicate_lexical_finding(
     rule: &DuplicateLexicalDeclarationRule,
     source: &str,
@@ -785,6 +842,123 @@ fn shadowed_lexical_finding(
             edits: vec![CriticTextEdit { range, new_text: replacement }],
         }),
     }
+}
+
+fn collect_assignment_in_condition_findings(
+    rule: &AssignmentInConditionRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    match &node.kind {
+        NodeKind::If { condition, elsif_branches, .. } => {
+            push_assignment_condition_finding(rule, source, condition, out);
+            for (elsif_condition, _) in elsif_branches {
+                push_assignment_condition_finding(rule, source, elsif_condition, out);
+            }
+        }
+        NodeKind::While { condition, .. } => {
+            push_assignment_condition_finding(rule, source, condition, out);
+        }
+        NodeKind::For { condition: Some(condition), .. } => {
+            push_assignment_condition_finding(rule, source, condition, out);
+        }
+        NodeKind::StatementModifier { modifier, condition, .. }
+            if matches!(modifier.as_str(), "if" | "unless" | "while" | "until") =>
+        {
+            push_assignment_condition_finding(rule, source, condition, out);
+        }
+        _ => {}
+    }
+
+    for child in node.children() {
+        collect_assignment_in_condition_findings(rule, source, child, out);
+    }
+}
+
+fn push_assignment_condition_finding(
+    rule: &AssignmentInConditionRule,
+    source: &str,
+    condition: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    if is_assignment_condition(source, condition) {
+        out.push(assignment_in_condition_finding(rule, source, condition));
+    }
+}
+
+fn is_assignment_condition(source: &str, condition: &Node) -> bool {
+    let is_assignment = matches!(
+        &condition.kind,
+        NodeKind::Binary { op, .. } if op == "="
+    ) || matches!(&condition.kind, NodeKind::Assignment { .. });
+
+    is_assignment
+        && !has_extra_condition_parentheses(
+            source,
+            condition.location.start,
+            condition.location.end,
+        )
+}
+
+fn has_extra_condition_parentheses(source: &str, start: usize, end: usize) -> bool {
+    preceding_open_parens(source, start) >= 2 && following_close_parens(source, end) >= 2
+}
+
+fn preceding_open_parens(source: &str, start: usize) -> usize {
+    let mut count = 0;
+    let mut cursor = start.min(source.len());
+    while cursor > 0 {
+        let Some((idx, ch)) = source[..cursor].char_indices().next_back() else {
+            break;
+        };
+        if ch.is_whitespace() {
+            cursor = idx;
+            continue;
+        }
+        if ch == '(' {
+            count += 1;
+            cursor = idx;
+            continue;
+        }
+        break;
+    }
+    count
+}
+
+fn following_close_parens(source: &str, end: usize) -> usize {
+    let mut count = 0;
+    let mut cursor = end.min(source.len());
+    while cursor < source.len() {
+        let Some(ch) = source[cursor..].chars().next() else {
+            break;
+        };
+        if ch.is_whitespace() {
+            cursor += ch.len_utf8();
+            continue;
+        }
+        if ch == ')' {
+            count += 1;
+            cursor += ch.len_utf8();
+            continue;
+        }
+        break;
+    }
+    count
+}
+
+fn assignment_comparison_fix(source: &str, start: usize, end: usize) -> Option<CriticFix> {
+    let start = start.min(source.len());
+    let end = end.min(source.len()).max(start);
+    let equals_offset = source[start..end].find('=')?;
+    let equals_start = start + equals_offset;
+    let range = range_for_byte_span(source, equals_start, equals_start + 1);
+
+    Some(CriticFix {
+        title: "Change to comparison (==)".to_string(),
+        safety: FixSafety::Suggested,
+        edits: vec![CriticTextEdit { range, new_text: "==".to_string() }],
+    })
 }
 
 fn duplicate_my_fix(source: &str, variable_start: usize) -> Option<CriticFix> {
@@ -1194,6 +1368,140 @@ mod tests {
     }
 
     #[test]
+    fn native_assignment_in_condition_rule_reports_if_assignment() {
+        let source = "use strict;\nuse warnings;\nmy $x = 0;\nif ($x = 5) { print $x; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(AssignmentInConditionRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.common.assignment_in_condition");
+        assert_eq!(finding.category, CriticCategory::Syntax);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Assignment in condition - did you mean '=='?");
+        assert_eq!(finding.suppression_key, "native.common.assignment_in_condition");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$x = 5");
+
+        let fix = finding.fix.as_ref().expect("assignment condition should offer comparison fix");
+        assert_eq!(fix.title, "Change to comparison (==)");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(&source[fix.edits[0].range.start.byte..fix.edits[0].range.end.byte], "=");
+        assert_eq!(fix.edits[0].new_text, "==");
+        assert_eq!(finding.related.len(), 2);
+    }
+
+    #[test]
+    fn native_assignment_in_condition_rule_reports_statement_modifier_assignment() {
+        let source = "use strict;\nuse warnings;\nmy $x = 0;\nprint $x if $x = 5;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(AssignmentInConditionRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "native.common.assignment_in_condition");
+        assert_eq!(&source[findings[0].range.start.byte..findings[0].range.end.byte], "$x = 5");
+    }
+
+    #[test]
+    fn native_assignment_in_condition_rule_reports_while_assignment() {
+        let source =
+            "use strict;\nuse warnings;\nmy $x = 0;\nwhile ($x = next_value()) { print $x; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(AssignmentInConditionRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "native.common.assignment_in_condition");
+        assert_eq!(
+            &source[findings[0].range.start.byte..findings[0].range.end.byte],
+            "$x = next_value()"
+        );
+    }
+
+    #[test]
+    fn native_assignment_in_condition_rule_accepts_comparisons() {
+        let source = "use strict;\nuse warnings;\nmy $x = 0;\nif ($x == 5) { print $x; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(AssignmentInConditionRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "comparison conditions should be accepted");
+    }
+
+    #[test]
+    fn native_assignment_in_condition_rule_accepts_explicitly_parenthesized_assignments() {
+        let source =
+            "use strict;\nuse warnings;\nmy $x = 0;\nif (($x = next_value())) { print $x; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(AssignmentInConditionRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(
+            findings.is_empty(),
+            "double-parenthesized assignment conditions are treated as intentional"
+        );
+    }
+
+    #[test]
+    fn native_assignment_in_condition_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $x = 0;\nif ($x = 5) { print $x; }\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.common.assignment_in_condition".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(AssignmentInConditionRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.common.assignment_in_condition -- intentional assignment\nuse strict;\nuse warnings;\nmy $x = 0;\nif ($x = 5) { print $x; }\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_assignment_in_condition_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $x = 0;\nif ($x = 5) { print $x; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(AssignmentInConditionRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.common.assignment_in_condition");
+        assert_eq!(violations[0].description, "Assignment in condition - did you mean '=='?");
+        assert_eq!(
+            violations[0].explanation,
+            "Assignments in conditions are usually accidental. Use '==' for numeric comparison, 'eq' for string comparison, or add parentheses if the assignment is intentional."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_recommended_registry_contains_initial_policy_bundle() {
         let source = "print 1;\n";
         let ast = parse_source(source);
@@ -1208,6 +1516,7 @@ mod tests {
             vec![
                 "native.testing.require_use_strict",
                 "native.testing.require_use_warnings",
+                "native.common.assignment_in_condition",
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",
                 "native.variables.duplicate_parameter",

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -75,6 +75,38 @@ pub(super) fn fix_unused_variable(
     actions
 }
 
+pub(super) fn fix_assignment_in_condition(
+    provider: &CodeActionsProvider,
+    diagnostic: &Diagnostic,
+) -> Vec<CodeAction> {
+    let Some(relative_pos) = provider.source()[diagnostic.range.0..diagnostic.range.1].find('=')
+    else {
+        return Vec::new();
+    };
+    let equals_pos = diagnostic.range.0 + relative_pos;
+
+    vec![
+        diagnostic_action(
+            diagnostic,
+            "Change to comparison (==)",
+            CodeActionKind::QuickFix,
+            TextEdit { range: (equals_pos, equals_pos + 1), new_text: "==".to_string() },
+        ),
+        diagnostic_action(
+            diagnostic,
+            "Keep assignment (add parentheses)",
+            CodeActionKind::QuickFix,
+            TextEdit {
+                range: diagnostic.range,
+                new_text: format!(
+                    "({})",
+                    &provider.source()[diagnostic.range.0..diagnostic.range.1]
+                ),
+            },
+        ),
+    ]
+}
+
 pub(super) fn add_use_strict(diagnostic: &Diagnostic) -> Vec<CodeAction> {
     vec![diagnostic_action(
         diagnostic,

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -63,6 +63,13 @@ impl CodeActionsProvider {
                 fixes::fix_unused_variable(self, diagnostic)
             }
             Some("native.variables.unused_lexical") => fixes::fix_unused_variable(self, diagnostic),
+            Some(c)
+                if c == DiagnosticCode::AssignmentInCondition.as_str()
+                    || c == "assignment-in-condition"
+                    || c == "native.common.assignment_in_condition" =>
+            {
+                fixes::fix_assignment_in_condition(self, diagnostic)
+            }
             Some("native.testing.require_use_strict") => fixes::add_use_strict(diagnostic),
             Some("native.testing.require_use_warnings") => fixes::add_use_warnings(diagnostic),
             Some(c)
@@ -613,6 +620,28 @@ mod tests {
         assert_eq!(actions[0].edit.new_text, "$p_name");
         assert_eq!(actions[1].title, "Rename parameter to '$name_param'");
         assert_eq!(actions[2].title, "Rename parameter to '$name_arg'");
+    }
+
+    #[test]
+    fn test_native_critic_assignment_in_condition_quick_fix() {
+        let source = "if ($x = 5) { }";
+        let diagnostic = make_diagnostic(
+            (4, 10),
+            DiagnosticSeverity::Warning,
+            "native.common.assignment_in_condition",
+            "Assignment in condition - did you mean '=='?",
+        );
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].title, "Change to comparison (==)");
+        assert_eq!(actions[0].edit.range, (7, 8));
+        assert_eq!(actions[0].edit.new_text, "==");
+        assert_eq!(actions[1].title, "Keep assignment (add parentheses)");
+        assert_eq!(actions[1].edit.range, (4, 10));
+        assert_eq!(actions[1].edit.new_text, "($x = 5)");
     }
 
     // ── Quick-fix: unused parameter ─────────────────────────────────────

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1348,7 +1348,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
             None,
             &context,
             None,
@@ -1379,6 +1379,25 @@ mod tests {
             })
             .ok_or("expected native warnings finding")?;
         assert_eq!(warnings.source.as_deref(), Some("perl-lsp-critic"));
+
+        let assignment = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.common.assignment_in_condition"))
+            })
+            .ok_or("expected native assignment-in-condition finding")?;
+        assert_eq!(assignment.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(assignment.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(assignment.message, "Assignment in condition - did you mean '=='?");
+        let data = assignment
+            .data
+            .as_ref()
+            .ok_or("native assignment-in-condition data should be populated")?;
+        assert_eq!(data["code"], "native.common.assignment_in_condition");
+        assert_eq!(data["suppressionKey"], "native.common.assignment_in_condition");
+        assert_eq!(data["fixable"], true);
 
         let unused = items
             .iter()

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1835,7 +1835,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
                 }
             })))
             .unwrap();
@@ -1853,6 +1853,14 @@ mod tests {
         assert!(
             text.contains("native.testing.require_use_warnings"),
             "native critic engine should publish native warnings finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.common.assignment_in_condition"),
+            "native critic engine should publish native assignment-in-condition finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Assignment in condition - did you mean '=='?"),
+            "native assignment-in-condition finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.variables.unused_lexical"),
@@ -1954,7 +1962,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
             }
         })))?;
 
@@ -1985,6 +1993,15 @@ mod tests {
                     && diag["source"].as_str() == Some("perl-lsp-critic")
             }),
             "native critic engine should add native warnings finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.common.assignment_in_condition")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Assignment in condition - did you mean '=='?")
+            }),
+            "native critic engine should add native assignment-in-condition finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.common.assignment_in_condition` for assignments used directly as control-flow conditions.

The rule reports direct condition assignments in `if`, `elsif`, `while`, `for`, and statement modifiers, while treating double-parenthesized assignments like `if (($x = next_value()))` as intentionally outside this rule boundary. It emits a stable native rule ID, `Syntax` category, `Stern` severity, suppression key, related guidance, and a suggested `Change to comparison (==)` fix.

## Notes

- Native critic remains explicit opt-in.
- Legacy/default critic behavior is unchanged.
- No formatter work, execute-command change, config-schema change, or runtime default change is included.
- The native rule is wired through pull, push, and workspace diagnostics, plus core and LSP-facing code-action aliases.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_assignment_in_condition --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs test_native_critic_assignment_in_condition_quick_fix --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`