### PR TITLE
feat(format): add native keyword spacing policy (#0000)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -20,8 +20,8 @@ pub mod native;
 
 pub use native::{
     BracePlacement, ElsePlacement, FinalNewline, FormatConfig, FormatDiagnostic,
-    FormatDiagnosticSeverity, FormatDoc, FormatResult, FormatterMode, NativeFormatter,
-    PerlFormatter, TextEdit, TextPosition, TextRange, TrailingComma,
+    FormatDiagnosticSeverity, FormatDoc, FormatResult, FormatterMode, KeywordSpacing,
+    NativeFormatter, PerlFormatter, TextEdit, TextPosition, TextRange, TrailingComma,
 };
 
 /// Configuration for perltidy.

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -219,6 +219,17 @@ pub enum ElsePlacement {
     SeparateLine,
 }
 
+/// Spacing between supported control keywords and their condition parentheses.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum KeywordSpacing {
+    /// Insert a space between the keyword and condition parentheses.
+    #[default]
+    Space,
+    /// Omit the space between the keyword and condition parentheses.
+    Compact,
+}
+
 /// Configuration shared by native formatter implementations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormatConfig {
@@ -238,6 +249,8 @@ pub struct FormatConfig {
     pub brace_placement: BracePlacement,
     /// Else/elsif placement for supported block tails.
     pub else_placement: ElsePlacement,
+    /// Keyword spacing for supported control-flow condition headers.
+    pub keyword_spacing: KeywordSpacing,
 }
 
 impl Default for FormatConfig {
@@ -251,6 +264,7 @@ impl Default for FormatConfig {
             trailing_comma: TrailingComma::Preserve,
             brace_placement: BracePlacement::SameLine,
             else_placement: ElsePlacement::Cuddled,
+            keyword_spacing: KeywordSpacing::Space,
         }
     }
 }
