### PR TITLE
feat(critic): complete scope analyzer adapters (#8361)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -258,6 +258,10 @@ impl NativeCriticRegistry {
             Box::new(ParameterShadowsGlobalRule),
             Box::new(DuplicateLexicalDeclarationRule),
             Box::new(ShadowedLexicalVariableRule),
+            Box::new(CaptureVarWithoutRegexMatchRule),
+            Box::new(UndeclaredVariableRule),
+            Box::new(UninitializedVariableRule),
+            Box::new(UnquotedBarewordRule),
         ])
     }
 
@@ -999,6 +1003,138 @@ impl CriticRule for ShadowedLexicalVariableRule {
     }
 }
 
+/// Native rule that reports capture variables used without a preceding regex match.
+///
+/// This rule delegates capture-variable tracking to the semantic scope analyzer
+/// so native critic diagnostics reuse existing control-flow facts while
+/// exposing a stable native policy ID.
+pub struct CaptureVarWithoutRegexMatchRule;
+
+impl CriticRule for CaptureVarWithoutRegexMatchRule {
+    fn id(&self) -> &'static str {
+        "native.regex.capture_without_match"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::CaptureVarWithoutRegexMatch)
+                .map(|issue| capture_var_without_match_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
+/// Native rule that reports variables used without a prior declaration in scope.
+///
+/// This rule delegates undeclared-variable detection to the semantic scope
+/// analyzer so native critic diagnostics reuse the same binding facts as
+/// existing strict-mode diagnostics while exposing a stable native policy ID.
+pub struct UndeclaredVariableRule;
+
+impl CriticRule for UndeclaredVariableRule {
+    fn id(&self) -> &'static str {
+        "native.variables.undeclared"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::UndeclaredVariable)
+                .map(|issue| undeclared_variable_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
+/// Native rule that reports variables read before an initializing assignment.
+///
+/// This rule delegates uninitialized-variable detection to the semantic scope
+/// analyzer so native critic diagnostics reuse existing binding facts while
+/// exposing a stable native policy ID.
+pub struct UninitializedVariableRule;
+
+impl CriticRule for UninitializedVariableRule {
+    fn id(&self) -> &'static str {
+        "native.variables.uninitialized"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Semantic
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::UninitializedVariable)
+                .map(|issue| uninitialized_variable_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
+/// Native rule that reports barewords used where strict mode requires clarity.
+///
+/// This rule delegates bareword detection to the semantic scope analyzer so
+/// native critic diagnostics reuse existing strict-mode facts while exposing a
+/// stable native policy ID and suggested quoting fix.
+pub struct UnquotedBarewordRule;
+
+impl CriticRule for UnquotedBarewordRule {
+    fn id(&self) -> &'static str {
+        "native.syntax.unquoted_bareword"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Syntax
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Stern
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        let pragma_map = PragmaTracker::build(ctx.ast);
+        let issues = ScopeAnalyzer::new().analyze(ctx.ast, ctx.source, &pragma_map);
+
+        out.extend(
+            issues
+                .into_iter()
+                .filter(|issue| issue.kind == IssueKind::UnquotedBareword)
+                .map(|issue| unquoted_bareword_finding(self, ctx.source, &issue)),
+        );
+    }
+}
+
 fn unused_lexical_finding(
     rule: &UnusedLexicalVariableRule,
     source: &str,
@@ -1571,6 +1707,101 @@ fn shadowed_lexical_finding(
             title: format!("Rename to '{replacement}'"),
             safety: FixSafety::Suggested,
             edits: vec![CriticTextEdit { range, new_text: replacement }],
+        }),
+    }
+}
+
+fn capture_var_without_match_finding(
+    rule: &CaptureVarWithoutRegexMatchRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!(
+            "Capture variable '{}' used without a preceding regex match in scope",
+            issue.variable_name
+        ),
+        explanation: "Capture variables are set by the most recent successful regex match. Using them without a match in scope may read undef or a stale value.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: None,
+    }
+}
+
+fn undeclared_variable_finding(
+    rule: &UndeclaredVariableRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+    let declared = format!("my {}", issue.variable_name);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Variable '{}' is used but not declared", issue.variable_name),
+        explanation: "Declare the variable with 'my', 'our', or 'local' before use. Under 'use strict' this is a compile-time error.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: format!("Change to '{declared}'"),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: declared }],
+        }),
+    }
+}
+
+fn uninitialized_variable_finding(
+    rule: &UninitializedVariableRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Variable '{}' used before initialization", issue.variable_name),
+        explanation:
+            "Assign a value to the variable before its first use to avoid unintended undef reads."
+                .to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: None,
+    }
+}
+
+fn unquoted_bareword_finding(
+    rule: &UnquotedBarewordRule,
+    source: &str,
+    issue: &ScopeIssue,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, issue.range.0, issue.range.1);
+    let quoted = format!("\"{}\"", issue.variable_name);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("Bareword '{}' not allowed under strict", issue.variable_name),
+        explanation: "Barewords are ambiguous under use strict. Quote the string explicitly, declare a filehandle, or import the symbol.".to_string(),
+        suppression_key: rule.id().to_string(),
+        related: Vec::new(),
+        fix: Some(CriticFix {
+            title: format!("Quote as {quoted}"),
+            safety: FixSafety::Suggested,
+            edits: vec![CriticTextEdit { range, new_text: quoted }],
         }),
     }
 }
