### PR TITLE
feat(critic): route native profile config (#8411)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -87,6 +87,12 @@ pub struct ServerConfig {
     /// Critic engine used for LSP policy diagnostics.
     pub critic_engine: CriticEngine,
 
+    /// Native critic profile used when `critic_engine` is [`CriticEngine::Native`].
+    ///
+    /// Defaults to `strict` to preserve the existing opt-in native critic behavior.
+    /// Projects can select `recommended` for the lower-noise native rule bundle.
+    pub native_critic_profile: String,
+
     /// Whether LSP formatting is enabled.
     ///
     /// Kept as `perltidy_enabled` for compatibility with older internal call sites
@@ -221,6 +227,7 @@ impl Default for ServerConfig {
             perlcritic_profile: None,
             perlcritic_theme: None,
             critic_engine: CriticEngine::Legacy,
+            native_critic_profile: "strict".to_string(),
             perltidy_enabled: true,
             formatting_engine: FormatterMode::Native,
             perltidy_profile: None,
@@ -305,6 +312,12 @@ impl ServerConfig {
             && let Some(engine) = parse_critic_engine(engine)
         {
             self.critic_engine = engine;
+        }
+        if let Some(critic) = settings.get("critic")
+            && let Some(profile) = critic.get("profile").and_then(|v| v.as_str())
+            && let Some(profile) = parse_native_critic_profile(profile)
+        {
+            self.native_critic_profile = profile.to_string();
         }
 
         if let Some(formatting) = settings.get("formatting") {
@@ -414,6 +427,14 @@ fn parse_critic_engine(value: &str) -> Option<CriticEngine> {
     match value.trim().to_ascii_lowercase().as_str() {
         "legacy" | "external" | "perlcritic" => Some(CriticEngine::Legacy),
         "native" => Some(CriticEngine::Native),
+        _ => None,
+    }
+}
+
+fn parse_native_critic_profile(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "recommended" => Some("recommended"),
+        "strict" => Some("strict"),
         _ => None,
     }
 }
@@ -743,6 +764,8 @@ pub struct ProjectDiagnosticsConfig {
 pub struct ProjectCriticConfig {
     /// Critic engine (`legacy`, `perlcritic`, or `native`).
     pub engine: Option<String>,
+    /// Native critic profile (`recommended` or `strict`).
+    pub profile: Option<String>,
 }
 
 /// `[features]` section of `.perl-lsp.toml`.
@@ -919,6 +942,11 @@ impl ProjectConfig {
         {
             config.critic_engine = engine;
         }
+        if let Some(ref profile) = self.critic.profile
+            && let Some(profile) = parse_native_critic_profile(profile)
+        {
+            config.native_critic_profile = profile.to_string();
+        }
         if let Some(ref profile) = self.formatting.perltidy_profile {
             config.perltidy_profile = Some(profile.clone());
         }
@@ -1030,6 +1058,7 @@ perltidy_extra_args = ["-noll"]
 
 [critic]
 engine = "native"
+profile = "recommended"
 "#,
         )?;
 
@@ -1050,6 +1079,7 @@ engine = "native"
         assert_eq!(config.formatting.perltidy_add_trailing_commas, Some(true));
         assert_eq!(config.formatting.perltidy_extra_args, vec!["-noll"]);
         assert_eq!(config.critic.engine.as_deref(), Some("native"));
+        assert_eq!(config.critic.profile.as_deref(), Some("recommended"));
         Ok(())
     }
 
@@ -1139,20 +1169,32 @@ engine = "native"
     fn server_config_accepts_native_critic_engine() {
         let mut config = ServerConfig::default();
         assert_eq!(config.critic_engine, CriticEngine::Legacy);
+        assert_eq!(config.native_critic_profile, "strict");
 
         config.update_from_value(&serde_json::json!({
             "critic": {
-                "engine": "native"
+                "engine": "native",
+                "profile": "recommended"
             }
         }));
         assert_eq!(config.critic_engine, CriticEngine::Native);
+        assert_eq!(config.native_critic_profile, "recommended");
 
         config.update_from_value(&serde_json::json!({
             "critic": {
-                "engine": "perlcritic"
+                "engine": "perlcritic",
+                "profile": "strict"
             }
         }));
         assert_eq!(config.critic_engine, CriticEngine::Legacy);
+        assert_eq!(config.native_critic_profile, "strict");
+
+        config.update_from_value(&serde_json::json!({
+            "critic": {
+                "profile": "unknown"
+            }
+        }));
+        assert_eq!(config.native_critic_profile, "strict");
     }
 
     #[test]
@@ -1190,10 +1232,12 @@ engine = "native"
         let mut config = ServerConfig::default();
         let mut project = ProjectConfig::default();
         project.critic.engine = Some("native".to_string());
+        project.critic.profile = Some("recommended".to_string());
 
         project.apply_to_server_config(&mut config);
 
         assert_eq!(config.critic_engine, CriticEngine::Native);
+        assert_eq!(config.native_critic_profile, "recommended");
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -21,7 +21,7 @@ use perl_diagnostics::codes::DiagnosticCode;
 use perl_lsp_rs_core::config::CriticEngine;
 use perl_lsp_rs_core::providers::diagnostics::{parse_error_code, parse_error_severity};
 use perl_lsp_rs_core::tooling::perl_critic::{
-    CriticConfig, CriticContext, CriticFinding, NativeCriticRegistry, Severity,
+    CriticConfig, CriticContext, CriticFinding, NativeCriticProfile, NativeCriticRegistry, Severity,
 };
 use perl_module::resolution::use_lib::resolve_use_lib_paths_from_source;
 use perl_parser::Parser;
@@ -50,6 +50,8 @@ pub struct PullDiagnosticsContext {
     pub perlcritic_profile: Option<String>,
     /// Critic engine used for policy diagnostics.
     pub critic_engine: CriticEngine,
+    /// Native critic profile used when `critic_engine` is native.
+    pub native_critic_profile: String,
     /// Workspace root for .perlcriticrc discovery
     pub workspace_root: Option<PathBuf>,
     /// @INC paths for module resolution
@@ -69,6 +71,7 @@ impl PullDiagnosticsContext {
             perlcritic_severity: 3,
             perlcritic_profile: None,
             critic_engine: CriticEngine::Legacy,
+            native_critic_profile: "strict".to_string(),
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -85,6 +88,7 @@ impl PullDiagnosticsContext {
             perlcritic_severity: severity,
             perlcritic_profile: profile,
             critic_engine: CriticEngine::Legacy,
+            native_critic_profile: "strict".to_string(),
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -103,6 +107,7 @@ impl PullDiagnosticsContext {
             perlcritic_severity: 3,
             perlcritic_profile: None,
             critic_engine: CriticEngine::Legacy,
+            native_critic_profile: "strict".to_string(),
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -118,6 +123,7 @@ impl std::fmt::Debug for PullDiagnosticsContext {
             .field("perlcritic_severity", &self.perlcritic_severity)
             .field("perlcritic_profile", &self.perlcritic_profile)
             .field("critic_engine", &self.critic_engine)
+            .field("native_critic_profile", &self.native_critic_profile)
             .field("workspace_root", &self.workspace_root)
             .field("include_paths", &self.include_paths)
             .field("markup_message_support", &self.markup_message_support)
@@ -489,7 +495,9 @@ impl PullDiagnosticsProvider {
             ..CriticConfig::default()
         };
         let critic_context = CriticContext::new(content, ast.as_ref(), &critic_config);
-        let registry = NativeCriticRegistry::recommended();
+        let profile = NativeCriticProfile::parse(&context.native_critic_profile)
+            .unwrap_or(NativeCriticProfile::Strict);
+        let registry = NativeCriticRegistry::for_profile(profile);
 
         for finding in registry.check(&critic_context) {
             diagnostics.push(self.native_finding_to_lsp_diagnostic(uri, content, finding));
@@ -1785,6 +1793,51 @@ mod tests {
         assert_eq!(data["code"], "native.documentation.require_pod_sections");
         assert_eq!(data["suppressionKey"], "native.documentation.require_pod_sections");
         assert_eq!(data["fixable"], false);
+        Ok(())
+    }
+
+    #[test]
+    fn native_critic_recommended_profile_filters_pull_diagnostics()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let provider = PullDiagnosticsProvider::new();
+        let uri: Uri = "file:///test.pl".parse()?;
+        let mut context = PullDiagnosticsContext::new();
+        context.critic_engine = CriticEngine::Native;
+        context.native_critic_profile = "recommended".to_string();
+
+        let items = get_full_items(provider.get_document_diagnostics_with_context(
+            &uri,
+            "my $unused = 1;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\n",
+            None,
+            &context,
+            None,
+        ));
+
+        assert!(
+            items.iter().any(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.testing.require_use_strict"),
+                )
+            }),
+            "recommended native critic profile should keep strict finding: {items:?}"
+        );
+        assert!(
+            items.iter().any(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.common.assignment_in_condition"),
+                )
+            }),
+            "recommended native critic profile should keep common findings: {items:?}"
+        );
+        assert!(
+            !items.iter().any(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.variables.unused_lexical"),
+                )
+            }),
+            "recommended native critic profile should omit broader variable findings: {items:?}"
+        );
+
         Ok(())
     }
 

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -94,13 +94,20 @@ impl PullDiagnosticsOrchestrator {
     /// Build context from LspServer state.
     pub fn build_context(&self, server: &LspServer, uri: &str) -> PullDiagnosticsContext {
         // Get config values
-        let (perlcritic_enabled, perlcritic_severity, perlcritic_profile, critic_engine) = {
+        let (
+            perlcritic_enabled,
+            perlcritic_severity,
+            perlcritic_profile,
+            critic_engine,
+            native_critic_profile,
+        ) = {
             let cfg = server.config.lock();
             (
                 cfg.perlcritic_enabled,
                 cfg.perlcritic_severity,
                 cfg.perlcritic_profile.clone(),
                 cfg.critic_engine,
+                cfg.native_critic_profile.clone(),
             )
         };
 
@@ -135,6 +142,7 @@ impl PullDiagnosticsOrchestrator {
             perlcritic_severity: perlcritic_severity.into(),
             perlcritic_profile: profile,
             critic_engine,
+            native_critic_profile,
             workspace_root,
             include_paths,
             markup_message_support,
@@ -1394,9 +1402,14 @@ impl LspServer {
         doc_text: &str,
         diagnostics: &mut Vec<InternalDiagnostic>,
     ) {
-        let (critic_engine, severity, profile) = {
+        let (critic_engine, severity, profile, native_profile) = {
             let cfg = self.config.lock();
-            (cfg.critic_engine, cfg.perlcritic_severity, cfg.perlcritic_profile.clone())
+            (
+                cfg.critic_engine,
+                cfg.perlcritic_severity,
+                cfg.perlcritic_profile.clone(),
+                cfg.native_critic_profile.clone(),
+            )
         };
         if critic_engine != perl_lsp_rs_core::config::CriticEngine::Native {
             return;
@@ -1409,7 +1422,9 @@ impl LspServer {
         };
         let critic_context =
             crate::perl_critic::CriticContext::new(doc_text, ast.as_ref(), &critic_config);
-        let registry = crate::perl_critic::NativeCriticRegistry::recommended();
+        let profile = crate::perl_critic::NativeCriticProfile::parse(&native_profile)
+            .unwrap_or(crate::perl_critic::NativeCriticProfile::Strict);
+        let registry = crate::perl_critic::NativeCriticRegistry::for_profile(profile);
 
         diagnostics
             .extend(registry.check(&critic_context).into_iter().map(native_finding_to_diagnostic));
@@ -2008,6 +2023,43 @@ mod tests {
         assert!(
             !text.contains("TestingAndDebugging::RequireUseStrict"),
             "native critic engine should not publish legacy built-in critic policy IDs; got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn native_critic_recommended_profile_publishes_lower_noise_policy_diagnostics() {
+        let (server, buf) = make_server_with_capture();
+        server.test_configure_critic_engine(perl_lsp_rs_core::config::CriticEngine::Native);
+        server.test_configure_native_critic_profile("recommended");
+        let uri = "file:///native_critic_recommended_push_test.pl";
+        server
+            .test_handle_did_open(Some(json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": "my $unused = 1;\nmy $cond = 0;\nif ($cond = 1) { print $cond; }\n"
+                }
+            })))
+            .unwrap();
+
+        server.publish_diagnostics(uri);
+        drop(server);
+        std::thread::sleep(Duration::from_millis(50));
+
+        let bytes = buf.lock().clone();
+        let text = String::from_utf8(bytes).unwrap_or_default();
+        assert!(
+            text.contains("native.testing.require_use_strict"),
+            "recommended native critic profile should publish strict finding; got: {text:?}"
+        );
+        assert!(
+            text.contains("native.common.assignment_in_condition"),
+            "recommended native critic profile should publish common-mistake findings; got: {text:?}"
+        );
+        assert!(
+            !text.contains("native.variables.unused_lexical"),
+            "recommended native critic profile should omit broader variable-noise findings; got: {text:?}"
         );
     }
 

--- a/crates/perl-lsp-rs/src/runtime/test_api.rs
+++ b/crates/perl-lsp-rs/src/runtime/test_api.rs
@@ -292,6 +292,15 @@ impl LspServer {
         self.config.lock().critic_engine = engine;
     }
 
+    /// Configure the native critic profile directly for test purposes.
+    pub fn test_configure_native_critic_profile(&self, profile: &str) {
+        if let Some(profile) =
+            perl_lsp_rs_core::tooling::perl_critic::NativeCriticProfile::parse(profile)
+        {
+            self.config.lock().native_critic_profile = profile.as_str().to_string();
+        }
+    }
+
     /// Test-only entrypoint for LSP `textDocument/inlineCompletion`.
     ///
     /// Exercises inline completion functionality in tests.

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -693,10 +693,20 @@ impl LspServer {
                             .and_then(|v| v.get("theme"))
                             .and_then(|v| v.as_str())
                             .map(|s| s.to_string());
+                        let new_native_profile = perl
+                            .get("critic")
+                            .and_then(|v| v.get("profile"))
+                            .and_then(|v| v.as_str())
+                            .and_then(
+                                perl_lsp_rs_core::tooling::perl_critic::NativeCriticProfile::parse,
+                            )
+                            .map(|profile| profile.as_str().to_string())
+                            .unwrap_or_else(|| cfg.native_critic_profile.clone());
                         new_enabled != cfg.perlcritic_enabled
                             || new_severity != cfg.perlcritic_severity
                             || new_profile != cfg.perlcritic_profile
                             || new_theme != cfg.perlcritic_theme
+                            || new_native_profile != cfg.native_critic_profile
                     };
 
                     // Update server config (inlay hints, test runner)

--- a/docs/how-to/NATIVE_TOOLING_MIGRATION.md
+++ b/docs/how-to/NATIVE_TOOLING_MIGRATION.md
@@ -105,6 +105,7 @@ perlcritic_severity = 3
 
 [critic]
 engine = "native"
+profile = "recommended"
 ```
 
 Use native critic diagnostics when:

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -567,6 +567,18 @@ Use `native` to route opt-in critic diagnostics through the Rust-native rule
 registry. Use `legacy`, `perlcritic`, or `external` to keep the
 Perl::Critic-compatible path.
 
+#### `perl.critic.profile`
+
+| Property | Value |
+|---|---|
+| Type | `"recommended"\|"strict"` |
+| Default | `"strict"` |
+
+Native-critic rule bundle used when `perl.critic.engine = "native"`.
+`strict` preserves the current full opt-in native registry. `recommended`
+selects the lower-noise security/common-mistake/testing profile intended for
+future default-readiness work.
+
 ```json
 {
   "perl": {
@@ -576,7 +588,8 @@ Perl::Critic-compatible path.
       "profile": "${workspaceFolder}/.perlcriticrc"
     },
     "critic": {
-      "engine": "native"
+      "engine": "native",
+      "profile": "recommended"
     }
   }
 }

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -95,6 +95,7 @@ Priority 3 (highest): didChangeConfiguration — live editor settings
 | `[diagnostics]` | `perlcritic` | bool | false | Enable critic diagnostics (opt-in). |
 | `[diagnostics]` | `perlcritic_severity` | int 1-5 | 3 | Minimum severity to report. 1 = least severe (reports everything), 5 = most severe (reports only strictest). |
 | `[critic]` | `engine` | string | `"legacy"` | Critic engine: `legacy` / `perlcritic` / `external` for Perl::Critic-compatible diagnostics, or `native` for Rust-native rules. |
+| `[critic]` | `profile` | string | `"strict"` | Native critic rule bundle: `recommended` or `strict`. |
 | `[formatting]` | `enabled` | bool | true | Enable LSP formatting. |
 | `[formatting]` | `engine` | string | `"native"` | Formatter engine: `native`, `compat`, `external-perltidy`, or `off`. |
 | `[formatting]` | `perltidy_profile` | string | none | `.perltidyrc` profile used by external perltidy compatibility and native-tooling compatibility reports. |
@@ -125,6 +126,7 @@ Priority 3 (highest): didChangeConfiguration — live editor settings
 | `perl.perlcritic.severity` | int 1-5 | `3` | Minimum severity to report |
 | `perl.perlcritic.profile` | string | none | Path to `.perlcriticrc` profile |
 | `perl.critic.engine` | string | `"legacy"` | Critic engine: `legacy`, `perlcritic`, `external`, or `native` |
+| `perl.critic.profile` | string | `"strict"` | Native critic profile: `recommended` or `strict` |
 | `perl.telemetry.enabled` | bool | `false` | Send telemetry events to client |
 | `perl.limits.*` | various | see below | Resource caps and timeouts |
 
@@ -310,6 +312,7 @@ perlcritic_severity = 3
 
 [critic]
 engine = "native"
+profile = "recommended"
 ```
 
 **Enable via editor settings** (personal preference):
@@ -322,7 +325,8 @@ engine = "native"
       "severity": 3
     },
     "critic": {
-      "engine": "native"
+      "engine": "native",
+      "profile": "recommended"
     }
   }
 }
@@ -489,6 +493,7 @@ Every `.perl-lsp.toml` setting has a VSCode `settings.json` counterpart. The tab
 | `[diagnostics] perlcritic = true` | `"perlcritic": {"enabled": true}` | |
 | `[diagnostics] perlcritic_severity = 3` | `"perlcritic": {"severity": 3}` | Note: LSP key is `severity`, not `perlcritic_severity` |
 | `[critic] engine = "native"` | `"critic": {"engine": "native"}` | Native critic remains opt-in |
+| `[critic] profile = "recommended"` | `"critic": {"profile": "recommended"}` | Lower-noise native rule bundle |
 | `[formatting] enabled = true` | `"formatting": {"enabled": true}` | |
 | `[formatting] engine = "native"` | `"formatting": {"engine": "native"}` | Use `"external-perltidy"` for legacy shell-out compatibility |
 | `[formatting] perltidy_profile = ".perltidyrc"` | `"formatting": {"profile": ".perltidyrc"}` | LSP key is `profile` |


### PR DESCRIPTION
## Summary

- add `critic.profile` / `perl.critic.profile` runtime config for the native critic registry
- keep the default native critic profile as `strict` so current opt-in behavior is unchanged
- route pull, push, and workspace native diagnostics through the configured profile and document `recommended` for lower-noise native runs

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code
- docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_critic_profile --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core critic_engine --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs native_critic --profile agent --locked --lib -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`

## Notes

This does not change the default critic engine or make native critic the default. Native critic remains explicit opt-in; `strict` preserves the existing full native registry, while `recommended` selects the lower-noise readiness profile.