### PR TITLE
docs(policy): map Rust 1.95 and 0.14.0 quality rollout (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- Documented the Rust 1.95 / 0.14.0 rollout plan. The implementation remains split across dedicated follow-up PRs for compatibility probing, MSRV/toolchain changes, lint ratchets, no-panic policy, file policy, CI routing, and release preparation.
+
 ## [0.13.4] - 2026-05-07
 
 Release notes: [v0.13.4](docs/releases/v0.13.4.md)

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -36,6 +36,21 @@ fn generated_table_lookup(table: &[usize], index: usize) -> usize {
 
 Do not use a silent `#[allow]`. If a lint needs repo-wide temporary treatment, add a scoped entry to `policy/clippy-debt.toml` with `lint`, `path`, `owner`, `reason`, and `expires`.
 
+## Rust 1.95 rollout checkpoint
+
+The Rust 1.95 / 0.14.0 rollout is mapped in [perl-lsp-rust-1.95-rollout.md](ci/perl-lsp-rust-1.95-rollout.md). The documentation PR does not change `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, or workflow pins.
+
+Current policy facts to preserve until their dedicated implementation PRs:
+
+- Workspace metadata remains edition 2024, version 0.13.4, and MSRV 1.93.
+- `rust-toolchain.toml` remains pinned to 1.93.1.
+- `clippy.toml` remains on MSRV 1.93 and still carries `allow-unwrap-in-tests = true`.
+- Root hard bans already deny `unwrap_used`, `expect_used`, `panic`, `todo`, `unimplemented`, and `dbg_macro`.
+- `collapsible_if = "allow"` remains explicit debt until a cleanup/exception-ledger PR handles it.
+- Rust 1.93 rustc lints and Rust 1.94/1.95 Clippy lints stay tracked or planned in `policy/clippy-lints.toml` until the dedicated activation PRs.
+
+The target posture after the rollout is Rust 1.95.0, no Clippy test carveout, active compiler lint floor, and measured Clippy 1.94/1.95 ratchets.
+
 ## Planned Rust upgrades
 
 The ledger tracks planned Rust 1.94 and 1.95 flips before the workspace MSRV moves. `cargo xtask check-lint-policy` verifies that planned lints are present in the ledger and not activated ahead of the MSRV bump.

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -1,0 +1,45 @@
+# File policy
+
+Rust and `xtask` are the default implementation surfaces for this repository.
+Non-Rust files are valid when they are intentional, owned, and covered by an
+allowlist or companion policy.
+
+## Legitimate non-Rust surfaces
+
+The Rust 1.95 / 0.14.0 rollout identifies these expected non-Rust surfaces:
+
+- Perl fixtures and corpus data;
+- tree-sitter C/native parser bindings;
+- VS Code extension assets and TypeScript surfaces;
+- GitHub workflows;
+- CI scripts;
+- generated docs/status artifacts;
+- release metadata.
+
+## Target ledger
+
+The target non-Rust allowlist entries include:
+
+```text
+id
+glob
+kind
+language
+surface
+classification
+owner
+reason
+covered_by
+created
+review_after
+```
+
+Broad globs also require `broad_glob_reason`. Companion ledgers should cover
+generated files, executable files, dependency surfaces, workflow behavior,
+process execution, and network access.
+
+The rollout map records the sequence: add the ledger first, add inventory and
+proposal tooling next, then wire blocking checks into gate receipts only after
+the allowlist is reviewable.
+
+See [Rust 1.95 / 0.14.0 rollout map](ci/perl-lsp-rust-1.95-rollout.md).

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -1,0 +1,38 @@
+# No-panic policy
+
+`perl-lsp` treats panic-family calls as policy-controlled debt. The Rust 1.95 /
+0.14.0 rollout does not reset any baseline in its documentation PR; it records
+the target posture and reserves implementation for dedicated policy PRs.
+
+## Current state
+
+- Root Clippy hard bans already deny `panic`, `todo`, `unimplemented`,
+  `unwrap_used`, `expect_used`, and `dbg_macro` through workspace lints.
+- Additional panic-family lints are tracked in `policy/clippy-lints.toml`.
+- The exact no-panic allowlist/baseline is missing or incomplete, so the
+  rollout must harden identity before creating a no-new-debt baseline.
+- `clippy.toml` still allows unwraps in tests; removing that carveout is a
+  separate Clippy policy PR, not part of the rollout map PR.
+
+## Target state
+
+The target no-panic model is exact and counted:
+
+```text
+path + family + selector_kind + selector_callee + snippet + count
+```
+
+Matching order:
+
+1. consume exact allowlist count slots;
+2. then consume baseline count slots unless mode is `blocking`;
+3. report anything left as new debt.
+
+Allowlist entries should include the reviewed snippet and count. Baseline reset
+is allowed only in the dedicated no-panic baseline PR after exact identity is in
+place.
+
+## Rollout link
+
+See [Rust 1.95 / 0.14.0 rollout map](ci/perl-lsp-rust-1.95-rollout.md) for the
+ordered PR ladder and validation gates.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -1,0 +1,28 @@
+# Policy allowlists
+
+Policy allowlists are receipts for intentionally retained risk. They should be
+narrow, owned, dated, reviewable, and enforced by repository tooling before they
+become blocking gates.
+
+## Rust 1.95 rollout targets
+
+The Rust 1.95 / 0.14.0 rollout maps these allowlist families without activating
+them in the documentation PR:
+
+| Family | Current state | Target |
+|---|---|---|
+| Clippy lint debt | `policy/clippy-lints.toml` and `policy/clippy-debt.toml` govern active/tracked/planned lints. | Activate Rust 1.93/1.95 floors in dedicated PRs and record retained exceptions with narrow receipts. |
+| No-panic | Exact counted allowlist/baseline is missing or incomplete. | Match by path, family, selector kind, selector callee, snippet, and count; enforce no-new-debt after baseline. |
+| Non-Rust files | Missing/incomplete file ledger. | Add blocking non-Rust allowlist with required owner, reason, surface, classification, coverage, and review dates. |
+| Companion file risks | Not yet represented as separate ledgers. | Add generated, executable, dependency, workflow, process, and network allowlists. |
+| ripr | Advisory suppressions exist through `policy/ripr-suppressions.toml` when configured. | Keep advisory while improving routing and artifact consistency. |
+
+## Required allowlist posture
+
+New allowlists should avoid broad anonymous globs. Each retained exception needs
+an owner, reason, created date, review date, and evidence of the gate or test
+that covers it. Broad globs need an explicit broad-glob reason.
+
+See [Rust 1.95 / 0.14.0 rollout map](ci/perl-lsp-rust-1.95-rollout.md) for the
+implementation order. Documentation-only rollout mapping must not create a new
+baseline or silently absorb new debt.

--- a/docs/ci/lem-budgeting.md
+++ b/docs/ci/lem-budgeting.md
@@ -97,6 +97,12 @@ of LEM is intentionally **not** part of this rollout.
 
 ---
 
+## Rust 1.95 rollout checkpoint
+
+The Rust 1.95 / 0.14.0 rollout uses the existing LEM, risk-pack, lane, receipt, and CI-actuals foundation. It does not add a new process layer in the documentation PR. Later rollout PRs may tune estimates from actuals using the documented model, but they must not hard-enforce learned estimates below the 125 LEM ceiling before enough actuals are calibrated.
+
+See [perl-lsp-rust-1.95-rollout.md](perl-lsp-rust-1.95-rollout.md) for the full rollout ladder.
+
 ## What LEM is not
 
 - **Not a billing source.** GitHub usage and Blacksmith billing reports are authoritative.

--- a/docs/ci/perl-lsp-rust-1.95-rollout.md
+++ b/docs/ci/perl-lsp-rust-1.95-rollout.md
@@ -1,0 +1,155 @@
+# Rust 1.95 / 0.14.0 rollout map
+
+This document is the control map for moving `perl-lsp` from the Rust 1.93
+line to Rust 1.95.0 and preparing the next minor release line, `0.14.0`.
+It is intentionally documentation-only: no MSRV, toolchain, lint, workflow,
+release-version, baseline, or API changes are part of this PR.
+
+## Current and target state
+
+Truth sources for the current state are `Cargo.toml`, `rust-toolchain.toml`,
+`clippy.toml`, and `policy/clippy-lints.toml`.
+
+| Layer | Current | Target | Status |
+|---|---:|---:|---|
+| Edition | 2024 | 2024 | done |
+| MSRV | 1.93 | 1.95.0 | planned |
+| Toolchain | 1.93.1 | 1.95.0 | planned |
+| Release line | 0.13.4 | 0.14.0 | planned |
+| Clippy panic-family | partly active | strict + no test carveouts | partial |
+| `collapsible_if` | broad allow | debt ledger / cleanup | todo |
+| Rust 1.93 rustc lints | planned/tracked | active | todo |
+| Rust 1.95 Clippy lints | planned | active or ratcheted | todo |
+| No-panic allowlist | missing/incomplete | exact counted no-new-debt | todo |
+| Non-Rust allowlist | missing/incomplete | blocking file policy | todo |
+| ripr | advisory, installed in workflow | advisory + better routing | partial |
+| CI economics | LEM/risk packs exist | tuned + actuals-backed | partial |
+
+## Rust 1.95 value for `perl-lsp`
+
+| Rust 1.95 item | Repo-specific value |
+|---|---|
+| `if let` guards | Parser/AST walkers, semantic extraction, import visibility, refactor preconditions, LSP provider routing. |
+| `Vec::push_mut` / `insert_mut` | Diagnostic/report builders, semantic facts, scorecards, CI receipts, LSP response builders. |
+| Atomic `update` / `try_update` | Session/cache counters, memory-pressure counters, cancellation or stream-state metrics. |
+| `cfg_select!` | Windows/Unix path behavior, subprocess handling, VS Code install surfaces, native/virtual URI handling. |
+| `cold_path` | Parser recovery, malformed URI/path handling, failed subprocess/perlcritic paths, policy failure reporting. |
+| Clippy 1.95 | `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, and future `disallowed_fields`. |
+
+`if let` guards matter materially for AST-heavy semantic walkers because they
+keep the branch shape and semantic precondition together. That should reduce
+review load in parser, semantic-analyzer, and provider paths once the MSRV has
+actually moved.
+
+## Operating rule
+
+The first implementation PR after this documentation PR is a Rust 1.95
+compatibility spike. No MSRV bump, lint activation, no-panic baseline reset,
+release bump, or API cleanup happens in the same PR.
+
+## Queue control
+
+The Rust 1.95 rollout must not be folded into unrelated product or test PRs.
+Open draft work such as UX race fixes or native critic rules remains separate.
+Each rollout PR starts from clean `master`/`origin/master` when available and
+contains one objective.
+
+## Policy status to carry forward
+
+### Clippy
+
+- Active root hard bans already cover `unwrap_used`, `expect_used`, `panic`,
+  `todo`, `unimplemented`, and `dbg_macro`.
+- `clippy::collapsible_if` remains a broad allow and is tracked as debt until
+  a dedicated cleanup or exception ledger PR removes the global carveout.
+- `policy/clippy-lints.toml` tracks Rust 1.93 rustc lints and Rust 1.94/1.95
+  Clippy lints, but activation is intentionally deferred until the relevant
+  rollout PRs.
+- `clippy.toml` still has `allow-unwrap-in-tests = true` while the policy
+  target is strict tests with no test carveouts. Removing that mismatch is a
+  dedicated PR after the MSRV bump and ratchet measurement.
+
+### No-panic
+
+The target posture is exact, counted identity for retained panic-family debt:
+`path + family + selector_kind + selector_callee + snippet + count`. Allowlist
+counts are consumed first, then baseline counts are consumed unless the mode is
+blocking, and anything left is reported as new debt. Baseline reset is reserved
+for the dedicated baseline PR only.
+
+### Non-Rust and file policy
+
+Rust and `xtask` remain the default implementation surfaces. Non-Rust files are
+allowed by receipt rather than anonymously. Legitimate surfaces include Perl
+fixtures/corpus data, tree-sitter C/native parser bindings, VS Code extension
+code, GitHub workflows, CI scripts, docs/status artifacts, and release metadata.
+The target is a blocking allowlist plus companion ledgers for generated files,
+executables, dependency surfaces, workflow behavior, process execution, and
+network access.
+
+### ripr
+
+`ripr` remains advisory. It is a fast PR-time exposure filter, not a mutation
+replacement and not branch-protection blocking. The rollout should tune routing
+so ordinary PRs get `ripr` plus normal gates, high-risk changes can trigger
+targeted mutation, nightly/release lanes can carry fuller mutation proof, and
+docs-only/test-fixture-only changes can be skipped unless labels force it.
+
+### CI economics
+
+LEM budget policy, CI lane policy, risk packs, PR smoke, merge-gate shards, UX
+tests, memory smoke, Windows guardrails, CI actuals, and advisory `ripr` already
+exist. The rollout should tune this control plane using receipts and actuals;
+it should not hard-enforce learned LEM estimates below the 125 LEM ceiling
+before enough actuals are calibrated.
+
+## PR ladder and acceptance gates
+
+| PR | Branch | Objective | Acceptance |
+|---:|---|---|---|
+| 1 | `docs/rust-1.95-rollout` | Document this rollout map only. | `cargo check -p xtask --locked`; `cargo xtask check-lint-policy`; `git diff --check` |
+| 2 | `probe/rust-1.95-compat` | Run the current repo under Rust 1.95.0 before changing declarations. | Rust 1.95 fmt/check/clippy/test, lint policy, pr-fast receipt, diff check |
+| 3 | `chore/msrv-rust-1.95` | Raise MSRV/toolchain/config/workflow pins to Rust 1.95.0 without release bump. | Rust 1.95 fmt/check, lint policy, pr-fast receipt, diff check |
+| 4 | `policy/rust-1.95-lints` | Activate the compiler lint floor. | workspace check, lint policy, pr-fast receipt |
+| 5 | `policy/clippy-rust-1.95-ratchets` | Measure and activate clean/cheap Rust 1.94/1.95 Clippy ratchets. | lint policy, workspace clippy |
+| 6 | `policy/no-test-clippy-carveouts` | Remove the test unwrap carveout and add fallible helper path. | targeted tests/checks from touched helper crate and lint policy |
+| 7 | `policy/no-panic-exact-identity` | Harden no-panic matching to exact counted identity. | `cargo test -p xtask no_panic --locked`; `cargo xtask check-no-panic-family` |
+| 8 | `policy/no-panic-baseline` | Add no-new-debt baseline after exact identity exists. | baseline reset, no-panic family check, no-panic tests, diff check |
+| 9 | `policy/no-panic-diagnostics` | Improve actionable no-panic reports. | no-panic tests/checks and report existence |
+| 10 | `policy/non-rust-file-ledger` | Add non-Rust allowlist/debt ledger without enforcement. | TOML parse, `cargo check -p xtask --locked` |
+| 11 | `policy/check-file-policy` | Add inventory, propose, and check-file-policy commands. | xtask check/tests and advisory file-policy commands |
+| 12 | `policy/file-companion-ledgers` | Add generated/executable/dependency/workflow/process/network ledgers. | companion checks in advisory mode and policy report |
+| 13 | `ci/policy-gate-wiring` | Wire policy checks into gate receipts. | file-policy gate receipt and receipt validation |
+| 14 | `ci/ripr-and-mutation-routing` | Tune advisory `ripr` exposure and mutation routing. | CI plan dry run if available, diff check |
+| 15 | `refactor/rust-1.95-ast-cleanups` | Use Rust 1.95 APIs in AST/semantic/provider paths where they reduce risk. | targeted parser/semantic/LSP tests, targeted clippy, no-panic family, diff check |
+| 16 | `policy/clippy-default-surface-cleanup` | Clean strict lint debt in parser/semantic/LSP default surfaces. | lint policy, clippy exceptions, workspace clippy |
+| 17 | `policy/no-panic-first-burndown` | Burn down one narrow no-panic owner lane. | touched-crate tests, no-panic family, baseline refresh that only drops entries |
+| 18 | `ci/learned-lem-estimates` | Use CI actuals to calibrate PR Plan LEM estimates. | `ci-plan.json` shows static/learned source and fallback behavior |
+| 19 | `release/0.14.0-prep-rust-1.95` | Prepare the `0.14.0` minor release. | workspace check, lint/file/no-panic policies, pr-fast receipt, diff check |
+| 20 | `release/0.14.0-dry-run` | Prove package and publish readiness before tagging. | package dry run, pr-fast receipt, policies, policy report |
+
+## Bot, CI, and self-review loop
+
+For every PR, inspect PR status and checks, then investigate the first real
+failing command from failed logs. Reproduce locally when possible, fix only the
+failing scope, rerun the matching local gate, push, and re-check bot comments.
+Treat bot findings as real defects unless current-HEAD evidence shows they are
+false positives, stale, or out of scope.
+
+Before marking a rollout PR ready, add a self-review covering:
+
+- scope matches PR title;
+- files touched are expected;
+- no unrelated cleanup;
+- policy changes are intentional;
+- no Clippy test carveouts added;
+- no bare `#[allow(clippy::...)]` added;
+- no-panic baseline handling is scoped;
+- non-Rust allowlist changes are narrow;
+- CI/ripr/LEM behavior matches docs;
+- local validation;
+- CI status;
+- bot comments addressed;
+- follow-ups.
+
+If any item is not true, the PR is not ready.

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -70,6 +70,12 @@ The suppression file is read by `ripr.toml`'s `[suppressions] path` setting.
 
 ---
 
+## Rust 1.95 rollout routing note
+
+During the Rust 1.95 / 0.14.0 rollout, `ripr` remains advisory and must not become a branch-protection blocker. The target routing is: PRs get `ripr` plus normal gates, riskier changes may request targeted mutation, nightly lanes carry fuller mutation proof, and release lanes prove mutation cleanliness appropriate to shipping. Docs-only and test-fixture-only changes may be skipped unless a label forces `ripr`.
+
+The rollout map is documented in [perl-lsp-rust-1.95-rollout.md](perl-lsp-rust-1.95-rollout.md).
+
 ## Promotion path
 
 | PR | What happens |


### PR DESCRIPTION
### Motivation

- Capture a repo-specific control map for moving the workspace from MSRV/toolchain Rust 1.93 → Rust 1.95.0 and preparing the next minor release line `0.14.0` without changing code or CI pins in this PR. 
- Prevent scope creep by documenting the ordered PR ladder (compat probe, MSRV bump, lint ratchets, no-panic baseline, file-policy, ripr/CI tuning, release prep) and recording current vs target policy posture. 
- Preserve current truths (workspace version `0.13.4`, edition `2024`, `rust-toolchain.toml` pinned to `1.93.1`, `clippy.toml` still carrying `allow-unwrap-in-tests = true`) and make clear which follow-ups will change them.

### Description

- Added a documentation-only rollout map at `docs/ci/perl-lsp-rust-1.95-rollout.md` that lists the PR ladder, acceptance gates, and operating rules for the Rust 1.95 / 0.14.0 rollout. 
- Added policy/guide documents: `docs/FILE_POLICY.md`, `docs/NO_PANIC_POLICY.md`, and `docs/POLICY_ALLOWLISTS.md`, and updated `docs/CLIPPY_POLICY.md`, `docs/ci/ripr.md`, and `docs/ci/lem-budgeting.md` with rollout checkpoints and routing guidance. 
- Added an Unreleased changelog note in `CHANGELOG.md` recording that the rollout plan is documented; this PR makes no changes to `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, workflows, or source code.

### Testing

- Ran `cargo check -p xtask --locked` and verified it completed successfully. 
- Ran `cargo xtask check-lint-policy` and verified the lint ledger gate reported OK. 
- Ran `git diff --check` to confirm no whitespace/patch problems. 
- Ran `./scripts/storage-doctor` (cleaned local `target/` during the run per storage policy) and confirmed repository storage checks passed.

All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe57f4bbe48333966b1d8f41a0b2d0)