@@ -820,7 +834,7 @@ fn format_simple_control_block_tokens(
 
     let body_indent = format!("{indent}{}", indent_unit(config));
     let mut formatted = render_simple_block_doc(
-        format!("{indent}{keyword} ({condition}) {{"),
+        render_condition_block_header(indent, keyword, &condition, config),
         &statements,
         indent,
         &body_indent,
@@ -1129,9 +1143,10 @@ fn render_simple_elsif_doc(
     config: &FormatConfig,
 ) -> String {
     let header = if config.else_placement == ElsePlacement::SeparateLine {
-        format!("\n{indent}elsif ({condition}) {{")
+        format!("\n{}", render_condition_block_header(indent, "elsif", condition, config))
     } else {
-        format!(" elsif ({condition}) {{")
+        let gap = keyword_condition_gap(config);
+        format!(" elsif{gap}({condition}) {{")
     };
     let mut parts = vec![FormatDoc::text(render_block_header(&header, indent, config))];
     push_simple_block_body_docs(&mut parts, statements, indent, body_indent);
@@ -1157,6 +1172,23 @@ fn render_block_header(header: &str, indent: &str, config: &FormatConfig) -> Str
     header
         .strip_suffix(" {")
         .map_or_else(|| header.to_string(), |prefix| format!("{prefix}\n{indent}{{"))
+}
+
+fn render_condition_block_header(
+    indent: &str,
+    keyword: &str,
+    condition: &str,
+    config: &FormatConfig,
+) -> String {
+    let gap = keyword_condition_gap(config);
+    format!("{indent}{keyword}{gap}({condition}) {{")
+}
+
+fn keyword_condition_gap(config: &FormatConfig) -> &'static str {
+    match config.keyword_spacing {
+        KeywordSpacing::Space => " ",
+        KeywordSpacing::Compact => "",
+    }
 }
 
 fn push_simple_block_body_docs(

--- a/crates/perl-lsp-perltidy/tests/native_contract_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_contract_tests.rs
@@ -1,6 +1,6 @@
 use perl_lsp_perltidy::{
     BracePlacement, ElsePlacement, FinalNewline, FormatConfig, FormatDiagnosticSeverity,
-    FormatResult, FormatterMode, TextPosition, TextRange, TrailingComma,
+    FormatResult, FormatterMode, KeywordSpacing, TextPosition, TextRange, TrailingComma,
 };
 
 #[test]
@@ -15,6 +15,7 @@ fn native_format_config_defaults_to_native_safe_profile() {
     assert_eq!(config.trailing_comma, TrailingComma::Preserve);
     assert_eq!(config.brace_placement, BracePlacement::SameLine);
     assert_eq!(config.else_placement, ElsePlacement::Cuddled);
+    assert_eq!(config.keyword_spacing, KeywordSpacing::Space);
 }
 
 #[test]

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -1,6 +1,6 @@
 use perl_lsp_perltidy::{
-    BracePlacement, ElsePlacement, FinalNewline, FormatConfig, NativeFormatter, PerlFormatter,
-    TextPosition, TextRange, TrailingComma,
+    BracePlacement, ElsePlacement, FinalNewline, FormatConfig, KeywordSpacing, NativeFormatter,
+    PerlFormatter, TextPosition, TextRange, TrailingComma,
 };
 
 #[test]
@@ -612,6 +612,37 @@ fn native_formatter_places_else_tails_on_separate_lines_when_configured() {
             "}\n",
             "else {\n",
             "    return 1;\n",
+            "}\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_compacts_keyword_condition_spacing_when_configured() {
+    let formatter = NativeFormatter::new();
+    let config =
+        FormatConfig { keyword_spacing: KeywordSpacing::Compact, ..FormatConfig::default() };
+    let source =
+        "if($a){return 1;}elsif($b){return 2;}else{return 3;}\nwhile($ok){next;}continue{last;}\n";
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "if($a) {\n",
+            "    return 1;\n",
+            "} elsif($b) {\n",
+            "    return 2;\n",
+            "} else {\n",
+            "    return 3;\n",
+            "}\n",
+            "while($ok) {\n",
+            "    next;\n",
+            "} continue {\n",
+            "    last;\n",
             "}\n",
         )
     );

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -16,8 +16,8 @@
 | Corpus literal bailouts | 24 |
 | Corpus unsupported diagnostics | 10 |
 | Corpus passed | true |
-| Perltidy compatibility options | 8 |
-| Perltidy compatibility supported | 6 |
+| Perltidy compatibility options | 9 |
+| Perltidy compatibility supported | 7 |
 | Perltidy compatibility approximated | 0 |
 | Perltidy compatibility unsupported-safe | 1 |
 | Perltidy compatibility external-only | 1 |

--- a/xtask/src/tasks/native_format.rs
+++ b/xtask/src/tasks/native_format.rs
@@ -474,9 +474,9 @@ fn classify_perltidy_option(option: &str, value: Option<String>) -> PerltidyComp
         "-sok" | "--space-after-keyword" | "-nsok" | "--nospace-after-keyword" => compat_result(
             option,
             value,
-            "approximated",
-            None,
-            "native formatter currently normalizes supported keywords with spaces",
+            "supported",
+            Some("format.keyword_spacing"),
+            "maps to native formatter keyword spacing for supported simple control-flow headers",
         ),
         "-bl" | "--opening-brace-on-new-line" | "-bar" | "--opening-brace-always-on-right" => {
             compat_result(
@@ -954,7 +954,7 @@ mod tests {
         let receipts = temp.path().join("receipts");
         fs::write(
             &profile,
-            "# common profile\n-l=100\n-i 2\n-nt\n-ce\n-q\n-atc\n-bl\n--unknown-style\n",
+            "# common profile\n-l=100\n-i 2\n-nt\n-ce\n-nsok\n-q\n-atc\n-bl\n--unknown-style\n",
         )?;
 
         perltidy_compat(NativeFormatPerltidyCompatConfig {
@@ -967,8 +967,8 @@ mod tests {
             receipts.join("native-format-perltidy-compat.json"),
         )?)?;
         assert_eq!(receipt["kind"], "native_format_perltidy_compat");
-        assert_eq!(receipt["option_count"], 8);
-        assert_eq!(receipt["supported_count"], 6);
+        assert_eq!(receipt["option_count"], 9);
+        assert_eq!(receipt["supported_count"], 7);
         assert_eq!(receipt["approximated_count"], 0);
         assert_eq!(receipt["external_only_count"], 1);
         assert_eq!(receipt["unsupported_safe_count"], 1);
@@ -976,11 +976,13 @@ mod tests {
         assert_eq!(receipt["options"][1]["value"], "2");
         assert_eq!(receipt["options"][3]["classification"], "supported");
         assert_eq!(receipt["options"][3]["native_field"], "format.else_placement");
-        assert_eq!(receipt["options"][4]["classification"], "unsupported_safe");
-        assert_eq!(receipt["options"][5]["classification"], "supported");
-        assert_eq!(receipt["options"][5]["native_field"], "format.trailing_comma");
+        assert_eq!(receipt["options"][4]["classification"], "supported");
+        assert_eq!(receipt["options"][4]["native_field"], "format.keyword_spacing");
+        assert_eq!(receipt["options"][5]["classification"], "unsupported_safe");
         assert_eq!(receipt["options"][6]["classification"], "supported");
-        assert_eq!(receipt["options"][6]["native_field"], "format.brace_placement");
+        assert_eq!(receipt["options"][6]["native_field"], "format.trailing_comma");
+        assert_eq!(receipt["options"][7]["classification"], "supported");
+        assert_eq!(receipt["options"][7]["native_field"], "format.brace_placement");
 
         let summary = fs::read_to_string(receipts.join("native-format-perltidy-compat.md"))?;
         assert!(summary.contains("# Native Format Perltidy Compatibility"));

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -901,8 +901,8 @@ mod tests {
         fs::write(
             &format_perltidy_compat_receipt,
             r#"{
-  "option_count": 8,
-  "supported_count": 6,
+  "option_count": 9,
+  "supported_count": 7,
   "approximated_count": 0,
   "unsupported_safe_count": 1,
   "external_only_count": 1
@@ -958,8 +958,8 @@ mod tests {
         assert_eq!(value["formatter"]["corpus_unsupported_patterns_count"], 0);
         assert_eq!(value["formatter"]["corpus_passed"], true);
         assert_eq!(value["formatter"]["format_perltidy_compat_receipt_present"], true);
-        assert_eq!(value["formatter"]["perltidy_compat_option_count"], 8);
-        assert_eq!(value["formatter"]["perltidy_compat_supported_count"], 6);
+        assert_eq!(value["formatter"]["perltidy_compat_option_count"], 9);
+        assert_eq!(value["formatter"]["perltidy_compat_supported_count"], 7);
         assert_eq!(value["formatter"]["perltidy_compat_approximated_count"], 0);
         assert_eq!(value["formatter"]["perltidy_compat_unsupported_safe_count"], 1);
         assert_eq!(value["formatter"]["perltidy_compat_external_only_count"], 1);
@@ -996,8 +996,8 @@ mod tests {
         assert!(markdown.contains("| Corpus literal bailouts | 1 |"));
         assert!(markdown.contains("| Corpus unsupported diagnostics | 0 |"));
         assert!(markdown.contains("| Corpus passed | true |"));
-        assert!(markdown.contains("| Perltidy compatibility options | 8 |"));
-        assert!(markdown.contains("| Perltidy compatibility supported | 6 |"));
+        assert!(markdown.contains("| Perltidy compatibility options | 9 |"));
+        assert!(markdown.contains("| Perltidy compatibility supported | 7 |"));
         assert!(markdown.contains("| Perltidy compatibility approximated | 0 |"));
         assert!(markdown.contains("| Perltidy compatibility unsupported-safe | 1 |"));
         assert!(markdown.contains("| Perltidy compatibility external-only | 1 |"));


### PR DESCRIPTION
## Summary

Adds an opt-in native formatter keyword-spacing policy for supported simple control-flow headers.

- adds `KeywordSpacing::{Space, Compact}` to `FormatConfig`
- keeps the default native-safe profile unchanged with spaces after control keywords
- applies compact keyword spacing only to existing supported simple condition headers (`if`, `elsif`, `unless`, `while`, `until`)
- maps perltidy `-sok` / `--space-after-keyword` and `-nsok` / `--nospace-after-keyword` to `format.keyword_spacing`
- refreshes `native_tooling.md` so perltidy compatibility shows 9 options / 7 supported / 0 approximated

This is formatter/config compatibility only. It does not change runtime defaults, LSP config wiring, critic behavior, or dangerous-surface formatting.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_compacts_keyword_condition_spacing_when_configured --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_format_config_defaults_to_native_safe_profile --profile agent --locked -- --nocapture`
- [x] `cargo test -p xtask native_format_perltidy_compat_classifies_common_options -- --nocapture`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo xtask native-format check` (`38/38` fixtures)
- [x] `cargo xtask native-format perltidy-compat --profile <tmp> --receipt target/receipts/format/native-format-perltidy-compat.json --summary target/receipts/format/native-format-perltidy-compat.md` (`7 supported`, `0 approximated`, `1 external-only`)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo clippy --locked -p perl-lsp-perltidy -p xtask --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

`just status-check` was run and failed only on pre-existing generated status drift outside this PR: `docs/project/status/tests.md`, `docs/project/status/parser.md`, `docs/project/status/quality.md`, and `docs/project/status/dap.md`. The touched `docs/project/status/native_tooling.md` was regenerated and was not listed as stale.
