### PR TITLE
fix(dap): guard setVariable value field against command injection (#7271)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/variables.rs
+++ b/crates/perl-dap/src/debug_adapter/variables.rs
@@ -289,6 +289,34 @@ impl DebugAdapter {
             };
         }
 
+        if contains_unquoted_statement_separator(value) {
+            return DapMessage::Response {
+                seq,
+                request_seq,
+                success: false,
+                command: "setVariable".to_string(),
+                body: None,
+                message: Some(
+                    "setVariable: unsafe value rejected: statement separators are not allowed"
+                        .to_string(),
+                ),
+            };
+        }
+
+        if !is_safe_set_variable_value(value) {
+            return DapMessage::Response {
+                seq,
+                request_seq,
+                success: false,
+                command: "setVariable".to_string(),
+                body: None,
+                message: Some(
+                    "setVariable: unsafe value rejected: only literal or simple variable-reference values are allowed"
+                        .to_string(),
+                ),
+            };
+        }
+
         let output_frame_markers = if let Some(ref mut session) =
             *lock_or_recover(&self.session, "debug_adapter.session")
         {
@@ -376,4 +404,74 @@ impl DebugAdapter {
             message: None,
         }
     }
+}
+
+fn contains_unquoted_statement_separator(value: &str) -> bool {
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+
+    for ch in value.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        match ch {
+            '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            '"' if !in_single_quote => in_double_quote = !in_double_quote,
+            ';' if !in_single_quote && !in_double_quote => return true,
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn is_safe_set_variable_value(value: &str) -> bool {
+    let value = value.trim();
+    value == "undef"
+        || is_quoted_literal(value)
+        || is_numeric_literal(value)
+        || is_valid_set_variable_name(value)
+}
+
+fn is_quoted_literal(value: &str) -> bool {
+    let Some(quote) = value.chars().next().filter(|ch| *ch == '\'' || *ch == '"') else {
+        return false;
+    };
+
+    let mut escaped = false;
+    for (idx, ch) in value.char_indices().skip(1) {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if ch == quote {
+            return idx + ch.len_utf8() == value.len();
+        }
+    }
+
+    false
+}
+
+fn is_numeric_literal(value: &str) -> bool {
+    let normalized: String = value.chars().filter(|ch| *ch != '_').collect();
+    let has_digit = normalized.chars().any(|ch| ch.is_ascii_digit());
+    let allowed_chars = normalized
+        .chars()
+        .all(|ch| ch.is_ascii_digit() || matches!(ch, '+' | '-' | '.' | 'e' | 'E'));
+
+    has_digit && allowed_chars && normalized.parse::<f64>().is_ok()
 }

--- a/crates/perl-dap/tests/session_lifecycle_tests.rs
+++ b/crates/perl-dap/tests/session_lifecycle_tests.rs
@@ -188,6 +188,261 @@ fn test_set_variable_rejects_invalid_variable_name() {
     }
 }
 
+// ── setVariable value-field injection guard (Issue #7271) ─────────────────────
+
+#[test]
+fn bdd_set_variable_rejects_system_call_in_value() {
+    // WHEN a setVariable request contains `system(...)` in the value field
+    // THEN the adapter must reject it before sending any command to the debugger
+    let (mut adapter, _rx) = create_test_adapter();
+
+    let response = adapter.handle_request(
+        1,
+        "setVariable",
+        Some(json!({
+            "variablesReference": 11,
+            "name": "$x",
+            "value": "system('id')"
+        })),
+    );
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "setVariable must reject system() in value");
+            assert_eq!(command, "setVariable");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("unsafe value rejected"),
+                "Error must mention unsafe value rejection: {msg}"
+            );
+        }
+        _ => must(Err::<(), _>("Expected Response message".to_string())),
+    }
+}
+
+#[test]
+fn bdd_set_variable_rejects_exec_injection_in_value() {
+    // WHEN a setVariable value field contains exec() (shell exec injection)
+    // THEN the adapter must reject it
+    let (mut adapter, _rx) = create_test_adapter();
+
+    let response = adapter.handle_request(
+        1,
+        "setVariable",
+        Some(json!({
+            "variablesReference": 11,
+            "name": "$x",
+            "value": "exec('/bin/sh')"
+        })),
+    );
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "setVariable must reject exec() in value");
+            assert_eq!(command, "setVariable");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("unsafe value rejected"),
+                "Error must mention unsafe value rejection: {msg}"
+            );
+        }
+        _ => must(Err::<(), _>("Expected Response message".to_string())),
+    }
+}
+
+#[test]
+fn bdd_set_variable_rejects_backtick_shell_in_value() {
+    // WHEN a setVariable value field contains backtick shell execution
+    // THEN the adapter must reject it
+    let (mut adapter, _rx) = create_test_adapter();
+
+    let response = adapter.handle_request(
+        1,
+        "setVariable",
+        Some(json!({
+            "variablesReference": 11,
+            "name": "$x",
+            "value": "`id`"
+        })),
+    );
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "setVariable must reject backtick shell execution in value");
+            assert_eq!(command, "setVariable");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("unsafe value rejected"),
+                "Error must mention unsafe value rejection: {msg}"
+            );
+        }
+        _ => must(Err::<(), _>("Expected Response message".to_string())),
+    }
+}
+
+#[test]
+fn bdd_set_variable_rejects_statement_injection_via_semicolon_with_system() {
+    // WHEN a setVariable value contains `1; system(...)` (statement injection)
+    // THEN the adapter must reject it because system() is dangerous
+    let (mut adapter, _rx) = create_test_adapter();
+
+    let response = adapter.handle_request(
+        1,
+        "setVariable",
+        Some(json!({
+            "variablesReference": 11,
+            "name": "$x",
+            "value": "1; system('id')"
+        })),
+    );
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "setVariable must reject statement injection via semicolon");
+            assert_eq!(command, "setVariable");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("unsafe value rejected"),
+                "Error must mention unsafe value rejection: {msg}"
+            );
+        }
+        _ => must(Err::<(), _>("Expected Response message".to_string())),
+    }
+}
+
+#[test]
+fn bdd_set_variable_rejects_statement_separator_before_unlisted_call() {
+    // WHEN a setVariable value contains a statement separator before an unlisted call
+    // THEN the adapter must reject it even if the safe-eval builtin denylist does not match it
+    let (mut adapter, _rx) = create_test_adapter();
+
+    let response = adapter.handle_request(
+        1,
+        "setVariable",
+        Some(json!({
+            "variablesReference": 11,
+            "name": "$x",
+            "value": "1; warn 'still executed'"
+        })),
+    );
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "setVariable must reject unquoted statement separators");
+            assert_eq!(command, "setVariable");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("statement separators are not allowed"),
+                "Error must explain the statement separator rejection: {msg}"
+            );
+        }
+        _ => must(Err::<(), _>("Expected Response message".to_string())),
+    }
+}
+
+#[test]
+fn bdd_set_variable_rejects_unlisted_function_call_value() {
+    // WHEN a setVariable value is a package-qualified function call
+    // THEN the adapter must reject it instead of treating evaluate's broader safe mode as enough
+    let (mut adapter, _rx) = create_test_adapter();
+
+    let response = adapter.handle_request(
+        1,
+        "setVariable",
+        Some(json!({
+            "variablesReference": 11,
+            "name": "$x",
+            "value": "My::Hook::run()"
+        })),
+    );
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "setVariable must reject function-call values");
+            assert_eq!(command, "setVariable");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("only literal or simple variable-reference values are allowed"),
+                "Error must explain the setVariable value grammar: {msg}"
+            );
+        }
+        _ => must(Err::<(), _>("Expected Response message".to_string())),
+    }
+}
+
+#[test]
+fn bdd_set_variable_rejects_bareword_call_value() {
+    // WHEN a setVariable value is a bareword-style function call without parentheses
+    // THEN the adapter must reject it before sending a debugger command
+    let (mut adapter, _rx) = create_test_adapter();
+
+    let response = adapter.handle_request(
+        1,
+        "setVariable",
+        Some(json!({
+            "variablesReference": 11,
+            "name": "$x",
+            "value": "warn 'still executed'"
+        })),
+    );
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "setVariable must reject bareword-call values");
+            assert_eq!(command, "setVariable");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("only literal or simple variable-reference values are allowed"),
+                "Error must explain the setVariable value grammar: {msg}"
+            );
+        }
+        _ => must(Err::<(), _>("Expected Response message".to_string())),
+    }
+}
+
+#[test]
+fn bdd_set_variable_allows_safe_literal_values() {
+    // WHEN a setVariable value field contains a safe literal (integer, string, float)
+    // THEN the adapter should proceed past validation (may fail later due to no session)
+    let cases = [
+        ("$x", "42"),
+        ("$x", "\"hello\""),
+        ("$x", "3.14"),
+        ("$x", "'single-quoted string'"),
+        ("$x", "\"quoted; semicolon\""),
+        ("$x", "'quoted; semicolon'"),
+        ("$x", "undef"),
+        ("$x", "$other_value"),
+        ("$x", "$Package::value"),
+        ("$x", "1e10"),
+    ];
+
+    for (name, value) in cases {
+        let (mut adapter, _rx) = create_test_adapter();
+
+        let response = adapter.handle_request(
+            1,
+            "setVariable",
+            Some(json!({
+                "variablesReference": 11,
+                "name": name,
+                "value": value
+            })),
+        );
+
+        match response {
+            DapMessage::Response { message, .. } => {
+                let msg = message.unwrap_or_default();
+                assert!(
+                    !msg.contains("unsafe value rejected"),
+                    "Safe value {value:?} must not be rejected by injection guard: {msg}"
+                );
+            }
+            _ => must(Err::<(), _>("Expected Response message".to_string())),
+        }
+    }
+}
+
 #[test]
 // AC:5.5
 fn test_session_lifecycle_launch_missing_arguments() {


### PR DESCRIPTION
Problem: `setVariable.value` was interpolated into a Perl debugger command, so a DAP client could turn a value update into debugger-side Perl execution.

Fix: validate `setVariable.name` as before, then restrict `setVariable.value` to literal values, `undef`, or simple variable references; reject unquoted statement separators and call-shaped values before any command is sent to `perl -d`.

Verification:
- `cargo test -p perl-dap --profile agent --locked --test session_lifecycle_tests bdd_set_variable -- --nocapture` passes
- `cargo test -p perl-dap --profile agent --locked --test session_lifecycle_tests -- --nocapture` passes
- `cargo clippy --locked -p perl-dap --profile agent -- -D warnings -A missing_docs` passes
- `cargo xtask fmt --check` passes
- `git diff --check` passes
- `cargo test -p perl-dap --profile agent --locked --lib` was attempted; it hit an unrelated Windows process-liveness failure in `bridge_adapter::tests::repeated_start_stop_cycles_do_not_leave_child_processes` (`tasklist failed while checking child process ...`), outside the changed `setVariable` path.

Security surface: DAP client input crossing into Perl debugger stdin. No `allowSideEffects` bypass is added for `setVariable`.

Closes #7271.