### PR TITLE
fix(status): mark old CPAN recovery-shape counts insufficient (#8417)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -8,7 +8,7 @@
 | --- | --- | --- | --- |
 | <!-- BEGIN: PARSER_TRACKING_TABLE -->
 | **Ubuntu system Perl** | 96.8% clean (`6871/7095`) / 20.5% salvage | Compatibility baseline; Perl `5.038002`, `48` unreadable, `36` recovery-only, `140` ERROR-node files, `0` catastrophic, baseline `2026-04-28` | `.ci/parser-corpus-baseline.json` |
-| **CPAN top 1000** | 95.3% clean (`8931/9372`) / insufficient_data salvage | Ecosystem breadth baseline; `6` unreadable, `0` recovery-only, `0` ERROR-node files, `0` catastrophic, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
+| **CPAN top 1000** | 95.3% clean (`8931/9372`) / insufficient_data salvage | Ecosystem breadth baseline; `6` unreadable, `insufficient_data` recovery-only, `insufficient_data` ERROR-node files, `insufficient_data` catastrophic, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
 | **Project corpus** | 100.0% clean (`96/96`) | Deterministic regression baseline; `74` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `66/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
 

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -3,6 +3,7 @@
 //! Owns corpus tracking, sweep report loading, and parser.md generation.
 
 use std::fs;
+use std::ops::Deref;
 use std::path::Path;
 use std::time::Duration;
 
@@ -36,16 +37,42 @@ fn replace_parser_status_block(text: &str, marker_name: &str, new_content: &str)
 
 pub(super) struct ParserMetrics {
     pub syntax_sections: usize,
-    pub system_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
-    pub cpan_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
+    pub system_receipt: Option<ParserSweepReceipt>,
+    pub cpan_receipt: Option<ParserSweepReceipt>,
     pub project_corpus: Option<super::super::corpus_audit::StatusSummary>,
     /// Receipt from `just common-corpus-check` — the strict-clean pinned-module gate.
-    pub common_corpus_receipt: Option<super::super::parser_corpus_sweep::SweepReport>,
+    pub common_corpus_receipt: Option<ParserSweepReceipt>,
     /// Number of pinned modules in `.ci/common-corpus-manifest.txt`.
     pub common_corpus_pinned: usize,
     pub performance_scorecard: Option<ParserPerformanceScorecard>,
     parser_accuracy: Option<ParserAccuracyArtifactSummary>,
     pub token_metrics: TokenHealthMetrics,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ParserSweepReceipt {
+    report: super::super::parser_corpus_sweep::SweepReport,
+    has_recovery_shape: bool,
+}
+
+impl ParserSweepReceipt {
+    #[cfg(test)]
+    fn with_recovery_shape(report: super::super::parser_corpus_sweep::SweepReport) -> Self {
+        Self { report, has_recovery_shape: true }
+    }
+
+    #[cfg(test)]
+    fn without_recovery_shape(report: super::super::parser_corpus_sweep::SweepReport) -> Self {
+        Self { report, has_recovery_shape: false }
+    }
+}
+
+impl Deref for ParserSweepReceipt {
+    type Target = super::super::parser_corpus_sweep::SweepReport;
+
+    fn deref(&self) -> &Self::Target {
+        &self.report
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -92,11 +119,15 @@ pub(super) fn count_common_corpus_pinned(root: &Path) -> usize {
     raw.lines().filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with('#')).count()
 }
 
-pub(super) fn read_sweep_report(
-    path: &Path,
-) -> Option<super::super::parser_corpus_sweep::SweepReport> {
+pub(super) fn read_sweep_report(path: &Path) -> Option<ParserSweepReceipt> {
     let raw = fs::read_to_string(path).ok()?;
-    serde_json::from_str(&raw).ok()
+    let value = serde_json::from_str::<serde_json::Value>(&raw).ok()?;
+    let has_recovery_shape = value.get("files_with_structured_recovery_only").is_some()
+        && value.get("files_with_error_nodes").is_some()
+        && value.get("files_with_catastrophic_parse_failure").is_some()
+        && value.get("total_dirty_files").is_some();
+    let report = serde_json::from_value(value).ok()?;
+    Some(ParserSweepReceipt { report, has_recovery_shape })
 }
 
 fn read_parser_performance_scorecard(root: &Path) -> Option<ParserPerformanceScorecard> {
@@ -134,6 +165,23 @@ fn format_salvage_rate(salvage_rate: Option<f64>) -> String {
     match salvage_rate {
         Some(rate) => format!("{:.1}% salvage", rate * 100.0),
         None => "insufficient_data salvage".to_string(),
+    }
+}
+
+fn format_recovery_shape_note(receipt: &ParserSweepReceipt) -> String {
+    if receipt.has_recovery_shape {
+        format!(
+            "`{}` unreadable, `{}` recovery-only, `{}` ERROR-node files, `{}` catastrophic",
+            receipt.files_unreadable,
+            receipt.files_with_structured_recovery_only,
+            receipt.files_with_error_nodes,
+            receipt.files_with_catastrophic_parse_failure,
+        )
+    } else {
+        format!(
+            "`{}` unreadable, `insufficient_data` recovery-only, `insufficient_data` ERROR-node files, `insufficient_data` catastrophic",
+            receipt.files_unreadable,
+        )
     }
 }
 
@@ -192,14 +240,11 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |report| {
             format!(
-                "| **Ubuntu system Perl** | {} / {} | Compatibility baseline; Perl `{}`, `{}` unreadable, `{}` recovery-only, `{}` ERROR-node files, `{}` catastrophic, baseline `{}` | `.ci/parser-corpus-baseline.json` |",
+                "| **Ubuntu system Perl** | {} / {} | Compatibility baseline; Perl `{}`, {}, baseline `{}` | `.ci/parser-corpus-baseline.json` |",
                 format_clean_rate(report.clean_files, report.total_files),
                 format_salvage_rate(report.recovery_salvage_rate),
                 report.perl_version,
-                report.files_unreadable,
-                report.files_with_structured_recovery_only,
-                report.files_with_error_nodes,
-                report.files_with_catastrophic_parse_failure,
+                format_recovery_shape_note(report),
                 short_day(&report.timestamp),
             )
         },
@@ -211,13 +256,10 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |report| {
             format!(
-                "| **CPAN top 1000** | {} / {} | Ecosystem breadth baseline; `{}` unreadable, `{}` recovery-only, `{}` ERROR-node files, `{}` catastrophic, cached downloads in `target/cpan-corpus/.cpanm`, baseline `{}` | `.ci/cpan-corpus-baseline.json` |",
+                "| **CPAN top 1000** | {} / {} | Ecosystem breadth baseline; {}, cached downloads in `target/cpan-corpus/.cpanm`, baseline `{}` | `.ci/cpan-corpus-baseline.json` |",
                 format_clean_rate(report.clean_files, report.total_files),
                 format_salvage_rate(report.recovery_salvage_rate),
-                report.files_unreadable,
-                report.files_with_structured_recovery_only,
-                report.files_with_error_nodes,
-                report.files_with_catastrophic_parse_failure,
+                format_recovery_shape_note(report),
                 short_day(&report.timestamp),
             )
         },
@@ -365,7 +407,7 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
             "| insufficient_data (no receipt — run `just corpus-sweep-check` to generate) | insufficient_data |"
                 .to_string()
         },
-        build_failure_worklist,
+        |receipt| build_failure_worklist(receipt),
     );
 
     let parser_coverage_bullets = format!(

--- a/xtask/src/tasks/update_status/parser/tests.rs
+++ b/xtask/src/tasks/update_status/parser/tests.rs
@@ -695,7 +695,7 @@ fn test_parser_strict_clean_row_with_receipt() -> Result<()> {
         system_receipt: None,
         cpan_receipt: None,
         project_corpus: None,
-        common_corpus_receipt: Some(receipt),
+        common_corpus_receipt: Some(ParserSweepReceipt::with_recovery_shape(receipt)),
         common_corpus_pinned: 10,
         performance_scorecard: None,
         parser_accuracy: None,
@@ -706,6 +706,75 @@ fn test_parser_strict_clean_row_with_receipt() -> Result<()> {
     assert!(result.contains("10/10"), "strict-clean row missing 10/10");
     assert!(result.contains("100%"), "strict-clean row missing 100%");
     assert!(result.contains("10 pinned modules"), "strict-clean row missing pinned modules note");
+    Ok(())
+}
+
+#[test]
+fn test_parser_tracking_old_cpan_receipt_missing_recovery_shape_reports_insufficient_data()
+-> Result<()> {
+    use std::collections::BTreeMap;
+
+    let receipt = super::super::super::parser_corpus_sweep::SweepReport {
+        schema_version: "1.2.0".to_string(),
+        commit: "old".to_string(),
+        timestamp: "2026-04-09T00:00:00Z".to_string(),
+        corpus_profile: "cpan".to_string(),
+        corpus_roots: vec![],
+        resolved_roots_count: 151,
+        perl_version: "5.038002".to_string(),
+        total_files: 9_372,
+        files_unreadable: 6,
+        clean_files: 8_931,
+        files_with_errors: 435,
+        total_dirty_files: 0,
+        files_with_structured_recovery_only: 0,
+        files_with_error_nodes: 0,
+        files_with_catastrophic_parse_failure: 0,
+        total_error_nodes: 3_015,
+        recovered_node_count: 0,
+        first_unrecovered_error_node_buckets: BTreeMap::new(),
+        first_error_buckets: BTreeMap::from([("unexpected_token_in_expr".to_string(), 435)]),
+        files_by_bucket: BTreeMap::new(),
+        file_results: vec![],
+        elapsed_secs: 1.0,
+        phase_timings: None,
+        median_error_density_per_1k_loc: None,
+        recovery_salvage_rate: None,
+        slowest_files: vec![],
+    };
+    let metrics = ParserMetrics {
+        syntax_sections: 611,
+        system_receipt: None,
+        cpan_receipt: Some(ParserSweepReceipt::without_recovery_shape(receipt)),
+        project_corpus: None,
+        common_corpus_receipt: None,
+        common_corpus_pinned: 10,
+        performance_scorecard: None,
+        parser_accuracy: None,
+        token_metrics: token::token_metrics_fixture(),
+    };
+
+    let result = generate_parser_status(&metrics, parser_status_template())?;
+    assert!(
+        result.contains("insufficient_data salvage"),
+        "old CPAN receipt must not fabricate a salvage rate"
+    );
+    assert!(
+        result.contains("`insufficient_data` recovery-only"),
+        "old CPAN receipt must mark missing recovery-only count as insufficient_data"
+    );
+    assert!(
+        result.contains("`insufficient_data` ERROR-node files"),
+        "old CPAN receipt must mark missing ERROR-node file count as insufficient_data"
+    );
+    assert!(
+        result.contains("`insufficient_data` catastrophic"),
+        "old CPAN receipt must mark missing catastrophic count as insufficient_data"
+    );
+    assert!(
+        !result.contains("`0` recovery-only, `0` ERROR-node files, `0` catastrophic"),
+        "old CPAN receipt must not render missing recovery-shape fields as zero"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Problem: old CPAN corpus baseline receipts lack recovery-shape fields, but parser status rendered their missing subcounts as zero.
Fix: track whether a sweep receipt contains recovery-shape fields and render missing CPAN recovery-only / ERROR-node-file / catastrophic counts as `insufficient_data` instead of fabricated zeroes.
Verification: `cargo test -p xtask --profile agent --locked update_status::parser -- --nocapture`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs`; `git diff --check`.