### PR TITLE
fix(xtask): restore native tooling clippy gate (#8405)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1922,6 +1922,9 @@ enum NativeCriticCommand {
 }
 
 #[derive(Subcommand)]
+// Native tooling status intentionally exposes many receipt path flags; boxing
+// clap fields would trade a diagnostic-only enum size for noisier CLI plumbing.
+#[allow(clippy::large_enum_variant)]
 enum NativeToolingCommand {
     /// Write native formatter and critic status receipts.
     Status {


### PR DESCRIPTION
Problem: #8405 added another native-tooling status receipt path and pushed the xtask clap subcommand enum over the `large_enum_variant` clippy threshold.
Fix: Add a narrowly justified allow on the native-tooling subcommand enum; the status command intentionally carries many receipt path flags, and boxing clap fields would make the CLI plumbing noisier without changing runtime behavior.
Verification:
- `cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `git diff --check`