### PR TITLE
feat(format): add simple C-style for block layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -739,6 +739,10 @@ fn format_simple_control_block_tokens(
 ) -> Option<String> {
     use perl_parser_core::TokenKind;
 
+    if let Some(formatted) = format_simple_c_style_for_block_tokens(tokens, indent, config) {
+        return Some(formatted);
+    }
+
     if let Some(formatted) = format_simple_foreach_block_tokens(tokens, indent, config) {
         return Some(formatted);
     }
@@ -817,6 +821,166 @@ fn format_simple_control_block_tokens(
         _ => return None,
     }
     Some(formatted)
+}
+
+fn format_simple_c_style_for_block_tokens(
+    tokens: &[perl_parser_core::Token],
+    indent: &str,
+    config: &FormatConfig,
+) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    if tokens.first()?.kind != TokenKind::For || tokens.get(1)?.kind != TokenKind::LeftParen {
+        return None;
+    }
+
+    let (first_semicolon, second_semicolon, header_end) = find_for_header_boundaries(tokens, 1)?;
+    if tokens.get(header_end + 1)?.kind != TokenKind::LeftBrace {
+        return None;
+    }
+
+    let init = format_simple_for_init_clause(tokens, 2, first_semicolon, config)?;
+    let condition =
+        format_simple_for_condition_clause(tokens, first_semicolon + 1, second_semicolon, config)?;
+    let update = format_simple_for_update_clause(tokens, second_semicolon + 1, header_end, config)?;
+
+    let body_start = header_end + 2;
+    let body_end = tokens[body_start..]
+        .iter()
+        .position(|token| token.kind == TokenKind::RightBrace)
+        .map(|offset| body_start + offset)?;
+    let statements = format_simple_statement_block(&tokens[body_start..body_end], config)?;
+
+    let body_indent = format!("{indent}{}", indent_unit(config));
+    let mut formatted = render_simple_block_doc(
+        format!("{indent}{}", render_simple_for_header(&init, &condition, &update)),
+        &statements,
+        indent,
+        &body_indent,
+        config,
+    );
+    if let Some(continue_statements) = format_simple_continue_tail(tokens, body_end, config)? {
+        formatted.push_str(&render_simple_continue_doc(
+            &continue_statements,
+            indent,
+            &body_indent,
+            config,
+        ));
+    }
+    Some(formatted)
+}
+
+fn find_for_header_boundaries(
+    tokens: &[perl_parser_core::Token],
+    open_index: usize,
+) -> Option<(usize, usize, usize)> {
+    use perl_parser_core::TokenKind;
+
+    let mut depth = 0usize;
+    let mut first_semicolon = None;
+    let mut second_semicolon = None;
+
+    for (index, token) in tokens.iter().enumerate().skip(open_index) {
+        match token.kind {
+            TokenKind::LeftParen => depth += 1,
+            TokenKind::RightParen => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some((first_semicolon?, second_semicolon?, index));
+                }
+            }
+            TokenKind::Semicolon if depth == 1 => {
+                if first_semicolon.is_none() {
+                    first_semicolon = Some(index);
+                } else if second_semicolon.is_none() {
+                    second_semicolon = Some(index);
+                } else {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn render_simple_for_header(init: &str, condition: &str, update: &str) -> String {
+    let mut header = format!("for ({init};");
+    if !condition.is_empty() {
+        header.push(' ');
+        header.push_str(condition);
+    }
+    header.push(';');
+    if !update.is_empty() {
+        header.push(' ');
+        header.push_str(update);
+    }
+    header.push_str(") {");
+    header
+}
+
+fn format_simple_for_init_clause(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+    end: usize,
+    config: &FormatConfig,
+) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    if start == end {
+        return Some(String::new());
+    }
+
+    match tokens.get(start)?.kind {
+        TokenKind::My | TokenKind::Our | TokenKind::State => {
+            format_simple_lexical_clause(tokens, start, end, config)
+        }
+        _ => format_simple_assignment_clause(tokens, start, end, config),
+    }
+}
+
+fn format_simple_for_condition_clause(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+    end: usize,
+    config: &FormatConfig,
+) -> Option<String> {
+    if start == end {
+        return Some(String::new());
+    }
+    format_simple_expression_tokens(tokens, start, end, config, 0)
+}
+
+fn format_simple_for_update_clause(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+    end: usize,
+    config: &FormatConfig,
+) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    if start == end {
+        return Some(String::new());
+    }
+
+    if let Some((variable, next_index)) = format_variable_tokens(tokens, start)
+        && next_index + 1 == end
+    {
+        return match tokens.get(next_index)?.kind {
+            TokenKind::Increment => Some(format!("{variable}++")),
+            TokenKind::Decrement => Some(format!("{variable}--")),
+            _ => None,
+        };
+    }
+
+    if matches!(tokens.get(start)?.kind, TokenKind::Increment | TokenKind::Decrement) {
+        let (variable, next_index) = format_variable_tokens(tokens, start + 1)?;
+        if next_index == end {
+            return Some(format!("{}{variable}", tokens[start].text));
+        }
+    }
+
+    format_simple_assignment_clause(tokens, start, end, config)
 }
 
 fn format_simple_foreach_block_tokens(
@@ -1160,34 +1324,42 @@ fn format_simple_lexical_tokens(
     tokens: &[perl_parser_core::Token],
     config: &FormatConfig,
 ) -> Option<String> {
+    if tokens.last()?.kind != perl_parser_core::TokenKind::Semicolon {
+        return None;
+    }
+
+    let semicolon_index = tokens.len() - 1;
+    Some(format!("{};", format_simple_lexical_clause(tokens, 0, semicolon_index, config)?))
+}
+
+fn format_simple_lexical_clause(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+    end: usize,
+    config: &FormatConfig,
+) -> Option<String> {
     use perl_parser_core::TokenKind;
 
-    let keyword = match tokens.first()?.kind {
+    let keyword = match tokens.get(start)?.kind {
         TokenKind::My => "my",
         TokenKind::Our => "our",
         TokenKind::State => "state",
         _ => return None,
     };
 
-    let semicolon = tokens.last()?;
-    if semicolon.kind != TokenKind::Semicolon {
-        return None;
-    }
-
-    let (variable, next_index) = format_lexical_target_tokens(tokens, 1)?;
-    let semicolon_index = tokens.len() - 1;
-    if next_index == semicolon_index {
-        Some(format!("{keyword} {variable};"))
+    let (variable, next_index) = format_lexical_target_tokens(tokens, start + 1)?;
+    if next_index == end {
+        Some(format!("{keyword} {variable}"))
     } else if tokens[next_index].kind == TokenKind::Assign {
         let prefix = format!("{keyword} {variable} = ");
         let value = format_simple_expression_tokens(
             tokens,
             next_index + 1,
-            semicolon_index,
+            end,
             config,
             prefix.chars().count(),
         )?;
-        Some(format!("{prefix}{value};"))
+        Some(format!("{prefix}{value}"))
     } else {
         None
     }
@@ -1315,8 +1487,19 @@ fn format_simple_assignment_tokens(
         return None;
     }
 
-    let (variable, next_index) = format_variable_tokens(tokens, 0)?;
     let semicolon_index = tokens.len() - 1;
+    Some(format!("{};", format_simple_assignment_clause(tokens, 0, semicolon_index, config)?))
+}
+
+fn format_simple_assignment_clause(
+    tokens: &[perl_parser_core::Token],
+    start: usize,
+    end: usize,
+    config: &FormatConfig,
+) -> Option<String> {
+    use perl_parser_core::TokenKind;
+
+    let (variable, next_index) = format_variable_tokens(tokens, start)?;
     if tokens.get(next_index)?.kind != TokenKind::Assign {
         return None;
     }
@@ -1325,11 +1508,11 @@ fn format_simple_assignment_tokens(
     let value = format_simple_expression_tokens(
         tokens,
         next_index + 1,
-        semicolon_index,
+        end,
         config,
         prefix.chars().count(),
     )?;
-    Some(format!("{variable} = {value};"))
+    Some(format!("{variable} = {value}"))
 }
 
 fn format_simple_expression_statement_tokens(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_c_style_for_blocks.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_c_style_for_blocks.expected.pl
@@ -1,0 +1,9 @@
+for (my $i = 0; $i < 3; $i++) {
+    next;
+}
+for (; $ok; --$remaining) {
+    last;
+}
+for (;;) {
+    redo;
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_c_style_for_blocks.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_c_style_for_blocks.pl
@@ -1,0 +1,3 @@
+for(my$i=0;$i<3;$i++){next;}
+for(;$ok;--$remaining){last;}
+for(;;){redo;}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -636,6 +636,31 @@ fn native_formatter_expands_simple_for_foreach_alias_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_c_style_for_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "for(my$i=0;$i<3;$i++){next;}\nfor(;$ok;--$remaining){last;}\nfor(;;){redo;}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "for (my $i = 0; $i < 3; $i++) {\n",
+            "    next;\n",
+            "}\n",
+            "for (; $ok; --$remaining) {\n",
+            "    last;\n",
+            "}\n",
+            "for (;;) {\n",
+            "    redo;\n",
+            "}\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_expands_simple_if_else_blocks() {
     let formatter = NativeFormatter::new();
     let source = "if($ok){return 1;}else{return 0;}\n";
@@ -783,6 +808,23 @@ fn native_range_formatter_formats_selected_simple_loop_control_line() {
         result.edits[0].new_text,
         "foreach my $item (@items) {\n    next;\n    last LOOP;\n    redo;\n}"
     );
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_c_style_for_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nfor(my$i=0;$i<3;$i++){next;}\n";
+    let range = TextRange {
+        start: TextPosition { line: 1, character: 0 },
+        end: TextPosition { line: 1, character: 28 },
+    };
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my$x=1;\nfor (my $i = 0; $i < 3; $i++) {\n    next;\n}\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].new_text, "for (my $i = 0; $i < 3; $i++) {\n    next;\n}");
 }
 
 #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 35 |
+| Fixture count | 36 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 


### PR DESCRIPTION
## Summary
- add conservative native formatter support for simple C-style `for (...) { ... }` blocks
- reuse the existing simple lexical/assignment/expression/body formatters for header clauses and block statements
- add document/range tests plus a native-format fixture, raising formatter fixtures to 36/36

## Scope
- formats simple `for (init; condition; update)` loops with lexical or assignment init clauses, simple expression conditions, assignment or increment/decrement update clauses, and simple statement bodies
- supports empty clauses such as `for (;;)` without introducing bogus spaces
- keeps runtime defaults, config, critic behavior, comments, POD, heredocs, regexes, and other dangerous surfaces unchanged

## Proof packet

Changed surfaces:
- native formatter
- generated native tooling status docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_expands_simple_c_style_for_blocks --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_c_style_for_line --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (36/36 fixtures passed)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Notes:
- `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests` still emits the existing dead-code warnings in test support; tests pass.
- `just status-check` still fails on unrelated generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR only updates `docs/project/status/native_tooling.md` via `cargo xtask native-tooling status`.
