### PR TITLE
fix(status): read token scorecard performance keys (#6461)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -80,6 +80,6 @@ Failures in the system-Perl baseline grouped by cluster. Counts come from `first
 | **Category partition** | PASS (132 tokens partitioned across canonical groups) | keywords/operators/delimiters/literals/identifiers/special | `crates/perl-token/src/lib.rs` |
 | **Display-name coverage** | 132/132 | user-facing token labels present | `crates/perl-token/src/lib.rs` |
 | **Lexer/parser conformance** | PASS (lexer + parser-core both consume shared `perl-token`) | integration through shared token crate | `crates/perl-lexer/Cargo.toml` + `crates/perl-parser-core/Cargo.toml` |
-| **Token perf (p50/p95)** | UNVERIFIED (token scorecard missing key metrics) | key token operations benchmark health | `docs/project/status/token_performance_scorecard.json` |
+| **Token perf (p50/p95)** | PASS (category predicates: p50 29 ns / p95 40 ns; clone: p50 47 ns / p95 59 ns; display_name: p50 29 ns / p95 40 ns; lexer->parser: p50 226 ns / p95 253 ns; new long: p50 60 ns / p95 85 ns; new short: p50 62 ns / p95 63 ns) | key token operations benchmark health | `docs/project/status/token_performance_scorecard.json` |
 | **Runtime dependencies** | 0 | non-dev deps in `perl-token` | `crates/perl-token/Cargo.toml` |
 <!-- END: TOKEN_HEALTH_TABLE -->

--- a/xtask/src/tasks/update_status/token.rs
+++ b/xtask/src/tasks/update_status/token.rs
@@ -110,18 +110,17 @@ pub fn collect_token_health_metrics(root: &Path) -> TokenHealthMetrics {
         || "UNVERIFIED (token scorecard missing)".to_string(),
         |scorecard| {
             let mut keys = [
-                ("display_name_lookup", "display_name"),
-                ("token_kind_clone", "kind copy"),
-                ("token_allocation", "token alloc"),
+                ("token_kind_display_name", "display_name"),
+                ("token_kind_category_predicates", "category predicates"),
+                ("token_clone", "clone"),
+                ("token_new_short", "new short"),
+                ("token_new_long", "new long"),
+                ("lexer_to_parser_token_conversion", "lexer->parser"),
             ]
             .into_iter()
             .filter_map(|(key, label)| {
                 scorecard.metrics.get(key).map(|metric| {
-                    format!(
-                        "{label}: p50 {:.3} ms / p95 {:.3} ms",
-                        ns_to_ms(metric.median_ns),
-                        ns_to_ms(metric.p95_ns)
-                    )
+                    format!("{label}: p50 {} ns / p95 {} ns", metric.median_ns, metric.p95_ns)
                 })
             })
             .collect::<Vec<_>>();
@@ -321,10 +320,6 @@ fn token_category_counts(source: &str) -> std::collections::BTreeMap<&'static st
     counts
 }
 
-fn ns_to_ms(ns: u128) -> f64 {
-    ns as f64 / 1_000_000.0
-}
-
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
@@ -384,7 +379,10 @@ mod tests {
         }
         // Spot-check: known TokenCategory variants must NOT appear in the list.
         // These were incorrectly included before the brace-tracking boundary fix.
-        for spurious in &["Keyword", "Operator", "Delimiter", "Literal", "Identifier", "Special"] {
+        // `TokenKind::Identifier` is a legitimate token kind, so it is not a
+        // spurious category-name sentinel here even though `TokenCategory` also
+        // has an `Identifier` variant.
+        for spurious in &["Keyword", "Operator", "Delimiter", "Literal", "Special"] {
             assert!(
                 !variants.iter().any(|v| v == spurious),
                 "TokenCategory variant {spurious:?} must not appear in TokenKind variant list"
@@ -458,5 +456,35 @@ mod tests {
             "variant_count is {} but fixture expects 132; update token_metrics_fixture()",
             metrics.variant_count
         );
+    }
+
+    /// The committed token scorecard uses benchmark names emitted by
+    /// `crates/perl-token/benches/support/perf_scorecard.rs`. The status reader
+    /// must consume those names directly so parser status does not report token
+    /// performance as unverified when the artifact exists.
+    #[test]
+    fn collect_token_health_metrics_reads_committed_perf_scorecard_keys() {
+        let root = project_root().expect("project root");
+        let metrics = collect_token_health_metrics(&root);
+
+        assert!(
+            metrics.performance_row.starts_with("PASS ("),
+            "token performance row must be verified from committed scorecard; got: {}",
+            metrics.performance_row
+        );
+        for label in [
+            "category predicates",
+            "clone",
+            "display_name",
+            "lexer->parser",
+            "new long",
+            "new short",
+        ] {
+            assert!(
+                metrics.performance_row.contains(label),
+                "token performance row must include {label:?}; got: {}",
+                metrics.performance_row
+            );
+        }
     }
 }


### PR DESCRIPTION
Problem: The parser status token perf row stayed unverified even though the committed token scorecard exists because the status reader looked for stale benchmark keys.
Fix: Read the actual token scorecard metric names, render ns-level p50/p95 values, and add a regression test for the committed scorecard keys.
Verification: `cargo test -p xtask --profile agent --locked token -- --nocapture`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`; `cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs`.