### PR TITLE
test(format): prove block trailing comments through LSP (#8426)

### DIFF
--- a/crates/perl-lsp-rs/tests/formatting_test.rs
+++ b/crates/perl-lsp-rs/tests/formatting_test.rs
@@ -95,6 +95,24 @@ fn test_formatting_preserves_trailing_comment() {
 }
 
 #[test]
+fn test_formatting_preserves_simple_block_trailing_comment() {
+    let formatter = CodeFormatter::new();
+    let options = FormattingOptions {
+        tab_size: 4,
+        insert_spaces: true,
+        trim_trailing_whitespace: None,
+        insert_final_newline: None,
+        trim_final_newlines: None,
+    };
+    let code = "if($ok){return 1;} # if tail\n";
+
+    let edits = must(formatter.format_document(code, &options));
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "if ($ok) {\n    return 1;\n} # if tail\n");
+}
+
+#[test]
 fn test_range_formatting_preserves_trailing_comment() {
     let formatter = CodeFormatter::new();
     let options = FormattingOptions {
@@ -111,6 +129,25 @@ fn test_range_formatting_preserves_trailing_comment() {
 
     assert_eq!(edits.len(), 1);
     assert_eq!(edits[0].new_text, "my $x = 1; # keep");
+}
+
+#[test]
+fn test_range_formatting_preserves_simple_block_trailing_comment() {
+    let formatter = CodeFormatter::new();
+    let options = FormattingOptions {
+        tab_size: 4,
+        insert_spaces: true,
+        trim_trailing_whitespace: None,
+        insert_final_newline: None,
+        trim_final_newlines: None,
+    };
+    let code = "if($ok){return 1;} # if tail\nmy$z=3;\n";
+    let range = WireRange { start: WirePosition::new(0, 0), end: WirePosition::new(0, 29) };
+
+    let edits = must(formatter.format_range(code, &range, &options));
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "if ($ok) {\n    return 1;\n} # if tail");
 }
 
 #[test]

--- a/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
@@ -114,6 +114,33 @@ fn test_range_formatting_preserves_trailing_comment_3_17() -> TestResult {
 }
 
 #[test]
+fn test_range_formatting_preserves_simple_block_trailing_comment_3_17() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open("file:///block-comment.pl", "if($ok){return 1;} # if tail\nmy$z=3;")?;
+
+    let result = harness.request(
+        "textDocument/rangeFormatting",
+        json!({
+            "textDocument": { "uri": "file:///block-comment.pl" },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 29 }
+            },
+            "options": {
+                "tabSize": 4,
+                "insertSpaces": true
+            }
+        }),
+    )?;
+
+    let edits = result.as_array().ok_or("rangeFormatting should return an edit array")?;
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0]["newText"], "if ($ok) {\n    return 1;\n} # if tail");
+    Ok(())
+}
+
+#[test]
 fn test_on_type_formatting_3_17() -> TestResult {
     let mut harness = LspHarness::new();
     harness.initialize(None)?;


### PR DESCRIPTION
## Summary

Adds LSP-facing proof for the native formatter's supported block trailing-comment preservation.

This is a test-only follow-up to the formatter behavior that expands supported one-line blocks while keeping a trailing `#` comment on the formatted closing brace line.

## Scope

- Direct `CodeFormatter` document formatting proof for `if($ok){return 1;} # if tail`
- Direct `CodeFormatter` range formatting proof for the same supported block line
- LSP 3.17 `textDocument/rangeFormatting` proof for the same behavior
- No formatter behavior changes
- No runtime/config/default changes

## Proof packet

Changed surfaces:
- LSP formatting tests

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs --test formatting_test simple_block_trailing_comment --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests simple_block_trailing_comment --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`
