### PR TITLE
feat(critic): add backtick execution native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -241,6 +241,7 @@ impl NativeCriticRegistry {
             Box::new(BarewordFilehandleRule),
             Box::new(TwoArgOpenRule),
             Box::new(PipeOpenRule),
+            Box::new(BacktickExecRule),
             Box::new(StringEvalRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
@@ -537,6 +538,31 @@ impl CriticRule for PipeOpenRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_pipe_open_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports backtick command execution.
+///
+/// This mirrors the existing security diagnostic through the native critic
+/// contract. The rule intentionally stays diagnostic-only because replacing
+/// shell command execution safely requires user intent.
+pub struct BacktickExecRule;
+
+impl CriticRule for BacktickExecRule {
+    fn id(&self) -> &'static str {
+        "native.security.backtick_exec"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Security
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_backtick_exec_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -989,6 +1015,29 @@ fn pipe_open_finding(rule: &PipeOpenRule, source: &str, open_node: &Node) -> Cri
     }
 }
 
+fn backtick_exec_finding(
+    rule: &BacktickExecRule,
+    source: &str,
+    string_node: &Node,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, string_node.location.start, string_node.location.end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: "Command execution detected".to_string(),
+        explanation: "Backticks execute shell commands. Prefer explicit command argument lists or IPC modules when command execution is required.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: vec![CriticRelatedInformation {
+            range,
+            message: "Validate command arguments and avoid shell command execution when input may be user-controlled.".to_string(),
+        }],
+        fix: None,
+    }
+}
+
 fn string_eval_finding(rule: &StringEvalRule, source: &str, eval_node: &Node) -> CriticFinding {
     let range = range_for_byte_span(source, eval_node.location.start, eval_node.location.end);
 
@@ -1200,6 +1249,27 @@ fn is_pipe_two_arg_string(node: &Node) -> bool {
         }
         _ => false,
     }
+}
+
+fn collect_backtick_exec_findings(
+    rule: &BacktickExecRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    if let NodeKind::String { value, interpolated: true } = &node.kind
+        && is_backtick_string(value)
+    {
+        out.push(backtick_exec_finding(rule, source, node));
+    }
+
+    for child in node.children() {
+        collect_backtick_exec_findings(rule, source, child, out);
+    }
+}
+
+fn is_backtick_string(value: &str) -> bool {
+    value.starts_with('`') && value.ends_with('`') && value.len() >= 2
 }
 
 fn collect_string_eval_findings(
@@ -2147,6 +2217,88 @@ mod tests {
     }
 
     #[test]
+    fn native_backtick_exec_rule_reports_backtick_strings() {
+        let source = "use strict;\nuse warnings;\nmy $out = `ls -la`;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(BacktickExecRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        for finding in &findings {
+            assert_eq!(finding.rule_id, "native.security.backtick_exec");
+            assert_eq!(finding.category, CriticCategory::Security);
+            assert_eq!(finding.severity, Severity::Harsh);
+            assert_eq!(finding.message, "Command execution detected");
+            assert_eq!(finding.suppression_key, "native.security.backtick_exec");
+            assert!(finding.fix.is_none(), "backtick command replacement is not safe to automate");
+        }
+        assert_eq!(&source[findings[0].range.start.byte..findings[0].range.end.byte], "`ls -la`");
+    }
+
+    #[test]
+    fn native_backtick_exec_rule_accepts_normal_strings() {
+        let source = "use strict;\nuse warnings;\nmy $text = 'not a command';\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(BacktickExecRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "ordinary strings should be accepted");
+    }
+
+    #[test]
+    fn native_backtick_exec_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $out = `ls -la`;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.security.backtick_exec".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(BacktickExecRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.security.backtick_exec -- trusted command\nuse strict;\nuse warnings;\nmy $out = `ls -la`;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+
+        let severity_config =
+            CriticConfig { severity: Severity::Stern as u8, ..Default::default() };
+        let severity_ctx = CriticContext::new(source, &ast, &severity_config);
+        assert!(registry.check(&severity_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_backtick_exec_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $out = `ls -la`;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(BacktickExecRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.security.backtick_exec");
+        assert_eq!(violations[0].description, "Command execution detected");
+        assert_eq!(
+            violations[0].explanation,
+            "Backticks execute shell commands. Prefer explicit command argument lists or IPC modules when command execution is required."
+        );
+        assert_eq!(violations[0].severity, Severity::Harsh);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_string_eval_rule_reports_literal_and_variable_eval() {
         let source =
             "use strict;\nuse warnings;\nmy $code = 'print 1';\neval $code;\neval 'print 2';\n";
@@ -2252,6 +2404,7 @@ mod tests {
                 "native.io.bareword_filehandle",
                 "native.io.two_arg_open",
                 "native.io.pipe_open",
+                "native.security.backtick_exec",
                 "native.security.string_eval",
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1350,7 +1350,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out;\n",
             None,
             &context,
             None,
@@ -1451,6 +1451,25 @@ mod tests {
         let data = pipe_open.data.as_ref().ok_or("native pipe-open data should be populated")?;
         assert_eq!(data["code"], "native.io.pipe_open");
         assert_eq!(data["suppressionKey"], "native.io.pipe_open");
+        assert_eq!(data["fixable"], false);
+
+        let backtick_exec = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.security.backtick_exec"),
+                )
+            })
+            .ok_or("expected native backtick execution finding")?;
+        assert_eq!(backtick_exec.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(backtick_exec.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(backtick_exec.message, "Command execution detected");
+        let data = backtick_exec
+            .data
+            .as_ref()
+            .ok_or("native backtick execution data should be populated")?;
+        assert_eq!(data["code"], "native.security.backtick_exec");
+        assert_eq!(data["suppressionKey"], "native.security.backtick_exec");
         assert_eq!(data["fixable"], false);
 
         let string_eval = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1837,7 +1837,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out;\n"
                 }
             })))
             .unwrap();
@@ -1887,6 +1887,14 @@ mod tests {
         assert!(
             text.contains("Pipe-open executes a shell command"),
             "native pipe-open finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.security.backtick_exec"),
+            "native critic engine should publish native backtick execution finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Command execution detected"),
+            "native backtick execution finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.security.string_eval"),
@@ -1996,7 +2004,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out;\n"
             }
         })))?;
 
@@ -2062,6 +2070,14 @@ mod tests {
                     && diag["message"].as_str() == Some("Pipe-open executes a shell command")
             }),
             "native critic engine should add native pipe-open finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.security.backtick_exec")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str() == Some("Command execution detected")
+            }),
+            "native critic engine should add native backtick execution finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

- adds the opt-in native critic rule `native.security.backtick_exec`
- reports parser-confirmed backtick command execution while accepting ordinary strings
- routes the finding through config/severity filtering, suppressions, the legacy violation bridge, pull diagnostics, push diagnostics, and workspace diagnostics
- marks the finding as non-fixable because replacing shell command execution safely requires user intent

Legacy/default critic behavior is unchanged; the native engine remains explicit opt-in. This PR intentionally scopes to backtick literals; `qx(...)`/`readpipe(...)` can follow with dedicated parser-backed coverage.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_backtick --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
