### PR TITLE
feat(format): add simple method-chain layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -1060,19 +1060,43 @@ fn format_simple_method_call_tokens(
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
-    let (receiver, mut index) = format_variable_tokens(tokens, start)?;
-    if tokens.get(index)?.kind != TokenKind::Arrow {
-        return None;
-    }
-    index += 1;
+    let (mut expression, mut index) = format_variable_tokens(tokens, start)?;
+    let mut saw_method = false;
 
-    let method = tokens.get(index)?;
-    if method.kind != TokenKind::Identifier || tokens.get(index + 1)?.kind != TokenKind::LeftParen {
+    loop {
+        if tokens.get(index)?.kind != TokenKind::Arrow {
+            break;
+        }
+        let (method_call, next_index) =
+            format_simple_method_call_segment(tokens, index, &expression)?;
+        expression = method_call;
+        index = next_index;
+        saw_method = true;
+    }
+
+    saw_method.then_some((expression, index))
+}
+
+fn format_simple_method_call_segment(
+    tokens: &[perl_parser_core::Token],
+    arrow_index: usize,
+    receiver: &str,
+) -> Option<(String, usize)> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.get(arrow_index)?.kind != TokenKind::Arrow {
         return None;
     }
-    index += 2;
+
+    let method = tokens.get(arrow_index + 1)?;
+    if method.kind != TokenKind::Identifier
+        || tokens.get(arrow_index + 2)?.kind != TokenKind::LeftParen
+    {
+        return None;
+    }
 
     let mut args = Vec::new();
+    let mut index = arrow_index + 3;
     if tokens.get(index)?.kind == TokenKind::RightParen {
         return Some((format!("{receiver}->{}()", method.text), index + 1));
     }
@@ -1086,7 +1110,7 @@ fn format_simple_method_call_tokens(
             TokenKind::Comma => index += 1,
             TokenKind::RightParen => {
                 return Some((
-                    render_simple_method_call_doc(&receiver, method.text.as_ref(), &args),
+                    render_simple_method_call_doc(receiver, method.text.as_ref(), &args),
                     index + 1,
                 ));
             }

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_method_chains.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_method_chains.expected.pl
@@ -1,0 +1,2 @@
+$x = $obj->build()->name();
+return $obj->find($id)->wrap(foo(1), {ok => 1});

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_method_chains.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_method_chains.pl
@@ -1,0 +1,2 @@
+$x=$obj->build()->name();
+return $obj->find($id)->wrap(foo(1),{ok=>1});

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -121,6 +121,21 @@ fn native_formatter_formats_simple_method_calls() {
 }
 
 #[test]
+fn native_formatter_formats_simple_method_call_chains() {
+    let formatter = NativeFormatter::new();
+    let source = "$x=$obj->build()->name();\nreturn $obj->find($id)->wrap(foo(1),{ok=>1});\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "$x = $obj->build()->name();\nreturn $obj->find($id)->wrap(foo(1), {ok => 1});\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";
@@ -294,6 +309,24 @@ fn native_range_formatter_formats_selected_simple_method_call_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "return $obj->build(1, $y);");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_method_chain_line() {
+    let formatter = NativeFormatter::new();
+    let source = "$x=$obj->build()->name();\nreturn $obj->find($id)->wrap({ok=>1});\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 38));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "$x=$obj->build()->name();\nreturn $obj->find($id)->wrap({ok => 1});\n"
+    );
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "return $obj->find($id)->wrap({ok => 1});");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds conservative native formatting for simple chained method calls.

This extends the existing simple method-call formatter from one `->method(...)` segment to same-line chains such as `$obj->build()->name()` and `$obj->find($id)->wrap(...)`. It keeps the safe-subset boundary: simple variable receivers, parenthesized method calls, and already-supported simple arguments only.

## Notes

- No formatter default/config/runtime behavior changes.
- No line wrapping or multi-line chain policy yet.
- Unsupported method-call shapes still fall through unchanged.
- Adds a native-format fixture pair for method chains; `cargo xtask native-format check` now reports 24/24 fixtures.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy method_chain --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`24/24` fixtures)
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`