### PR TITLE
feat(lsp): add provider fact-source trace receipts (#8197)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
@@ -726,7 +726,10 @@ mod tests {
 
         assert_eq!(result.receipt.query, ShadowQueryName::CompletionVisibility);
         assert_eq!(result.receipt.input.symbol, "use Foo");
-        assert_eq!(result.receipt.schema_version, 1);
+        assert_eq!(
+            result.receipt.schema_version,
+            perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
@@ -456,7 +456,10 @@ mod tests {
         assert!(result.legacy_should_warn);
         assert_eq!(result.receipt.query, ShadowQueryName::DiagnosticsCheck);
         assert_eq!(result.receipt.input.symbol, "undefined_sub");
-        assert_eq!(result.receipt.schema_version, 1);
+        assert_eq!(
+            result.receipt.schema_version,
+            perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION
+        );
         // Legacy warns (1 identity), new also warns (1 identity) -> Same.
         assert_eq!(result.receipt.old_result.available, true);
         assert_eq!(result.receipt.old_result.match_count, 1);
@@ -508,7 +511,10 @@ mod tests {
 
         assert_eq!(result.receipt.query, ShadowQueryName::DiagnosticsCheck);
         assert_eq!(result.receipt.input.symbol, "test");
-        assert_eq!(result.receipt.schema_version, 1);
+        assert_eq!(
+            result.receipt.schema_version,
+            perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/dynamic_boundary_acceptance.rs
@@ -33,6 +33,7 @@ mod tests {
     use perl_workspace::semantic::queries::{
         DynamicCallableEvidence, QueryContext, SemanticQueries,
     };
+    use perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION;
 
     // ── Configurable SemanticQueries stub ──
 
@@ -512,12 +513,16 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_scope_receipt_schema_version_is_one() -> Result<(), Box<dyn std::error::Error>> {
+    fn dynamic_scope_receipt_uses_current_schema_version() -> Result<(), Box<dyn std::error::Error>>
+    {
         let stub = DynamicBoundaryStub::empty_in_dynamic_scope();
         let outcome =
             diagnostics_undefined_symbol_cutover(true, &stub, "test_sym", FileId(1), None, 0, true);
 
-        assert_eq!(outcome.receipt.schema_version, 1, "receipt schema version should be 1");
+        assert_eq!(
+            outcome.receipt.schema_version, SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION,
+            "receipt schema version should match semantic shadow compare"
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
@@ -433,7 +433,10 @@ mod tests {
         let result = goto_definition_shadow(&index, &queries, "test", &ctx);
         assert_eq!(result.receipt.query, ShadowQueryName::FindDefinition);
         assert_eq!(result.receipt.input.symbol, "test");
-        assert_eq!(result.receipt.schema_version, 1);
+        assert_eq!(
+            result.receipt.schema_version,
+            perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
@@ -849,7 +849,10 @@ mod tests {
 
         assert_eq!(result.legacy_text.as_deref(), Some("legacy hover"));
         assert_eq!(result.receipt.input.symbol, "test");
-        assert_eq!(result.receipt.schema_version, 1);
+        assert_eq!(
+            result.receipt.schema_version,
+            perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
@@ -430,7 +430,10 @@ mod tests {
 
         assert_eq!(result.receipt.query, ShadowQueryName::FindReferences);
         assert_eq!(result.receipt.input.symbol, "test");
-        assert_eq!(result.receipt.schema_version, 1);
+        assert_eq!(
+            result.receipt.schema_version,
+            perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/navigation/rename_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/rename_shadow.rs
@@ -394,7 +394,10 @@ mod tests {
         let result = rename_shadow(true, &queries, EntityId(1), "new");
 
         assert_eq!(result.receipt.query, ShadowQueryName::RenamePlan);
-        assert_eq!(result.receipt.schema_version, 1);
+        assert_eq!(
+            result.receipt.schema_version,
+            perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/navigation/safe_delete_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/safe_delete_shadow.rs
@@ -347,7 +347,10 @@ mod tests {
         let result = safe_delete_shadow(true, &queries, EntityId(1), "test");
 
         assert_eq!(result.receipt.query, ShadowQueryName::SafeDeletePlan);
-        assert_eq!(result.receipt.schema_version, 1);
+        assert_eq!(
+            result.receipt.schema_version,
+            perl_workspace::semantic_shadow_compare::SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION
+        );
         Ok(())
     }
 

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -618,6 +618,126 @@ pub enum ValueShape {
     },
 }
 
+// ── Provider Fact-Source Tracing ─────────────────────────────────────
+
+/// LSP provider surface that consumed or considered a semantic fact.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ProviderSurface {
+    Diagnostics,
+    Completion,
+    Hover,
+    Definition,
+    References,
+    Rename,
+    SafeDelete,
+    WorkspaceSymbols,
+    SemanticTokens,
+}
+
+/// Coarse source class for a provider answer.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ProviderFactSourceKind {
+    /// Parser tokens or AST shape.
+    ParserSyntax,
+    /// Legacy workspace index or provider-local data.
+    LegacyWorkspace,
+    /// Canonical semantic fact graph.
+    SemanticFact,
+    /// Rust compiler-substrate fact.
+    CompilerFact,
+    /// Framework adapter projection.
+    FrameworkAdapter,
+    /// Dynamic-boundary fact used to avoid false precision.
+    DynamicBoundary,
+    /// Fallback behavior because no stronger fact was available.
+    Fallback,
+    /// Source is intentionally unknown or unavailable.
+    Unknown,
+}
+
+/// Freshness state for a provider fact source.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ProviderFactFreshness {
+    Fresh,
+    Stale,
+    Unknown,
+    NotApplicable,
+}
+
+/// How a provider used a traced fact source.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum ProviderFallbackState {
+    /// Primary answer path used this source.
+    Primary,
+    /// Source was measured but not used for live behavior.
+    Shadow,
+    /// Provider fell back from a stronger unavailable source.
+    Fallback,
+    /// Source existed but could not answer this request.
+    Unavailable,
+    /// Source blocked an unsafe provider action.
+    Blocked,
+}
+
+/// Source/provenance trace for a provider answer.
+///
+/// This is an additive contract for provider cutover proof. It lets providers
+/// report where an answer came from before any broad provider behavior change.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderFactTrace {
+    /// Provider surface that produced the answer.
+    pub surface: ProviderSurface,
+    /// Coarse source class used by the provider.
+    pub source: ProviderFactSourceKind,
+    /// Semantic provenance for the underlying fact, when known.
+    pub provenance: Provenance,
+    /// Confidence in the underlying fact or fallback.
+    pub confidence: Confidence,
+    /// Freshness of the underlying fact relative to the request.
+    pub freshness: ProviderFactFreshness,
+    /// Whether this source drove live behavior, shadow proof, fallback, or a blocker.
+    pub fallback_state: ProviderFallbackState,
+    /// Optional stable source hash used by the producer.
+    pub source_hash: Option<String>,
+    /// Optional semantic anchor used by the producer.
+    pub anchor_id: Option<AnchorId>,
+    /// Optional fact/model version used by the producer.
+    pub model_version: Option<u32>,
+}
+
+impl ProviderFactTrace {
+    /// Construct a new provider fact trace.
+    #[allow(clippy::too_many_arguments)] // mirrors the public trace fields 1-to-1
+    pub fn new(
+        surface: ProviderSurface,
+        source: ProviderFactSourceKind,
+        provenance: Provenance,
+        confidence: Confidence,
+        freshness: ProviderFactFreshness,
+        fallback_state: ProviderFallbackState,
+        source_hash: Option<String>,
+        anchor_id: Option<AnchorId>,
+        model_version: Option<u32>,
+    ) -> Self {
+        Self {
+            surface,
+            source,
+            provenance,
+            confidence,
+            freshness,
+            fallback_state,
+            source_hash,
+            anchor_id,
+            model_version,
+        }
+    }
+}
+
 // ── Rename and Safe Delete Plans ────────────────────────────────────
 
 /// A conservative rename plan enumerating affected occurrences and blockers.
@@ -1145,6 +1265,114 @@ mod tests {
         let serialized = serde_json::to_string(&candidate)?;
         let decoded: DefinitionCandidate = serde_json::from_str(&serialized)?;
         assert_eq!(decoded, candidate);
+        Ok(())
+    }
+
+    /// ProviderFactTrace round-trips through JSON with source hash and model version.
+    #[test]
+    fn provider_fact_trace_roundtrips_through_json() -> Result<(), serde_json::Error> {
+        let trace = ProviderFactTrace::new(
+            ProviderSurface::Completion,
+            ProviderFactSourceKind::CompilerFact,
+            Provenance::ImportExportInference,
+            Confidence::High,
+            ProviderFactFreshness::Fresh,
+            ProviderFallbackState::Shadow,
+            Some("fixture-source-sha".to_string()),
+            Some(AnchorId(10)),
+            Some(1),
+        );
+
+        let serialized = serde_json::to_string(&trace)?;
+        let decoded: ProviderFactTrace = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, trace);
+        Ok(())
+    }
+
+    /// ProviderFactTrace keeps null freshness metadata explicit when unavailable.
+    #[test]
+    fn provider_fact_trace_optional_metadata_roundtrips() -> Result<(), serde_json::Error> {
+        let trace = ProviderFactTrace::new(
+            ProviderSurface::Diagnostics,
+            ProviderFactSourceKind::Fallback,
+            Provenance::SearchFallback,
+            Confidence::Low,
+            ProviderFactFreshness::NotApplicable,
+            ProviderFallbackState::Fallback,
+            None,
+            None,
+            None,
+        );
+
+        let serialized = serde_json::to_string(&trace)?;
+        let decoded: ProviderFactTrace = serde_json::from_str(&serialized)?;
+        assert_eq!(decoded, trace);
+        assert!(
+            serialized.contains("\"source_hash\":null")
+                && serialized.contains("\"anchor_id\":null")
+                && serialized.contains("\"model_version\":null"),
+            "optional trace metadata should remain explicit for downstream consumers"
+        );
+        Ok(())
+    }
+
+    /// Provider trace enums round-trip through JSON for every current variant.
+    #[test]
+    fn provider_fact_trace_enums_roundtrip_through_json() -> Result<(), serde_json::Error> {
+        for surface in [
+            ProviderSurface::Diagnostics,
+            ProviderSurface::Completion,
+            ProviderSurface::Hover,
+            ProviderSurface::Definition,
+            ProviderSurface::References,
+            ProviderSurface::Rename,
+            ProviderSurface::SafeDelete,
+            ProviderSurface::WorkspaceSymbols,
+            ProviderSurface::SemanticTokens,
+        ] {
+            let serialized = serde_json::to_string(&surface)?;
+            let decoded: ProviderSurface = serde_json::from_str(&serialized)?;
+            assert_eq!(decoded, surface);
+        }
+
+        for source in [
+            ProviderFactSourceKind::ParserSyntax,
+            ProviderFactSourceKind::LegacyWorkspace,
+            ProviderFactSourceKind::SemanticFact,
+            ProviderFactSourceKind::CompilerFact,
+            ProviderFactSourceKind::FrameworkAdapter,
+            ProviderFactSourceKind::DynamicBoundary,
+            ProviderFactSourceKind::Fallback,
+            ProviderFactSourceKind::Unknown,
+        ] {
+            let serialized = serde_json::to_string(&source)?;
+            let decoded: ProviderFactSourceKind = serde_json::from_str(&serialized)?;
+            assert_eq!(decoded, source);
+        }
+
+        for freshness in [
+            ProviderFactFreshness::Fresh,
+            ProviderFactFreshness::Stale,
+            ProviderFactFreshness::Unknown,
+            ProviderFactFreshness::NotApplicable,
+        ] {
+            let serialized = serde_json::to_string(&freshness)?;
+            let decoded: ProviderFactFreshness = serde_json::from_str(&serialized)?;
+            assert_eq!(decoded, freshness);
+        }
+
+        for fallback_state in [
+            ProviderFallbackState::Primary,
+            ProviderFallbackState::Shadow,
+            ProviderFallbackState::Fallback,
+            ProviderFallbackState::Unavailable,
+            ProviderFallbackState::Blocked,
+        ] {
+            let serialized = serde_json::to_string(&fallback_state)?;
+            let decoded: ProviderFallbackState = serde_json::from_str(&serialized)?;
+            assert_eq!(decoded, fallback_state);
+        }
+
         Ok(())
     }
 

--- a/crates/perl-semantic-facts/tests/bdd_semantic_facts.rs
+++ b/crates/perl-semantic-facts/tests/bdd_semantic_facts.rs
@@ -13,8 +13,9 @@ use perl_semantic_facts::{
     ExportSet, ExportTag, FileId, GeneratedMember, GeneratedMemberKind, ImportKind, ImportSpec,
     ImportSymbols, OccurrenceFact, OccurrenceId, OccurrenceKind, PackageEdge, PackageEdgeKind,
     PackageKind, PackageNode, PlanBlocker, PlanBlockerReason, PlanWarning, PlannedEdit,
-    PlannedEditCategory, Provenance, RenamePlan, SafeDeletePlan, ScopeId, ValueShape,
-    VisibleSymbol, VisibleSymbolContext, VisibleSymbolSource,
+    PlannedEditCategory, Provenance, ProviderFactFreshness, ProviderFactSourceKind,
+    ProviderFactTrace, ProviderFallbackState, ProviderSurface, RenamePlan, SafeDeletePlan, ScopeId,
+    ValueShape, VisibleSymbol, VisibleSymbolContext, VisibleSymbolSource,
 };
 
 // ── Scenario 1: Goto-Definition Provider — Candidate Ranking ──────────────
@@ -897,6 +898,58 @@ fn given_mixed_package_nodes_when_filtering_by_kind_then_classes_and_roles_separ
     assert_eq!(externals.len(), 1);
     assert_eq!(classes[0].name, "App::Model");
     assert_eq!(roles[0].name, "Role::Printable");
+}
+
+// ── Scenario 17: Provider Fact Trace — Cutover Proof ─────────────────
+
+/// Given a provider answer sourced from shadowed compiler facts,
+/// when the answer is traced,
+/// then the trace records provider surface, fact source, provenance, confidence,
+/// freshness, and fallback state without changing provider behavior.
+#[test]
+fn given_provider_answer_when_traced_then_source_provenance_and_fallback_are_explicit() {
+    let trace = ProviderFactTrace::new(
+        ProviderSurface::Completion,
+        ProviderFactSourceKind::CompilerFact,
+        Provenance::ImportExportInference,
+        Confidence::High,
+        ProviderFactFreshness::Fresh,
+        ProviderFallbackState::Shadow,
+        Some("fixture-source-sha".to_string()),
+        Some(AnchorId(17)),
+        Some(1),
+    );
+
+    assert_eq!(trace.surface, ProviderSurface::Completion);
+    assert_eq!(trace.source, ProviderFactSourceKind::CompilerFact);
+    assert_eq!(trace.provenance, Provenance::ImportExportInference);
+    assert_eq!(trace.confidence, Confidence::High);
+    assert_eq!(trace.freshness, ProviderFactFreshness::Fresh);
+    assert_eq!(trace.fallback_state, ProviderFallbackState::Shadow);
+    assert_eq!(trace.anchor_id, Some(AnchorId(17)));
+}
+
+/// Given a provider blocks an unsafe refactor because of a dynamic boundary,
+/// when the blocker is traced,
+/// then the trace records the dynamic-boundary source and blocked state.
+#[test]
+fn given_dynamic_boundary_blocker_when_traced_then_provider_source_is_blocked() {
+    let trace = ProviderFactTrace::new(
+        ProviderSurface::Rename,
+        ProviderFactSourceKind::DynamicBoundary,
+        Provenance::DynamicBoundary,
+        Confidence::Low,
+        ProviderFactFreshness::Fresh,
+        ProviderFallbackState::Blocked,
+        None,
+        Some(AnchorId(18)),
+        Some(1),
+    );
+
+    assert_eq!(trace.surface, ProviderSurface::Rename);
+    assert_eq!(trace.source, ProviderFactSourceKind::DynamicBoundary);
+    assert_eq!(trace.fallback_state, ProviderFallbackState::Blocked);
+    assert_eq!(trace.anchor_id, Some(AnchorId(18)));
 }
 
 // ── Scenario 17: ExportSet — Tag-Based Resolution ─────────────────────────

--- a/crates/perl-workspace/src/semantic_shadow_compare.rs
+++ b/crates/perl-workspace/src/semantic_shadow_compare.rs
@@ -1,5 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+use perl_semantic_facts::ProviderFactTrace;
+
+/// Current semantic shadow-compare receipt schema version.
+pub const SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION: u32 = 2;
+
 /// Deterministic verdict for semantic shadow compare receipts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -79,6 +84,8 @@ pub struct SemanticShadowCompareReceipt {
     pub verdict: ShadowCompareVerdict,
     /// Additional notes for operators.
     pub notes: Vec<String>,
+    /// Typed fact-source traces for provider cutover proof.
+    pub fact_source_traces: Vec<ProviderFactTrace>,
 }
 
 impl SemanticShadowCompareReceipt {
@@ -90,8 +97,36 @@ impl SemanticShadowCompareReceipt {
         new_result: ShadowResultSummary,
         notes: Vec<String>,
     ) -> Self {
+        Self::from_summaries_with_fact_source_traces(
+            query,
+            input,
+            old_result,
+            new_result,
+            notes,
+            Vec::new(),
+        )
+    }
+
+    /// Build a deterministic receipt with typed provider fact-source traces.
+    pub fn from_summaries_with_fact_source_traces(
+        query: ShadowQueryName,
+        input: ShadowQueryInput,
+        old_result: ShadowResultSummary,
+        new_result: ShadowResultSummary,
+        notes: Vec<String>,
+        fact_source_traces: Vec<ProviderFactTrace>,
+    ) -> Self {
         let verdict = classify_verdict(&old_result, &new_result);
-        Self { schema_version: 1, query, input, old_result, new_result, verdict, notes }
+        Self {
+            schema_version: SEMANTIC_SHADOW_COMPARE_RECEIPT_SCHEMA_VERSION,
+            query,
+            input,
+            old_result,
+            new_result,
+            verdict,
+            notes,
+            fact_source_traces,
+        }
     }
 }
 
@@ -154,7 +189,7 @@ mod tests {
 
         let got: serde_json::Value = serde_json::to_value(&receipt)?;
         let expected = serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "query": "find_references",
             "input": {"symbol": "My::pkg::f"},
             "old_result": {
@@ -168,7 +203,64 @@ mod tests {
                 "identities": ["a.pm:1:1", "c.pm:9:9"]
             },
             "verdict": "ambiguous",
-            "notes": ["fixture=h1"]
+            "notes": ["fixture=h1"],
+            "fact_source_traces": []
+        });
+        assert_eq!(got, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn receipt_json_shape_includes_provider_fact_source_traces()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let trace = ProviderFactTrace::new(
+            perl_semantic_facts::ProviderSurface::Definition,
+            perl_semantic_facts::ProviderFactSourceKind::CompilerFact,
+            perl_semantic_facts::Provenance::SemanticAnalyzer,
+            perl_semantic_facts::Confidence::High,
+            perl_semantic_facts::ProviderFactFreshness::Fresh,
+            perl_semantic_facts::ProviderFallbackState::Shadow,
+            Some("fixture-source-sha".to_string()),
+            Some(perl_semantic_facts::AnchorId(10)),
+            Some(1),
+        );
+        let receipt = SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
+            ShadowQueryName::FindDefinition,
+            ShadowQueryInput { symbol: "Foo::bar".to_string() },
+            summarize_identities(Some(vec!["lib/Foo.pm:10:5".to_string()])),
+            summarize_identities(Some(vec!["lib/Foo.pm:10:5".to_string()])),
+            vec!["fact-source trace fixture".to_string()],
+            vec![trace],
+        );
+
+        let got: serde_json::Value = serde_json::to_value(&receipt)?;
+        let expected = serde_json::json!({
+            "schema_version": 2,
+            "query": "find_definition",
+            "input": {"symbol": "Foo::bar"},
+            "old_result": {
+                "available": true,
+                "match_count": 1,
+                "identities": ["lib/Foo.pm:10:5"]
+            },
+            "new_result": {
+                "available": true,
+                "match_count": 1,
+                "identities": ["lib/Foo.pm:10:5"]
+            },
+            "verdict": "same",
+            "notes": ["fact-source trace fixture"],
+            "fact_source_traces": [{
+                "surface": "Definition",
+                "source": "CompilerFact",
+                "provenance": "SemanticAnalyzer",
+                "confidence": "High",
+                "freshness": "Fresh",
+                "fallback_state": "Shadow",
+                "source_hash": "fixture-source-sha",
+                "anchor_id": 10,
+                "model_version": 1
+            }]
         });
         assert_eq!(got, expected);
         Ok(())
@@ -327,7 +419,7 @@ mod tests {
 
         let got: serde_json::Value = serde_json::to_value(&receipt)?;
         let expected = serde_json::json!({
-            "schema_version": 1,
+            "schema_version": 2,
             "query": "visible_symbols",
             "input": {"symbol": "my_func"},
             "old_result": {
@@ -341,7 +433,8 @@ mod tests {
                 "identities": ["a.pm:1:1", "b.pm:2:2"]
             },
             "verdict": "improved",
-            "notes": []
+            "notes": [],
+            "fact_source_traces": []
         });
         assert_eq!(got, expected);
         Ok(())

--- a/docs/project/status/semantic_shadow_compare.json
+++ b/docs/project/status/semantic_shadow_compare.json
@@ -1,10 +1,10 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "measured_at": "deterministic-fixture-baseline",
   "subsystem": "semantic_shadow_compare",
   "receipts": [
     {
-      "schema_version": 1,
+      "schema_version": 2,
       "query": "find_definition",
       "input": {
         "symbol": "Foo::bar"
@@ -26,10 +26,23 @@
       "verdict": "same",
       "notes": [
         "definition exact match fixture"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Definition",
+          "source": "CompilerFact",
+          "provenance": "SemanticAnalyzer",
+          "confidence": "High",
+          "freshness": "Fresh",
+          "fallback_state": "Shadow",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
       ]
     },
     {
-      "schema_version": 1,
+      "schema_version": 2,
       "query": "find_references",
       "input": {
         "symbol": "Foo::bar"
@@ -52,10 +65,23 @@
       "verdict": "improved",
       "notes": [
         "reference improved count fixture"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "References",
+          "source": "SemanticFact",
+          "provenance": "SemanticAnalyzer",
+          "confidence": "High",
+          "freshness": "Fresh",
+          "fallback_state": "Shadow",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
       ]
     },
     {
-      "schema_version": 1,
+      "schema_version": 2,
       "query": "count_usages",
       "input": {
         "symbol": "Foo::bar"
@@ -73,10 +99,23 @@
       "verdict": "regression",
       "notes": [
         "count regression sentinel fixture"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "References",
+          "source": "SemanticFact",
+          "provenance": "SemanticAnalyzer",
+          "confidence": "Medium",
+          "freshness": "Fresh",
+          "fallback_state": "Shadow",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
       ]
     },
     {
-      "schema_version": 1,
+      "schema_version": 2,
       "query": "visible_symbols",
       "input": {
         "symbol": "Foo::bar"
@@ -100,10 +139,23 @@
       "verdict": "ambiguous",
       "notes": [
         "visible symbol ambiguity fixture"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Completion",
+          "source": "CompilerFact",
+          "provenance": "ImportExportInference",
+          "confidence": "Medium",
+          "freshness": "Fresh",
+          "fallback_state": "Shadow",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
       ]
     },
     {
-      "schema_version": 1,
+      "schema_version": 2,
       "query": "hover",
       "input": {
         "symbol": "Foo::bar"
@@ -123,6 +175,19 @@
       "verdict": "unavailable",
       "notes": [
         "unavailable fact-backed hover fixture"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Hover",
+          "source": "Fallback",
+          "provenance": "SearchFallback",
+          "confidence": "Low",
+          "freshness": "NotApplicable",
+          "fallback_state": "Unavailable",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
       ]
     }
   ],

--- a/docs/project/status/semantic_shadow_compare.md
+++ b/docs/project/status/semantic_shadow_compare.md
@@ -44,4 +44,14 @@ Receipts: `5`
 | schema-fixture | VisibleSymbols | `Foo::bar` | ambiguous | 2 | 2 |
 | schema-fixture | Hover | `Foo::bar` | unavailable | 0 | 1 |
 
+## Fact Source Traces
+
+| Scope | Query | Surface | Source | Provenance | Confidence | Freshness | State |
+|---|---|---|---|---|---|---|---|
+| release-readiness | FindDefinition | Definition | CompilerFact | SemanticAnalyzer | High | Fresh | Shadow |
+| release-readiness | FindReferences | References | SemanticFact | SemanticAnalyzer | High | Fresh | Shadow |
+| schema-fixture | CountUsages | References | SemanticFact | SemanticAnalyzer | Medium | Fresh | Shadow |
+| schema-fixture | VisibleSymbols | Completion | CompilerFact | ImportExportInference | Medium | Fresh | Shadow |
+| schema-fixture | Hover | Hover | Fallback | SearchFallback | Low | NotApplicable | Unavailable |
+
 0.13.2 semantic shadow proof: release-readiness counts include provider-gating receipts only; schema fixture receipts exercise non-gating verdict shapes.

--- a/xtask/src/tasks/semantic_shadow_compare.rs
+++ b/xtask/src/tasks/semantic_shadow_compare.rs
@@ -1,5 +1,9 @@
 use crate::utils::project_root;
 use color_eyre::eyre::{Context, Result, bail};
+use perl_semantic_facts::{
+    AnchorId, Confidence, Provenance, ProviderFactFreshness, ProviderFactSourceKind,
+    ProviderFactTrace, ProviderFallbackState, ProviderSurface,
+};
 use perl_workspace::semantic_shadow_compare::{
     SemanticShadowCompareReceipt, ShadowCompareVerdict, ShadowQueryInput, ShadowQueryName,
     ShadowResultSummary, summarize_identities,
@@ -54,6 +58,14 @@ fn build_artifact() -> Artifact {
             Some(vec!["lib/Foo.pm:10:5"]),
             Some(vec!["lib/Foo.pm:10:5"]),
             "definition exact match fixture",
+            vec![trace(
+                ProviderSurface::Definition,
+                ProviderFactSourceKind::CompilerFact,
+                Provenance::SemanticAnalyzer,
+                Confidence::High,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Shadow,
+            )],
         ),
         receipt_from_identities(
             ShadowQueryName::FindReferences,
@@ -61,6 +73,14 @@ fn build_artifact() -> Artifact {
             Some(vec!["lib/Foo.pm:10:5"]),
             Some(vec!["lib/Foo.pm:10:5", "t/foo.t:4:1"]),
             "reference improved count fixture",
+            vec![trace(
+                ProviderSurface::References,
+                ProviderFactSourceKind::SemanticFact,
+                Provenance::SemanticAnalyzer,
+                Confidence::High,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Shadow,
+            )],
         ),
         receipt_from_counts(
             ShadowQueryName::CountUsages,
@@ -68,6 +88,14 @@ fn build_artifact() -> Artifact {
             ShadowResultSummary { available: true, match_count: 4, identities: Vec::new() },
             ShadowResultSummary { available: true, match_count: 3, identities: Vec::new() },
             "count regression sentinel fixture",
+            vec![trace(
+                ProviderSurface::References,
+                ProviderFactSourceKind::SemanticFact,
+                Provenance::SemanticAnalyzer,
+                Confidence::Medium,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Shadow,
+            )],
         ),
         receipt_from_identities(
             ShadowQueryName::VisibleSymbols,
@@ -75,6 +103,14 @@ fn build_artifact() -> Artifact {
             Some(vec!["alpha", "beta"]),
             Some(vec!["alpha", "gamma"]),
             "visible symbol ambiguity fixture",
+            vec![trace(
+                ProviderSurface::Completion,
+                ProviderFactSourceKind::CompilerFact,
+                Provenance::ImportExportInference,
+                Confidence::Medium,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Shadow,
+            )],
         ),
         receipt_from_identities(
             ShadowQueryName::Hover,
@@ -82,6 +118,14 @@ fn build_artifact() -> Artifact {
             None,
             Some(vec!["hover:Foo::bar"]),
             "unavailable fact-backed hover fixture",
+            vec![trace(
+                ProviderSurface::Hover,
+                ProviderFactSourceKind::Fallback,
+                Provenance::SearchFallback,
+                Confidence::Low,
+                ProviderFactFreshness::NotApplicable,
+                ProviderFallbackState::Unavailable,
+            )],
         ),
     ];
 
@@ -92,7 +136,7 @@ fn build_artifact() -> Artifact {
         count_verdicts(receipts.iter().filter(|receipt| !is_release_readiness_receipt(receipt)));
 
     Artifact {
-        schema_version: 2,
+        schema_version: 3,
         measured_at: "deterministic-fixture-baseline",
         subsystem: "semantic_shadow_compare",
         receipts,
@@ -138,13 +182,15 @@ fn receipt_from_identities(
     old: Option<Vec<&str>>,
     new: Option<Vec<&str>>,
     note: &str,
+    fact_source_traces: Vec<ProviderFactTrace>,
 ) -> SemanticShadowCompareReceipt {
-    SemanticShadowCompareReceipt::from_summaries(
+    SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
         query,
         ShadowQueryInput { symbol: symbol.to_string() },
         summarize_identities(old.map(strs_to_strings)),
         summarize_identities(new.map(strs_to_strings)),
         vec![note.to_string()],
+        fact_source_traces,
     )
 }
 
@@ -154,13 +200,36 @@ fn receipt_from_counts(
     old_result: ShadowResultSummary,
     new_result: ShadowResultSummary,
     note: &str,
+    fact_source_traces: Vec<ProviderFactTrace>,
 ) -> SemanticShadowCompareReceipt {
-    SemanticShadowCompareReceipt::from_summaries(
+    SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
         query,
         ShadowQueryInput { symbol: symbol.to_string() },
         old_result,
         new_result,
         vec![note.to_string()],
+        fact_source_traces,
+    )
+}
+
+fn trace(
+    surface: ProviderSurface,
+    source: ProviderFactSourceKind,
+    provenance: Provenance,
+    confidence: Confidence,
+    freshness: ProviderFactFreshness,
+    fallback_state: ProviderFallbackState,
+) -> ProviderFactTrace {
+    ProviderFactTrace::new(
+        surface,
+        source,
+        provenance,
+        confidence,
+        freshness,
+        fallback_state,
+        Some("deterministic-fixture".to_string()),
+        Some(AnchorId(1)),
+        Some(1),
     )
 }
 
@@ -238,6 +307,27 @@ fn render_status_markdown(artifact: &Artifact) -> String {
         ));
     }
 
+    text.push_str("\n## Fact Source Traces\n\n");
+    text.push_str(
+        "| Scope | Query | Surface | Source | Provenance | Confidence | Freshness | State |\n",
+    );
+    text.push_str("|---|---|---|---|---|---|---|---|\n");
+    for receipt in &artifact.receipts {
+        for trace in &receipt.fact_source_traces {
+            text.push_str(&format!(
+                "| {} | {:?} | {:?} | {:?} | {:?} | {:?} | {:?} | {:?} |\n",
+                receipt_scope(receipt),
+                receipt.query,
+                trace.surface,
+                trace.source,
+                trace.provenance,
+                trace.confidence,
+                trace.freshness,
+                trace.fallback_state
+            ));
+        }
+    }
+
     text.push('\n');
     text.push_str(artifact.notes);
     text.push('\n');
@@ -251,7 +341,7 @@ mod tests {
     #[test]
     fn artifact_includes_required_verdict_rows() {
         let artifact = build_artifact();
-        assert_eq!(artifact.schema_version, 2);
+        assert_eq!(artifact.schema_version, 3);
         assert_eq!(artifact.verdict_counts.get("same"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("improved"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("regression"), Some(&1));
@@ -264,6 +354,10 @@ mod tests {
         assert_eq!(artifact.schema_fixture_verdict_counts.get("regression"), Some(&1));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("ambiguous"), Some(&1));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("unavailable"), Some(&1));
+        assert!(
+            artifact.receipts.iter().all(|receipt| !receipt.fact_source_traces.is_empty()),
+            "every deterministic shadow-compare receipt should carry fact-source trace proof"
+        );
     }
 
     #[test]
@@ -281,6 +375,8 @@ mod tests {
         assert!(markdown.contains("## Schema Fixture Verdict Counts"));
         assert!(markdown.contains("| release-readiness | FindDefinition"));
         assert!(markdown.contains("| schema-fixture | CountUsages"));
+        assert!(markdown.contains("## Fact Source Traces"));
+        assert!(markdown.contains("| release-readiness | FindDefinition | Definition | CompilerFact | SemanticAnalyzer | High | Fresh | Shadow |"));
     }
 
     #[test]


### PR DESCRIPTION
Problem: Provider cutover proof has shadow receipts, but no typed fact-source trace contract for showing where provider answers came from.
Fix: Add additive provider fact-source trace types, include them in semantic shadow-compare receipts/status output, and regenerate the deterministic status artifacts without changing provider runtime behavior. Provider shadow tests now assert the shared receipt schema constant instead of hardcoding the old schema version.
Verification:
- `cargo test -p perl-semantic-facts --profile agent --locked provider_fact_trace -- --nocapture`
- `cargo test -p perl-semantic-facts --profile agent --locked given_provider_answer -- --nocapture`
- `cargo test -p perl-semantic-facts --profile agent --locked dynamic_boundary_blocker -- --nocapture`
- `cargo test -p perl-workspace --profile agent --locked semantic_shadow_compare -- --nocapture`
- `cargo test -p xtask --profile agent --locked semantic_shadow_compare -- --nocapture`
- `cargo test --locked --lib -p perl-lsp-rs-core shadow_receipt_uses_completion_visibility_query_name -- --nocapture`
- `cargo test --locked --lib -p perl-lsp-rs -p perl-lsp-rs-core -p perl-semantic-facts -p perl-workspace`
- `cargo clippy --locked --lib -p perl-lsp-rs -p perl-lsp-rs-core -p perl-semantic-facts -p perl-workspace -- -D warnings -A missing_docs`
- `cargo check --locked --tests -p perl-lsp-rs -p perl-lsp-rs-core -p perl-semantic-facts -p perl-workspace -p xtask`
- `cargo xtask semantic-shadow-compare --check`
- `cargo xtask semantic-scorecard --check`
- `cargo check -p perl-semantic-facts -p perl-workspace -p xtask --all-targets --profile agent --locked`
- `cargo xtask fmt --check`
- `git diff --check`