### PR TITLE
feat(critic): add unreachable-code native rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -264,7 +264,9 @@ impl CodeActionsProvider {
                         actions.extend(quick_fixes::fix_misspelled_pragma(&self.source, &qf_diag));
                     }
                     // PL406: Unreachable code
-                    c if c == DiagnosticCode::UnreachableCode.as_str() => {
+                    c if c == DiagnosticCode::UnreachableCode.as_str()
+                        || c == "native.common.unreachable_code" =>
+                    {
                         actions.extend(quick_fixes::fix_unreachable_code(&self.source, &qf_diag));
                     }
                     // PL300: Duplicate subroutine
@@ -402,6 +404,32 @@ mod tests {
         assert!(
             actions.iter().any(|a| a.title == "Keep assignment (add parentheses)"),
             "Expected native critic alias to offer intentional-assignment fix, got: {:?}",
+            actions
+        );
+    }
+
+    #[test]
+    fn test_native_unreachable_code_alias_produces_quick_fix() {
+        let source = "sub f {\nreturn 1;\nmy $dead = 2;\n}\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let start = source.find("my $dead").expect("dead statement start");
+        let end = start + "my $dead = 2;".len();
+        let diagnostics = vec![make_diagnostic(
+            start,
+            end,
+            "native.common.unreachable_code",
+            "Unreachable code: this statement cannot be executed",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(
+            actions.iter().any(|action| action.title == "Remove unreachable code"
+                && action.edit.changes.iter().any(|edit| edit.new_text.is_empty()
+                    && &source[edit.location.start..edit.location.end] == "my $dead = 2;\n")),
+            "Expected native unreachable-code alias to remove dead line, got: {:?}",
             actions
         );
     }

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -17,8 +17,8 @@ pub use native::{
     CriticSuppressionScope, CriticTextEdit, DeprecatedDefinedRule, DuplicateLexicalDeclarationRule,
     DuplicateParameterRule, FixSafety, NativeCriticRegistry, ParameterShadowsGlobalRule,
     PrintfFormatArityRule, RequireUseStrictRule, RequireUseWarningsRule,
-    ShadowedLexicalVariableRule, StaleDollarAtRule, UndefComparisonRule, UnusedLexicalVariableRule,
-    UnusedParameterRule,
+    ShadowedLexicalVariableRule, StaleDollarAtRule, UndefComparisonRule, UnreachableCodeRule,
+    UnusedLexicalVariableRule, UnusedParameterRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -6,6 +6,7 @@
 //! migrate rule-by-rule without changing runtime behavior in one large step.
 
 use super::{CriticConfig, Severity, Violation, insertion_range};
+use crate::providers::diagnostics::unreachable_code::check_unreachable_code;
 use perl_parser_core::Node;
 use perl_parser_core::NodeKind;
 use perl_parser_core::position::{Position, Range};
@@ -242,6 +243,7 @@ impl NativeCriticRegistry {
             Box::new(DeprecatedDefinedRule),
             Box::new(UndefComparisonRule),
             Box::new(StaleDollarAtRule),
+            Box::new(UnreachableCodeRule),
             Box::new(BarewordFilehandleRule),
             Box::new(TwoArgOpenRule),
             Box::new(PipeOpenRule),
@@ -571,6 +573,30 @@ impl CriticRule for StaleDollarAtRule {
 
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
         collect_stale_dollar_at_findings(self, ctx.source, ctx.ast, out);
+    }
+}
+
+/// Native rule that reports unreachable statements after unconditional exits.
+///
+/// This delegates reachability to the existing PL406 analysis so the native
+/// critic path and built-in diagnostic path share the same control-flow model.
+pub struct UnreachableCodeRule;
+
+impl CriticRule for UnreachableCodeRule {
+    fn id(&self) -> &'static str {
+        "native.common.unreachable_code"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Maintainability
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        collect_unreachable_code_findings(self, ctx.source, ctx.ast, out);
     }
 }
 
@@ -1264,6 +1290,32 @@ fn stale_dollar_at_finding(
     }
 }
 
+fn unreachable_code_finding(
+    rule: &UnreachableCodeRule,
+    source: &str,
+    start: usize,
+    end: usize,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, start, end);
+    let removal_range = full_line_range_for_byte_span(source, start, end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: "Unreachable code: this statement cannot be executed".to_string(),
+        explanation: "This statement follows an unconditional control-flow exit such as return, die, exit, last, next, redo, croak, or confess. Remove it or move it before the exit if it is still needed.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: "Remove unreachable code".to_string(),
+            safety: FixSafety::Safe,
+            edits: vec![CriticTextEdit { range: removal_range, new_text: String::new() }],
+        }),
+    }
+}
+
 fn bareword_filehandle_finding(
     rule: &BarewordFilehandleRule,
     source: &str,
@@ -1642,6 +1694,19 @@ fn collect_stale_dollar_at_findings(
     }
 }
 
