### PR TITLE
docs(policy): map Rust 1.95 and 0.14.0 quality rollout (#0000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- Documented the Rust 1.95 / 0.14.0 rollout sequence before implementation: compatibility spike first, then MSRV/toolchain, lint, no-panic, file-policy, CI routing, and release-prep lanes.
+
 ## [0.13.4] - 2026-05-07
 
 Release notes: [v0.13.4](docs/releases/v0.13.4.md)

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -40,7 +40,9 @@ Do not use a silent `#[allow]`. If a lint needs repo-wide temporary treatment, a
 
 The ledger tracks planned Rust 1.94 and 1.95 flips before the workspace MSRV moves. `cargo xtask check-lint-policy` verifies that planned lints are present in the ledger and not activated ahead of the MSRV bump.
 
-The current workspace remains on the MSRV recorded in `Cargo.toml` and `policy/clippy-lints.toml`; the Rust 1.93 toolchain ratchet is intentionally left to a dedicated follow-up lane because toolchain changes affect CI, documentation, and release policy together.
+The Rust 1.95 / 0.14.0 rollout is mapped in [`docs/ci/perl-lsp-rust-1.95-rollout.md`](ci/perl-lsp-rust-1.95-rollout.md). The current workspace remains on the MSRV recorded in `Cargo.toml`, `clippy.toml`, and `policy/clippy-lints.toml` until the dedicated MSRV/toolchain PR lands. The compatibility spike comes first; it must not also activate lint floors, remove test carveouts, reset no-panic baselines, or bump the release version.
+
+The legacy `allow-unwrap-in-tests = true` setting in `clippy.toml` is a known mismatch with the target panic-free test posture. It stays visible as policy debt until the dedicated no-test-carveout PR removes it and adds fallible helper paths for later test-suite burndown work.
 
 ## Local check
 

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -1,0 +1,42 @@
+# File policy
+
+Rust and `xtask` are the default implementation surfaces for this repository.
+Non-Rust files are allowed where they serve a clear product, test, release, or CI
+purpose, but the Rust 1.95 / 0.14.0 rollout targets receipt-backed file policy so
+those surfaces do not expand anonymously.
+
+## Legitimate non-Rust surfaces
+
+The rollout map recognizes these legitimate non-Rust areas:
+
+- Perl fixtures and corpus data.
+- Tree-sitter C/native parser bindings.
+- VS Code extension surfaces.
+- GitHub workflows.
+- CI scripts.
+- Generated docs/status artifacts.
+- Release metadata.
+
+## Target ledger fields
+
+The planned non-Rust allowlist ledger should require each entry to include:
+
+- `id`
+- `glob`
+- `kind`
+- `language`
+- `surface`
+- `classification`
+- `owner`
+- `reason`
+- `covered_by`
+- `created`
+- `review_after`
+
+Broad globs should also include `broad_glob_reason`.
+
+## Rollout boundary
+
+This documentation PR does not add enforcement. Enforcement belongs in the later
+file-policy checker PR described in
+[`docs/ci/perl-lsp-rust-1.95-rollout.md`](ci/perl-lsp-rust-1.95-rollout.md).

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -1,0 +1,42 @@
+# No-panic policy
+
+`perl-lsp` treats unchecked panic paths as reliability debt. Parser, LSP, DAP,
+workspace, release, and policy tooling should return structured errors or use
+reviewed test helpers instead of collapsing `Result` or `Option` values.
+
+## Current rollout status
+
+The Rust 1.95 / 0.14.0 rollout targets an exact counted no-new-debt policy, but
+that target is not active in this documentation PR. The rollout map lives in
+[`docs/ci/perl-lsp-rust-1.95-rollout.md`](ci/perl-lsp-rust-1.95-rollout.md).
+
+Current guardrails are split across:
+
+- active panic-family Clippy bans in [`Cargo.toml`](../Cargo.toml), including
+  `unwrap_used`, `expect_used`, `panic`, `todo`, `unimplemented`, and
+  `dbg_macro`;
+- the governed lint ledger in
+  [`policy/clippy-lints.toml`](../policy/clippy-lints.toml);
+- the legacy Clippy test unwrap carveout in [`clippy.toml`](../clippy.toml),
+  which is intentionally left for a dedicated follow-up PR.
+
+## Target posture
+
+The target no-panic lane is exact and counted:
+
+1. Findings are keyed by path, family, selector kind, selector callee, snippet,
+   and count.
+2. Exact allowlist count slots are consumed first.
+3. Baseline count slots are consumed second unless policy mode is blocking.
+4. Anything left is reported as new debt.
+
+Do not reset the no-panic baseline outside the dedicated baseline PR. A baseline
+refresh may drop disappeared entries, but it must not absorb new panic-family debt
+without an explicit reset.
+
+## Test guidance
+
+Tests should return `Result` or use repository helpers such as
+`perl_tdd_support::must` and `perl_tdd_support::must_some`. The planned fallible
+helper lane will add helper APIs for cases that need to convert `Option` or
+`Result` values into `anyhow::Result` with context.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -1,0 +1,36 @@
+# Policy allowlists
+
+Policy allowlists are receipts for intentionally retained risk. They are not a
+shortcut around the default rule that Rust and `xtask` are the preferred
+implementation surfaces and that unchecked panic paths should be burned down.
+
+## Rust 1.95 rollout target
+
+The Rust 1.95 / 0.14.0 rollout map is
+[`docs/ci/perl-lsp-rust-1.95-rollout.md`](ci/perl-lsp-rust-1.95-rollout.md). The
+planned policy ledgers are staged so each PR tightens one concern at a time:
+
+- Clippy lints and exceptions stay governed by
+  [`policy/clippy-lints.toml`](../policy/clippy-lints.toml) and future exception
+  ledgers.
+- No-panic allowlists and baselines should use exact counted matching before any
+  baseline reset.
+- Non-Rust file allowlists should identify the owner, reason, surface,
+  classification, coverage, creation date, and review date for each entry.
+- Companion ledgers for generated, executable, dependency, workflow, process, and
+  network surfaces should describe risky behavior separately from where files are
+  allowed to exist.
+
+## Allowlist hygiene
+
+Every allowlist entry should answer these questions:
+
+- What exact path, glob, finding, or behavior is allowed?
+- Who owns the exception?
+- Why is the exception retained?
+- What gate, test, document, or operational control covers it?
+- When should it be reviewed or expired?
+
+Broad globs need an explicit broad-glob reason. Absolute paths and backslash paths
+should be rejected because policy ledgers must be portable across Linux, macOS,
+and Windows worktrees.

--- a/docs/ci/lem-budgeting.md
+++ b/docs/ci/lem-budgeting.md
@@ -9,6 +9,10 @@ on the same axis regardless of which runner type or OS the work runs on.
 
 ---
 
+## Rust 1.95 rollout note
+
+The Rust 1.95 / 0.14.0 rollout tunes the existing LEM, risk-pack, lane, receipt, and CI actuals control plane rather than adding a parallel process. Learned estimates should remain actuals-backed and must not hard-enforce below the 125 LEM ceiling before calibration. See [perl-lsp-rust-1.95-rollout.md](perl-lsp-rust-1.95-rollout.md).
+
 ## Definition
 
 ```text

--- a/docs/ci/perl-lsp-rust-1.95-rollout.md
+++ b/docs/ci/perl-lsp-rust-1.95-rollout.md
@@ -1,0 +1,187 @@
+# Rust 1.95 / 0.14.0 rollout map
+
+This document is the control map for moving `perl-lsp` from the current Rust
+1.93 line to Rust 1.95.0 and preparing the next minor release, 0.14.0. It is
+intentionally documentation-only: no MSRV, toolchain, workflow, lint, baseline,
+or version changes happen in this PR.
+
+Truth sources for rollout facts are the repository files, not this document:
+
+- Workspace edition, MSRV, package version, and active workspace lints:
+  [`Cargo.toml`](../../Cargo.toml).
+- Pinned toolchain: [`rust-toolchain.toml`](../../rust-toolchain.toml).
+- Clippy runtime configuration: [`clippy.toml`](../../clippy.toml).
+- Governed lint ledger and planned Rust-version flips:
+  [`policy/clippy-lints.toml`](../../policy/clippy-lints.toml).
+- CI lane, risk-pack, LEM, and actuals policy:
+  [`policy/ci-lanes.toml`](../../policy/ci-lanes.toml),
+  [`policy/ci-risk-packs.toml`](../../policy/ci-risk-packs.toml), and
+  [`policy/ci-budget.toml`](../../policy/ci-budget.toml).
+
+## Current and target state
+
+| Layer | Current | Target | Status |
+|---|---:|---:|---|
+| Edition | 2024 | 2024 | done |
+| MSRV | 1.93 | 1.95.0 | planned |
+| Toolchain | 1.93.1 | 1.95.0 | planned |
+| Release line | 0.13.4 | 0.14.0 | planned |
+| Clippy panic-family | partly active | strict + no test carveouts | partial |
+| `collapsible_if` | broad allow | debt ledger / cleanup | todo |
+| Rust 1.93 rustc lints | planned/tracked | active | todo |
+| Rust 1.95 Clippy lints | planned | active or ratcheted | todo |
+| No-panic allowlist | missing/incomplete | exact counted no-new-debt | todo |
+| Non-Rust allowlist | missing/incomplete | blocking file policy | todo |
+| ripr | advisory, installed in workflow | advisory + better routing | partial |
+| CI economics | LEM/risk packs exist | tuned + actuals-backed | partial |
+
+## Why Rust 1.95 matters for `perl-lsp`
+
+| Rust 1.95 item | Repo-specific value |
+|---|---|
+| `if let` guards | Parser/AST walkers, semantic extraction, import visibility, refactor preconditions, LSP provider routing. |
+| `Vec::push_mut` / `insert_mut` | Diagnostic/report builders, semantic facts, scorecards, CI receipts, LSP response builders. |
+| Atomic `update` / `try_update` | Session/cache counters, memory-pressure counters, cancellation or stream-state metrics. |
+| `cfg_select!` | Windows/Unix path behavior, subprocess handling, VS Code install surfaces, native/virtual URI handling. |
+| `cold_path` | Parser recovery, malformed URI/path handling, failed subprocess/perlcritic paths, policy failure reporting. |
+| Clippy 1.95 | `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, and future `disallowed_fields`. |
+
+The AST-heavy parts of this repository are the main beneficiary: `if let` guards
+let semantic walkers keep the branch shape and the semantic precondition in the
+same expression, which reduces review load and helps keep parser/provider paths
+from drifting into panic-prone precondition checks.
+
+## Operating rule
+
+The first implementation PR after this documentation PR is a Rust 1.95
+compatibility spike. No MSRV bump, lint activation, no-panic baseline reset,
+release bump, or API cleanup happens in the same PR.
+
+## Queue control
+
+The Rust 1.95 rollout is separate from unrelated product and test PRs. If draft
+or in-flight work such as UX diagnostic lifecycle fixes or native critic rules is
+open, keep it separate: start rollout PRs from a clean `master` snapshot and
+rebase after those PRs merge rather than folding Rust 1.95 work into them.
+
+## Policy surfaces to watch
+
+### Clippy policy
+
+- `Cargo.toml` currently carries the active hard bans for
+  `unwrap_used`, `expect_used`, `panic`, `todo`, `unimplemented`, and
+  `dbg_macro`.
+- `clippy.toml` still has `allow-unwrap-in-tests = true` while
+  `policy/clippy-lints.toml` says tests should be panic-free. Removing that
+  carveout is a later policy PR, not part of the compatibility spike or MSRV
+  bump.
+- `collapsible_if = "allow"` is current debt. It should move through a debt
+  ledger and behavior-preserving cleanup rather than being flipped while
+  changing the toolchain.
+- Rust 1.93 rustc lints and Rust 1.94/1.95 Clippy lints are already tracked in
+  `policy/clippy-lints.toml`; they should be activated only in their dedicated
+  lint-floor and ratchet PRs.
+
+### No-panic policy
+
+The target posture is exact, counted, no-new-debt policy:
+
+1. Match panic-family findings by path, family, selector kind, selector callee,
+   snippet, and count.
+2. Consume exact allowlist counts first.
+3. Consume baseline counts second, except in blocking mode.
+4. Report anything left as new debt.
+
+Do not reset or add a no-panic baseline until exact counted identity exists.
+
+### Non-Rust and file policy
+
+Rust and `xtask` remain the default implementation surfaces. Non-Rust files are
+legitimate for Perl corpus fixtures, tree-sitter/native parser bindings, VS Code
+extension code, workflows, CI scripts, generated status artifacts, and release
+metadata, but the target is receipt-backed allowlisting rather than anonymous
+expansion.
+
+### ripr
+
+`ripr` is advisory static oracle-gap detection. It should remain non-blocking for
+normal PRs during this rollout. The target is better routing: skip docs-only and
+test-fixture-only changes unless a label forces analysis, keep artifacts
+consistent, and reserve mutation testing for targeted, nightly, or release lanes.
+
+### CI economics
+
+LEM budgets, CI risk packs, CI lane policy, PR smoke, merge-gate shards, UX tests,
+memory smoke, Windows guardrails, CI actuals, and advisory `ripr` already exist.
+This rollout should tune that control plane; it should not replace it or add a
+new parallel process. Learned estimates should be actuals-backed and must not
+hard-enforce below the existing 125 LEM ceiling before calibration.
+
+## PR ladder and acceptance gates
+
+| Step | Branch | Objective | Acceptance gate |
+|---:|---|---|---|
+| 1 | `docs/rust-1.95-rollout` | Map the rollout, docs only. | `cargo check -p xtask --locked`; `cargo xtask check-lint-policy`; `git diff --check` |
+| 2 | `probe/rust-1.95-compat` | Run current repo under Rust 1.95.0 before declaring MSRV. | fmt, workspace checks, clippy, tests, lint policy, pr-fast receipt, diff check |
+| 3 | `chore/msrv-rust-1.95` | Raise MSRV/toolchain/config/workflow pins to Rust 1.95.0; no release bump. | Rust 1.95 override, fmt, workspace check, lint policy, pr-fast receipt, diff check |
+| 4 | `policy/rust-1.95-lints` | Activate the Rust compiler lint floor. | workspace check, lint policy, pr-fast receipt |
+| 5 | `policy/clippy-rust-1.95-ratchets` | Measure and activate clean or cheap Rust 1.94/1.95 Clippy ratchets. | lint policy and workspace clippy without global `-D warnings` until debt is receipted |
+| 6 | `policy/no-test-clippy-carveouts` | Remove Clippy test unwrap carveout and add fallible test helper path. | targeted checks for the touched helper crate plus lint policy |
+| 7 | `policy/no-panic-exact-identity` | Harden no-panic matching by exact counted identity. | `cargo test -p xtask no_panic --locked`; `cargo xtask check-no-panic-family` |
+| 8 | `policy/no-panic-baseline` | Add generated no-panic baseline and no-new-debt mode. | baseline reset, no-panic family check, xtask no-panic tests, diff check |
+| 9 | `policy/no-panic-diagnostics` | Improve no-panic diagnostics. | xtask no-panic tests, no-panic family check, report existence |
+| 10 | `policy/non-rust-file-ledger` | Add non-Rust file allowlist ledger; no enforcement yet. | TOML parse check and `cargo check -p xtask --locked` |
+| 11 | `policy/check-file-policy` | Add inventory, proposal, and file-policy checker commands. | xtask check, file-policy tests, inventory, propose, advisory check |
+| 12 | `policy/file-companion-ledgers` | Add generated, executable, dependency, workflow, process, and network ledgers. | advisory companion policy checks and `policy-report` |
+| 13 | `ci/policy-gate-wiring` | Wire policy checks into gate receipts. | file-policy gate receipt and receipt validation |
+| 14 | `ci/ripr-and-mutation-routing` | Tune ripr routing and keep mutation off normal PRs. | CI plan dry run where available and diff check |
+| 15 | `refactor/rust-1.95-ast-cleanups` | Apply targeted Rust 1.95 API cleanup in AST/LSP paths. | targeted parser, semantic, LSP tests; targeted clippy; no-panic family; diff check |
+| 16 | `policy/clippy-default-surface-cleanup` | Clean strict lint debt in parser, semantic, and LSP default surface. | lint policy, clippy exceptions, workspace clippy |
+| 17 | `policy/no-panic-first-burndown` | Burn down one narrow no-panic owner lane. | touched-crate tests, no-panic family check, baseline refresh that only drops disappeared entries |
+| 18 | `ci/learned-lem-estimates` | Use CI actuals to calibrate PR Plan LEM estimates. | plan JSON shows `estimate_source`, summaries compare static vs learned, static fallback remains |
+| 19 | `release/0.14.0-prep-rust-1.95` | Prepare 0.14.0 release surfaces. | workspace check, lint/file/no-panic policy checks, pr-fast receipt, diff check |
+| 20 | `release/0.14.0-dry-run` | Prove package/publish readiness before tagging. | package dry run, pr-fast receipt, policy checks, release readiness docs |
+
+## Bot, CI, and self-review loop
+
+For each PR, inspect the current check and review state before claiming green:
+
+```bash
+gh pr view <PR> --json statusCheckRollup,reviewDecision,mergeStateStatus
+gh pr checks <PR> --watch
+```
+
+If CI fails:
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+Then identify the first real failing command, reproduce locally if possible, fix
+only that failure, rerun the matching local gate, push, and check bot comments
+again. Bot comments should be treated as follows: fix real defects, answer false
+positives with evidence, fix cheap in-scope style comments, defer out-of-scope
+requests with a follow-up, and mark stale comments only after verifying current
+HEAD.
+
+Every rollout PR should self-review before it is marked ready:
+
+```markdown
+## Self-review
+
+- Scope matches PR title:
+- Files touched are expected:
+- No unrelated cleanup:
+- Policy changes are intentional:
+- No Clippy test carveouts added:
+- No bare `#[allow(clippy::...)]` added:
+- No-panic baseline handling is scoped:
+- Non-Rust allowlist changes are narrow:
+- CI/ripr/LEM behavior matches docs:
+- Local validation:
+- CI status:
+- Bot comments addressed:
+- Follow-ups:
+```
+
+If any item is not true, do not merge.

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -10,6 +10,10 @@ oracle-aware than coverage, far cheaper than mutation testing.
 
 ---
 
+## Rust 1.95 rollout note
+
+During the Rust 1.95 / 0.14.0 rollout, `ripr` remains advisory. The rollout map in [perl-lsp-rust-1.95-rollout.md](perl-lsp-rust-1.95-rollout.md) keeps normal PRs on ripr plus existing gates, reserves mutation testing for targeted/nightly/release lanes, and calls out routing follow-up work for docs-only and fixture-only changes.
+
 ## What ripr does
 
 For each changed Rust function, ripr asks the mutation-testing-shaped question


### PR DESCRIPTION
### Motivation

- Provide a repository-specific control map before changing MSRV, toolchain, lint floors, or release metadata so the rollout proceeds in narrow, reviewable steps.
- Capture the PR ladder, policy boundaries (Clippy, no-panic, file allowlists, ripr, LEM), and the explicit rule that the first implementation PR is a compatibility spike only.

### Description

- Added a documentation-only rollout map at `docs/ci/perl-lsp-rust-1.95-rollout.md` that records current vs target state, the PR ladder (20-step plan), policy surfaces to watch, and CI/self-review rules.
- Added targeted policy docs: `docs/NO_PANIC_POLICY.md`, `docs/FILE_POLICY.md`, and `docs/POLICY_ALLOWLISTS.md` describing no-panic exact-count identity, non-Rust file allowlist fields, and allowlist hygiene.
- Updated `docs/CLIPPY_POLICY.md`, `docs/ci/ripr.md`, and `docs/ci/lem-budgeting.md` with rollout notes (including the existing `allow-unwrap-in-tests = true` carveout as debt) and added an `Unreleased` note to `CHANGELOG.md`; no `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, workflow, or code changes were made in this PR.

### Testing

- Ran `cargo check -p xtask --locked` which completed successfully.
- Ran `cargo xtask check-lint-policy` which reported the lint policy is OK and completed successfully.
- Verified `git diff --check` / `git diff --stat` produced no check failures and committed the documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe57f4bbe48333966b1d8f41a0b2d0)