### PR TITLE
ci: reject zero issue refs and clarify target triples (#7282)

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -38,8 +38,9 @@ jobs:
             }
 
             const BOT_MARKER = '<!-- pr-title-check-bot -->';
+            const issueMatches = [...title.matchAll(/\B#(\d+)\b/g)];
 
-            if (!/\B#\d+\b/.test(title)) {
+            if (issueMatches.length === 0) {
               core.setFailed(
                 `PR title must reference an issue (e.g. "feat: add thing (#42)"). Got: "${title}"`
               );
@@ -89,23 +90,31 @@ jobs:
               return;
             }
 
-            // Extract issue number and validate it exists
-            const match = title.match(/\B#(\d+)\b/);
-            if (match) {
-              const issueNumber = parseInt(match[1], 10);
-              try {
-                await github.rest.issues.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber,
-                });
-                core.info(`Referenced issue #${issueNumber} exists.`);
-              } catch (e) {
-                core.warning(
-                  `Referenced issue #${issueNumber} was not found. Please verify the issue number.`
-                );
-                // Don't fail the check for this — it may be a private/internal reference
-              }
+            // Reject zero-valued issue references anywhere in the title.
+            // Real GitHub issues start at #1; zero is the placeholder for an unknown issue.
+            const zeroIssueMatch = issueMatches.find((match) => parseInt(match[1], 10) === 0);
+            if (zeroIssueMatch) {
+              core.setFailed(
+                `PR title contains zero-valued issue reference "${zeroIssueMatch[0]}", which is the Codex placeholder for an unknown issue. ` +
+                `Please replace it with the actual issue number, e.g. "(#1234)". Got: "${title}"`
+              );
+              return;
+            }
+
+            // Validate the first non-placeholder issue reference.
+            const issueNumber = parseInt(issueMatches[0][1], 10);
+            try {
+              await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              core.info(`Referenced issue #${issueNumber} exists.`);
+            } catch (e) {
+              core.warning(
+                `Referenced issue #${issueNumber} was not found. Please verify the issue number.`
+              );
+              // Don't fail the check for this — it may be a private/internal reference
             }
 
             core.info('PR title passes validation.');

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -217,7 +217,8 @@ cargo install perllsp
 
 ### GitHub Releases
 
-Binaries are published for all platforms:
+Binaries are published for all platforms. These target strings are Rust target
+triples; `unknown` is the standard Linux vendor field and is expected.
 
 | Platform | Target | Format |
 |----------|--------|--------|

--- a/docs/how-to/INSTALLATION.md
+++ b/docs/how-to/INSTALLATION.md
@@ -86,6 +86,9 @@ Check the latest release page before copying a version number.
 Most Linux users should choose the `gnu` archive. Use `musl` mainly for Alpine
 Linux or musl-based containers. You do not need both GNU and musl archives.
 
+These suffixes are Rust target triples. On Linux, `unknown` is the standard
+vendor field and is expected; choose based on the final `gnu` or `musl` segment.
+
 | Your system | Asset suffix |
 | --- | --- |
 | Linux x64 / AMD64, most distributions | `x86_64-unknown-linux-gnu` |

--- a/docs/releases/v0.13.4.md
+++ b/docs/releases/v0.13.4.md
@@ -86,6 +86,9 @@ MSRV to Rust 1.93.1.
 Most Linux users should choose `gnu`. Use `musl` mainly for Alpine Linux or
 musl-based containers. You do not need both GNU and musl archives.
 
+These suffixes are Rust target triples. On Linux, `unknown` is the standard
+vendor field and is expected; choose based on the final `gnu` or `musl` segment.
+
 | Your system | Download suffix |
 |---|---|
 | Linux x64 / AMD64, most distributions | `x86_64-unknown-linux-gnu` |


### PR DESCRIPTION
Problem: Zero-valued placeholder issue refs could pass PR title validation, and release asset suffix docs did not explain Rust target triple naming.
Fix: Reject zero-valued issue refs anywhere in PR titles, and document that `unknown` is the expected Linux vendor field in release target triples.
Verification: `node -e` title-regex smoke passed; `cargo xtask fmt --check` passed; `git diff --check` passed.

Fixes #7282, #7951.