### PR TITLE
feat(format): add simple module declaration layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -593,8 +593,30 @@ fn range_includes_line(range: TextRange, line: u32) -> bool {
 fn format_simple_line(line: &str, config: &FormatConfig) -> Option<String> {
     format_simple_control_block_line(line, config)
         .or_else(|| format_simple_subroutine_line(line, config))
+        .or_else(|| format_simple_module_line(line, config))
         .or_else(|| format_simple_statement_line(line, config))
         .or_else(|| format_simple_lexical_line(line, config))
+}
+
+fn format_simple_module_line(line: &str, config: &FormatConfig) -> Option<String> {
+    let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
+    let (indent, body) = line.split_at(indent_len);
+    if body.is_empty() || body.contains('#') {
+        return None;
+    }
+
+    let mut stream = perl_parser_core::TokenStream::new(body);
+    let mut tokens = Vec::new();
+    loop {
+        let token = stream.next().ok()?;
+        if token.kind == perl_parser_core::TokenKind::Eof {
+            break;
+        }
+        tokens.push(token);
+    }
+
+    let formatted = format_simple_module_tokens(&tokens, config)?;
+    Some(format!("{indent}{formatted}"))
 }
 
 fn format_simple_lexical_line(line: &str, config: &FormatConfig) -> Option<String> {
@@ -924,6 +946,89 @@ fn format_simple_statement_tokens(
         .or_else(|| format_simple_return_tokens(tokens, config))
         .or_else(|| format_simple_assignment_tokens(tokens, config))
         .or_else(|| format_simple_expression_statement_tokens(tokens, config))
+}
+
+fn format_simple_module_tokens(
+    tokens: &[perl_parser_core::Token],
+    config: &FormatConfig,
+) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.last()?.kind != TokenKind::Semicolon {
+        return None;
+    }
+
+    match tokens.first()?.kind {
+        TokenKind::Package => format_simple_package_tokens(tokens, config),
+        TokenKind::Use => format_simple_import_tokens("use", tokens, 1, config),
+        TokenKind::No => format_simple_import_tokens("no", tokens, 1, config),
+        TokenKind::Identifier if tokens.first()?.text.as_ref() == "require" => {
+            format_simple_import_tokens("require", tokens, 1, config)
+        }
+        _ => None,
+    }
+}
+
+fn format_simple_package_tokens(
+    tokens: &[perl_parser_core::Token],
+    config: &FormatConfig,
+) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.len() < 3 || tokens.first()?.kind != TokenKind::Package {
+        return None;
+    }
+
+    let semicolon_index = tokens.len() - 1;
+    let name = tokens.get(1)?;
+    if name.kind != TokenKind::Identifier {
+        return None;
+    }
+
+    if semicolon_index == 2 {
+        return Some(format!("package {};", name.text));
+    }
+
+    let version = format_simple_module_args(tokens, 2, semicolon_index, config, "package ".len())?;
+    Some(format!("package {} {version};", name.text))
+}
+
+fn format_simple_import_tokens(
+    keyword: &str,
+    tokens: &[perl_parser_core::Token],
+    args_start: usize,
+    config: &FormatConfig,
+) -> Option<String> {
+    let semicolon_index = tokens.len() - 1;
+    let args = format_simple_module_args(
+        tokens,
+        args_start,
+        semicolon_index,
+        config,
+        keyword.chars().count() + 1,
+    )?;
+    Some(format!("{keyword} {args};"))
+}
+
+fn format_simple_module_args(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+    end: usize,
+    config: &FormatConfig,
+    start_column: usize,
+) -> Option<String> {
+    let mut parts = Vec::new();
+    let mut index = start;
+    let mut column = start_column;
+
+    while index < end {
+        let (part, next_index) = format_simple_atom_tokens(tokens, index, config, column)?;
+        column = advance_column(column, &part) + 1;
+        parts.push(part);
+        index = next_index;
+    }
+
+    (!parts.is_empty()).then(|| parts.join(" "))
 }
 
 fn format_simple_lexical_tokens(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_module_declarations.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_module_declarations.expected.pl
@@ -1,0 +1,5 @@
+package Foo::Bar;
+use strict;
+no warnings;
+require Foo::Bar;
+use lib 'lib';

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_module_declarations.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_module_declarations.pl
@@ -1,0 +1,5 @@
+package Foo::Bar ;
+use strict ;
+no warnings ;
+require Foo::Bar ;
+use lib 'lib';

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -106,6 +106,22 @@ fn native_formatter_formats_simple_hash_constructors() {
 }
 
 #[test]
+fn native_formatter_formats_simple_module_declarations() {
+    let formatter = NativeFormatter::new();
+    let source =
+        "package Foo::Bar ;\nuse strict ;\nno warnings ;\nrequire Foo::Bar ;\nuse lib 'lib';\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "package Foo::Bar;\nuse strict;\nno warnings;\nrequire Foo::Bar;\nuse lib 'lib';\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_formats_simple_method_calls() {
     let formatter = NativeFormatter::new();
     let source = "$x=$obj->build();\n$z=$obj->empty();\nreturn $obj->wrap(foo(1),{ok=>1});\n";
@@ -357,6 +373,21 @@ fn native_range_formatter_formats_selected_simple_hash_constructor_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "return {answer => 42};");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_module_declaration_line() {
+    let formatter = NativeFormatter::new();
+    let source = "package Foo::Bar ;\nuse strict ;\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 12));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "package Foo::Bar ;\nuse strict;\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "use strict;");
 }
 
 #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 31 |
+| Fixture count | 32 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 


### PR DESCRIPTION
## Summary

Adds a narrow native formatter slice for simple module declaration lines:

- `package Foo::Bar ;` -> `package Foo::Bar;`
- `use strict ;` / `no warnings ;` -> normalized semicolon spacing
- `require Foo::Bar ;` -> `require Foo::Bar;`
- simple `use` arguments such as `use lib 'lib';`

The formatter remains parse-gated and safe-subset only. This does not change runtime defaults, formatter mode selection, external perltidy behavior, critic behavior, or LSP capability advertising.

## Scope notes

- Keeps comments out of scope; lines with `#` are preserved.
- Does not touch quote-like/POD/heredoc/regex literal-preserve behavior.
- Does not add broad import sorting or semantic module normalization.
- Keeps `require` support to parser-confirmed simple token forms.

## Proof packet

Changed surfaces:
- native formatter safe subset
- formatter fixtures/status receipt

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_formats_simple_module_declarations --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_module_declaration_line --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`32/32` fixtures passed)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Known unrelated status-doc drift:
- `just status-check` still reports `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md` as out of date. Those are outside this formatter slice; this PR only regenerates `docs/project/status/native_tooling.md` via `cargo xtask native-tooling status`.
