### PR TITLE
feat(format): add simple loop control statements (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -998,6 +998,7 @@ fn format_simple_statement_tokens(
 ) -> Option<String> {
     format_simple_lexical_tokens(tokens, config)
         .or_else(|| format_simple_return_tokens(tokens, config))
+        .or_else(|| format_simple_loop_control_tokens(tokens))
         .or_else(|| format_simple_assignment_tokens(tokens, config))
         .or_else(|| format_simple_expression_statement_tokens(tokens, config))
 }
@@ -1210,6 +1211,28 @@ fn format_simple_return_tokens(
         prefix.chars().count(),
     )?;
     Some(format!("return {value};"))
+}
+
+fn format_simple_loop_control_tokens(tokens: &[perl_parser_core::Token]) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    let keyword = match tokens.first()?.kind {
+        TokenKind::Next => "next",
+        TokenKind::Last => "last",
+        TokenKind::Redo => "redo",
+        _ => return None,
+    };
+    if tokens.last()?.kind != TokenKind::Semicolon {
+        return None;
+    }
+
+    match tokens {
+        [_, _] => Some(format!("{keyword};")),
+        [_, label, _] if label.kind == TokenKind::Identifier => {
+            Some(format!("{keyword} {};", label.text))
+        }
+        _ => None,
+    }
 }
 
 fn format_simple_assignment_tokens(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_loop_control_statements.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_loop_control_statements.expected.pl
@@ -1,0 +1,5 @@
+foreach my $item (@items) {
+    next;
+    last LOOP;
+    redo;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_loop_control_statements.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_loop_control_statements.pl
@@ -1,0 +1,1 @@
+foreach my$item(@items){next;last LOOP;redo;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -582,6 +582,21 @@ fn native_formatter_expands_simple_foreach_blocks() {
 }
 
 #[test]
+fn native_formatter_formats_simple_loop_control_statements() {
+    let formatter = NativeFormatter::new();
+    let source = "foreach my$item(@items){next;last LOOP;redo;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "foreach my $item (@items) {\n    next;\n    last LOOP;\n    redo;\n}\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_expands_simple_for_foreach_alias_blocks() {
     let formatter = NativeFormatter::new();
     let source = "for$item(@items){return$item;}\n";
@@ -705,6 +720,27 @@ fn native_range_formatter_formats_selected_simple_foreach_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "foreach my $item (@items) {\n    return $item;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_loop_control_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nforeach my$item(@items){next;last LOOP;redo;}\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 45));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my$x=1;\nforeach my $item (@items) {\n    next;\n    last LOOP;\n    redo;\n}\n"
+    );
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(
+        result.edits[0].new_text,
+        "foreach my $item (@items) {\n    next;\n    last LOOP;\n    redo;\n}"
+    );
 }
 
 #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 33 |
+| Fixture count | 34 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 


### PR DESCRIPTION
## Summary

Adds conservative native formatter support for simple loop-control statements inside already-supported statement blocks:

- `next;`
- `last;`
- `redo;`
- one bare label form such as `last LOOP;`

This lets the existing native formatter block path handle common loop bodies without adding new loop-tail parsing or widening expression support.

Out of scope:

- computed labels or expression arguments
- `continue { ... }` block tails
- runtime/default/config behavior changes
- comments, POD, heredocs, regex, or quote-like formatting changes

The native formatter fixture suite now includes the loop-control case and the native tooling fixture count is refreshed from 33 to 34.

## Proof packet

Changed surfaces:
- native formatter safe subset
- native formatter fixtures/status docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_formats_simple_loop_control_statements --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_loop_control_line --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`34/34` fixtures passed)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

`just status-check` was also run; it still reports the pre-existing generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR only updates `docs/project/status/native_tooling.md` for the new formatter fixture count.
