### PR TITLE
feat(critic): add undef comparison native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -163,6 +163,12 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_deprecated_defined(&self.source, &qf_diag));
                     }
                     // PL404: Numeric comparison with undef
+                    "native.common.undef_comparison" => {
+                        actions.extend(quick_fixes::fix_native_undef_comparison(
+                            &self.source,
+                            &qf_diag,
+                        ));
+                    }
                     c if c == DiagnosticCode::NumericComparisonWithUndef.as_str() => {
                         actions.extend(quick_fixes::fix_numeric_undef(&self.source, &qf_diag));
                     }
@@ -442,6 +448,29 @@ mod tests {
             actions.iter().any(|a| a.title == "Replace with '%seen'"
                 && a.edit.changes.iter().any(|edit| edit.new_text == "%seen")),
             "Expected native deprecated-defined alias to normalize parenthesized defined() removal, got: {:?}",
+            actions
+        );
+    }
+
+    #[test]
+    fn test_native_undef_comparison_alias_produces_defined_quick_fix() {
+        let source = "if ($value == undef) { print $value; }";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let diagnostics = vec![make_diagnostic(
+            4,
+            19,
+            "native.common.undef_comparison",
+            "Using '==' with undef -- use defined() to check first",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(
+            actions.iter().any(|a| a.title == "Use defined() check"
+                && a.edit.changes.iter().any(|edit| edit.new_text == "!defined($value)")),
+            "Expected native undef-comparison alias to offer defined() fix, got: {:?}",
             actions
         );
     }

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -424,6 +424,61 @@ pub fn fix_numeric_undef(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<C
     actions
 }
 
+/// Fix explicit numeric comparison with `undef` from native critic.
+pub fn fix_native_undef_comparison(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some(replacement) =
+        native_undef_comparison_replacement(&source[diagnostic.range.0..diagnostic.range.1])
+    else {
+        return Vec::new();
+    };
+
+    vec![CodeAction {
+        title: "Use defined() check".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec!["native.common.undef_comparison".to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                new_text: replacement,
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+fn native_undef_comparison_replacement(text: &str) -> Option<String> {
+    if let Some((left, right)) = text.split_once("==") {
+        return native_defined_replacement(left, right, true);
+    }
+    if let Some((left, right)) = text.split_once("!=") {
+        return native_defined_replacement(left, right, false);
+    }
+
+    None
+}
+
+fn native_defined_replacement(left: &str, right: &str, equal: bool) -> Option<String> {
+    let left = left.trim();
+    let right = right.trim();
+    let compared = if left == "undef" {
+        right
+    } else if right == "undef" {
+        left
+    } else {
+        return None;
+    };
+    if compared.is_empty() {
+        return None;
+    }
+
+    let replacement =
+        if equal { format!("!defined({compared})") } else { format!("defined({compared})") };
+    Some(replacement)
+}
+
 /// Fix unquoted bareword by quoting or declaring as filehandle
 ///
 /// Provides three options for fixing bareword issues under strict mode:

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -17,7 +17,8 @@ pub use native::{
     CriticSuppressionScope, CriticTextEdit, DeprecatedDefinedRule, DuplicateLexicalDeclarationRule,
     DuplicateParameterRule, FixSafety, NativeCriticRegistry, ParameterShadowsGlobalRule,
     PrintfFormatArityRule, RequireUseStrictRule, RequireUseWarningsRule,
-    ShadowedLexicalVariableRule, UnusedLexicalVariableRule, UnusedParameterRule,
+    ShadowedLexicalVariableRule, UndefComparisonRule, UnusedLexicalVariableRule,
+    UnusedParameterRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -240,6 +240,7 @@ impl NativeCriticRegistry {
             Box::new(AssignmentInConditionRule),
             Box::new(PrintfFormatArityRule),
             Box::new(DeprecatedDefinedRule),
+            Box::new(UndefComparisonRule),
             Box::new(BarewordFilehandleRule),
             Box::new(TwoArgOpenRule),
             Box::new(PipeOpenRule),
@@ -518,6 +519,31 @@ impl CriticRule for DeprecatedDefinedRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_deprecated_defined_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports numeric comparison with explicit `undef`.
+///
+/// This wraps the parser-confirmed PL404 surface through the native critic
+/// contract. It intentionally starts with literal `undef` comparisons; broader
+/// maybe-undef semantic inference can be added as a separate rule slice.
+pub struct UndefComparisonRule;
+
+impl CriticRule for UndefComparisonRule {
+    fn id(&self) -> &'static str {
+        "native.common.undef_comparison"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Syntax
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_undef_comparison_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -1137,6 +1163,54 @@ fn deprecated_defined_finding(
     }
 }
 
+fn undef_comparison_finding(
+    rule: &UndefComparisonRule,
+    source: &str,
+    comparison_node: &Node,
+    op: &str,
+    compared_node: &Node,
+    undef_node: &Node,
+) -> CriticFinding {
+    let range =
+        range_for_byte_span(source, comparison_node.location.start, comparison_node.location.end);
+    let compared_range =
+        range_for_byte_span(source, compared_node.location.start, compared_node.location.end);
+    let undef_range =
+        range_for_byte_span(source, undef_node.location.start, undef_node.location.end);
+    let compared_text =
+        source[compared_node.location.start..compared_node.location.end].trim().to_string();
+    let replacement = match op {
+        "==" => format!("!defined({compared_text})"),
+        "!=" => format!("defined({compared_text})"),
+        _ => compared_text,
+    };
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Using '{op}' with undef -- use defined() to check first"),
+        explanation: "Numeric comparison with undef is usually wrong because undef is coerced before comparison. Use defined(...) for definedness checks, or normalize the value before comparing.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: vec![
+            CriticRelatedInformation {
+                range: undef_range,
+                message: "This undef literal should be checked with defined(...) instead.".to_string(),
+            },
+            CriticRelatedInformation {
+                range: compared_range,
+                message: "Check this expression with defined(...) before comparing values.".to_string(),
+            },
+        ],
+        fix: Some(CriticFix {
+            title: "Use defined() check".to_string(),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: replacement }],
+        }),
+    }
+}
+
 fn bareword_filehandle_finding(
     rule: &BarewordFilehandleRule,
     source: &str,
@@ -1469,6 +1543,31 @@ fn collect_deprecated_defined_findings(
 
     for child in node.children() {
         collect_deprecated_defined_findings(rule, source, child, out);
+    }
+}
+
+fn collect_undef_comparison_findings(
+    rule: &UndefComparisonRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    if let NodeKind::Binary { op, left, right } = &node.kind
+        && matches!(op.as_str(), "==" | "!=")
+    {
+        match (&left.kind, &right.kind) {
+            (NodeKind::Undef, _) => {
+                out.push(undef_comparison_finding(rule, source, node, op, right, left));
+            }
+            (_, NodeKind::Undef) => {
+                out.push(undef_comparison_finding(rule, source, node, op, left, right));
+            }
+            _ => {}
+        }
+    }
+
+    for child in node.children() {
+        collect_undef_comparison_findings(rule, source, child, out);
     }
 }
 
@@ -2695,6 +2794,113 @@ mod tests {
     }
 
     #[test]
+    fn native_undef_comparison_rule_reports_numeric_comparison_with_undef() {
+        let source = "use strict;\nuse warnings;\nmy $value = maybe();\nif ($value == undef) { print $value; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndefComparisonRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.common.undef_comparison");
+        assert_eq!(finding.category, CriticCategory::Syntax);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Using '==' with undef -- use defined() to check first");
+        assert_eq!(finding.suppression_key, "native.common.undef_comparison");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$value == undef");
+        assert_eq!(finding.related.len(), 2);
+
+        let fix = finding.fix.as_ref().expect("undef comparison should offer defined() fix");
+        assert_eq!(fix.title, "Use defined() check");
+        assert_eq!(fix.safety, FixSafety::Suggested);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].new_text, "!defined($value)");
+    }
+
+    #[test]
+    fn native_undef_comparison_rule_reports_reversed_not_equal_comparison() {
+        let source = "use strict;\nuse warnings;\nmy $value = maybe();\nif (undef != $value) { print $value; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndefComparisonRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "native.common.undef_comparison");
+        assert_eq!(
+            &source[findings[0].range.start.byte..findings[0].range.end.byte],
+            "undef != $value"
+        );
+        assert_eq!(
+            findings[0].fix.as_ref().expect("defined fix").edits[0].new_text,
+            "defined($value)"
+        );
+    }
+
+    #[test]
+    fn native_undef_comparison_rule_accepts_defined_checks_and_other_comparisons() {
+        let source = "use strict;\nuse warnings;\nmy $value = maybe();\nif (defined $value) { print $value; }\nif ($value == 0) { print $value; }\nif ($value eq undef) { print $value; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndefComparisonRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "only numeric ==/!= comparisons with undef should report");
+    }
+
+    #[test]
+    fn native_undef_comparison_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $value = maybe();\nif ($value == undef) { print $value; }\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.common.undef_comparison".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndefComparisonRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.common.undef_comparison -- legacy check\nuse strict;\nuse warnings;\nmy $value = maybe();\nif ($value == undef) { print $value; }\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_undef_comparison_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $value = maybe();\n$value == undef;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndefComparisonRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.common.undef_comparison");
+        assert_eq!(
+            violations[0].description,
+            "Using '==' with undef -- use defined() to check first"
+        );
+        assert_eq!(
+            violations[0].explanation,
+            "Numeric comparison with undef is usually wrong because undef is coerced before comparison. Use defined(...) for definedness checks, or normalize the value before comparing."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_bareword_filehandle_rule_reports_open_bareword() {
         let source = "use strict;\nuse warnings;\nopen(FH, '<', 'file.txt');\n";
         let ast = parse_source(source);
@@ -3461,6 +3667,7 @@ mod tests {
                 "native.common.assignment_in_condition",
                 "native.common.printf_format_arity",
                 "native.common.deprecated_defined",
+                "native.common.undef_comparison",
                 "native.io.bareword_filehandle",
                 "native.io.two_arg_open",
                 "native.io.pipe_open",

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/fixes.rs
@@ -139,6 +139,54 @@ fn normalize_deprecated_defined_arg(raw_arg: &str) -> &str {
         .unwrap_or(raw_arg)
 }
 
+pub(super) fn fix_native_undef_comparison(
+    provider: &CodeActionsProvider,
+    diagnostic: &Diagnostic,
+) -> Vec<CodeAction> {
+    let Some(replacement) = native_undef_comparison_replacement(
+        &provider.source()[diagnostic.range.0..diagnostic.range.1],
+    ) else {
+        return Vec::new();
+    };
+
+    vec![diagnostic_action(
+        diagnostic,
+        "Use defined() check",
+        CodeActionKind::QuickFix,
+        TextEdit { range: diagnostic.range, new_text: replacement },
+    )]
+}
+
+fn native_undef_comparison_replacement(text: &str) -> Option<String> {
+    if let Some((left, right)) = text.split_once("==") {
+        return native_defined_replacement(left, right, true);
+    }
+    if let Some((left, right)) = text.split_once("!=") {
+        return native_defined_replacement(left, right, false);
+    }
+
+    None
+}
+
+fn native_defined_replacement(left: &str, right: &str, equal: bool) -> Option<String> {
+    let left = left.trim();
+    let right = right.trim();
+    let compared = if left == "undef" {
+        right
+    } else if right == "undef" {
+        left
+    } else {
+        return None;
+    };
+    if compared.is_empty() {
+        return None;
+    }
+
+    let replacement =
+        if equal { format!("!defined({compared})") } else { format!("defined({compared})") };
+    Some(replacement)
+}
+
 pub(super) fn add_use_strict(diagnostic: &Diagnostic) -> Vec<CodeAction> {
     vec![diagnostic_action(
         diagnostic,

--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -77,6 +77,9 @@ impl CodeActionsProvider {
             {
                 fixes::fix_deprecated_defined(self, diagnostic)
             }
+            Some("native.common.undef_comparison") => {
+                fixes::fix_native_undef_comparison(self, diagnostic)
+            }
             Some("native.testing.require_use_strict") => fixes::add_use_strict(diagnostic),
             Some("native.testing.require_use_warnings") => fixes::add_use_warnings(diagnostic),
             Some(c)
@@ -701,6 +704,25 @@ mod tests {
         assert_eq!(actions[0].title, "Replace with '%seen'");
         assert_eq!(actions[0].edit.range, (4, 18));
         assert_eq!(actions[0].edit.new_text, "%seen");
+    }
+
+    #[test]
+    fn test_native_critic_undef_comparison_quick_fix() {
+        let source = "if ($value == undef) { print $value; }";
+        let diagnostic = make_diagnostic(
+            (4, 19),
+            DiagnosticSeverity::Warning,
+            "native.common.undef_comparison",
+            "Using '==' with undef -- use defined() to check first",
+        );
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_actions_for_diagnostic(&diagnostic);
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].title, "Use defined() check");
+        assert_eq!(actions[0].edit.range, (4, 19));
+        assert_eq!(actions[0].edit.new_text, "!defined($value)");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1114,6 +1114,7 @@ fn is_fixable_diagnostic(code: &str) -> bool {
             | "native.testing.require_use_strict"
             | "native.testing.require_use_warnings"
             | "native.common.deprecated_defined"
+            | "native.common.undef_comparison"
             | "native.io.bareword_filehandle"
             | "native.io.two_arg_open"
             | "InputOutput::ProhibitBarewordFileHandles"
@@ -1336,6 +1337,7 @@ mod tests {
         assert!(is_fixable_diagnostic("PL503"));
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseStrict"));
         assert!(is_fixable_diagnostic("TestingAndDebugging::RequireUseWarnings"));
+        assert!(is_fixable_diagnostic("native.common.undef_comparison"));
         assert!(is_fixable_diagnostic("InputOutput::RequireThreeArgOpen"));
         assert!(is_fixable_diagnostic("Variables::ProhibitUnusedVariables"));
     }
@@ -1351,7 +1353,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nif ($path == undef) { print $path; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
             None,
             &context,
             None,
@@ -1441,6 +1443,28 @@ mod tests {
             .ok_or("native deprecated-defined data should be populated")?;
         assert_eq!(data["code"], "native.common.deprecated_defined");
         assert_eq!(data["suppressionKey"], "native.common.deprecated_defined");
+        assert_eq!(data["fixable"], true);
+
+        let undef_comparison = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.common.undef_comparison"),
+                )
+            })
+            .ok_or("expected native undef-comparison finding")?;
+        assert_eq!(undef_comparison.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(undef_comparison.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(
+            undef_comparison.message,
+            "Using '==' with undef -- use defined() to check first"
+        );
+        let data = undef_comparison
+            .data
+            .as_ref()
+            .ok_or("native undef-comparison data should be populated")?;
+        assert_eq!(data["code"], "native.common.undef_comparison");
+        assert_eq!(data["suppressionKey"], "native.common.undef_comparison");
         assert_eq!(data["fixable"], true);
 
         let bareword_filehandle = items

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1673,6 +1673,7 @@ fn is_fixable_perlcritic_policy(code: &str) -> bool {
             | "TestingAndDebugging::RequireUseWarnings"
             | "native.testing.require_use_strict"
             | "native.testing.require_use_warnings"
+            | "native.common.undef_comparison"
             | "native.io.bareword_filehandle"
             | "native.io.two_arg_open"
             | "Variables::ProhibitUnusedVariables"
@@ -1837,7 +1838,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
                 }
             })))
             .unwrap();
@@ -1863,6 +1864,14 @@ mod tests {
         assert!(
             text.contains("Assignment in condition - did you mean '=='?"),
             "native assignment-in-condition finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.common.undef_comparison"),
+            "native critic engine should publish native undef-comparison finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Using '==' with undef -- use defined() to check first"),
+            "native undef-comparison finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.io.bareword_filehandle"),
@@ -2028,7 +2037,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
             }
         })))?;
 
