### PR TITLE
feat(critic): add native critic check profiles (#8409)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/mod.rs
@@ -15,10 +15,10 @@ pub use native::{
     AssignmentInConditionRule, CriticCategory, CriticContext, CriticFinding, CriticFix,
     CriticRelatedInformation, CriticRule, CriticSuppression, CriticSuppressionMap,
     CriticSuppressionScope, CriticTextEdit, DeprecatedDefinedRule, DuplicateLexicalDeclarationRule,
-    DuplicateParameterRule, FixSafety, NativeCriticRegistry, ParameterShadowsGlobalRule,
-    PrintfFormatArityRule, RequirePodSectionsRule, RequireUseStrictRule, RequireUseWarningsRule,
-    ShadowedLexicalVariableRule, StaleDollarAtRule, UndefComparisonRule, UnreachableCodeRule,
-    UnusedLexicalVariableRule, UnusedParameterRule,
+    DuplicateParameterRule, FixSafety, NativeCriticProfile, NativeCriticRegistry,
+    ParameterShadowsGlobalRule, PrintfFormatArityRule, RequirePodSectionsRule,
+    RequireUseStrictRule, RequireUseWarningsRule, ShadowedLexicalVariableRule, StaleDollarAtRule,
+    UndefComparisonRule, UnreachableCodeRule, UnusedLexicalVariableRule, UnusedParameterRule,
 };
 pub use quick_fix::{QuickFix, TextEdit};
 pub use types::{CriticConfig, Severity, Violation};

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -204,6 +204,36 @@ pub trait CriticRule: Send + Sync {
     fn check(&self, ctx: &CriticContext<'_>, out: &mut Vec<CriticFinding>);
 }
 
+/// Native critic rule bundle used by receipt and readiness tooling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NativeCriticProfile {
+    /// Lower-noise candidate for eventual default/native recommended use.
+    Recommended,
+    /// Every registered native rule, useful for strict audits and rule coverage.
+    Strict,
+}
+
+impl NativeCriticProfile {
+    /// Parse a native critic profile token.
+    #[must_use]
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "recommended" => Some(Self::Recommended),
+            "strict" => Some(Self::Strict),
+            _ => None,
+        }
+    }
+
+    /// Stable profile label for receipts.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Recommended => "recommended",
+            Self::Strict => "strict",
+        }
+    }
+}
+
 /// Registry for Rust-native critic rules.
 ///
 /// The registry is intentionally small orchestration: it owns rule instances,
