### PR TITLE
feat(critic): add string eval native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -240,6 +240,7 @@ impl NativeCriticRegistry {
             Box::new(AssignmentInConditionRule),
             Box::new(BarewordFilehandleRule),
             Box::new(TwoArgOpenRule),
+            Box::new(StringEvalRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
             Box::new(DuplicateParameterRule),
@@ -509,6 +510,31 @@ impl CriticRule for TwoArgOpenRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_two_arg_open_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports string-based `eval`.
+///
+/// This mirrors the existing security diagnostic and built-in policy through
+/// the native critic contract. The rule intentionally does not attach an
+/// automatic edit: replacing string eval safely requires user intent.
+pub struct StringEvalRule;
+
+impl CriticRule for StringEvalRule {
+    fn id(&self) -> &'static str {
+        "native.security.string_eval"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Security
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_string_eval_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -917,6 +943,25 @@ fn two_arg_open_fix_text(source: &str, open_args: &[Node]) -> Option<String> {
     Some(format!("open({handle_text}, '<', {path_text})"))
 }
 
+fn string_eval_finding(rule: &StringEvalRule, source: &str, eval_node: &Node) -> CriticFinding {
+    let range = range_for_byte_span(source, eval_node.location.start, eval_node.location.end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: "String eval is a security risk".to_string(),
+        explanation: "String eval executes dynamically generated Perl code and is difficult to analyze safely. Prefer block eval for exception handling or a safer dispatch mechanism.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: vec![CriticRelatedInformation {
+            range,
+            message: "String eval executes arbitrary Perl code at runtime when the string contains user-controlled input.".to_string(),
+        }],
+        fix: None,
+    }
+}
+
 fn duplicate_lexical_finding(
     rule: &DuplicateLexicalDeclarationRule,
     source: &str,
@@ -1058,6 +1103,38 @@ fn collect_two_arg_open_findings(
 
     for child in node.children() {
         collect_two_arg_open_findings(rule, source, child, out);
+    }
+}
+
+fn collect_string_eval_findings(
+    rule: &StringEvalRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    match &node.kind {
+        NodeKind::Eval { block } if is_string_eval_expression(block) => {
+            out.push(string_eval_finding(rule, source, node));
+        }
+        NodeKind::FunctionCall { name, args } if name == "eval" => {
+            let eval_args = effective_call_args(args);
+            if eval_args.first().is_some_and(is_string_eval_expression) {
+                out.push(string_eval_finding(rule, source, node));
+            }
+        }
+        _ => {}
+    }
+
+    for child in node.children() {
+        collect_string_eval_findings(rule, source, child, out);
+    }
+}
+
+fn is_string_eval_expression(node: &Node) -> bool {
+    match &node.kind {
+        NodeKind::String { .. } | NodeKind::Variable { .. } => true,
+        NodeKind::Binary { op, .. } => op == ".",
+        _ => false,
     }
 }
 
@@ -1878,6 +1955,93 @@ mod tests {
     }
 
     #[test]
+    fn native_string_eval_rule_reports_literal_and_variable_eval() {
+        let source =
+            "use strict;\nuse warnings;\nmy $code = 'print 1';\neval $code;\neval 'print 2';\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StringEvalRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 2);
+        for finding in &findings {
+            assert_eq!(finding.rule_id, "native.security.string_eval");
+            assert_eq!(finding.category, CriticCategory::Security);
+            assert_eq!(finding.severity, Severity::Harsh);
+            assert_eq!(finding.message, "String eval is a security risk");
+            assert_eq!(finding.suppression_key, "native.security.string_eval");
+            assert!(finding.fix.is_none(), "string eval replacement is not safe to automate");
+        }
+        assert_eq!(&source[findings[0].range.start.byte..findings[0].range.end.byte], "eval $code");
+        assert_eq!(
+            &source[findings[1].range.start.byte..findings[1].range.end.byte],
+            "eval 'print 2'"
+        );
+    }
+
+    #[test]
+    fn native_string_eval_rule_accepts_block_eval() {
+        let source = "use strict;\nuse warnings;\neval { my $x = 1; };\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StringEvalRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "block eval should be accepted");
+    }
+
+    #[test]
+    fn native_string_eval_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $code = 'print 1';\neval $code;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.security.string_eval".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StringEvalRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.security.string_eval -- generated DSL\nuse strict;\nuse warnings;\nmy $code = 'print 1';\neval $code;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+
+        let severity_config =
+            CriticConfig { severity: Severity::Stern as u8, ..Default::default() };
+        let severity_ctx = CriticContext::new(source, &ast, &severity_config);
+        assert!(registry.check(&severity_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_string_eval_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $code = 'print 1';\neval $code;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StringEvalRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.security.string_eval");
+        assert_eq!(violations[0].description, "String eval is a security risk");
+        assert_eq!(
+            violations[0].explanation,
+            "String eval executes dynamically generated Perl code and is difficult to analyze safely. Prefer block eval for exception handling or a safer dispatch mechanism."
+        );
+        assert_eq!(violations[0].severity, Severity::Harsh);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_recommended_registry_contains_initial_policy_bundle() {
         let source = "print 1;\n";
         let ast = parse_source(source);
@@ -1895,6 +2059,7 @@ mod tests {
                 "native.common.assignment_in_condition",
                 "native.io.bareword_filehandle",
                 "native.io.two_arg_open",
+                "native.security.string_eval",
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",
                 "native.variables.duplicate_parameter",

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1350,7 +1350,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\neval $eval_code;\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
             None,
             &context,
             None,
@@ -1436,6 +1436,23 @@ mod tests {
         assert_eq!(data["code"], "native.io.two_arg_open");
         assert_eq!(data["suppressionKey"], "native.io.two_arg_open");
         assert_eq!(data["fixable"], true);
+
+        let string_eval = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.security.string_eval"),
+                )
+            })
+            .ok_or("expected native string eval finding")?;
+        assert_eq!(string_eval.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(string_eval.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(string_eval.message, "String eval is a security risk");
+        let data =
+            string_eval.data.as_ref().ok_or("native string eval data should be populated")?;
+        assert_eq!(data["code"], "native.security.string_eval");
+        assert_eq!(data["suppressionKey"], "native.security.string_eval");
+        assert_eq!(data["fixable"], false);
 
         let unused = items
             .iter()

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1837,7 +1837,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\neval $eval_code;\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
                 }
             })))
             .unwrap();
@@ -1879,6 +1879,14 @@ mod tests {
         assert!(
             text.contains("Two-argument open should use an explicit mode"),
             "native two-arg open finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.security.string_eval"),
+            "native critic engine should publish native string eval finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("String eval is a security risk"),
+            "native string eval finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.variables.unused_lexical"),
@@ -1980,7 +1988,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\neval $eval_code;\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
             }
         })))?;
 
@@ -2038,6 +2046,14 @@ mod tests {
                         == Some("Two-argument open should use an explicit mode")
             }),
             "native critic engine should add native two-arg open finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.security.string_eval")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str() == Some("String eval is a security risk")
+            }),
+            "native critic engine should add native string eval finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

- adds the opt-in native critic rule `native.security.string_eval`
- reports literal, variable, and concatenated string eval while accepting block eval
- routes the finding through config/severity filtering, suppressions, the legacy violation bridge, pull diagnostics, push diagnostics, and workspace diagnostics
- marks the finding as non-fixable because replacing string eval safely requires user intent

Legacy/default critic behavior is unchanged; the native engine remains explicit opt-in.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_string_eval --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
