### PR TITLE
feat(critic): add pipe-open native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -240,6 +240,7 @@ impl NativeCriticRegistry {
             Box::new(AssignmentInConditionRule),
             Box::new(BarewordFilehandleRule),
             Box::new(TwoArgOpenRule),
+            Box::new(PipeOpenRule),
             Box::new(StringEvalRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
@@ -510,6 +511,32 @@ impl CriticRule for TwoArgOpenRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_two_arg_open_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports pipe-open command execution.
+///
+/// Pipe-open forms execute shell commands through `open`. The rule mirrors the
+/// existing security diagnostic through the native critic contract and remains
+/// diagnostic-only because rewriting command execution safely needs user
+/// intent.
+pub struct PipeOpenRule;
+
+impl CriticRule for PipeOpenRule {
+    fn id(&self) -> &'static str {
+        "native.io.pipe_open"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Security
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_pipe_open_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -943,6 +970,25 @@ fn two_arg_open_fix_text(source: &str, open_args: &[Node]) -> Option<String> {
     Some(format!("open({handle_text}, '<', {path_text})"))
 }
 
+fn pipe_open_finding(rule: &PipeOpenRule, source: &str, open_node: &Node) -> CriticFinding {
+    let range = range_for_byte_span(source, open_node.location.start, open_node.location.end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: "Pipe-open executes a shell command".to_string(),
+        explanation: "Pipe-open forms run a command through the shell. Prefer explicit command argument lists or IPC modules when command execution is required.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: vec![CriticRelatedInformation {
+            range,
+            message: "Validate command arguments and avoid string command execution when input may be user-controlled.".to_string(),
+        }],
+        fix: None,
+    }
+}
+
 fn string_eval_finding(rule: &StringEvalRule, source: &str, eval_node: &Node) -> CriticFinding {
     let range = range_for_byte_span(source, eval_node.location.start, eval_node.location.end);
 
@@ -1103,6 +1149,56 @@ fn collect_two_arg_open_findings(
 
     for child in node.children() {
         collect_two_arg_open_findings(rule, source, child, out);
+    }
+}
+
+fn collect_pipe_open_findings(
+    rule: &PipeOpenRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    if let NodeKind::FunctionCall { name, args } = &node.kind
+        && name == "open"
+    {
+        let open_args = effective_call_args(args);
+        if is_pipe_open_args(open_args) {
+            out.push(pipe_open_finding(rule, source, node));
+        }
+    }
+
+    for child in node.children() {
+        collect_pipe_open_findings(rule, source, child, out);
+    }
+}
+
+fn is_pipe_open_args(open_args: &[Node]) -> bool {
+    match open_args.len() {
+        // 3+ arg form: open(my $fh, "|-", "cmd") or open(my $fh, "-|", "cmd")
+        n if n >= 3 => open_args.get(1).is_some_and(is_pipe_mode_string),
+        // 2-arg form: open(FH, "|cmd")
+        2 => open_args.get(1).is_some_and(is_pipe_two_arg_string),
+        _ => false,
+    }
+}
+
+fn is_pipe_mode_string(node: &Node) -> bool {
+    match &node.kind {
+        NodeKind::String { value, .. } => {
+            let trimmed = value.trim_matches(['"', '\'']);
+            trimmed == "|-" || trimmed == "-|"
+        }
+        _ => false,
+    }
+}
+
+fn is_pipe_two_arg_string(node: &Node) -> bool {
+    match &node.kind {
+        NodeKind::String { value, .. } => {
+            let trimmed = value.trim_matches(['"', '\'']);
+            trimmed.starts_with('|')
+        }
+        _ => false,
     }
 }
 
@@ -1955,6 +2051,98 @@ mod tests {
     }
 
     #[test]
+    fn native_pipe_open_rule_reports_pipe_open_forms() {
+        let source = "use strict;\nuse warnings;\nopen(my $read_fh, '-|', 'ls');\nopen(my $write_fh, '|-', 'cat');\nopen(FH, '|cmd');\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(PipeOpenRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 3);
+        for finding in &findings {
+            assert_eq!(finding.rule_id, "native.io.pipe_open");
+            assert_eq!(finding.category, CriticCategory::Security);
+            assert_eq!(finding.severity, Severity::Harsh);
+            assert_eq!(finding.message, "Pipe-open executes a shell command");
+            assert_eq!(finding.suppression_key, "native.io.pipe_open");
+            assert!(finding.fix.is_none(), "pipe-open replacement is not safe to automate");
+        }
+        assert_eq!(
+            &source[findings[0].range.start.byte..findings[0].range.end.byte],
+            "open(my $read_fh, '-|', 'ls')"
+        );
+        assert_eq!(
+            &source[findings[1].range.start.byte..findings[1].range.end.byte],
+            "open(my $write_fh, '|-', 'cat')"
+        );
+        assert_eq!(
+            &source[findings[2].range.start.byte..findings[2].range.end.byte],
+            "open(FH, '|cmd')"
+        );
+    }
+
+    #[test]
+    fn native_pipe_open_rule_accepts_normal_open() {
+        let source =
+            "use strict;\nuse warnings;\nmy $path = 'file.txt';\nopen(my $fh, '<', $path);\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(PipeOpenRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "normal three-argument open should be accepted");
+    }
+
+    #[test]
+    fn native_pipe_open_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nopen(my $fh, '-|', 'ls');\n";
+        let ast = parse_source(source);
+        let excluded_config =
+            CriticConfig { exclude: vec!["native.io.pipe_open".to_string()], ..Default::default() };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(PipeOpenRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.io.pipe_open -- trusted command\nuse strict;\nuse warnings;\nopen(my $fh, '-|', 'ls');\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+
+        let severity_config =
+            CriticConfig { severity: Severity::Stern as u8, ..Default::default() };
+        let severity_ctx = CriticContext::new(source, &ast, &severity_config);
+        assert!(registry.check(&severity_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_pipe_open_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nopen(my $fh, '-|', 'ls');\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(PipeOpenRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.io.pipe_open");
+        assert_eq!(violations[0].description, "Pipe-open executes a shell command");
+        assert_eq!(
+            violations[0].explanation,
+            "Pipe-open forms run a command through the shell. Prefer explicit command argument lists or IPC modules when command execution is required."
+        );
+        assert_eq!(violations[0].severity, Severity::Harsh);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_string_eval_rule_reports_literal_and_variable_eval() {
         let source =
             "use strict;\nuse warnings;\nmy $code = 'print 1';\neval $code;\neval 'print 2';\n";
@@ -2059,6 +2247,7 @@ mod tests {
                 "native.common.assignment_in_condition",
                 "native.io.bareword_filehandle",
                 "native.io.two_arg_open",
+                "native.io.pipe_open",
                 "native.security.string_eval",
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -1196,7 +1196,7 @@ fn is_pipe_two_arg_string(node: &Node) -> bool {
     match &node.kind {
         NodeKind::String { value, .. } => {
             let trimmed = value.trim_matches(['"', '\'']);
-            trimmed.starts_with('|')
+            trimmed.starts_with('|') || trimmed.ends_with('|')
         }
         _ => false,
     }
@@ -2052,7 +2052,7 @@ mod tests {
 
     #[test]
     fn native_pipe_open_rule_reports_pipe_open_forms() {
-        let source = "use strict;\nuse warnings;\nopen(my $read_fh, '-|', 'ls');\nopen(my $write_fh, '|-', 'cat');\nopen(FH, '|cmd');\n";
+        let source = "use strict;\nuse warnings;\nopen(my $read_fh, '-|', 'ls');\nopen(my $write_fh, '|-', 'cat');\nopen(FH, '|cmd');\nopen(my $legacy_read_fh, 'cat |');\n";
         let ast = parse_source(source);
         let config = CriticConfig::default();
         let ctx = CriticContext::new(source, &ast, &config);
@@ -2060,7 +2060,7 @@ mod tests {
 
         let findings = registry.check(&ctx);
 
-        assert_eq!(findings.len(), 3);
+        assert_eq!(findings.len(), 4);
         for finding in &findings {
             assert_eq!(finding.rule_id, "native.io.pipe_open");
             assert_eq!(finding.category, CriticCategory::Security);
@@ -2080,6 +2080,10 @@ mod tests {
         assert_eq!(
             &source[findings[2].range.start.byte..findings[2].range.end.byte],
             "open(FH, '|cmd')"
+        );
+        assert_eq!(
+            &source[findings[3].range.start.byte..findings[3].range.end.byte],
+            "open(my $legacy_read_fh, 'cat |')"
         );
     }
 

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1350,7 +1350,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\neval $eval_code;\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
             None,
             &context,
             None,
@@ -1436,6 +1436,22 @@ mod tests {
         assert_eq!(data["code"], "native.io.two_arg_open");
         assert_eq!(data["suppressionKey"], "native.io.two_arg_open");
         assert_eq!(data["fixable"], true);
+
+        let pipe_open = items
+            .iter()
+            .find(|diag| {
+                diag.code
+                    .as_ref()
+                    .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.io.pipe_open"))
+            })
+            .ok_or("expected native pipe-open finding")?;
+        assert_eq!(pipe_open.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(pipe_open.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(pipe_open.message, "Pipe-open executes a shell command");
+        let data = pipe_open.data.as_ref().ok_or("native pipe-open data should be populated")?;
+        assert_eq!(data["code"], "native.io.pipe_open");
+        assert_eq!(data["suppressionKey"], "native.io.pipe_open");
+        assert_eq!(data["fixable"], false);
 
         let string_eval = items
             .iter()

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1837,7 +1837,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\neval $eval_code;\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
                 }
             })))
             .unwrap();
@@ -1879,6 +1879,14 @@ mod tests {
         assert!(
             text.contains("Two-argument open should use an explicit mode"),
             "native two-arg open finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.io.pipe_open"),
+            "native critic engine should publish native pipe-open finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Pipe-open executes a shell command"),
+            "native pipe-open finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.security.string_eval"),
@@ -1988,7 +1996,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\neval $eval_code;\nprint $log_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
             }
         })))?;
 
@@ -2046,6 +2054,14 @@ mod tests {
                         == Some("Two-argument open should use an explicit mode")
             }),
             "native critic engine should add native two-arg open finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.io.pipe_open")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str() == Some("Pipe-open executes a shell command")
+            }),
+            "native critic engine should add native pipe-open finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

- adds the opt-in native critic rule `native.io.pipe_open`
- reports read-pipe, write-pipe, and two-argument pipe-open forms, including both leading-pipe and trailing-pipe legacy strings, while accepting normal three-argument file opens
- routes the finding through config/severity filtering, suppressions, the legacy violation bridge, pull diagnostics, push diagnostics, and workspace diagnostics
- marks the finding as non-fixable because replacing shell-command pipe-open safely requires user intent

Legacy/default critic behavior is unchanged; the native engine remains explicit opt-in.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_pipe_open --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Fix-forward review:
- [x] Added regression coverage for trailing two-argument pipe open: `open(my $fh, 'cmd |')`.
- [x] Re-ran `cargo test -p perl-lsp-rs-core native_pipe_open --profile agent --locked -- --nocapture`.
- [x] Re-ran `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`.
- [x] Re-ran `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`.
- [x] Re-ran `cargo xtask fmt --check` and `git diff --check`.

Receipt:
- `target/devex/local-proof.json`