### PR TITLE
feat(format): wrap simple calls/lists/hashes by line width (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -890,9 +890,15 @@ fn format_simple_lexical_tokens(
     if next_index == semicolon_index {
         Some(format!("{keyword} {variable};"))
     } else if tokens[next_index].kind == TokenKind::Assign {
-        let value =
-            format_simple_expression_tokens(tokens, next_index + 1, semicolon_index, config)?;
-        Some(format!("{keyword} {variable} = {value};"))
+        let prefix = format!("{keyword} {variable} = ");
+        let value = format_simple_expression_tokens(
+            tokens,
+            next_index + 1,
+            semicolon_index,
+            config,
+            prefix.chars().count(),
+        )?;
+        Some(format!("{prefix}{value};"))
     } else {
         None
     }
@@ -977,7 +983,14 @@ fn format_simple_return_tokens(
         return Some("return;".to_string());
     }
 
-    let value = format_simple_expression_tokens(tokens, 1, semicolon_index, config)?;
+    let prefix = "return ";
+    let value = format_simple_expression_tokens(
+        tokens,
+        1,
+        semicolon_index,
+        config,
+        prefix.chars().count(),
+    )?;
     Some(format!("return {value};"))
 }
 
@@ -997,7 +1010,14 @@ fn format_simple_assignment_tokens(
         return None;
     }
 
-    let value = format_simple_expression_tokens(tokens, next_index + 1, semicolon_index, config)?;
+    let prefix = format!("{variable} = ");
+    let value = format_simple_expression_tokens(
+        tokens,
+        next_index + 1,
+        semicolon_index,
+        config,
+        prefix.chars().count(),
+    )?;
     Some(format!("{variable} = {value};"))
 }
 
@@ -1012,7 +1032,7 @@ fn format_simple_expression_statement_tokens(
     }
 
     let semicolon_index = tokens.len() - 1;
-    let (call, next_index) = format_simple_call_tokens(tokens, 0, config)?;
+    let (call, next_index) = format_simple_call_tokens(tokens, 0, config, 0)?;
     (next_index == semicolon_index).then(|| format!("{call};"))
 }
 
@@ -1028,7 +1048,7 @@ fn format_simple_condition_tokens(
         .position(|token| token.kind == TokenKind::RightParen)
         .map(|offset| start + offset)?;
     let condition_config = FormatConfig { line_width: u32::MAX, ..config.clone() };
-    let condition = format_simple_expression_tokens(tokens, start, end, &condition_config)?;
+    let condition = format_simple_expression_tokens(tokens, start, end, &condition_config, 0)?;
     Some((condition, end))
 }
 
@@ -1037,14 +1057,17 @@ fn format_simple_expression_tokens(
     start: usize,
     end: usize,
     config: &FormatConfig,
+    start_column: usize,
 ) -> Option<String> {
-    let (left, next_index) = format_simple_atom_tokens(tokens, start, config)?;
+    let (left, next_index) = format_simple_atom_tokens(tokens, start, config, start_column)?;
     if next_index == end {
         return Some(left);
     }
 
     let operator = simple_binary_operator_text(tokens.get(next_index)?)?;
-    let (right, final_index) = format_simple_atom_tokens(tokens, next_index + 1, config)?;
+    let right_column = advance_column(start_column, &left) + operator.chars().count() + 2;
+    let (right, final_index) =
+        format_simple_atom_tokens(tokens, next_index + 1, config, right_column)?;
     (final_index == end).then(|| format!("{left} {operator} {right}"))
 }
 
@@ -1052,8 +1075,10 @@ fn format_simple_atom_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
     config: &FormatConfig,
