### PR TITLE
docs(tooling): add native tooling migration guide (#0000)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,7 @@ Choose the path that matches what you are trying to do:
 | Set up continuous testing and watch loops | [Continuous Testing](how-to/CONTINUOUS_TESTING.md) |
 | Configure editor or workspace settings | [Configuration Reference](reference/CONFIG.md) |
 | Share project settings with my team | [Project Configuration File (.perl-lsp.toml)](reference/CONFIG.md#project-configuration-file-perl-lsptoml) |
+| Migrate from perltidy or perlcritic to native tooling | [Native Tooling Migration](how-to/NATIVE_TOOLING_MIGRATION.md) |
 | Troubleshoot startup, indexing, or editor issues | [Troubleshooting](how-to/TROUBLESHOOTING.md) |
 | Understand the server architecture | [Architecture Overview](reference/ARCHITECTURE_OVERVIEW.md) |
 | Understand the compiler-backed LSP direction | [Compiler-Backed LSP Roadmap](project/COMPILER_BACKED_LSP_ROADMAP.md) |
@@ -63,6 +64,7 @@ Task-focused instructions for common workflows (goal-oriented).
 - [GitHub Actions Integration](how-to/GITHUB_ACTIONS.md)
 - [Upgrading](how-to/UPGRADING.md)
 - [Editor Setup](how-to/EDITOR_SETUP.md)
+- [Native Tooling Migration](how-to/NATIVE_TOOLING_MIGRATION.md)
 - [Troubleshooting](how-to/TROUBLESHOOTING.md)
 - [Continuous Testing](how-to/CONTINUOUS_TESTING.md)
 - [Contributing LSP Features](how-to/CONTRIBUTING_LSP.md)

--- a/docs/how-to/NATIVE_TOOLING_MIGRATION.md
+++ b/docs/how-to/NATIVE_TOOLING_MIGRATION.md
@@ -1,0 +1,159 @@
+# Native Tooling Migration
+
+This guide explains how to move from shelling out to `perltidy` and
+`perlcritic` toward the Rust-native formatter and native critic surfaces in
+`perl-lsp`.
+
+The migration target is native-first tooling:
+
+- native formatting for normal editor formatting and range formatting
+- native critic diagnostics for structured LSP findings, suppressions, and code
+  actions
+- external `perltidy` and `perlcritic` only when a project still needs exact
+  legacy behavior
+
+The current native path is useful, but it is still intentionally conservative.
+Use the status and compatibility receipts below to decide whether a project can
+move fully native or should keep an external compatibility path for now.
+
+## Check Current Coverage
+
+Start with the generated native-tooling dashboard:
+
+```bash
+cargo xtask native-tooling status \
+  --markdown docs/project/status/native_tooling.md
+```
+
+The dashboard summarizes formatter fixtures, literal-preserve bailouts, native
+critic rule coverage, code-action coverage, and compatibility receipt counts.
+See [Native Tooling Status](../project/status/native_tooling.md) for the current
+checked-in snapshot.
+
+For formatter proof, run:
+
+```bash
+cargo xtask native-format check
+cargo xtask native-format corpus
+```
+
+For compatibility reporting, run:
+
+```bash
+cargo xtask native-format perltidy-compat \
+  --profile .perltidyrc \
+  --receipt target/receipts/format/native-format-perltidy-compat.json \
+  --summary target/receipts/format/native-format-perltidy-compat.md
+
+cargo xtask native-tooling perlcritic-compat \
+  --profile .perlcriticrc \
+  --receipt target/receipts/native-tooling/perlcritic-compat.json \
+  --summary target/receipts/native-tooling/perlcritic-compat.md
+```
+
+These commands do not change runtime behavior. They classify existing legacy
+profiles against native support so teams can migrate deliberately.
+
+## Formatter Migration
+
+The native formatter is the default formatter engine in the Rust formatting
+provider. The subprocess-backed `PerlTidyFormatter` remains available as a
+compatibility adapter and comparison surface.
+
+Use native formatting when:
+
+- the native-format fixture and corpus receipts pass
+- the project does not require exact `perltidy` output
+- `.perltidyrc` options are classified as `supported`, `approximated`, or
+  `unsupported_safe`
+- unsupported literal surfaces are preserved or produce explicit diagnostics
+
+Keep external `perltidy` compatibility when:
+
+- review policy requires byte-for-byte `perltidy` output
+- `.perltidyrc` contains options classified as `external_only`
+- a project depends on layout behavior that native formatting has not learned
+  yet
+
+The native formatter should not silently rewrite risky Perl constructs. When it
+cannot safely format a surface such as POD, heredocs, DATA or END sections,
+regexes, substitutions, quote-like forms, or format bodies, it preserves the
+source and records the unsupported surface through native-format receipts.
+
+## Critic Migration
+
+The native critic is opt-in. Legacy `perlcritic` remains the default external
+engine until the native recommended profile is broad enough and boring under
+receipts.
+
+To try the native critic in project config:
+
+```toml
+[diagnostics]
+perlcritic = true
+perlcritic_severity = 3
+
+[critic]
+engine = "native"
+```
+
+Use native critic diagnostics when:
+
+- the needed policies map to native rule IDs in the compatibility receipt
+- suppressions and severity filtering match the project policy
+- editor diagnostics should expose stable rule IDs, precise spans, and code
+  actions
+
+Keep external `perlcritic` compatibility when:
+
+- the project depends on policies classified as `external_only`
+- theme expansion or profile loading behavior is required
+- the team needs exact Perl::Critic policy output during a transition window
+
+Native critic diagnostics use `source: perl-lsp-critic` and rule IDs such as
+`native.io.two_arg_open` or `native.variables.unused_lexical`. Inline
+suppressions can use the native suppression prefix:
+
+```perl
+## no perl-lsp-critic native.variables.unused_lexical -- migration exception
+```
+
+## Interpret Compatibility Results
+
+Compatibility receipts use these classifications:
+
+| Classification | Meaning |
+| --- | --- |
+| `supported` / `native_equivalent` | Native behavior directly covers the legacy option or policy. |
+| `native_superset` | Native behavior covers the legacy policy and adds more precise or broader checks. |
+| `approximated` | Native behavior is close, but not a one-to-one legacy match. Review before cutover. |
+| `unsupported_safe` | The legacy setting has no runtime effect on native tooling or can be ignored safely. |
+| `external_only` | Keep the external adapter if this behavior is required. |
+
+After regenerating compatibility receipts, refresh the dashboard:
+
+```bash
+cargo xtask native-tooling status \
+  --markdown docs/project/status/native_tooling.md
+```
+
+## PR Proof
+
+For PRs that touch native formatter, native critic, or compatibility reporting,
+include the relevant receipt commands in the proof packet:
+
+```bash
+cargo xtask fmt
+cargo xtask native-format check
+cargo xtask native-format corpus
+cargo xtask native-tooling status \
+  --markdown docs/project/status/native_tooling.md
+cargo xtask check-memory-lifecycle-policy
+cargo xtask check-memory-retained-owner-drift --base origin/master
+cargo xtask devex pr-body --base origin/master
+git diff --check
+```
+
+Do not make native tooling the default for more surfaces just because a single
+fixture passes. Cutover should happen only after fixture, corpus,
+compatibility, LSP, and code-action receipts are stable.


### PR DESCRIPTION
## Summary

- add a native tooling migration guide for moving from `perltidy` / `perlcritic` toward native formatter and native critic surfaces
- document the compatibility receipt commands and how to interpret classifications
- link the guide from the documentation index
- include the native-format corpus receipt in the PR proof checklist

This is docs-only. It does not change runtime behavior, formatter defaults, critic defaults, compatibility receipt schemas, or CI gates.

## Proof packet

Changed surfaces:
- docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo xtask native-format check`
- [x] `cargo xtask native-format corpus`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Unavailable local command:
- `cargo xtask markdown-links` is not available in this checkout, so it was not used.

Receipt:
- `target/devex/local-proof.json`