+fn collect_unreachable_code_findings(
+    rule: &UnreachableCodeRule,
+    source: &str,
+    node: &Node,
+    out: &mut Vec<CriticFinding>,
+) {
+    let mut diagnostics = Vec::new();
+    check_unreachable_code(node, &mut diagnostics);
+    out.extend(diagnostics.into_iter().map(|diagnostic| {
+        unreachable_code_finding(rule, source, diagnostic.range.0, diagnostic.range.1)
+    }));
+}
+
 fn collect_stale_dollar_at_in_statements(
     rule: &StaleDollarAtRule,
     source: &str,
@@ -1709,6 +1774,12 @@ fn is_dollar_at_variable(node: &Node) -> bool {
         &node.kind,
         NodeKind::Variable { sigil, name } if sigil == "$" && name == "@"
     )
+}
+
+fn full_line_range_for_byte_span(source: &str, start: usize, end: usize) -> Range {
+    let line_start = source[..start].rfind('\n').map_or(0, |pos| pos + 1);
+    let line_end = source[end..].find('\n').map_or(source.len(), |pos| end + pos + 1);
+    range_for_byte_span(source, line_start, line_end)
 }
 
 fn push_printf_format_arity_finding(
@@ -3133,6 +3204,88 @@ mod tests {
     }
 
     #[test]
+    fn native_unreachable_code_rule_reports_dead_statement_after_return() {
+        let source = "use strict;\nuse warnings;\nsub f {\nreturn 1;\nmy $dead = 2;\n}\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnreachableCodeRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.common.unreachable_code");
+        assert_eq!(finding.category, CriticCategory::Maintainability);
+        assert_eq!(finding.severity, Severity::Harsh);
+        assert_eq!(finding.message, "Unreachable code: this statement cannot be executed");
+        assert_eq!(finding.suppression_key, "native.common.unreachable_code");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "my $dead");
+        let fix = finding.fix.as_ref().expect("unreachable code should offer removal fix");
+        assert_eq!(fix.title, "Remove unreachable code");
+        assert_eq!(fix.safety, FixSafety::Safe);
+        assert_eq!(
+            &source[fix.edits[0].range.start.byte..fix.edits[0].range.end.byte],
+            "my $dead = 2;\n"
+        );
+        assert_eq!(fix.edits[0].new_text, "");
+    }
+
+    #[test]
+    fn native_unreachable_code_rule_accepts_conditional_return_and_eval_die() {
+        let source = "use strict;\nuse warnings;\nsub f {\nreturn if $cond;\nmy $live = 1;\neval { die 'caught'; };\nmy $after_eval = 2;\nreturn $live + $after_eval;\n}\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnreachableCodeRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "conditional return and caught eval die should be accepted");
+    }
+
+    #[test]
+    fn native_unreachable_code_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nsub f {\nreturn 1;\nmy $dead = 2;\n}\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.common.unreachable_code".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnreachableCodeRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.common.unreachable_code -- generated dead branch\nuse strict;\nuse warnings;\nsub f {\nreturn 1;\nmy $dead = 2;\n}\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_unreachable_code_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nsub f {\nreturn 1;\nmy $dead = 2;\n}\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnreachableCodeRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.common.unreachable_code");
+        assert_eq!(
+            violations[0].description,
+            "Unreachable code: this statement cannot be executed"
+        );
+        assert_eq!(violations[0].severity, Severity::Harsh);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_bareword_filehandle_rule_reports_open_bareword() {
         let source = "use strict;\nuse warnings;\nopen(FH, '<', 'file.txt');\n";
         let ast = parse_source(source);
@@ -3901,6 +4054,7 @@ mod tests {
                 "native.common.deprecated_defined",
                 "native.common.undef_comparison",
                 "native.common.stale_dollar_at",
+                "native.common.unreachable_code",
                 "native.io.bareword_filehandle",
                 "native.io.two_arg_open",
                 "native.io.pipe_open",

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1115,6 +1115,7 @@ fn is_fixable_diagnostic(code: &str) -> bool {
             | "native.testing.require_use_warnings"
             | "native.common.deprecated_defined"
             | "native.common.undef_comparison"
+            | "native.common.unreachable_code"
             | "native.io.bareword_filehandle"
             | "native.io.two_arg_open"
             | "InputOutput::ProhibitBarewordFileHandles"
@@ -1353,7 +1354,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nsub unreachable_helper { return 1; my $dead_after_return = 2; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
             None,
             &context,
             None,
@@ -1485,6 +1486,25 @@ mod tests {
         assert_eq!(data["code"], "native.common.stale_dollar_at");
         assert_eq!(data["suppressionKey"], "native.common.stale_dollar_at");
         assert_eq!(data["fixable"], false);
+
+        let unreachable_code = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.common.unreachable_code"),
+                )
+            })
+            .ok_or("expected native unreachable-code finding")?;
+        assert_eq!(unreachable_code.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(unreachable_code.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(unreachable_code.message, "Unreachable code: this statement cannot be executed");
+        let data = unreachable_code
+            .data
+            .as_ref()
+            .ok_or("native unreachable-code data should be populated")?;
+        assert_eq!(data["code"], "native.common.unreachable_code");
+        assert_eq!(data["suppressionKey"], "native.common.unreachable_code");
+        assert_eq!(data["fixable"], true);
 
         let bareword_filehandle = items
             .iter()
@@ -1633,6 +1653,7 @@ mod tests {
                 diag.code
                     .as_ref()
                     .is_some_and(|code| matches!(code, NumberOrString::String(value) if value == "native.variables.unused_lexical"))
+                    && diag.message == "Lexical variable '$unused' is declared but never used"
             })
             .ok_or("expected native unused lexical finding")?;
         assert_eq!(unused.source.as_deref(), Some("perl-lsp-critic"));

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -1838,7 +1838,7 @@ mod tests {
                     "uri": uri,
                     "languageId": "perl",
                     "version": 1,
-                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
+                    "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nsub unreachable_helper { return 1; my $dead_after_return = 2; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
                 }
             })))
             .unwrap();
