### PR TITLE
feat(format): add native brace placement policy (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 pub mod native;
 
 pub use native::{
-    FinalNewline, FormatConfig, FormatDiagnostic, FormatDiagnosticSeverity, FormatDoc,
-    FormatResult, FormatterMode, NativeFormatter, PerlFormatter, TextEdit, TextPosition, TextRange,
-    TrailingComma,
+    BracePlacement, FinalNewline, FormatConfig, FormatDiagnostic, FormatDiagnosticSeverity,
+    FormatDoc, FormatResult, FormatterMode, NativeFormatter, PerlFormatter, TextEdit, TextPosition,
+    TextRange, TrailingComma,
 };
 
 /// Configuration for perltidy.

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -197,6 +197,17 @@ pub enum TrailingComma {
     AddWhenWrapped,
 }
 
+/// Opening brace placement for supported native block layouts.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BracePlacement {
+    /// Keep the opening brace on the block header line.
+    #[default]
+    SameLine,
+    /// Place the opening brace on its own line at the block indentation.
+    NextLine,
+}
+
 /// Configuration shared by native formatter implementations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormatConfig {
@@ -212,6 +223,8 @@ pub struct FormatConfig {
     pub final_newline: FinalNewline,
     /// Trailing comma handling for wrapped delimited expressions.
     pub trailing_comma: TrailingComma,
+    /// Opening brace placement for supported block layouts.
+    pub brace_placement: BracePlacement,
 }
 
 impl Default for FormatConfig {
@@ -223,6 +236,7 @@ impl Default for FormatConfig {
             use_tabs: false,
             final_newline: FinalNewline::Preserve,
             trailing_comma: TrailingComma::Preserve,
+            brace_placement: BracePlacement::SameLine,
         }
     }
 }
@@ -1072,7 +1086,7 @@ fn render_simple_block_doc(
     body_indent: &str,
     config: &FormatConfig,
 ) -> String {
-    let mut parts = vec![FormatDoc::text(header)];
+    let mut parts = vec![FormatDoc::text(render_block_header(&header, indent, config))];
     push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
     FormatDoc::group(parts).render(config)
 }
@@ -1083,7 +1097,7 @@ fn render_simple_else_doc(
     body_indent: &str,
     config: &FormatConfig,
 ) -> String {
-    let mut parts = vec![FormatDoc::text(" else {")];
+    let mut parts = vec![FormatDoc::text(render_block_header(" else {", indent, config))];
     push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
     FormatDoc::group(parts).render(config)
 }
@@ -1095,7 +1109,8 @@ fn render_simple_elsif_doc(
     body_indent: &str,
     config: &FormatConfig,
 ) -> String {
-    let mut parts = vec![FormatDoc::text(format!(" elsif ({condition}) {{"))];
+    let header = format!(" elsif ({condition}) {{");
+    let mut parts = vec![FormatDoc::text(render_block_header(&header, indent, config))];
     push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
     FormatDoc::group(parts).render(config)
 }
