### PR TITLE
docs(tooling): refresh native tooling status (#8401)

### DIFF
--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -36,13 +36,13 @@
 
 | Metric | Value |
 | --- | ---: |
-| Native rule count | 27 |
-| Rules with suppressions | 27 |
+| Native rule count | 28 |
+| Rules with suppressions | 28 |
 | Rules with fixes | 14 |
-| Pull diagnostics coverage | 27 |
-| Push diagnostics coverage | 27 |
-| Workspace diagnostics coverage | 27 |
-| Violation bridge coverage | 27 |
+| Pull diagnostics coverage | 28 |
+| Push diagnostics coverage | 28 |
+| Workspace diagnostics coverage | 28 |
+| Violation bridge coverage | 28 |
 | Native critic check files | 65 |
 | Native critic check parse errors | 0 |
 | Native critic check rules run | 27 |
@@ -84,6 +84,7 @@ Native rules:
 - `native.variables.uninitialized`
 - `native.syntax.unquoted_bareword`
 - `native.documentation.require_pod_sections`
+- `native.syntax.prohibit_leading_zeros`
 
 Fixable native rules:
 - `native.common.assignment_in_condition`

--- a/docs/project/status/native_tooling_readiness.md
+++ b/docs/project/status/native_tooling_readiness.md
@@ -16,7 +16,7 @@
 | formatter | dangerous surfaces visible | ready | true | expected_diagnostic_fixtures=8 literal_preserve_fixtures=8 bailout_count=8 | expand literal/comment preservation fixtures before treating format-on-save as broad coverage |
 | formatter | perltidy compatibility has no external-only gaps | blocked | true | options=9 supported=7 approximated=0 external_only=1 | map, approximate, or document remaining external-only perltidy options |
 | critic | native critic default | blocked | true | default perlcritic_enabled=false critic_engine=Legacy | keep native critic opt-in until recommended profile false-positive receipts are boring |
-| critic | native rule surface has LSP and bridge coverage | ready | true | rules=27 pull=27 push=27 workspace=27 bridge=27 | route every recommended rule through pull, push, workspace diagnostics, and violation bridge |
+| critic | native rule surface has LSP and bridge coverage | ready | true | rules=28 pull=28 push=28 workspace=28 bridge=28 | route every recommended rule through pull, push, workspace diagnostics, and violation bridge |
 | critic | native critic check receipt is parse-clean | ready | true | files=65 parse_errors=0 findings=187 fixable=173 | run `cargo xtask native-critic check` and fix parse errors before relying on critic receipts |
-| critic | native critic has fixes and suppression coverage | ready | true | rules=27 suppression=27 fixes=14 | add suppression/config/fix tests for new rules before enabling them in recommended profile |
+| critic | native critic has fixes and suppression coverage | ready | true | rules=28 suppression=28 fixes=14 | add suppression/config/fix tests for new rules before enabling them in recommended profile |
 | critic | perlcritic compatibility has no external-only gaps | ready | true | items=12 equivalent=5 superset=2 approximated=3 external_only=0 | map high-value perlcritic policies or keep external mode documented for remaining policies |


### PR DESCRIPTION
## Summary

- refresh generated native-tooling status after the latest native critic rule landed on master
- update readiness/status counts from 27 to 28 native rules and include `native.syntax.prohibit_leading_zeros`

## Proof packet

- `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- `cargo xtask native-tooling readiness --markdown docs/project/status/native_tooling_readiness.md`
- `git diff --check HEAD~1..HEAD`

This is generated status output only; no runtime or policy behavior changes.
