### PR TITLE
feat(diagnostics): enable compiler fact suppression cutover (#8321)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
@@ -89,7 +89,8 @@ pub fn diagnostics_undefined_symbol_shadow<Q: SemanticQueries>(
     let new_summary = classification_to_summary(&classification, symbol);
 
     // Build receipt
-    let fact_source_traces = diagnostics_fact_source_traces(&classification, &candidates);
+    let fact_source_traces =
+        diagnostics_fact_source_traces(&classification, &candidates, ProviderFallbackState::Shadow);
     let receipt = SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
         ShadowQueryName::DiagnosticsCheck,
         ShadowQueryInput { symbol: symbol.to_string() },
@@ -244,7 +245,11 @@ pub fn diagnostics_undefined_symbol_cutover<Q: SemanticQueries>(
         }
     };
 
-    let fact_source_traces = diagnostics_fact_source_traces(&classification, &candidates);
+    let fact_source_traces = diagnostics_fact_source_traces(
+        &classification,
+        &candidates,
+        cutover_fallback_state(&classification, &candidates),
+    );
     let receipt = SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
         ShadowQueryName::DiagnosticsCheck,
         ShadowQueryInput { symbol: symbol.to_string() },
@@ -352,13 +357,14 @@ fn classification_to_summary(
 fn diagnostics_fact_source_traces(
     classification: &DiagnosticClassification,
     candidates: &[DefinitionCandidate],
+    fallback_state: ProviderFallbackState,
 ) -> Vec<ProviderFactTrace> {
-    if let Some(candidate) = candidates.first() {
+    if let Some(candidate) = select_trace_candidate(candidates, fallback_state) {
         return vec![diagnostics_trace(
             provider_source_for_provenance(candidate.provenance),
             candidate.provenance,
             candidate.confidence,
-            ProviderFallbackState::Shadow,
+            fallback_state,
             Some(candidate.anchor_id),
         )];
     }
@@ -375,7 +381,50 @@ fn diagnostics_fact_source_traces(
         }
     };
 
-    vec![diagnostics_trace(source, provenance, confidence, ProviderFallbackState::Shadow, None)]
+    vec![diagnostics_trace(source, provenance, confidence, fallback_state, None)]
+}
+
+fn select_trace_candidate(
+    candidates: &[DefinitionCandidate],
+    fallback_state: ProviderFallbackState,
+) -> Option<&DefinitionCandidate> {
+    match fallback_state {
+        ProviderFallbackState::Blocked => candidates
+            .iter()
+            .find(|candidate| candidate.provenance == Provenance::DynamicBoundary)
+            .or_else(|| candidates.first()),
+        ProviderFallbackState::Primary => {
+            candidates.iter().find(|candidate| is_primary_cutover_candidate(candidate))
+        }
+        _ => candidates.first(),
+    }
+}
+
+fn cutover_fallback_state(
+    classification: &DiagnosticClassification,
+    candidates: &[DefinitionCandidate],
+) -> ProviderFallbackState {
+    if candidates.iter().any(|candidate| candidate.provenance == Provenance::DynamicBoundary) {
+        return ProviderFallbackState::Blocked;
+    }
+
+    match classification {
+        DiagnosticClassification::Exact => ProviderFallbackState::Primary,
+        DiagnosticClassification::DynamicOrUnavailable
+            if candidates.len() == 1 && candidates.iter().any(is_primary_cutover_candidate) =>
+        {
+            ProviderFallbackState::Primary
+        }
+        DiagnosticClassification::DynamicOrUnavailable => ProviderFallbackState::Fallback,
+        DiagnosticClassification::Ambiguous => ProviderFallbackState::Fallback,
+    }
+}
+
+fn is_primary_cutover_candidate(candidate: &DefinitionCandidate) -> bool {
+    matches!(
+        candidate.provenance,
+        Provenance::ImportExportInference | Provenance::FrameworkSynthesis
+    ) && candidate.confidence == Confidence::High
 }
 
 fn diagnostics_trace(
@@ -850,6 +899,44 @@ mod tests {
 
         // Semantic path finds the import -> suppress (no false positive).
         assert_eq!(outcome.action, DiagnosticAction::Suppress);
+        assert_eq!(
+            outcome.receipt.fact_source_traces[0].fallback_state,
+            ProviderFallbackState::Primary
+        );
+        assert_eq!(
+            outcome.receipt.fact_source_traces[0].provenance,
+            Provenance::ImportExportInference
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cutover_suppress_generated_symbol_with_primary_trace()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let generated = make_candidate(
+            "generated_accessor",
+            10,
+            20,
+            Provenance::FrameworkSynthesis,
+            Confidence::High,
+        );
+        let queries = StubSemanticQueries { definitions_result: vec![generated] };
+
+        let outcome = diagnostics_undefined_symbol_cutover(
+            true,
+            &queries,
+            "generated_accessor",
+            FileId(1),
+            None,
+            5,
+            false,
+        );
+
+        assert_eq!(outcome.action, DiagnosticAction::Suppress);
+        let trace = &outcome.receipt.fact_source_traces[0];
+        assert_eq!(trace.source, ProviderFactSourceKind::CompilerFact);
+        assert_eq!(trace.provenance, Provenance::FrameworkSynthesis);
+        assert_eq!(trace.fallback_state, ProviderFallbackState::Primary);
         Ok(())
     }
 
@@ -872,6 +959,10 @@ mod tests {
         assert_eq!(outcome.action, DiagnosticAction::Suppress);
         // Must NOT be Exact classification in dynamic scope.
         assert_eq!(outcome.classification, DiagnosticClassification::DynamicOrUnavailable);
+        assert_eq!(
+            outcome.receipt.fact_source_traces[0].fallback_state,
+            ProviderFallbackState::Blocked
+        );
         Ok(())
     }
 
@@ -915,6 +1006,77 @@ mod tests {
 
         // Medium confidence is usable -> symbol is defined -> suppress.
         assert_eq!(outcome.action, DiagnosticAction::Suppress);
+        assert_eq!(
+            outcome.receipt.fact_source_traces[0].fallback_state,
+            ProviderFallbackState::Fallback
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cutover_low_confidence_trace_uses_fallback_state() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let low = make_candidate(
+            "maybe_imported",
+            1,
+            1,
+            Provenance::ImportExportInference,
+            Confidence::Low,
+        );
+        let queries = StubSemanticQueries { definitions_result: vec![low] };
+
+        let outcome = diagnostics_undefined_symbol_cutover(
+            true,
+            &queries,
+            "maybe_imported",
+            FileId(1),
+            None,
+            10,
+            false,
+        );
+
+        assert_eq!(outcome.action, DiagnosticAction::WeakWarn);
+        assert_eq!(
+            outcome.receipt.fact_source_traces[0].fallback_state,
+            ProviderFallbackState::Fallback
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cutover_ambiguous_compiler_fact_trace_uses_fallback_state()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let first = make_candidate(
+            "ambiguous_import",
+            1,
+            1,
+            Provenance::ImportExportInference,
+            Confidence::High,
+        );
+        let second = make_candidate(
+            "ambiguous_import",
+            2,
+            2,
+            Provenance::FrameworkSynthesis,
+            Confidence::High,
+        );
+        let queries = StubSemanticQueries { definitions_result: vec![first, second] };
+
+        let outcome = diagnostics_undefined_symbol_cutover(
+            true,
+            &queries,
+            "ambiguous_import",
+            FileId(1),
+            None,
+            10,
+            false,
+        );
+
+        assert_eq!(outcome.action, DiagnosticAction::Suppress);
+        assert_eq!(
+            outcome.receipt.fact_source_traces[0].fallback_state,
+            ProviderFallbackState::Fallback
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/scope.rs
@@ -5,7 +5,7 @@
 
 use perl_diagnostics::codes::DiagnosticCode;
 use perl_semantic_analyzer::scope_analyzer::{IssueKind, ScopeIssue};
-use perl_semantic_facts::FileId;
+use perl_semantic_facts::{Confidence, FileId, VisibleSymbol, VisibleSymbolSource};
 use perl_workspace::semantic::queries::SemanticQueries;
 
 use super::internal_types::{Diagnostic, DiagnosticTag, RelatedInformation};
@@ -101,6 +101,9 @@ pub fn scope_issues_to_diagnostics(issues: Vec<ScopeIssue>) -> Vec<Diagnostic> {
 ///   (e.g. `Foo->import(@names)`) — any bareword in the file might be imported.
 /// - The file has a `DynamicBoundary` occurrence whose entity name matches the
 ///   bareword (e.g. `eval "sub NAME { ... }"` — only `NAME` is suppressed).
+/// - The symbol is visible from exactly one high-confidence imported,
+///   exported, or generated compiler fact. Low-confidence, ambiguous, or
+///   dynamic visibility remains diagnosed.
 ///
 /// Non-literal evals, non-Dynamic imports, and genuinely missing subs still fire.
 ///
@@ -188,6 +191,14 @@ pub fn scope_issues_to_diagnostics_with_semantics<Q: SemanticQueries>(
                 );
                 continue;
             }
+
+            if has_proven_compiler_visible_symbol(semantic_queries, file_id, byte_offset, symbol) {
+                tracing::debug!(
+                    bareword = %issue.variable_name,
+                    "suppressed UnquotedBareword diagnostic: compiler fact proves imported/generated symbol"
+                );
+                continue;
+            }
         }
 
         // ── All other issue kinds ── (and unsuppressed UndeclaredVariable /
@@ -241,6 +252,35 @@ pub fn scope_issues_to_diagnostics_with_semantics<Q: SemanticQueries>(
     }
 
     diagnostics
+}
+
+fn has_proven_compiler_visible_symbol<Q: SemanticQueries>(
+    semantic_queries: &Q,
+    file_id: FileId,
+    byte_offset: u32,
+    symbol: &str,
+) -> bool {
+    let visible = semantic_queries.visible_symbols_at(file_id, byte_offset, None);
+    let mut matching = visible.iter().filter(|candidate| candidate.name == symbol);
+    let Some(candidate) = matching.next() else {
+        return false;
+    };
+
+    if matching.next().is_some() {
+        return false;
+    }
+
+    is_proven_compiler_visible_symbol(candidate)
+}
+
+fn is_proven_compiler_visible_symbol(candidate: &VisibleSymbol) -> bool {
+    matches!(
+        candidate.source,
+        VisibleSymbolSource::ExplicitImport
+            | VisibleSymbolSource::DefaultExport
+            | VisibleSymbolSource::ExportTag
+            | VisibleSymbolSource::Generated
+    ) && candidate.confidence == Confidence::High
 }
 
 /// Build related information for a scope issue (extracted for reuse).
@@ -408,7 +448,7 @@ mod tests {
     use perl_semantic_facts::{
         AnchorId, Confidence, DefinitionCandidate, EntityFact, EntityId, FileId, OccurrenceFact,
         OccurrenceId, OccurrenceKind, Provenance, RenamePlan, SafeDeletePlan, ScopeId,
-        VisibleSymbol,
+        VisibleSymbol, VisibleSymbolSource,
     };
     use perl_workspace::semantic::queries::{
         DynamicCallableEvidence, QueryContext, SemanticQueries,
@@ -655,6 +695,85 @@ mod tests {
         }
     }
 
+    struct VisibleSymbolsStubQueries {
+        visible_symbols: Vec<VisibleSymbol>,
+    }
+
+    impl SemanticQueries for VisibleSymbolsStubQueries {
+        fn symbol_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+        ) -> Option<(EntityFact, OccurrenceFact)> {
+            None
+        }
+
+        fn definitions(&self, _symbol: &str, _context: &QueryContext) -> Vec<DefinitionCandidate> {
+            Vec::new()
+        }
+
+        fn references(&self, _entity_id: EntityId) -> Vec<OccurrenceFact> {
+            Vec::new()
+        }
+
+        fn visible_symbols_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _scope_id: Option<ScopeId>,
+        ) -> Vec<VisibleSymbol> {
+            self.visible_symbols.clone()
+        }
+
+        fn method_candidates(
+            &self,
+            _receiver_package: &str,
+            _method_name: &str,
+        ) -> Vec<DefinitionCandidate> {
+            Vec::new()
+        }
+
+        fn rename_plan(&self, entity_id: EntityId, new_name: &str) -> RenamePlan {
+            RenamePlan::new(entity_id, String::new(), new_name.to_string(), vec![], vec![], vec![])
+        }
+
+        fn safe_delete_plan(&self, entity_id: EntityId) -> SafeDeletePlan {
+            SafeDeletePlan::new(entity_id, String::new(), vec![], vec![])
+        }
+
+        fn dynamic_boundary_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: Option<&str>,
+        ) -> Option<OccurrenceFact> {
+            None
+        }
+
+        fn dynamic_callable_may_be_visible_at(
+            &self,
+            _file_id: FileId,
+            _byte_offset: u32,
+            _symbol: &str,
+        ) -> Option<DynamicCallableEvidence> {
+            None
+        }
+    }
+
+    fn visible_symbol(
+        name: &str,
+        source: VisibleSymbolSource,
+        confidence: Confidence,
+    ) -> VisibleSymbol {
+        VisibleSymbol {
+            name: name.to_string(),
+            entity_id: Some(EntityId(9001)),
+            source,
+            confidence,
+            context: None,
+        }
+    }
+
     // ── Tests ──
 
     #[test]
@@ -835,6 +954,152 @@ mod tests {
             diagnostics.len(),
             1,
             "UnquotedBareword with no dynamic evidence must still fire"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn suppresses_unquoted_bareword_when_high_confidence_import_fact_exists()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let issues = vec![bareword_issue("imported_func", (10, 23))];
+        let queries = VisibleSymbolsStubQueries {
+            visible_symbols: vec![visible_symbol(
+                "imported_func",
+                VisibleSymbolSource::ExplicitImport,
+                Confidence::High,
+            )],
+        };
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert!(
+            diagnostics.is_empty(),
+            "high-confidence import/export compiler fact should suppress imported bareword"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn suppresses_unquoted_bareword_when_high_confidence_export_visibility_exists()
+    -> Result<(), Box<dyn std::error::Error>> {
+        for source in [VisibleSymbolSource::DefaultExport, VisibleSymbolSource::ExportTag] {
+            let issues = vec![bareword_issue("exported_func", (10, 23))];
+            let queries = VisibleSymbolsStubQueries {
+                visible_symbols: vec![visible_symbol(
+                    "exported_func",
+                    source.clone(),
+                    Confidence::High,
+                )],
+            };
+
+            let diagnostics =
+                scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+            assert!(
+                diagnostics.is_empty(),
+                "high-confidence {source:?} visibility should suppress exported bareword"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn suppresses_unquoted_bareword_when_high_confidence_framework_fact_exists()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let issues = vec![bareword_issue("generated_member", (10, 26))];
+        let queries = VisibleSymbolsStubQueries {
+            visible_symbols: vec![visible_symbol(
+                "generated_member",
+                VisibleSymbolSource::Generated,
+                Confidence::High,
+            )],
+        };
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert!(
+            diagnostics.is_empty(),
+            "high-confidence framework compiler fact should suppress generated bareword"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn low_confidence_import_fact_does_not_suppress_unquoted_bareword()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let issues = vec![bareword_issue("maybe_imported_func", (10, 29))];
+        let queries = VisibleSymbolsStubQueries {
+            visible_symbols: vec![visible_symbol(
+                "maybe_imported_func",
+                VisibleSymbolSource::ExplicitImport,
+                Confidence::Low,
+            )],
+        };
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "low-confidence import/export fact should not silently suppress diagnostics"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_boundary_candidate_blocks_compiler_fact_suppression()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let issues = vec![bareword_issue("dynamic_symbol", (10, 24))];
+        let queries = VisibleSymbolsStubQueries {
+            visible_symbols: vec![
+                visible_symbol(
+                    "dynamic_symbol",
+                    VisibleSymbolSource::DynamicUnknown,
+                    Confidence::Low,
+                ),
+                visible_symbol(
+                    "dynamic_symbol",
+                    VisibleSymbolSource::ExplicitImport,
+                    Confidence::High,
+                ),
+            ],
+        };
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "dynamic-boundary candidate should block imported/generated fact suppression"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ambiguous_import_visibility_does_not_expand_live_bareword_cutover()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let issues = vec![bareword_issue("ambiguous_sub", (10, 23))];
+        let queries = VisibleSymbolsStubQueries {
+            visible_symbols: vec![
+                visible_symbol(
+                    "ambiguous_sub",
+                    VisibleSymbolSource::ExplicitImport,
+                    Confidence::High,
+                ),
+                visible_symbol(
+                    "ambiguous_sub",
+                    VisibleSymbolSource::DefaultExport,
+                    Confidence::High,
+                ),
+            ],
+        };
+
+        let diagnostics = scope_issues_to_diagnostics_with_semantics(issues, FileId(1), &queries);
+
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "ambiguous imported/generated visibility should not silently suppress diagnostics"
         );
         Ok(())
     }

--- a/docs/project/status/provider_cutover.md
+++ b/docs/project/status/provider_cutover.md
@@ -11,16 +11,20 @@ fallback behavior and rollback proof.
 
 - Fact-source trace receipt wiring is in place through `ProviderFactTrace`
   entries in the semantic shadow compare receipt schema.
-- The current shadow receipt records five fact-source traces across definition,
-  references, completion, and hover surfaces.
-- This is trace/proof infrastructure only. It does not make a provider consume
-  compiler facts in live LSP behavior.
+- The current shadow receipt records ten fact-source traces across definition,
+  references, completion, hover, and diagnostics surfaces.
+- Diagnostics now have a narrow live cutover for high-confidence imported and
+  generated visible-symbol facts. Ambiguous, low-confidence, and
+  dynamic-boundary cases remain fallback or blocked instead of being silently
+  suppressed.
+- Other provider surfaces remain trace/proof infrastructure only until their
+  own cutover proof lands.
 
 ## Cutover Matrix
 
 | Provider surface | Current state | Current source of truth | Next proof |
 | --- | --- | --- | --- |
-| Diagnostics | `partial live` | Existing semantic queries suppress selected dynamic false positives; fallback diagnostics remain available | False-positive / false-negative fixture receipts that include fact-source traces |
+| Diagnostics | `partial live` | Existing semantic queries suppress selected dynamic false positives, plus high-confidence imported/generated visible-symbol facts; fallback diagnostics remain available | Broader false-positive / false-negative fixture receipts before any additional diagnostic families move live |
 | Completion | `partial live / shadowed` | Existing completion paths and semantic-shadow fixtures can use visible symbols and generated members | Provider-impact rows for compiler facts, ranking stability, and fact-source traces |
 | Hover | `shadowed` | Hover shadow code can query visible symbols and provenance | Promote only after provenance labels, fallback behavior, and trace receipts are fixture-backed |
 | Definition / goto | `shadowed` | Definition shadow compare tracks regressions before live migration | Ranked compiler candidates with exact/static/generated/dynamic source labels |

--- a/docs/project/status/semantic_shadow_compare.json
+++ b/docs/project/status/semantic_shadow_compare.json
@@ -210,7 +210,7 @@
       },
       "verdict": "improved",
       "notes": [
-        "diagnostics shadow fixture: legacy=warn compiler_fact=suppress via ImportSpec/ExportSet; false_positive_delta=-1; false_negative_delta=0"
+        "diagnostics live cutover fixture: legacy=warn compiler_fact=suppress via ImportSpec/ExportSet; false_positive_delta=-1; false_negative_delta=0"
       ],
       "fact_source_traces": [
         {
@@ -219,7 +219,43 @@
           "provenance": "ImportExportInference",
           "confidence": "High",
           "freshness": "Fresh",
-          "fallback_state": "Shadow",
+          "fallback_state": "Primary",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
+      ]
+    },
+    {
+      "schema_version": 2,
+      "query": "diagnostics_check",
+      "input": {
+        "symbol": "generated_accessor"
+      },
+      "old_result": {
+        "available": true,
+        "match_count": 0,
+        "identities": []
+      },
+      "new_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "false_positive_removed:generated_accessor"
+        ]
+      },
+      "verdict": "improved",
+      "notes": [
+        "diagnostics live cutover fixture: legacy=warn compiler_fact=suppress via framework-generated visibility; false_positive_delta=-1; false_negative_delta=0"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Diagnostics",
+          "source": "CompilerFact",
+          "provenance": "FrameworkSynthesis",
+          "confidence": "High",
+          "freshness": "Fresh",
+          "fallback_state": "Primary",
           "source_hash": "deterministic-fixture",
           "anchor_id": 1,
           "model_version": 1
@@ -248,7 +284,7 @@
       },
       "verdict": "same",
       "notes": [
-        "diagnostics shadow fixture: compiler facts preserve exact undefined-symbol warning; false_positive_delta=0; false_negative_delta=0"
+        "diagnostics live cutover fixture: compiler facts preserve exact undefined-symbol warning; false_positive_delta=0; false_negative_delta=0"
       ],
       "fact_source_traces": [
         {
@@ -257,7 +293,45 @@
           "provenance": "SemanticAnalyzer",
           "confidence": "High",
           "freshness": "Fresh",
-          "fallback_state": "Shadow",
+          "fallback_state": "Primary",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
+      ]
+    },
+    {
+      "schema_version": 2,
+      "query": "diagnostics_check",
+      "input": {
+        "symbol": "ambiguous_import"
+      },
+      "old_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "warn:ambiguous_import"
+        ]
+      },
+      "new_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "weak_warn:ambiguous_import"
+        ]
+      },
+      "verdict": "ambiguous",
+      "notes": [
+        "diagnostics live cutover fixture: ambiguous/low-confidence compiler fact falls back instead of suppressing; false_positive_delta=0; false_negative_delta=0"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Diagnostics",
+          "source": "CompilerFact",
+          "provenance": "ImportExportInference",
+          "confidence": "Low",
+          "freshness": "Fresh",
+          "fallback_state": "Fallback",
           "source_hash": "deterministic-fixture",
           "anchor_id": 1,
           "model_version": 1
@@ -302,8 +376,8 @@
     }
   ],
   "verdict_counts": {
-    "ambiguous": 1,
-    "improved": 3,
+    "ambiguous": 2,
+    "improved": 4,
     "regression": 1,
     "same": 2,
     "unavailable": 1
@@ -316,8 +390,8 @@
     "unavailable": 0
   },
   "schema_fixture_verdict_counts": {
-    "ambiguous": 1,
-    "improved": 2,
+    "ambiguous": 2,
+    "improved": 3,
     "regression": 1,
     "same": 1,
     "unavailable": 1

--- a/docs/project/status/semantic_shadow_compare.md
+++ b/docs/project/status/semantic_shadow_compare.md
@@ -2,14 +2,14 @@
 
 Measured: `deterministic-fixture-baseline`
 
-Receipts: `8`
+Receipts: `10`
 
 ## Verdict Counts
 
 | Verdict | Count |
 |---|---:|
-| ambiguous | 1 |
-| improved | 3 |
+| ambiguous | 2 |
+| improved | 4 |
 | regression | 1 |
 | same | 2 |
 | unavailable | 1 |
@@ -28,8 +28,8 @@ Receipts: `8`
 
 | Verdict | Count |
 |---|---:|
-| ambiguous | 1 |
-| improved | 2 |
+| ambiguous | 2 |
+| improved | 3 |
 | regression | 1 |
 | same | 1 |
 | unavailable | 1 |
@@ -44,7 +44,9 @@ Receipts: `8`
 | schema-fixture | VisibleSymbols | `Foo::bar` | ambiguous | 2 | 2 |
 | schema-fixture | Hover | `Foo::bar` | unavailable | 0 | 1 |
 | schema-fixture | DiagnosticsCheck | `imported_func` | improved | 0 | 1 |
+| schema-fixture | DiagnosticsCheck | `generated_accessor` | improved | 0 | 1 |
 | schema-fixture | DiagnosticsCheck | `genuinely_missing` | same | 1 | 1 |
+| schema-fixture | DiagnosticsCheck | `ambiguous_import` | ambiguous | 1 | 1 |
 | schema-fixture | DiagnosticsCheck | `symbolic_ref_boundary` | improved | 0 | 1 |
 
 ## Fact Source Traces
@@ -56,8 +58,10 @@ Receipts: `8`
 | schema-fixture | CountUsages | References | SemanticFact | SemanticAnalyzer | Medium | Fresh | Shadow |
 | schema-fixture | VisibleSymbols | Completion | CompilerFact | ImportExportInference | Medium | Fresh | Shadow |
 | schema-fixture | Hover | Hover | Fallback | SearchFallback | Low | NotApplicable | Unavailable |
-| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | High | Fresh | Shadow |
-| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | SemanticAnalyzer | High | Fresh | Shadow |
+| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | High | Fresh | Primary |
+| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | FrameworkSynthesis | High | Fresh | Primary |
+| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | SemanticAnalyzer | High | Fresh | Primary |
+| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | Low | Fresh | Fallback |
 | schema-fixture | DiagnosticsCheck | Diagnostics | DynamicBoundary | DynamicBoundary | High | Fresh | Blocked |
 
 0.13.2 semantic shadow proof: release-readiness counts include provider-gating receipts only; schema fixture receipts exercise non-gating verdict shapes.

--- a/xtask/src/tasks/semantic_shadow_compare.rs
+++ b/xtask/src/tasks/semantic_shadow_compare.rs
@@ -132,14 +132,29 @@ fn build_artifact() -> Artifact {
             "imported_func",
             Some(vec![]),
             Some(vec!["false_positive_removed:imported_func"]),
-            "diagnostics shadow fixture: legacy=warn compiler_fact=suppress via ImportSpec/ExportSet; false_positive_delta=-1; false_negative_delta=0",
+            "diagnostics live cutover fixture: legacy=warn compiler_fact=suppress via ImportSpec/ExportSet; false_positive_delta=-1; false_negative_delta=0",
             vec![trace(
                 ProviderSurface::Diagnostics,
                 ProviderFactSourceKind::CompilerFact,
                 Provenance::ImportExportInference,
                 Confidence::High,
                 ProviderFactFreshness::Fresh,
-                ProviderFallbackState::Shadow,
+                ProviderFallbackState::Primary,
+            )],
+        ),
+        receipt_from_identities(
+            ShadowQueryName::DiagnosticsCheck,
+            "generated_accessor",
+            Some(vec![]),
+            Some(vec!["false_positive_removed:generated_accessor"]),
+            "diagnostics live cutover fixture: legacy=warn compiler_fact=suppress via framework-generated visibility; false_positive_delta=-1; false_negative_delta=0",
+            vec![trace(
+                ProviderSurface::Diagnostics,
+                ProviderFactSourceKind::CompilerFact,
+                Provenance::FrameworkSynthesis,
+                Confidence::High,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Primary,
             )],
         ),
         receipt_from_identities(
@@ -147,14 +162,29 @@ fn build_artifact() -> Artifact {
             "genuinely_missing",
             Some(vec!["warn:genuinely_missing"]),
             Some(vec!["warn:genuinely_missing"]),
-            "diagnostics shadow fixture: compiler facts preserve exact undefined-symbol warning; false_positive_delta=0; false_negative_delta=0",
+            "diagnostics live cutover fixture: compiler facts preserve exact undefined-symbol warning; false_positive_delta=0; false_negative_delta=0",
             vec![trace(
                 ProviderSurface::Diagnostics,
                 ProviderFactSourceKind::CompilerFact,
                 Provenance::SemanticAnalyzer,
                 Confidence::High,
                 ProviderFactFreshness::Fresh,
-                ProviderFallbackState::Shadow,
+                ProviderFallbackState::Primary,
+            )],
+        ),
+        receipt_from_identities(
+            ShadowQueryName::DiagnosticsCheck,
+            "ambiguous_import",
+            Some(vec!["warn:ambiguous_import"]),
+            Some(vec!["weak_warn:ambiguous_import"]),
+            "diagnostics live cutover fixture: ambiguous/low-confidence compiler fact falls back instead of suppressing; false_positive_delta=0; false_negative_delta=0",
+            vec![trace(
+                ProviderSurface::Diagnostics,
+                ProviderFactSourceKind::CompilerFact,
+                Provenance::ImportExportInference,
+                Confidence::Low,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Fallback,
             )],
         ),
         receipt_from_identities(
@@ -388,18 +418,18 @@ mod tests {
         let artifact = build_artifact();
         assert_eq!(artifact.schema_version, 3);
         assert_eq!(artifact.verdict_counts.get("same"), Some(&2));
-        assert_eq!(artifact.verdict_counts.get("improved"), Some(&3));
+        assert_eq!(artifact.verdict_counts.get("improved"), Some(&4));
         assert_eq!(artifact.verdict_counts.get("regression"), Some(&1));
-        assert_eq!(artifact.verdict_counts.get("ambiguous"), Some(&1));
+        assert_eq!(artifact.verdict_counts.get("ambiguous"), Some(&2));
         assert_eq!(artifact.verdict_counts.get("unavailable"), Some(&1));
         assert_eq!(artifact.release_readiness_verdict_counts.get("same"), Some(&1));
         assert_eq!(artifact.release_readiness_verdict_counts.get("improved"), Some(&1));
         assert_eq!(artifact.release_readiness_verdict_counts.get("regression"), Some(&0));
         assert_eq!(artifact.release_readiness_verdict_counts.get("unavailable"), Some(&0));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("same"), Some(&1));
-        assert_eq!(artifact.schema_fixture_verdict_counts.get("improved"), Some(&2));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("improved"), Some(&3));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("regression"), Some(&1));
-        assert_eq!(artifact.schema_fixture_verdict_counts.get("ambiguous"), Some(&1));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("ambiguous"), Some(&2));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("unavailable"), Some(&1));
         assert!(
             artifact.receipts.iter().all(|receipt| !receipt.fact_source_traces.is_empty()),
@@ -424,7 +454,9 @@ mod tests {
         assert!(markdown.contains("| schema-fixture | CountUsages"));
         assert!(markdown.contains("## Fact Source Traces"));
         assert!(markdown.contains("| release-readiness | FindDefinition | Definition | CompilerFact | SemanticAnalyzer | High | Fresh | Shadow |"));
-        assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | High | Fresh | Shadow |"));
+        assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | High | Fresh | Primary |"));
+        assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | FrameworkSynthesis | High | Fresh | Primary |"));
+        assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | Low | Fresh | Fallback |"));
         assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | DynamicBoundary | DynamicBoundary | High | Fresh | Blocked |"));
     }
 


### PR DESCRIPTION
Problem: Diagnostics had compiler-fact proof traces, but the live path only consumed dynamic callable evidence for undefined bareword suppression.

Fix: Suppress `UnquotedBareword` only when exactly one fresh high-confidence visible compiler fact proves an imported/exported/generated symbol; low-confidence, ambiguous, and dynamic-boundary cases stay fallback or blocked. Refresh semantic-shadow receipts and provider cutover status with Primary/Fallback/Blocked diagnostics traces.

Verification:
- `cargo test -p perl-lsp-rs-core --profile agent --locked diagnostics_shadow -- --nocapture`
- `cargo test -p perl-lsp-rs-core --profile agent --locked scope::tests -- --nocapture`
- `cargo test -p xtask --profile agent --locked semantic_shadow_compare -- --nocapture`
- `cargo xtask semantic-shadow-compare --check`
- `cargo xtask semantic-scorecard --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `cargo clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs`
- `git diff --check`

Closes #8321.