### PR TITLE
test(critic): prove unchecked suppression control (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -2560,9 +2560,12 @@ mod tests {
         let other_include_ctx = CriticContext::new(source, &ast, &other_include_config);
         assert!(registry.check(&other_include_ctx).is_empty());
 
+        let config = CriticConfig::default();
+        let unsuppressed_ctx = CriticContext::new(source, &ast, &config);
+        assert_eq!(registry.check(&unsuppressed_ctx).len(), 1);
+
         let suppressed_source = "## no critic native.io.unchecked_open_close -- handled by caller\nuse strict;\nuse warnings;\nmy $path = 'file.txt';\nopen(my $fh, '<', $path);\n";
         let suppressed_ast = parse_source(suppressed_source);
-        let config = CriticConfig::default();
         let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
 
         assert!(registry.check(&suppressed_ctx).is_empty());


### PR DESCRIPTION
Problem: Droid noted that the unchecked open/close suppression test only asserted the suppressed result was empty, without proving the same source emits a finding when the suppression directive is absent.

Fix: Add an unsuppressed positive-control assertion before the suppressed case in the native unchecked open/close config/suppression test.

Verification: `cargo test -p perl-lsp-rs-core native_unchecked --profile agent --locked -- --nocapture`, `cargo xtask fmt --check`, and `git diff --check` pass.