@@ -235,6 +265,44 @@ impl NativeCriticRegistry {
     /// diagnostics and receipts are deterministic.
     #[must_use]
     pub fn recommended() -> Self {
+        Self::for_profile(NativeCriticProfile::Strict)
+    }
+
+    /// Create a native critic registry for a named profile.
+    ///
+    /// Runtime diagnostics still use `recommended()` for compatibility. The
+    /// explicit profile entry point lets receipts and readiness checks measure
+    /// lower-noise default candidates without changing the opt-in runtime path.
+    #[must_use]
+    pub fn for_profile(profile: NativeCriticProfile) -> Self {
+        match profile {
+            NativeCriticProfile::Recommended => Self::recommended_profile(),
+            NativeCriticProfile::Strict => Self::strict_profile(),
+        }
+    }
+
+    fn recommended_profile() -> Self {
+        Self::with_rules(vec![
+            Box::new(RequireUseStrictRule),
+            Box::new(RequireUseWarningsRule),
+            Box::new(AssignmentInConditionRule),
+            Box::new(PrintfFormatArityRule),
+            Box::new(DeprecatedDefinedRule),
+            Box::new(UndefComparisonRule),
+            Box::new(StaleDollarAtRule),
+            Box::new(UnreachableCodeRule),
+            Box::new(BarewordFilehandleRule),
+            Box::new(TwoArgOpenRule),
+            Box::new(PipeOpenRule),
+            Box::new(UncheckedOpenCloseRule),
+            Box::new(QxReadpipeRule),
+            Box::new(BacktickExecRule),
+            Box::new(StringEvalRule),
+            Box::new(SystemExecRule),
+        ])
+    }
+
+    fn strict_profile() -> Self {
         Self::with_rules(vec![
             Box::new(RequireUseStrictRule),
             Box::new(RequireUseWarningsRule),
@@ -3068,6 +3136,35 @@ mod tests {
         assert_eq!(registry.rule_ids(), vec!["native.test.second"]);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].category, CriticCategory::Maintainability);
+    }
+
+    #[test]
+    fn native_critic_profiles_keep_recommended_lower_noise_than_strict() {
+        let recommended = NativeCriticRegistry::for_profile(NativeCriticProfile::Recommended);
+        let strict = NativeCriticRegistry::for_profile(NativeCriticProfile::Strict);
+        let recommended_ids = recommended.rule_ids();
+        let strict_ids = strict.rule_ids();
+
+        assert!(recommended_ids.contains(&"native.testing.require_use_strict"));
+        assert!(recommended_ids.contains(&"native.security.string_eval"));
+        assert!(recommended_ids.contains(&"native.io.two_arg_open"));
+        assert!(!recommended_ids.contains(&"native.variables.unused_lexical"));
+        assert!(!recommended_ids.contains(&"native.syntax.unquoted_bareword"));
+        assert!(recommended_ids.len() < strict_ids.len());
+        assert_eq!(strict_ids.len(), NativeCriticRegistry::recommended().len());
+    }
+
+    #[test]
+    fn native_critic_profile_parser_accepts_stable_labels() {
+        assert_eq!(
+            NativeCriticProfile::parse("recommended").map(NativeCriticProfile::as_str),
+            Some("recommended")
+        );
+        assert_eq!(
+            NativeCriticProfile::parse("strict").map(NativeCriticProfile::as_str),
+            Some("strict")
+        );
+        assert_eq!(NativeCriticProfile::parse("unknown"), None);
     }
 
     #[test]

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -43,12 +43,13 @@
 | Push diagnostics coverage | 28 |
 | Workspace diagnostics coverage | 28 |
 | Violation bridge coverage | 28 |
+| Native critic check profile | recommended |
 | Native critic check files | 65 |
 | Native critic check parse errors | 0 |
-| Native critic check rules run | 27 |
-| Native critic check findings | 187 |
+| Native critic check rules run | 16 |
+| Native critic check findings | 112 |
 | Native critic check suppressed | 0 |
-| Native critic check fixable | 173 |
+| Native critic check fixable | 110 |
 | Native critic false-positive files | 6 |
 | Native critic false-positive parse errors | 0 |
 | Native critic false-positive rules run | 28 |

--- a/docs/project/status/native_tooling_readiness.md
+++ b/docs/project/status/native_tooling_readiness.md
@@ -17,7 +17,7 @@
 | formatter | perltidy compatibility has no external-only gaps | ready | true | options=8 supported=7 approximated=0 external_only=0 | map, approximate, or document remaining external-only perltidy options |
 | critic | native critic default | blocked | true | default perlcritic_enabled=false critic_engine=Legacy | keep native critic opt-in until recommended profile false-positive receipts are boring |
 | critic | native rule surface has LSP and bridge coverage | ready | true | rules=28 pull=28 push=28 workspace=28 bridge=28 | route every recommended rule through pull, push, workspace diagnostics, and violation bridge |
-| critic | native critic check receipt is parse-clean | ready | true | files=65 parse_errors=0 findings=187 fixable=173 | run `cargo xtask native-critic check` and fix parse errors before relying on critic receipts |
+| critic | native critic check receipt is parse-clean | ready | true | profile=recommended files=65 parse_errors=0 findings=112 fixable=110 | run `cargo xtask native-critic check` and fix parse errors before relying on critic receipts |
 | critic | native critic false-positive fixtures are clean | ready | true | files=6 parse_errors=0 findings=0 suppressed=0 | run the native critic false-positive fixture receipt and fix any emitted finding |
 | critic | native critic has fixes and suppression coverage | ready | true | rules=28 suppression=28 fixes=14 | add suppression/config/fix tests for new rules before enabling them in recommended profile |
 | critic | perlcritic compatibility has no external-only gaps | ready | true | items=12 equivalent=5 superset=2 approximated=3 external_only=0 | map high-value perlcritic policies or keep external mode documented for remaining policies |

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1903,7 +1903,11 @@ enum NativeCriticCommand {
         #[arg(long, default_value_t = 3)]
         severity: u8,
 
-        /// Native rule IDs to include. Empty means all recommended rules.
+        /// Native critic profile to run: recommended or strict.
+        #[arg(long, default_value = "recommended")]
+        profile: String,
+
+        /// Native rule IDs to include. Empty means all selected-profile rules.
         #[arg(long = "include")]
         include: Vec<String>,
 
@@ -2377,16 +2381,23 @@ fn main() -> Result<()> {
             }
         },
         Commands::NativeCritic { command } => match command {
-            NativeCriticCommand::Check { roots, severity, include, exclude, receipt, summary } => {
-                native_critic::check(native_critic::NativeCriticCheckConfig {
-                    roots,
-                    severity,
-                    include,
-                    exclude,
-                    receipt,
-                    summary,
-                })
-            }
+            NativeCriticCommand::Check {
+                roots,
+                profile,
+                severity,
+                include,
+                exclude,
+                receipt,
+                summary,
+            } => native_critic::check(native_critic::NativeCriticCheckConfig {
+                roots,
+                profile,
+                severity,
+                include,
+                exclude,
+                receipt,
+                summary,
+            }),
         },
         Commands::NativeTooling { command } => match command {
             NativeToolingCommand::Status {

--- a/xtask/src/tasks/native_critic.rs
+++ b/xtask/src/tasks/native_critic.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Context, Result, eyre};
 use perl_lsp_rs_core::tooling::perl_critic::{
-    CriticConfig, CriticContext, CriticFinding, NativeCriticRegistry,
+    CriticConfig, CriticContext, CriticFinding, NativeCriticProfile, NativeCriticRegistry,
 };
 use perl_parser::Parser;
 use serde::Serialize;
@@ -19,9 +19,11 @@ const SCHEMA_VERSION: u32 = 1;
 pub struct NativeCriticCheckConfig {
     /// Files or directories containing Perl sources.
     pub roots: Vec<PathBuf>,
+    /// Native critic profile to run.
+    pub profile: String,
     /// Minimum native critic severity to report.
     pub severity: u8,
-    /// Native rule IDs to include. Empty means all recommended rules.
+    /// Native rule IDs to include. Empty means all selected-profile rules.
     pub include: Vec<String>,
     /// Native rule IDs to exclude.
     pub exclude: Vec<String>,
@@ -38,7 +40,7 @@ struct NativeCriticCheckReceipt {
     generated_at: DateTime<Utc>,
     commit: String,
     roots: Vec<String>,
-    profile: &'static str,
+    profile: String,
     engine: &'static str,
     severity: u8,
     include: Vec<String>,
@@ -77,13 +79,16 @@ pub fn check(config: NativeCriticCheckConfig) -> Result<()> {
         ));
     }
 
+    let profile = NativeCriticProfile::parse(&config.profile).ok_or_else(|| {
+        eyre!("unknown native critic profile '{}'; expected recommended or strict", config.profile)
+    })?;
     let critic_config = CriticConfig {
         severity: config.severity,
         include: config.include.clone(),
         exclude: config.exclude.clone(),
         ..CriticConfig::default()
     };
-    let registry = NativeCriticRegistry::recommended();
+    let registry = NativeCriticRegistry::for_profile(profile);
     let rule_ids = registry.rule_ids().into_iter().map(ToOwned::to_owned).collect::<Vec<_>>();
     let mut results = Vec::new();
 
@@ -109,7 +114,7 @@ pub fn check(config: NativeCriticCheckConfig) -> Result<()> {
         generated_at: Utc::now(),
         commit: current_commit(),
         roots: roots.iter().map(|root| root.display().to_string()).collect(),
-        profile: "recommended",
+        profile: profile.as_str().to_string(),
         engine: "native",
         severity: config.severity,
         include: config.include,
@@ -347,6 +352,7 @@ mod tests {
 
         check(NativeCriticCheckConfig {
             roots: vec![source],
+            profile: "strict".to_string(),
             severity: 1,
             include: vec!["native.variables.unused_lexical".to_string()],
             exclude: Vec::new(),
@@ -357,7 +363,7 @@ mod tests {
         let value: Value = serde_json::from_str(&fs::read_to_string(receipt)?)?;
         assert_eq!(value["kind"], "native_critic_check");
         assert_eq!(value["engine"], "native");
-        assert_eq!(value["profile"], "recommended");
+        assert_eq!(value["profile"], "strict");
         assert_eq!(value["files_checked"], 1);
         assert_eq!(value["rules_run"], 28);
         assert_eq!(value["findings_count"], 1);
@@ -383,6 +389,7 @@ mod tests {
 
         check(NativeCriticCheckConfig {
             roots: vec![source],
+            profile: "strict".to_string(),
             severity: 1,
             include: vec!["native.variables.unused_lexical".to_string()],
             exclude: Vec::new(),
@@ -398,6 +405,31 @@ mod tests {
     }
 
     #[test]
+    fn native_critic_check_profiles_lower_noise_recommended_rules() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let source = temp.path().join("App.pm");
+        fs::write(&source, "package App;\nsub run { my $unused = 1; return 1; }\n1;\n")?;
+        let receipt = temp.path().join("native-critic-check.json");
+        let summary = temp.path().join("native-critic-check.md");
+
+        check(NativeCriticCheckConfig {
+            roots: vec![source],
+            profile: "recommended".to_string(),
+            severity: 1,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            receipt: receipt.clone(),
+            summary,
+        })?;
+
+        let value: Value = serde_json::from_str(&fs::read_to_string(receipt)?)?;
+        assert_eq!(value["profile"], "recommended");
+        assert_eq!(value["rules_run"], 16);
+        assert_eq!(value["findings_by_rule"]["native.variables.unused_lexical"], Value::Null);
+        Ok(())
+    }
+
+    #[test]
     fn native_critic_check_keeps_false_positive_fixtures_clean() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let receipt = temp.path().join("native-critic-check.json");
@@ -408,6 +440,7 @@ mod tests {
 
         check(NativeCriticCheckConfig {
             roots: vec![fixture_root],
+            profile: "strict".to_string(),
             severity: 1,
             include: Vec::new(),
             exclude: Vec::new(),

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -167,6 +167,7 @@ struct CriticStatus {
     rules_with_violation_bridge: usize,
     critic_check_receipt: String,
     critic_check_receipt_present: bool,
+    critic_check_profile: Option<String>,
     critic_check_files_checked: Option<usize>,
     critic_check_files_with_parse_errors: Option<usize>,
     critic_check_rules_run: Option<usize>,
@@ -514,7 +515,11 @@ fn build_readiness_receipt(
         critic.critic_check_receipt_present,
         true,
         format!(
-            "files={} parse_errors={} findings={} fixable={}",
+            "profile={} files={} parse_errors={} findings={} fixable={}",
+            optional_text_metric(
+                critic.critic_check_profile.as_deref(),
+                critic.critic_check_receipt_present,
+            ),
             optional_metric(critic.critic_check_files_checked, critic.critic_check_receipt_present),
             optional_metric(
                 critic.critic_check_files_with_parse_errors,
@@ -902,6 +907,7 @@ fn critic_status(
         rules_with_violation_bridge: native_rules.len(),
         critic_check_receipt: critic_check_receipt.display().to_string(),
         critic_check_receipt_present: check_receipt.is_some(),
+        critic_check_profile: optional_string(&check_receipt, "profile"),
         critic_check_files_checked: optional_usize(&check_receipt, "files_checked"),
         critic_check_files_with_parse_errors: optional_usize(
             &check_receipt,
@@ -1106,6 +1112,10 @@ fn render_markdown(receipt: &NativeToolingStatusReceipt) -> String {
     );
     let critic_check_files_checked =
         optional_metric(critic.critic_check_files_checked, critic.critic_check_receipt_present);
+    let critic_check_profile = optional_text_metric(
+        critic.critic_check_profile.as_deref(),
+        critic.critic_check_receipt_present,
+    );
     let critic_check_parse_errors = optional_metric(
         critic.critic_check_files_with_parse_errors,
         critic.critic_check_receipt_present,
@@ -1216,6 +1226,7 @@ fn render_markdown(receipt: &NativeToolingStatusReceipt) -> String {
 | Push diagnostics coverage | {} |
 | Workspace diagnostics coverage | {} |
 | Violation bridge coverage | {} |
+| Native critic check profile | {} |
 | Native critic check files | {} |
 | Native critic check parse errors | {} |
 | Native critic check rules run | {} |
@@ -1273,6 +1284,7 @@ Fixable native rules:
         critic.rules_surfaced_in_push_diagnostics,
         critic.rules_surfaced_in_workspace_diagnostics,
         critic.rules_with_violation_bridge,
+        critic_check_profile,
         critic_check_files_checked,
         critic_check_parse_errors,
         critic_check_rules_run,
@@ -1729,6 +1741,7 @@ mod tests {
         fs::write(
             &critic_check_receipt,
             r#"{
+  "profile": "recommended",
   "files_checked": 3,
   "files_with_parse_errors": 0,
   "rules_run": 28,
@@ -1808,6 +1821,7 @@ mod tests {
         assert_eq!(value["formatter"]["format_trailing_comma"], "add-when-wrapped");
         assert!(value["critic"]["native_rule_count"].as_u64().unwrap_or_default() > 0);
         assert_eq!(value["critic"]["critic_check_receipt_present"], true);
+        assert_eq!(value["critic"]["critic_check_profile"], "recommended");
         assert_eq!(value["critic"]["critic_check_files_checked"], 3);
         assert_eq!(value["critic"]["critic_check_files_with_parse_errors"], 0);
         assert_eq!(value["critic"]["critic_check_rules_run"], 28);
@@ -1868,6 +1882,7 @@ mod tests {
         assert!(markdown.contains("| Config else placement | separate-line |"));
         assert!(markdown.contains("| Config keyword spacing | compact |"));
         assert!(markdown.contains("| Config trailing comma | add-when-wrapped |"));
+        assert!(markdown.contains("| Native critic check profile | recommended |"));
         assert!(markdown.contains("| Native critic check files | 3 |"));
         assert!(markdown.contains("| Native critic check parse errors | 0 |"));
         assert!(markdown.contains("| Native critic check rules run | 28 |"));
@@ -2042,6 +2057,7 @@ color = 1
                 rules_with_violation_bridge: 2,
                 critic_check_receipt: "native-critic-check.json".to_string(),
                 critic_check_receipt_present: true,
+                critic_check_profile: Some("recommended".to_string()),
                 critic_check_files_checked: Some(3),
                 critic_check_files_with_parse_errors: Some(0),
                 critic_check_rules_run: Some(2),


### PR DESCRIPTION
## Summary

Adds native critic check profiles so receipt/readiness tooling can distinguish the lower-noise `recommended` candidate from the full `strict` native rule surface.

- adds `NativeCriticProfile::{Recommended, Strict}` and `NativeCriticRegistry::for_profile`
- keeps runtime `NativeCriticRegistry::recommended()` behavior unchanged by mapping it to the existing full/strict rule set
- makes `cargo xtask native-critic check` default to `--profile recommended`, with `--profile strict` still available
- records the selected profile in native critic receipts and surfaces it in native-tooling status/readiness docs

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_critic_profile --profile agent --locked -- --nocapture`
- [x] `cargo test -p xtask native_critic -- --nocapture`
- [x] `cargo test -p xtask native_tooling -- --nocapture`
- [x] `cargo xtask native-critic check --severity 1 --receipt target/receipts/native-tooling/native-critic-check.json --summary target/receipts/native-tooling/native-critic-check.md`
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo xtask native-tooling readiness --markdown docs/project/status/native_tooling_readiness.md`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p xtask --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

## Known unrelated status drift

`just status-check` still reports existing generated status drift in:

- `docs/project/status/tests.md`
- `docs/project/status/parser.md`
- `docs/project/status/quality.md`
- `docs/project/status/dap.md`

This PR intentionally leaves those unrelated status files untouched.
