### PR TITLE
feat(completion): shadow compiler visible-symbol candidates (#8322)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion_shadow.rs
@@ -32,7 +32,9 @@
 //!   Dynamic/Unavailable → show low or omit.
 
 use perl_semantic_facts::{
-    Confidence, DefinitionCandidate, FileId, ScopeId, VisibleSymbol, VisibleSymbolSource,
+    Confidence, DefinitionCandidate, FileId, Provenance, ProviderFactFreshness,
+    ProviderFactSourceKind, ProviderFactTrace, ProviderFallbackState, ProviderSurface, ScopeId,
+    VisibleSymbol, VisibleSymbolSource,
 };
 use perl_workspace::semantic::queries::SemanticQueries;
 use perl_workspace::semantic_shadow_compare::{
@@ -99,17 +101,21 @@ pub fn completion_visibility_shadow<Q: SemanticQueries>(
     // ── Legacy path ──
     let old_summary = legacy_symbols_to_summary(&legacy_symbols);
 
-    // ── New semantic path ──
+    // ── New compiler-fact path ──
     let new_visible = semantic_queries.visible_symbols_at(file_id, byte_offset, scope_id);
     let new_summary = semantic_visible_to_summary(&new_visible);
+    let notes = completion_shadow_notes(&legacy_symbols, &new_visible);
+    let fact_source_traces =
+        completion_fact_source_traces(&new_visible, ProviderFallbackState::Shadow);
 
     // ── Build receipt ──
-    let receipt = SemanticShadowCompareReceipt::from_summaries(
+    let receipt = SemanticShadowCompareReceipt::from_summaries_with_fact_source_traces(
         ShadowQueryName::CompletionVisibility,
         ShadowQueryInput { symbol: input_label.to_string() },
         old_summary,
         new_summary,
-        Vec::new(),
+        notes,
+        fact_source_traces,
     );
 
     tracing::debug!(
@@ -403,6 +409,7 @@ fn semantic_visible_to_summary(symbols: &[VisibleSymbol]) -> ShadowResultSummary
 
     let identities: Vec<String> = symbols
         .iter()
+        .filter(|s| is_completion_candidate_source(&s.source))
         .map(|s| {
             // Use name + source as a stable identity for shadow comparison.
             format!("{}:{:?}", s.name, s.source)
@@ -410,6 +417,126 @@ fn semantic_visible_to_summary(symbols: &[VisibleSymbol]) -> ShadowResultSummary
         .collect();
 
     summarize_identities(Some(identities))
+}
+
+fn completion_shadow_notes(
+    legacy_symbols: &[String],
+    visible_symbols: &[VisibleSymbol],
+) -> Vec<String> {
+    let candidate_count = visible_symbols
+        .iter()
+        .filter(|symbol| is_completion_candidate_source(&symbol.source))
+        .count();
+    let rank_delta = i64::try_from(candidate_count).unwrap_or(i64::MAX)
+        - i64::try_from(legacy_symbols.len()).unwrap_or(i64::MAX);
+    let mut notes = vec![
+        format!("legacy_candidates={}", legacy_symbols.len()),
+        format!("compiler_fact_candidates={candidate_count}"),
+        format!("rank_delta={rank_delta:+}"),
+    ];
+
+    let mut generated_labels: Vec<String> = visible_symbols
+        .iter()
+        .filter(|symbol| symbol.source == VisibleSymbolSource::Generated)
+        .map(|symbol| symbol.name.clone())
+        .collect();
+    generated_labels.sort();
+    generated_labels.dedup();
+    if !generated_labels.is_empty() {
+        notes.push(format!("generated_labels={}", generated_labels.join(",")));
+    }
+
+    let mut dynamic_blockers: Vec<String> = visible_symbols
+        .iter()
+        .filter(|symbol| symbol.source == VisibleSymbolSource::DynamicUnknown)
+        .map(|symbol| symbol.name.clone())
+        .collect();
+    dynamic_blockers.sort();
+    dynamic_blockers.dedup();
+    if !dynamic_blockers.is_empty() {
+        notes.push(format!("dynamic_boundary_blockers={}", dynamic_blockers.join(",")));
+    }
+
+    notes
+}
+
+fn is_completion_candidate_source(source: &VisibleSymbolSource) -> bool {
+    *source != VisibleSymbolSource::DynamicUnknown
+}
+
+fn completion_fact_source_traces(
+    visible_symbols: &[VisibleSymbol],
+    fallback_state: ProviderFallbackState,
+) -> Vec<ProviderFactTrace> {
+    let mut traces = Vec::new();
+    for symbol in visible_symbols {
+        let (source, provenance, state) = completion_trace_shape(symbol, fallback_state);
+        let anchor_id = symbol.context.as_ref().and_then(|context| {
+            context.source_import_anchor_id.or(context.source_export_anchor_id)
+        });
+        traces.push(ProviderFactTrace::new(
+            ProviderSurface::Completion,
+            source,
+            provenance,
+            symbol.confidence,
+            ProviderFactFreshness::Fresh,
+            state,
+            None,
+            anchor_id,
+            Some(1),
+        ));
+    }
+
+    if traces.is_empty() {
+        traces.push(ProviderFactTrace::new(
+            ProviderSurface::Completion,
+            ProviderFactSourceKind::Fallback,
+            Provenance::SearchFallback,
+            Confidence::Low,
+            ProviderFactFreshness::NotApplicable,
+            ProviderFallbackState::Fallback,
+            None,
+            None,
+            Some(1),
+        ));
+    }
+
+    traces
+}
+
+fn completion_trace_shape(
+    symbol: &VisibleSymbol,
+    fallback_state: ProviderFallbackState,
+) -> (ProviderFactSourceKind, Provenance, ProviderFallbackState) {
+    match symbol.source {
+        VisibleSymbolSource::ExplicitImport
+        | VisibleSymbolSource::DefaultExport
+        | VisibleSymbolSource::ExportTag => (
+            ProviderFactSourceKind::CompilerFact,
+            Provenance::ImportExportInference,
+            fallback_state,
+        ),
+        VisibleSymbolSource::Generated => (
+            ProviderFactSourceKind::FrameworkAdapter,
+            Provenance::FrameworkSynthesis,
+            fallback_state,
+        ),
+        VisibleSymbolSource::DynamicUnknown => (
+            ProviderFactSourceKind::DynamicBoundary,
+            Provenance::DynamicBoundary,
+            ProviderFallbackState::Blocked,
+        ),
+        VisibleSymbolSource::LocalLexical
+        | VisibleSymbolSource::LocalPackage
+        | VisibleSymbolSource::Constant => {
+            (ProviderFactSourceKind::CompilerFact, Provenance::SemanticAnalyzer, fallback_state)
+        }
+        VisibleSymbolSource::External => (
+            ProviderFactSourceKind::Fallback,
+            Provenance::SearchFallback,
+            ProviderFallbackState::Fallback,
+        ),
+    }
 }
 
 fn method_probe_names(
@@ -747,6 +874,112 @@ mod tests {
 
         assert_eq!(result.receipt.new_result.match_count, 3);
         assert_eq!(result.receipt.new_result.available, true);
+        Ok(())
+    }
+
+    #[test]
+    fn completion_compiler_shadow_traces_import_export_and_generated_candidates()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let syms = vec![
+            make_visible("imported_func", VisibleSymbolSource::ExplicitImport, Confidence::High),
+            make_visible("default_func", VisibleSymbolSource::DefaultExport, Confidence::High),
+            make_visible("generated_accessor", VisibleSymbolSource::Generated, Confidence::Medium),
+        ];
+        let queries = StubSemanticQueries { visible_result: syms };
+
+        let result = completion_visibility_shadow(
+            vec!["legacy_func".to_string()],
+            &queries,
+            FileId(1),
+            10,
+            None,
+            "completion shadow import/export",
+        );
+
+        assert_eq!(result.legacy_symbols, vec!["legacy_func".to_string()]);
+        assert_eq!(result.receipt.verdict, ShadowCompareVerdict::Improved);
+        assert!(result.receipt.notes.iter().any(|note| note == "legacy_candidates=1"));
+        assert!(result.receipt.notes.iter().any(|note| note == "compiler_fact_candidates=3"));
+        assert!(result.receipt.notes.iter().any(|note| note == "rank_delta=+2"));
+        assert!(
+            result.receipt.notes.iter().any(|note| note == "generated_labels=generated_accessor"),
+            "generated labels should be recorded in the shadow receipt notes"
+        );
+
+        assert!(result.receipt.fact_source_traces.iter().any(|trace| {
+            trace.surface == ProviderSurface::Completion
+                && trace.source == ProviderFactSourceKind::CompilerFact
+                && trace.provenance == Provenance::ImportExportInference
+                && trace.confidence == Confidence::High
+                && trace.freshness == ProviderFactFreshness::Fresh
+                && trace.fallback_state == ProviderFallbackState::Shadow
+        }));
+        assert!(result.receipt.fact_source_traces.iter().any(|trace| {
+            trace.surface == ProviderSurface::Completion
+                && trace.source == ProviderFactSourceKind::FrameworkAdapter
+                && trace.provenance == Provenance::FrameworkSynthesis
+                && trace.confidence == Confidence::Medium
+                && trace.fallback_state == ProviderFallbackState::Shadow
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn completion_compiler_shadow_labels_dynamic_boundary_blockers()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let syms = vec![make_visible(
+            "symbolic_ref_candidate",
+            VisibleSymbolSource::DynamicUnknown,
+            Confidence::Low,
+        )];
+        let queries = StubSemanticQueries { visible_result: syms };
+
+        let result =
+            completion_visibility_shadow(vec![], &queries, FileId(1), 0, None, "symbolic ref");
+
+        assert_eq!(result.receipt.new_result.match_count, 0);
+        assert!(result.receipt.notes.iter().any(|note| note == "compiler_fact_candidates=0"));
+        assert!(
+            result
+                .receipt
+                .notes
+                .iter()
+                .any(|note| note == "dynamic_boundary_blockers=symbolic_ref_candidate"),
+            "dynamic boundary blockers should be labeled instead of ranked as ordinary completions"
+        );
+        assert!(result.receipt.fact_source_traces.iter().any(|trace| {
+            trace.surface == ProviderSurface::Completion
+                && trace.source == ProviderFactSourceKind::DynamicBoundary
+                && trace.provenance == Provenance::DynamicBoundary
+                && trace.confidence == Confidence::Low
+                && trace.fallback_state == ProviderFallbackState::Blocked
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn completion_compiler_shadow_records_fallback_trace_when_no_fact_candidates()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let queries = StubSemanticQueries { visible_result: vec![] };
+
+        let result = completion_visibility_shadow(
+            vec!["legacy_func".to_string()],
+            &queries,
+            FileId(1),
+            0,
+            None,
+            "legacy only",
+        );
+
+        assert_eq!(result.legacy_symbols, vec!["legacy_func".to_string()]);
+        assert!(result.receipt.fact_source_traces.iter().any(|trace| {
+            trace.surface == ProviderSurface::Completion
+                && trace.source == ProviderFactSourceKind::Fallback
+                && trace.provenance == Provenance::SearchFallback
+                && trace.confidence == Confidence::Low
+                && trace.freshness == ProviderFactFreshness::NotApplicable
+                && trace.fallback_state == ProviderFallbackState::Fallback
+        }));
         Ok(())
     }
 
@@ -1136,8 +1369,8 @@ mod tests {
             "test",
         );
 
-        // Receipt should reflect ALL visible symbols (before ranking).
-        assert_eq!(outcome.receipt.new_result.match_count, 2);
+        // DynamicUnknown blockers are traced separately instead of counted as candidates.
+        assert_eq!(outcome.receipt.new_result.match_count, 1);
         assert_eq!(outcome.receipt.query, ShadowQueryName::CompletionVisibility);
         Ok(())
     }

--- a/docs/project/status/provider_cutover.md
+++ b/docs/project/status/provider_cutover.md
@@ -11,8 +11,11 @@ fallback behavior and rollback proof.
 
 - Fact-source trace receipt wiring is in place through `ProviderFactTrace`
   entries in the semantic shadow compare receipt schema.
-- The current shadow receipt records ten fact-source traces across definition,
+- The current shadow receipt records thirteen fact-source traces across definition,
   references, completion, hover, and diagnostics surfaces.
+- Completion shadow proof now records compiler visible-symbol candidate deltas,
+  generated-member labels, and dynamic-boundary blockers without changing live
+  completion behavior.
 - Diagnostics now have a narrow live cutover for high-confidence imported and
   generated visible-symbol facts. Ambiguous, low-confidence, and
   dynamic-boundary cases remain fallback or blocked instead of being silently
@@ -25,7 +28,7 @@ fallback behavior and rollback proof.
 | Provider surface | Current state | Current source of truth | Next proof |
 | --- | --- | --- | --- |
 | Diagnostics | `partial live` | Existing semantic queries suppress selected dynamic false positives, plus high-confidence imported/generated visible-symbol facts; fallback diagnostics remain available | Broader false-positive / false-negative fixture receipts before any additional diagnostic families move live |
-| Completion | `partial live / shadowed` | Existing completion paths and semantic-shadow fixtures can use visible symbols and generated members | Provider-impact rows for compiler facts, ranking stability, and fact-source traces |
+| Completion | `partial live / shadowed` | Existing completion paths remain live; semantic-shadow fixtures trace compiler visible-symbol candidates, generated labels, rank deltas, and dynamic-boundary blockers | Ranking stability and real-workspace candidate quality before any broader live cutover |
 | Hover | `shadowed` | Hover shadow code can query visible symbols and provenance | Promote only after provenance labels, fallback behavior, and trace receipts are fixture-backed |
 | Definition / goto | `shadowed` | Definition shadow compare tracks regressions before live migration | Ranked compiler candidates with exact/static/generated/dynamic source labels |
 | References | `shadowed` | Reference shadow compare tracks regressions before live migration | Reference precision/recall fixtures from compiler facts |

--- a/docs/project/status/semantic_shadow_compare.json
+++ b/docs/project/status/semantic_shadow_compare.json
@@ -156,6 +156,115 @@
     },
     {
       "schema_version": 2,
+      "query": "completion_visibility",
+      "input": {
+        "symbol": "completion_import_candidates"
+      },
+      "old_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "legacy_helper"
+        ]
+      },
+      "new_result": {
+        "available": true,
+        "match_count": 2,
+        "identities": [
+          "imported_func",
+          "legacy_helper"
+        ]
+      },
+      "verdict": "improved",
+      "notes": [
+        "completion shadow proof: compiler visible-symbol candidate from ImportSpec/ExportSet; legacy_candidates=1; compiler_fact_candidates=2; rank_delta=+1; no_expected_legacy_candidates_removed"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Completion",
+          "source": "CompilerFact",
+          "provenance": "ImportExportInference",
+          "confidence": "High",
+          "freshness": "Fresh",
+          "fallback_state": "Shadow",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
+      ]
+    },
+    {
+      "schema_version": 2,
+      "query": "completion_visibility",
+      "input": {
+        "symbol": "completion_generated_candidates"
+      },
+      "old_result": {
+        "available": true,
+        "match_count": 0,
+        "identities": []
+      },
+      "new_result": {
+        "available": true,
+        "match_count": 1,
+        "identities": [
+          "generated_accessor"
+        ]
+      },
+      "verdict": "improved",
+      "notes": [
+        "completion shadow proof: framework-generated member is labeled as generated, not live-ranked; legacy_candidates=0; compiler_fact_candidates=1; rank_delta=+1; generated_labels=generated_accessor"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Completion",
+          "source": "FrameworkAdapter",
+          "provenance": "FrameworkSynthesis",
+          "confidence": "Medium",
+          "freshness": "Fresh",
+          "fallback_state": "Shadow",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
+      ]
+    },
+    {
+      "schema_version": 2,
+      "query": "completion_visibility",
+      "input": {
+        "symbol": "completion_dynamic_boundary"
+      },
+      "old_result": {
+        "available": true,
+        "match_count": 0,
+        "identities": []
+      },
+      "new_result": {
+        "available": true,
+        "match_count": 0,
+        "identities": []
+      },
+      "verdict": "same",
+      "notes": [
+        "completion shadow proof: dynamic-boundary hint is traced and blocked, not ranked as an ordinary completion; dynamic_boundary_blockers=symbolic_ref_candidate"
+      ],
+      "fact_source_traces": [
+        {
+          "surface": "Completion",
+          "source": "DynamicBoundary",
+          "provenance": "DynamicBoundary",
+          "confidence": "High",
+          "freshness": "Fresh",
+          "fallback_state": "Blocked",
+          "source_hash": "deterministic-fixture",
+          "anchor_id": 1,
+          "model_version": 1
+        }
+      ]
+    },
+    {
+      "schema_version": 2,
       "query": "hover",
       "input": {
         "symbol": "Foo::bar"
@@ -377,9 +486,9 @@
   ],
   "verdict_counts": {
     "ambiguous": 2,
-    "improved": 4,
+    "improved": 6,
     "regression": 1,
-    "same": 2,
+    "same": 3,
     "unavailable": 1
   },
   "release_readiness_verdict_counts": {
@@ -391,9 +500,9 @@
   },
   "schema_fixture_verdict_counts": {
     "ambiguous": 2,
-    "improved": 3,
+    "improved": 5,
     "regression": 1,
-    "same": 1,
+    "same": 2,
     "unavailable": 1
   },
   "notes": "0.13.2 semantic shadow proof: release-readiness counts include provider-gating receipts only; schema fixture receipts exercise non-gating verdict shapes."

--- a/docs/project/status/semantic_shadow_compare.md
+++ b/docs/project/status/semantic_shadow_compare.md
@@ -2,16 +2,16 @@
 
 Measured: `deterministic-fixture-baseline`
 
-Receipts: `10`
+Receipts: `13`
 
 ## Verdict Counts
 
 | Verdict | Count |
 |---|---:|
 | ambiguous | 2 |
-| improved | 4 |
+| improved | 6 |
 | regression | 1 |
-| same | 2 |
+| same | 3 |
 | unavailable | 1 |
 
 ## Release-Readiness Verdict Counts
@@ -29,9 +29,9 @@ Receipts: `10`
 | Verdict | Count |
 |---|---:|
 | ambiguous | 2 |
-| improved | 3 |
+| improved | 5 |
 | regression | 1 |
-| same | 1 |
+| same | 2 |
 | unavailable | 1 |
 
 ## Receipts
@@ -42,6 +42,9 @@ Receipts: `10`
 | release-readiness | FindReferences | `Foo::bar` | improved | 1 | 2 |
 | schema-fixture | CountUsages | `Foo::bar` | regression | 4 | 3 |
 | schema-fixture | VisibleSymbols | `Foo::bar` | ambiguous | 2 | 2 |
+| schema-fixture | CompletionVisibility | `completion_import_candidates` | improved | 1 | 2 |
+| schema-fixture | CompletionVisibility | `completion_generated_candidates` | improved | 0 | 1 |
+| schema-fixture | CompletionVisibility | `completion_dynamic_boundary` | same | 0 | 0 |
 | schema-fixture | Hover | `Foo::bar` | unavailable | 0 | 1 |
 | schema-fixture | DiagnosticsCheck | `imported_func` | improved | 0 | 1 |
 | schema-fixture | DiagnosticsCheck | `generated_accessor` | improved | 0 | 1 |
@@ -57,6 +60,9 @@ Receipts: `10`
 | release-readiness | FindReferences | References | SemanticFact | SemanticAnalyzer | High | Fresh | Shadow |
 | schema-fixture | CountUsages | References | SemanticFact | SemanticAnalyzer | Medium | Fresh | Shadow |
 | schema-fixture | VisibleSymbols | Completion | CompilerFact | ImportExportInference | Medium | Fresh | Shadow |
+| schema-fixture | CompletionVisibility | Completion | CompilerFact | ImportExportInference | High | Fresh | Shadow |
+| schema-fixture | CompletionVisibility | Completion | FrameworkAdapter | FrameworkSynthesis | Medium | Fresh | Shadow |
+| schema-fixture | CompletionVisibility | Completion | DynamicBoundary | DynamicBoundary | High | Fresh | Blocked |
 | schema-fixture | Hover | Hover | Fallback | SearchFallback | Low | NotApplicable | Unavailable |
 | schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | High | Fresh | Primary |
 | schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | FrameworkSynthesis | High | Fresh | Primary |

--- a/xtask/src/tasks/semantic_shadow_compare.rs
+++ b/xtask/src/tasks/semantic_shadow_compare.rs
@@ -113,6 +113,51 @@ fn build_artifact() -> Artifact {
             )],
         ),
         receipt_from_identities(
+            ShadowQueryName::CompletionVisibility,
+            "completion_import_candidates",
+            Some(vec!["legacy_helper"]),
+            Some(vec!["legacy_helper", "imported_func"]),
+            "completion shadow proof: compiler visible-symbol candidate from ImportSpec/ExportSet; legacy_candidates=1; compiler_fact_candidates=2; rank_delta=+1; no_expected_legacy_candidates_removed",
+            vec![trace(
+                ProviderSurface::Completion,
+                ProviderFactSourceKind::CompilerFact,
+                Provenance::ImportExportInference,
+                Confidence::High,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Shadow,
+            )],
+        ),
+        receipt_from_identities(
+            ShadowQueryName::CompletionVisibility,
+            "completion_generated_candidates",
+            Some(vec![]),
+            Some(vec!["generated_accessor"]),
+            "completion shadow proof: framework-generated member is labeled as generated, not live-ranked; legacy_candidates=0; compiler_fact_candidates=1; rank_delta=+1; generated_labels=generated_accessor",
+            vec![trace(
+                ProviderSurface::Completion,
+                ProviderFactSourceKind::FrameworkAdapter,
+                Provenance::FrameworkSynthesis,
+                Confidence::Medium,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Shadow,
+            )],
+        ),
+        receipt_from_identities(
+            ShadowQueryName::CompletionVisibility,
+            "completion_dynamic_boundary",
+            Some(vec![]),
+            Some(vec![]),
+            "completion shadow proof: dynamic-boundary hint is traced and blocked, not ranked as an ordinary completion; dynamic_boundary_blockers=symbolic_ref_candidate",
+            vec![trace(
+                ProviderSurface::Completion,
+                ProviderFactSourceKind::DynamicBoundary,
+                Provenance::DynamicBoundary,
+                Confidence::High,
+                ProviderFactFreshness::Fresh,
+                ProviderFallbackState::Blocked,
+            )],
+        ),
+        receipt_from_identities(
             ShadowQueryName::Hover,
             "Foo::bar",
             None,
@@ -417,8 +462,8 @@ mod tests {
     fn artifact_includes_required_verdict_rows() {
         let artifact = build_artifact();
         assert_eq!(artifact.schema_version, 3);
-        assert_eq!(artifact.verdict_counts.get("same"), Some(&2));
-        assert_eq!(artifact.verdict_counts.get("improved"), Some(&4));
+        assert_eq!(artifact.verdict_counts.get("same"), Some(&3));
+        assert_eq!(artifact.verdict_counts.get("improved"), Some(&6));
         assert_eq!(artifact.verdict_counts.get("regression"), Some(&1));
         assert_eq!(artifact.verdict_counts.get("ambiguous"), Some(&2));
         assert_eq!(artifact.verdict_counts.get("unavailable"), Some(&1));
@@ -426,8 +471,8 @@ mod tests {
         assert_eq!(artifact.release_readiness_verdict_counts.get("improved"), Some(&1));
         assert_eq!(artifact.release_readiness_verdict_counts.get("regression"), Some(&0));
         assert_eq!(artifact.release_readiness_verdict_counts.get("unavailable"), Some(&0));
-        assert_eq!(artifact.schema_fixture_verdict_counts.get("same"), Some(&1));
-        assert_eq!(artifact.schema_fixture_verdict_counts.get("improved"), Some(&3));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("same"), Some(&2));
+        assert_eq!(artifact.schema_fixture_verdict_counts.get("improved"), Some(&5));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("regression"), Some(&1));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("ambiguous"), Some(&2));
         assert_eq!(artifact.schema_fixture_verdict_counts.get("unavailable"), Some(&1));
@@ -452,8 +497,14 @@ mod tests {
         assert!(markdown.contains("## Schema Fixture Verdict Counts"));
         assert!(markdown.contains("| release-readiness | FindDefinition"));
         assert!(markdown.contains("| schema-fixture | CountUsages"));
+        assert!(markdown.contains("| schema-fixture | CompletionVisibility | `completion_import_candidates` | improved | 1 | 2 |"));
+        assert!(markdown.contains("| schema-fixture | CompletionVisibility | `completion_generated_candidates` | improved | 0 | 1 |"));
+        assert!(markdown.contains("| schema-fixture | CompletionVisibility | `completion_dynamic_boundary` | same | 0 | 0 |"));
         assert!(markdown.contains("## Fact Source Traces"));
         assert!(markdown.contains("| release-readiness | FindDefinition | Definition | CompilerFact | SemanticAnalyzer | High | Fresh | Shadow |"));
+        assert!(markdown.contains("| schema-fixture | CompletionVisibility | Completion | CompilerFact | ImportExportInference | High | Fresh | Shadow |"));
+        assert!(markdown.contains("| schema-fixture | CompletionVisibility | Completion | FrameworkAdapter | FrameworkSynthesis | Medium | Fresh | Shadow |"));
+        assert!(markdown.contains("| schema-fixture | CompletionVisibility | Completion | DynamicBoundary | DynamicBoundary | High | Fresh | Blocked |"));
         assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | High | Fresh | Primary |"));
         assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | FrameworkSynthesis | High | Fresh | Primary |"));
         assert!(markdown.contains("| schema-fixture | DiagnosticsCheck | Diagnostics | CompilerFact | ImportExportInference | Low | Fresh | Fallback |"));


### PR DESCRIPTION
Problem: Completion provider cutover needs shadow proof for compiler visible-symbol candidates before any live behavior change.
Fix: Add completion shadow fact-source traces, candidate delta notes, generated-label proof, and dynamic-boundary blocker receipts; refresh semantic shadow/provider status artifacts.
Verification:
- `cargo test -p perl-lsp-rs-core --profile agent --locked completion_compiler_shadow -- --nocapture`
- `cargo test -p xtask semantic_shadow_compare --profile agent --locked -- --nocapture`
- `cargo xtask semantic-shadow-compare --check`
- `cargo xtask semantic-scorecard --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `cargo clippy -p perl-lsp-rs-core -p xtask --profile agent --locked -- -D warnings -A missing_docs`
- `git diff --check`

Closes #8322.