### PR TITLE
test(critic): expand native critic false-positive fixtures (#8406)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -1132,6 +1132,7 @@ impl CriticRule for UnquotedBarewordRule {
             issues
                 .into_iter()
                 .filter(|issue| issue.kind == IssueKind::UnquotedBareword)
+                .filter(|issue| !bareword_is_fat_comma_key(ctx.source, issue))
                 .map(|issue| unquoted_bareword_finding(self, ctx.source, &issue)),
         );
     }
@@ -1898,6 +1899,10 @@ fn unquoted_bareword_finding(
             edits: vec![CriticTextEdit { range, new_text: quoted }],
         }),
     }
+}
+
+fn bareword_is_fat_comma_key(source: &str, issue: &ScopeIssue) -> bool {
+    source.get(issue.range.1..).is_some_and(|rest| rest.trim_start().starts_with("=>"))
 }
 
 fn collect_assignment_in_condition_findings(
@@ -5445,6 +5450,19 @@ mod tests {
         let findings = registry.check(&ctx);
 
         assert!(findings.is_empty(), "quoted strings should be accepted");
+    }
+
+    #[test]
+    fn native_unquoted_bareword_rule_accepts_fat_comma_keys() {
+        let source = "use strict;\nuse warnings;\nplan tests => 2;\nhas name => (is => 'ro');\n";
+        let ast = parse_source(source);
+        let config = CriticConfig::default();
+        let ctx = CriticContext::new(source, &ast, &config);
+        let registry = NativeCriticRegistry::with_rules(vec![Box::new(UnquotedBarewordRule)]);
+
+        let findings = registry.check(&ctx);
+
+        assert!(findings.is_empty(), "fat-comma keys should be accepted as quoted strings");
     }
 
     #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -49,7 +49,7 @@
 | Native critic check findings | 187 |
 | Native critic check suppressed | 0 |
 | Native critic check fixable | 173 |
-| Native critic false-positive files | 3 |
+| Native critic false-positive files | 6 |
 | Native critic false-positive parse errors | 0 |
 | Native critic false-positive rules run | 28 |
 | Native critic false-positive findings | 0 |

--- a/docs/project/status/native_tooling_readiness.md
+++ b/docs/project/status/native_tooling_readiness.md
@@ -18,6 +18,6 @@
 | critic | native critic default | blocked | true | default perlcritic_enabled=false critic_engine=Legacy | keep native critic opt-in until recommended profile false-positive receipts are boring |
 | critic | native rule surface has LSP and bridge coverage | ready | true | rules=28 pull=28 push=28 workspace=28 bridge=28 | route every recommended rule through pull, push, workspace diagnostics, and violation bridge |
 | critic | native critic check receipt is parse-clean | ready | true | files=65 parse_errors=0 findings=187 fixable=173 | run `cargo xtask native-critic check` and fix parse errors before relying on critic receipts |
-| critic | native critic false-positive fixtures are clean | ready | true | files=3 parse_errors=0 findings=0 suppressed=0 | run the native critic false-positive fixture receipt and fix any emitted finding |
+| critic | native critic false-positive fixtures are clean | ready | true | files=6 parse_errors=0 findings=0 suppressed=0 | run the native critic false-positive fixture receipt and fix any emitted finding |
 | critic | native critic has fixes and suppression coverage | ready | true | rules=28 suppression=28 fixes=14 | add suppression/config/fix tests for new rules before enabling them in recommended profile |
 | critic | perlcritic compatibility has no external-only gaps | ready | true | items=12 equivalent=5 superset=2 approximated=3 external_only=0 | map high-value perlcritic policies or keep external mode documented for remaining policies |

--- a/xtask/src/tasks/native_critic.rs
+++ b/xtask/src/tasks/native_critic.rs
@@ -416,7 +416,7 @@ mod tests {
         })?;
 
         let value: Value = serde_json::from_str(&fs::read_to_string(receipt)?)?;
