### PR TITLE
fix(parser): parse prototype attributes ending in scalar slots (#8414)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -138,10 +138,18 @@ impl<'a> Parser<'a> {
                         let token = self.tokens.next()?;
                         attr_name.push_str(&token.text);
 
-                        match token.kind {
-                            TokenKind::LeftParen => paren_depth += 1,
-                            TokenKind::RightParen => paren_depth -= 1,
-                            _ => {}
+                        if base_name == "prototype"
+                            && paren_depth == 1
+                            && token.kind == TokenKind::Identifier
+                            && token.text.as_ref() == "$)"
+                        {
+                            paren_depth -= 1;
+                        } else {
+                            match token.kind {
+                                TokenKind::LeftParen => paren_depth += 1,
+                                TokenKind::RightParen => paren_depth -= 1,
+                                _ => {}
+                            }
                         }
                     }
 

--- a/crates/perl-parser-core/tests/variable_declaration_edge_tests.rs
+++ b/crates/perl-parser-core/tests/variable_declaration_edge_tests.rs
@@ -34,6 +34,11 @@ fn test_sub_with_multiple_attributes() {
     assert_clean_parse("sub foo :lvalue :method { }");
 }
 
+#[test]
+fn test_sub_prototype_attribute_ending_with_scalar_slot() {
+    assert_clean_parse("sub index :prototype($$;$) { BEGIN { import() } &CORE::index }");
+}
+
 // ---------------------------------------------------------------------------
 // Package-qualified `our` declarations
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Problem: Strawberry Perl 5.42 `bytes.pm` exposes `:prototype($$;$)`, where the final `$)` was consumed as a special variable and left the declaration attribute unterminated.
Fix: Treat that `$)` token as the closing paren only while parsing `prototype` declaration attributes, and add a parser-core regression for the common-corpus shape.
Verification: `cargo test -p perl-parser-core --test variable_declaration_edge_tests --profile agent --locked test_sub_prototype_attribute_ending_with_scalar_slot -- --nocapture`; `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `cargo clippy --locked -p perl-parser-core --profile agent -- -D warnings -A missing_docs`; `git diff --check`.