### PR TITLE
test(format): expand literal-preserve formatter matrix (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -1397,7 +1397,7 @@ fn literal_preserve_region(source: &str) -> Option<&'static str> {
         if is_pod_start(trimmed) {
             return Some("POD");
         }
-        if matches!(trimmed, "__DATA__" | "__END__") {
+        if matches!(trimmed.trim_end(), "__DATA__" | "__END__") {
             return Some("DATA/END section");
         }
         if contains_likely_heredoc_start(line) {

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -1398,13 +1398,39 @@ fn literal_preserve_region(source: &str) -> Option<&'static str> {
             return Some("POD");
         }
         if matches!(trimmed, "__DATA__" | "__END__") {
-            return Some("DATA section");
+            return Some("DATA/END section");
         }
         if contains_likely_heredoc_start(line) {
             return Some("heredoc");
         }
+        if is_format_declaration_start(trimmed) {
+            return Some("format body");
+        }
     }
-    None
+    token_literal_preserve_region(source)
+}
+
+fn token_literal_preserve_region(source: &str) -> Option<&'static str> {
+    use perl_parser_core::TokenKind;
+
+    let mut stream = perl_parser_core::TokenStream::new(source);
+    loop {
+        let Ok(token) = stream.next() else {
+            return None;
+        };
+        match token.kind {
+            TokenKind::Eof => return None,
+            TokenKind::Regex => return Some("regex literal"),
+            TokenKind::Substitution => return Some("substitution operator"),
+            TokenKind::Transliteration => return Some("transliteration operator"),
+            TokenKind::QuoteSingle
+            | TokenKind::QuoteDouble
+            | TokenKind::QuoteWords
+            | TokenKind::QuoteCommand => return Some("quote-like operator"),
+            TokenKind::FormatBody => return Some("format body"),
+            _ => {}
+        }
+    }
 }
 
 fn is_pod_start(trimmed_line: &str) -> bool {
@@ -1440,6 +1466,17 @@ fn contains_likely_heredoc_start(line: &str) -> bool {
     let marker = after_indent.strip_prefix('~').unwrap_or(after_indent).trim_start();
     let marker = marker.strip_prefix(['\'', '"', '`']).unwrap_or(marker);
     marker.chars().next().is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+}
+
+fn is_format_declaration_start(trimmed_line: &str) -> bool {
+    if !trimmed_line.ends_with('=') {
+        return false;
+    }
+
+    let Some(rest) = trimmed_line.strip_prefix("format") else {
+        return false;
+    };
+    rest.is_empty() || rest.starts_with(char::is_whitespace)
 }
 
 impl TextRange {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/end_literal_preserve.expected-diagnostics.txt
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/end_literal_preserve.expected-diagnostics.txt
@@ -1,0 +1,1 @@
+native.format.literal_preserve_region

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/end_literal_preserve.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/end_literal_preserve.expected.pl
@@ -1,0 +1,3 @@
+my $x = 1;
+__END__
+raw fixture bytes

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/end_literal_preserve.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/end_literal_preserve.pl
@@ -1,0 +1,3 @@
+my $x = 1;
+__END__
+raw fixture bytes

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/format_body_literal_preserve.expected-diagnostics.txt
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/format_body_literal_preserve.expected-diagnostics.txt
@@ -1,0 +1,1 @@
+native.format.literal_preserve_region

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/format_body_literal_preserve.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/format_body_literal_preserve.expected.pl
@@ -1,0 +1,5 @@
+format STDOUT =
+@<<<<
+$name
+.
+write;

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/format_body_literal_preserve.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/format_body_literal_preserve.pl
@@ -1,0 +1,5 @@
+format STDOUT =
+@<<<<
+$name
+.
+write;

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/quote_like_literal_preserve.expected-diagnostics.txt
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/quote_like_literal_preserve.expected-diagnostics.txt
@@ -1,0 +1,1 @@
+native.format.literal_preserve_region

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/quote_like_literal_preserve.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/quote_like_literal_preserve.expected.pl
@@ -1,0 +1,2 @@
+my @words = qw(alpha beta gamma);
+print @words;

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/quote_like_literal_preserve.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/quote_like_literal_preserve.pl
@@ -1,0 +1,2 @@
+my @words = qw(alpha beta gamma);
+print @words;

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/regex_literal_preserve.expected-diagnostics.txt
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/regex_literal_preserve.expected-diagnostics.txt
@@ -1,0 +1,1 @@
+native.format.literal_preserve_region

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/regex_literal_preserve.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/regex_literal_preserve.expected.pl
@@ -1,0 +1,2 @@
+my $matched = $text =~ /needle/i;
+print $matched;

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/regex_literal_preserve.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/regex_literal_preserve.pl
@@ -1,0 +1,2 @@
+my $matched = $text =~ /needle/i;
+print $matched;

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/substitution_literal_preserve.expected-diagnostics.txt
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/substitution_literal_preserve.expected-diagnostics.txt
@@ -1,0 +1,1 @@
+native.format.literal_preserve_region

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/substitution_literal_preserve.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/substitution_literal_preserve.expected.pl
@@ -1,0 +1,2 @@
+$text =~ s/foo/bar/g;
+print $text;

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/substitution_literal_preserve.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/substitution_literal_preserve.pl
@@ -1,0 +1,2 @@
+$text =~ s/foo/bar/g;
+print $text;

--- a/crates/perl-lsp-perltidy/tests/native_formatter_parse_gate_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_parse_gate_tests.rs
@@ -102,7 +102,7 @@ fn native_formatter_refuses_data_section_until_preservation_pass_exists() {
 #[test]
 fn native_formatter_refuses_end_section_until_preservation_pass_exists() {
     let formatter = NativeFormatter::new();
-    let source = "my $x = 1;\n__END__\nraw\n";
+    let source = "my $x = 1;\n__END__   \nraw\n";
     let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
 
     let result = formatter.format_document(source, &config);

--- a/crates/perl-lsp-perltidy/tests/native_formatter_parse_gate_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_parse_gate_tests.rs
@@ -96,7 +96,77 @@ fn native_formatter_refuses_data_section_until_preservation_pass_exists() {
     assert!(!result.changed);
     assert_eq!(result.formatted, source);
     assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
-    assert!(result.diagnostics[0].message.contains("DATA section"));
+    assert!(result.diagnostics[0].message.contains("DATA/END section"));
+}
+
+#[test]
+fn native_formatter_refuses_end_section_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "my $x = 1;\n__END__\nraw\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("DATA/END section"));
+}
+
+#[test]
+fn native_formatter_refuses_regex_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "my $matched = $text =~ /needle/i;\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("regex literal"));
+}
+
+#[test]
+fn native_formatter_refuses_substitution_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "$text =~ s/foo/bar/g;\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("substitution operator"));
+}
+
+#[test]
+fn native_formatter_refuses_quote_like_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "my @words = qw(alpha beta gamma);\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("quote-like operator"));
+}
+
+#[test]
+fn native_formatter_refuses_format_body_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "format STDOUT =\n@<<<<\n$name\n.\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("format body"));
 }
 
 #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 25 |
+| Fixture count | 30 |
 
 ## Critic
 


### PR DESCRIPTION
## Summary

- extend the native formatter literal-preserve safety gate to skip regex literals, substitution/transliteration operators, quote-like operators, `format` bodies, and `__END__` sections
- preserve `__DATA__` / `__END__` marker lines with trailing whitespace
- add expected-diagnostic native-format fixtures for the new no-edit bailout surfaces
- update the native tooling status fixture count from 25 to 30

This keeps the formatter conservative: risky Perl literal/body constructs remain byte-for-byte unchanged until dedicated preservation/layout support exists.

## Proof

- `cargo xtask fmt`
- `cargo test -p perl-lsp-perltidy native_formatter_refuses --profile agent --locked -- --nocapture`
- `cargo test -p perl-lsp-perltidy native_formatter_does_not_treat_bitshift_as_heredoc --profile agent --locked -- --nocapture`
- `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- `cargo xtask native-format check`
  - native formatter fixtures: 30/30 passed
- `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
  - native tooling status: 30 formatter fixtures, 17 native critic rules
- `cargo xtask fmt --check`
- `git diff --check`