@@ -4068,7 +4299,11 @@ mod tests {
                 "native.variables.duplicate_parameter",
                 "native.variables.parameter_shadows_global",
                 "native.variables.duplicate_lexical",
-                "native.variables.shadowed_lexical"
+                "native.variables.shadowed_lexical",
+                "native.regex.capture_without_match",
+                "native.variables.undeclared",
+                "native.variables.uninitialized",
+                "native.syntax.unquoted_bareword"
             ]
         );
         assert_eq!(findings.len(), 2);
@@ -4616,6 +4851,306 @@ mod tests {
             violations[0].explanation,
             "Rename the inner lexical variable or use the outer variable directly to avoid confusing scope shadowing."
         );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_capture_var_rule_reports_capture_used_without_match() {
+        let source = "use strict;\nuse warnings;\nmy $x = $1;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(CaptureVarWithoutRegexMatchRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.regex.capture_without_match");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(
+            finding.message,
+            "Capture variable '$1' used without a preceding regex match in scope"
+        );
+        assert_eq!(finding.suppression_key, "native.regex.capture_without_match");
+        assert_eq!(finding.fix.as_ref().map(|fix| fix.title.as_str()), None);
+    }
+
+    #[test]
+    fn native_capture_var_rule_accepts_capture_after_regex_match() {
+        let source = "use strict;\nuse warnings;\nif ('hello' =~ /(ell)/) { my $x = $1; }\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(CaptureVarWithoutRegexMatchRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "capture after a regex match should be accepted");
+    }
+
+    #[test]
+    fn native_capture_var_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $x = $1;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.regex.capture_without_match".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(CaptureVarWithoutRegexMatchRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.regex.capture_without_match -- fixture\nuse strict;\nuse warnings;\nmy $x = $1;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_capture_var_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $x = $1;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry =
+            NativeCriticRegistry::with_rules(vec![Box::new(CaptureVarWithoutRegexMatchRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.regex.capture_without_match");
+        assert_eq!(
+            violations[0].description,
+            "Capture variable '$1' used without a preceding regex match in scope"
+        );
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_undeclared_variable_rule_reports_undeclared_use() {
+        let source = "use strict;\nuse warnings;\nprint $undeclared;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndeclaredVariableRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.variables.undeclared");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Variable '$undeclared' is used but not declared");
+        assert_eq!(finding.suppression_key, "native.variables.undeclared");
+        assert_eq!(
+            finding.fix.as_ref().map(|fix| (fix.title.as_str(), fix.safety)),
+            Some(("Change to 'my $undeclared'", FixSafety::Suggested))
+        );
+    }
+
+    #[test]
+    fn native_undeclared_variable_rule_accepts_declared_variables() {
+        let source = "use strict;\nuse warnings;\nmy $declared = 1;\nprint $declared;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndeclaredVariableRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "declared variables should be accepted");
+    }
+
+    #[test]
+    fn native_undeclared_variable_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nprint $undeclared;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.variables.undeclared".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndeclaredVariableRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.variables.undeclared -- fixture\nuse strict;\nuse warnings;\nprint $undeclared;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_undeclared_variable_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nprint $undeclared;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UndeclaredVariableRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.variables.undeclared");
+        assert_eq!(violations[0].description, "Variable '$undeclared' is used but not declared");
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_uninitialized_variable_rule_reports_use_before_init() {
+        let source = "use strict;\nuse warnings;\nmy $count;\nprint $count;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UninitializedVariableRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.variables.uninitialized");
+        assert_eq!(finding.category, CriticCategory::Semantic);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Variable '$count' used before initialization");
+        assert_eq!(finding.suppression_key, "native.variables.uninitialized");
+        assert_eq!(finding.fix.as_ref().map(|fix| fix.title.as_str()), None);
+    }
+
+    #[test]
+    fn native_uninitialized_variable_rule_accepts_initialized_variables() {
+        let source = "use strict;\nuse warnings;\nmy $count = 0;\nprint $count;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UninitializedVariableRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "initialized variables should be accepted");
+    }
+
+    #[test]
+    fn native_uninitialized_variable_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $count;\nprint $count;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.variables.uninitialized".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UninitializedVariableRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.variables.uninitialized -- fixture\nuse strict;\nuse warnings;\nmy $count;\nprint $count;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_uninitialized_variable_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $count;\nprint $count;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UninitializedVariableRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.variables.uninitialized");
+        assert_eq!(violations[0].description, "Variable '$count' used before initialization");
+        assert_eq!(violations[0].severity, Severity::Stern);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
+    fn native_unquoted_bareword_rule_reports_bareword_under_strict() {
+        let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnquotedBarewordRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.syntax.unquoted_bareword");
+        assert_eq!(finding.category, CriticCategory::Syntax);
+        assert_eq!(finding.severity, Severity::Stern);
+        assert_eq!(finding.message, "Bareword 'FOO' not allowed under strict");
+        assert_eq!(finding.suppression_key, "native.syntax.unquoted_bareword");
+        assert_eq!(
+            finding.fix.as_ref().map(|fix| (fix.title.as_str(), fix.safety)),
+            Some(("Quote as \"FOO\"", FixSafety::Suggested))
+        );
+    }
+
+    #[test]
+    fn native_unquoted_bareword_rule_accepts_quoted_strings() {
+        let source = "use strict;\nuse warnings;\nmy $x = \"FOO\";\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnquotedBarewordRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "quoted strings should be accepted");
+    }
+
+    #[test]
+    fn native_unquoted_bareword_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.syntax.unquoted_bareword".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnquotedBarewordRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.syntax.unquoted_bareword -- fixture\nuse strict;\nuse warnings;\nmy $x = FOO;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_unquoted_bareword_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\nmy $x = FOO;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnquotedBarewordRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.syntax.unquoted_bareword");
+        assert_eq!(violations[0].description, "Bareword 'FOO' not allowed under strict");
         assert_eq!(violations[0].severity, Severity::Stern);
         assert_eq!(violations[0].file, "lib/App.pm");
     }

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -14,13 +14,13 @@
 
 | Metric | Value |
 | --- | ---: |
