### PR TITLE
docs(policy): map Rust 1.95 and 0.14.0 quality rollout (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Planned the Rust 1.95 / 0.14.0 rollout map so compatibility probing, MSRV changes, lint ratchets, no-panic policy, file policy, CI tuning, and release prep stay split across focused PRs.
+
 ## [0.13.4] - 2026-05-07
 
 Release notes: [v0.13.4](docs/releases/v0.13.4.md)

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -38,9 +38,13 @@ Do not use a silent `#[allow]`. If a lint needs repo-wide temporary treatment, a
 
 ## Planned Rust upgrades
 
+The Rust 1.95 / 0.14.0 rollout is mapped in [docs/ci/perl-lsp-rust-1.95-rollout.md](ci/perl-lsp-rust-1.95-rollout.md). The current repository state remains Rust 2024, workspace MSRV 1.93, pinned toolchain 1.93.1, and release line 0.13.4 until the dedicated implementation PRs land.
+
 The ledger tracks planned Rust 1.94 and 1.95 flips before the workspace MSRV moves. `cargo xtask check-lint-policy` verifies that planned lints are present in the ledger and not activated ahead of the MSRV bump.
 
-The current workspace remains on the MSRV recorded in `Cargo.toml` and `policy/clippy-lints.toml`; the Rust 1.93 toolchain ratchet is intentionally left to a dedicated follow-up lane because toolchain changes affect CI, documentation, and release policy together.
+The workspace still has a known mismatch between the target no-carveout posture and `clippy.toml`'s `allow-unwrap-in-tests = true`. Removing that carveout is a dedicated policy PR after the MSRV/toolchain bump; the compatibility spike, MSRV bump, release bump, and test-carveout cleanup must stay separate.
+
+The `collapsible_if` broad allow remains debt. It should move through ledgered cleanup or explicit exceptions rather than disappearing inside a Rust 1.95 compatibility or release-prep PR.
 
 ## Local check
 

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -1,0 +1,46 @@
+# File policy
+
+Rust and `xtask` are the default implementation surfaces for this repository. Non-Rust
+files are allowed when they are intentional, owned, covered, and recorded by policy.
+
+## Rust 1.95 / 0.14.0 rollout target
+
+The docs-first rollout PR does not enforce file policy. It records the target shape so
+later PRs can add a non-Rust ledger, proposal tooling, companion risky-surface ledgers,
+and CI gate wiring without mixing them into the MSRV or release bumps.
+
+Legitimate non-Rust surfaces include:
+
+- Perl fixtures and corpus files;
+- tree-sitter C/native parser bindings;
+- VS Code extension files;
+- GitHub workflows;
+- CI scripts;
+- generated docs/status artifacts;
+- release metadata.
+
+## Target non-Rust entry shape
+
+Every non-Rust allowlist entry should include:
+
+- `id`
+- `glob`
+- `kind`
+- `language`
+- `surface`
+- `classification`
+- `owner`
+- `reason`
+- `covered_by`
+- `created`
+- `review_after`
+
+Broad globs also need `broad_glob_reason`.
+
+## Enforcement ladder
+
+1. Add the ledger and parse it, with no enforcement.
+2. Add inventory and proposal commands that write reports under `target/policy/` and do
+   not mutate the real ledger.
+3. Add advisory and blocking checker modes.
+4. Wire blocking allowlist checks into gate receipts once the ledger is populated.

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -1,0 +1,36 @@
+# No-panic policy
+
+`perl-lsp` treats panic-family calls as governed debt because the parser, LSP, DAP,
+workspace index, and CI policy tools should return structured failures rather than
+abort the process.
+
+## Current rollout status
+
+The Rust 1.95 / 0.14.0 rollout keeps the current no-panic state unchanged in the first
+PR. The target state is exact counted no-new-debt enforcement, but that happens only
+after the compatibility spike and MSRV/toolchain PRs have landed.
+
+| Surface | Current | Target | Rollout step |
+|---|---|---|---|
+| Panic-family linting | Partly active through workspace Clippy lints and the lint ledger | Strict policy with no hidden test carveouts | Clippy and no-panic policy PRs |
+| Allowlist identity | Missing or incomplete | `path + family + selector_kind + selector_callee + snippet + count` | Exact identity PR |
+| Baseline mode | Not reset in docs-first PR | `no-new-debt` with generated baseline | Baseline PR only |
+| Diagnostics | Existing reports only | Missing-baseline, stale-entry, delta, and blocking-mode explanations | Diagnostics PR |
+
+## Rollout rule
+
+Do not reset or regenerate a no-panic baseline outside the dedicated baseline PR. The
+first implementation PR after the docs map is a Rust 1.95 compatibility spike, and it
+must not change no-panic identity, allowlists, baselines, or policy mode.
+
+## Target matching model
+
+The target no-panic matcher consumes findings in this order:
+
+1. exact allowlist count slots;
+2. baseline count slots unless the policy mode is blocking;
+3. remaining findings reported as new debt.
+
+Allowlist entries should include a precise snippet and count. Coarse matching by file
+or callee alone is not acceptable because it can cover unrelated panic-family calls in
+the same file.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -1,0 +1,24 @@
+# Policy allowlists
+
+Policy allowlists are review receipts, not escape hatches. The Rust 1.95 / 0.14.0
+rollout uses dedicated PRs to add or tighten allowlists so version, lint, no-panic,
+file, and CI changes do not collapse into one broad policy change.
+
+## Rollout targets
+
+| Ledger | Current rollout state | Target state |
+|---|---|---|
+| Clippy lint ledger | Active, tracked, planned, and debt entries already exist in `policy/clippy-lints.toml` and `policy/clippy-debt.toml`. | Rust 1.93 rustc lints active; Rust 1.94/1.95 Clippy ratchets active or receipted. |
+| No-panic allowlist | Missing or incomplete for exact counted enforcement. | Deliberately retained findings recorded with snippet and count before no-new-debt reporting. |
+| Non-Rust file allowlist | Missing or incomplete. | Every allowed non-Rust surface has owner, reason, classification, coverage, dates, and broad-glob justification when needed. |
+| Companion ledgers | Not yet part of the first documentation PR. | Generated, executable, dependency, workflow, process, and network surfaces are allowlisted by risk class. |
+| ripr suppressions | Advisory suppressions live separately from branch protection. | ripr remains advisory and routes exposure findings without replacing mutation or gate receipts. |
+
+## Required discipline
+
+- Add allowlist entries in the PR dedicated to that policy surface.
+- Prefer narrow entries with owners, reasons, creation dates, review dates, and expiry
+  where applicable.
+- Do not use allowlists to absorb new debt silently.
+- Do not mix no-panic baseline resets, Clippy test-carveout removal, non-Rust inventory,
+  and release preparation in the same PR.

--- a/docs/ci/lem-budgeting.md
+++ b/docs/ci/lem-budgeting.md
@@ -7,6 +7,10 @@ on the same axis regardless of which runner type or OS the work runs on.
 > operating thesis and [verification-ladder.md](verification-ladder.md) for which lanes
 > sit at which cost band.
 
+## Rust 1.95 rollout note
+
+The Rust 1.95 / 0.14.0 rollout should tune the existing LEM, lane, risk-pack, receipt, and CI-actuals control plane rather than introduce a parallel process. Do not hard-enforce learned LEM estimates below the existing 125 LEM ceiling until actuals have been calibrated. Skipped lanes should be reported as skipped by policy, not as passed.
+
 ---
 
 ## Definition

--- a/docs/ci/perl-lsp-rust-1.95-rollout.md
+++ b/docs/ci/perl-lsp-rust-1.95-rollout.md
@@ -1,0 +1,115 @@
+# Rust 1.95 / 0.14.0 rollout map
+
+This document is the control map for moving `perl-lsp` from Rust 1.93 / toolchain
+1.93.1 to Rust 1.95.0 and preparing the next minor release line, 0.14.0. It is
+intentionally documentation-only: no MSRV, workflow, lint, release, or code changes
+belong in this PR.
+
+## Current and target state
+
+| Layer | Current | Target | Status |
+|---|---:|---:|---|
+| Edition | 2024 | 2024 | done |
+| MSRV | 1.93 | 1.95.0 | planned |
+| Toolchain | 1.93.1 | 1.95.0 | planned |
+| Release line | 0.13.4 | 0.14.0 | planned |
+| Clippy panic-family | partly active | strict + no test carveouts | partial |
+| `collapsible_if` | broad allow | debt ledger / cleanup | todo |
+| Rust 1.93 rustc lints | planned/tracked | active | todo |
+| Rust 1.95 Clippy lints | planned | active or ratcheted | todo |
+| No-panic allowlist | missing/incomplete | exact counted no-new-debt | todo |
+| Non-Rust allowlist | missing/incomplete | blocking file policy | todo |
+| ripr | advisory, installed in workflow | advisory + better routing | partial |
+| CI economics | LEM/risk packs exist | tuned + actuals-backed | partial |
+
+Truth sources for the current state are `Cargo.toml`, `rust-toolchain.toml`,
+`clippy.toml`, and `policy/clippy-lints.toml`. Do not infer release, MSRV, or lint
+state from this document after implementation begins; update this map as the ladder
+lands.
+
+## Why Rust 1.95 matters here
+
+| Rust 1.95 item | Repo-specific value |
+| --- | --- |
+| `if let` guards | Parser/AST walkers, semantic extraction, import visibility, refactor preconditions, LSP provider routing. |
+| `Vec::push_mut` / `insert_mut` | Diagnostic/report builders, semantic facts, scorecards, CI receipts, LSP response builders. |
+| Atomic `update` / `try_update` | Session/cache counters, memory-pressure counters, cancellation or stream-state metrics. |
+| `cfg_select!` | Windows/Unix path behavior, subprocess handling, VS Code install surfaces, native/virtual URI handling. |
+| `cold_path` | Parser recovery, malformed URI/path handling, failed subprocess/perlcritic paths, policy failure reporting. |
+| Clippy 1.95 | `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, and future `disallowed_fields`. |
+
+The AST-heavy parts of this repo benefit especially from `if let` guards because the
+branch shape and semantic precondition stay together. That matters in parser recovery,
+semantic walkers, import visibility extraction, and LSP provider routing, where a split
+condition can hide which fact justified a branch.
+
+## Operating rule
+
+The first implementation PR after this documentation PR is a Rust 1.95 compatibility
+spike. No MSRV bump, lint activation, no-panic baseline reset, release bump, or API
+cleanup happens in the same PR.
+
+## Queue control
+
+The Rust 1.95 rollout must stay separate from product/test PRs. If unrelated draft PRs
+are open, either let them finish first or start each rollout PR from a clean `master`
+and expect to rebase after they merge. Do not fold rollout changes into unrelated UX,
+critic, parser, or provider branches.
+
+## Policy status to carry into the ladder
+
+- **Clippy ledger:** `policy/clippy-lints.toml` already tracks active strict lints,
+  debt such as the broad `collapsible_if` allow, and planned Rust 1.94/1.95 flips.
+- **Test unwrap carveout:** `clippy.toml` still contains `allow-unwrap-in-tests = true`
+  while the target posture is no test carveouts. Removing it is a dedicated policy PR,
+  not part of the MSRV bump.
+- **No-panic policy:** exact counted identity must land before any baseline reset.
+  Allowlist and baseline matching should consume `path + family + selector_kind +
+  selector_callee + snippet` counts before reporting new debt.
+- **File policy:** Rust and `xtask` remain the default implementation surface. Non-Rust
+  surfaces are allowed by receipt through a ledger before CI enforces the policy.
+- **ripr:** keep ripr advisory. Use it as a fast PR-time exposure filter, not as a
+  branch-protection replacement for mutation testing.
+- **CI economics:** LEM budget policy, lane intent, risk packs, gate receipts, CI
+  actuals, PR smoke, merge-gate shards, UX tests, memory smoke, and Windows guardrails
+  already exist. The rollout should tune those controls rather than add a parallel
+  process.
+
+## PR ladder and acceptance gates
+
+| Step | Branch | Purpose | Acceptance |
+|---:|---|---|---|
+| 1 | `docs/rust-1.95-rollout` | Map the rollout. | `cargo check -p xtask --locked`; `cargo xtask check-lint-policy`; `git diff --check` |
+| 2 | `probe/rust-1.95-compat` | Run the current repo under Rust 1.95.0 before changing declared MSRV. | Rust 1.95 fmt, check, all-features check, clippy, tests, lint policy, PR-fast receipt, diff check |
+| 3 | `chore/msrv-rust-1.95` | Raise MSRV/toolchain metadata to Rust 1.95.0 without release bump. | Rust 1.95 fmt, workspace check, lint policy, PR-fast receipt, diff check |
+| 4 | `policy/rust-1.95-lints` | Activate Rust compiler lint floor. | Workspace check, lint policy, PR-fast receipt |
+| 5 | `policy/clippy-rust-1.95-ratchets` | Measure and activate clean or cheap Clippy 1.94/1.95 ratchets. | Lint policy and workspace clippy without global `-D warnings` for warn-stage debt |
+| 6 | `policy/no-test-clippy-carveouts` | Remove the test unwrap carveout and add fallible helper path. | Policy config consistent; no full test-suite migration required |
+| 7 | `policy/no-panic-exact-identity` | Make no-panic matching exact and counted before baseline. | `cargo test -p xtask no_panic --locked`; `cargo xtask check-no-panic-family` |
+| 8 | `policy/no-panic-baseline` | Add generated no-panic baseline and no-new-debt mode. | Baseline reset, no-panic check, no-panic tests, diff check |
+| 9 | `policy/no-panic-diagnostics` | Improve no-panic failure reports. | No-panic tests, no-panic check, markdown/json report existence |
+| 10 | `policy/non-rust-file-ledger` | Add non-Rust file allowlist ledgers without enforcement. | TOML parse check and `cargo check -p xtask --locked` |
+| 11 | `policy/check-file-policy` | Add inventory, proposal, and advisory/blocking file-policy checker modes. | xtask check, file-policy tests, inventory, propose, advisory check |
+| 12 | `policy/file-companion-ledgers` | Add generated, executable, dependency, workflow, process, and network ledgers. | Advisory companion checks and policy report |
+| 13 | `ci/policy-gate-wiring` | Wire file and lint policy into gate receipts. | File-policy gate receipt and receipt validation |
+| 14 | `ci/ripr-and-mutation-routing` | Tune advisory ripr exposure routing and keep mutation off normal PRs. | CI plan dry-run if available and diff check |
+| 15 | `refactor/rust-1.95-ast-cleanups` | Use Rust 1.95 APIs where they reduce AST/LSP review load. | Targeted parser, semantic, core, LSP tests; targeted clippy; no-panic check; diff check |
+| 16 | `policy/clippy-default-surface-cleanup` | Burn down strict lint debt in default parser/semantic/LSP surface. | Lint policy, clippy exceptions, workspace clippy |
+| 17 | `policy/no-panic-first-burndown` | Burn down one narrow no-panic owner lane. | Touched-crate tests, no-panic check, baseline refresh that only drops disappeared entries |
+| 18 | `ci/learned-lem-estimates` | Calibrate PR Plan estimates from CI actuals. | Plan output shows static vs learned source with fallback and no branch-protection change |
+| 19 | `release/0.14.0-prep-rust-1.95` | Prepare the 0.14.0 minor release. | Workspace check, lint policy, file policy, no-panic, PR-fast receipt, diff check |
+| 20 | `release/0.14.0-dry-run` | Prove package and release readiness before tagging. | Workspace package dry-run and policy/gate reports |
+
+## Bot, CI, and self-review rules
+
+For every PR, inspect status checks and review state, then watch checks. If CI fails,
+identify the first real failing command, reproduce it locally when practical, fix only
+that failure, rerun the matching local gate, push, and re-check bot comments. Treat bot
+comments as defects when real, stale when current HEAD proves them obsolete, and follow-up
+work when they are correct but out of scope.
+
+Before marking a rollout PR ready, record a self-review covering scope/title match,
+expected files, absence of unrelated cleanup, intentional policy changes, no added Clippy
+test carveouts, no bare `#[allow(clippy::...)]`, scoped no-panic baseline handling,
+narrow non-Rust allowlist changes, CI/ripr/LEM behavior, local validation, CI status,
+bot comments, and follow-ups.

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -90,8 +90,9 @@ ripr is **never** used as proof; it is used as a **prompt**.
 
 ## Toolchain
 
-`rust-toolchain.toml` pins `1.93.1`, which satisfies `ripr`'s `>= 1.93` MSRV. The workflow
-uses the toolchain pinned in the repo and installs `ripr` via `cargo install ripr --locked`.
+`rust-toolchain.toml` currently pins `1.93.1`, which satisfies `ripr`'s `>= 1.93` MSRV. The Rust 1.95 / 0.14.0 rollout keeps ripr advisory while the toolchain moves to `1.95.0` in a dedicated MSRV PR. That PR should update workflow toolchain pins without making ripr branch-protection blocking.
+
+The workflow uses the toolchain pinned in the repo and installs `ripr` via `cargo install ripr --locked`.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Provide a repo-specific, documentation-first control map for moving from Rust 1.93 / toolchain 1.93.1 → Rust 1.95.0 and preparing the 0.14.0 minor release so implementation work is sequenced and scoped. 
- Prevent scope creep by separating compatibility probing, MSRV/toolchain changes, lint ratchets, no-panic baseline work, file-policy ledgers, CI tuning, and release prep into focused PRs.

### Description

- Added a rollout map at `docs/ci/perl-lsp-rust-1.95-rollout.md` describing current vs target state, Rust 1.95 value matrix, an explicit compatibility-spike-first operating rule, the PR ladder, and acceptance gates. 
- Added policy docs: `docs/NO_PANIC_POLICY.md`, `docs/POLICY_ALLOWLISTS.md`, and `docs/FILE_POLICY.md` describing no-panic exact-identity goals, allowlist discipline, and non-Rust ledger shape; these are documentation-only and do not change enforcement. 
- Updated `docs/CLIPPY_POLICY.md`, `docs/ci/ripr.md`, and `docs/ci/lem-budgeting.md` to reference the rollout map, call out the `allow-unwrap-in-tests` carveout mismatch and `collapsible_if` debt, and to preserve ripr/LEM advisory posture while the toolchain move is planned. 
- Added an Unreleased note to `CHANGELOG.md` describing the planned Rust 1.95 / 0.14.0 rollout. 
- No code, `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, workflow, or lint activation changes were made in this PR.

### Testing

- Ran `cargo check -p xtask --locked` and it completed successfully. 
- Ran `cargo xtask check-lint-policy` and it reported the lint ledger as OK. 
- Ran `git diff --check` / repository diff checks and no whitespace or formatting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe57f4bbe48333966b1d8f41a0b2d0)