### PR TITLE
feat(format): add native trailing comma policy (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -21,6 +21,7 @@ pub mod native;
 pub use native::{
     FinalNewline, FormatConfig, FormatDiagnostic, FormatDiagnosticSeverity, FormatDoc,
     FormatResult, FormatterMode, NativeFormatter, PerlFormatter, TextEdit, TextPosition, TextRange,
+    TrailingComma,
 };
 
 /// Configuration for perltidy.

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -186,6 +186,17 @@ pub enum FinalNewline {
     Trim,
 }
 
+/// Trailing comma handling for wrapped delimited expressions.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrailingComma {
+    /// Preserve the native formatter's current behavior and do not add commas.
+    #[default]
+    Preserve,
+    /// Add a trailing comma when a call, list, or hash is rendered across lines.
+    AddWhenWrapped,
+}
+
 /// Configuration shared by native formatter implementations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormatConfig {
@@ -199,6 +210,8 @@ pub struct FormatConfig {
     pub use_tabs: bool,
     /// Final newline handling.
     pub final_newline: FinalNewline,
+    /// Trailing comma handling for wrapped delimited expressions.
+    pub trailing_comma: TrailingComma,
 }
 
 impl Default for FormatConfig {
@@ -209,6 +222,7 @@ impl Default for FormatConfig {
             indent_width: 4,
             use_tabs: false,
             final_newline: FinalNewline::Preserve,
+            trailing_comma: TrailingComma::Preserve,
         }
     }
 }
@@ -1822,6 +1836,9 @@ fn render_delimited_doc(
                 item_docs.push(FormatDoc::SoftLine);
             }
             item_docs.push(FormatDoc::text(item));
+        }
+        if config.trailing_comma == TrailingComma::AddWhenWrapped {
+            item_docs.push(FormatDoc::if_break(FormatDoc::text(","), FormatDoc::text("")));
         }
         parts.push(FormatDoc::indent(item_docs));
         parts.push(FormatDoc::if_break(FormatDoc::SoftLine, FormatDoc::text("")));

--- a/crates/perl-lsp-perltidy/tests/native_contract_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_contract_tests.rs
@@ -1,6 +1,6 @@
 use perl_lsp_perltidy::{
     FinalNewline, FormatConfig, FormatDiagnosticSeverity, FormatResult, FormatterMode,
-    TextPosition, TextRange,
+    TextPosition, TextRange, TrailingComma,
 };
 
 #[test]
@@ -12,6 +12,7 @@ fn native_format_config_defaults_to_native_safe_profile() {
     assert_eq!(config.indent_width, 4);
     assert!(!config.use_tabs);
     assert_eq!(config.final_newline, FinalNewline::Preserve);
+    assert_eq!(config.trailing_comma, TrailingComma::Preserve);
 }
 
 #[test]

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -1,5 +1,6 @@
 use perl_lsp_perltidy::{
     FinalNewline, FormatConfig, NativeFormatter, PerlFormatter, TextPosition, TextRange,
+    TrailingComma,
 };
 
 #[test]
@@ -187,6 +188,48 @@ fn native_formatter_wraps_simple_calls_lists_and_hashes_by_line_width() {
             "  $beta,\n",
             "  $gamma\n",
             ");\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_adds_trailing_commas_only_when_wrapped_and_configured() {
+    let formatter = NativeFormatter::new();
+    let config = FormatConfig {
+        line_width: 18,
+        indent_width: 2,
+        trailing_comma: TrailingComma::AddWhenWrapped,
+        ..FormatConfig::default()
+    };
+    let source = concat!(
+        "my$result=foo($alpha,$beta,$gamma);\n",
+        "my@items=($alpha,$beta,$gamma);\n",
+        "my$hash={alpha=>$alpha,beta=>$beta};\n",
+        "return foo($a,$b);\n",
+    );
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "my $result = foo(\n",
+            "  $alpha,\n",
+            "  $beta,\n",
+            "  $gamma,\n",
+            ");\n",
+            "my @items = (\n",
+            "  $alpha,\n",
+            "  $beta,\n",
+            "  $gamma,\n",
+            ");\n",
+            "my $hash = {\n",
+            "  alpha => $alpha,\n",
+            "  beta => $beta,\n",
+            "};\n",
+            "return foo($a, $b);\n",
         )
     );
     assert!(result.diagnostics.is_empty());

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -17,10 +17,10 @@
 | Corpus unsupported diagnostics | 10 |
 | Corpus passed | true |
 | Perltidy compatibility options | 7 |
-| Perltidy compatibility supported | 3 |
+| Perltidy compatibility supported | 4 |
 | Perltidy compatibility approximated | 1 |
 | Perltidy compatibility unsupported-safe | 1 |
-| Perltidy compatibility external-only | 2 |
+| Perltidy compatibility external-only | 1 |
 
 ## Critic
 

--- a/xtask/src/tasks/native_format.rs
+++ b/xtask/src/tasks/native_format.rs
@@ -490,9 +490,9 @@ fn classify_perltidy_option(option: &str, value: Option<String>) -> PerltidyComp
         "-atc" | "--add-trailing-commas" | "-natc" | "--no-add-trailing-commas" => compat_result(
             option,
             value,
-            "external_only",
-            None,
-            "native formatter does not yet expose trailing comma policy",
+            "supported",
+            Some("format.trailing_comma"),
+            "maps to native formatter trailing comma policy for wrapped calls, lists, and hashes",
         ),
         "-ci" | "--block-comment-indentation" => compat_result(
             option,
@@ -968,14 +968,15 @@ mod tests {
         )?)?;
         assert_eq!(receipt["kind"], "native_format_perltidy_compat");
         assert_eq!(receipt["option_count"], 7);
