### PR TITLE
feat(format): add simple foreach block layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -717,6 +717,10 @@ fn format_simple_control_block_tokens(
 ) -> Option<String> {
     use perl_parser_core::TokenKind;
 
+    if let Some(formatted) = format_simple_foreach_block_tokens(tokens, indent, config) {
+        return Some(formatted);
+    }
+
     if tokens.len() < 6 {
         return None;
     }
@@ -764,6 +768,61 @@ fn format_simple_control_block_tokens(
         formatted.push_str(&render_simple_else_doc(&else_statements, indent, &body_indent, config));
     }
     Some(formatted)
+}
+
+fn format_simple_foreach_block_tokens(
+    tokens: &[perl_parser_core::Token],
+    indent: &str,
+    config: &FormatConfig,
+) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    let keyword = match tokens.first()?.kind {
+        TokenKind::For => "for",
+        TokenKind::Foreach => "foreach",
+        _ => return None,
+    };
+
+    let mut index = 1;
+    let iterator =
+        if matches!(tokens.get(index)?.kind, TokenKind::My | TokenKind::Our | TokenKind::State) {
+            let lexical = tokens[index].text.as_ref();
+            let (variable, next_index) = format_variable_tokens(tokens, index + 1)?;
+            index = next_index;
+            format!("{lexical} {variable}")
+        } else {
+            let (variable, next_index) = format_variable_tokens(tokens, index)?;
+            index = next_index;
+            variable
+        };
+
+    if tokens.get(index)?.kind != TokenKind::LeftParen {
+        return None;
+    }
+    let list_start = index + 1;
+    let list_end = tokens[list_start..]
+        .iter()
+        .position(|token| token.kind == TokenKind::RightParen)
+        .map(|offset| list_start + offset)?;
+    let list = format_simple_expression_tokens(tokens, list_start, list_end, config, 0)?;
+
+    if tokens.get(list_end)?.kind != TokenKind::RightParen
+        || tokens.get(list_end + 1)?.kind != TokenKind::LeftBrace
+        || tokens.last()?.kind != TokenKind::RightBrace
+    {
+        return None;
+    }
+
+    let body_tokens = &tokens[list_end + 2..tokens.len() - 1];
+    let statements = format_simple_statement_block(body_tokens, config)?;
+    let body_indent = format!("{indent}{}", indent_unit(config));
+    Some(render_simple_block_doc(
+        format!("{indent}{keyword} {iterator} ({list}) {{"),
+        &statements,
+        indent,
+        &body_indent,
+        config,
+    ))
 }
 
 fn render_simple_block_doc(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_foreach_blocks.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_foreach_blocks.expected.pl
@@ -1,0 +1,6 @@
+foreach my $item (@items) {
+    return $item;
+}
+for $item (@items) {
+    return $item;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_foreach_blocks.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_foreach_blocks.pl
@@ -1,0 +1,2 @@
+foreach my$item(@items){return$item;}
+for$item(@items){return$item;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -539,6 +539,30 @@ fn native_formatter_expands_simple_until_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_foreach_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "foreach my$item(@items){return$item;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "foreach my $item (@items) {\n    return $item;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_expands_simple_for_foreach_alias_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "for$item(@items){return$item;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "for $item (@items) {\n    return $item;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_expands_simple_if_else_blocks() {
     let formatter = NativeFormatter::new();
     let source = "if($ok){return 1;}else{return 0;}\n";
@@ -620,6 +644,21 @@ fn native_range_formatter_formats_selected_simple_unless_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "unless ($ok) {\n    return $x;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_foreach_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nforeach my$item(@items){return$item;}\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 37));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my$x=1;\nforeach my $item (@items) {\n    return $item;\n}\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "foreach my $item (@items) {\n    return $item;\n}");
 }
 
 #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 30 |
+| Fixture count | 31 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 


### PR DESCRIPTION
## Summary

Adds conservative native formatter support for simple foreach-style loop blocks:

- `foreach my$item(@items){return$item;}`
- `for$item(@items){return$item;}`

The formatter expands only simple iterator/list/body forms already covered by the safe-subset expression and statement formatter. C-style `for (...)` loops, `continue` blocks, comments, POD, heredocs, regexes, and other unsafe surfaces remain out of scope.

The native formatter fixture count moves from 30 to 31.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_expands_simple_for --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_foreach_line --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`31/31` fixtures passed)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Note: `cargo xtask native-format idempotence` and `cargo xtask native-format parse-preservation` were probed but are not implemented subcommands in this repo yet. The available native-format receipt path is `cargo xtask native-format check`.
