### PR TITLE
feat(critic): add deprecated defined native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -157,7 +157,9 @@ impl CodeActionsProvider {
                         ));
                     }
                     // PL500: Deprecated defined()
-                    c if c == DiagnosticCode::DeprecatedDefined.as_str() => {
+                    c if c == DiagnosticCode::DeprecatedDefined.as_str()
+                        || c == "native.common.deprecated_defined" =>
+                    {
                         actions.extend(quick_fixes::fix_deprecated_defined(&self.source, &qf_diag));
                     }
                     // PL404: Numeric comparison with undef
@@ -394,6 +396,52 @@ mod tests {
         assert!(
             actions.iter().any(|a| a.title == "Keep assignment (add parentheses)"),
             "Expected native critic alias to offer intentional-assignment fix, got: {:?}",
+            actions
+        );
+    }
+
+    #[test]
+    fn test_native_deprecated_defined_alias_produces_quick_fix() {
+        let source = "if (defined @items) { print @items; }";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![make_diagnostic(
+            4,
+            18,
+            "native.common.deprecated_defined",
+            "Use of 'defined @items' is deprecated",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(
+            actions.iter().any(|a| a.title == "Replace with '@items'"
+                && a.edit.changes.iter().any(|edit| edit.new_text == "@items")),
+            "Expected native deprecated-defined alias to offer defined() removal, got: {:?}",
+            actions
+        );
+    }
+
+    #[test]
+    fn test_native_deprecated_defined_alias_normalizes_parenthesized_quick_fix() {
+        let source = "if (defined(%seen)) { print keys %seen; }";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![make_diagnostic(
+            4,
+            18,
+            "native.common.deprecated_defined",
+            "Use of 'defined %seen' is deprecated",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(
+            actions.iter().any(|a| a.title == "Replace with '%seen'"
+                && a.edit.changes.iter().any(|edit| edit.new_text == "%seen")),
+            "Expected native deprecated-defined alias to normalize parenthesized defined() removal, got: {:?}",
             actions
         );
     }

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -353,10 +353,11 @@ pub fn fix_deprecated_defined(source: &str, diagnostic: &QuickFixDiagnostic) -> 
         let arg_start = defined_start + 7; // "defined".len()
 
         // Find the argument
-        let arg_text = &source[arg_start..diagnostic.range.1].trim();
+        let raw_arg = source[arg_start..diagnostic.range.1].trim();
+        let arg_text = normalize_deprecated_defined_arg(raw_arg);
 
         actions.push(CodeAction {
-            title: format!("Replace with 'if ({})'", arg_text),
+            title: format!("Replace with '{}'", arg_text),
             kind: CodeActionKind::QuickFix,
             diagnostics: vec![DiagnosticCode::DeprecatedDefined.as_str().to_string()],
             edit: CodeActionEdit {
@@ -370,6 +371,14 @@ pub fn fix_deprecated_defined(source: &str, diagnostic: &QuickFixDiagnostic) -> 
     }
 
     actions
+}
+
+fn normalize_deprecated_defined_arg(raw_arg: &str) -> &str {
+    raw_arg
+        .strip_prefix('(')
+        .and_then(|inner| inner.strip_suffix(')'))
+        .map(str::trim)
+        .unwrap_or(raw_arg)
 }
 
 /// Fix numeric comparison with undef

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -14,7 +14,7 @@ pub use built_in::{BuiltInAnalyzer, Policy};
 pub use native::{
     AssignmentInConditionRule, CriticCategory, CriticContext, CriticFinding, CriticFix,
     CriticRelatedInformation, CriticRule, CriticSuppression, CriticSuppressionMap,
-    CriticSuppressionScope, CriticTextEdit, DuplicateLexicalDeclarationRule,
+    CriticSuppressionScope, CriticTextEdit, DeprecatedDefinedRule, DuplicateLexicalDeclarationRule,
     DuplicateParameterRule, FixSafety, NativeCriticRegistry, ParameterShadowsGlobalRule,
     PrintfFormatArityRule, RequireUseStrictRule, RequireUseWarningsRule,
     ShadowedLexicalVariableRule, UnusedLexicalVariableRule, UnusedParameterRule,

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -239,6 +239,7 @@ impl NativeCriticRegistry {
             Box::new(RequireUseWarningsRule),
             Box::new(AssignmentInConditionRule),
             Box::new(PrintfFormatArityRule),
+            Box::new(DeprecatedDefinedRule),
             Box::new(BarewordFilehandleRule),
             Box::new(TwoArgOpenRule),
             Box::new(PipeOpenRule),
@@ -491,6 +492,32 @@ impl CriticRule for PrintfFormatArityRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_printf_format_arity_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports deprecated `defined @array` / `defined %hash` use.
+///
+/// This wraps the existing PL500 deprecated-syntax lint through the native
+/// critic contract so opt-in native critic users get stable rule IDs,
+/// suppressions, severity filtering, violation bridge coverage, and quick-fix
+/// metadata.
+pub struct DeprecatedDefinedRule;
+
+impl CriticRule for DeprecatedDefinedRule {
+    fn id(&self) -> &'static str {
+        "native.common.deprecated_defined"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Syntax
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_deprecated_defined_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -1075,6 +1102,41 @@ fn printf_format_arity_finding(
     }
 }
 
+fn deprecated_defined_finding(
+    rule: &DeprecatedDefinedRule,
+    source: &str,
+    call_node: &Node,
+    arg_node: &Node,
+    sigil: &str,
+    name: &str,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, call_node.location.start, call_node.location.end);
+    let arg_range = range_for_byte_span(source, arg_node.location.start, arg_node.location.end);
+    let variable_text = format!("{sigil}{name}");
+    let type_name = if sigil == "@" { "array" } else { "hash" };
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Use of 'defined {variable_text}' is deprecated"),
+        explanation: format!(
+            "Testing definedness of a whole {type_name} is deprecated because it was rarely useful and often wrong. Use the {type_name} in boolean context instead."
+        ),
+        suppression_key: rule.id().to_string(),
+        related: vec![CriticRelatedInformation {
+            range: arg_range,
+            message: format!("Use 'if ({variable_text})' instead"),
+        }],
+        fix: Some(CriticFix {
+            title: format!("Replace with '{variable_text}'"),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: variable_text }],
+        }),
+    }
+}
+
 fn bareword_filehandle_finding(
     rule: &BarewordFilehandleRule,
     source: &str,
@@ -1384,6 +1446,29 @@ fn collect_printf_format_arity_findings(
 
     for child in node.children() {
         collect_printf_format_arity_findings(rule, source, child, out);
+    }
+}
+
+fn collect_deprecated_defined_findings(
+    rule: &DeprecatedDefinedRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    if let NodeKind::FunctionCall { name, args } = &node.kind
+        && name == "defined"
+    {
+        let effective_args = effective_call_args(args);
+        if let Some(arg) = effective_args.first()
+            && let NodeKind::Variable { sigil, name } = &arg.kind
+            && matches!(sigil.as_str(), "@" | "%")
+        {
+            out.push(deprecated_defined_finding(rule, source, node, arg, sigil, name));
+        }
+    }
+
+    for child in node.children() {
+        collect_deprecated_defined_findings(rule, source, child, out);
     }
 }
 
@@ -2512,6 +2597,104 @@ mod tests {
     }
 
     #[test]
+    fn native_deprecated_defined_rule_reports_array_defined() {
+        let source = "use strict;\nuse warnings;\nmy @items = (1, 2);\nif (defined @items) { print @items; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DeprecatedDefinedRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.common.deprecated_defined");
+        assert_eq!(finding.category, CriticCategory::Syntax);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Use of 'defined @items' is deprecated");
+        assert_eq!(finding.suppression_key, "native.common.deprecated_defined");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "defined @items");
+        assert_eq!(finding.related.len(), 1);
+
+        let fix = finding.fix.as_ref().expect("deprecated defined should offer direct fix");
+        assert_eq!(fix.title, "Replace with '@items'");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].new_text, "@items");
+    }
+
+    #[test]
+    fn native_deprecated_defined_rule_reports_parenthesized_hash_defined() {
+        let source = "use strict;\nuse warnings;\nmy %seen = (a => 1);\nif (defined(%seen)) { print keys %seen; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DeprecatedDefinedRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "native.common.deprecated_defined");
+        assert_eq!(findings[0].message, "Use of 'defined %seen' is deprecated");
+    }
+
+    #[test]
+    fn native_deprecated_defined_rule_accepts_scalar_defined() {
+        let source =
+            "use strict;\nuse warnings;\nmy $item = 1;\nif (defined $item) { print $item; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DeprecatedDefinedRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "scalar defined checks should be accepted");
+    }
+
+    #[test]
+    fn native_deprecated_defined_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy @items = (1, 2);\nif (defined @items) { print @items; }\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.common.deprecated_defined".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DeprecatedDefinedRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.common.deprecated_defined -- legacy code\nuse strict;\nuse warnings;\nmy @items = (1, 2);\nif (defined @items) { print @items; }\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_deprecated_defined_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy @items = (1, 2);\ndefined @items;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(DeprecatedDefinedRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.common.deprecated_defined");
+        assert_eq!(violations[0].description, "Use of 'defined @items' is deprecated");
+        assert_eq!(
+            violations[0].explanation,
+            "Testing definedness of a whole array is deprecated because it was rarely useful and often wrong. Use the array in boolean context instead."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_bareword_filehandle_rule_reports_open_bareword() {
         let source = "use strict;\nuse warnings;\nopen(FH, '<', 'file.txt');\n";
         let ast = parse_source(source);
@@ -3277,6 +3460,7 @@ mod tests {
                 "native.testing.require_use_warnings",
                 "native.common.assignment_in_condition",
                 "native.common.printf_format_arity",
+                "native.common.deprecated_defined",
                 "native.io.bareword_filehandle",
                 "native.io.two_arg_open",
                 "native.io.pipe_open",

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -107,6 +107,38 @@ pub(super) fn fix_assignment_in_condition(
     ]
 }
 
+pub(super) fn fix_deprecated_defined(
+    provider: &CodeActionsProvider,
+    diagnostic: &Diagnostic,
+) -> Vec<CodeAction> {
+    let diagnostic_text = &provider.source()[diagnostic.range.0..diagnostic.range.1];
+    let Some(relative_start) = diagnostic_text.find("defined") else {
+        return Vec::new();
+    };
+
+    let defined_start = diagnostic.range.0 + relative_start;
+    let raw_arg = provider.source()[defined_start + "defined".len()..diagnostic.range.1].trim();
+    let arg_text = normalize_deprecated_defined_arg(raw_arg);
+    if arg_text.is_empty() {
+        return Vec::new();
+    }
+
+    vec![diagnostic_action(
+        diagnostic,
+        format!("Replace with '{arg_text}'"),
+        CodeActionKind::QuickFix,
+        TextEdit { range: (defined_start, diagnostic.range.1), new_text: arg_text.to_string() },
+    )]
+}
+
+fn normalize_deprecated_defined_arg(raw_arg: &str) -> &str {
+    raw_arg
+        .strip_prefix('(')
+        .and_then(|inner| inner.strip_suffix(')'))
+        .map(str::trim)
+        .unwrap_or(raw_arg)
+}
+
 pub(super) fn add_use_strict(diagnostic: &Diagnostic) -> Vec<CodeAction> {
     vec![diagnostic_action(
         diagnostic,

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -70,6 +70,13 @@ impl CodeActionsProvider {
             {
                 fixes::fix_assignment_in_condition(self, diagnostic)
             }
+            Some(c)
+                if c == DiagnosticCode::DeprecatedDefined.as_str()
+                    || c == "deprecated-defined"
+                    || c == "native.common.deprecated_defined" =>
+            {
+                fixes::fix_deprecated_defined(self, diagnostic)
+            }
             Some("native.testing.require_use_strict") => fixes::add_use_strict(diagnostic),
             Some("native.testing.require_use_warnings") => fixes::add_use_warnings(diagnostic),
             Some(c)
@@ -656,6 +663,44 @@ mod tests {
         assert_eq!(actions[1].title, "Keep assignment (add parentheses)");
         assert_eq!(actions[1].edit.range, (4, 10));
         assert_eq!(actions[1].edit.new_text, "($x = 5)");
+    }
+
+    #[test]
+    fn test_native_critic_deprecated_defined_quick_fix() {
+        let source = "if (defined @items) { print @items; }";
+        let diagnostic = make_diagnostic(
+            (4, 18),
+            DiagnosticSeverity::Warning,
+            "native.common.deprecated_defined",
+            "Use of 'defined @items' is deprecated",
+        );
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Replace with '@items'");
+        assert_eq!(actions[0].edit.range, (4, 18));
+        assert_eq!(actions[0].edit.new_text, "@items");
+    }
+
+    #[test]
+    fn test_native_critic_deprecated_defined_quick_fix_normalizes_parentheses() {
+        let source = "if (defined(%seen)) { print keys %seen; }";
+        let diagnostic = make_diagnostic(
+            (4, 18),
+            DiagnosticSeverity::Warning,
+            "native.common.deprecated_defined",
+            "Use of 'defined %seen' is deprecated",
+        );
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Replace with '%seen'");
+        assert_eq!(actions[0].edit.range, (4, 18));
+        assert_eq!(actions[0].edit.new_text, "%seen");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1113,6 +1113,7 @@ fn is_fixable_diagnostic(code: &str) -> bool {
             | "TestingAndDebugging::RequireUseWarnings"
             | "native.testing.require_use_strict"
             | "native.testing.require_use_warnings"
+            | "native.common.deprecated_defined"
             | "native.io.bareword_filehandle"
             | "native.io.two_arg_open"
             | "InputOutput::ProhibitBarewordFileHandles"
@@ -1350,7 +1351,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
             None,
             &context,
             None,
@@ -1422,6 +1423,25 @@ mod tests {
         assert_eq!(data["code"], "native.common.printf_format_arity");
         assert_eq!(data["suppressionKey"], "native.common.printf_format_arity");
         assert_eq!(data["fixable"], false);
+
+        let deprecated_defined = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.common.deprecated_defined"),
+                )
+            })
+            .ok_or("expected native deprecated-defined finding")?;
+        assert_eq!(deprecated_defined.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(deprecated_defined.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(deprecated_defined.message, "Use of 'defined @items' is deprecated");
+        let data = deprecated_defined
+            .data
+            .as_ref()
+            .ok_or("native deprecated-defined data should be populated")?;
+        assert_eq!(data["code"], "native.common.deprecated_defined");
+        assert_eq!(data["suppressionKey"], "native.common.deprecated_defined");
+        assert_eq!(data["fixable"], true);
 
         let bareword_filehandle = items
             .iter()

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -14,19 +14,20 @@
 
 | Metric | Value |
 | --- | ---: |
-| Native rule count | 18 |
-| Rules with suppressions | 18 |
-| Rules with fixes | 11 |
-| Pull diagnostics coverage | 18 |
-| Push diagnostics coverage | 18 |
-| Workspace diagnostics coverage | 18 |
-| Violation bridge coverage | 18 |
+| Native rule count | 19 |
+| Rules with suppressions | 19 |
+| Rules with fixes | 12 |
+| Pull diagnostics coverage | 19 |
+| Push diagnostics coverage | 19 |
+| Workspace diagnostics coverage | 19 |
+| Violation bridge coverage | 19 |
 
 Native rules:
 - `native.testing.require_use_strict`
 - `native.testing.require_use_warnings`
 - `native.common.assignment_in_condition`
 - `native.common.printf_format_arity`
+- `native.common.deprecated_defined`
 - `native.io.bareword_filehandle`
 - `native.io.two_arg_open`
 - `native.io.pipe_open`
@@ -44,6 +45,7 @@ Native rules:
 
 Fixable native rules:
 - `native.common.assignment_in_condition`
+- `native.common.deprecated_defined`
 - `native.io.bareword_filehandle`
 - `native.io.two_arg_open`
 - `native.testing.require_use_strict`

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -204,6 +204,7 @@ fn critic_status() -> Result<CriticStatus> {
 fn fixable_rule_ids() -> BTreeSet<String> {
     [
         "native.common.assignment_in_condition",
+        "native.common.deprecated_defined",
         "native.io.bareword_filehandle",
         "native.io.two_arg_open",
         "native.testing.require_use_strict",


### PR DESCRIPTION
## Summary

Adds opt-in native critic coverage for deprecated whole-array/hash defined checks:

- registers `native.common.deprecated_defined` in `NativeCriticRegistry::recommended()`
- reports parser-backed `defined @array` / `defined %hash` calls while accepting scalar `defined`
- routes through config filtering, suppressions, violation bridge, pull diagnostics, push/workspace diagnostics, and quick-fix aliases
- updates native-tooling status so the rule and fixability surface show in the dashboard

Legacy/default critic behavior is unchanged. Native critic remains explicit opt-in.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_deprecated --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs code_actions_provider::tests::test_native_critic_deprecated_defined_quick_fix --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

## Known status-doc drift

`just status-check` still fails on the existing broad generated-status drift in:

- `docs/project/status/tests.md`
- `docs/project/status/parser.md`
- `docs/project/status/quality.md`
- `docs/project/status/dap.md`

This PR only updates `docs/project/status/native_tooling.md` for the new native critic rule count and fixable-rule inventory.
