### PR TITLE
feat(critic): add system/exec native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -244,6 +244,7 @@ impl NativeCriticRegistry {
             Box::new(QxReadpipeRule),
             Box::new(BacktickExecRule),
             Box::new(StringEvalRule),
+            Box::new(SystemExecRule),
             Box::new(UnusedLexicalVariableRule),
             Box::new(UnusedParameterRule),
             Box::new(DuplicateParameterRule),
@@ -614,6 +615,31 @@ impl CriticRule for StringEvalRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_string_eval_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports `system` and `exec` command execution.
+///
+/// This mirrors the existing security diagnostics through the native critic
+/// contract. The rule stays diagnostic-only because replacing process
+/// execution safely requires user intent.
+pub struct SystemExecRule;
+
+impl CriticRule for SystemExecRule {
+    fn id(&self) -> &'static str {
+        "native.security.system_exec"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Security
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_system_exec_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -1102,6 +1128,34 @@ fn string_eval_finding(rule: &StringEvalRule, source: &str, eval_node: &Node) ->
     }
 }
 
+fn system_exec_finding(
+    rule: &SystemExecRule,
+    source: &str,
+    call_node: &Node,
+    name: &str,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, call_node.location.start, call_node.location.end);
+    let message = match name {
+        "exec" => "exec() replaces the current process with a shell command",
+        _ => "system() executes a shell command",
+    };
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: message.to_string(),
+        explanation: "system and exec run external commands. Prefer explicit argument lists or IPC modules when command execution is required, and validate any user-controlled input.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: vec![CriticRelatedInformation {
+            range,
+            message: "List form avoids shell interpolation, but command execution still needs an explicit security review.".to_string(),
+        }],
+        fix: None,
+    }
+}
+
 fn duplicate_lexical_finding(
     rule: &DuplicateLexicalDeclarationRule,
     source: &str,
@@ -1368,6 +1422,23 @@ fn collect_string_eval_findings(
 
     for child in node.children() {
         collect_string_eval_findings(rule, source, child, out);
+    }
+}
+
+fn collect_system_exec_findings(
+    rule: &SystemExecRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    if let NodeKind::FunctionCall { name, .. } = &node.kind
+        && matches!(name.as_str(), "system" | "exec")
+    {
+        out.push(system_exec_finding(rule, source, node, name));
+    }
+
+    for child in node.children() {
+        collect_system_exec_findings(rule, source, child, out);
     }
 }
 
@@ -2548,6 +2619,106 @@ mod tests {
     }
 
     #[test]
+    fn native_system_exec_rule_reports_system_and_exec_forms() {
+        let source = "use strict;\nuse warnings;\nmy $cmd = 'ls';\nsystem($cmd);\nsystem('ls', '-la');\nexec($cmd);\nexec('ls', '-la');\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(SystemExecRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 4);
+        for finding in &findings {
+            assert_eq!(finding.rule_id, "native.security.system_exec");
+            assert_eq!(finding.category, CriticCategory::Security);
+            assert_eq!(finding.severity, Severity::Harsh);
+            assert_eq!(finding.suppression_key, "native.security.system_exec");
+            assert!(finding.fix.is_none(), "system/exec replacement is not safe to automate");
+        }
+        assert_eq!(findings[0].message, "system() executes a shell command");
+        assert_eq!(findings[1].message, "system() executes a shell command");
+        assert_eq!(findings[2].message, "exec() replaces the current process with a shell command");
+        assert_eq!(findings[3].message, "exec() replaces the current process with a shell command");
+        assert_eq!(
+            &source[findings[0].range.start.byte..findings[0].range.end.byte],
+            "system($cmd)"
+        );
+        assert_eq!(
+            &source[findings[1].range.start.byte..findings[1].range.end.byte],
+            "system('ls', '-la')"
+        );
+        assert_eq!(&source[findings[2].range.start.byte..findings[2].range.end.byte], "exec($cmd)");
+        assert_eq!(
+            &source[findings[3].range.start.byte..findings[3].range.end.byte],
+            "exec('ls', '-la')"
+        );
+    }
+
+    #[test]
+    fn native_system_exec_rule_accepts_non_command_calls() {
+        let source = "use strict;\nuse warnings;\nmy $system = 'name';\nmy $exec_ok = run_exec($system);\nprint $exec_ok;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(SystemExecRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(
+            findings.is_empty(),
+            "ordinary variables and non-system/exec calls should be accepted"
+        );
+    }
+
+    #[test]
+    fn native_system_exec_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $cmd = 'ls';\nsystem($cmd);\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.security.system_exec".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(SystemExecRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.security.system_exec -- trusted command\nuse strict;\nuse warnings;\nmy $cmd = 'ls';\nexec($cmd);\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+
+        let severity_config =
+            CriticConfig { severity: Severity::Stern as u8, ..Default::default() };
+        let severity_ctx = CriticContext::new(source, &ast, &severity_config);
+        assert!(registry.check(&severity_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_system_exec_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $cmd = 'ls';\nsystem($cmd);\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(SystemExecRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.security.system_exec");
+        assert_eq!(violations[0].description, "system() executes a shell command");
+        assert_eq!(
+            violations[0].explanation,
+            "system and exec run external commands. Prefer explicit argument lists or IPC modules when command execution is required, and validate any user-controlled input."
+        );
+        assert_eq!(violations[0].severity, Severity::Harsh);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_recommended_registry_contains_initial_policy_bundle() {
         let source = "print 1;\n";
         let ast = parse_source(source);
@@ -2569,6 +2740,7 @@ mod tests {
                 "native.security.qx_readpipe",
                 "native.security.backtick_exec",
                 "native.security.string_eval",
+                "native.security.system_exec",
                 "native.variables.unused_lexical",
                 "native.variables.unused_parameter",
                 "native.variables.duplicate_parameter",

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1350,7 +1350,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
             None,
             &context,
             None,
@@ -1504,6 +1504,23 @@ mod tests {
             string_eval.data.as_ref().ok_or("native string eval data should be populated")?;
         assert_eq!(data["code"], "native.security.string_eval");
         assert_eq!(data["suppressionKey"], "native.security.string_eval");
+        assert_eq!(data["fixable"], false);
+
+        let system_exec = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.security.system_exec"),
+                )
+            })
+            .ok_or("expected native system/exec finding")?;
+        assert_eq!(system_exec.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(system_exec.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(system_exec.message, "system() executes a shell command");
+        let data =
+            system_exec.data.as_ref().ok_or("native system/exec data should be populated")?;
+        assert_eq!(data["code"], "native.security.system_exec");
+        assert_eq!(data["suppressionKey"], "native.security.system_exec");
         assert_eq!(data["fixable"], false);
 
         let unused = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1837,7 +1837,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
                 }
             })))
             .unwrap();
@@ -1911,6 +1911,14 @@ mod tests {
         assert!(
             text.contains("String eval is a security risk"),
             "native string eval finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.security.system_exec"),
+            "native critic engine should publish native system/exec finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("system() executes a shell command"),
+            "native system/exec finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.variables.unused_lexical"),
@@ -2012,7 +2020,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
             }
         })))?;
 
@@ -2102,6 +2110,14 @@ mod tests {
                     && diag["message"].as_str() == Some("String eval is a security risk")
             }),
             "native critic engine should add native string eval finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.security.system_exec")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str() == Some("system() executes a shell command")
+            }),
+            "native critic engine should add native system/exec finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.security.system_exec` for command execution through:

- `system(...)`
- `exec(...)`
- string and list forms, matching the existing legacy security stance that list form is safer but still command execution
- config/severity filtering, suppressions, and legacy violation bridge coverage
- pull, push, and workspace diagnostics under `[critic].engine = "native"`

The rule is diagnostic-only. Replacing process execution needs user intent, so no automatic fix is exposed. Legacy/default critic behavior is unchanged.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_system --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