@@ -1106,9 +1121,19 @@ fn render_simple_continue_doc(
     body_indent: &str,
     config: &FormatConfig,
 ) -> String {
-    let mut parts = vec![FormatDoc::text(" continue {")];
+    let mut parts = vec![FormatDoc::text(render_block_header(" continue {", indent, config))];
     push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
     FormatDoc::group(parts).render(config)
+}
+
+fn render_block_header(header: &str, indent: &str, config: &FormatConfig) -> String {
+    if config.brace_placement != BracePlacement::NextLine {
+        return header.to_string();
+    }
+
+    header
+        .strip_suffix(" {")
+        .map_or_else(|| header.to_string(), |prefix| format!("{prefix}\n{indent}{{"))
 }
 
 fn push_simple_block_body_docs(

--- a/crates/perl-lsp-perltidy/tests/native_contract_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_contract_tests.rs
@@ -1,6 +1,6 @@
 use perl_lsp_perltidy::{
-    FinalNewline, FormatConfig, FormatDiagnosticSeverity, FormatResult, FormatterMode,
-    TextPosition, TextRange, TrailingComma,
+    BracePlacement, FinalNewline, FormatConfig, FormatDiagnosticSeverity, FormatResult,
+    FormatterMode, TextPosition, TextRange, TrailingComma,
 };
 
 #[test]
@@ -13,6 +13,7 @@ fn native_format_config_defaults_to_native_safe_profile() {
     assert!(!config.use_tabs);
     assert_eq!(config.final_newline, FinalNewline::Preserve);
     assert_eq!(config.trailing_comma, TrailingComma::Preserve);
+    assert_eq!(config.brace_placement, BracePlacement::SameLine);
 }
 
 #[test]

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -1,6 +1,6 @@
 use perl_lsp_perltidy::{
-    FinalNewline, FormatConfig, NativeFormatter, PerlFormatter, TextPosition, TextRange,
-    TrailingComma,
+    BracePlacement, FinalNewline, FormatConfig, NativeFormatter, PerlFormatter, TextPosition,
+    TextRange, TrailingComma,
 };
 
 #[test]
@@ -546,6 +546,42 @@ fn native_formatter_expands_simple_subroutine_blocks() {
 
     assert!(result.changed);
     assert_eq!(result.formatted, "sub answer {\n    my $x = 1;\n    return $x;\n}\n");
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_places_opening_braces_on_next_line_when_configured() {
+    let formatter = NativeFormatter::new();
+    let config =
+        FormatConfig { brace_placement: BracePlacement::NextLine, ..FormatConfig::default() };
+    let source = "sub answer{return 1;}\nif($ok){return 1;}else{return 0;}\nwhile($ok){next;}continue{last;}\n";
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "sub answer\n",
+            "{\n",
+            "    return 1;\n",
+            "}\n",
+            "if ($ok)\n",
+            "{\n",
+            "    return 1;\n",
+            "} else\n",
+            "{\n",
+            "    return 0;\n",
+            "}\n",
+            "while ($ok)\n",
+            "{\n",
+            "    next;\n",
+            "} continue\n",
+            "{\n",
+            "    last;\n",
+            "}\n",
+        )
+    );
     assert!(result.diagnostics.is_empty());
 }
 

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -16,8 +16,8 @@
 | Corpus literal bailouts | 24 |
 | Corpus unsupported diagnostics | 10 |
 | Corpus passed | true |
-| Perltidy compatibility options | 7 |
-| Perltidy compatibility supported | 4 |
+| Perltidy compatibility options | 8 |
+| Perltidy compatibility supported | 5 |
 | Perltidy compatibility approximated | 1 |
 | Perltidy compatibility unsupported-safe | 1 |
 | Perltidy compatibility external-only | 1 |

