### PR TITLE
feat(critic): add bareword filehandle native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -204,7 +204,9 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_variable_shadowing(&qf_diag));
                     }
                     // PL400: Bareword filehandle
-                    c if c == DiagnosticCode::BarewordFilehandle.as_str() => {
+                    c if c == DiagnosticCode::BarewordFilehandle.as_str()
+                        || c == "native.io.bareword_filehandle" =>
+                    {
                         actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
                     }
                     // Perl::Critic policy alias for bareword filehandle.
@@ -615,6 +617,31 @@ mod tests {
         let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
 
         assert!(actions.iter().any(|a| a.title.contains("three-argument open() for safety")));
+    }
+
+    #[test]
+    fn test_native_bareword_filehandle_alias_produces_quick_fix() {
+        let source = "open FH, $path;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![Diagnostic {
+            range: (5, 7),
+            severity: DiagnosticSeverity::Warning,
+            code: Some("native.io.bareword_filehandle".to_string()),
+            message: "Bareword filehandle 'FH' should be lexical".to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        let fix = actions
+            .iter()
+            .find(|action| action.title.contains("bareword filehandle"))
+            .expect("native bareword filehandle diagnostic should produce a quick fix");
+        assert_eq!(fix.edit.changes[0].new_text, "my $fh_fh");
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -238,6 +238,7 @@ impl NativeCriticRegistry {
             Box::new(RequireUseStrictRule),
             Box::new(RequireUseWarningsRule),
             Box::new(AssignmentInConditionRule),
+            Box::new(BarewordFilehandleRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
             Box::new(DuplicateParameterRule),
@@ -457,6 +458,31 @@ impl CriticRule for AssignmentInConditionRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_assignment_in_condition_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports bareword filehandles passed to `open`.
+///
+/// This mirrors the existing common-mistake and Perl::Critic policy surfaces
+/// while giving opt-in native critic users a stable rule ID, precise handle
+/// span, suppression key, and fix metadata.
+pub struct BarewordFilehandleRule;
+
+impl CriticRule for BarewordFilehandleRule {
+    fn id(&self) -> &'static str {
+        "native.io.bareword_filehandle"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Syntax
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_bareword_filehandle_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -793,6 +819,37 @@ fn assignment_in_condition_finding(
     }
 }
 
+fn bareword_filehandle_finding(
+    rule: &BarewordFilehandleRule,
+    source: &str,
+    handle: &Node,
+    handle_name: &str,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, handle.location.start, handle.location.end);
+    let lexical_name = bareword_filehandle_lexical_name(handle_name);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Bareword filehandle '{handle_name}' should be lexical"),
+        explanation: "Bareword filehandles are package globals and can be accidentally reused across scopes. Use lexical filehandles for safer IO.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: format!(
+                "Replace bareword filehandle '{handle_name}' with lexical '{lexical_name}'"
+            ),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit {
+                range,
+                new_text: format!("my {lexical_name}"),
+            }],
+        }),
+    }
+}
+
 fn duplicate_lexical_finding(
     rule: &DuplicateLexicalDeclarationRule,
     source: &str,
@@ -874,6 +931,55 @@ fn collect_assignment_in_condition_findings(
     for child in node.children() {
         collect_assignment_in_condition_findings(rule, source, child, out);
     }
+}
+
+fn collect_bareword_filehandle_findings(
+    rule: &BarewordFilehandleRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    if let NodeKind::FunctionCall { name, args } = &node.kind {
+        push_bareword_filehandle_finding(rule, source, name, args, out);
+    }
+
+    for child in node.children() {
+        collect_bareword_filehandle_findings(rule, source, child, out);
+    }
+}
+
+fn push_bareword_filehandle_finding(
+    rule: &BarewordFilehandleRule,
+    source: &str,
+    function_name: &str,
+    args: &[Node],
+    out: &mut Vec<CriticFinding>,
+) {
+    if function_name != "open" {
+        return;
+    }
+
+    let open_args: &[Node] = if args.len() == 1 {
+        if let NodeKind::ArrayLiteral { elements } = &args[0].kind { elements } else { args }
+    } else {
+        args
+    };
+
+    let Some(handle) = open_args.first() else {
+        return;
+    };
+    let NodeKind::Identifier { name } = &handle.kind else {
+        return;
+    };
+    if open_args.len() < 2 || is_standard_filehandle(name) {
+        return;
+    }
+
+    out.push(bareword_filehandle_finding(rule, source, handle, name));
+}
+
+fn is_standard_filehandle(name: &str) -> bool {
+    matches!(name, "STDIN" | "STDOUT" | "STDERR" | "ARGV" | "ARGVOUT" | "DATA")
 }
 
 fn push_assignment_condition_finding(
@@ -1012,6 +1118,10 @@ fn prefixed_unused_name(name: &str) -> String {
         }
         _ => format!("_{name}"),
     }
+}
+
+fn bareword_filehandle_lexical_name(name: &str) -> String {
+    format!("${}_fh", name.to_lowercase())
 }
 
 fn split_sigil(name: &str) -> (&str, &str) {
@@ -1502,6 +1612,88 @@ mod tests {
     }
 
     #[test]
+    fn native_bareword_filehandle_rule_reports_open_bareword() {
+        let source = "use strict;\nuse warnings;\nopen(FH, '<', 'file.txt');\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(BarewordFilehandleRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.io.bareword_filehandle");
+        assert_eq!(finding.category, CriticCategory::Syntax);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Bareword filehandle 'FH' should be lexical");
+        assert_eq!(finding.suppression_key, "native.io.bareword_filehandle");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "FH");
+
+        let fix = finding.fix.as_ref().expect("bareword filehandle should offer lexical fix");
+        assert_eq!(fix.title, "Replace bareword filehandle 'FH' with lexical '$fh_fh'");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].range, finding.range);
+        assert_eq!(fix.edits[0].new_text, "my $fh_fh");
+    }
+
+    #[test]
+    fn native_bareword_filehandle_rule_accepts_lexical_and_standard_filehandles() {
+        let source = "use strict;\nuse warnings;\nopen(my $fh, '<', 'file.txt');\nopen(STDOUT, '>', 'out.txt');\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(BarewordFilehandleRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "lexical and standard filehandles should be accepted");
+    }
+
+    #[test]
+    fn native_bareword_filehandle_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nopen(FH, '<', 'file.txt');\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.io.bareword_filehandle".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(BarewordFilehandleRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.io.bareword_filehandle -- legacy handle\nuse strict;\nuse warnings;\nopen(FH, '<', 'file.txt');\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_bareword_filehandle_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nopen(FH, '<', 'file.txt');\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(BarewordFilehandleRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.io.bareword_filehandle");
+        assert_eq!(violations[0].description, "Bareword filehandle 'FH' should be lexical");
+        assert_eq!(
+            violations[0].explanation,
+            "Bareword filehandles are package globals and can be accidentally reused across scopes. Use lexical filehandles for safer IO."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_recommended_registry_contains_initial_policy_bundle() {
         let source = "print 1;\n";
         let ast = parse_source(source);
@@ -1517,6 +1709,7 @@ mod tests {
                 "native.testing.require_use_strict",
                 "native.testing.require_use_warnings",
                 "native.common.assignment_in_condition",
+                "native.io.bareword_filehandle",
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",
                 "native.variables.duplicate_parameter",

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -337,3 +337,17 @@ pub(super) fn fix_unquoted_bareword(
 
     actions
 }
+
+pub(super) fn fix_bareword_filehandle(diagnostic: &Diagnostic) -> Vec<CodeAction> {
+    let Some(handle_name) = source_utils::extract_quoted_value(&diagnostic.message) else {
+        return Vec::new();
+    };
+    let lexical_name = format!("${}_fh", handle_name.to_lowercase());
+
+    vec![diagnostic_action(
+        diagnostic,
+        format!("Replace bareword filehandle '{}' with lexical '{}'", handle_name, lexical_name),
+        CodeActionKind::QuickFix,
+        TextEdit { range: diagnostic.range, new_text: format!("my {lexical_name}") },
+    )]
+}

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -112,6 +112,13 @@ impl CodeActionsProvider {
             {
                 fixes::fix_unquoted_bareword(self, diagnostic)
             }
+            Some(c)
+                if c == DiagnosticCode::BarewordFilehandle.as_str()
+                    || c == "bareword-filehandle"
+                    || c == "native.io.bareword_filehandle" =>
+            {
+                fixes::fix_bareword_filehandle(diagnostic)
+            }
             Some(code) if code.starts_with("parse-error-") => {
                 fixes::fix_parse_error(self, diagnostic, code)
             }
@@ -642,6 +649,24 @@ mod tests {
         assert_eq!(actions[1].title, "Keep assignment (add parentheses)");
         assert_eq!(actions[1].edit.range, (4, 10));
         assert_eq!(actions[1].edit.new_text, "($x = 5)");
+    }
+
+    #[test]
+    fn test_native_critic_bareword_filehandle_quick_fix() {
+        let diagnostic = make_diagnostic(
+            (5, 7),
+            DiagnosticSeverity::Warning,
+            "native.io.bareword_filehandle",
+            "Bareword filehandle 'FH' should be lexical",
+        );
+
+        let provider = CodeActionsProvider::new("open FH, $path;\n".to_string());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Replace bareword filehandle 'FH' with lexical '$fh_fh'");
+        assert_eq!(actions[0].edit.range, (5, 7));
+        assert_eq!(actions[0].edit.new_text, "my $fh_fh");
     }
 
     // ── Quick-fix: unused parameter ─────────────────────────────────────

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1113,6 +1113,7 @@ fn is_fixable_diagnostic(code: &str) -> bool {
             | "TestingAndDebugging::RequireUseWarnings"
             | "native.testing.require_use_strict"
             | "native.testing.require_use_warnings"
+            | "native.io.bareword_filehandle"
             | "InputOutput::ProhibitBarewordFileHandles"
             | "InputOutput::RequireBriefOpen"
             | "InputOutput::RequireThreeArgOpen"
@@ -1348,7 +1349,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
             None,
             &context,
             None,
@@ -1397,6 +1398,25 @@ mod tests {
             .ok_or("native assignment-in-condition data should be populated")?;
         assert_eq!(data["code"], "native.common.assignment_in_condition");
         assert_eq!(data["suppressionKey"], "native.common.assignment_in_condition");
+        assert_eq!(data["fixable"], true);
+
+        let bareword_filehandle = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.io.bareword_filehandle"))
+            })
+            .ok_or("expected native bareword filehandle finding")?;
+        assert_eq!(bareword_filehandle.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(bareword_filehandle.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(bareword_filehandle.message, "Bareword filehandle 'FH' should be lexical");
+        let data = bareword_filehandle
+            .data
+            .as_ref()
+            .ok_or("native bareword filehandle data should be populated")?;
+        assert_eq!(data["code"], "native.io.bareword_filehandle");
+        assert_eq!(data["suppressionKey"], "native.io.bareword_filehandle");
         assert_eq!(data["fixable"], true);
 
         let unused = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1673,6 +1673,7 @@ fn is_fixable_perlcritic_policy(code: &str) -> bool {
             | "TestingAndDebugging::RequireUseWarnings"
             | "native.testing.require_use_strict"
             | "native.testing.require_use_warnings"
+            | "native.io.bareword_filehandle"
             | "Variables::ProhibitUnusedVariables"
     )
 }
@@ -1835,7 +1836,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
                 }
             })))
             .unwrap();