-        assert_eq!(value["files_checked"], 3);
+        assert_eq!(value["files_checked"], 6);
         assert_eq!(value["files_with_parse_errors"], 0);
         assert_eq!(value["rules_run"], 28);
         assert_eq!(value["findings_count"], 0);

--- a/xtask/tests/fixtures/native-critic/false-positive/localized_eval.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/localized_eval.pm
@@ -1,0 +1,31 @@
+package Clean::LocalizedEval;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Clean::LocalizedEval - localized eval native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps localized block eval error handling quiet under native critic.
+
+=cut
+
+sub parse_number {
+    my ($source) = @_;
+    my $value;
+    {
+        local $@;
+        my $ok = eval {
+            $value = 0 + $source;
+            1;
+        };
+        if (!$ok) {
+            return undef;
+        }
+    }
+    return $value;
+}
+
+1;

--- a/xtask/tests/fixtures/native-critic/false-positive/object_attributes.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/object_attributes.pm
@@ -1,0 +1,31 @@
+package Clean::ObjectAttributes;
+use strict;
+use warnings;
+use Moo;
+
+=head1 NAME
+
+Clean::ObjectAttributes - object attribute native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps common Moo-style attribute declarations quiet under native critic.
+
+=cut
+
+has name => (
+    is       => 'ro',
+    required => 1,
+);
+
+has tags => (
+    is      => 'ro',
+    default => sub { [] },
+);
+
+sub label {
+    my ($self) = @_;
+    return $self->name;
+}
+
+1;

--- a/xtask/tests/fixtures/native-critic/false-positive/test_more_usage.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/test_more_usage.pm
@@ -1,0 +1,28 @@
+package Clean::TestMoreUsage;
+use strict;
+use warnings;
+use Test::More;
+
+=head1 NAME
+
+Clean::TestMoreUsage - Test::More native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps common Test::More assertions quiet under native critic.
+
+=cut
+
+sub add {
+    my ($left, $right) = @_;
+    return $left + $right;
+}
+
+sub run_tests {
+    plan tests => 2;
+    ok(add(1, 1) == 2, 'addition works');
+    is(add(2, 3), 5, 'addition returns expected result');
+    return 1;
+}
+
+1;


### PR DESCRIPTION
## Summary

- expands the native critic false-positive fixture pack from 3 to 6 files with Test::More usage, Moo-style attribute declarations, and localized eval handling
- fixes `native.syntax.unquoted_bareword` so barewords immediately followed by Perl's fat comma (`=>`) are accepted as quoted keys instead of flagged under `use strict`
- refreshes native-tooling status/readiness so the false-positive receipt now records 6 clean files

## Why

The native critic default cutover remains blocked until the recommended profile is boring under false-positive receipts. These fixtures cover common real Perl idioms that should stay quiet without suppressions, and they exposed a concrete precision bug in the unquoted-bareword rule.

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_unquoted_bareword --profile agent --locked -- --nocapture`
- [x] `cargo test -p xtask native_critic -- --nocapture`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo xtask native-critic check --root xtask/tests/fixtures/native-critic/false-positive --severity 1 --receipt target/receipts/native-tooling/native-critic-false-positive.json --summary target/receipts/native-tooling/native-critic-false-positive.md`
  - 6 files checked
  - 28 rules run
  - 0 findings / 0 suppressed / 0 fixable
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo xtask native-tooling readiness --markdown docs/project/status/native_tooling_readiness.md`
  - `not_ready` remains correct: 10 ready criteria, 1 blocker
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p xtask --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

## Known unrelated check result

- [ ] `just status-check`
  - Still reports unrelated generated-status drift in `docs/project/status/tests.md`, `docs/project/status/parser.md`, `docs/project/status/quality.md`, and `docs/project/status/dap.md`.
  - This PR only updates `native_tooling.md` and `native_tooling_readiness.md`; I did not fold the broader generated status refresh into this focused critic PR.

## Scope notes

This does not change native critic defaults, legacy perlcritic behavior, formatter behavior, runtime configuration, or shell-out policy.