-        assert_eq!(receipt["supported_count"], 3);
+        assert_eq!(receipt["supported_count"], 4);
         assert_eq!(receipt["approximated_count"], 1);
-        assert_eq!(receipt["external_only_count"], 2);
+        assert_eq!(receipt["external_only_count"], 1);
         assert_eq!(receipt["unsupported_safe_count"], 1);
         assert_eq!(receipt["options"][0]["native_field"], "format.line_width");
         assert_eq!(receipt["options"][1]["value"], "2");
         assert_eq!(receipt["options"][4]["classification"], "unsupported_safe");
-        assert_eq!(receipt["options"][5]["classification"], "external_only");
+        assert_eq!(receipt["options"][5]["classification"], "supported");
+        assert_eq!(receipt["options"][5]["native_field"], "format.trailing_comma");
 
         let summary = fs::read_to_string(receipts.join("native-format-perltidy-compat.md"))?;
         assert!(summary.contains("# Native Format Perltidy Compatibility"));

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -902,10 +902,10 @@ mod tests {
             &format_perltidy_compat_receipt,
             r#"{
   "option_count": 7,
-  "supported_count": 3,
+  "supported_count": 4,
   "approximated_count": 1,
   "unsupported_safe_count": 1,
-  "external_only_count": 2
+  "external_only_count": 1
 }
 "#,
         )?;
@@ -959,10 +959,10 @@ mod tests {
         assert_eq!(value["formatter"]["corpus_passed"], true);
         assert_eq!(value["formatter"]["format_perltidy_compat_receipt_present"], true);
         assert_eq!(value["formatter"]["perltidy_compat_option_count"], 7);
-        assert_eq!(value["formatter"]["perltidy_compat_supported_count"], 3);
+        assert_eq!(value["formatter"]["perltidy_compat_supported_count"], 4);
         assert_eq!(value["formatter"]["perltidy_compat_approximated_count"], 1);
         assert_eq!(value["formatter"]["perltidy_compat_unsupported_safe_count"], 1);
-        assert_eq!(value["formatter"]["perltidy_compat_external_only_count"], 2);
+        assert_eq!(value["formatter"]["perltidy_compat_external_only_count"], 1);
         assert!(value["critic"]["native_rule_count"].as_u64().unwrap_or_default() > 0);
         assert_eq!(value["critic"]["critic_perlcritic_compat_receipt_present"], true);
         assert_eq!(value["critic"]["perlcritic_compat_item_count"], 12);
@@ -997,10 +997,10 @@ mod tests {
         assert!(markdown.contains("| Corpus unsupported diagnostics | 0 |"));
         assert!(markdown.contains("| Corpus passed | true |"));
         assert!(markdown.contains("| Perltidy compatibility options | 7 |"));
-        assert!(markdown.contains("| Perltidy compatibility supported | 3 |"));
+        assert!(markdown.contains("| Perltidy compatibility supported | 4 |"));
         assert!(markdown.contains("| Perltidy compatibility approximated | 1 |"));
         assert!(markdown.contains("| Perltidy compatibility unsupported-safe | 1 |"));
-        assert!(markdown.contains("| Perltidy compatibility external-only | 2 |"));
+        assert!(markdown.contains("| Perltidy compatibility external-only | 1 |"));
         assert!(markdown.contains("| Perlcritic compatibility items | 12 |"));
         assert!(markdown.contains("| Perlcritic compatibility native-equivalent | 5 |"));
         assert!(markdown.contains("| Perlcritic compatibility native-superset | 2 |"));


### PR DESCRIPTION
## Summary

Adds an opt-in native formatter trailing comma policy for wrapped delimited expressions. The default native formatter behavior is unchanged.

- introduces `TrailingComma::AddWhenWrapped` on `FormatConfig`
- emits trailing commas only when simple calls, lists, or hashes break across lines
- reports `-atc` / `--add-trailing-commas` and `-natc` / `--no-add-trailing-commas` as supported in the perltidy compatibility receipt
- regenerates `docs/project/status/native_tooling.md`, moving perltidy compatibility from 3 supported / 2 external-only to 4 supported / 1 external-only

## Scope

No formatter default change, no runtime LSP config wiring, no critic behavior change, and no broad syntax expansion.

## Proof packet

Changed surfaces:
- formatter config / native formatting
- perltidy compatibility receipts
- native-tooling status docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_adds_trailing_commas_only_when_wrapped_and_configured --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_format_config_defaults_to_native_safe_profile --profile agent --locked -- --nocapture`
- [x] `cargo test -p xtask native_format_perltidy_compat_classifies_common_options -- --nocapture`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo xtask native-format check` (`38/38` fixtures)
- [x] `cargo xtask native-format perltidy-compat --profile <sample> --receipt target/receipts/format/native-format-perltidy-compat.json --summary target/receipts/format/native-format-perltidy-compat.md` (`4` supported, `1` external-only)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p xtask --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

`just status-check` was also run. It fails on pre-existing generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`; `native_tooling.md` was regenerated for this PR and was not listed as stale.
