### PR TITLE
feat(critic): add stale dollar-at native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -17,7 +17,7 @@ pub use native::{
     CriticSuppressionScope, CriticTextEdit, DeprecatedDefinedRule, DuplicateLexicalDeclarationRule,
     DuplicateParameterRule, FixSafety, NativeCriticRegistry, ParameterShadowsGlobalRule,
     PrintfFormatArityRule, RequireUseStrictRule, RequireUseWarningsRule,
-    ShadowedLexicalVariableRule, UndefComparisonRule, UnusedLexicalVariableRule,
+    ShadowedLexicalVariableRule, StaleDollarAtRule, UndefComparisonRule, UnusedLexicalVariableRule,
     UnusedParameterRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -241,6 +241,7 @@ impl NativeCriticRegistry {
             Box::new(PrintfFormatArityRule),
             Box::new(DeprecatedDefinedRule),
             Box::new(UndefComparisonRule),
+            Box::new(StaleDollarAtRule),
             Box::new(BarewordFilehandleRule),
             Box::new(TwoArgOpenRule),
             Box::new(PipeOpenRule),
@@ -544,6 +545,32 @@ impl CriticRule for UndefComparisonRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_undef_comparison_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports unlocalized `$@` checks after block `eval`.
+///
+/// Checking `$@` after `eval` without localizing it can observe a stale or
+/// clobbered error value. This rule starts with the parser-confirmed
+/// `eval { ... }; if ($@) { ... }` family and leaves broader exception-flow
+/// analysis for later semantic rule slices.
+pub struct StaleDollarAtRule;
+
+impl CriticRule for StaleDollarAtRule {
+    fn id(&self) -> &'static str {
+        "native.common.stale_dollar_at"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Syntax
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_stale_dollar_at_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -1211,6 +1238,32 @@ fn undef_comparison_finding(
     }
 }
 
+fn stale_dollar_at_finding(
+    rule: &StaleDollarAtRule,
+    source: &str,
+    eval_node: &Node,
+    dollar_at_node: &Node,
+) -> CriticFinding {
+    let range =
+        range_for_byte_span(source, dollar_at_node.location.start, dollar_at_node.location.end);
+    let eval_range = range_for_byte_span(source, eval_node.location.start, eval_node.location.end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: "Checking $@ after eval can observe a stale error".to_string(),
+        explanation: "The $@ variable is global and can retain or be clobbered by unrelated exception handling. Localize $@ around eval, or check the eval return value before inspecting the error.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: vec![CriticRelatedInformation {
+            range: eval_range,
+            message: "This eval should localize $@ or have its return value checked.".to_string(),
+        }],
+        fix: None,
+    }
+}
+
 fn bareword_filehandle_finding(
     rule: &BarewordFilehandleRule,
     source: &str,
@@ -1569,6 +1622,93 @@ fn collect_undef_comparison_findings(
     for child in node.children() {
         collect_undef_comparison_findings(rule, source, child, out);
     }
+}
+
+fn collect_stale_dollar_at_findings(
+    rule: &StaleDollarAtRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    match &node.kind {
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            collect_stale_dollar_at_in_statements(rule, source, statements, out);
+        }
+        _ => {}
+    }
+
+    for child in node.children() {
+        collect_stale_dollar_at_findings(rule, source, child, out);
+    }
+}
+
+fn collect_stale_dollar_at_in_statements(
+    rule: &StaleDollarAtRule,
+    source: &str,
+    statements: &[Node],
+    out: &mut Vec<CriticFinding>,
+) {
+    for (idx, statement) in statements.iter().enumerate() {
+        let Some(eval_node) = eval_statement_node(statement) else {
+            continue;
+        };
+        if idx > 0 && localizes_dollar_at(&statements[idx - 1]) {
+            continue;
+        }
+        let Some(next_statement) = statements.get(idx + 1) else {
+            continue;
+        };
+        if let Some(dollar_at) = condition_dollar_at_read(next_statement) {
+            out.push(stale_dollar_at_finding(rule, source, eval_node, dollar_at));
+        }
+    }
+}
+
+fn eval_statement_node(statement: &Node) -> Option<&Node> {
+    match &statement.kind {
+        NodeKind::ExpressionStatement { expression }
+            if matches!(&expression.kind, NodeKind::Eval { .. }) =>
+        {
+            Some(expression)
+        }
+        NodeKind::Eval { .. } => Some(statement),
+        _ => None,
+    }
+}
+
+fn localizes_dollar_at(statement: &Node) -> bool {
+    match &statement.kind {
+        NodeKind::VariableDeclaration { declarator, variable, .. } if declarator == "local" => {
+            is_dollar_at_variable(variable)
+        }
+        NodeKind::ExpressionStatement { expression } => localizes_dollar_at(expression),
+        _ => false,
+    }
+}
+
+fn condition_dollar_at_read(statement: &Node) -> Option<&Node> {
+    match &statement.kind {
+        NodeKind::If { condition, .. } | NodeKind::While { condition, .. } => {
+            first_dollar_at_variable(condition)
+        }
+        NodeKind::StatementModifier { condition, .. } => first_dollar_at_variable(condition),
+        _ => None,
+    }
+}
+
+fn first_dollar_at_variable(node: &Node) -> Option<&Node> {
+    if is_dollar_at_variable(node) {
+        return Some(node);
+    }
+
+    node.children().into_iter().find_map(first_dollar_at_variable)
+}
+
+fn is_dollar_at_variable(node: &Node) -> bool {
+    matches!(
+        &node.kind,
+        NodeKind::Variable { sigil, name } if sigil == "$" && name == "@"
+    )
 }
 
 fn push_printf_format_arity_finding(
@@ -2901,6 +3041,98 @@ mod tests {
     }
 
     #[test]
+    fn native_stale_dollar_at_rule_reports_if_check_after_unlocalized_eval() {
+        let source = "use strict;\nuse warnings;\neval { risky_call(); };\nif ($@) { warn $@; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StaleDollarAtRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.common.stale_dollar_at");
+        assert_eq!(finding.category, CriticCategory::Syntax);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Checking $@ after eval can observe a stale error");
+        assert_eq!(finding.suppression_key, "native.common.stale_dollar_at");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "$@");
+        assert_eq!(finding.related.len(), 1);
+        assert!(finding.fix.is_none());
+    }
+
+    #[test]
+    fn native_stale_dollar_at_rule_reports_statement_modifier_after_unlocalized_eval() {
+        let source = "use strict;\nuse warnings;\neval { risky_call(); };\nwarn $@ if $@;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StaleDollarAtRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "native.common.stale_dollar_at");
+        assert_eq!(&source[findings[0].range.start.byte..findings[0].range.end.byte], "$@");
+    }
+
+    #[test]
+    fn native_stale_dollar_at_rule_accepts_localized_or_return_checked_eval() {
+        let source = "use strict;\nuse warnings;\n{\nlocal $@;\neval { risky_call(); };\nif ($@) { warn $@; }\n}\nmy $ok = eval { risky_call(); };\nif (!$ok) { warn 'failed'; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StaleDollarAtRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "localized $@ and eval return checks should be accepted");
+    }
+
+    #[test]
+    fn native_stale_dollar_at_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\neval { risky_call(); };\nif ($@) { warn $@; }\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.common.stale_dollar_at".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StaleDollarAtRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.common.stale_dollar_at -- legacy eval\nuse strict;\nuse warnings;\neval { risky_call(); };\nif ($@) { warn $@; }\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_stale_dollar_at_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\neval { risky_call(); };\nif ($@) { warn $@; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(StaleDollarAtRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.common.stale_dollar_at");
+        assert_eq!(violations[0].description, "Checking $@ after eval can observe a stale error");
+        assert_eq!(
+            violations[0].explanation,
+            "The $@ variable is global and can retain or be clobbered by unrelated exception handling. Localize $@ around eval, or check the eval return value before inspecting the error."
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_bareword_filehandle_rule_reports_open_bareword() {
         let source = "use strict;\nuse warnings;\nopen(FH, '<', 'file.txt');\n";
         let ast = parse_source(source);
@@ -3668,6 +3900,7 @@ mod tests {
                 "native.common.printf_format_arity",
                 "native.common.deprecated_defined",
                 "native.common.undef_comparison",
+                "native.common.stale_dollar_at",
                 "native.io.bareword_filehandle",
                 "native.io.two_arg_open",
                 "native.io.pipe_open",

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1353,7 +1353,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nif ($path == undef) { print $path; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
             None,
             &context,
             None,
@@ -1466,6 +1466,25 @@ mod tests {
         assert_eq!(data["code"], "native.common.undef_comparison");
         assert_eq!(data["suppressionKey"], "native.common.undef_comparison");
         assert_eq!(data["fixable"], true);
+
+        let stale_dollar_at = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.common.stale_dollar_at"),
+                )
+            })
+            .ok_or("expected native stale-dollar-at finding")?;
+        assert_eq!(stale_dollar_at.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(stale_dollar_at.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(stale_dollar_at.message, "Checking $@ after eval can observe a stale error");
+        let data = stale_dollar_at
+            .data
+            .as_ref()
+            .ok_or("native stale-dollar-at data should be populated")?;
+        assert_eq!(data["code"], "native.common.stale_dollar_at");
+        assert_eq!(data["suppressionKey"], "native.common.stale_dollar_at");
+        assert_eq!(data["fixable"], false);
 
         let bareword_filehandle = items
             .iter()

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1838,7 +1838,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
                 }
             })))
             .unwrap();