-| Native rule count | 22 |
-| Rules with suppressions | 22 |
+| Native rule count | 26 |
+| Rules with suppressions | 26 |
 | Rules with fixes | 14 |
-| Pull diagnostics coverage | 22 |
-| Push diagnostics coverage | 22 |
-| Workspace diagnostics coverage | 22 |
-| Violation bridge coverage | 22 |
+| Pull diagnostics coverage | 26 |
+| Push diagnostics coverage | 26 |
+| Workspace diagnostics coverage | 26 |
+| Violation bridge coverage | 26 |
 
 Native rules:
 - `native.testing.require_use_strict`
@@ -45,6 +45,10 @@ Native rules:
 - `native.variables.parameter_shadows_global`
 - `native.variables.duplicate_lexical`
 - `native.variables.shadowed_lexical`
+- `native.regex.capture_without_match`
+- `native.variables.undeclared`
+- `native.variables.uninitialized`
+- `native.syntax.unquoted_bareword`
 
 Fixable native rules:
 - `native.common.assignment_in_condition`


### PR DESCRIPTION
Problem: Native critic still had ScopeAnalyzer IssueKind gaps, with draft PRs #8310 and #8333 covering overlapping registry snapshots.
Fix: Add one current-master native adapter pass for capture-without-match, undeclared variables, uninitialized variables, and unquoted barewords, then regenerate native-tooling status.
Verification: `cargo test -p perl-lsp-rs-core --lib --profile agent --locked` passes; `cargo clippy --locked -p perl-lsp-rs-core --lib --profile agent -- -D warnings -A missing_docs` passes; `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md` passes; `cargo xtask fmt --check` passes; `git diff --check` passes.

Closes #8361.
Supersedes draft PRs #8310 and #8333.