--- a/xtask/src/tasks/native_format.rs
+++ b/xtask/src/tasks/native_format.rs
@@ -482,9 +482,9 @@ fn classify_perltidy_option(option: &str, value: Option<String>) -> PerltidyComp
             compat_result(
                 option,
                 value,
-                "external_only",
-                None,
-                "native formatter does not yet expose brace placement policy",
+                "supported",
+                Some("format.brace_placement"),
+                "maps to native formatter brace placement for supported simple block layouts",
             )
         }
         "-atc" | "--add-trailing-commas" | "-natc" | "--no-add-trailing-commas" => compat_result(
@@ -954,7 +954,7 @@ mod tests {
         let receipts = temp.path().join("receipts");
         fs::write(
             &profile,
-            "# common profile\n-l=100\n-i 2\n-nt\n-ce\n-q\n-atc\n--unknown-style\n",
+            "# common profile\n-l=100\n-i 2\n-nt\n-ce\n-q\n-atc\n-bl\n--unknown-style\n",
         )?;
 
         perltidy_compat(NativeFormatPerltidyCompatConfig {
@@ -967,8 +967,8 @@ mod tests {
             receipts.join("native-format-perltidy-compat.json"),
         )?)?;
         assert_eq!(receipt["kind"], "native_format_perltidy_compat");
-        assert_eq!(receipt["option_count"], 7);
-        assert_eq!(receipt["supported_count"], 4);
+        assert_eq!(receipt["option_count"], 8);
+        assert_eq!(receipt["supported_count"], 5);
         assert_eq!(receipt["approximated_count"], 1);
         assert_eq!(receipt["external_only_count"], 1);
         assert_eq!(receipt["unsupported_safe_count"], 1);
@@ -977,6 +977,8 @@ mod tests {
         assert_eq!(receipt["options"][4]["classification"], "unsupported_safe");
         assert_eq!(receipt["options"][5]["classification"], "supported");
         assert_eq!(receipt["options"][5]["native_field"], "format.trailing_comma");
+        assert_eq!(receipt["options"][6]["classification"], "supported");
+        assert_eq!(receipt["options"][6]["native_field"], "format.brace_placement");
 
         let summary = fs::read_to_string(receipts.join("native-format-perltidy-compat.md"))?;
         assert!(summary.contains("# Native Format Perltidy Compatibility"));

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -901,8 +901,8 @@ mod tests {
         fs::write(
             &format_perltidy_compat_receipt,
             r#"{
-  "option_count": 7,
-  "supported_count": 4,
+  "option_count": 8,
+  "supported_count": 5,
   "approximated_count": 1,
   "unsupported_safe_count": 1,
   "external_only_count": 1
@@ -958,8 +958,8 @@ mod tests {
         assert_eq!(value["formatter"]["corpus_unsupported_patterns_count"], 0);
         assert_eq!(value["formatter"]["corpus_passed"], true);
         assert_eq!(value["formatter"]["format_perltidy_compat_receipt_present"], true);
-        assert_eq!(value["formatter"]["perltidy_compat_option_count"], 7);
-        assert_eq!(value["formatter"]["perltidy_compat_supported_count"], 4);
+        assert_eq!(value["formatter"]["perltidy_compat_option_count"], 8);
+        assert_eq!(value["formatter"]["perltidy_compat_supported_count"], 5);
         assert_eq!(value["formatter"]["perltidy_compat_approximated_count"], 1);
         assert_eq!(value["formatter"]["perltidy_compat_unsupported_safe_count"], 1);
         assert_eq!(value["formatter"]["perltidy_compat_external_only_count"], 1);
@@ -996,8 +996,8 @@ mod tests {
         assert!(markdown.contains("| Corpus literal bailouts | 1 |"));
         assert!(markdown.contains("| Corpus unsupported diagnostics | 0 |"));
         assert!(markdown.contains("| Corpus passed | true |"));
-        assert!(markdown.contains("| Perltidy compatibility options | 7 |"));
-        assert!(markdown.contains("| Perltidy compatibility supported | 4 |"));
+        assert!(markdown.contains("| Perltidy compatibility options | 8 |"));
+        assert!(markdown.contains("| Perltidy compatibility supported | 5 |"));
         assert!(markdown.contains("| Perltidy compatibility approximated | 1 |"));
         assert!(markdown.contains("| Perltidy compatibility unsupported-safe | 1 |"));
         assert!(markdown.contains("| Perltidy compatibility external-only | 1 |"));


### PR DESCRIPTION
## Summary

Adds an opt-in native formatter brace placement policy for supported simple block layouts.

- adds `BracePlacement::{SameLine, NextLine}` to `FormatConfig`
- keeps the default native-safe profile unchanged as same-line braces
- applies next-line opening braces to the existing supported block renderers (`sub`, `if`/`elsif`/`else`, loops, `continue`)
- maps perltidy `-bl` / `--opening-brace-on-new-line` and `-bar` / `--opening-brace-always-on-right` to `format.brace_placement` in the compatibility receipt
- refreshes `native_tooling.md` so perltidy compatibility shows 8 options / 5 supported

This is formatter/config compatibility only. It does not change runtime defaults, LSP config wiring, critic behavior, or dangerous-surface formatting.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_places_opening_braces_on_next_line_when_configured --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_format_config_defaults_to_native_safe_profile --profile agent --locked -- --nocapture`
- [x] `cargo test -p xtask native_format_perltidy_compat_classifies_common_options -- --nocapture`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo xtask native-format check` (`38/38` fixtures)
- [x] `cargo xtask native-format perltidy-compat --profile <tmp> --receipt target/receipts/format/native-format-perltidy-compat.json --summary target/receipts/format/native-format-perltidy-compat.md` (`5 supported`, `1 approximated`, `1 external-only`)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p xtask --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

`just status-check` was run and failed only on pre-existing generated status drift outside this PR: `docs/project/status/tests.md`, `docs/project/status/parser.md`, `docs/project/status/quality.md`, and `docs/project/status/dap.md`. The touched `docs/project/status/native_tooling.md` was regenerated and was not listed as stale.
