### PR TITLE
feat(format): add C-style for continue-tail layout (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_c_style_for_continue_blocks.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_c_style_for_continue_blocks.expected.pl
@@ -1,0 +1,5 @@
+for (my $i = 0; $i < 3; $i++) {
+    next;
+} continue {
+    tick($i);
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_c_style_for_continue_blocks.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_c_style_for_continue_blocks.pl
@@ -1,0 +1,1 @@
+for(my$i=0;$i<3;$i++){next;}continue{tick($i);}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -661,6 +661,27 @@ fn native_formatter_expands_simple_c_style_for_blocks() {
 }
 
 #[test]
+fn native_formatter_expands_simple_c_style_for_continue_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = "for(my$i=0;$i<3;$i++){next;}continue{tick($i);}\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "for (my $i = 0; $i < 3; $i++) {\n",
+            "    next;\n",
+            "} continue {\n",
+            "    tick($i);\n",
+            "}\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_expands_simple_if_else_blocks() {
     let formatter = NativeFormatter::new();
     let source = "if($ok){return 1;}else{return 0;}\n";
@@ -825,6 +846,29 @@ fn native_range_formatter_formats_selected_simple_c_style_for_line() {
     assert_eq!(result.formatted, "my$x=1;\nfor (my $i = 0; $i < 3; $i++) {\n    next;\n}\n");
     assert_eq!(result.edits.len(), 1);
     assert_eq!(result.edits[0].new_text, "for (my $i = 0; $i < 3; $i++) {\n    next;\n}");
+}
+
+#[test]
+fn native_range_formatter_formats_selected_simple_c_style_for_continue_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1;\nfor(my$i=0;$i<3;$i++){next;}continue{tick($i);}\n";
+    let range = TextRange {
+        start: TextPosition { line: 1, character: 0 },
+        end: TextPosition { line: 1, character: 47 },
+    };
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        "my$x=1;\nfor (my $i = 0; $i < 3; $i++) {\n    next;\n} continue {\n    tick($i);\n}\n"
+    );
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(
+        result.edits[0].new_text,
+        "for (my $i = 0; $i < 3; $i++) {\n    next;\n} continue {\n    tick($i);\n}"
+    );
 }
 
 #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 36 |
+| Fixture count | 37 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 


### PR DESCRIPTION
## Summary
- add explicit native formatter coverage for simple C-style `for (...) { ... } continue { ... }` tails
- add document/range formatter tests and a native-format fixture
- regenerate native tooling status, raising formatter fixtures to 37/37

## Scope
- C-style `for` only
- simple init/condition/update clauses only
- simple body and continue-block statements only
- no formatter runtime/default/config changes
- no critic, comment, POD, heredoc, regex, or literal-preserve behavior changes

## Proof packet

Changed surfaces:
- native formatter fixtures/tests
- generated native tooling status docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_expands_simple_c_style_for_continue_blocks --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_formats_selected_simple_c_style_for_continue_line --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (37/37 fixtures passed)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Notes:
- `lsp_3_17_formatting_tests` still emits the existing dead-code warnings in test support; tests pass.
