### PR TITLE
feat(format): add simple loop continue blocks (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -771,7 +771,6 @@ fn format_simple_control_block_tokens(
         .map(|offset| body_start + offset)?;
     let body_tokens = &tokens[body_start..body_end];
     let statements = format_simple_statement_block(body_tokens, config)?;
-    let tail = format_simple_control_tail(tokens, body_end, keyword, config)?;
 
     let body_indent = format!("{indent}{}", indent_unit(config));
     let mut formatted = render_simple_block_doc(
@@ -782,17 +781,40 @@ fn format_simple_control_block_tokens(
         config,
     );
 
-    for (condition, statements) in tail.elsif_branches {
-        formatted.push_str(&render_simple_elsif_doc(
-            &condition,
-            &statements,
-            indent,
-            &body_indent,
-            config,
-        ));
-    }
-    if let Some(else_statements) = tail.else_statements {
-        formatted.push_str(&render_simple_else_doc(&else_statements, indent, &body_indent, config));
+    match keyword {
+        "if" | "unless" => {
+            let tail = format_simple_control_tail(tokens, body_end, keyword, config)?;
+            for (condition, statements) in tail.elsif_branches {
+                formatted.push_str(&render_simple_elsif_doc(
+                    &condition,
+                    &statements,
+                    indent,
+                    &body_indent,
+                    config,
+                ));
+            }
+            if let Some(else_statements) = tail.else_statements {
+                formatted.push_str(&render_simple_else_doc(
+                    &else_statements,
+                    indent,
+                    &body_indent,
+                    config,
+                ));
+            }
+        }
+        "while" | "until" => {
+            if let Some(continue_statements) =
+                format_simple_continue_tail(tokens, body_end, config)?
+            {
+                formatted.push_str(&render_simple_continue_doc(
+                    &continue_statements,
+                    indent,
+                    &body_indent,
+                    config,
+                ));
+            }
+        }
+        _ => return None,
     }
     Some(formatted)
 }
@@ -835,21 +857,34 @@ fn format_simple_foreach_block_tokens(
 
     if tokens.get(list_end)?.kind != TokenKind::RightParen
         || tokens.get(list_end + 1)?.kind != TokenKind::LeftBrace
-        || tokens.last()?.kind != TokenKind::RightBrace
     {
         return None;
     }
 
-    let body_tokens = &tokens[list_end + 2..tokens.len() - 1];
+    let body_start = list_end + 2;
+    let body_end = tokens[body_start..]
+        .iter()
+        .position(|token| token.kind == TokenKind::RightBrace)
+        .map(|offset| body_start + offset)?;
+    let body_tokens = &tokens[body_start..body_end];
     let statements = format_simple_statement_block(body_tokens, config)?;
     let body_indent = format!("{indent}{}", indent_unit(config));
-    Some(render_simple_block_doc(
+    let mut formatted = render_simple_block_doc(
         format!("{indent}{keyword} {iterator} ({list}) {{"),
         &statements,
         indent,
         &body_indent,
         config,
-    ))
+    );
+    if let Some(continue_statements) = format_simple_continue_tail(tokens, body_end, config)? {
+        formatted.push_str(&render_simple_continue_doc(
+            &continue_statements,
+            indent,
+            &body_indent,
+            config,
+        ));
+    }
+    Some(formatted)
 }
 
 fn render_simple_block_doc(
@@ -883,6 +918,17 @@ fn render_simple_elsif_doc(
     config: &FormatConfig,
 ) -> String {
     let mut parts = vec![FormatDoc::text(format!(" elsif ({condition}) {{"))];
+    push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
+    FormatDoc::group(parts).render(config)
+}
+
+fn render_simple_continue_doc(
+    statements: &[String],
+    indent: &str,
+    body_indent: &str,
+    config: &FormatConfig,
+) -> String {
+    let mut parts = vec![FormatDoc::text(" continue {")];
     push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
     FormatDoc::group(parts).render(config)
 }
@@ -965,6 +1011,30 @@ fn format_simple_control_tail(
     let statements = format_simple_statement_block(else_body_tokens, config)?;
     tail.else_statements = Some(statements);
     Some(tail)
+}
+
+fn format_simple_continue_tail(
+    tokens: &[perl_parser_core::Token],
+    body_end: usize,
+    config: &FormatConfig,
+) -> Option<Option<Vec<String>>> {
+    use perl_parser_core::TokenKind;
+
+    let next = body_end + 1;
+    if next == tokens.len() {
+        return Some(None);
+    }
+    if tokens.get(next)?.kind != TokenKind::Continue
+        || tokens.get(next + 1)?.kind != TokenKind::LeftBrace
+        || tokens.last()?.kind != TokenKind::RightBrace
+    {
+        return None;
+    }
+
+    let continue_body_start = next + 2;
+    let continue_body_tokens = &tokens[continue_body_start..tokens.len() - 1];
+    let statements = format_simple_statement_block(continue_body_tokens, config)?;
+    Some(Some(statements))
 }
 
 fn format_simple_statement_block(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_loop_continue_blocks.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_loop_continue_blocks.expected.pl
@@ -1,0 +1,10 @@
+while ($ok) {
+    next;
+} continue {
+    last;
+}
+foreach my $item (@items) {
+    next;
+} continue {
+    redo;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_loop_continue_blocks.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_loop_continue_blocks.pl
@@ -1,0 +1,2 @@
+while($ok){next;}continue{last;}
+foreach my$item(@items){next;}continue{redo;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -535,6 +535,18 @@ fn native_formatter_expands_simple_while_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_while_continue_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "while($ok){next;}continue{last;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "while ($ok) {\n    next;\n} continue {\n    last;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_uses_configured_indent_for_simple_while_blocks() {
     let formatter = NativeFormatter::new();
     let config = FormatConfig { indent_width: 2, ..FormatConfig::default() };
@@ -592,6 +604,21 @@ fn native_formatter_formats_simple_loop_control_statements() {
     assert_eq!(
         result.formatted,
         "foreach my $item (@items) {\n    next;\n    last LOOP;\n    redo;\n}\n"
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_expands_simple_foreach_continue_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "foreach my$item(@items){next;}continue{redo;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "foreach my $item (@items) {\n    next;\n} continue {\n    redo;\n}\n"
     );
     assert!(result.diagnostics.is_empty());
 }
@@ -690,6 +717,21 @@ fn native_range_formatter_formats_selected_simple_while_line() {
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].range, range);
     assert_eq!(result.edits[0].new_text, "while ($ok) {\n    return $x;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_while_continue_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nwhile($ok){next;}continue{last;}\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 32));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my$x=1;\nwhile ($ok) {\n    next;\n} continue {\n    last;\n}\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "while ($ok) {\n    next;\n} continue {\n    last;\n}");
 }
 
 #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 34 |
+| Fixture count | 35 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 


### PR DESCRIPTION
## Summary

Adds conservative native formatter support for simple loop `continue { ... }` tails on already-supported loop shapes:

- `while (...) { ... } continue { ... }`
- `foreach my $item (...) { ... } continue { ... }`

The formatter only accepts simple statement bodies already handled by the native safe subset. This PR does not add C-style `for (...)` formatting, nested block expansion, comment/POD/heredoc/regex handling, runtime defaults, or config behavior.

The native formatter fixture suite now includes a loop-continue fixture and the native tooling fixture count is refreshed from 34 to 35.

## Proof packet

Changed surfaces:
- native formatter safe subset
- native formatter fixtures/status docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_expands_simple_while_continue_blocks --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_expands_simple_foreach_continue_blocks --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_while_continue_line --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`35/35` fixtures passed)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

`just status-check` was also run; it still reports the pre-existing generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR only updates `docs/project/status/native_tooling.md` for the new formatter fixture count.
