### PR TITLE
feat(diagnostics): add compiler shadow proof traces (#8317)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
@@ -28,7 +28,10 @@
 //! - **Req 22.6**: Exact -> warn; Ambiguous -> suppress / weak warning;
 //!   Dynamic/Unavailable -> suppress.
 
-use perl_semantic_facts::{Confidence, FileId, Provenance, ScopeId};
+use perl_semantic_facts::{
+    Confidence, DefinitionCandidate, FileId, Provenance, ProviderFactFreshness,
+    ProviderFactSourceKind, ProviderFactTrace, ProviderFallbackState, ProviderSurface, ScopeId,
+};
 use perl_workspace::semantic::queries::{QueryContext, SemanticQueries};
 use perl_workspace::semantic_shadow_compare::{
     SemanticShadowCompareReceipt, ShadowQueryInput, ShadowQueryName, ShadowResultSummary,
@@ -86,12 +89,14 @@ pub fn diagnostics_undefined_symbol_shadow<Q: SemanticQueries>(
     let new_summary = classification_to_summary(&classification, symbol);
 
     // Build receipt
-    let receipt = SemanticShadowCompareReceipt::from_summaries(
+    let fact_source_traces = diagnostics_fact_source_traces(&classification, &candidates);
+    let receipt = SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
         ShadowQueryName::DiagnosticsCheck,
         ShadowQueryInput { symbol: symbol.to_string() },
         old_summary,
         new_summary,
         Vec::new(),
+        fact_source_traces,
     );
 
     tracing::debug!(
@@ -197,12 +202,19 @@ pub fn diagnostics_undefined_symbol_cutover<Q: SemanticQueries>(
         let old_summary = legacy_warn_to_summary(legacy_should_warn);
         let new_summary = summarize_identities(Some(Vec::new()));
 
-        let receipt = SemanticShadowCompareReceipt::from_summaries(
+        let receipt = SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
             ShadowQueryName::DiagnosticsCheck,
             ShadowQueryInput { symbol: symbol.to_string() },
             old_summary,
             new_summary,
             vec!["suppressed: dynamic boundary scope".to_string()],
+            vec![diagnostics_trace(
+                ProviderFactSourceKind::DynamicBoundary,
+                Provenance::DynamicBoundary,
+                Confidence::High,
+                ProviderFallbackState::Blocked,
+                None,
+            )],
         );
 
         return DiagnosticsCutoverOutcome {
@@ -232,12 +244,14 @@ pub fn diagnostics_undefined_symbol_cutover<Q: SemanticQueries>(
         }
     };
 
-    let receipt = SemanticShadowCompareReceipt::from_summaries(
+    let fact_source_traces = diagnostics_fact_source_traces(&classification, &candidates);
+    let receipt = SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
         ShadowQueryName::DiagnosticsCheck,
         ShadowQueryInput { symbol: symbol.to_string() },
         old_summary,
         new_summary,
         notes,
+        fact_source_traces,
     );
 
     // Map classification to action
@@ -331,6 +345,68 @@ fn classification_to_summary(
         DiagnosticClassification::DynamicOrUnavailable => {
             // Suppressed -> no diagnostic.
             summarize_identities(Some(Vec::new()))
+        }
+    }
+}
+
+fn diagnostics_fact_source_traces(
+    classification: &DiagnosticClassification,
+    candidates: &[DefinitionCandidate],
+) -> Vec<ProviderFactTrace> {
+    if let Some(candidate) = candidates.first() {
+        return vec![diagnostics_trace(
+            provider_source_for_provenance(candidate.provenance),
+            candidate.provenance,
+            candidate.confidence,
+            ProviderFallbackState::Shadow,
+            Some(candidate.anchor_id),
+        )];
+    }
+
+    let (source, provenance, confidence) = match classification {
+        DiagnosticClassification::Exact => {
+            (ProviderFactSourceKind::CompilerFact, Provenance::SemanticAnalyzer, Confidence::High)
+        }
+        DiagnosticClassification::Ambiguous => {
+            (ProviderFactSourceKind::SemanticFact, Provenance::NameHeuristic, Confidence::Low)
+        }
+        DiagnosticClassification::DynamicOrUnavailable => {
+            (ProviderFactSourceKind::DynamicBoundary, Provenance::DynamicBoundary, Confidence::High)
+        }
+    };
+
+    vec![diagnostics_trace(source, provenance, confidence, ProviderFallbackState::Shadow, None)]
+}
+
+fn diagnostics_trace(
+    source: ProviderFactSourceKind,
+    provenance: Provenance,
+    confidence: Confidence,
+    fallback_state: ProviderFallbackState,
+    anchor_id: Option<perl_semantic_facts::AnchorId>,
+) -> ProviderFactTrace {
+    ProviderFactTrace::new(
+        ProviderSurface::Diagnostics,
+        source,
+        provenance,
+        confidence,
+        ProviderFactFreshness::Fresh,
+        fallback_state,
+        None,
+        anchor_id,
+        Some(1),
+    )
+}
+
+fn provider_source_for_provenance(provenance: Provenance) -> ProviderFactSourceKind {
+    match provenance {
+        Provenance::ImportExportInference
+        | Provenance::FrameworkSynthesis
+        | Provenance::PragmaInference => ProviderFactSourceKind::CompilerFact,
+        Provenance::DynamicBoundary => ProviderFactSourceKind::DynamicBoundary,
+        Provenance::SearchFallback | Provenance::NameHeuristic => ProviderFactSourceKind::Fallback,
+        Provenance::ExactAst | Provenance::DesugaredAst | Provenance::SemanticAnalyzer => {
+            ProviderFactSourceKind::SemanticFact
         }
     }
 }
@@ -488,7 +564,13 @@ mod tests {
     #[test]
     fn shadow_legacy_warn_semantic_suppresses() -> Result<(), Box<dyn std::error::Error>> {
         // Legacy would warn (false positive), but semantic finds the symbol.
-        let candidate = make_exact_candidate("imported_sub", 10, 20);
+        let candidate = make_candidate(
+            "imported_sub",
+            10,
+            20,
+            Provenance::ImportExportInference,
+            Confidence::High,
+        );
         let queries = StubSemanticQueries { definitions_result: vec![candidate] };
 
         let result =
@@ -498,6 +580,67 @@ mod tests {
         assert_eq!(result.receipt.old_result.match_count, 1); // legacy warns
         assert_eq!(result.receipt.new_result.match_count, 0); // semantic suppresses
         assert_eq!(result.receipt.verdict, ShadowCompareVerdict::Regression);
+        assert_eq!(result.receipt.fact_source_traces.len(), 1);
+        let trace = &result.receipt.fact_source_traces[0];
+        assert_eq!(trace.surface, ProviderSurface::Diagnostics);
+        assert_eq!(trace.source, ProviderFactSourceKind::CompilerFact);
+        assert_eq!(trace.provenance, Provenance::ImportExportInference);
+        assert_eq!(trace.confidence, Confidence::High);
+        assert_eq!(trace.freshness, ProviderFactFreshness::Fresh);
+        assert_eq!(trace.fallback_state, ProviderFallbackState::Shadow);
+        Ok(())
+    }
+
+    #[test]
+    fn diagnostics_compiler_shadow_exact_warning_trace_is_shadow_only()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let queries = StubSemanticQueries { definitions_result: vec![] };
+
+        let result = diagnostics_undefined_symbol_shadow(
+            true,
+            &queries,
+            "genuinely_missing",
+            FileId(1),
+            None,
+            42,
+        );
+
+        assert!(result.legacy_should_warn, "shadow mode must preserve legacy behavior");
+        assert_eq!(result.receipt.old_result.match_count, 1);
+        assert_eq!(result.receipt.new_result.match_count, 1);
+        let trace = &result.receipt.fact_source_traces[0];
+        assert_eq!(trace.surface, ProviderSurface::Diagnostics);
+        assert_eq!(trace.source, ProviderFactSourceKind::CompilerFact);
+        assert_eq!(trace.provenance, Provenance::SemanticAnalyzer);
+        assert_eq!(trace.confidence, Confidence::High);
+        assert_eq!(trace.fallback_state, ProviderFallbackState::Shadow);
+        Ok(())
+    }
+
+    #[test]
+    fn diagnostics_compiler_shadow_dynamic_boundary_trace_is_labeled()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let dynamic =
+            make_candidate("maybe_dynamic", 10, 20, Provenance::DynamicBoundary, Confidence::Low);
+        let queries = StubSemanticQueries { definitions_result: vec![dynamic] };
+
+        let result = diagnostics_undefined_symbol_shadow(
+            true,
+            &queries,
+            "maybe_dynamic",
+            FileId(1),
+            None,
+            5,
+        );
+
+        assert!(result.legacy_should_warn, "shadow mode must preserve legacy behavior");
+        assert_eq!(result.receipt.new_result.match_count, 0);
+        let trace = &result.receipt.fact_source_traces[0];
+        assert_eq!(trace.surface, ProviderSurface::Diagnostics);
+        assert_eq!(trace.source, ProviderFactSourceKind::DynamicBoundary);
+        assert_eq!(trace.provenance, Provenance::DynamicBoundary);
+        assert_eq!(trace.confidence, Confidence::Low);
+        assert_eq!(trace.fallback_state, ProviderFallbackState::Shadow);
         Ok(())
     }
 

--- a/docs/project/status/semantic_shadow_compare.json
+++ b/docs/project/status/semantic_shadow_compare.json
@@ -189,13 +189,123 @@
           "model_version": 1
         }
       ]
+    },
+    {
+      "schema_version": 2,
+      "query": "diagnostics_check",
+      "input": {
+        "symbol": "imported_func"
+      },
+      "old_result": {
+        "available": true,
+        "match_count": 0,
+        "identities": []
+      },
+      "new_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "false_positive_removed:imported_func"
+        ]
+      },
+      "verdict": "improved",
+      "notes": [
+        "diagnostics shadow fixture: legacy=warn compiler_fact=suppress via ImportSpec/ExportSet; false_positive_delta=-1; false_negative_delta=0"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Diagnostics",
+          "source": "CompilerFact",
+          "provenance": "ImportExportInference",
+          "confidence": "High",
+          "freshness": "Fresh",
+          "fallback_state": "Shadow",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
+      ]
+    },
+    {
+      "schema_version": 2,
+      "query": "diagnostics_check",
+      "input": {
+        "symbol": "genuinely_missing"
+      },
+      "old_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "warn:genuinely_missing"
+        ]
+      },
+      "new_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "warn:genuinely_missing"
+        ]
+      },
+      "verdict": "same",
+      "notes": [
+        "diagnostics shadow fixture: compiler facts preserve exact undefined-symbol warning; false_positive_delta=0; false_negative_delta=0"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Diagnostics",
+          "source": "CompilerFact",
+          "provenance": "SemanticAnalyzer",
+          "confidence": "High",
+          "freshness": "Fresh",
+          "fallback_state": "Shadow",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
+      ]
+    },
+    {
+      "schema_version": 2,
+      "query": "diagnostics_check",
+      "input": {
+        "symbol": "symbolic_ref_boundary"
+      },
+      "old_result": {
+        "available": true,
+        "match_count": 0,
+        "identities": []
+      },
+      "new_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "dynamic_boundary_blocked:symbolic_ref_boundary"
+        ]
+      },
+      "verdict": "improved",
+      "notes": [
+        "diagnostics shadow fixture: legacy=warn compiler_fact=dynamic-boundary-blocked for symbolic ref; false_positive_delta=-1; false_negative_delta=0"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Diagnostics",
+          "source": "DynamicBoundary",
+          "provenance": "DynamicBoundary",
+          "confidence": "High",
+          "freshness": "Fresh",
+          "fallback_state": "Blocked",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
+      ]
     }
   ],
   "verdict_counts": {
     "ambiguous": 1,
-    "improved": 1,
+    "improved": 3,
     "regression": 1,
-    "same": 1,
+    "same": 2,
     "unavailable": 1
   },
   "release_readiness_verdict_counts": {
@@ -207,9 +317,9 @@
   },
   "schema_fixture_verdict_counts": {
     "ambiguous": 1,
-    "improved": 0,
+    "improved": 2,
     "regression": 1,
-    "same": 0,
+    "same": 1,
     "unavailable": 1
   },
   "notes": "0.13.2 semantic shadow proof: release-readiness counts include provider-gating receipts only; schema fixture receipts exercise non-gating verdict shapes."

