### PR TITLE
feat(format): add simple elsif block layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -771,11 +771,7 @@ fn format_simple_control_block_tokens(
         .map(|offset| body_start + offset)?;
     let body_tokens = &tokens[body_start..body_end];
     let statements = format_simple_statement_block(body_tokens, config)?;
-    let else_statements = format_simple_else_branch(tokens, body_end, keyword, config)?;
-
-    if else_statements.is_none() && body_end + 1 != tokens.len() {
-        return None;
-    }
+    let tail = format_simple_control_tail(tokens, body_end, keyword, config)?;
 
     let body_indent = format!("{indent}{}", indent_unit(config));
     let mut formatted = render_simple_block_doc(
@@ -786,7 +782,16 @@ fn format_simple_control_block_tokens(
         config,
     );
 
-    if let Some(else_statements) = else_statements {
+    for (condition, statements) in tail.elsif_branches {
+        formatted.push_str(&render_simple_elsif_doc(
+            &condition,
+            &statements,
+            indent,
+            &body_indent,
+            config,
+        ));
+    }
+    if let Some(else_statements) = tail.else_statements {
         formatted.push_str(&render_simple_else_doc(&else_statements, indent, &body_indent, config));
     }
     Some(formatted)
@@ -870,6 +875,18 @@ fn render_simple_else_doc(
     FormatDoc::group(parts).render(config)
 }
 
+fn render_simple_elsif_doc(
+    condition: &str,
+    statements: &[String],
+    indent: &str,
+    body_indent: &str,
+    config: &FormatConfig,
+) -> String {
+    let mut parts = vec![FormatDoc::text(format!(" elsif ({condition}) {{"))];
+    push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
+    FormatDoc::group(parts).render(config)
+}
+
 fn push_simple_block_body_docs(
     parts: &mut Vec<FormatDoc>,
     statements: &[String],
@@ -884,33 +901,70 @@ fn push_simple_block_body_docs(
     parts.push(FormatDoc::text(format!("{indent}}}")));
 }
 
-fn format_simple_else_branch(
+struct SimpleControlTail {
+    elsif_branches: Vec<(String, Vec<String>)>,
+    else_statements: Option<Vec<String>>,
+}
+
+fn format_simple_control_tail(
     tokens: &[perl_parser_core::Token],
     body_end: usize,
     keyword: &str,
     config: &FormatConfig,
-) -> Option<Option<Vec<String>>> {
+) -> Option<SimpleControlTail> {
     use perl_parser_core::TokenKind;
 
-    let next = body_end + 1;
-    if next == tokens.len() {
-        return Some(None);
+    let mut index = body_end + 1;
+    let mut tail = SimpleControlTail { elsif_branches: Vec::new(), else_statements: None };
+    if index == tokens.len() {
+        return Some(tail);
     }
 
-    if !matches!(keyword, "if" | "unless") {
+    while tokens.get(index)?.kind == TokenKind::Elsif {
+        if keyword != "if" {
+            return None;
+        }
+        if tokens.get(index + 1)?.kind != TokenKind::LeftParen {
+            return None;
+        }
+
+        let (condition, next_index) = format_simple_condition_tokens(tokens, index + 2, config)?;
+        if tokens.get(next_index)?.kind != TokenKind::RightParen
+            || tokens.get(next_index + 1)?.kind != TokenKind::LeftBrace
+        {
+            return None;
+        }
+
+        let elsif_body_start = next_index + 2;
+        let elsif_body_end = tokens[elsif_body_start..]
+            .iter()
+            .position(|token| token.kind == TokenKind::RightBrace)
+            .map(|offset| elsif_body_start + offset)?;
+        let statements =
+            format_simple_statement_block(&tokens[elsif_body_start..elsif_body_end], config)?;
+        tail.elsif_branches.push((condition, statements));
+        index = elsif_body_end + 1;
+
+        if index == tokens.len() {
+            return Some(tail);
+        }
+    }
+
+    if tokens.get(index)?.kind != TokenKind::Else {
         return None;
     }
-    if tokens.get(next)?.kind != TokenKind::Else
-        || tokens.get(next + 1)?.kind != TokenKind::LeftBrace
+    if !matches!(keyword, "if" | "unless")
+        || tokens.get(index + 1)?.kind != TokenKind::LeftBrace
         || tokens.last()?.kind != TokenKind::RightBrace
     {
         return None;
     }
 
-    let else_body_start = next + 2;
+    let else_body_start = index + 2;
     let else_body_tokens = &tokens[else_body_start..tokens.len() - 1];
     let statements = format_simple_statement_block(else_body_tokens, config)?;
-    Some(Some(statements))
+    tail.else_statements = Some(statements);
+    Some(tail)
 }
 
 fn format_simple_statement_block(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if_elsif_else.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if_elsif_else.expected.pl
@@ -1,0 +1,9 @@
+if ($ok) {
+    return 1;
+} elsif ($maybe) {
+    return 2;
+} elsif ($fallback) {
+    return 3;
+} else {
+    return 0;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if_elsif_else.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_if_elsif_else.pl
@@ -1,0 +1,1 @@
+if($ok){return 1;}elsif($maybe){return 2;}elsif($fallback){return 3;}else{return 0;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -606,6 +606,21 @@ fn native_formatter_expands_simple_if_else_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_if_elsif_else_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "if($ok){return 1;}elsif($maybe){return 2;}else{return 0;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "if ($ok) {\n    return 1;\n} elsif ($maybe) {\n    return 2;\n} else {\n    return 0;\n}\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_expands_simple_unless_else_blocks() {
     let formatter = NativeFormatter::new();
     let source = "unless($ok){return 0;}else{return 1;}\n";
@@ -708,4 +723,25 @@ fn native_range_formatter_formats_selected_simple_if_else_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "if ($ok) {\n    return 1;\n} else {\n    return 0;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_if_elsif_else_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nif($ok){return 1;}elsif($maybe){return 2;}else{return 0;}\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 57));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my$x=1;\nif ($ok) {\n    return 1;\n} elsif ($maybe) {\n    return 2;\n} else {\n    return 0;\n}\n"
+    );
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(
+        result.edits[0].new_text,
+        "if ($ok) {\n    return 1;\n} elsif ($maybe) {\n    return 2;\n} else {\n    return 0;\n}"
+    );
 }

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 32 |
+| Fixture count | 33 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 


### PR DESCRIPTION
## Summary

Adds conservative native formatter support for simple `if` / `elsif` / `else` control-block chains.

This keeps the same safe-subset boundary as the existing `if` and `if/else` formatter support:

- parse-gated formatter path only
- simple parenthesized conditions already accepted by the native formatter
- simple semicolon-delimited statement bodies only
- no nested block expansion, comments, POD, heredocs, regex, quote-like, or runtime/default behavior changes

The fixture suite now includes a multi-`elsif` chain and the native tooling status count is refreshed from 32 to 33 formatter fixtures.

## Proof packet

Changed surfaces:
- native formatter safe subset
- native formatter fixtures/status docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_expands_simple_if_elsif_else_blocks --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_if_elsif_else_line --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`33/33` fixtures passed)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

`just status-check` was also run; it still reports the pre-existing generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR only updates `docs/project/status/native_tooling.md` for the new formatter fixture count.
