### PR TITLE
test(format): prove native formatter config policies route through LSP (#8387)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -1022,6 +1022,10 @@ inlay_hints = false
 enabled = true
 engine = "external-perltidy"
 perltidy_maximum_line_length = 100
+perltidy_opening_brace_on_new_line = true
+perltidy_cuddled_else = false
+perltidy_space_after_keyword = false
+perltidy_add_trailing_commas = true
 perltidy_extra_args = ["-noll"]
 
 [critic]
@@ -1040,6 +1044,10 @@ engine = "native"
         assert_eq!(config.formatting.enabled, Some(true));
         assert_eq!(config.formatting.engine.as_deref(), Some("external-perltidy"));
         assert_eq!(config.formatting.perltidy_maximum_line_length, Some(100));
+        assert_eq!(config.formatting.perltidy_opening_brace_on_new_line, Some(true));
+        assert_eq!(config.formatting.perltidy_cuddled_else, Some(false));
+        assert_eq!(config.formatting.perltidy_space_after_keyword, Some(false));
+        assert_eq!(config.formatting.perltidy_add_trailing_commas, Some(true));
         assert_eq!(config.formatting.perltidy_extra_args, vec!["-noll"]);
         assert_eq!(config.critic.engine.as_deref(), Some("native"));
         Ok(())
@@ -1156,6 +1164,25 @@ engine = "native"
         project.apply_to_server_config(&mut config);
 
         assert_eq!(config.formatting_engine, FormatterMode::Off);
+    }
+
+    #[test]
+    fn project_config_applies_native_formatting_policy_fields() {
+        let mut config = ServerConfig::default();
+        let mut project = ProjectConfig::default();
+        project.formatting.engine = Some("native".to_string());
+        project.formatting.perltidy_opening_brace_on_new_line = Some(true);
+        project.formatting.perltidy_cuddled_else = Some(false);
+        project.formatting.perltidy_space_after_keyword = Some(false);
+        project.formatting.perltidy_add_trailing_commas = Some(true);
+
+        project.apply_to_server_config(&mut config);
+
+        assert_eq!(config.formatting_engine, FormatterMode::Native);
+        assert_eq!(config.perltidy_opening_brace_on_new_line, Some(true));
+        assert_eq!(config.perltidy_cuddled_else, Some(false));
+        assert_eq!(config.perltidy_space_after_keyword, Some(false));
+        assert_eq!(config.perltidy_add_trailing_commas, Some(true));
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
@@ -4,8 +4,8 @@ pub use crate::providers::formatting_types::{
     FormatPosition, FormatRange, FormatTextEdit, FormattedDocument, FormattingOptions,
 };
 use crate::tooling::perltidy::{
-    FinalNewline, FormatConfig, FormatterMode, NativeFormatter, PerlFormatter, TextPosition,
-    TextRange,
+    BracePlacement, ElsePlacement, FinalNewline, FormatConfig, FormatterMode, KeywordSpacing,
+    NativeFormatter, PerlFormatter, TextPosition, TextRange, TrailingComma,
 };
 
 /// Re-export PerlTidyConfig from perl-lsp-perltidy for convenience.
@@ -102,7 +102,7 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
     ) -> Result<FormattedDocument, FormattingError> {
         match self.mode {
             FormatterMode::Native | FormatterMode::Compat => {
-                Ok(native_format_document(content, options))
+                Ok(native_format_document(content, options, self.perltidy_config.as_ref()))
             }
             FormatterMode::ExternalLegacy => self.format_document_with_perltidy(content, options),
             FormatterMode::Off => {
@@ -132,7 +132,7 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
 
         match self.mode {
             FormatterMode::Native | FormatterMode::Compat => {
-                Ok(native_format_range(content, range, options))
+                Ok(native_format_range(content, range, options, self.perltidy_config.as_ref()))
             }
             FormatterMode::ExternalLegacy => {
                 self.format_range_with_perltidy(content, options, &lines, start_line, end_line)
@@ -263,8 +263,12 @@ impl<R: perl_subprocess_runtime::SubprocessRuntime> FormattingProvider<R> {
     }
 }
 
-fn native_format_document(content: &str, options: &FormattingOptions) -> FormattedDocument {
-    let config = native_format_config(options, true);
+fn native_format_document(
+    content: &str,
+    options: &FormattingOptions,
+    perltidy_config: Option<&PerlTidyConfig>,
+) -> FormattedDocument {
+    let config = native_format_config(options, perltidy_config, true);
     let result = NativeFormatter::new().format_document(content, &config);
     if result.diagnostics.is_empty() {
         let formatted = apply_lsp_whitespace_options(&result.formatted, options);
@@ -302,6 +306,7 @@ fn native_format_range(
     content: &str,
     range: &FormatRange,
     options: &FormattingOptions,
+    perltidy_config: Option<&PerlTidyConfig>,
 ) -> FormattedDocument {
     let native_range = TextRange::new(
         TextPosition::new(range.start.line, range.start.character),
@@ -310,7 +315,7 @@ fn native_format_range(
     let result = NativeFormatter::new().format_range(
         content,
         native_range,
-        &native_format_config(options, false),
+        &native_format_config(options, perltidy_config, false),
     );
     if result.diagnostics.is_empty() {
         if result.edits.is_empty() {
@@ -326,8 +331,12 @@ fn native_format_range(
     whitespace_range_fallback(content, range, options)
 }
 
-fn native_format_config(options: &FormattingOptions, allow_final_newline: bool) -> FormatConfig {
-    FormatConfig {
+fn native_format_config(
+    options: &FormattingOptions,
+    perltidy_config: Option<&PerlTidyConfig>,
+    allow_final_newline: bool,
+) -> FormatConfig {
+    let mut config = FormatConfig {
         indent_width: options.tab_size,
         use_tabs: !options.insert_spaces,
         final_newline: if allow_final_newline {
@@ -342,7 +351,37 @@ fn native_format_config(options: &FormattingOptions, allow_final_newline: bool) 
             FinalNewline::Preserve
         },
         ..FormatConfig::default()
+    };
+
+    if let Some(perltidy_config) = perltidy_config {
+        if let Some(width) = perltidy_config.maximum_line_length {
+            config.line_width = width;
+        }
+        if let Some(opening_brace_on_new_line) = perltidy_config.opening_brace_on_new_line {
+            config.brace_placement = if opening_brace_on_new_line {
+                BracePlacement::NextLine
+            } else {
+                BracePlacement::SameLine
+            };
+        }
+        if let Some(cuddled_else) = perltidy_config.cuddled_else {
+            config.else_placement =
+                if cuddled_else { ElsePlacement::Cuddled } else { ElsePlacement::SeparateLine };
+        }
+        if let Some(space_after_keyword) = perltidy_config.space_after_keyword {
+            config.keyword_spacing =
+                if space_after_keyword { KeywordSpacing::Space } else { KeywordSpacing::Compact };
+        }
+        if let Some(add_trailing_commas) = perltidy_config.add_trailing_commas {
+            config.trailing_comma = if add_trailing_commas {
+                TrailingComma::AddWhenWrapped
+            } else {
+                TrailingComma::Preserve
+            };
+        }
     }
+
+    config
 }
 
 fn native_edit_to_format_edit(edit: crate::tooling::perltidy::TextEdit) -> FormatTextEdit {
@@ -471,6 +510,93 @@ mod tests {
         let formatted = provider.format_document("my$x=1;\n", &options)?;
         assert_eq!(formatted.edits.len(), 1);
         assert_eq!(formatted.edits[0].new_text, "my $x = 1;\n");
+        Ok(())
+    }
+
+    #[test]
+    fn format_document_native_applies_configured_formatting_policies() -> Result<()> {
+        let config = PerlTidyConfig {
+            maximum_line_length: Some(20),
+            opening_brace_on_new_line: Some(true),
+            cuddled_else: Some(false),
+            space_after_keyword: Some(false),
+            add_trailing_commas: Some(true),
+            ..PerlTidyConfig::default()
+        };
+        let provider = FormattingProvider::new(MissingPerltidyRuntime)
+            .with_perltidy_config(config)
+            .with_formatter_mode(FormatterMode::Native);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: None,
+            insert_final_newline: None,
+            trim_final_newlines: None,
+        };
+
+        let formatted = provider.format_document(
+            "if($ok){return foo($alpha,$beta,$gamma);}else{return bar();}\n",
+            &options,
+        )?;
+
+        assert_eq!(formatted.edits.len(), 1);
+        assert_eq!(
+            formatted.edits[0].new_text,
+            concat!(
+                "if($ok)\n",
+                "{\n",
+                "    return foo(\n",
+                "    $alpha,\n",
+                "    $beta,\n",
+                "    $gamma,\n",
+                ");\n",
+                "}\n",
+                "else\n",
+                "{\n",
+                "    return bar();\n",
+                "}\n",
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn format_range_native_applies_configured_formatting_policies() -> Result<()> {
+        let config = PerlTidyConfig {
+            opening_brace_on_new_line: Some(true),
+            cuddled_else: Some(false),
+            space_after_keyword: Some(false),
+            ..PerlTidyConfig::default()
+        };
+        let provider = FormattingProvider::new(MissingPerltidyRuntime)
+            .with_perltidy_config(config)
+            .with_formatter_mode(FormatterMode::Native);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: None,
+            insert_final_newline: None,
+            trim_final_newlines: None,
+        };
+        let source = "my $prefix = 1;\nif($ok){return 1;}else{return 0;}\nmy $suffix = 1;\n";
+        let range = FormatRange::new(FormatPosition::new(1, 0), FormatPosition::new(1, 34));
+
+        let formatted = provider.format_range(source, &range, &options)?;
+
+        assert_eq!(formatted.edits.len(), 1);
+        assert_eq!(
+            formatted.edits[0].new_text,
+            concat!(
+                "if($ok)\n",
+                "{\n",
+                "    return 1;\n",
+                "}\n",
+                "else\n",
+                "{\n",
+                "    return 0;\n",
+                "}"
+            )
+        );
         Ok(())
     }
 

--- a/crates/perl-lsp-rs/tests/lsp_formatting_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_formatting_tests.rs
@@ -13,6 +13,7 @@
 mod support;
 use serde_json::json;
 use support::lsp_harness::LspHarness;
+use support::test_helpers::apply_text_edits;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -316,6 +317,134 @@ fn test_formatting_disabled_via_configuration_returns_no_edits() -> TestResult {
     assert!(
         range_edits.is_empty(),
         "expected no range formatting edits when formatting is disabled"
+    );
+
+    Ok(())
+}
+
+/// Test that configured native formatter policy fields route through LSP document formatting.
+#[test]
+fn test_native_formatting_policies_route_through_document_formatting() -> TestResult {
+    let mut harness = LspHarness::new();
+    let _init = harness.initialize(None)?;
+
+    harness.notify(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "perl": {
+                    "formatting": {
+                        "engine": "native",
+                        "maximumLineLength": 20,
+                        "openingBraceOnNewLine": true,
+                        "cuddledElse": false,
+                        "spaceAfterKeyword": false,
+                        "addTrailingCommas": true
+                    }
+                }
+            }
+        }),
+    );
+
+    let doc_uri = "file:///test_native_formatting_policies.pl";
+    let source = "if($ok){return foo($alpha,$beta,$gamma);}else{return bar();}\n";
+    harness.open(doc_uri, source)?;
+
+    let response = harness.request(
+        "textDocument/formatting",
+        json!({
+            "textDocument": { "uri": doc_uri },
+            "options": {
+                "tabSize": 4,
+                "insertSpaces": true
+            }
+        }),
+    )?;
+    let edits = response.as_array().ok_or("formatting response must be an array")?;
+    let formatted = edits
+        .first()
+        .and_then(|edit| edit.get("newText"))
+        .and_then(|text| text.as_str())
+        .ok_or("formatting edit must include newText")?;
+
+    assert_eq!(
+        formatted,
+        concat!(
+            "if($ok)\n",
+            "{\n",
+            "    return foo(\n",
+            "    $alpha,\n",
+            "    $beta,\n",
+            "    $gamma,\n",
+            ");\n",
+            "}\n",
+            "else\n",
+            "{\n",
+            "    return bar();\n",
+            "}\n",
+        )
+    );
+
+    Ok(())
+}
+
+/// Test that configured native formatter policy fields route through LSP range formatting.
+#[test]
+fn test_native_formatting_policies_route_through_range_formatting() -> TestResult {
+    let mut harness = LspHarness::new();
+    let _init = harness.initialize(None)?;
+
+    harness.notify(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "perl": {
+                    "formatting": {
+                        "engine": "native",
+                        "openingBraceOnNewLine": true,
+                        "cuddledElse": false,
+                        "spaceAfterKeyword": false
+                    }
+                }
+            }
+        }),
+    );
+
+    let doc_uri = "file:///test_native_range_formatting_policies.pl";
+    let source = "my $prefix = 1;\nif($ok){return 1;}else{return 0;}\nmy $suffix = 1;\n";
+    harness.open(doc_uri, source)?;
+
+    let response = harness.request(
+        "textDocument/rangeFormatting",
+        json!({
+            "textDocument": { "uri": doc_uri },
+            "range": {
+                "start": { "line": 1, "character": 0 },
+                "end": { "line": 1, "character": 34 }
+            },
+            "options": {
+                "tabSize": 4,
+                "insertSpaces": true
+            }
+        }),
+    )?;
+    let edits = response.as_array().ok_or("rangeFormatting response must be an array")?;
+    let formatted = apply_text_edits(source, edits);
+
+    assert_eq!(
+        formatted,
+        concat!(
+            "my $prefix = 1;\n",
+            "if($ok)\n",
+            "{\n",
+            "    return 1;\n",
+            "}\n",
+            "else\n",
+            "{\n",
+            "    return 0;\n",
+            "}\n",
+            "my $suffix = 1;\n",
+        )
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

This PR proves native formatter policy settings route through the actual LSP formatting path instead of stopping at formatter-unit coverage.

- maps configured perltidy compatibility policy fields into native `FormatConfig` for native/compat formatting modes
- adds core provider tests for configured document and range formatting
- extends project config parsing/application coverage for the native formatting policy fields
- adds LSP document/range formatting tests that drive `workspace/didChangeConfiguration` and assert configured native output

External legacy perltidy behavior is unchanged; this does not change formatter defaults, runtime defaults, or add new formatter syntax coverage.

## Root cause

`LspServer` already built a `PerlTidyConfig` from runtime configuration, but native formatting constructed `FormatConfig` only from LSP `FormattingOptions`. That meant policy fields such as opening-brace placement, else placement, keyword spacing, line width, and trailing commas were unit-tested in the formatter but not actually honored by the native LSP provider path.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core formatting --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core load_project_config_parses_known_sections --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask native-format check` (38/38 fixtures)
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`