--- a/docs/project/status/semantic_shadow_compare.md
+++ b/docs/project/status/semantic_shadow_compare.md
@@ -2,16 +2,16 @@
 
 Measured: `deterministic-fixture-baseline`
 
-Receipts: `5`
+Receipts: `8`
 
 ## Verdict Counts
 
 | Verdict | Count |
 |---|---:|
 | ambiguous | 1 |
-| improved | 1 |
+| improved | 3 |
 | regression | 1 |
-| same | 1 |
+| same | 2 |
 | unavailable | 1 |
 
 ## Release-Readiness Verdict Counts
@@ -29,9 +29,9 @@ Receipts: `5`
 | Verdict | Count |
 |---|---:|
 | ambiguous | 1 |
-| improved | 0 |
+| improved | 2 |
 | regression | 1 |
-| same | 0 |
+| same | 1 |
 | unavailable | 1 |
 
 ## Receipts
@@ -43,6 +43,9 @@ Receipts: `5`
 | schema-fixture | CountUsages | `Foo::bar` | regression | 4 | 3 |
 | schema-fixture | VisibleSymbols | `Foo::bar` | ambiguous | 2 | 2 |
 | schema-fixture | Hover | `Foo::bar` | unavailable | 0 | 1 |
+| schema-fixture | DiagnosticsCheck | `imported_func` | improved | 0 | 1 |
+| schema-fixture | DiagnosticsCheck | `genuinely_missing` | same | 1 | 1 |
+| schema-fixture | DiagnosticsCheck | `symbolic_ref_boundary` | improved | 0 | 1 |
 
 ## Fact Source Traces
 