@@ -2068,6 +2077,15 @@ mod tests {
                         == Some("Assignment in condition - did you mean '=='?")
             }),
             "native critic engine should add native assignment-in-condition finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.common.undef_comparison")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Using '==' with undef -- use defined() to check first")
+            }),
+            "native critic engine should add native undef-comparison finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -14,13 +14,13 @@
 
 | Metric | Value |
 | --- | ---: |
-| Native rule count | 19 |
-| Rules with suppressions | 19 |
-| Rules with fixes | 12 |
-| Pull diagnostics coverage | 19 |
-| Push diagnostics coverage | 19 |
-| Workspace diagnostics coverage | 19 |
-| Violation bridge coverage | 19 |
+| Native rule count | 20 |
+| Rules with suppressions | 20 |
+| Rules with fixes | 13 |
+| Pull diagnostics coverage | 20 |
+| Push diagnostics coverage | 20 |
+| Workspace diagnostics coverage | 20 |
+| Violation bridge coverage | 20 |
 
 Native rules:
 - `native.testing.require_use_strict`
@@ -28,6 +28,7 @@ Native rules:
 - `native.common.assignment_in_condition`
 - `native.common.printf_format_arity`
 - `native.common.deprecated_defined`
+- `native.common.undef_comparison`
 - `native.io.bareword_filehandle`
 - `native.io.two_arg_open`
 - `native.io.pipe_open`
