### PR TITLE
test(format): lock comment preservation matrix (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/comment_preserve_matrix.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/comment_preserve_matrix.expected.pl
@@ -1,0 +1,5 @@
+# leading file comment
+my$x=1; # trailing assignment comment
+if($x){ # trailing block opener comment
+    return$x; # trailing return comment
+}

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/comment_preserve_matrix.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/comment_preserve_matrix.pl
@@ -1,0 +1,5 @@
+# leading file comment
+my$x=1; # trailing assignment comment
+if($x){ # trailing block opener comment
+    return$x; # trailing return comment
+}

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -258,6 +258,24 @@ fn native_formatter_preserves_comment_lines_until_comment_aware_layout_exists() 
 }
 
 #[test]
+fn native_formatter_preserves_comment_matrix_until_comment_aware_layout_exists() {
+    let formatter = NativeFormatter::new();
+    let source = concat!(
+        "# leading file comment\n",
+        "my$x=1; # trailing assignment comment\n",
+        "if($x){ # trailing block opener comment\n",
+        "    return$x; # trailing return comment\n",
+        "}\n",
+    );
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_combines_simple_layout_with_final_newline_policy() {
     let formatter = NativeFormatter::new();
     let config = FormatConfig { final_newline: FinalNewline::Insert, ..FormatConfig::default() };

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 37 |
+| Fixture count | 38 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 


### PR DESCRIPTION
## Summary

- add a native formatter fixture for leading, trailing assignment, block-opener, and return-line comments
- add a focused layout test proving the native formatter preserves that comment matrix unchanged until comment-aware layout is implemented
- regenerate the native tooling status fixture count to 38

This is a test/receipt slice only. It does not change formatter runtime behavior, defaults, config, critic behavior, or dangerous-surface handling.

## Proof packet

Changed surfaces:
- generated_status_docs
- rust_code
- docs

Required proof:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_preserves_comment_matrix_until_comment_aware_layout_exists --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check`
  - native formatter fixtures: 38/38 passed
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Known local caveat:
- `just status-check` currently reports unrelated generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR intentionally does not include those unrelated generated docs; its status-doc change is limited to `docs/project/status/native_tooling.md` from `cargo xtask native-tooling status`.
