### PR TITLE
docs(policy): map Rust 1.95 and 0.14.0 quality rollout (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Planned the Rust 1.95 / `0.14.0` rollout as a docs-first sequence before any
+  MSRV, toolchain, lint, no-panic, file-policy, workflow, or release-version
+  changes.
+
 ## [0.13.4] - 2026-05-07
 
 Release notes: [v0.13.4](docs/releases/v0.13.4.md)

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -42,6 +42,26 @@ The ledger tracks planned Rust 1.94 and 1.95 flips before the workspace MSRV mov
 
 The current workspace remains on the MSRV recorded in `Cargo.toml` and `policy/clippy-lints.toml`; the Rust 1.93 toolchain ratchet is intentionally left to a dedicated follow-up lane because toolchain changes affect CI, documentation, and release policy together.
 
+
+## Rust 1.95 rollout map
+
+The Rust 1.95 / `0.14.0` rollout is mapped in
+[`docs/ci/perl-lsp-rust-1.95-rollout.md`](ci/perl-lsp-rust-1.95-rollout.md).
+For that rollout, Clippy changes stay split across dedicated PRs:
+
+- the compatibility spike runs Rust 1.95 without changing MSRV or lint policy;
+- the MSRV/toolchain PR updates `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`,
+  and workflow toolchain references without removing the test unwrap carveout;
+- the Rust compiler lint-floor PR activates tracked rustc lints;
+- the Clippy ratchet PR measures and then activates clean or cheaply fixable
+  Rust 1.94/1.95 lints;
+- the test-carveout PR removes `allow-unwrap-in-tests = true` and adds a fallible
+  helper path before broader test migration work.
+
+The current mismatch is intentional and visible: `policy/clippy-lints.toml` still
+allows test carveouts while `Cargo.toml` denies `unwrap_used` and `expect_used` at
+the workspace level. Do not resolve that mismatch in the MSRV bump PR.
+
 ## Local check
 
 Run the policy gate before changing lint configuration:

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -1,0 +1,22 @@
+# File policy
+
+Rust and `xtask` are the default implementation surfaces for `perl-lsp`.
+Non-Rust files are allowed when their role is explicit, reviewed, and covered by
+an appropriate policy gate or companion ledger.
+
+## Rust 1.95 rollout target
+
+The Rust 1.95 / `0.14.0` rollout map is
+[`docs/ci/perl-lsp-rust-1.95-rollout.md`](ci/perl-lsp-rust-1.95-rollout.md). File
+policy work is staged after the MSRV, lint, and no-panic foundation:
+
+1. Add the non-Rust ledger without enforcement.
+2. Add inventory, proposal, and checker commands.
+3. Add companion ledgers for generated, executable, dependency, workflow,
+   process, and network surfaces.
+4. Wire the checks into existing CI gate receipts.
+
+Legitimate non-Rust surfaces include Perl fixtures and corpus files,
+tree-sitter/native parser bindings, VS Code extension files, GitHub workflows,
+CI scripts, generated status artifacts, and release metadata. The policy target is
+not "no non-Rust"; it is "non-Rust by receipt".

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -1,0 +1,28 @@
+# No-panic policy
+
+`perl-lsp` treats panic-family calls as policy debt because parser, LSP, DAP,
+and CI-control code should report structured failure instead of aborting. The
+active Clippy bans live in the workspace lint block and the broader policy plan
+lives in `policy/clippy-lints.toml`.
+
+## Rust 1.95 rollout target
+
+The Rust 1.95 / `0.14.0` rollout target is an exact, counted, no-new-debt
+no-panic gate. The rollout map is
+[`docs/ci/perl-lsp-rust-1.95-rollout.md`](ci/perl-lsp-rust-1.95-rollout.md).
+
+The intended sequence is:
+
+1. Harden finding identity before any baseline reset.
+2. Match by `path + family + selector_kind + selector_callee + snippet`.
+3. Require allowlist entries to include the exact snippet and count.
+4. Consume exact allowlist counts first.
+5. Consume baseline counts second unless the gate is running in blocking mode.
+6. Report anything left as new debt.
+
+## Baseline discipline
+
+The baseline PR is the only rollout step allowed to reset the no-panic baseline.
+Baseline refreshes after that should drop disappeared findings only. New panic
+family findings must be fixed, narrowly allowlisted with count and expiry, or
+handled through an explicit baseline reset PR.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -1,0 +1,27 @@
+# Policy allowlists
+
+Policy allowlists are receipts for intentional exceptions. They should be narrow,
+owned, dated, reviewed, and connected to a gate or companion policy.
+
+## Rust 1.95 rollout target
+
+The Rust 1.95 / `0.14.0` rollout map is
+[`docs/ci/perl-lsp-rust-1.95-rollout.md`](ci/perl-lsp-rust-1.95-rollout.md). It
+splits allowlist work into separate lanes so the MSRV bump does not also change
+panic, file, workflow, process, or network policy.
+
+Planned allowlist surfaces include:
+
+- exact counted no-panic allowlist entries;
+- a generated no-panic baseline marked as generated metadata;
+- a non-Rust file allowlist with owner, reason, surface, classification, and
+  coverage fields;
+- companion ledgers for generated files, executable files, dependency surfaces,
+  workflow surfaces, process execution, and network access;
+- `ripr` suppressions for advisory static oracle-gap findings.
+
+## Required posture
+
+Allowlists are not blanket permission. Broad globs require a `broad_glob_reason`,
+entries need review dates, and generated or risky surfaces need companion policy
+coverage before they become blocking CI gates.

--- a/docs/ci/lem-budgeting.md
+++ b/docs/ci/lem-budgeting.md
@@ -97,6 +97,24 @@ of LEM is intentionally **not** part of this rollout.
 
 ---
 
+
+## Rust 1.95 rollout use
+
+The Rust 1.95 / `0.14.0` rollout uses the existing LEM, risk-pack, lane, and
+actuals control plane rather than adding a parallel process. The rollout map is
+[`perl-lsp-rust-1.95-rollout.md`](perl-lsp-rust-1.95-rollout.md).
+
+For the rollout, learned estimates remain a later tuning step:
+
+```text
+estimate = max(static_floor, p50_recent_actual * 1.15)
+warning = p90_recent_actual
+hard planning = p95_recent_actual
+```
+
+Do not hard-enforce learned estimates below the 125 LEM ceiling until actuals
+have been calibrated and surfaced in PR Plan summaries.
+
 ## What LEM is not
 
 - **Not a billing source.** GitHub usage and Blacksmith billing reports are authoritative.

--- a/docs/ci/perl-lsp-rust-1.95-rollout.md
+++ b/docs/ci/perl-lsp-rust-1.95-rollout.md
@@ -1,0 +1,174 @@
+# Rust 1.95 / 0.14.0 rollout map
+
+This document is the control map for moving `perl-lsp` from the current Rust
+1.93 / toolchain 1.93.1 line to Rust 1.95.0 and preparing the next minor release,
+`0.14.0`. It is intentionally documentation-only: no MSRV, workflow, policy,
+code, or release-version changes happen in this PR.
+
+## Current and target state
+
+Truth sources for the current state are `Cargo.toml`, `rust-toolchain.toml`,
+`clippy.toml`, and `policy/clippy-lints.toml`.
+
+| Layer | Current | Target | Status |
+|---|---:|---:|---|
+| Edition | 2024 | 2024 | done |
+| MSRV | 1.93 | 1.95.0 | planned |
+| Toolchain | 1.93.1 | 1.95.0 | planned |
+| Release line | 0.13.4 | 0.14.0 | planned |
+| Clippy panic-family | partly active | strict + no test carveouts | partial |
+| `collapsible_if` | broad allow | debt ledger / cleanup | todo |
+| Rust 1.93 rustc lints | planned/tracked | active | todo |
+| Rust 1.95 Clippy lints | planned | active or ratcheted | todo |
+| No-panic allowlist | missing/incomplete | exact counted no-new-debt | todo |
+| Non-Rust allowlist | missing/incomplete | blocking file policy | todo |
+| ripr | advisory, installed in workflow | advisory + better routing | partial |
+| CI economics | LEM/risk packs exist | tuned + actuals-backed | partial |
+
+## Why Rust 1.95 matters here
+
+Rust 1.95 is not being adopted only because it is newer. The useful changes map
+directly to `perl-lsp`'s parser, semantic, LSP, DAP, policy, and CI-control
+surfaces.
+
+| Rust 1.95 item | Repo-specific value |
+|---|---|
+| `if let` guards | Parser/AST walkers, semantic extraction, import visibility, refactor preconditions, LSP provider routing. |
+| `Vec::push_mut` / `insert_mut` | Diagnostic/report builders, semantic facts, scorecards, CI receipts, LSP response builders. |
+| Atomic `update` / `try_update` | Session/cache counters, memory-pressure counters, cancellation or stream-state metrics. |
+| `cfg_select!` | Windows/Unix path behavior, subprocess handling, VS Code install surfaces, native/virtual URI handling. |
+| `cold_path` | Parser recovery, malformed URI/path handling, failed subprocess/perlcritic paths, policy failure reporting. |
+| Clippy 1.95 | `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, and future `disallowed_fields`. |
+
+The biggest implementation value is `if let` guards in AST-heavy semantic walkers:
+they keep branch shape and semantic preconditions together, which reduces review
+load and lowers the odds of panic-prone follow-up indexing or unwraps.
+
+
+## Queue control
+
+Two open draft PRs are not part of the Rust 1.95 rollout and must stay separate:
+
+- `#8306 fix(ux-tests): eliminate post-fix race in scenario_19 diagnostics lifecycle`
+- `#8301 feat(critic): add parameter_shadows_global native critic rule`
+
+Do not fold Rust 1.95 work into either product/test PR. Start rollout work from a
+clean `master` baseline and expect to rebase after unrelated queue items merge.
+
+## Explicit operating rule
+
+The first implementation PR after this documentation PR is a Rust 1.95
+compatibility spike. No MSRV bump, lint activation, no-panic baseline reset,
+release bump, or API cleanup happens in the same PR.
+
+## Current policy notes
+
+### Clippy
+
+- Root `Cargo.toml` already hard-bans the core panic-family Clippy lints:
+  `unwrap_used`, `expect_used`, `panic`, `todo`, `unimplemented`, and `dbg_macro`.
+- Root `Cargo.toml` still carries `collapsible_if = "allow"`; this remains debt
+  until a cleanup or exception-ledger PR addresses it deliberately.
+- `policy/clippy-lints.toml` records the broader active/tracked/planned lint
+  posture and still uses `msrv = "1.93"`.
+- `clippy.toml` still has `allow-unwrap-in-tests = true`, while the target
+  posture is no test carveouts. The rollout keeps this mismatch visible and
+  resolves it in its own policy PR with helper functions, not as part of the
+  MSRV bump.
+
+### No-panic
+
+The target no-panic posture is exact, counted, and no-new-debt:
+
+1. Findings are keyed by path, family, selector kind, selector callee, and snippet.
+2. Allowlist entries consume exact counted slots.
+3. Baseline entries consume remaining counted slots only outside blocking mode.
+4. New unmatched findings fail the gate.
+
+The baseline reset is deliberately deferred until exact matching exists.
+
+### Non-Rust and file policy
+
+Rust and `xtask` remain the default implementation surface. Non-Rust files are
+allowed when the reason, owner, surface, classification, and coverage are recorded
+in policy. Legitimate non-Rust surfaces include Perl fixtures/corpus,
+tree-sitter/native C bindings, VS Code extension assets, GitHub workflows, CI
+scripts, generated status artifacts, and release metadata.
+
+The file-policy rollout is ledger-first, checker-second, then CI wiring. That
+prevents a broad allowlist from silently becoming the policy.
+
+### ripr
+
+`ripr` is advisory static oracle-gap detection. It complements normal gates and
+mutation testing but does not replace either. During this rollout it remains
+advisory, skips low-risk docs/test-fixture-only changes unless forced by label,
+and routes higher-risk results toward targeted follow-up or mutation lanes.
+
+### CI economics
+
+The existing control plane already has LEM budgeting, risk packs, lane policy, PR
+smoke, merge-gate shards, UX tests, memory smoke, Windows guardrails, CI actuals,
+and advisory `ripr`. This rollout tunes those rails instead of inventing a new
+process. Learned LEM estimates should use recent actuals only after a calibration
+window, and no sub-125-LEM hard enforcement should be added before that work lands.
+
+## PR ladder
+
+| Step | Branch | Title | Scope boundary | Acceptance gate |
+|---:|---|---|---|---|
+| 1 | `docs/rust-1.95-rollout` | `docs(policy): map Rust 1.95 and 0.14.0 quality rollout` | Documentation-only rollout map. | `cargo check -p xtask --locked`; `cargo xtask check-lint-policy`; `git diff --check` |
+| 2 | `probe/rust-1.95-compat` | `chore(msrv): probe Rust 1.95 compatibility` | Run current repo under Rust 1.95 before declaring it. Prefer audit note only. | fmt, workspace checks, clippy, tests, lint policy, pr-fast receipt, diff check |
+| 3 | `chore/msrv-rust-1.95` | `chore(msrv): raise workspace toolchain to Rust 1.95` | MSRV/toolchain/config/workflow references only; no release bump. | Rust 1.95 override, fmt, workspace check, lint policy, pr-fast receipt, diff check |
+| 4 | `policy/rust-1.95-lints` | `policy(rust): enable Rust 1.95 compiler lint floor` | Activate rustc lint floor and update ledger. | workspace check, lint policy, pr-fast receipt |
+| 5 | `policy/clippy-rust-1.95-ratchets` | `policy(clippy): activate Rust 1.95 lint ratchets` | Measure first; activate clean or cheaply fixable Clippy 1.94/1.95 lints. | lint policy and workspace clippy without global `-D warnings` until debt is receipted |
+| 6 | `policy/no-test-clippy-carveouts` | `policy(clippy): remove test unwrap carveout` | Remove test unwrap carveout and add fallible helper path; do not migrate the whole suite. | targeted helper tests and lint-policy check |
+| 7 | `policy/no-panic-exact-identity` | `policy(panic): harden no-panic allowlist identity` | Exact counted no-panic matching before any baseline reset. | `cargo test -p xtask no_panic --locked`; `cargo xtask check-no-panic-family` |
+| 8 | `policy/no-panic-baseline` | `policy(panic): add no-panic baseline and no-new-debt gate` | Generate baseline once from current master after exact identity exists. | baseline reset, no-panic family check, no-panic tests, diff check |
+| 9 | `policy/no-panic-diagnostics` | `policy(panic): improve no-panic report diagnostics` | More actionable missing/stale/delta/blocking diagnostics. | no-panic tests, no-panic family check, report existence check |
+| 10 | `policy/non-rust-file-ledger` | `policy(files): add non-Rust file allowlist` | Ledger only; no enforcement. | TOML parse and `cargo check -p xtask --locked` |
+| 11 | `policy/check-file-policy` | `policy(files): enforce non-Rust allowlist` | Inventory/proposal/checker commands and advisory/blocking modes. | xtask check, file-policy tests, inventory, propose, advisory check |
+| 12 | `policy/file-companion-ledgers` | `policy(files): add companion allowlists for risky surfaces` | Generated, executable, dependency, workflow, process, and network ledgers. | companion checks in advisory mode and policy report |
+| 13 | `ci/policy-gate-wiring` | `ci(policy): wire file and lint policies into gate receipts` | Add policy gate receipt to existing conveyor. | file-policy gate receipt and receipt validation |
+| 14 | `ci/ripr-and-mutation-routing` | `ci(ripr): tune advisory exposure routing` | Tune `ripr` routing; keep mutation off normal PRs. | CI plan dry-run if available and diff check |
+| 15 | `refactor/rust-1.95-ast-cleanups` | `refactor: use Rust 1.95 APIs in AST and provider paths` | Targeted API cleanup where Rust 1.95 reduces complexity. | targeted parser/semantic/LSP tests, clippy, no-panic check, diff check |
+| 16 | `policy/clippy-default-surface-cleanup` | `policy(clippy): clean strict lint debt in default surface` | Fix or receipt strict-lint debt in parser, semantic, and LSP defaults. | lint policy, clippy exceptions, workspace clippy |
+| 17 | `policy/no-panic-first-burndown` | `policy(panic): burn down first no-panic owner lane` | One narrow owner lane only. | touched-crate tests, no-panic family check, baseline refresh that only drops disappeared entries |
+| 18 | `ci/learned-lem-estimates` | `ci: use actuals to calibrate PR Plan LEM estimates` | Actuals-backed estimates with static fallback; no branch-protection change. | plan JSON includes estimate source and summary distinguishes static vs learned |
+| 19 | `release/0.14.0-prep-rust-1.95` | `release: prepare 0.14.0 for Rust 1.95` | Version and release-facing prep for the minor release. | workspace check, lint/file/no-panic checks, pr-fast receipt, diff check |
+| 20 | `release/0.14.0-dry-run` | `release: validate 0.14.0 publish readiness` | Package/publish readiness proof and release docs. | package dry-run, pr-fast receipt, policy checks, policy report |
+
+## Bot, CI, and self-review rules
+
+For every rollout PR:
+
+1. Start from a clean `master` baseline when possible; do not stack unless a step
+   explicitly depends on the previous branch.
+2. Keep one PR per objective and do not fold unrelated cleanup into a failing CI fix.
+3. If CI fails, identify the first real failing command, reproduce locally when
+   possible, fix only that failure, rerun the matching local gate, then re-check CI.
+4. Treat bot comments as defects when real, stale when superseded by current HEAD,
+   and follow-up material when correct but out of scope.
+5. Report skipped lanes as skipped by policy, not passed.
+
+Before marking a PR ready, the author must self-review:
+
+```markdown
+## Self-review
+
+- Scope matches PR title:
+- Files touched are expected:
+- No unrelated cleanup:
+- Policy changes are intentional:
+- No Clippy test carveouts added:
+- No bare `#[allow(clippy::...)]` added:
+- No-panic baseline handling is scoped:
+- Non-Rust allowlist changes are narrow:
+- CI/ripr/LEM behavior matches docs:
+- Local validation:
+- CI status:
+- Bot comments addressed:
+- Follow-ups:
+```
+
+If any item is not true, the PR should not merge.

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -70,6 +70,25 @@ The suppression file is read by `ripr.toml`'s `[suppressions] path` setting.
 
 ---
 
+
+## Rust 1.95 rollout routing
+
+The Rust 1.95 / `0.14.0` rollout keeps `ripr` advisory. The rollout map is
+[`perl-lsp-rust-1.95-rollout.md`](perl-lsp-rust-1.95-rollout.md). During that
+work, `ripr` should remain the fast PR-time exposure filter rather than a
+mutation-testing replacement or branch-protection gate.
+
+Target routing for the later `ripr` tuning PR:
+
+- normal PRs run `ripr`, normal gates, and targeted mutation only when risk
+  warrants it;
+- nightly or explicit full-CI lanes own broad mutation work;
+- release readiness reports whether mutation/ripr evidence is clean enough to
+  ship;
+- docs-only and test-fixture-only changes may skip `ripr` unless a label forces
+  it;
+- skipped lanes must be reported as skipped by policy, not passed.
+
 ## Promotion path
 
 | PR | What happens |


### PR DESCRIPTION
### Motivation

- Provide a repo-specific, docs-first control map for moving the workspace MSRV/toolchain to Rust 1.95 and preparing the 0.14.0 minor release while preserving the existing CI/policy conveyor and avoiding bundling implementation, lint, or release changes into one PR.

### Description

- Added the rollout control map `docs/ci/perl-lsp-rust-1.95-rollout.md` that enumerates the PR ladder, acceptance gates, and explicit operating rules for the Rust 1.95 / 0.14.0 sequence.
- Added policy/reference docs: `docs/NO_PANIC_POLICY.md`, `docs/POLICY_ALLOWLISTS.md`, and `docs/FILE_POLICY.md` describing target no-panic identity, allowlist posture, and non-Rust file policy surface.
- Updated `docs/CLIPPY_POLICY.md`, `docs/ci/ripr.md`, and `docs/ci/lem-budgeting.md` to reference the rollout, preserve the intended sequencing (compatibility spike → MSRV bump → lint ratchets → policy work), and keep `ripr`/LEM routing advisory during rollout.
- Updated `CHANGELOG.md` with an `Unreleased` note describing the docs-first rollout plan and made no code, workflow, `Cargo.toml`, `rust-toolchain.toml`, or `clippy.toml` changes in this PR.

### Testing

- Ran `cargo check -p xtask --locked` and it completed successfully.
- Ran `cargo xtask check-lint-policy` and it reported the lint ledger as OK.
- Verified `git diff --check` had no whitespace/format errors.
- Executed `./scripts/storage-doctor` to validate storage guidance (fixed repo-local `target/` transient artifact and re-ran), resulting in a successful check.

All automated checks listed above passed for the documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe57f4bbe48333966b1d8f41a0b2d0)