### PR TITLE
feat(critic): add two-arg open native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -214,7 +214,9 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
                     }
                     // PL401: Two-arg open
-                    c if c == DiagnosticCode::TwoArgOpen.as_str() => {
+                    c if c == DiagnosticCode::TwoArgOpen.as_str()
+                        || c == "native.io.two_arg_open" =>
+                    {
                         actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
                     }
                     // Perl::Critic policy aliases for two-arg open.
@@ -642,6 +644,31 @@ mod tests {
             .find(|action| action.title.contains("bareword filehandle"))
             .expect("native bareword filehandle diagnostic should produce a quick fix");
         assert_eq!(fix.edit.changes[0].new_text, "my $fh_fh");
+    }
+
+    #[test]
+    fn test_native_two_arg_open_alias_produces_quick_fix() {
+        let source = "open(my $fh, $path);\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![Diagnostic {
+            range: (0, 19),
+            severity: DiagnosticSeverity::Warning,
+            code: Some("native.io.two_arg_open".to_string()),
+            message: "Two-argument open should use an explicit mode".to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        let fix = actions
+            .iter()
+            .find(|action| action.title.contains("three-argument open()"))
+            .expect("native two-arg open diagnostic should produce a quick fix");
+        assert_eq!(fix.edit.changes[0].new_text, "open(my $fh, '<', $filename)");
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -294,7 +294,7 @@ mod tests {
     use super::*;
     use crate::providers::diagnostics::DiagnosticSeverity;
     use perl_parser_core::Parser;
-    use perl_tdd_support::must;
+    use perl_tdd_support::{must, must_some};
 
     /// Create a diagnostic with byte offsets
     fn make_diagnostic(start: usize, end: usize, code: &str, msg: &str) -> Diagnostic {
@@ -669,6 +669,56 @@ mod tests {
             .find(|action| action.title.contains("three-argument open()"))
             .expect("native two-arg open diagnostic should produce a quick fix");
         assert_eq!(fix.edit.changes[0].new_text, "open(my $fh, '<', $path)");
+    }
+
+    #[test]
+    fn test_legacy_two_arg_open_alias_range_only_open_edits_whole_call() {
+        let source = "open FH, $path;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![Diagnostic {
+            range: (0, 4),
+            severity: DiagnosticSeverity::Warning,
+            code: Some("InputOutput::RequireThreeArgOpen".to_string()),
+            message: "Two-argument open should use an explicit mode".to_string(),
+            suggestion: None,
+            related_information: Vec::new(),
+            tags: Vec::new(),
+        }];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        let fix =
+            must_some(actions.iter().find(|action| action.title.contains("three-argument open()")));
+        assert_eq!(fix.edit.changes[0].location.start, 0);
+        assert_eq!(fix.edit.changes[0].location.end, "open FH, $path".len());
+        assert_eq!(fix.edit.changes[0].new_text, "open(FH, '<', $path)");
+    }
+
+    #[test]
+    fn test_legacy_two_arg_open_alias_range_only_open_rejects_ambiguous_line_fallback() {
+        for source in ["open FH, $path; # legacy\n", "open FH, $path; close FH;\n"] {
+            let mut parser = Parser::new(source);
+            let ast = must(parser.parse());
+            let diagnostics = vec![Diagnostic {
+                range: (0, 4),
+                severity: DiagnosticSeverity::Warning,
+                code: Some("InputOutput::RequireThreeArgOpen".to_string()),
+                message: "Two-argument open should use an explicit mode".to_string(),
+                suggestion: None,
+                related_information: Vec::new(),
+                tags: Vec::new(),
+            }];
+
+            let provider = CodeActionsProvider::new(source.to_string());
+            let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+            assert!(
+                actions.iter().all(|action| !action.title.contains("three-argument open()")),
+                "ambiguous fallback should not produce a two-arg open fix for {source:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -217,13 +217,13 @@ impl CodeActionsProvider {
                     c if c == DiagnosticCode::TwoArgOpen.as_str()
                         || c == "native.io.two_arg_open" =>
                     {
-                        actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
+                        actions.extend(quick_fixes::fix_two_arg_open(&self.source, &qf_diag));
                     }
                     // Perl::Critic policy aliases for two-arg open.
                     "InputOutput::ProhibitTwoArgOpen"
                     | "InputOutput::RequireBriefOpen"
                     | "InputOutput::RequireThreeArgOpen" => {
-                        actions.extend(quick_fixes::fix_two_arg_open(&qf_diag));
+                        actions.extend(quick_fixes::fix_two_arg_open(&self.source, &qf_diag));
                     }
                     // Perl::Critic/native critic policies for missing strict/warnings.
                     "TestingAndDebugging::RequireUseStrict"
@@ -668,7 +668,7 @@ mod tests {
             .iter()
             .find(|action| action.title.contains("three-argument open()"))
             .expect("native two-arg open diagnostic should produce a quick fix");
-        assert_eq!(fix.edit.changes[0].new_text, "open(my $fh, '<', $filename)");
+        assert_eq!(fix.edit.changes[0].new_text, "open(my $fh, '<', $path)");
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1033,7 +1033,11 @@ pub fn fix_missing_return(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<
 /// Two-argument `open($fh, $filename)` is unsafe because `$filename` can
 /// contain shell metacharacters. The three-argument form separates the mode
 /// from the filename, e.g. `open(my $fh, '<', $filename)`.
-pub fn fix_two_arg_open(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+pub fn fix_two_arg_open(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let Some(new_text) = two_arg_open_replacement(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
     vec![CodeAction {
         title: "Convert to three-argument open() for safety".to_string(),
         kind: CodeActionKind::QuickFix,
@@ -1041,9 +1045,64 @@ pub fn fix_two_arg_open(diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
         edit: CodeActionEdit {
             changes: vec![TextEdit {
                 location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
-                new_text: "open(my $fh, '<', $filename)".to_string(),
+                new_text,
             }],
         },
         is_preferred: true,
     }]
+}
+
+fn two_arg_open_replacement(source: &str, range: (usize, usize)) -> Option<String> {
+    let snippet = source.get(range.0..range.1)?.trim();
+    let call = snippet.trim_end_matches(';').trim();
+    let body = call.strip_prefix("open")?.trim_start();
+    let body = body.strip_prefix('(')?.strip_suffix(')')?;
+    let (handle, path) = split_two_top_level_args(body)?;
+
+    Some(format!("open({}, '<', {})", handle.trim(), path.trim()))
+}
+
+fn split_two_top_level_args(input: &str) -> Option<(&str, &str)> {
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut split = None;
+
+    for (idx, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if let Some(quote_char) = quote {
+            if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                if split.replace(idx).is_some() {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let idx = split?;
+    let first = &input[..idx];
+    let second = &input[idx + 1..];
+
+    if first.trim().is_empty() || second.trim().is_empty() {
+        return None;
+    }
+
+    Some((first, second))
 }

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1034,7 +1034,7 @@ pub fn fix_missing_return(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<
 /// contain shell metacharacters. The three-argument form separates the mode
 /// from the filename, e.g. `open(my $fh, '<', $filename)`.
 pub fn fix_two_arg_open(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
-    let Some(new_text) = two_arg_open_replacement(source, diagnostic.range) else {
+    let Some((range, new_text)) = two_arg_open_replacement(source, diagnostic.range) else {
         return Vec::new();
     };
 
@@ -1044,7 +1044,7 @@ pub fn fix_two_arg_open(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<Co
         diagnostics: vec![DiagnosticCode::TwoArgOpen.as_str().to_string()],
         edit: CodeActionEdit {
             changes: vec![TextEdit {
-                location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                location: SourceLocation { start: range.0, end: range.1 },
                 new_text,
             }],
         },
@@ -1052,27 +1052,194 @@ pub fn fix_two_arg_open(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<Co
     }]
 }
 
-fn two_arg_open_replacement(source: &str, range: (usize, usize)) -> Option<String> {
-    let snippet = source.get(range.0..range.1)?.trim();
-    parse_two_arg_open_call(snippet).or_else(|| {
-        let start = range.0.min(source.len());
-        let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);
-        let line_end = source[start..].find('\n').map_or(source.len(), |offset| start + offset);
-        parse_two_arg_open_call(&source[line_start..line_end])
-    })
+fn two_arg_open_replacement(
+    source: &str,
+    range: (usize, usize),
+) -> Option<((usize, usize), String)> {
+    let snippet = source.get(range.0..range.1)?;
+    if let Some(((start, end), new_text)) = parse_two_arg_open_call(snippet) {
+        return Some(((range.0 + start, range.0 + end), new_text));
+    }
+
+    let start = range.0.min(source.len());
+    let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);
+    let line_end = source[start..].find('\n').map_or(source.len(), |offset| start + offset);
+    let diagnostic_offset = start.saturating_sub(line_start);
+    source.get(start..line_end).and_then(parse_two_arg_open_call).map(
+        |((call_start, call_end), new_text)| {
+            (
+                (
+                    line_start + diagnostic_offset + call_start,
+                    line_start + diagnostic_offset + call_end,
+                ),
+                new_text,
+            )
+        },
+    )
 }
 
-fn parse_two_arg_open_call(snippet: &str) -> Option<String> {
-    let call = snippet.trim().trim_end_matches(';').trim();
-    let body = call.strip_prefix("open")?.trim_start();
-    let body = if let Some(parenthesized) = body.strip_prefix('(') {
-        parenthesized.strip_suffix(')')?
-    } else {
-        body
-    };
-    let (handle, path) = split_two_top_level_args(body)?;
+fn parse_two_arg_open_call(snippet: &str) -> Option<((usize, usize), String)> {
+    let call_start = first_non_whitespace(snippet)?;
+    let call = &snippet[call_start..];
+    let after_open = call.strip_prefix("open")?;
+    let next = after_open.chars().next()?;
+    if !next.is_whitespace() && next != '(' {
+        return None;
+    }
 
-    Some(format!("open({}, '<', {})", handle.trim(), path.trim()))
+    let body_start = call_start + "open".len();
+    let body_start = body_start + first_non_whitespace(&snippet[body_start..])?;
+    let body = &snippet[body_start..];
+
+    let (args, call_end) = if body.starts_with('(') {
+        let close = find_matching_parenthesis(body)?;
+        if has_non_statement_trailing_text(&body[close + 1..]) {
+            return None;
+        }
+        (&body[1..close], body_start + close + 1)
+    } else {
+        let args_end = bare_call_args_end(body)?;
+        (&body[..args_end], body_start + args_end)
+    };
+    let (handle, path) = split_two_top_level_args(args)?;
+
+    Some(((call_start, call_end), format!("open({}, '<', {})", handle.trim(), path.trim())))
+}
+
+fn first_non_whitespace(input: &str) -> Option<usize> {
+    input.char_indices().find_map(|(idx, ch)| (!ch.is_whitespace()).then_some(idx))
+}
+
+fn has_non_statement_trailing_text(input: &str) -> bool {
+    let trimmed = input.trim_start();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let Some(after_semicolon) = trimmed.strip_prefix(';') else {
+        return true;
+    };
+
+    !after_semicolon.trim().is_empty()
+}
+
+fn bare_call_args_end(input: &str) -> Option<usize> {
+    if input.trim().is_empty() {
+        return None;
+    }
+
+    find_statement_semicolon(input).map_or_else(
+        || {
+            if contains_unquoted_comment(input) { None } else { Some(input.trim_end().len()) }
+        },
+        |semicolon| {
+            let trailing = input[semicolon + 1..].trim();
+            if trailing.is_empty() && !contains_unquoted_comment(&input[..semicolon]) {
+                Some(input[..semicolon].trim_end().len())
+            } else {
+                None
+            }
+        },
+    )
+}
+
+fn find_statement_semicolon(input: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (idx, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if let Some(quote_char) = quote {
+            if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ';' if depth == 0 => return Some(idx),
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn contains_unquoted_comment(input: &str) -> bool {
+    let mut quote = None;
+    let mut escaped = false;
+
+    for ch in input.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if let Some(quote_char) = quote {
+            if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '#' => return true,
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn find_matching_parenthesis(input: &str) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (idx, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if let Some(quote_char) = quote {
+            if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '(' => paren_depth += 1,
+            '[' => bracket_depth += 1,
+            '{' => brace_depth += 1,
+            ')' if paren_depth == 1 && bracket_depth == 0 && brace_depth == 0 => return Some(idx),
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+
+    None
 }
 
 fn split_two_top_level_args(input: &str) -> Option<(&str, &str)> {

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1054,9 +1054,22 @@ pub fn fix_two_arg_open(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<Co
 
 fn two_arg_open_replacement(source: &str, range: (usize, usize)) -> Option<String> {
     let snippet = source.get(range.0..range.1)?.trim();
-    let call = snippet.trim_end_matches(';').trim();
+    parse_two_arg_open_call(snippet).or_else(|| {
+        let start = range.0.min(source.len());
+        let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);
+        let line_end = source[start..].find('\n').map_or(source.len(), |offset| start + offset);
+        parse_two_arg_open_call(&source[line_start..line_end])
+    })
+}
+
+fn parse_two_arg_open_call(snippet: &str) -> Option<String> {
+    let call = snippet.trim().trim_end_matches(';').trim();
     let body = call.strip_prefix("open")?.trim_start();
-    let body = body.strip_prefix('(')?.strip_suffix(')')?;
+    let body = if let Some(parenthesized) = body.strip_prefix('(') {
+        parenthesized.strip_suffix(')')?
+    } else {
+        body
+    };
     let (handle, path) = split_two_top_level_args(body)?;
 
     Some(format!("open({}, '<', {})", handle.trim(), path.trim()))

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -239,6 +239,7 @@ impl NativeCriticRegistry {
             Box::new(RequireUseWarningsRule),
             Box::new(AssignmentInConditionRule),
             Box::new(BarewordFilehandleRule),
+            Box::new(TwoArgOpenRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
             Box::new(DuplicateParameterRule),
@@ -483,6 +484,31 @@ impl CriticRule for BarewordFilehandleRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_bareword_filehandle_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports two-argument `open` calls.
+///
+/// The rule keeps the current native critic migration pattern: stable native
+/// policy ID, suppression/config filtering, violation bridge support, and
+/// quick-fix metadata while legacy/default critic behavior remains unchanged.
+pub struct TwoArgOpenRule;
+
+impl CriticRule for TwoArgOpenRule {
+    fn id(&self) -> &'static str {
+        "native.io.two_arg_open"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Security
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_two_arg_open_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -850,6 +876,29 @@ fn bareword_filehandle_finding(
     }
 }
 
+fn two_arg_open_finding(rule: &TwoArgOpenRule, source: &str, call: &Node) -> CriticFinding {
+    let range = range_for_byte_span(source, call.location.start, call.location.end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: "Two-argument open should use an explicit mode".to_string(),
+        explanation: "Two-argument open combines mode and filename, which can allow shell interpretation when the filename is derived from input. Use three-argument open with a separate mode.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: "Convert to three-argument open() for safety".to_string(),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit {
+                range,
+                new_text: "open(my $fh, '<', $filename)".to_string(),
+            }],
+        }),
+    }
+}
+
 fn duplicate_lexical_finding(
     rule: &DuplicateLexicalDeclarationRule,
     source: &str,
@@ -959,11 +1008,7 @@ fn push_bareword_filehandle_finding(
         return;
     }
 
-    let open_args: &[Node] = if args.len() == 1 {
-        if let NodeKind::ArrayLiteral { elements } = &args[0].kind { elements } else { args }
-    } else {
-        args
-    };
+    let open_args = effective_call_args(args);
 
     let Some(handle) = open_args.first() else {
         return;
@@ -976,6 +1021,34 @@ fn push_bareword_filehandle_finding(
     }
 
     out.push(bareword_filehandle_finding(rule, source, handle, name));
+}
+
+fn collect_two_arg_open_findings(
+    rule: &TwoArgOpenRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    if let NodeKind::FunctionCall { name, args } = &node.kind
+        && name == "open"
+        && effective_call_args(args).len() == 2
+    {
+        out.push(two_arg_open_finding(rule, source, node));
+    }
+
+    for child in node.children() {
+        collect_two_arg_open_findings(rule, source, child, out);
+    }
+}
+
+fn effective_call_args(args: &[Node]) -> &[Node] {
+    if args.len() == 1
+        && let NodeKind::ArrayLiteral { elements } = &args[0].kind
+    {
+        return elements;
+    }
+
+    args
 }
 
 fn is_standard_filehandle(name: &str) -> bool {
@@ -1694,6 +1767,97 @@ mod tests {
     }
 
     #[test]
+    fn native_two_arg_open_rule_reports_two_arg_open() {
+        let source = "use strict;\nuse warnings;\nmy $path = 'file.txt';\nopen(my $fh, $path);\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(TwoArgOpenRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.io.two_arg_open");
+        assert_eq!(finding.category, CriticCategory::Security);
+        assert_eq!(finding.severity, Severity::Harsh);
+        assert_eq!(finding.message, "Two-argument open should use an explicit mode");
+        assert_eq!(finding.suppression_key, "native.io.two_arg_open");
+        assert_eq!(
+            &source[finding.range.start.byte..finding.range.end.byte],
+            "open(my $fh, $path)"
+        );
+
+        let fix = finding.fix.as_ref().expect("two-arg open should offer a safety fix");
+        assert_eq!(fix.title, "Convert to three-argument open() for safety");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].range, finding.range);
+        assert_eq!(fix.edits[0].new_text, "open(my $fh, '<', $filename)");
+    }
+
+    #[test]
+    fn native_two_arg_open_rule_accepts_three_arg_open() {
+        let source =
+            "use strict;\nuse warnings;\nmy $path = 'file.txt';\nopen(my $fh, '<', $path);\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(TwoArgOpenRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "three-argument open should be accepted");
+    }
+
+    #[test]
+    fn native_two_arg_open_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $path = 'file.txt';\nopen(my $fh, $path);\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.io.two_arg_open".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(TwoArgOpenRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.io.two_arg_open -- trusted legacy filename\nuse strict;\nuse warnings;\nmy $path = 'file.txt';\nopen(my $fh, $path);\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+
+        let severity_config =
+            CriticConfig { severity: Severity::Stern as u8, ..Default::default() };
+        let severity_ctx = CriticContext::new(source, &ast, &severity_config);
+        assert!(registry.check(&severity_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_two_arg_open_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $path = 'file.txt';\nopen(my $fh, $path);\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(TwoArgOpenRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.io.two_arg_open");
+        assert_eq!(violations[0].description, "Two-argument open should use an explicit mode");
+        assert_eq!(
+            violations[0].explanation,
+            "Two-argument open combines mode and filename, which can allow shell interpretation when the filename is derived from input. Use three-argument open with a separate mode."
+        );
+        assert_eq!(violations[0].severity, Severity::Harsh);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_recommended_registry_contains_initial_policy_bundle() {
         let source = "print 1;\n";
         let ast = parse_source(source);
@@ -1710,6 +1874,7 @@ mod tests {
                 "native.testing.require_use_warnings",
                 "native.common.assignment_in_condition",
                 "native.io.bareword_filehandle",
+                "native.io.two_arg_open",
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",
                 "native.variables.duplicate_parameter",

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -876,8 +876,18 @@ fn bareword_filehandle_finding(
     }
 }
 
-fn two_arg_open_finding(rule: &TwoArgOpenRule, source: &str, call: &Node) -> CriticFinding {
+fn two_arg_open_finding(
+    rule: &TwoArgOpenRule,
+    source: &str,
+    call: &Node,
+    open_args: &[Node],
+) -> CriticFinding {
     let range = range_for_byte_span(source, call.location.start, call.location.end);
+    let fix = two_arg_open_fix_text(source, open_args).map(|new_text| CriticFix {
+        title: "Convert to three-argument open() for safety".to_string(),
+        safety: FixSafety::Suggested,
+        edits: vec![CriticTextEdit { range, new_text }],
+    });
 
     CriticFinding {
         rule_id: rule.id().to_string(),
@@ -888,15 +898,23 @@ fn two_arg_open_finding(rule: &TwoArgOpenRule, source: &str, call: &Node) -> Cri
         explanation: "Two-argument open combines mode and filename, which can allow shell interpretation when the filename is derived from input. Use three-argument open with a separate mode.".to_string(),
         suppression_key: rule.id().to_string(),
         related: Vec::new(),
-        fix: Some(CriticFix {
-            title: "Convert to three-argument open() for safety".to_string(),
-            safety: FixSafety::Suggested,
-            edits: vec![CriticTextEdit {
-                range,
-                new_text: "open(my $fh, '<', $filename)".to_string(),
-            }],
-        }),
+        fix,
     }
+}
+
+fn two_arg_open_fix_text(source: &str, open_args: &[Node]) -> Option<String> {
+    let [handle, path] = open_args else {
+        return None;
+    };
+
+    let handle_text = source.get(handle.location.start..handle.location.end)?.trim();
+    let path_text = source.get(path.location.start..path.location.end)?.trim();
+
+    if handle_text.is_empty() || path_text.is_empty() {
+        return None;
+    }
+
+    Some(format!("open({handle_text}, '<', {path_text})"))
 }
 
 fn duplicate_lexical_finding(
@@ -1031,9 +1049,11 @@ fn collect_two_arg_open_findings(
 ) {
     if let NodeKind::FunctionCall { name, args } = &node.kind
         && name == "open"
-        && effective_call_args(args).len() == 2
     {
-        out.push(two_arg_open_finding(rule, source, node));
+        let open_args = effective_call_args(args);
+        if open_args.len() == 2 {
+            out.push(two_arg_open_finding(rule, source, node, open_args));
+        }
     }
 
     for child in node.children() {
@@ -1793,7 +1813,7 @@ mod tests {
         assert_eq!(fix.safety, FixSafety::Suggested);
         assert_eq!(fix.edits.len(), 1);
         assert_eq!(fix.edits[0].range, finding.range);
-        assert_eq!(fix.edits[0].new_text, "open(my $fh, '<', $filename)");
+        assert_eq!(fix.edits[0].new_text, "open(my $fh, '<', $path)");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -370,9 +370,22 @@ pub(super) fn fix_two_arg_open(
 
 fn two_arg_open_replacement(source: &str, range: (usize, usize)) -> Option<String> {
     let snippet = source.get(range.0..range.1)?.trim();
-    let call = snippet.trim_end_matches(';').trim();
+    parse_two_arg_open_call(snippet).or_else(|| {
+        let start = range.0.min(source.len());
+        let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);
+        let line_end = source[start..].find('\n').map_or(source.len(), |offset| start + offset);
+        parse_two_arg_open_call(&source[line_start..line_end])
+    })
+}
+
+fn parse_two_arg_open_call(snippet: &str) -> Option<String> {
+    let call = snippet.trim().trim_end_matches(';').trim();
     let body = call.strip_prefix("open")?.trim_start();
-    let body = body.strip_prefix('(')?.strip_suffix(')')?;
+    let body = if let Some(parenthesized) = body.strip_prefix('(') {
+        parenthesized.strip_suffix(')')?
+    } else {
+        body
+    };
     let (handle, path) = split_two_top_level_args(body)?;
 
     Some(format!("open({}, '<', {})", handle.trim(), path.trim()))

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -351,3 +351,12 @@ pub(super) fn fix_bareword_filehandle(diagnostic: &Diagnostic) -> Vec<CodeAction
         TextEdit { range: diagnostic.range, new_text: format!("my {lexical_name}") },
     )]
 }
+
+pub(super) fn fix_two_arg_open(diagnostic: &Diagnostic) -> Vec<CodeAction> {
+    vec![diagnostic_action(
+        diagnostic,
+        "Convert to three-argument open() for safety",
+        CodeActionKind::QuickFix,
+        TextEdit { range: diagnostic.range, new_text: "open(my $fh, '<', $filename)".to_string() },
+    )]
+}

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -356,7 +356,8 @@ pub(super) fn fix_two_arg_open(
     provider: &CodeActionsProvider,
     diagnostic: &Diagnostic,
 ) -> Vec<CodeAction> {
-    let Some(new_text) = two_arg_open_replacement(provider.source(), diagnostic.range) else {
+    let Some((range, new_text)) = two_arg_open_replacement(provider.source(), diagnostic.range)
+    else {
         return Vec::new();
     };
 
@@ -364,31 +365,198 @@ pub(super) fn fix_two_arg_open(
         diagnostic,
         "Convert to three-argument open() for safety",
         CodeActionKind::QuickFix,
-        TextEdit { range: diagnostic.range, new_text },
+        TextEdit { range, new_text },
     )]
 }
 
-fn two_arg_open_replacement(source: &str, range: (usize, usize)) -> Option<String> {
-    let snippet = source.get(range.0..range.1)?.trim();
-    parse_two_arg_open_call(snippet).or_else(|| {
-        let start = range.0.min(source.len());
-        let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);
-        let line_end = source[start..].find('\n').map_or(source.len(), |offset| start + offset);
-        parse_two_arg_open_call(&source[line_start..line_end])
-    })
+fn two_arg_open_replacement(
+    source: &str,
+    range: (usize, usize),
+) -> Option<((usize, usize), String)> {
+    let snippet = source.get(range.0..range.1)?;
+    if let Some(((start, end), new_text)) = parse_two_arg_open_call(snippet) {
+        return Some(((range.0 + start, range.0 + end), new_text));
+    }
+
+    let start = range.0.min(source.len());
+    let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);
+    let line_end = source[start..].find('\n').map_or(source.len(), |offset| start + offset);
+    let diagnostic_offset = start.saturating_sub(line_start);
+    source.get(start..line_end).and_then(parse_two_arg_open_call).map(
+        |((call_start, call_end), new_text)| {
+            (
+                (
+                    line_start + diagnostic_offset + call_start,
+                    line_start + diagnostic_offset + call_end,
+                ),
+                new_text,
+            )
+        },
+    )
 }
 
-fn parse_two_arg_open_call(snippet: &str) -> Option<String> {
-    let call = snippet.trim().trim_end_matches(';').trim();
-    let body = call.strip_prefix("open")?.trim_start();
-    let body = if let Some(parenthesized) = body.strip_prefix('(') {
-        parenthesized.strip_suffix(')')?
-    } else {
-        body
-    };
-    let (handle, path) = split_two_top_level_args(body)?;
+fn parse_two_arg_open_call(snippet: &str) -> Option<((usize, usize), String)> {
+    let call_start = first_non_whitespace(snippet)?;
+    let call = &snippet[call_start..];
+    let after_open = call.strip_prefix("open")?;
+    let next = after_open.chars().next()?;
+    if !next.is_whitespace() && next != '(' {
+        return None;
+    }
 
-    Some(format!("open({}, '<', {})", handle.trim(), path.trim()))
+    let body_start = call_start + "open".len();
+    let body_start = body_start + first_non_whitespace(&snippet[body_start..])?;
+    let body = &snippet[body_start..];
+
+    let (args, call_end) = if body.starts_with('(') {
+        let close = find_matching_parenthesis(body)?;
+        if has_non_statement_trailing_text(&body[close + 1..]) {
+            return None;
+        }
+        (&body[1..close], body_start + close + 1)
+    } else {
+        let args_end = bare_call_args_end(body)?;
+        (&body[..args_end], body_start + args_end)
+    };
+    let (handle, path) = split_two_top_level_args(args)?;
+
+    Some(((call_start, call_end), format!("open({}, '<', {})", handle.trim(), path.trim())))
+}
+
+fn first_non_whitespace(input: &str) -> Option<usize> {
+    input.char_indices().find_map(|(idx, ch)| (!ch.is_whitespace()).then_some(idx))
+}
+
+fn has_non_statement_trailing_text(input: &str) -> bool {
+    let trimmed = input.trim_start();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let Some(after_semicolon) = trimmed.strip_prefix(';') else {
+        return true;
+    };
+
+    !after_semicolon.trim().is_empty()
+}
+
+fn bare_call_args_end(input: &str) -> Option<usize> {
+    if input.trim().is_empty() {
+        return None;
+    }
+
+    find_statement_semicolon(input).map_or_else(
+        || {
+            if contains_unquoted_comment(input) { None } else { Some(input.trim_end().len()) }
+        },
+        |semicolon| {
+            let trailing = input[semicolon + 1..].trim();
+            if trailing.is_empty() && !contains_unquoted_comment(&input[..semicolon]) {
+                Some(input[..semicolon].trim_end().len())
+            } else {
+                None
+            }
+        },
+    )
+}
+
+fn find_statement_semicolon(input: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (idx, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if let Some(quote_char) = quote {
+            if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ';' if depth == 0 => return Some(idx),
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn contains_unquoted_comment(input: &str) -> bool {
+    let mut quote = None;
+    let mut escaped = false;
+
+    for ch in input.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if let Some(quote_char) = quote {
+            if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '#' => return true,
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn find_matching_parenthesis(input: &str) -> Option<usize> {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (idx, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if let Some(quote_char) = quote {
+            if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '(' => paren_depth += 1,
+            '[' => bracket_depth += 1,
+            '{' => brace_depth += 1,
+            ')' if paren_depth == 1 && bracket_depth == 0 && brace_depth == 0 => return Some(idx),
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+
+    None
 }
 
 fn split_two_top_level_args(input: &str) -> Option<(&str, &str)> {

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -352,11 +352,73 @@ pub(super) fn fix_bareword_filehandle(diagnostic: &Diagnostic) -> Vec<CodeAction
     )]
 }
 
-pub(super) fn fix_two_arg_open(diagnostic: &Diagnostic) -> Vec<CodeAction> {
+pub(super) fn fix_two_arg_open(
+    provider: &CodeActionsProvider,
+    diagnostic: &Diagnostic,
+) -> Vec<CodeAction> {
+    let Some(new_text) = two_arg_open_replacement(provider.source(), diagnostic.range) else {
+        return Vec::new();
+    };
+
     vec![diagnostic_action(
         diagnostic,
         "Convert to three-argument open() for safety",
         CodeActionKind::QuickFix,
-        TextEdit { range: diagnostic.range, new_text: "open(my $fh, '<', $filename)".to_string() },
+        TextEdit { range: diagnostic.range, new_text },
     )]
+}
+
+fn two_arg_open_replacement(source: &str, range: (usize, usize)) -> Option<String> {
+    let snippet = source.get(range.0..range.1)?.trim();
+    let call = snippet.trim_end_matches(';').trim();
+    let body = call.strip_prefix("open")?.trim_start();
+    let body = body.strip_prefix('(')?.strip_suffix(')')?;
+    let (handle, path) = split_two_top_level_args(body)?;
+
+    Some(format!("open({}, '<', {})", handle.trim(), path.trim()))
+}
+
+fn split_two_top_level_args(input: &str) -> Option<(&str, &str)> {
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut split = None;
+
+    for (idx, ch) in input.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if let Some(quote_char) = quote {
+            if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                if split.replace(idx).is_some() {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let idx = split?;
+    let first = &input[..idx];
+    let second = &input[idx + 1..];
+
+    if first.trim().is_empty() || second.trim().is_empty() {
+        return None;
+    }
+
+    Some((first, second))
 }

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -124,7 +124,7 @@ impl CodeActionsProvider {
                     || c == "two-arg-open"
                     || c == "native.io.two_arg_open" =>
             {
-                fixes::fix_two_arg_open(diagnostic)
+                fixes::fix_two_arg_open(self, diagnostic)
             }
             Some(code) if code.starts_with("parse-error-") => {
                 fixes::fix_parse_error(self, diagnostic, code)
@@ -691,7 +691,7 @@ mod tests {
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Convert to three-argument open() for safety");
         assert_eq!(actions[0].edit.range, (0, 19));
-        assert_eq!(actions[0].edit.new_text, "open(my $fh, '<', $filename)");
+        assert_eq!(actions[0].edit.new_text, "open(my $fh, '<', $path)");
     }
 
     // ── Quick-fix: unused parameter ─────────────────────────────────────

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -694,6 +694,44 @@ mod tests {
         assert_eq!(actions[0].edit.new_text, "open(my $fh, '<', $path)");
     }
 
+    #[test]
+    fn test_legacy_two_arg_open_range_only_open_edits_whole_call() {
+        let diagnostic = make_diagnostic(
+            (0, 4),
+            DiagnosticSeverity::Warning,
+            "two-arg-open",
+            "Two-argument open should use an explicit mode",
+        );
+
+        let provider = CodeActionsProvider::new("open FH, $path;\n".to_string());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Convert to three-argument open() for safety");
+        assert_eq!(actions[0].edit.range, (0, "open FH, $path".len()));
+        assert_eq!(actions[0].edit.new_text, "open(FH, '<', $path)");
+    }
+
+    #[test]
+    fn test_legacy_two_arg_open_range_only_open_rejects_ambiguous_line_fallback() {
+        let diagnostic = make_diagnostic(
+            (0, 4),
+            DiagnosticSeverity::Warning,
+            "two-arg-open",
+            "Two-argument open should use an explicit mode",
+        );
+
+        for source in ["open FH, $path; # legacy\n", "open FH, $path; close FH;\n"] {
+            let provider = CodeActionsProvider::new(source.to_string());
+            let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+            assert!(
+                actions.is_empty(),
+                "ambiguous fallback should not produce a fix for {source:?}"
+            );
+        }
+    }
+
     // ── Quick-fix: unused parameter ─────────────────────────────────────
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -119,6 +119,13 @@ impl CodeActionsProvider {
             {
                 fixes::fix_bareword_filehandle(diagnostic)
             }
+            Some(c)
+                if c == DiagnosticCode::TwoArgOpen.as_str()
+                    || c == "two-arg-open"
+                    || c == "native.io.two_arg_open" =>
+            {
+                fixes::fix_two_arg_open(diagnostic)
+            }
             Some(code) if code.starts_with("parse-error-") => {
                 fixes::fix_parse_error(self, diagnostic, code)
             }
@@ -667,6 +674,24 @@ mod tests {
         assert_eq!(actions[0].title, "Replace bareword filehandle 'FH' with lexical '$fh_fh'");
         assert_eq!(actions[0].edit.range, (5, 7));
         assert_eq!(actions[0].edit.new_text, "my $fh_fh");
+    }
+
+    #[test]
+    fn test_native_critic_two_arg_open_quick_fix() {
+        let diagnostic = make_diagnostic(
+            (0, 19),
+            DiagnosticSeverity::Warning,
+            "native.io.two_arg_open",
+            "Two-argument open should use an explicit mode",
+        );
+
+        let provider = CodeActionsProvider::new("open(my $fh, $path);\n".to_string());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Convert to three-argument open() for safety");
+        assert_eq!(actions[0].edit.range, (0, 19));
+        assert_eq!(actions[0].edit.new_text, "open(my $fh, '<', $filename)");
     }
 
     // ── Quick-fix: unused parameter ─────────────────────────────────────

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1114,6 +1114,7 @@ fn is_fixable_diagnostic(code: &str) -> bool {
             | "native.testing.require_use_strict"
             | "native.testing.require_use_warnings"
             | "native.io.bareword_filehandle"
+            | "native.io.two_arg_open"
             | "InputOutput::ProhibitBarewordFileHandles"
             | "InputOutput::RequireBriefOpen"
             | "InputOutput::RequireThreeArgOpen"
@@ -1349,7 +1350,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
             None,
             &context,
             None,
@@ -1417,6 +1418,23 @@ mod tests {
             .ok_or("native bareword filehandle data should be populated")?;
         assert_eq!(data["code"], "native.io.bareword_filehandle");
         assert_eq!(data["suppressionKey"], "native.io.bareword_filehandle");
+        assert_eq!(data["fixable"], true);
+
+        let two_arg_open = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.io.two_arg_open"))
+            })
+            .ok_or("expected native two-arg open finding")?;
+        assert_eq!(two_arg_open.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(two_arg_open.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(two_arg_open.message, "Two-argument open should use an explicit mode");
+        let data =
+            two_arg_open.data.as_ref().ok_or("native two-arg open data should be populated")?;
+        assert_eq!(data["code"], "native.io.two_arg_open");
+        assert_eq!(data["suppressionKey"], "native.io.two_arg_open");
         assert_eq!(data["fixable"], true);
 
         let unused = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1674,6 +1674,7 @@ fn is_fixable_perlcritic_policy(code: &str) -> bool {
             | "native.testing.require_use_strict"
             | "native.testing.require_use_warnings"
             | "native.io.bareword_filehandle"
+            | "native.io.two_arg_open"
             | "Variables::ProhibitUnusedVariables"
     )
 }
@@ -1836,7 +1837,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
                 }
             })))
             .unwrap();
@@ -1870,6 +1871,14 @@ mod tests {
         assert!(
             text.contains("Bareword filehandle 'FH' should be lexical"),
             "native bareword filehandle finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.io.two_arg_open"),
+            "native critic engine should publish native two-arg open finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Two-argument open should use an explicit mode"),
+            "native two-arg open finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.variables.unused_lexical"),
@@ -1971,7 +1980,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
             }
         })))?;
 
@@ -2020,6 +2029,15 @@ mod tests {
                         == Some("Bareword filehandle 'FH' should be lexical")
             }),
             "native critic engine should add native bareword filehandle finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.io.two_arg_open")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Two-argument open should use an explicit mode")
+            }),
+            "native critic engine should add native two-arg open finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary
- add opt-in native critic rule `native.io.two_arg_open` for two-argument `open(...)` calls
- wire the rule through config/severity/suppression filtering, violation bridge, pull/push/workspace diagnostics, and fixability metadata
- route `native.io.two_arg_open` through the existing two-argument-open quick-fix path in core and LSP-facing code actions
- fix-forward Droid review: quick fixes now preserve the actual second `open` argument instead of hardcoding `$filename`

## Notes
- Native critic remains explicit opt-in.
- Legacy/default critic behavior is unchanged.
- The rule accepts three-argument `open(my $fh, '<', $path)` and reports only two-argument `open(my $fh, $path)` shapes.
- If a code-action diagnostic range cannot be safely parsed as a parenthesized two-argument `open`, no quick fix is emitted rather than inventing source text.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Required proof:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_two_arg --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_two_arg --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask fmt --check`
- [x] `cargo xtask metrics parser-accuracy --check`
- [x] `cargo xtask metrics ratchet-check parser_accuracy`
- [x] `git diff --check`

Deltas:
- Parser denominator: unchanged at 49 fixtures / 29 families; 135 scored lines; 115 scored symbols.
- Failure packets: unchanged at 0 active.
- Provider row: diagnostic/code-action behavior change only for the native two-arg-open quick-fix text; no compiler provider cutover row changes.
- Ratchet: no floor changes; `parser_accuracy` ratchet passed.