@@ -1880,6 +1880,14 @@ mod tests {
         assert!(
             text.contains("Checking $@ after eval can observe a stale error"),
             "native stale-dollar-at finding should preserve rule message; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.common.unreachable_code"),
+            "native critic engine should publish native unreachable-code finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("Unreachable code: this statement cannot be executed"),
+            "native unreachable-code finding should preserve rule message; got: {text:?}"
         );
         assert!(
             text.contains("native.io.bareword_filehandle"),
@@ -2045,7 +2053,7 @@ mod tests {
                 "uri": uri,
                 "languageId": "perl",
                 "version": 1,
-                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
+                "text": "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nsub unreachable_helper { return 1; my $dead_after_return = 2; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n"
             }
         })))?;
 
@@ -2103,6 +2111,15 @@ mod tests {
                         == Some("Checking $@ after eval can observe a stale error")
             }),
             "native critic engine should add native stale-dollar-at finding to workspace diagnostics: {report}"
+        );
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag["code"].as_str() == Some("native.common.unreachable_code")
+                    && diag["source"].as_str() == Some("perl-lsp-critic")
+                    && diag["message"].as_str()
+                        == Some("Unreachable code: this statement cannot be executed")
+            }),
+            "native critic engine should add native unreachable-code finding to workspace diagnostics: {report}"
         );
         assert!(
             diagnostics.iter().any(|diag| {

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -14,13 +14,13 @@
 
 | Metric | Value |
 | --- | ---: |
-| Native rule count | 21 |
-| Rules with suppressions | 21 |
-| Rules with fixes | 13 |
-| Pull diagnostics coverage | 21 |
-| Push diagnostics coverage | 21 |
-| Workspace diagnostics coverage | 21 |
-| Violation bridge coverage | 21 |
+| Native rule count | 22 |
+| Rules with suppressions | 22 |
+| Rules with fixes | 14 |
+| Pull diagnostics coverage | 22 |
+| Push diagnostics coverage | 22 |
+| Workspace diagnostics coverage | 22 |
+| Violation bridge coverage | 22 |
 
 Native rules:
 - `native.testing.require_use_strict`
@@ -30,6 +30,7 @@ Native rules:
 - `native.common.deprecated_defined`
 - `native.common.undef_comparison`
 - `native.common.stale_dollar_at`
+- `native.common.unreachable_code`
 - `native.io.bareword_filehandle`
 - `native.io.two_arg_open`
 - `native.io.pipe_open`
@@ -49,6 +50,7 @@ Fixable native rules:
 - `native.common.assignment_in_condition`
 - `native.common.deprecated_defined`
 - `native.common.undef_comparison`
+- `native.common.unreachable_code`
 - `native.io.bareword_filehandle`
 - `native.io.two_arg_open`
 - `native.testing.require_use_strict`

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -206,6 +206,7 @@ fn fixable_rule_ids() -> BTreeSet<String> {
         "native.common.assignment_in_condition",
         "native.common.deprecated_defined",
         "native.common.undef_comparison",
+        "native.common.unreachable_code",
         "native.io.bareword_filehandle",
         "native.io.two_arg_open",
         "native.testing.require_use_strict",


### PR DESCRIPTION
## Summary

Adds the opt-in native critic rule `native.common.unreachable_code` by delegating to the existing PL406 unreachable-code analysis, so native critic and built-in diagnostics share the same control-flow model.

The rule is routed through the native registry, include/exclude/severity filtering, suppressions, the legacy violation bridge, pull diagnostics, push/workspace diagnostics, and the existing unreachable-code quick-fix path. Native critic remains explicit opt-in; legacy/default critic behavior is unchanged.

Also updates the native-tooling status report from 21 to 22 native critic rules, and from 13 to 14 fixable rules.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_unreachable --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Note: `just status-check` was also tried because the DevEx planner flags generated status docs. It failed on unrelated generated status pages (`docs/project/status/tests.md`, `parser.md`, `quality.md`, `dap.md`) and was not included in this scoped PR.
