### PR TITLE
feat(format): add native else placement policy (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 pub mod native;
 
 pub use native::{
-    BracePlacement, FinalNewline, FormatConfig, FormatDiagnostic, FormatDiagnosticSeverity,
-    FormatDoc, FormatResult, FormatterMode, NativeFormatter, PerlFormatter, TextEdit, TextPosition,
-    TextRange, TrailingComma,
+    BracePlacement, ElsePlacement, FinalNewline, FormatConfig, FormatDiagnostic,
+    FormatDiagnosticSeverity, FormatDoc, FormatResult, FormatterMode, NativeFormatter,
+    PerlFormatter, TextEdit, TextPosition, TextRange, TrailingComma,
 };
 
 /// Configuration for perltidy.

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -208,6 +208,17 @@ pub enum BracePlacement {
     NextLine,
 }
 
+/// Placement for supported native `else` and `elsif` block tails.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ElsePlacement {
+    /// Keep `else` and `elsif` cuddled to the previous closing brace.
+    #[default]
+    Cuddled,
+    /// Place `else` and `elsif` on a fresh line at the block indentation.
+    SeparateLine,
+}
+
 /// Configuration shared by native formatter implementations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormatConfig {
@@ -225,6 +236,8 @@ pub struct FormatConfig {
     pub trailing_comma: TrailingComma,
     /// Opening brace placement for supported block layouts.
     pub brace_placement: BracePlacement,
+    /// Else/elsif placement for supported block tails.
+    pub else_placement: ElsePlacement,
 }
 
 impl Default for FormatConfig {
@@ -237,6 +250,7 @@ impl Default for FormatConfig {
             final_newline: FinalNewline::Preserve,
             trailing_comma: TrailingComma::Preserve,
             brace_placement: BracePlacement::SameLine,
+            else_placement: ElsePlacement::Cuddled,
         }
     }
 }
@@ -1097,7 +1111,12 @@ fn render_simple_else_doc(
     body_indent: &str,
     config: &FormatConfig,
 ) -> String {
-    let mut parts = vec![FormatDoc::text(render_block_header(" else {", indent, config))];
+    let header = if config.else_placement == ElsePlacement::SeparateLine {
+        format!("\n{indent}else {{")
+    } else {
+        " else {".to_string()
+    };
+    let mut parts = vec![FormatDoc::text(render_block_header(&header, indent, config))];
     push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
     FormatDoc::group(parts).render(config)
 }
@@ -1109,7 +1128,11 @@ fn render_simple_elsif_doc(
     body_indent: &str,
     config: &FormatConfig,
 ) -> String {
-    let header = format!(" elsif ({condition}) {{");
+    let header = if config.else_placement == ElsePlacement::SeparateLine {
+        format!("\n{indent}elsif ({condition}) {{")
+    } else {
+        format!(" elsif ({condition}) {{")
+    };
     let mut parts = vec![FormatDoc::text(render_block_header(&header, indent, config))];
     push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
     FormatDoc::group(parts).render(config)

--- a/crates/perl-lsp-perltidy/tests/native_contract_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_contract_tests.rs
@@ -1,6 +1,6 @@
 use perl_lsp_perltidy::{
-    BracePlacement, FinalNewline, FormatConfig, FormatDiagnosticSeverity, FormatResult,
-    FormatterMode, TextPosition, TextRange, TrailingComma,
+    BracePlacement, ElsePlacement, FinalNewline, FormatConfig, FormatDiagnosticSeverity,
+    FormatResult, FormatterMode, TextPosition, TextRange, TrailingComma,
 };
 
 #[test]
@@ -14,6 +14,7 @@ fn native_format_config_defaults_to_native_safe_profile() {
     assert_eq!(config.final_newline, FinalNewline::Preserve);
     assert_eq!(config.trailing_comma, TrailingComma::Preserve);
     assert_eq!(config.brace_placement, BracePlacement::SameLine);
+    assert_eq!(config.else_placement, ElsePlacement::Cuddled);
 }
 
 #[test]

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -1,6 +1,6 @@
 use perl_lsp_perltidy::{
-    BracePlacement, FinalNewline, FormatConfig, NativeFormatter, PerlFormatter, TextPosition,
-    TextRange, TrailingComma,
+    BracePlacement, ElsePlacement, FinalNewline, FormatConfig, NativeFormatter, PerlFormatter,
+    TextPosition, TextRange, TrailingComma,
 };
 
 #[test]
@@ -579,6 +579,39 @@ fn native_formatter_places_opening_braces_on_next_line_when_configured() {
             "} continue\n",
             "{\n",
             "    last;\n",
+            "}\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_places_else_tails_on_separate_lines_when_configured() {
+    let formatter = NativeFormatter::new();
+    let config =
+        FormatConfig { else_placement: ElsePlacement::SeparateLine, ..FormatConfig::default() };
+    let source = "if($a){return 1;}elsif($b){return 2;}else{return 3;}\nunless($ok){return 0;}else{return 1;}\n";
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "if ($a) {\n",
+            "    return 1;\n",
+            "}\n",
+            "elsif ($b) {\n",
+            "    return 2;\n",
+            "}\n",
+            "else {\n",
+            "    return 3;\n",
+            "}\n",
+            "unless ($ok) {\n",
+            "    return 0;\n",
+            "}\n",
+            "else {\n",
+            "    return 1;\n",
             "}\n",
         )
     );

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -17,8 +17,8 @@
 | Corpus unsupported diagnostics | 10 |
 | Corpus passed | true |
 | Perltidy compatibility options | 8 |
