### PR TITLE
feat(critic): add qx/readpipe native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -241,6 +241,7 @@ impl NativeCriticRegistry {
             Box::new(BarewordFilehandleRule),
             Box::new(TwoArgOpenRule),
             Box::new(PipeOpenRule),
+            Box::new(QxReadpipeRule),
             Box::new(BacktickExecRule),
             Box::new(StringEvalRule),
             Box::new(UnusedLexicalVariableRule),
@@ -538,6 +539,31 @@ impl CriticRule for PipeOpenRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_pipe_open_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports `qx` and `readpipe` command execution.
+///
+/// This complements the backtick rule with parser-confirmed quote-command and
+/// function-call forms. It stays diagnostic-only because replacing shell
+/// command execution safely requires user intent.
+pub struct QxReadpipeRule;
+
+impl CriticRule for QxReadpipeRule {
+    fn id(&self) -> &'static str {
+        "native.security.qx_readpipe"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Security
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_qx_readpipe_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -1038,6 +1064,25 @@ fn backtick_exec_finding(
     }
 }
 
+fn qx_readpipe_finding(rule: &QxReadpipeRule, source: &str, command_node: &Node) -> CriticFinding {
+    let range = range_for_byte_span(source, command_node.location.start, command_node.location.end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: "qx/readpipe command execution detected".to_string(),
+        explanation: "qx and readpipe execute shell commands. Prefer explicit command argument lists or IPC modules when command execution is required.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: vec![CriticRelatedInformation {
+            range,
+            message: "Validate command arguments and avoid shell command execution when input may be user-controlled.".to_string(),
+        }],
+        fix: None,
+    }
+}
+
 fn string_eval_finding(rule: &StringEvalRule, source: &str, eval_node: &Node) -> CriticFinding {
     let range = range_for_byte_span(source, eval_node.location.start, eval_node.location.end);
 
@@ -1249,6 +1294,36 @@ fn is_pipe_two_arg_string(node: &Node) -> bool {
         }
         _ => false,
     }
