### PR TITLE
feat(critic): add native POD sections rule (#0000)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -16,7 +16,7 @@ pub use native::{
     CriticRelatedInformation, CriticRule, CriticSuppression, CriticSuppressionMap,
     CriticSuppressionScope, CriticTextEdit, DeprecatedDefinedRule, DuplicateLexicalDeclarationRule,
     DuplicateParameterRule, FixSafety, NativeCriticRegistry, ParameterShadowsGlobalRule,
-    PrintfFormatArityRule, RequireUseStrictRule, RequireUseWarningsRule,
+    PrintfFormatArityRule, RequirePodSectionsRule, RequireUseStrictRule, RequireUseWarningsRule,
     ShadowedLexicalVariableRule, StaleDollarAtRule, UndefComparisonRule, UnreachableCodeRule,
     UnusedLexicalVariableRule, UnusedParameterRule,
 };

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -262,6 +262,7 @@ impl NativeCriticRegistry {
             Box::new(UndeclaredVariableRule),
             Box::new(UninitializedVariableRule),
             Box::new(UnquotedBarewordRule),
+            Box::new(RequirePodSectionsRule),
         ])
     }
 
@@ -1135,6 +1136,38 @@ impl CriticRule for UnquotedBarewordRule {
     }
 }
 
+/// Native rule that checks required sections inside existing POD blocks.
+pub struct RequirePodSectionsRule;
+
+impl CriticRule for RequirePodSectionsRule {
+    fn id(&self) -> &'static str {
+        "native.documentation.require_pod_sections"
+    }
+
+    fn category(&self) -> CriticCategory {
+        CriticCategory::Documentation
+    }
+
+    fn default_severity(&self) -> Severity {
+        Severity::Harsh
+    }
+
+    fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>) {
+        out.extend(
+            missing_pod_sections(ctx.source)
+                .into_iter()
+                .map(|missing| require_pod_sections_finding(self, ctx.source, &missing)),
+        );
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MissingPodSection {
+    name: &'static str,
+    range_start: usize,
+    range_end: usize,
+}
+
 fn unused_lexical_finding(
     rule: &UnusedLexicalVariableRule,
     source: &str,
@@ -1655,6 +1688,32 @@ fn system_exec_finding(
         related: vec![CriticRelatedInformation {
             range,
             message: "List form avoids shell interpolation, but command execution still needs an explicit security review.".to_string(),
+        }],
+        fix: None,
+    }
+}
+
+fn require_pod_sections_finding(
+    rule: &RequirePodSectionsRule,
+    source: &str,
+    missing: &MissingPodSection,
+) -> CriticFinding {
+    let range = range_for_byte_span(source, missing.range_start, missing.range_end);
+
+    CriticFinding {
+        rule_id: rule.id().to_string(),
+        category: rule.category(),
+        severity: rule.default_severity(),
+        range,
+        message: format!("POD is missing required =head1 {} section", missing.name),
+        explanation: format!(
+            "Native critic checks existing POD for required high-level sections. Add an =head1 {} section or suppress this documentation policy for generated or internal-only files.",
+            missing.name
+        ),
+        suppression_key: rule.id().to_string(),
+        related: vec![CriticRelatedInformation {
+            range,
+            message: "This POD block is missing a required documentation section.".to_string(),
         }],
         fix: None,
     }
@@ -2586,6 +2645,56 @@ fn has_use_statement_line(line: &str, feature: &str) -> bool {
         return false;
     };
     module.trim_end_matches(';') == feature
+}
+
+fn missing_pod_sections(source: &str) -> Vec<MissingPodSection> {
+    const REQUIRED: &[&str] = &["NAME", "DESCRIPTION"];
+
+    let mut has_pod = false;
+    let mut sections = Vec::new();
+    let mut first_pod_span = None;
+    let mut byte_offset = 0;
+
+    for line in source.split_inclusive('\n') {
+        let line_without_newline = line.trim_end_matches(['\r', '\n']);
+        let trimmed = line_without_newline.trim_start();
+
+        if let Some(section) = trimmed.strip_prefix("=head1") {
+            has_pod = true;
+            first_pod_span.get_or_insert((byte_offset, byte_offset + line_without_newline.len()));
+
+            let section_name = section
+                .split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .trim_end_matches(|ch: char| !ch.is_alphanumeric())
+                .to_ascii_uppercase();
+            if !section_name.is_empty() {
+                sections.push(section_name);
+            }
+        } else if trimmed.starts_with("=pod")
+            || trimmed.starts_with("=over")
+            || trimmed.starts_with("=item")
+            || trimmed.starts_with("=begin")
+        {
+            has_pod = true;
+            first_pod_span.get_or_insert((byte_offset, byte_offset + line_without_newline.len()));
+        }
+
+        byte_offset += line.len();
+    }
+
+    if !has_pod {
+        return Vec::new();
+    }
+
+    let (range_start, range_end) = first_pod_span.unwrap_or((0, source.len().min(1)));
+
+    REQUIRED
+        .iter()
+        .filter(|required| !sections.iter().any(|section| section == **required))
+        .map(|name| MissingPodSection { name, range_start, range_end })
+        .collect()
 }
 
 fn range_for_byte_span(content: &str, start: usize, end: usize) -> Range {
@@ -4266,6 +4375,86 @@ mod tests {
     }
 
     #[test]
+    fn native_require_pod_sections_rule_reports_incomplete_pod() {
+        let source =
+            "use strict;\nuse warnings;\n=head1 NAME\n\nApp::Demo - demo module\n\n=cut\n\n1;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(RequirePodSectionsRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert_eq!(findings.len(), 1);
+        let finding = &findings[0];
+        assert_eq!(finding.rule_id, "native.documentation.require_pod_sections");
+        assert_eq!(finding.category, CriticCategory::Documentation);
+        assert_eq!(finding.severity, Severity::Harsh);
+        assert_eq!(finding.message, "POD is missing required =head1 DESCRIPTION section");
+        assert_eq!(finding.suppression_key, "native.documentation.require_pod_sections");
+        assert_eq!(&source[finding.range.start.byte..finding.range.end.byte], "=head1 NAME");
+        assert!(finding.fix.is_none(), "documentation policy should not fabricate POD content");
+    }
+
+    #[test]
+    fn native_require_pod_sections_rule_accepts_complete_pod_and_files_without_pod() {
+        let complete_source = "use strict;\nuse warnings;\n=head1 NAME\n\nApp::Demo\n\n=head1 DESCRIPTION\n\nDemo.\n\n=cut\n\n1;\n";
+        let complete_ast = parse_source(complete_source);
+        let config = CriticConfig::default();
+        let complete_ctx = CriticContext::new(complete_source, &complete_ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(RequirePodSectionsRule)]);
+
+        assert!(registry.check(&complete_ctx).is_empty());
+
+        let no_pod_source = "use strict;\nuse warnings;\npackage App::Demo;\n1;\n";
+        let no_pod_ast = parse_source(no_pod_source);
+        let no_pod_ctx = CriticContext::new(no_pod_source, &no_pod_ast, &config);
+
+        assert!(
+            registry.check(&no_pod_ctx).is_empty(),
+            "native rule only checks existing POD sections to avoid noisy opt-in diagnostics"
+        );
+    }
+
+    #[test]
+    fn native_require_pod_sections_rule_composes_with_config_and_suppressions() {
+        let source = "use strict;\nuse warnings;\n=head1 NAME\n\nApp::Demo\n\n=cut\n\n1;\n";
+        let ast = parse_source(source);
+        let excluded_config = CriticConfig {
+            exclude: vec!["native.documentation.require_pod_sections".to_string()],
+            ..Default::default()
+        };
+        let excluded_ctx = CriticContext::new(source, &ast, &excluded_config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(RequirePodSectionsRule)]);
+
+        assert!(registry.check(&excluded_ctx).is_empty());
+
+        let suppressed_source = "## no critic native.documentation.require_pod_sections -- generated docs\nuse strict;\nuse warnings;\n=head1 NAME\n\nApp::Demo\n\n=cut\n\n1;\n";
+        let suppressed_ast = parse_source(suppressed_source);
+        let config = CriticConfig::default();
+        let suppressed_ctx = CriticContext::new(suppressed_source, &suppressed_ast, &config);
+
+        assert!(registry.check(&suppressed_ctx).is_empty());
+    }
+
+    #[test]
+    fn native_require_pod_sections_rule_flows_through_violation_bridge() {
+        let source = "use strict;\nuse warnings;\n=head1 DESCRIPTION\n\nDemo.\n\n=cut\n\n1;\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(RequirePodSectionsRule)]);
+
+        let violations = registry.check_violations(&ctx, "lib/App.pm");
+
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].policy, "native.documentation.require_pod_sections");
+        assert_eq!(violations[0].description, "POD is missing required =head1 NAME section");
+        assert_eq!(violations[0].severity, Severity::Harsh);
+        assert_eq!(violations[0].file, "lib/App.pm");
+    }
+
+    #[test]
     fn native_recommended_registry_contains_initial_policy_bundle() {
         let source = "print 1;\n";
         let ast = parse_source(source);
@@ -4303,7 +4492,8 @@ mod tests {
                 "native.regex.capture_without_match",
                 "native.variables.undeclared",
                 "native.variables.uninitialized",
-                "native.syntax.unquoted_bareword"
+                "native.syntax.unquoted_bareword",
+                "native.documentation.require_pod_sections"
             ]
         );
         assert_eq!(findings.len(), 2);

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -1354,7 +1354,7 @@ mod tests {
 
         let items = get_full_items(provider.get_document_diagnostics_with_context(
             &uri,
-            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nsub unreachable_helper { return 1; my $dead_after_return = 2; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n",
+            "my $x = 1;\nmy $x = 2;\nmy $unused = 3;\nmy $shadow = 4;\nmy $outer_param = 0;\nmy $cond = 0;\nmy $path = 'file.txt';\nmy @items = (1, 2);\nmy $eval_code = 'print 1';\nmy $cmd_out = `ls`;\nmy $qx_out = qx(date);\nmy $readpipe_out = readpipe($path);\nif ($cond = 1) { print $cond; }\nif (defined @items) { print @items; }\nif ($path == undef) { print $path; }\neval { die $path; };\nif ($@) { warn $@; }\nprintf \"%s %s\", $path;\nopen(FH, '<', 'file.txt');\nopen(my $log_fh, $path);\nopen(my $pipe_fh, '-|', 'ls');\neval $eval_code;\nsystem($path);\nexec('ls', '-la');\nprint $log_fh;\nprint $pipe_fh;\n{ my $shadow = 5; print $shadow; }\nsub helper($used_param, $unused_param) { return $used_param; }\nsub duplicate_param($dup_param, $dup_param) { return $dup_param; }\nsub shadow_param($outer_param) { return $outer_param; }\nsub unreachable_helper { return 1; my $dead_after_return = 2; }\nprint $x + $shadow + $outer_param + $cond + $cmd_out + $qx_out + $readpipe_out;\n=head1 NAME\n\nDemo\n\n=cut\n",
             None,
             &context,
             None,
@@ -1763,6 +1763,28 @@ mod tests {
         assert_eq!(data["code"], "native.variables.shadowed_lexical");
         assert_eq!(data["suppressionKey"], "native.variables.shadowed_lexical");
         assert_eq!(data["fixable"], true);
+
+        let require_pod_sections = items
+            .iter()
+            .find(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.documentation.require_pod_sections"),
+                )
+            })
+            .ok_or("expected native required POD sections finding")?;
+        assert_eq!(require_pod_sections.source.as_deref(), Some("perl-lsp-critic"));
+        assert_eq!(require_pod_sections.severity, Some(LspDiagnosticSeverity::WARNING));
+        assert_eq!(
+            require_pod_sections.message,
+            "POD is missing required =head1 DESCRIPTION section"
+        );
+        let data = require_pod_sections
+            .data
+            .as_ref()
+            .ok_or("native required POD sections data should be populated")?;
+        assert_eq!(data["code"], "native.documentation.require_pod_sections");
+        assert_eq!(data["suppressionKey"], "native.documentation.require_pod_sections");
+        assert_eq!(data["fixable"], false);
         Ok(())
     }
 

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -26,19 +26,19 @@
 
 | Metric | Value |
 | --- | ---: |
-| Native rule count | 26 |
-| Rules with suppressions | 26 |
+| Native rule count | 27 |
+| Rules with suppressions | 27 |
 | Rules with fixes | 14 |
-| Pull diagnostics coverage | 26 |
-| Push diagnostics coverage | 26 |
-| Workspace diagnostics coverage | 26 |
-| Violation bridge coverage | 26 |
+| Pull diagnostics coverage | 27 |
+| Push diagnostics coverage | 27 |
+| Workspace diagnostics coverage | 27 |
+| Violation bridge coverage | 27 |
 | Perlcritic compatibility items | 12 |
 | Perlcritic compatibility native-equivalent | 5 |
 | Perlcritic compatibility native-superset | 2 |
-| Perlcritic compatibility approximated | 1 |
+| Perlcritic compatibility approximated | 2 |
 | Perlcritic compatibility unsupported-safe | 1 |
-| Perlcritic compatibility external-only | 3 |
+| Perlcritic compatibility external-only | 2 |
 
 Native rules:
 - `native.testing.require_use_strict`
@@ -67,6 +67,7 @@ Native rules:
 - `native.variables.undeclared`
 - `native.variables.uninitialized`
 - `native.syntax.unquoted_bareword`
+- `native.documentation.require_pod_sections`
 
 Fixable native rules:
 - `native.common.assignment_in_condition`

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -722,6 +722,11 @@ fn perlcritic_policy_native_mapping(
             "approximated",
             "native critic has duplicate and shadowing rules but not a single combined perlcritic policy",
         )),
+        "Documentation::RequirePodSections" => Some((
+            "native.documentation.require_pod_sections",
+            "approximated",
+            "native critic checks required NAME/DESCRIPTION sections when a file already contains POD",
+        )),
         _ => None,
     }
 }