-| Perltidy compatibility supported | 5 |
-| Perltidy compatibility approximated | 1 |
+| Perltidy compatibility supported | 6 |
+| Perltidy compatibility approximated | 0 |
 | Perltidy compatibility unsupported-safe | 1 |
 | Perltidy compatibility external-only | 1 |
 

--- a/xtask/src/tasks/native_format.rs
+++ b/xtask/src/tasks/native_format.rs
@@ -467,9 +467,9 @@ fn classify_perltidy_option(option: &str, value: Option<String>) -> PerltidyComp
         "-ce" | "--cuddled-else" | "-nce" | "--nocuddled-else" => compat_result(
             option,
             value,
-            "approximated",
-            None,
-            "native block rendering has fixed else layout today",
+            "supported",
+            Some("format.else_placement"),
+            "maps to native formatter else placement for supported simple block layouts",
         ),
         "-sok" | "--space-after-keyword" | "-nsok" | "--nospace-after-keyword" => compat_result(
             option,
@@ -968,12 +968,14 @@ mod tests {
         )?)?;
         assert_eq!(receipt["kind"], "native_format_perltidy_compat");
         assert_eq!(receipt["option_count"], 8);
-        assert_eq!(receipt["supported_count"], 5);
-        assert_eq!(receipt["approximated_count"], 1);
+        assert_eq!(receipt["supported_count"], 6);
+        assert_eq!(receipt["approximated_count"], 0);
         assert_eq!(receipt["external_only_count"], 1);
         assert_eq!(receipt["unsupported_safe_count"], 1);
         assert_eq!(receipt["options"][0]["native_field"], "format.line_width");
         assert_eq!(receipt["options"][1]["value"], "2");
+        assert_eq!(receipt["options"][3]["classification"], "supported");
+        assert_eq!(receipt["options"][3]["native_field"], "format.else_placement");
         assert_eq!(receipt["options"][4]["classification"], "unsupported_safe");
         assert_eq!(receipt["options"][5]["classification"], "supported");
         assert_eq!(receipt["options"][5]["native_field"], "format.trailing_comma");

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -902,8 +902,8 @@ mod tests {
             &format_perltidy_compat_receipt,
             r#"{
   "option_count": 8,
-  "supported_count": 5,
-  "approximated_count": 1,
+  "supported_count": 6,
+  "approximated_count": 0,
   "unsupported_safe_count": 1,
   "external_only_count": 1
 }
@@ -959,8 +959,8 @@ mod tests {
         assert_eq!(value["formatter"]["corpus_passed"], true);
         assert_eq!(value["formatter"]["format_perltidy_compat_receipt_present"], true);
         assert_eq!(value["formatter"]["perltidy_compat_option_count"], 8);
-        assert_eq!(value["formatter"]["perltidy_compat_supported_count"], 5);
-        assert_eq!(value["formatter"]["perltidy_compat_approximated_count"], 1);
+        assert_eq!(value["formatter"]["perltidy_compat_supported_count"], 6);
+        assert_eq!(value["formatter"]["perltidy_compat_approximated_count"], 0);
         assert_eq!(value["formatter"]["perltidy_compat_unsupported_safe_count"], 1);
         assert_eq!(value["formatter"]["perltidy_compat_external_only_count"], 1);
         assert!(value["critic"]["native_rule_count"].as_u64().unwrap_or_default() > 0);
@@ -997,8 +997,8 @@ mod tests {
         assert!(markdown.contains("| Corpus unsupported diagnostics | 0 |"));
         assert!(markdown.contains("| Corpus passed | true |"));
         assert!(markdown.contains("| Perltidy compatibility options | 8 |"));
-        assert!(markdown.contains("| Perltidy compatibility supported | 5 |"));
-        assert!(markdown.contains("| Perltidy compatibility approximated | 1 |"));
+        assert!(markdown.contains("| Perltidy compatibility supported | 6 |"));
+        assert!(markdown.contains("| Perltidy compatibility approximated | 0 |"));
         assert!(markdown.contains("| Perltidy compatibility unsupported-safe | 1 |"));
         assert!(markdown.contains("| Perltidy compatibility external-only | 1 |"));
         assert!(markdown.contains("| Perlcritic compatibility items | 12 |"));


### PR DESCRIPTION
## Summary

Adds an opt-in native formatter else-placement policy for supported simple block tails.

- adds `ElsePlacement::{Cuddled, SeparateLine}` to `FormatConfig`
- keeps the default native-safe profile unchanged as cuddled `else` / `elsif`
- applies separate-line `else` / `elsif` only to existing supported simple `if` / `unless` block renderers
- maps perltidy `-ce` / `--cuddled-else` and `-nce` / `--nocuddled-else` to `format.else_placement`
- refreshes `native_tooling.md` so perltidy compatibility shows 8 options / 6 supported / 0 approximated

This is formatter/config compatibility only. It does not change runtime defaults, LSP config wiring, critic behavior, or dangerous-surface formatting.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_places_else_tails_on_separate_lines_when_configured --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_format_config_defaults_to_native_safe_profile --profile agent --locked -- --nocapture`
- [x] `cargo test -p xtask native_format_perltidy_compat_classifies_common_options -- --nocapture`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo xtask native-format check` (`38/38` fixtures)
- [x] `cargo xtask native-format perltidy-compat --profile <tmp> --receipt target/receipts/format/native-format-perltidy-compat.json --summary target/receipts/format/native-format-perltidy-compat.md` (`6 supported`, `0 approximated`, `1 external-only`)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p xtask --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

`just status-check` was run and failed only on pre-existing generated status drift outside this PR: `docs/project/status/tests.md`, `docs/project/status/parser.md`, `docs/project/status/quality.md`, and `docs/project/status/dap.md`. The touched `docs/project/status/native_tooling.md` was regenerated and was not listed as stale.
