### PR TITLE
feat(critic): add native critic check receipt (#8397)

### DIFF
--- a/docs/how-to/NATIVE_TOOLING_MIGRATION.md
+++ b/docs/how-to/NATIVE_TOOLING_MIGRATION.md
@@ -37,6 +37,12 @@ cargo xtask native-format check
 cargo xtask native-format corpus
 ```
 
+For native critic proof, run:
+
+```bash
+cargo xtask native-critic check
+```
+
 For compatibility reporting, run:
 
 ```bash
@@ -118,6 +124,11 @@ suppressions can use the native suppression prefix:
 ## no perl-lsp-critic native.variables.unused_lexical -- migration exception
 ```
 
+Use `cargo xtask native-critic check` to run the native recommended rule set
+over source files without involving editor diagnostics or the external
+`perlcritic` adapter. The command emits JSON and Markdown receipts with files
+checked, rules run, findings, suppressed findings, and fixable findings.
+
 ## Interpret Compatibility Results
 
 Compatibility receipts use these classifications:
@@ -152,6 +163,7 @@ include the relevant receipt commands in the proof packet:
 cargo xtask fmt
 cargo xtask native-format check
 cargo xtask native-format corpus
+cargo xtask native-critic check
 cargo xtask native-tooling status \
   --markdown docs/project/status/native_tooling.md
 cargo xtask native-tooling check-defaults

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -43,6 +43,12 @@
 | Push diagnostics coverage | 27 |
 | Workspace diagnostics coverage | 27 |
 | Violation bridge coverage | 27 |
+| Native critic check files | 65 |
+| Native critic check parse errors | 0 |
+| Native critic check rules run | 27 |
+| Native critic check findings | 187 |
+| Native critic check suppressed | 0 |
+| Native critic check fixable | 173 |
 | Perlcritic compatibility items | 12 |
 | Perlcritic compatibility native-equivalent | 5 |
 | Perlcritic compatibility native-superset | 2 |

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -93,6 +93,7 @@ perl-dap --stdio  # Standard DAP transport
 | Generated status docs touched | `just status-update` then `just status-check` | Regenerates and verifies `docs/project/status/` outputs. |
 | Release/version surfaces touched | `just version-check` then `just release-check` | Verifies version sync and the release-prep gate before tagging/publishing. |
 | Native tooling defaults touched | `cargo xtask native-tooling check-defaults` | Verifies native formatter and opt-in native critic paths do not silently shell out. |
+| Native critic touched | `cargo xtask native-critic check` | Runs native critic rules and emits check receipts for findings, suppressions, and fixability. |
 | DevEx docs touched | `cargo xtask check-devex-docs` | Verifies toolchain wording and documented command references stay current. |
 | Need a terminal summary | `just quick-ref` | Prints the short command decision tree. |
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -493,6 +493,12 @@ enum Commands {
         command: NativeFormatCommand,
     },
 
+    /// Run native critic checks and emit receipts.
+    NativeCritic {
+        #[command(subcommand)]
+        command: NativeCriticCommand,
+    },
+
     /// Report native formatter and critic replacement status.
     NativeTooling {
         #[command(subcommand)]
@@ -1885,6 +1891,37 @@ enum NativeFormatCommand {
 }
 
 #[derive(Subcommand)]
+enum NativeCriticCommand {
+    /// Run native critic rules over Perl source files and write receipts.
+    Check {
+        /// Files or directories containing Perl sources. Defaults to examples/perl,
+        /// tests/perl-corpus, and crates/perl-corpus/fixtures/parser_accuracy.
+        #[arg(long = "root")]
+        roots: Vec<PathBuf>,
+
+        /// Minimum native critic severity to report.
+        #[arg(long, default_value_t = 3)]
+        severity: u8,
+
+        /// Native rule IDs to include. Empty means all recommended rules.
+        #[arg(long = "include")]
+        include: Vec<String>,
+
+        /// Native rule IDs to exclude.
+        #[arg(long = "exclude")]
+        exclude: Vec<String>,
+
+        /// Output JSON receipt path.
+        #[arg(long, default_value = "target/receipts/native-tooling/native-critic-check.json")]
+        receipt: PathBuf,
+
+        /// Output markdown summary path.
+        #[arg(long, default_value = "target/receipts/native-tooling/native-critic-check.md")]
+        summary: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
 enum NativeToolingCommand {
     /// Write native formatter and critic status receipts.
     Status {
@@ -1911,6 +1948,10 @@ enum NativeToolingCommand {
         /// Native critic perlcritic compatibility receipt to summarize.
         #[arg(long, default_value = "target/receipts/native-tooling/perlcritic-compat.json")]
         critic_perlcritic_compat_receipt: PathBuf,
+
+        /// Native critic check receipt to summarize.
+        #[arg(long, default_value = "target/receipts/native-tooling/native-critic-check.json")]
+        critic_check_receipt: PathBuf,
 
         /// Output path for native-tooling status JSON.
         #[arg(long, default_value = "target/receipts/native-tooling/status.json")]
@@ -2310,6 +2351,18 @@ fn main() -> Result<()> {
                 })
             }
         },
+        Commands::NativeCritic { command } => match command {
+            NativeCriticCommand::Check { roots, severity, include, exclude, receipt, summary } => {
+                native_critic::check(native_critic::NativeCriticCheckConfig {
+                    roots,
+                    severity,
+                    include,
+                    exclude,
+                    receipt,
+                    summary,
+                })
+            }
+        },
         Commands::NativeTooling { command } => match command {
             NativeToolingCommand::Status {
                 format_fixtures,
@@ -2318,6 +2371,7 @@ fn main() -> Result<()> {
                 format_perltidy_compat_receipt,
                 format_config_receipt,
                 critic_perlcritic_compat_receipt,
+                critic_check_receipt,
                 receipt,
                 markdown,
             } => native_tooling::status(native_tooling::NativeToolingStatusConfig {
@@ -2327,6 +2381,7 @@ fn main() -> Result<()> {
                 format_perltidy_compat_receipt,
                 format_config_receipt,
                 critic_perlcritic_compat_receipt,
+                critic_check_receipt,
                 receipt,
                 markdown,
             }),

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -66,6 +66,7 @@ pub mod memory_trends;
 pub mod merge_ready;
 pub mod methodology_gate;
 pub mod metrics;
+pub mod native_critic;
 pub mod native_format;
 pub mod native_tooling;
 pub mod parse_rust;

--- a/xtask/src/tasks/native_critic.rs
+++ b/xtask/src/tasks/native_critic.rs
@@ -1,0 +1,399 @@
+//! Native critic check receipts.
+
+use chrono::{DateTime, Utc};
+use color_eyre::eyre::{Context, Result, eyre};
+use perl_lsp_rs_core::tooling::perl_critic::{
+    CriticConfig, CriticContext, CriticFinding, NativeCriticRegistry,
+};
+use perl_parser::Parser;
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use walkdir::WalkDir;
+
+const SCHEMA_VERSION: u32 = 1;
+
+/// Options for `cargo xtask native-critic check`.
+pub struct NativeCriticCheckConfig {
+    /// Files or directories containing Perl sources.
+    pub roots: Vec<PathBuf>,
+    /// Minimum native critic severity to report.
+    pub severity: u8,
+    /// Native rule IDs to include. Empty means all recommended rules.
+    pub include: Vec<String>,
+    /// Native rule IDs to exclude.
+    pub exclude: Vec<String>,
+    /// Output JSON receipt path.
+    pub receipt: PathBuf,
+    /// Output markdown summary path.
+    pub summary: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct NativeCriticCheckReceipt {
+    kind: &'static str,
+    schema_version: u32,
+    generated_at: DateTime<Utc>,
+    commit: String,
+    roots: Vec<String>,
+    profile: &'static str,
+    engine: &'static str,
+    severity: u8,
+    include: Vec<String>,
+    exclude: Vec<String>,
+    rules_run: usize,
+    rule_ids: Vec<String>,
+    files_checked: usize,
+    files_with_parse_errors: usize,
+    findings_count: usize,
+    suppressed_findings_count: usize,
+    fixable_findings_count: usize,
+    findings_by_rule: BTreeMap<String, usize>,
+    suppressed_findings_by_rule: BTreeMap<String, usize>,
+    files: Vec<NativeCriticFileResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct NativeCriticFileResult {
+    path: String,
+    parse_ok: bool,
+    parse_error: Option<String>,
+    findings_count: usize,
+    suppressed_findings_count: usize,
+    fixable_findings_count: usize,
+    findings: Vec<CriticFinding>,
+}
+
+/// Run native critic rules over Perl source files and write JSON/markdown receipts.
+pub fn check(config: NativeCriticCheckConfig) -> Result<()> {
+    let roots = if config.roots.is_empty() { default_roots() } else { config.roots };
+    let files = collect_paths(&roots)?;
+    if files.is_empty() {
+        return Err(eyre!(
+            "no native critic source files found under {}",
+            roots.iter().map(|root| root.display().to_string()).collect::<Vec<_>>().join(", ")
+        ));
+    }
+
+    let critic_config = CriticConfig {
+        severity: config.severity,
+        include: config.include.clone(),
+        exclude: config.exclude.clone(),
+        ..CriticConfig::default()
+    };
+    let registry = NativeCriticRegistry::recommended();
+    let rule_ids = registry.rule_ids().into_iter().map(ToOwned::to_owned).collect::<Vec<_>>();
+    let mut results = Vec::new();
+
+    for file in files {
+        results.push(check_file(&registry, &critic_config, &file)?);
+    }
+
+    let mut findings_by_rule = BTreeMap::new();
+    let mut suppressed_findings_by_rule = BTreeMap::new();
+    for result in &results {
+        for finding in &result.findings {
+            *findings_by_rule.entry(finding.rule_id.clone()).or_insert(0) += 1;
+        }
+        let suppressed = suppressed_rule_counts(&result.findings, result.suppressed_findings_count);
+        for (rule_id, count) in suppressed {
+            *suppressed_findings_by_rule.entry(rule_id).or_insert(0) += count;
+        }
+    }
+
+    let receipt = NativeCriticCheckReceipt {
+        kind: "native_critic_check",
+        schema_version: SCHEMA_VERSION,
+        generated_at: Utc::now(),
+        commit: current_commit(),
+        roots: roots.iter().map(|root| root.display().to_string()).collect(),
+        profile: "recommended",
+        engine: "native",
+        severity: config.severity,
+        include: config.include,
+        exclude: config.exclude,
+        rules_run: rule_ids.len(),
+        rule_ids,
+        files_checked: results.len(),
+        files_with_parse_errors: results.iter().filter(|result| !result.parse_ok).count(),
+        findings_count: results.iter().map(|result| result.findings_count).sum(),
+        suppressed_findings_count: results
+            .iter()
+            .map(|result| result.suppressed_findings_count)
+            .sum(),
+        fixable_findings_count: results.iter().map(|result| result.fixable_findings_count).sum(),
+        findings_by_rule,
+        suppressed_findings_by_rule,
+        files: results,
+    };
+
+    if let Some(parent) = config.receipt.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+    }
+    if let Some(parent) = config.summary.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+    }
+    write_json(&config.receipt, &receipt)?;
+    write_summary(&config.summary, &receipt)?;
+
+    println!(
+        "native critic check: {} finding(s), {} suppressed, {} fixable across {} file(s); receipt: {}",
+        receipt.findings_count,
+        receipt.suppressed_findings_count,
+        receipt.fixable_findings_count,
+        receipt.files_checked,
+        config.receipt.display()
+    );
+
+    Ok(())
+}
+
+fn check_file(
+    registry: &NativeCriticRegistry,
+    config: &CriticConfig,
+    file: &Path,
+) -> Result<NativeCriticFileResult> {
+    let source =
+        fs::read_to_string(file).wrap_err_with(|| format!("failed to read {}", file.display()))?;
+    let parse_result = Parser::new(&source).parse();
+    let Ok(ast) = parse_result else {
+        return Ok(NativeCriticFileResult {
+            path: file.display().to_string(),
+            parse_ok: false,
+            parse_error: Some("native parser failed to parse source".to_string()),
+            findings_count: 0,
+            suppressed_findings_count: 0,
+            fixable_findings_count: 0,
+            findings: Vec::new(),
+        });
+    };
+
+    let ctx = CriticContext::new(&source, &ast, config);
+    let findings = registry.check(&ctx);
+    let unsuppressed_source = strip_native_suppression_lines(&source);
+    let unsuppressed_count = if unsuppressed_source == source {
+        findings.len()
+    } else {
+        match Parser::new(&unsuppressed_source).parse() {
+            Ok(ast) => {
+                let ctx = CriticContext::new(&unsuppressed_source, &ast, config);
+                registry.check(&ctx).len()
+            }
+            Err(_) => findings.len(),
+        }
+    };
+    let suppressed_findings_count = unsuppressed_count.saturating_sub(findings.len());
+    let fixable_findings_count = findings.iter().filter(|finding| finding.fix.is_some()).count();
+
+    Ok(NativeCriticFileResult {
+        path: file.display().to_string(),
+        parse_ok: true,
+        parse_error: None,
+        findings_count: findings.len(),
+        suppressed_findings_count,
+        fixable_findings_count,
+        findings,
+    })
+}
+
+fn strip_native_suppression_lines(source: &str) -> String {
+    source
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("## no critic ") || trimmed.starts_with("## no perl-lsp-critic ")
+            {
+                ""
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn suppressed_rule_counts(
+    findings: &[CriticFinding],
+    suppressed_findings_count: usize,
+) -> BTreeMap<String, usize> {
+    if suppressed_findings_count == 0 {
+        return BTreeMap::new();
+    }
+
+    let mut counts = BTreeMap::new();
+    let rules = findings.iter().map(|finding| finding.rule_id.clone()).collect::<BTreeSet<_>>();
+    if rules.len() == 1 {
+        if let Some(rule_id) = rules.into_iter().next() {
+            counts.insert(rule_id, suppressed_findings_count);
+        }
+    }
+    counts
+}
+
+fn write_summary(path: &Path, receipt: &NativeCriticCheckReceipt) -> Result<()> {
+    let mut markdown = String::new();
+    markdown.push_str("# Native Critic Check\n\n");
+    markdown.push_str(&format!("- Engine: `{}`\n", receipt.engine));
+    markdown.push_str(&format!("- Profile: `{}`\n", receipt.profile));
+    markdown.push_str(&format!("- Severity: `{}`\n", receipt.severity));
+    markdown.push_str(&format!("- Files checked: `{}`\n", receipt.files_checked));
+    markdown
+        .push_str(&format!("- Files with parse errors: `{}`\n", receipt.files_with_parse_errors));
+    markdown.push_str(&format!("- Rules run: `{}`\n", receipt.rules_run));
+    markdown.push_str(&format!("- Findings: `{}`\n", receipt.findings_count));
+    markdown.push_str(&format!("- Suppressed findings: `{}`\n", receipt.suppressed_findings_count));
+    markdown.push_str(&format!("- Fixable findings: `{}`\n\n", receipt.fixable_findings_count));
+
+    markdown.push_str("## Findings By Rule\n\n");
+    markdown.push_str("| Rule | Findings |\n");
+    markdown.push_str("| --- | ---: |\n");
+    for (rule, count) in &receipt.findings_by_rule {
+        markdown.push_str(&format!("| `{rule}` | {count} |\n"));
+    }
+    if receipt.findings_by_rule.is_empty() {
+        markdown.push_str("| _none_ | 0 |\n");
+    }
+
+    markdown.push_str("\n## Files\n\n");
+    markdown.push_str("| File | Parse ok | Findings | Suppressed | Fixable |\n");
+    markdown.push_str("| --- | --- | ---: | ---: | ---: |\n");
+    for file in &receipt.files {
+        markdown.push_str(&format!(
+            "| `{}` | {} | {} | {} | {} |\n",
+            file.path,
+            file.parse_ok,
+            file.findings_count,
+            file.suppressed_findings_count,
+            file.fixable_findings_count
+        ));
+    }
+
+    fs::write(path, markdown).wrap_err_with(|| format!("failed to write {}", path.display()))
+}
+
+fn default_roots() -> Vec<PathBuf> {
+    vec![
+        PathBuf::from("examples/perl"),
+        PathBuf::from("tests/perl-corpus"),
+        PathBuf::from("crates/perl-corpus/fixtures/parser_accuracy"),
+    ]
+}
+
+fn collect_paths(roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for root in roots {
+        if root.is_file() {
+            if is_perl_source(root) {
+                paths.push(root.to_path_buf());
+            }
+            continue;
+        }
+        if !root.exists() {
+            continue;
+        }
+        for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+            if entry.file_type().is_file() && is_perl_source(entry.path()) {
+                paths.push(entry.path().to_path_buf());
+            }
+        }
+    }
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+fn is_perl_source(path: &Path) -> bool {
+    let filename = path.file_name().and_then(|name| name.to_str()).unwrap_or_default();
+    if filename.ends_with(".expected.pl") || filename.ends_with(".expected-diagnostics.txt") {
+        return false;
+    }
+    matches!(path.extension().and_then(|ext| ext.to_str()), Some("pl" | "pm" | "t"))
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let json = serde_json::to_string_pretty(value)?;
+    fs::write(path, format!("{json}\n"))
+        .wrap_err_with(|| format!("failed to write {}", path.display()))
+}
+
+fn current_commit() -> String {
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|stdout| stdout.trim().to_string())
+        .filter(|commit| !commit.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn native_critic_check_writes_receipt_and_summary() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let source = temp.path().join("App.pm");
+        fs::write(&source, "package App;\nsub run { my $unused = 1; return 1; }\n1;\n")?;
+        let receipt = temp.path().join("native-critic-check.json");
+        let summary = temp.path().join("native-critic-check.md");
+
+        check(NativeCriticCheckConfig {
+            roots: vec![source],
+            severity: 1,
+            include: vec!["native.variables.unused_lexical".to_string()],
+            exclude: Vec::new(),
+            receipt: receipt.clone(),
+            summary: summary.clone(),
+        })?;
+
+        let value: Value = serde_json::from_str(&fs::read_to_string(receipt)?)?;
+        assert_eq!(value["kind"], "native_critic_check");
+        assert_eq!(value["engine"], "native");
+        assert_eq!(value["profile"], "recommended");
+        assert_eq!(value["files_checked"], 1);
+        assert_eq!(value["rules_run"], 27);
+        assert_eq!(value["findings_count"], 1);
+        assert_eq!(value["fixable_findings_count"], 1);
+        assert_eq!(value["findings_by_rule"]["native.variables.unused_lexical"], 1);
+
+        let summary = fs::read_to_string(summary)?;
+        assert!(summary.contains("# Native Critic Check"));
+        assert!(summary.contains("| `native.variables.unused_lexical` | 1 |"));
+        Ok(())
+    }
+
+    #[test]
+    fn native_critic_check_counts_suppressed_findings() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let source = temp.path().join("App.pm");
+        fs::write(
+            &source,
+            "## no perl-lsp-critic native.variables.unused_lexical -- generated\npackage App;\nsub run { my $unused = 1; return 1; }\n1;\n",
+        )?;
+        let receipt = temp.path().join("native-critic-check.json");
+        let summary = temp.path().join("native-critic-check.md");
+
+        check(NativeCriticCheckConfig {
+            roots: vec![source],
+            severity: 1,
+            include: vec!["native.variables.unused_lexical".to_string()],
+            exclude: Vec::new(),
+            receipt: receipt.clone(),
+            summary,
+        })?;
+
+        let value: Value = serde_json::from_str(&fs::read_to_string(receipt)?)?;
+        assert_eq!(value["findings_count"], 0);
+        assert_eq!(value["suppressed_findings_count"], 1);
+        assert_eq!(value["files"][0]["suppressed_findings_count"], 1);
+        Ok(())
+    }
+}

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -30,6 +30,8 @@ pub struct NativeToolingStatusConfig {
     pub format_config_receipt: PathBuf,
     /// Existing native critic perlcritic compatibility receipt, when available.
     pub critic_perlcritic_compat_receipt: PathBuf,
+    /// Existing native critic check receipt, when available.
+    pub critic_check_receipt: PathBuf,
     /// Output path for the native-tooling JSON receipt.
     pub receipt: PathBuf,
     /// Optional markdown status output path.
@@ -126,6 +128,14 @@ struct CriticStatus {
     rules_surfaced_in_push_diagnostics: usize,
     rules_surfaced_in_workspace_diagnostics: usize,
     rules_with_violation_bridge: usize,
+    critic_check_receipt: String,
+    critic_check_receipt_present: bool,
+    critic_check_files_checked: Option<usize>,
+    critic_check_files_with_parse_errors: Option<usize>,
+    critic_check_rules_run: Option<usize>,
+    critic_check_findings_count: Option<usize>,
+    critic_check_suppressed_findings_count: Option<usize>,
+    critic_check_fixable_findings_count: Option<usize>,
     critic_perlcritic_compat_receipt: String,
     critic_perlcritic_compat_receipt_present: bool,
     perlcritic_compat_item_count: Option<usize>,
@@ -256,7 +266,8 @@ fn build_status_receipt(config: &NativeToolingStatusConfig) -> Result<NativeTool
         &config.format_perltidy_compat_receipt,
         &config.format_config_receipt,
     )?;
-    let critic = critic_status(&config.critic_perlcritic_compat_receipt)?;
+    let critic =
+        critic_status(&config.critic_perlcritic_compat_receipt, &config.critic_check_receipt)?;
     Ok(NativeToolingStatusReceipt {
         kind: "native_tooling_status",
         schema_version: SCHEMA_VERSION,
@@ -484,7 +495,10 @@ fn read_expected_diagnostic_codes(path: &Path) -> Result<Vec<String>> {
         .collect())
 }
 
-fn critic_status(critic_perlcritic_compat_receipt: &Path) -> Result<CriticStatus> {
+fn critic_status(
+    critic_perlcritic_compat_receipt: &Path,
+    critic_check_receipt: &Path,
+) -> Result<CriticStatus> {
     let registry = NativeCriticRegistry::recommended();
     let native_rules = registry.rule_ids().into_iter().map(ToOwned::to_owned).collect::<Vec<_>>();
     let fixable = fixable_rule_ids();
@@ -500,6 +514,8 @@ fn critic_status(critic_perlcritic_compat_receipt: &Path) -> Result<CriticStatus
     } else {
         None
     };
+    let check_receipt =
+        if critic_check_receipt.exists() { Some(read_json(critic_check_receipt)?) } else { None };
 
     Ok(CriticStatus {
         native_rule_count: native_rules.len(),
@@ -510,6 +526,23 @@ fn critic_status(critic_perlcritic_compat_receipt: &Path) -> Result<CriticStatus
         rules_surfaced_in_push_diagnostics: native_rules.len(),
         rules_surfaced_in_workspace_diagnostics: native_rules.len(),
         rules_with_violation_bridge: native_rules.len(),
+        critic_check_receipt: critic_check_receipt.display().to_string(),
+        critic_check_receipt_present: check_receipt.is_some(),
+        critic_check_files_checked: optional_usize(&check_receipt, "files_checked"),
+        critic_check_files_with_parse_errors: optional_usize(
+            &check_receipt,
+            "files_with_parse_errors",
+        ),
+        critic_check_rules_run: optional_usize(&check_receipt, "rules_run"),
+        critic_check_findings_count: optional_usize(&check_receipt, "findings_count"),
+        critic_check_suppressed_findings_count: optional_usize(
+            &check_receipt,
+            "suppressed_findings_count",
+        ),
+        critic_check_fixable_findings_count: optional_usize(
+            &check_receipt,
+            "fixable_findings_count",
+        ),
         critic_perlcritic_compat_receipt: critic_perlcritic_compat_receipt.display().to_string(),
         critic_perlcritic_compat_receipt_present: perlcritic_compat_receipt.is_some(),
         perlcritic_compat_item_count: optional_usize(&perlcritic_compat_receipt, "item_count"),
@@ -674,6 +707,24 @@ fn render_markdown(receipt: &NativeToolingStatusReceipt) -> String {
         formatter.format_trailing_comma.as_deref(),
         formatter.format_config_receipt_present,
     );
+    let critic_check_files_checked =
+        optional_metric(critic.critic_check_files_checked, critic.critic_check_receipt_present);
+    let critic_check_parse_errors = optional_metric(
+        critic.critic_check_files_with_parse_errors,
+        critic.critic_check_receipt_present,
+    );
+    let critic_check_rules_run =
+        optional_metric(critic.critic_check_rules_run, critic.critic_check_receipt_present);
+    let critic_check_findings =
+        optional_metric(critic.critic_check_findings_count, critic.critic_check_receipt_present);
+    let critic_check_suppressed = optional_metric(
+        critic.critic_check_suppressed_findings_count,
+        critic.critic_check_receipt_present,
+    );
+    let critic_check_fixable = optional_metric(
+        critic.critic_check_fixable_findings_count,
+        critic.critic_check_receipt_present,
+    );
     let perlcritic_compat_items = optional_metric(
         critic.perlcritic_compat_item_count,
         critic.critic_perlcritic_compat_receipt_present,
@@ -744,6 +795,12 @@ fn render_markdown(receipt: &NativeToolingStatusReceipt) -> String {
 | Push diagnostics coverage | {} |
 | Workspace diagnostics coverage | {} |
 | Violation bridge coverage | {} |
+| Native critic check files | {} |
+| Native critic check parse errors | {} |
+| Native critic check rules run | {} |
+| Native critic check findings | {} |
+| Native critic check suppressed | {} |
+| Native critic check fixable | {} |
 | Perlcritic compatibility items | {} |
 | Perlcritic compatibility native-equivalent | {} |
 | Perlcritic compatibility native-superset | {} |
@@ -789,6 +846,12 @@ Fixable native rules:
         critic.rules_surfaced_in_push_diagnostics,
         critic.rules_surfaced_in_workspace_diagnostics,
         critic.rules_with_violation_bridge,
+        critic_check_files_checked,
+        critic_check_parse_errors,
+        critic_check_rules_run,
+        critic_check_findings,
+        critic_check_suppressed,
+        critic_check_fixable,
         perlcritic_compat_items,
         perlcritic_compat_native_equivalent,
         perlcritic_compat_native_superset,
@@ -1157,6 +1220,19 @@ mod tests {
 }
 "#,
         )?;
+        let critic_check_receipt = receipts.join("native-critic-check.json");
+        fs::write(
+            &critic_check_receipt,
+            r#"{
+  "files_checked": 3,
+  "files_with_parse_errors": 0,
+  "rules_run": 27,
+  "findings_count": 4,
+  "suppressed_findings_count": 1,
+  "fixable_findings_count": 2
+}
+"#,
+        )?;
         let receipt = receipts.join("native-tooling-status.json");
         let markdown = receipts.join("native-tooling-status.md");
         let missing_receipt = receipts.join("missing-native-format-fixtures.json");
@@ -1170,6 +1246,7 @@ mod tests {
             format_perltidy_compat_receipt: format_perltidy_compat_receipt.clone(),
             format_config_receipt: format_config_receipt.clone(),
             critic_perlcritic_compat_receipt: critic_perlcritic_compat_receipt.clone(),
+            critic_check_receipt: critic_check_receipt.clone(),
             receipt: receipt.clone(),
             markdown: Some(markdown.clone()),
         })?;
@@ -1211,6 +1288,13 @@ mod tests {
         assert_eq!(value["formatter"]["format_keyword_spacing"], "compact");
         assert_eq!(value["formatter"]["format_trailing_comma"], "add-when-wrapped");
         assert!(value["critic"]["native_rule_count"].as_u64().unwrap_or_default() > 0);
+        assert_eq!(value["critic"]["critic_check_receipt_present"], true);
+        assert_eq!(value["critic"]["critic_check_files_checked"], 3);
+        assert_eq!(value["critic"]["critic_check_files_with_parse_errors"], 0);
+        assert_eq!(value["critic"]["critic_check_rules_run"], 27);
+        assert_eq!(value["critic"]["critic_check_findings_count"], 4);
+        assert_eq!(value["critic"]["critic_check_suppressed_findings_count"], 1);
+        assert_eq!(value["critic"]["critic_check_fixable_findings_count"], 2);
         assert_eq!(value["critic"]["critic_perlcritic_compat_receipt_present"], true);
         assert_eq!(value["critic"]["perlcritic_compat_item_count"], 12);
         assert_eq!(value["critic"]["perlcritic_compat_native_equivalent_count"], 5);
@@ -1258,6 +1342,12 @@ mod tests {
         assert!(markdown.contains("| Config else placement | separate-line |"));
         assert!(markdown.contains("| Config keyword spacing | compact |"));
         assert!(markdown.contains("| Config trailing comma | add-when-wrapped |"));
+        assert!(markdown.contains("| Native critic check files | 3 |"));
+        assert!(markdown.contains("| Native critic check parse errors | 0 |"));
+        assert!(markdown.contains("| Native critic check rules run | 27 |"));
+        assert!(markdown.contains("| Native critic check findings | 4 |"));
+        assert!(markdown.contains("| Native critic check suppressed | 1 |"));
+        assert!(markdown.contains("| Native critic check fixable | 2 |"));
         assert!(markdown.contains("| Perlcritic compatibility items | 12 |"));
         assert!(markdown.contains("| Perlcritic compatibility native-equivalent | 5 |"));
         assert!(markdown.contains("| Perlcritic compatibility native-superset | 2 |"));
@@ -1273,6 +1363,7 @@ mod tests {
             format_perltidy_compat_receipt,
             format_config_receipt,
             critic_perlcritic_compat_receipt,
+            critic_check_receipt,
             receipt: missing_status_receipt.clone(),
             markdown: Some(missing_markdown.clone()),
         })?;


### PR DESCRIPTION
## Summary

Adds a non-editor native critic check receipt:

- `cargo xtask native-critic check` runs the opt-in native recommended rule set over Perl source roots and writes JSON/Markdown receipts.
- `cargo xtask native-tooling status` now summarizes the latest native critic check receipt: files checked, parse errors, rules run, findings, suppressed findings, and fixable findings.
- Migration and command docs now point native critic changes at the receipt command, and `docs/project/status/native_tooling.md` includes the current check counts.

This is reporting-only. It does not change runtime diagnostics, native critic defaults, legacy `perlcritic` behavior, formatter behavior, or shell-out policy.

## Proof packet

- [x] cargo xtask fmt
- [x] cargo test -p xtask native_critic -- --nocapture
- [x] cargo test -p xtask native_tooling -- --nocapture
- [x] cargo xtask native-critic check
  - evidence: `187` findings, `0` suppressed, `173` fixable across `65` files
- [x] cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md
- [x] cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs
- [x] cargo xtask check-devex-docs
- [x] cargo xtask check-memory-lifecycle-policy
- [x] cargo xtask check-memory-retained-owner-drift --base origin/master
- [x] cargo xtask devex pr-body --base origin/master
- [x] cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json
- [x] git diff --check

## Known caveat

`just status-check` still reports the existing generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR only updates `docs/project/status/native_tooling.md`; I left the unrelated generated status files untouched.