@@ -1872,6 +1872,14 @@ mod tests {
         assert!(
             text.contains("Using '==' with undef -- use defined() to check first"),
             "native undef-comparison finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.common.stale_dollar_at"),
+            "native critic engine should publish native stale-dollar-at finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Checking $@ after eval can observe a stale error"),
+            "native stale-dollar-at finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.io.bareword_filehandle"),
@@ -2037,7 +2045,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
             }
         })))?;
 
@@ -2086,6 +2094,15 @@ mod tests {
                         == Some("Using '==' with undef -- use defined() to check first")
             }),
             "native critic engine should add native undef-comparison finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.common.stale_dollar_at")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Checking $@ after eval can observe a stale error")
+            }),
+            "native critic engine should add native stale-dollar-at finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -14,13 +14,13 @@
 
 | Metric | Value |
 | --- | ---: |
-| Native rule count | 20 |
-| Rules with suppressions | 20 |
+| Native rule count | 21 |
+| Rules with suppressions | 21 |
 | Rules with fixes | 13 |
-| Pull diagnostics coverage | 20 |
-| Push diagnostics coverage | 20 |
-| Workspace diagnostics coverage | 20 |
-| Violation bridge coverage | 20 |
+| Pull diagnostics coverage | 21 |
+| Push diagnostics coverage | 21 |
+| Workspace diagnostics coverage | 21 |
+| Violation bridge coverage | 21 |
 
 Native rules:
 - `native.testing.require_use_strict`
@@ -29,6 +29,7 @@ Native rules:
 - `native.common.printf_format_arity`
 - `native.common.deprecated_defined`
 - `native.common.undef_comparison`
+- `native.common.stale_dollar_at`
 - `native.io.bareword_filehandle`
 - `native.io.two_arg_open`
 - `native.io.pipe_open`


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.common.stale_dollar_at` for parser-confirmed block `eval` followed by an unlocalized `$@` condition check.

The rule stays intentionally narrow:
- reports `eval { ... }; if ($@) { ... }` and statement-modifier `$@` checks
- accepts `local $@` before the eval and eval-return checks
- routes through native critic config filtering, suppressions, violation bridge, pull diagnostics, push diagnostics, and workspace diagnostics
- records the new rule in the native-tooling status report
- leaves legacy/default critic behavior unchanged
- does not add a quick fix because stale `$@` remediation depends on user intent

## Proof packet

Changed surfaces:
- native critic registry/rule engine
- LSP pull/push/workspace diagnostics
- native-tooling status docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_stale --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `git diff --check`

Note: `just status-check` still reports unrelated generated-status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR updates only `docs/project/status/native_tooling.md`, which was regenerated by `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`.