@@ -46,6 +47,7 @@ Native rules:
 Fixable native rules:
 - `native.common.assignment_in_condition`
 - `native.common.deprecated_defined`
+- `native.common.undef_comparison`
 - `native.io.bareword_filehandle`
 - `native.io.two_arg_open`
 - `native.testing.require_use_strict`

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -205,6 +205,7 @@ fn fixable_rule_ids() -> BTreeSet<String> {
     [
         "native.common.assignment_in_condition",
         "native.common.deprecated_defined",
+        "native.common.undef_comparison",
         "native.io.bareword_filehandle",
         "native.io.two_arg_open",
         "native.testing.require_use_strict",


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.common.undef_comparison` for parser-confirmed numeric comparisons against literal `undef`:

- reports `==` / `!=` comparisons where either side is `undef`
- preserves legacy/default critic behavior unchanged
- flows through config/severity filtering, suppressions, violation bridge, pull diagnostics, push diagnostics, and workspace diagnostics
- adds native quick-fix aliases in core and LSP code actions, replacing explicit undef comparisons with `defined(...)` checks
- refreshes native-tooling status to 20 native critic rules and 13 fixable rules

This intentionally does not add broader maybe-undef semantic inference; it only wraps the explicit literal-`undef` surface as the next narrow native critic slice.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_undef --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core test_native_undef --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs test_native_critic_undef --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

## Notes

`just status-check` was run and failed on existing broad generated-status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md` with the standard `Run just status-update` message. I left those unrelated generated docs untouched; this PR only refreshes `docs/project/status/native_tooling.md` for the new rule count/fix count.