@@ -1861,6 +1862,14 @@ mod tests {
         assert!(
             text.contains("Assignment in condition - did you mean '=='?"),
             "native assignment-in-condition finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.io.bareword_filehandle"),
+            "native critic engine should publish native bareword filehandle finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Bareword filehandle 'FH' should be lexical"),
+            "native bareword filehandle finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.variables.unused_lexical"),
@@ -1962,7 +1971,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
             }
         })))?;
 
@@ -2002,6 +2011,15 @@ mod tests {
                         == Some("Assignment in condition - did you mean '=='?")
             }),
             "native critic engine should add native assignment-in-condition finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.io.bareword_filehandle")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Bareword filehandle 'FH' should be lexical")
+            }),
+            "native critic engine should add native bareword filehandle finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds `native.io.bareword_filehandle` to the opt-in native critic registry.

This native rule detects bareword handles passed to `open`, spans the handle itself, skips lexical and standard handles, and emits native critic metadata with suppression and suggested fix support. Legacy/default critic behavior remains unchanged.

## Notes

- Native critic remains explicit opt-in through `[critic].engine = "native"`.
- The rule reuses the existing bareword-filehandle quick-fix shape in both core and LSP-facing code-action providers.
- Pull, push, and workspace diagnostics now prove the native rule appears through the opt-in native engine.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_bareword --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_bareword --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`