### PR TITLE
feat(format): preserve trailing comments on simple blocks (#8425)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -701,9 +701,10 @@ fn format_simple_lexical_line(line: &str, config: &FormatConfig) -> Option<Strin
 fn format_simple_subroutine_line(line: &str, config: &FormatConfig) -> Option<String> {
     let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
     let (indent, body) = line.split_at(indent_len);
-    if body.is_empty() || body.contains('#') {
+    if body.is_empty() {
         return None;
     }
+    let (body, trailing_comment) = split_trailing_comment(body);
 
     let mut stream = perl_parser_core::TokenStream::new(body);
     let mut tokens = Vec::new();
@@ -716,15 +717,16 @@ fn format_simple_subroutine_line(line: &str, config: &FormatConfig) -> Option<St
     }
 
     let formatted = format_simple_subroutine_tokens(&tokens, indent, config)?;
-    Some(formatted)
+    Some(append_trailing_comment(formatted, trailing_comment))
 }
 
 fn format_simple_control_block_line(line: &str, config: &FormatConfig) -> Option<String> {
     let indent_len = line.len() - line.trim_start_matches([' ', '\t']).len();
     let (indent, body) = line.split_at(indent_len);
-    if body.is_empty() || body.contains('#') {
+    if body.is_empty() {
         return None;
     }
+    let (body, trailing_comment) = split_trailing_comment(body);
 
     let mut stream = perl_parser_core::TokenStream::new(body);
     let mut tokens = Vec::new();
@@ -736,7 +738,8 @@ fn format_simple_control_block_line(line: &str, config: &FormatConfig) -> Option
         tokens.push(token);
     }
 
-    format_simple_control_block_tokens(&tokens, indent, config)
+    let formatted = format_simple_control_block_tokens(&tokens, indent, config)?;
+    Some(append_trailing_comment(formatted, trailing_comment))
 }
 
 fn format_simple_statement_line(line: &str, config: &FormatConfig) -> Option<String> {

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_block_trailing_comments.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_block_trailing_comments.expected.pl
@@ -7,3 +7,25 @@ if ($ok) {
 while ($ok) {
     next;
 } # while tail
+unless ($ok) {
+    return 0;
+} # unless tail
+until ($done) {
+    return 1;
+} # until tail
+foreach my $item (@items) {
+    return $item;
+} # foreach tail
+for (my $i = 0; $i < 3; $i++) {
+    next;
+} # for tail
+if ($maybe) {
+    return 2;
+} else {
+    return 3;
+} # if else tail
+while ($again) {
+    next;
+} continue {
+    last;
+} # continue tail

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_block_trailing_comments.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_block_trailing_comments.expected.pl
@@ -1,0 +1,9 @@
+sub demo {
+    return 1;
+} # sub tail
+if ($ok) {
+    return 1;
+} # if tail
+while ($ok) {
+    next;
+} # while tail

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_block_trailing_comments.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_block_trailing_comments.pl
@@ -1,3 +1,9 @@
 sub demo{return 1;} # sub tail
 if($ok){return 1;} # if tail
 while($ok){next;} # while tail
+unless($ok){return 0;} # unless tail
+until($done){return 1;} # until tail
+foreach my$item(@items){return$item;} # foreach tail
+for(my$i=0;$i<3;$i++){next;} # for tail
+if($maybe){return 2;}else{return 3;} # if else tail
+while($again){next;}continue{last;} # continue tail

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_block_trailing_comments.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/simple_block_trailing_comments.pl
@@ -1,0 +1,3 @@
+sub demo{return 1;} # sub tail
+if($ok){return 1;} # if tail
+while($ok){next;} # while tail

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -334,6 +334,12 @@ fn native_formatter_preserves_trailing_comments_on_supported_blocks() {
         "sub demo{return 1;} # sub tail\n",
         "if($ok){return 1;} # if tail\n",
         "while($ok){next;} # while tail\n",
+        "unless($ok){return 0;} # unless tail\n",
+        "until($done){return 1;} # until tail\n",
+        "foreach my$item(@items){return$item;} # foreach tail\n",
+        "for(my$i=0;$i<3;$i++){next;} # for tail\n",
+        "if($maybe){return 2;}else{return 3;} # if else tail\n",
+        "while($again){next;}continue{last;} # continue tail\n",
     );
 
     let result = formatter.format_document(source, &FormatConfig::default());
@@ -351,6 +357,28 @@ fn native_formatter_preserves_trailing_comments_on_supported_blocks() {
             "while ($ok) {\n",
             "    next;\n",
             "} # while tail\n",
+            "unless ($ok) {\n",
+            "    return 0;\n",
+            "} # unless tail\n",
+            "until ($done) {\n",
+            "    return 1;\n",
+            "} # until tail\n",
+            "foreach my $item (@items) {\n",
+            "    return $item;\n",
+            "} # foreach tail\n",
+            "for (my $i = 0; $i < 3; $i++) {\n",
+            "    next;\n",
+            "} # for tail\n",
+            "if ($maybe) {\n",
+            "    return 2;\n",
+            "} else {\n",
+            "    return 3;\n",
+            "} # if else tail\n",
+            "while ($again) {\n",
+            "    next;\n",
+            "} continue {\n",
+            "    last;\n",
+            "} # continue tail\n",
         )
     );
     assert!(result.diagnostics.is_empty());

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -328,6 +328,35 @@ fn native_formatter_formats_simple_trailing_comment_matrix() {
 }
 
 #[test]
+fn native_formatter_preserves_trailing_comments_on_supported_blocks() {
+    let formatter = NativeFormatter::new();
+    let source = concat!(
+        "sub demo{return 1;} # sub tail\n",
+        "if($ok){return 1;} # if tail\n",
+        "while($ok){next;} # while tail\n",
+    );
+
+    let result = formatter.format_document(source, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(
+        result.formatted,
+        concat!(
+            "sub demo {\n",
+            "    return 1;\n",
+            "} # sub tail\n",
+            "if ($ok) {\n",
+            "    return 1;\n",
+            "} # if tail\n",
+            "while ($ok) {\n",
+            "    next;\n",
+            "} # while tail\n",
+        )
+    );
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
 fn native_formatter_does_not_treat_hash_inside_strings_as_trailing_comment() {
     let formatter = NativeFormatter::new();
     let source = "my$msg=\"#not a comment\";\nreturn\"#value\";\n";

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,7 +6,7 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 38 |
+| Fixture count | 39 |
 | Expected diagnostic fixtures | 8 |
 | Literal-preserve bailout fixtures | 8 |
 | Corpus files checked | 65 |


### PR DESCRIPTION
## Summary

Preserves trailing `#` comments when the native formatter expands supported one-line subroutine and control-flow blocks.

This keeps the scope intentionally narrow:
- supported one-line `sub`, `if`, and `while` block layouts only
- trailing comments are appended to the formatted closing brace line
- no leading/block comment movement
- no multiline comment handling changes
- no formatter default, runtime config, critic, or literal-preserve behavior changes

## Proof packet

Changed surfaces:
- native formatter
- formatter fixtures/status docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_formatter_preserves_trailing_comments_on_supported_blocks --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` (`39/39` fixtures passed)
- [x] `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-perltidy --profile agent -- -D warnings -A missing_docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

`just status-check` was also run; it completed the status scan but failed on unrelated generated status drift in `docs/project/status/tests.md`, `parser.md`, `quality.md`, and `dap.md`. This PR intentionally keeps those unrelated generated files out of scope and only updates `docs/project/status/native_tooling.md` for the formatter fixture count.