@@ -53,5 +56,8 @@ Receipts: `5`
 | schema-fixture | CountUsages | References | SemanticFact | SemanticAnalyzer | Medium | Fresh | Shadow |
 | schema-fixture | VisibleSymbols | Completion | CompilerFact | ImportExportInference | Medium | Fresh | Shadow |
 | schema-fixture | Hover | Hover | Fallback | SearchFallback | Low | NotApplicable | Unavailable |
+| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | High | Fresh | Shadow |
+| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | SemanticAnalyzer | High | Fresh | Shadow |
+| schema-fixture | DiagnosticsCheck | Diagnostics | DynamicBoundary | DynamicBoundary | High | Fresh | Blocked |
 
 0.13.2 semantic shadow proof: release-readiness counts include provider-gating receipts only; schema fixture receipts exercise non-gating verdict shapes.

--- a/xtask/src/tasks/semantic_shadow_compare.rs
+++ b/xtask/src/tasks/semantic_shadow_compare.rs
@@ -127,6 +127,51 @@ fn build_artifact() -> Artifact {
                 ProviderFallbackState::Unavailable,
             )],
         ),
+        receipt_from_identities(
+            ShadowQueryName::DiagnosticsCheck,
+            "imported_func",
+            Some(vec![]),
+            Some(vec!["false_positive_removed:imported_func"]),
+            "diagnostics shadow fixture: legacy=warn compiler_fact=suppress via ImportSpec/ExportSet; false_positive_delta=-1; false_negative_delta=0",
+            vec![trace(
+                ProviderSurface::Diagnostics,
+                ProviderFactSourceKind::CompilerFact,
+                Provenance::ImportExportInference,
+                Confidence::High,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Shadow,
+            )],
+        ),
+        receipt_from_identities(
+            ShadowQueryName::DiagnosticsCheck,
+            "genuinely_missing",
+            Some(vec!["warn:genuinely_missing"]),
+            Some(vec!["warn:genuinely_missing"]),
+            "diagnostics shadow fixture: compiler facts preserve exact undefined-symbol warning; false_positive_delta=0; false_negative_delta=0",
+            vec![trace(
+                ProviderSurface::Diagnostics,
+                ProviderFactSourceKind::CompilerFact,
+                Provenance::SemanticAnalyzer,
+                Confidence::High,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Shadow,
+            )],
+        ),
+        receipt_from_identities(
+            ShadowQueryName::DiagnosticsCheck,
+            "symbolic_ref_boundary",
+            Some(vec![]),
+            Some(vec!["dynamic_boundary_blocked:symbolic_ref_boundary"]),
+            "diagnostics shadow fixture: legacy=warn compiler_fact=dynamic-boundary-blocked for symbolic ref; false_positive_delta=-1; false_negative_delta=0",
+            vec![trace(
+                ProviderSurface::Diagnostics,
+                ProviderFactSourceKind::DynamicBoundary,
+                Provenance::DynamicBoundary,
+                Confidence::High,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Blocked,
+            )],
+        ),
     ];
 
     let verdict_counts = count_verdicts(&receipts);