+    start_column: usize,
 ) -> Option<(String, usize)> {
-    if let Some((method_call, next_index)) = format_simple_method_call_tokens(tokens, start, config)
+    if let Some((method_call, next_index)) =
+        format_simple_method_call_tokens(tokens, start, config, start_column)
     {
         return Some((method_call, next_index));
     }
@@ -1062,15 +1087,18 @@ fn format_simple_atom_tokens(
         return Some((variable, next_index));
     }
 
-    if let Some((call, next_index)) = format_simple_call_tokens(tokens, start, config) {
+    if let Some((call, next_index)) = format_simple_call_tokens(tokens, start, config, start_column)
+    {
         return Some((call, next_index));
     }
 
-    if let Some((list, next_index)) = format_simple_list_tokens(tokens, start, config) {
+    if let Some((list, next_index)) = format_simple_list_tokens(tokens, start, config, start_column)
+    {
         return Some((list, next_index));
     }
 
-    if let Some((hash, next_index)) = format_simple_hash_tokens(tokens, start, config) {
+    if let Some((hash, next_index)) = format_simple_hash_tokens(tokens, start, config, start_column)
+    {
         return Some((hash, next_index));
     }
 
@@ -1083,6 +1111,7 @@ fn format_simple_method_call_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
     config: &FormatConfig,
+    start_column: usize,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1094,7 +1123,7 @@ fn format_simple_method_call_tokens(
             break;
         }
         let (method_call, next_index) =
-            format_simple_method_call_segment(tokens, index, &expression, config)?;
+            format_simple_method_call_segment(tokens, index, &expression, config, start_column)?;
         expression = method_call;
         index = next_index;
         saw_method = true;
@@ -1108,6 +1137,7 @@ fn format_simple_method_call_segment(
     arrow_index: usize,
     receiver: &str,
     config: &FormatConfig,
+    start_column: usize,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1128,8 +1158,11 @@ fn format_simple_method_call_segment(
         return Some((format!("{receiver}->{}()", method.text), index + 1));
     }
 
+    let open = format!("{receiver}->{}(", method.text);
+    let mut arg_column = start_column + open.chars().count();
     loop {
-        let (arg, next_index) = format_simple_atom_tokens(tokens, index, config)?;
+        let (arg, next_index) = format_simple_atom_tokens(tokens, index, config, arg_column)?;
+        arg_column = advance_column(arg_column, &arg) + 2;
         args.push(arg);
         index = next_index;
 
@@ -1137,7 +1170,7 @@ fn format_simple_method_call_segment(
             TokenKind::Comma => index += 1,
             TokenKind::RightParen => {
                 return Some((
-                    render_simple_method_call_doc(receiver, method.text.as_ref(), &args, config),
+                    render_delimited_doc(&open, ")", &args, config, start_column),
                     index + 1,
                 ));
             }
@@ -1146,19 +1179,11 @@ fn format_simple_method_call_segment(
     }
 }
 
-fn render_simple_method_call_doc(
-    receiver: &str,
-    method: &str,
-    args: &[String],
-    config: &FormatConfig,
-) -> String {
-    render_delimited_doc(&format!("{receiver}->{method}("), ")", args, config)
-}
-
 fn format_simple_call_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
     config: &FormatConfig,
+    start_column: usize,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1173,8 +1198,11 @@ fn format_simple_call_tokens(
         return Some((format!("{}()", name.text), index + 1));
     }
 
+    let open = format!("{}(", name.text);
+    let mut arg_column = start_column + open.chars().count();
     loop {
-        let (arg, next_index) = format_simple_atom_tokens(tokens, index, config)?;
+        let (arg, next_index) = format_simple_atom_tokens(tokens, index, config, arg_column)?;
+        arg_column = advance_column(arg_column, &arg) + 2;
         args.push(arg);
         index = next_index;
 
@@ -1182,7 +1210,7 @@ fn format_simple_call_tokens(
             TokenKind::Comma => index += 1,
             TokenKind::RightParen => {
                 return Some((
-                    render_delimited_doc(&format!("{}(", name.text), ")", &args, config),
+                    render_delimited_doc(&open, ")", &args, config, start_column),
                     index + 1,
                 ));
             }
@@ -1195,6 +1223,7 @@ fn format_simple_list_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
     config: &FormatConfig,
+    start_column: usize,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1208,15 +1237,20 @@ fn format_simple_list_tokens(
         return Some(("()".to_string(), index + 1));
     }
 
+    let mut item_column = start_column + 1;
     loop {
-        let (item, next_index) = format_simple_atom_tokens(tokens, index, config)?;
+        let (item, next_index) = format_simple_atom_tokens(tokens, index, config, item_column)?;
+        item_column = advance_column(item_column, &item) + 2;
         items.push(item);
         index = next_index;
 
         match tokens.get(index)?.kind {
             TokenKind::Comma => index += 1,
             TokenKind::RightParen => {
-                return Some((render_delimited_doc("(", ")", &items, config), index + 1));
+                return Some((
+                    render_delimited_doc("(", ")", &items, config, start_column),
+                    index + 1,
+                ));
             }
             _ => return None,
         }
@@ -1227,6 +1261,7 @@ fn format_simple_hash_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
     config: &FormatConfig,
+    start_column: usize,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1248,14 +1283,15 @@ fn format_simple_hash_tokens(
         }
         index += 1;
 
-        let (value, next_index) = format_simple_atom_tokens(tokens, index, config)?;
+        let value_column = start_column + 1 + key.chars().count() + " => ".len();
+        let (value, next_index) = format_simple_atom_tokens(tokens, index, config, value_column)?;
         pairs.push((key, value));
         index = next_index;
 
         match tokens.get(index)?.kind {
             TokenKind::Comma => index += 1,
             TokenKind::RightBrace => {
-                return Some((render_simple_hash_doc(&pairs, config), index + 1));
+                return Some((render_simple_hash_doc(&pairs, config, start_column), index + 1));
             }
             _ => return None,
         }
@@ -1266,9 +1302,13 @@ fn format_simple_hash_key_token(token: &perl_parser_core::Token) -> Option<Strin
     simple_value_text(token).map(str::to_string)
 }
 
-fn render_simple_hash_doc(pairs: &[(String, String)], config: &FormatConfig) -> String {
+fn render_simple_hash_doc(
+    pairs: &[(String, String)],
+    config: &FormatConfig,
+    start_column: usize,
+) -> String {
     let items = pairs.iter().map(|(key, value)| format!("{key} => {value}")).collect::<Vec<_>>();
-    render_delimited_doc("{", "}", &items, config)
+    render_delimited_doc("{", "}", &items, config, start_column)
 }
 
 fn render_delimited_doc(
@@ -1276,7 +1316,9 @@ fn render_delimited_doc(
     close: &str,
     items: &[String],
     config: &FormatConfig,
+    start_column: usize,
 ) -> String {
+    let render_config = config_for_start_column(config, start_column);
     let mut parts = vec![FormatDoc::text(open)];
     if !items.is_empty() {
         let mut item_docs = vec![FormatDoc::if_break(FormatDoc::SoftLine, FormatDoc::text(""))];
@@ -1291,7 +1333,24 @@ fn render_delimited_doc(
         parts.push(FormatDoc::if_break(FormatDoc::SoftLine, FormatDoc::text("")));
     }
     parts.push(FormatDoc::text(close));
-    FormatDoc::group(parts).render(config)
+    FormatDoc::group(parts).render(&render_config)
+}
+
+fn config_for_start_column(config: &FormatConfig, start_column: usize) -> FormatConfig {
+    if config.line_width == u32::MAX {
+        return config.clone();
+    }
+
+    let remaining = (config.line_width as usize).saturating_sub(start_column).max(1);
+    FormatConfig { line_width: remaining.min(u32::MAX as usize) as u32, ..config.clone() }
+}
+
+fn advance_column(start_column: usize, text: &str) -> usize {
+    if let Some((_, tail)) = text.rsplit_once('\n') {
+        tail.chars().count()
+    } else {
+        start_column + text.chars().count()
+    }
 }
 
 fn simple_binary_operator_text(token: &perl_parser_core::Token) -> Option<&str> {

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -593,11 +593,11 @@ fn range_includes_line(range: TextRange, line: u32) -> bool {
 fn format_simple_line(line: &str, config: &FormatConfig) -> Option<String> {
     format_simple_control_block_line(line, config)
         .or_else(|| format_simple_subroutine_line(line, config))
-        .or_else(|| format_simple_statement_line(line))
-        .or_else(|| format_simple_lexical_line(line))
+        .or_else(|| format_simple_statement_line(line, config))
+        .or_else(|| format_simple_lexical_line(line, config))
 }
 
-fn format_simple_lexical_line(line: &str) -> Option<String> {
+fn format_simple_lexical_line(line: &str, config: &FormatConfig) -> Option<String> {
     let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
     let (indent, body) = line.split_at(indent_len);
     if body.is_empty() || body.contains('#') {
@@ -614,7 +614,7 @@ fn format_simple_lexical_line(line: &str) -> Option<String> {
         tokens.push(token);
     }
 
-    let formatted = format_simple_lexical_tokens(&tokens)?;
+    let formatted = format_simple_lexical_tokens(&tokens, config)?;
     Some(format!("{indent}{formatted}"))
 }
 
@@ -659,7 +659,7 @@ fn format_simple_control_block_line(line: &str, config: &FormatConfig) -> Option
     format_simple_control_block_tokens(&tokens, indent, config)
 }
 
-fn format_simple_statement_line(line: &str) -> Option<String> {
+fn format_simple_statement_line(line: &str, config: &FormatConfig) -> Option<String> {
     let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
     let (indent, body) = line.split_at(indent_len);
     if body.is_empty() || body.contains('#') {
@@ -676,7 +676,7 @@ fn format_simple_statement_line(line: &str) -> Option<String> {
         tokens.push(token);
     }
 
-    let formatted = format_simple_statement_tokens(&tokens)?;
+    let formatted = format_simple_statement_tokens(&tokens, config)?;
     Some(format!("{indent}{formatted}"))
 }
 
@@ -699,7 +699,7 @@ fn format_simple_subroutine_tokens(
     }
 
     let body_tokens = &tokens[3..tokens.len() - 1];
-    let statements = format_simple_statement_block(body_tokens)?;
+    let statements = format_simple_statement_block(body_tokens, config)?;
     let body_indent = format!("{indent}{}", indent_unit(config));
     Some(render_simple_block_doc(
         format!("{indent}sub {} {{", tokens[1].text),
@@ -731,7 +731,7 @@ fn format_simple_control_block_tokens(
         return None;
     }
 
-    let (condition, next_index) = format_simple_condition_tokens(tokens, 2)?;
+    let (condition, next_index) = format_simple_condition_tokens(tokens, 2, config)?;
     if tokens.get(next_index)?.kind != TokenKind::RightParen
         || tokens.get(next_index + 1)?.kind != TokenKind::LeftBrace
     {
@@ -744,8 +744,8 @@ fn format_simple_control_block_tokens(
         .position(|token| token.kind == TokenKind::RightBrace)
         .map(|offset| body_start + offset)?;
     let body_tokens = &tokens[body_start..body_end];
-    let statements = format_simple_statement_block(body_tokens)?;
-    let else_statements = format_simple_else_branch(tokens, body_end, keyword)?;
+    let statements = format_simple_statement_block(body_tokens, config)?;
+    let else_statements = format_simple_else_branch(tokens, body_end, keyword, config)?;
 
     if else_statements.is_none() && body_end + 1 != tokens.len() {
         return None;
@@ -807,6 +807,7 @@ fn format_simple_else_branch(
     tokens: &[perl_parser_core::Token],
     body_end: usize,
     keyword: &str,
+    config: &FormatConfig,
 ) -> Option<Option<Vec<String>>> {
     use perl_parser_core::TokenKind;
 
@@ -827,11 +828,14 @@ fn format_simple_else_branch(
 
     let else_body_start = next + 2;
     let else_body_tokens = &tokens[else_body_start..tokens.len() - 1];
-    let statements = format_simple_statement_block(else_body_tokens)?;
+    let statements = format_simple_statement_block(else_body_tokens, config)?;
     Some(Some(statements))
 }
 
-fn format_simple_statement_block(tokens: &[perl_parser_core::Token]) -> Option<Vec<String>> {
+fn format_simple_statement_block(
+    tokens: &[perl_parser_core::Token],
+    config: &FormatConfig,
+) -> Option<Vec<String>> {
     use perl_parser_core::TokenKind;
 
     if tokens.is_empty() {
@@ -846,21 +850,27 @@ fn format_simple_statement_block(tokens: &[perl_parser_core::Token]) -> Option<V
         }
 
         let statement_tokens = &tokens[start..=idx];
-        statements.push(format_simple_statement_tokens(statement_tokens)?);
+        statements.push(format_simple_statement_tokens(statement_tokens, config)?);
         start = idx + 1;
     }
 
     (start == tokens.len()).then_some(statements)
 }
 
-fn format_simple_statement_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
-    format_simple_lexical_tokens(tokens)
-        .or_else(|| format_simple_return_tokens(tokens))
-        .or_else(|| format_simple_assignment_tokens(tokens))
-        .or_else(|| format_simple_expression_statement_tokens(tokens))
+fn format_simple_statement_tokens(
+    tokens: &[perl_parser_core::Token],
+    config: &FormatConfig,
+) -> Option<String> {
+    format_simple_lexical_tokens(tokens, config)
+        .or_else(|| format_simple_return_tokens(tokens, config))
+        .or_else(|| format_simple_assignment_tokens(tokens, config))
+        .or_else(|| format_simple_expression_statement_tokens(tokens, config))
 }
 
-fn format_simple_lexical_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
+fn format_simple_lexical_tokens(
+    tokens: &[perl_parser_core::Token],
+    config: &FormatConfig,
+) -> Option<String> {
     use perl_parser_core::TokenKind;
 
     let keyword = match tokens.first()?.kind {
@@ -880,7 +890,8 @@ fn format_simple_lexical_tokens(tokens: &[perl_parser_core::Token]) -> Option<St
     if next_index == semicolon_index {
         Some(format!("{keyword} {variable};"))
     } else if tokens[next_index].kind == TokenKind::Assign {
-        let value = format_simple_expression_tokens(tokens, next_index + 1, semicolon_index)?;
+        let value =
+            format_simple_expression_tokens(tokens, next_index + 1, semicolon_index, config)?;
         Some(format!("{keyword} {variable} = {value};"))
     } else {
         None
@@ -951,7 +962,10 @@ fn format_variable_tokens(
     Some((format!("{}{}", sigil.text, name.text), start + 2))
 }
 
-fn format_simple_return_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
+fn format_simple_return_tokens(
+    tokens: &[perl_parser_core::Token],
+    config: &FormatConfig,
+) -> Option<String> {
     use perl_parser_core::TokenKind;
 
     if tokens.first()?.kind != TokenKind::Return || tokens.last()?.kind != TokenKind::Semicolon {
@@ -963,11 +977,14 @@ fn format_simple_return_tokens(tokens: &[perl_parser_core::Token]) -> Option<Str
         return Some("return;".to_string());
     }
 
-    let value = format_simple_expression_tokens(tokens, 1, semicolon_index)?;
+    let value = format_simple_expression_tokens(tokens, 1, semicolon_index, config)?;
     Some(format!("return {value};"))
 }
 
-fn format_simple_assignment_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
+fn format_simple_assignment_tokens(
+    tokens: &[perl_parser_core::Token],
+    config: &FormatConfig,
+) -> Option<String> {
     use perl_parser_core::TokenKind;
 
     if tokens.last()?.kind != TokenKind::Semicolon {
@@ -980,11 +997,14 @@ fn format_simple_assignment_tokens(tokens: &[perl_parser_core::Token]) -> Option
         return None;
     }
 
-    let value = format_simple_expression_tokens(tokens, next_index + 1, semicolon_index)?;
+    let value = format_simple_expression_tokens(tokens, next_index + 1, semicolon_index, config)?;
     Some(format!("{variable} = {value};"))
 }
 
-fn format_simple_expression_statement_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
+fn format_simple_expression_statement_tokens(
+    tokens: &[perl_parser_core::Token],
+    config: &FormatConfig,
+) -> Option<String> {
     use perl_parser_core::TokenKind;
 
     if tokens.last()?.kind != TokenKind::Semicolon {
@@ -992,13 +1012,14 @@ fn format_simple_expression_statement_tokens(tokens: &[perl_parser_core::Token])
     }
 
     let semicolon_index = tokens.len() - 1;
-    let (call, next_index) = format_simple_call_tokens(tokens, 0)?;
+    let (call, next_index) = format_simple_call_tokens(tokens, 0, config)?;
     (next_index == semicolon_index).then(|| format!("{call};"))
 }
 
 fn format_simple_condition_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
+    config: &FormatConfig,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1006,7 +1027,8 @@ fn format_simple_condition_tokens(
         .iter()
         .position(|token| token.kind == TokenKind::RightParen)
         .map(|offset| start + offset)?;
-    let condition = format_simple_expression_tokens(tokens, start, end)?;
+    let condition_config = FormatConfig { line_width: u32::MAX, ..config.clone() };
+    let condition = format_simple_expression_tokens(tokens, start, end, &condition_config)?;
     Some((condition, end))
 }
 
@@ -1014,22 +1036,25 @@ fn format_simple_expression_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
     end: usize,
+    config: &FormatConfig,
 ) -> Option<String> {
-    let (left, next_index) = format_simple_atom_tokens(tokens, start)?;
+    let (left, next_index) = format_simple_atom_tokens(tokens, start, config)?;
     if next_index == end {
         return Some(left);
     }
 
     let operator = simple_binary_operator_text(tokens.get(next_index)?)?;
-    let (right, final_index) = format_simple_atom_tokens(tokens, next_index + 1)?;
+    let (right, final_index) = format_simple_atom_tokens(tokens, next_index + 1, config)?;
     (final_index == end).then(|| format!("{left} {operator} {right}"))
 }
 
 fn format_simple_atom_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
+    config: &FormatConfig,
 ) -> Option<(String, usize)> {
-    if let Some((method_call, next_index)) = format_simple_method_call_tokens(tokens, start) {
+    if let Some((method_call, next_index)) = format_simple_method_call_tokens(tokens, start, config)
+    {
         return Some((method_call, next_index));
     }
 
@@ -1037,15 +1062,15 @@ fn format_simple_atom_tokens(
         return Some((variable, next_index));
     }
 
-    if let Some((call, next_index)) = format_simple_call_tokens(tokens, start) {
+    if let Some((call, next_index)) = format_simple_call_tokens(tokens, start, config) {
         return Some((call, next_index));
     }
 
-    if let Some((list, next_index)) = format_simple_list_tokens(tokens, start) {
+    if let Some((list, next_index)) = format_simple_list_tokens(tokens, start, config) {
         return Some((list, next_index));
     }
 
-    if let Some((hash, next_index)) = format_simple_hash_tokens(tokens, start) {
+    if let Some((hash, next_index)) = format_simple_hash_tokens(tokens, start, config) {
         return Some((hash, next_index));
     }
 
@@ -1057,6 +1082,7 @@ fn format_simple_atom_tokens(
 fn format_simple_method_call_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
+    config: &FormatConfig,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1068,7 +1094,7 @@ fn format_simple_method_call_tokens(
             break;
         }
         let (method_call, next_index) =
-            format_simple_method_call_segment(tokens, index, &expression)?;
+            format_simple_method_call_segment(tokens, index, &expression, config)?;
         expression = method_call;
         index = next_index;
         saw_method = true;
@@ -1081,6 +1107,7 @@ fn format_simple_method_call_segment(
     tokens: &[perl_parser_core::Token],
     arrow_index: usize,
     receiver: &str,
+    config: &FormatConfig,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1102,7 +1129,7 @@ fn format_simple_method_call_segment(
     }
 
     loop {
-        let (arg, next_index) = format_simple_atom_tokens(tokens, index)?;
+        let (arg, next_index) = format_simple_atom_tokens(tokens, index, config)?;
         args.push(arg);
         index = next_index;
 
@@ -1110,7 +1137,7 @@ fn format_simple_method_call_segment(
             TokenKind::Comma => index += 1,
             TokenKind::RightParen => {
                 return Some((
-                    render_simple_method_call_doc(receiver, method.text.as_ref(), &args),
+                    render_simple_method_call_doc(receiver, method.text.as_ref(), &args, config),
                     index + 1,
                 ));
             }
@@ -1119,27 +1146,19 @@ fn format_simple_method_call_segment(
     }
 }
 
-fn render_simple_method_call_doc(receiver: &str, method: &str, args: &[String]) -> String {
-    let mut parts = vec![
-        FormatDoc::text(receiver),
-        FormatDoc::text("->"),
-        FormatDoc::text(method),
-        FormatDoc::text("("),
-    ];
-    for (index, arg) in args.iter().enumerate() {
-        if index > 0 {
-            parts.push(FormatDoc::text(","));
-            parts.push(FormatDoc::Space);
-        }
-        parts.push(FormatDoc::text(arg));
-    }
-    parts.push(FormatDoc::text(")"));
-    FormatDoc::group(parts).render(&FormatConfig::default())
+fn render_simple_method_call_doc(
+    receiver: &str,
+    method: &str,
+    args: &[String],
+    config: &FormatConfig,
+) -> String {
+    render_delimited_doc(&format!("{receiver}->{method}("), ")", args, config)
 }
 
 fn format_simple_call_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
+    config: &FormatConfig,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1155,14 +1174,17 @@ fn format_simple_call_tokens(
     }
 
     loop {
-        let (arg, next_index) = format_simple_atom_tokens(tokens, index)?;
+        let (arg, next_index) = format_simple_atom_tokens(tokens, index, config)?;
         args.push(arg);
         index = next_index;
 
         match tokens.get(index)?.kind {
             TokenKind::Comma => index += 1,
             TokenKind::RightParen => {
-                return Some((format!("{}({})", name.text, args.join(", ")), index + 1));
+                return Some((
+                    render_delimited_doc(&format!("{}(", name.text), ")", &args, config),
+                    index + 1,
+                ));
             }
             _ => return None,
         }
@@ -1172,6 +1194,7 @@ fn format_simple_call_tokens(
 fn format_simple_list_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
+    config: &FormatConfig,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1186,36 +1209,24 @@ fn format_simple_list_tokens(
     }
 
     loop {
-        let (item, next_index) = format_simple_atom_tokens(tokens, index)?;
+        let (item, next_index) = format_simple_atom_tokens(tokens, index, config)?;
         items.push(item);
         index = next_index;
 
         match tokens.get(index)?.kind {
             TokenKind::Comma => index += 1,
             TokenKind::RightParen => {
-                return Some((render_simple_list_doc(&items), index + 1));
+                return Some((render_delimited_doc("(", ")", &items, config), index + 1));
             }
             _ => return None,
         }
     }
 }
 
-fn render_simple_list_doc(items: &[String]) -> String {
-    let mut parts = vec![FormatDoc::text("(")];
-    for (index, item) in items.iter().enumerate() {
-        if index > 0 {
-            parts.push(FormatDoc::text(","));
-            parts.push(FormatDoc::Space);
-        }
-        parts.push(FormatDoc::text(item));
-    }
-    parts.push(FormatDoc::text(")"));
-    FormatDoc::group(parts).render(&FormatConfig::default())
-}
-
 fn format_simple_hash_tokens(
     tokens: &[perl_parser_core::Token],
     start: usize,
+    config: &FormatConfig,
 ) -> Option<(String, usize)> {
     use perl_parser_core::TokenKind;
 
@@ -1237,14 +1248,14 @@ fn format_simple_hash_tokens(
         }
         index += 1;
 
-        let (value, next_index) = format_simple_atom_tokens(tokens, index)?;
+        let (value, next_index) = format_simple_atom_tokens(tokens, index, config)?;
         pairs.push((key, value));
         index = next_index;
 
         match tokens.get(index)?.kind {
             TokenKind::Comma => index += 1,
             TokenKind::RightBrace => {
-                return Some((render_simple_hash_doc(&pairs), index + 1));
+                return Some((render_simple_hash_doc(&pairs, config), index + 1));
             }
             _ => return None,
         }
@@ -1255,21 +1266,32 @@ fn format_simple_hash_key_token(token: &perl_parser_core::Token) -> Option<Strin
     simple_value_text(token).map(str::to_string)
 }
 
-fn render_simple_hash_doc(pairs: &[(String, String)]) -> String {
-    let mut parts = vec![FormatDoc::text("{")];
-    for (index, (key, value)) in pairs.iter().enumerate() {
-        if index > 0 {
-            parts.push(FormatDoc::text(","));
-            parts.push(FormatDoc::Space);
+fn render_simple_hash_doc(pairs: &[(String, String)], config: &FormatConfig) -> String {
+    let items = pairs.iter().map(|(key, value)| format!("{key} => {value}")).collect::<Vec<_>>();
+    render_delimited_doc("{", "}", &items, config)
+}
+
+fn render_delimited_doc(
+    open: &str,
+    close: &str,
+    items: &[String],
+    config: &FormatConfig,
+) -> String {
+    let mut parts = vec![FormatDoc::text(open)];
+    if !items.is_empty() {
+        let mut item_docs = vec![FormatDoc::if_break(FormatDoc::SoftLine, FormatDoc::text(""))];
+        for (index, item) in items.iter().enumerate() {
+            if index > 0 {
+                item_docs.push(FormatDoc::text(","));
+                item_docs.push(FormatDoc::SoftLine);
+            }
+            item_docs.push(FormatDoc::text(item));
         }
-        parts.push(FormatDoc::text(key));
-        parts.push(FormatDoc::Space);
-        parts.push(FormatDoc::text("=>"));
-        parts.push(FormatDoc::Space);
-        parts.push(FormatDoc::text(value));
+        parts.push(FormatDoc::indent(item_docs));
+        parts.push(FormatDoc::if_break(FormatDoc::SoftLine, FormatDoc::text("")));
     }
-    parts.push(FormatDoc::text("}"));
-    FormatDoc::group(parts).render(&FormatConfig::default())
+    parts.push(FormatDoc::text(close));
+    FormatDoc::group(parts).render(config)
 }
 
 fn simple_binary_operator_text(token: &perl_parser_core::Token) -> Option<&str> {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_wrapped_delimited_expressions.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_wrapped_delimited_expressions.expected.pl
@@ -1,0 +1,14 @@
+my $result = build_result(
+    $alpha_beta_gamma_delta_epsilon_zeta_eta,
+    $beta_gamma_delta_epsilon_zeta_eta_theta,
+    $gamma_delta_epsilon_zeta_eta_theta_iota
+);
+my @items = (
+    $alpha_beta_gamma_delta_epsilon_zeta_eta,
+    $beta_gamma_delta_epsilon_zeta_eta_theta,
+    $gamma_delta_epsilon_zeta_eta_theta_iota
+);
+my $hash = {
+    alpha_beta_gamma_delta_epsilon_zeta_eta => $alpha_beta_gamma_delta_epsilon_zeta_eta,
+    beta_gamma_delta_epsilon_zeta_eta_theta => $beta_gamma_delta_epsilon_zeta_eta_theta
+};

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_wrapped_delimited_expressions.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_wrapped_delimited_expressions.pl
@@ -1,0 +1,3 @@
+my$result=build_result($alpha_beta_gamma_delta_epsilon_zeta_eta,$beta_gamma_delta_epsilon_zeta_eta_theta,$gamma_delta_epsilon_zeta_eta_theta_iota);
+my@items=($alpha_beta_gamma_delta_epsilon_zeta_eta,$beta_gamma_delta_epsilon_zeta_eta_theta,$gamma_delta_epsilon_zeta_eta_theta_iota);
+my$hash={alpha_beta_gamma_delta_epsilon_zeta_eta=>$alpha_beta_gamma_delta_epsilon_zeta_eta,beta_gamma_delta_epsilon_zeta_eta_theta=>$beta_gamma_delta_epsilon_zeta_eta_theta};

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -136,6 +136,47 @@ fn native_formatter_formats_simple_method_call_chains() {
 }
 
 #[test]
+fn native_formatter_wraps_simple_calls_lists_and_hashes_by_line_width() {
+    let formatter = NativeFormatter::new();
+    let config = FormatConfig { line_width: 18, indent_width: 2, ..FormatConfig::default() };
+    let source = concat!(
+        "my$result=foo($alpha,$beta,$gamma);\n",
+        "my@items=($alpha,$beta,$gamma);\n",
+        "my$hash={alpha=>$alpha,beta=>$beta};\n",
+        "return $object->wrap($alpha,$beta,$gamma);\n",
+    );
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "my $result = foo(\n",
+            "  $alpha,\n",
+            "  $beta,\n",
+            "  $gamma\n",
+            ");\n",
+            "my @items = (\n",
+            "  $alpha,\n",
+            "  $beta,\n",
+            "  $gamma\n",
+            ");\n",
+            "my $hash = {\n",
+            "  alpha => $alpha,\n",
+            "  beta => $beta\n",
+            "};\n",
+            "return $object->wrap(\n",
+            "  $alpha,\n",
+            "  $beta,\n",
+            "  $gamma\n",
+            ");\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";
@@ -327,6 +368,35 @@ fn native_range_formatter_formats_selected_simple_method_chain_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "return $obj->find($id)->wrap({ok => 1});");
+}
+
+#[test]
+fn native_range_formatter_wraps_selected_simple_call_line_by_width() {
+    let formatter = NativeFormatter::new();
+    let source = "$x=1;\nreturn $object->wrap($alpha,$beta,$gamma);\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 42));
+    let config = FormatConfig { line_width: 18, indent_width: 2, ..FormatConfig::default() };
+
+    let result = formatter.format_range(source, range, &config);
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "$x=1;\n",
+            "return $object->wrap(\n",
+            "  $alpha,\n",
+            "  $beta,\n",
+            "  $gamma\n",
+            ");\n",
+        )
+    );
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(
+        result.edits[0].new_text,
+        "return $object->wrap(\n  $alpha,\n  $beta,\n  $gamma\n);"
+    );
 }
 
 #[test]

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -177,6 +177,28 @@ fn native_formatter_wraps_simple_calls_lists_and_hashes_by_line_width() {
 }
 
 #[test]
+fn native_formatter_wraps_delimited_expression_when_statement_prefix_exceeds_width() {
+    let formatter = NativeFormatter::new();
+    let config = FormatConfig { line_width: 30, indent_width: 2, ..FormatConfig::default() };
+    let source = "my$long_variable_name=foo($a,$b);\nreturn foo($a,$b);\n";
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "my $long_variable_name = foo(\n",
+            "  $a,\n",
+            "  $b\n",
+            ");\n",
+            "return foo($a, $b);\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_preserves_indent_and_line_endings_for_simple_declarations() {
     let formatter = NativeFormatter::new();
     let source = "  my $x=1;\r\n\tour @y;\r\n";

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 24 |
+| Fixture count | 25 |
 
 ## Critic
 


### PR DESCRIPTION
## Summary

Adds native formatter line-width wrapping for the already-supported safe delimited expression surfaces:

- simple parenthesized calls
- simple list literals
- simple hash constructors
- simple method calls using those argument forms

The change threads `FormatConfig` through the safe expression path and renders delimited forms through `FormatDoc` groups. Existing flat output remains unchanged when the expression fits. When the expression or its containing assignment/return prefix exceeds the configured line width, the formatter breaks one item per line using the configured indent width.

This does not expand syntax coverage: comments, POD, heredocs, regex/quote-like forms, complex arguments, and unsupported Perl surfaces remain outside this slice.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_wraps --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_wraps_selected_simple_call_line_by_width --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check`
  - native formatter fixtures: 25/25 passed
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
  - no markdown drift beyond the committed fixture-count update
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask fmt --check`
- [x] `git diff --check`

## Notes

`lsp_3_17_formatting_tests` still emits the existing unused BDD support warnings; tests pass.

The native-tooling status doc now reports 25 formatter fixtures after adding the wrapping fixture.