### PR TITLE
test(critic): add native critic false-positive fixtures (#8404)

### DIFF
--- a/xtask/src/tasks/native_critic.rs
+++ b/xtask/src/tasks/native_critic.rs
@@ -359,7 +359,7 @@ mod tests {
         assert_eq!(value["engine"], "native");
         assert_eq!(value["profile"], "recommended");
         assert_eq!(value["files_checked"], 1);
-        assert_eq!(value["rules_run"], 27);
+        assert_eq!(value["rules_run"], 28);
         assert_eq!(value["findings_count"], 1);
         assert_eq!(value["fixable_findings_count"], 1);
         assert_eq!(value["findings_by_rule"]["native.variables.unused_lexical"], 1);
@@ -394,6 +394,39 @@ mod tests {
         assert_eq!(value["findings_count"], 0);
         assert_eq!(value["suppressed_findings_count"], 1);
         assert_eq!(value["files"][0]["suppressed_findings_count"], 1);
+        Ok(())
+    }
+
+    #[test]
+    fn native_critic_check_keeps_false_positive_fixtures_clean() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let receipt = temp.path().join("native-critic-check.json");
+        let summary = temp.path().join("native-critic-check.md");
+        let fixture_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("xtask/tests/fixtures/native-critic/false-positive");
+
+        check(NativeCriticCheckConfig {
+            roots: vec![fixture_root],
+            severity: 1,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            receipt: receipt.clone(),
+            summary: summary.clone(),
+        })?;
+
+        let value: Value = serde_json::from_str(&fs::read_to_string(receipt)?)?;
+        assert_eq!(value["files_checked"], 3);
+        assert_eq!(value["files_with_parse_errors"], 0);
+        assert_eq!(value["rules_run"], 28);
+        assert_eq!(value["findings_count"], 0);
+        assert_eq!(value["suppressed_findings_count"], 0);
+        assert_eq!(value["fixable_findings_count"], 0);
+        assert_eq!(value["findings_by_rule"].as_object().map(|rules| rules.len()), Some(0));
+
+        let summary = fs::read_to_string(summary)?;
+        assert!(summary.contains("- Findings: `0`"));
+        assert!(summary.contains("| _none_ | 0 |"));
         Ok(())
     }
 }

--- a/xtask/tests/fixtures/native-critic/false-positive/clean_module.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/clean_module.pm
@@ -1,0 +1,34 @@
+package Clean::Module;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Clean::Module - clean native critic fixture
+
+=head1 SYNOPSIS
+
+    Clean::Module::sum(1, 2);
+
+=head1 DESCRIPTION
+
+Exercises common clean Perl idioms that should not produce native critic findings.
+
+=cut
+
+sub sum {
+    my ($left, $right) = @_;
+    my $total = $left + $right;
+    return $total;
+}
+
+sub count_items {
+    my (@items) = @_;
+    my $count = 0;
+    for my $item (@items) {
+        $count += length $item;
+    }
+    return $count;
+}
+
+1;

--- a/xtask/tests/fixtures/native-critic/false-positive/closure_and_eval.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/closure_and_eval.pm
@@ -1,0 +1,34 @@
+package Clean::ClosureAndEval;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Clean::ClosureAndEval - closure and eval native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps closure captures and guarded eval handling quiet under native critic.
+
+=cut
+
+sub make_counter {
+    my ($start) = @_;
+    my $count = $start;
+    return sub {
+        $count += 1;
+        return $count;
+    };
+}
+
+sub parse_value {
+    my ($source) = @_;
+    my $result = eval { 0 + $source };
+    my $error = $@;
+    if (defined $error && length $error) {
+        return undef;
+    }
+    return $result;
+}
+
+1;

--- a/xtask/tests/fixtures/native-critic/false-positive/package_exports.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/package_exports.pm
@@ -1,0 +1,23 @@
+package Clean::Exports;
+use strict;
+use warnings;
+use Exporter 'import';
+
+our @EXPORT_OK = qw(clean_name);
+
+=head1 NAME
+
+Clean::Exports - export native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps simple Exporter package setup quiet under native critic.
+
+=cut
+
+sub clean_name {
+    my ($name) = @_;
+    return ucfirst lc $name;
+}
+
+1;


### PR DESCRIPTION
## Summary

- add a small native critic false-positive fixture pack for clean Perl idioms
- lock the fixture pack through the real `cargo xtask native-critic check` receipt path
- refresh the stale native critic rule-count assertion from 27 to 28

This is a test/proof PR only. It does not change runtime critic defaults, native rule behavior, diagnostics, formatter code, or CI gates.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p xtask native_critic_check_keeps_false_positive_fixtures_clean -- --nocapture`
- [x] `cargo test -p xtask native_critic -- --nocapture`
- [x] `cargo xtask native-critic check --root xtask/tests/fixtures/native-critic/false-positive --severity 1 --receipt target/receipts/native-tooling/native-critic-false-positive.json --summary target/receipts/native-tooling/native-critic-false-positive.md`
  - 3 files checked
  - 28 rules run
  - 0 findings
  - 0 suppressed
  - 0 fixable
- [x] `cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check origin/master...HEAD`
