### PR TITLE
test(critic): expand native false-positive fixtures (#8413)

### DIFF
--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -50,7 +50,7 @@
 | Native critic check findings | 112 |
 | Native critic check suppressed | 0 |
 | Native critic check fixable | 110 |
-| Native critic false-positive files | 6 |
+| Native critic false-positive files | 11 |
 | Native critic false-positive parse errors | 0 |
 | Native critic false-positive rules run | 28 |
 | Native critic false-positive findings | 0 |

--- a/xtask/src/tasks/native_critic.rs
+++ b/xtask/src/tasks/native_critic.rs
@@ -449,7 +449,7 @@ mod tests {
         })?;
 
         let value: Value = serde_json::from_str(&fs::read_to_string(receipt)?)?;
-        assert_eq!(value["files_checked"], 6);
+        assert_eq!(value["files_checked"], 11);
         assert_eq!(value["files_with_parse_errors"], 0);
         assert_eq!(value["rules_run"], 28);
         assert_eq!(value["findings_count"], 0);

--- a/xtask/tests/fixtures/native-critic/false-positive/checked_io.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/checked_io.pm
@@ -1,0 +1,26 @@
+package Clean::CheckedIO;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Clean::CheckedIO - checked IO native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps three-argument open, checked close, and explicit print-handle usage quiet.
+
+=cut
+
+sub write_lines {
+    my ($path, @lines) = @_;
+    my $fh = undef;
+    open($fh, '>', $path) or die "cannot open $path: $!";
+    for my $line (@lines) {
+        print {$fh} $line, "\n";
+    }
+    close($fh) or die "cannot close $path: $!";
+    return scalar @lines;
+}
+
+1;

--- a/xtask/tests/fixtures/native-critic/false-positive/dispatch_table.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/dispatch_table.pm
@@ -1,0 +1,35 @@
+package Clean::DispatchTable;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Clean::DispatchTable - generated-dispatch native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps a common hash-of-coderefs dispatch table quiet under native critic.
+
+=cut
+
+my %HANDLERS = (
+    add => sub {
+        my ($left, $right) = @_;
+        return $left + $right;
+    },
+    join_names => sub {
+        my (@names) = @_;
+        return join q{:}, @names;
+    },
+);
+
+sub dispatch {
+    my ($name, @args) = @_;
+    my $handler = $HANDLERS{$name};
+    if (!defined $handler) {
+        return undef;
+    }
+    return $handler->(@args);
+}
+
+1;

--- a/xtask/tests/fixtures/native-critic/false-positive/printf_usage.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/printf_usage.pm
@@ -1,0 +1,22 @@
+package Clean::PrintfUsage;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Clean::PrintfUsage - printf native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps correctly matched printf and sprintf calls quiet under native critic.
+
+=cut
+
+sub render {
+    my ($name, $count) = @_;
+    my $label = sprintf "%s:%d", $name, $count;
+    printf "%s\n", $label;
+    return $label;
+}
+
+1;

--- a/xtask/tests/fixtures/native-critic/false-positive/regex_capture_guarded.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/regex_capture_guarded.pm
@@ -1,0 +1,23 @@
+package Clean::RegexCaptureGuarded;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Clean::RegexCaptureGuarded - guarded regex capture native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps capture-variable reads quiet when guarded by a successful regex match.
+
+=cut
+
+sub first_word {
+    my ($text) = @_;
+    if ($text =~ /(\w+)/) {
+        return $1;
+    }
+    return undef;
+}
+
+1;

--- a/xtask/tests/fixtures/native-critic/false-positive/test_more_subtests.pm
+++ b/xtask/tests/fixtures/native-critic/false-positive/test_more_subtests.pm
@@ -1,0 +1,30 @@
+package Clean::TestMoreSubtests;
+use strict;
+use warnings;
+use Test::More;
+
+=head1 NAME
+
+Clean::TestMoreSubtests - Test::More subtest native critic fixture
+
+=head1 DESCRIPTION
+
+Keeps common subtest and done_testing idioms quiet under native critic.
+
+=cut
+
+sub multiply {
+    my ($left, $right) = @_;
+    return $left * $right;
+}
+
+sub run_tests {
+    subtest 'multiplication' => sub {
+        is(multiply(2, 3), 6, 'multiplies integers');
+        ok(multiply(1, 0) == 0, 'zero works');
+    };
+    done_testing();
+    return 1;
+}
+
+1;


### PR DESCRIPTION
## Summary

Expands the native critic false-positive fixture pack from 6 to 11 files, covering checked IO, hash-of-coderefs dispatch tables, correct printf/sprintf arity, guarded regex capture reads, and Test::More subtests.

Updates the native critic fixture receipt assertion and regenerated native tooling status so the dashboard reports 11 clean false-positive fixtures under the strict native profile.

## Proof packet

- [x] cargo xtask fmt
- [x] cargo test -p xtask native_critic -- --nocapture
- [x] cargo test -p xtask native_tooling -- --nocapture
- [x] cargo xtask native-critic check --root xtask/tests/fixtures/native-critic/false-positive --profile strict --severity 1 --receipt target/receipts/native-tooling/native-critic-false-positive.json --summary target/receipts/native-tooling/native-critic-false-positive.md
  - result: 11 files, 28 rules, 0 findings, 0 suppressed, 0 fixable
- [x] cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md
- [x] cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs
- [x] cargo xtask check-devex-docs
- [x] cargo xtask check-memory-lifecycle-policy
- [x] cargo xtask check-memory-retained-owner-drift --base origin/master
- [x] cargo xtask devex pr-body --base origin/master
- [x] cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json
- [x] git diff --check

## Notes

`just status-check` was run and failed on unrelated generated status surfaces (`tests.md`, `parser.md`, `quality.md`, `dap.md`). This PR intentionally leaves those out of scope and only updates `docs/project/status/native_tooling.md` for the native critic false-positive receipt count.