@@ -342,8 +387,8 @@ mod tests {
     fn artifact_includes_required_verdict_rows() {
         let artifact = build_artifact();
         assert_eq!(artifact.schema_version, 3);
-        assert_eq!(artifact.verdict_counts.get("same"), Some(&1));
-        assert_eq!(artifact.verdict_counts.get("improved"), Some(&1));
+        assert_eq!(artifact.verdict_counts.get("same"), Some(&2));
+        assert_eq!(artifact.verdict_counts.get("improved"), Some(&3));
         assert_eq!(artifact.verdict_counts.get("regression"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("ambiguous"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("unavailable"), Some(&1));
@@ -351,6 +396,8 @@ mod tests {
         assert_eq!(artifact.release_readiness_verdict_counts.get("improved"), Some(&1));
         assert_eq!(artifact.release_readiness_verdict_counts.get("regression"), Some(&0));
         assert_eq!(artifact.release_readiness_verdict_counts.get("unavailable"), Some(&0));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("same"), Some(&1));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("improved"), Some(&2));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("regression"), Some(&1));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("ambiguous"), Some(&1));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("unavailable"), Some(&1));
@@ -377,6 +424,8 @@ mod tests {
         assert!(markdown.contains("| schema-fixture | CountUsages"));
         assert!(markdown.contains("## Fact Source Traces"));
         assert!(markdown.contains("| release-readiness | FindDefinition | Definition | CompilerFact | SemanticAnalyzer | High | Fresh | Shadow |"));
+        assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | High | Fresh | Shadow |"));
+        assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | DynamicBoundary | DynamicBoundary | High | Fresh | Blocked |"));
     }
 
     #[test]


### PR DESCRIPTION
Problem: Diagnostics need compiler-fact shadow proof before live provider cutover.
Fix: Add Diagnostics ProviderFactTrace receipts for imported-symbol suppression, exact undefined warnings, and symbolic-ref dynamic-boundary blockers without changing live diagnostic behavior.
Verification:
- `cargo test -p perl-lsp-rs-core --lib -- diagnostics_compiler_shadow --nocapture`
- `cargo test -p perl-lsp-rs-core --profile agent --locked diagnostics_shadow -- --nocapture`
- `cargo test -p xtask --profile agent --locked semantic_shadow_compare -- --nocapture`
- `cargo xtask semantic-shadow-compare --check`
- `cargo xtask semantic-scorecard --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`

Notes: `cargo clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs` passes. A broader `cargo clippy -p perl-lsp-rs-core -p xtask ...` currently reports pre-existing xtask lints outside this PR's diff in `parser_accuracy.rs` and `workflow_policy_lint.rs`.