### PR TITLE
feat(format): preserve trailing comments in simple statements (#8420)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -657,9 +657,10 @@ fn format_simple_line(line: &str, config: &FormatConfig) -> Option<String> {
 fn format_simple_module_line(line: &str, config: &FormatConfig) -> Option<String> {
     let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
     let (indent, body) = line.split_at(indent_len);
-    if body.is_empty() || body.contains('#') {
+    if body.is_empty() {
         return None;
     }
+    let (body, trailing_comment) = split_trailing_comment(body);
 
     let mut stream = perl_parser_core::TokenStream::new(body);
     let mut tokens = Vec::new();
@@ -672,15 +673,16 @@ fn format_simple_module_line(line: &str, config: &FormatConfig) -> Option<String
     }
 
     let formatted = format_simple_module_tokens(&tokens, config)?;
-    Some(format!("{indent}{formatted}"))
+    Some(format!("{indent}{}", append_trailing_comment(formatted, trailing_comment)))
 }
 
 fn format_simple_lexical_line(line: &str, config: &FormatConfig) -> Option<String> {
     let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
     let (indent, body) = line.split_at(indent_len);
-    if body.is_empty() || body.contains('#') {
+    if body.is_empty() {
         return None;
     }
+    let (body, trailing_comment) = split_trailing_comment(body);
 
     let mut stream = perl_parser_core::TokenStream::new(body);
     let mut tokens = Vec::new();
@@ -693,7 +695,7 @@ fn format_simple_lexical_line(line: &str, config: &FormatConfig) -> Option<Strin
     }
 
     let formatted = format_simple_lexical_tokens(&tokens, config)?;
-    Some(format!("{indent}{formatted}"))
+    Some(format!("{indent}{}", append_trailing_comment(formatted, trailing_comment)))
 }
 
 fn format_simple_subroutine_line(line: &str, config: &FormatConfig) -> Option<String> {
@@ -740,9 +742,10 @@ fn format_simple_control_block_line(line: &str, config: &FormatConfig) -> Option
 fn format_simple_statement_line(line: &str, config: &FormatConfig) -> Option<String> {
     let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
     let (indent, body) = line.split_at(indent_len);
-    if body.is_empty() || body.contains('#') {
+    if body.is_empty() {
         return None;
     }
+    let (body, trailing_comment) = split_trailing_comment(body);
 
     let mut stream = perl_parser_core::TokenStream::new(body);
     let mut tokens = Vec::new();
@@ -755,7 +758,48 @@ fn format_simple_statement_line(line: &str, config: &FormatConfig) -> Option<Str
     }
 
     let formatted = format_simple_statement_tokens(&tokens, config)?;
-    Some(format!("{indent}{formatted}"))
+    Some(format!("{indent}{}", append_trailing_comment(formatted, trailing_comment)))
+}
+
+fn split_trailing_comment(body: &str) -> (&str, Option<&str>) {
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+
+    for (index, ch) in body.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' && (in_single || in_double) {
+            escaped = true;
+            continue;
+        }
+
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            '#' if !in_single && !in_double => {
+                let code = body[..index].trim_end();
+                if code.trim().is_empty() {
+                    return (body, None);
+                }
+                return (code, Some(&body[index..]));
+            }
+            _ => {}
+        }
+    }
+
+    (body, None)
+}
+
+fn append_trailing_comment(mut formatted: String, trailing_comment: Option<&str>) -> String {
+    if let Some(comment) = trailing_comment {
+        formatted.push(' ');
+        formatted.push_str(comment);
+    }
+    formatted
 }
 
 fn format_simple_subroutine_tokens(

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/comment_preserve.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/comment_preserve.expected.pl
@@ -1,1 +1,1 @@
-my$x=1; # keep this exact comment
+my $x = 1; # keep this exact comment

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/comment_preserve_matrix.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/comment_preserve_matrix.expected.pl
@@ -1,5 +1,5 @@
 # leading file comment
-my$x=1; # trailing assignment comment
+my $x = 1; # trailing assignment comment
 if($x){ # trailing block opener comment
-    return$x; # trailing return comment
+    return $x; # trailing return comment
 }

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -290,18 +290,18 @@ fn native_formatter_keeps_unsupported_lines_unchanged() {
 }
 
 #[test]
-fn native_formatter_preserves_comment_lines_until_comment_aware_layout_exists() {
+fn native_formatter_preserves_trailing_comment_while_formatting_simple_statement() {
     let formatter = NativeFormatter::new();
     let source = "my$x=1; # keep this exact comment\n";
 
     let result = formatter.format_document(source, &FormatConfig::default());
 
-    assert!(!result.changed);
-    assert_eq!(result.formatted, source);
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my $x = 1; # keep this exact comment\n");
 }
 
 #[test]
-fn native_formatter_preserves_comment_matrix_until_comment_aware_layout_exists() {
+fn native_formatter_formats_simple_trailing_comment_matrix() {
     let formatter = NativeFormatter::new();
     let source = concat!(
         "# leading file comment\n",
@@ -313,8 +313,29 @@ fn native_formatter_preserves_comment_matrix_until_comment_aware_layout_exists()
 
     let result = formatter.format_document(source, &FormatConfig::default());
 
-    assert!(!result.changed);
-    assert_eq!(result.formatted, source);
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "# leading file comment\n",
+            "my $x = 1; # trailing assignment comment\n",
+            "if($x){ # trailing block opener comment\n",
+            "    return $x; # trailing return comment\n",
+            "}\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn native_formatter_does_not_treat_hash_inside_strings_as_trailing_comment() {
+    let formatter = NativeFormatter::new();
+    let source = "my$msg=\"#not a comment\";\nreturn\"#value\";\n";
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my $msg = \"#not a comment\";\nreturn \"#value\";\n");
     assert!(result.diagnostics.is_empty());
 }
 
@@ -344,6 +365,21 @@ fn native_range_formatter_formats_only_selected_simple_declaration_line() {
         TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 7))
     );
     assert_eq!(result.edits[0].new_text, "my $y = 2;");
+}
+
+#[test]
+fn native_range_formatter_preserves_trailing_comment_on_selected_simple_statement_line() {
+    let formatter = NativeFormatter::new();
+    let source = "my$x=1; # keep\nmy$y=2;\n";
+    let range = TextRange::new(TextPosition::new(0, 0), TextPosition::new(0, 14));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "my $x = 1; # keep\nmy$y=2;\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "my $x = 1; # keep");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the first comment-aware native formatter behavior for simple statement lines:

- formats supported code before a trailing `#` comment while keeping the comment attached and unchanged
- supports document and range formatting for simple lexical/statement/module lines with trailing comments
- keeps leading/comment-only lines and unsupported control-block opener comments unchanged
- avoids treating `#` inside single- or double-quoted strings as a trailing comment delimiter

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_preserves_trailing_comment_while_formatting_simple_statement --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_formats_simple_trailing_comment_matrix --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_does_not_treat_hash_inside_strings_as_trailing_comment --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_preserves_trailing_comment_on_selected_simple_statement_line --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` — 38/38 fixtures passed
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

## Notes

This keeps the formatter conservative: block opener comments, leading comments, POD, heredocs, regexes, and other risky literal surfaces remain preserve/bailout territory.

Closes #8420
