### PR TITLE
test(format): prove trailing comments through LSP formatting (#8422)

### DIFF
--- a/crates/perl-lsp-rs/tests/formatting_test.rs
+++ b/crates/perl-lsp-rs/tests/formatting_test.rs
@@ -77,6 +77,43 @@ fn test_range_formatting() {
 }
 
 #[test]
+fn test_formatting_preserves_trailing_comment() {
+    let formatter = CodeFormatter::new();
+    let options = FormattingOptions {
+        tab_size: 4,
+        insert_spaces: true,
+        trim_trailing_whitespace: None,
+        insert_final_newline: None,
+        trim_final_newlines: None,
+    };
+    let code = "my$x=1; # keep\n";
+
+    let edits = must(formatter.format_document(code, &options));
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "my $x = 1; # keep\n");
+}
+
+#[test]
+fn test_range_formatting_preserves_trailing_comment() {
+    let formatter = CodeFormatter::new();
+    let options = FormattingOptions {
+        tab_size: 4,
+        insert_spaces: true,
+        trim_trailing_whitespace: None,
+        insert_final_newline: None,
+        trim_final_newlines: None,
+    };
+    let code = "my$x=1; # keep\nmy$y=2;\n";
+    let range = WireRange { start: WirePosition::new(0, 0), end: WirePosition::new(0, 14) };
+
+    let edits = must(formatter.format_range(code, &range, &options));
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "my $x = 1; # keep");
+}
+
+#[test]
 fn test_empty_document() {
     let formatter = CodeFormatter::new();
     let options = FormattingOptions {

--- a/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
@@ -87,6 +87,33 @@ fn test_range_formatting_3_17() -> TestResult {
 }
 
 #[test]
+fn test_range_formatting_preserves_trailing_comment_3_17() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open("file:///comment.pl", "my$x=1; # keep\nmy$y=2;")?;
+
+    let result = harness.request(
+        "textDocument/rangeFormatting",
+        json!({
+            "textDocument": { "uri": "file:///comment.pl" },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 14 }
+            },
+            "options": {
+                "tabSize": 4,
+                "insertSpaces": true
+            }
+        }),
+    )?;
+
+    let edits = result.as_array().ok_or("rangeFormatting should return an edit array")?;
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0]["newText"], "my $x = 1; # keep");
+    Ok(())
+}
+
+#[test]
 fn test_on_type_formatting_3_17() -> TestResult {
     let mut harness = LspHarness::new();
     harness.initialize(None)?;


### PR DESCRIPTION
## Summary

Adds LSP-facing proof for the native formatter trailing-comment behavior merged in #8419:

- `CodeFormatter::format_document` preserves the trailing comment while formatting the supported statement before it
- `CodeFormatter::format_range` preserves the trailing comment on the selected line
- LSP 3.17 `textDocument/rangeFormatting` returns the expected edit for a selected trailing-comment line

## Proof packet

- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs --test formatting_test trailing_comment --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests trailing_comment --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`