+}
+
+fn collect_qx_readpipe_findings(
+    rule: &QxReadpipeRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    match &node.kind {
+        NodeKind::String { value, interpolated: true } if is_qx_string(value) => {
+            out.push(qx_readpipe_finding(rule, source, node));
+        }
+        NodeKind::FunctionCall { name, .. } if name == "readpipe" => {
+            out.push(qx_readpipe_finding(rule, source, node));
+        }
+        _ => {}
+    }
+
+    for child in node.children() {
+        collect_qx_readpipe_findings(rule, source, child, out);
+    }
+}
+
+fn is_qx_string(value: &str) -> bool {
+    let Some(rest) = value.strip_prefix("qx") else {
+        return false;
+    };
+    rest.chars().next().is_some_and(|delimiter| {
+        matches!(delimiter, '(' | '[' | '{' | '<' | '/' | '!' | '\'' | '"')
+    })
 }
 
 fn collect_backtick_exec_findings(
@@ -2217,6 +2292,93 @@ mod tests {
     }
 
     #[test]
+    fn native_qx_readpipe_rule_reports_qx_and_readpipe_forms() {
+        let source = "use strict;\nuse warnings;\nmy $date = qx(date);\nmy $listing = qx/ls -la/;\nmy $pipe = readpipe($date);\nprint $listing . $pipe;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(QxReadpipeRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 3);
+        for finding in &findings {
+            assert_eq!(finding.rule_id, "native.security.qx_readpipe");
+            assert_eq!(finding.category, CriticCategory::Security);
+            assert_eq!(finding.severity, Severity::Harsh);
+            assert_eq!(finding.message, "qx/readpipe command execution detected");
+            assert_eq!(finding.suppression_key, "native.security.qx_readpipe");
+            assert!(finding.fix.is_none(), "qx/readpipe replacement is not safe to automate");
+        }
+        assert_eq!(&source[findings[0].range.start.byte..findings[0].range.end.byte], "qx(date)");
+        assert_eq!(&source[findings[1].range.start.byte..findings[1].range.end.byte], "qx/ls -la/");
+        assert_eq!(
+            &source[findings[2].range.start.byte..findings[2].range.end.byte],
+            "readpipe($date)"
+        );
+    }
+
+    #[test]
+    fn native_qx_readpipe_rule_accepts_non_command_strings_and_calls() {
+        let source = "use strict;\nuse warnings;\nmy $text = 'qx(date)';\nmy $value = read_line($text);\nprint $value;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(QxReadpipeRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "ordinary strings and non-readpipe calls should be accepted");
+    }
+
+    #[test]
+    fn native_qx_readpipe_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $out = qx(date);\nprint $out;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.security.qx_readpipe".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(QxReadpipeRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.security.qx_readpipe -- trusted command\nuse strict;\nuse warnings;\nmy $out = readpipe('date');\nprint $out;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+
+        let severity_config =
+            CriticConfig { severity: Severity::Stern as u8, ..Default::default() };
+        let severity_ctx = CriticContext::new(source, &ast, &severity_config);
+        assert!(registry.check(&severity_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_qx_readpipe_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $out = qx(date);\nprint $out;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(QxReadpipeRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.security.qx_readpipe");
+        assert_eq!(violations[0].description, "qx/readpipe command execution detected");
+        assert_eq!(
+            violations[0].explanation,
+            "qx and readpipe execute shell commands. Prefer explicit command argument lists or IPC modules when command execution is required."
+        );
+        assert_eq!(violations[0].severity, Severity::Harsh);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_backtick_exec_rule_reports_backtick_strings() {
         let source = "use strict;\nuse warnings;\nmy $out = `ls -la`;\n";
         let ast = parse_source(source);
@@ -2404,6 +2566,7 @@ mod tests {
                 "native.io.bareword_filehandle",
                 "native.io.two_arg_open",
                 "native.io.pipe_open",
+                "native.security.qx_readpipe",
                 "native.security.backtick_exec",
                 "native.security.string_eval",
                 "native.variables.unused_lexical",

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1350,7 +1350,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
             None,
             &context,
             None,
@@ -1470,6 +1470,23 @@ mod tests {
             .ok_or("native backtick execution data should be populated")?;
         assert_eq!(data["code"], "native.security.backtick_exec");
         assert_eq!(data["suppressionKey"], "native.security.backtick_exec");
+        assert_eq!(data["fixable"], false);
+
+        let qx_readpipe = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.security.qx_readpipe"),
+                )
+            })
+            .ok_or("expected native qx/readpipe finding")?;
+        assert_eq!(qx_readpipe.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(qx_readpipe.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(qx_readpipe.message, "qx/readpipe command execution detected");
+        let data =
+            qx_readpipe.data.as_ref().ok_or("native qx/readpipe data should be populated")?;
+        assert_eq!(data["code"], "native.security.qx_readpipe");
+        assert_eq!(data["suppressionKey"], "native.security.qx_readpipe");
         assert_eq!(data["fixable"], false);
 
         let string_eval = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1837,7 +1837,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
                 }
             })))
             .unwrap();
@@ -1895,6 +1895,14 @@ mod tests {
         assert!(
             text.contains("Command execution detected"),
             "native backtick execution finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.security.qx_readpipe"),
+            "native critic engine should publish native qx/readpipe finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("qx/readpipe command execution detected"),
+            "native qx/readpipe finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.security.string_eval"),
@@ -2004,7 +2012,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
             }
         })))?;
 
@@ -2078,6 +2086,14 @@ mod tests {
                     && diag["message"].as_str() == Some("Command execution detected")
             }),
             "native critic engine should add native backtick execution finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.security.qx_readpipe")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str() == Some("qx/readpipe command execution detected")
+            }),
+            "native critic engine should add native qx/readpipe finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.security.qx_readpipe` for parser-backed qx/readpipe command execution forms:

- `qx(date)` and delimiter forms like `qx/ls -la/`
- `readpipe($cmd)` function calls
- config/severity filtering, suppressions, and legacy violation bridge coverage
- pull, push, and workspace diagnostics under `[critic].engine = "native"`

The rule is diagnostic-only. Replacing shell execution needs user intent, so no automatic fix is exposed. Legacy/default critic behavior is unchanged.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_qx --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