@@ -1057,15 +1062,15 @@ color = 1
         assert_eq!(receipt["item_count"], 12);
         assert_eq!(receipt["native_equivalent_count"], 5);
         assert_eq!(receipt["native_superset_count"], 2);
-        assert_eq!(receipt["approximated_count"], 1);
+        assert_eq!(receipt["approximated_count"], 2);
         assert_eq!(receipt["unsupported_safe_count"], 1);
-        assert_eq!(receipt["external_only_count"], 3);
+        assert_eq!(receipt["external_only_count"], 2);
         assert_eq!(receipt["items"][0]["classification"], "native_equivalent");
         assert_eq!(receipt["items"][2]["name"], "exclude");
         assert_eq!(receipt["items"][5]["native_rule"], "native.io.two_arg_open");
         assert_eq!(receipt["items"][6]["native_rule"], "native.io.unchecked_open_close");
         assert_eq!(receipt["items"][8]["classification"], "approximated");
-        assert_eq!(receipt["items"][9]["classification"], "external_only");
+        assert_eq!(receipt["items"][9]["classification"], "approximated");
         assert_eq!(receipt["items"][11]["name"], "color");
 
         let summary = fs::read_to_string(receipts.join("perlcritic-compat.md"))?;
@@ -1075,9 +1080,7 @@ color = 1
         ));
         assert!(summary.contains("| policy | `InputOutput::ProhibitTwoArgOpen` |  | native_equivalent | native.io.two_arg_open |"));
         assert!(summary.contains("| policy | `InputOutput::RequireCheckedOpen` |  | native_superset | native.io.unchecked_open_close |"));
-        assert!(
-            summary.contains("| policy | `Documentation::RequirePodSections` |  | external_only |")
-        );
+        assert!(summary.contains("| policy | `Documentation::RequirePodSections` |  | approximated | native.documentation.require_pod_sections |"));
         assert!(summary.contains("| setting | `profile-strictness` | quiet | unsupported_safe |"));
         assert!(summary.contains("| setting | `color` | 1 | external_only |"));
 


### PR DESCRIPTION
## Summary

- Add `native.documentation.require_pod_sections` to the opt-in native critic registry.
- Keep the rule conservative: it checks existing POD blocks for `=head1 NAME` and `=head1 DESCRIPTION`, but does not warn on files with no POD yet.
- Surface the rule through pull diagnostics, violation bridge coverage, and native-tooling status.
- Map `Documentation::RequirePodSections` in the `.perlcriticrc` compatibility report as an approximated native rule instead of external-only.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_require_pod_sections --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_recommended_registry_contains_initial_policy_bundle --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- [x] `cargo test -p xtask perlcritic_compat -- --nocapture`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic_engine_emits_opt_in_lsp_diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

## Notes

`just status-check` was run and still reports the pre-existing generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR intentionally only regenerates `docs/project/status/native_tooling.md` for the native critic status change.
