### PR TITLE
fix(parser): accept spaced slash qw delimiters (#6487)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1965,12 +1965,19 @@ impl<'a> PerlLexer<'a> {
                             //     is a valid file-size filetest and must not be treated as a
                             //     substitution start. All other operators (qw, q, qq, qr, qx, m,
                             //     tr, y) have no corresponding file-test operator.
+                            //   - / is safe for non-substitution quote operators; `qw /a b/` and
+                            //     `m /re/` are common, while `s /foo/bar/` remains ambiguous with
+                            //     the file-size test shape and stays rejected here.
                             //   - Non-paired, non-quote chars ($, @, ,, etc.) remain rejected.
                             let is_paired_delim = matches!(next, '{' | '[' | '(' | '<');
                             let is_quote_char = matches!(next, '\'' | '"') && op != "s";
+                            let is_spaced_slash_delim = next == '/' && op != "s";
                             let is_valid_delim = Self::is_quote_delim(next)
                                 && !is_fat_arrow
-                                && (!has_whitespace || is_paired_delim || is_quote_char);
+                                && (!has_whitespace
+                                    || is_paired_delim
+                                    || is_quote_char
+                                    || is_spaced_slash_delim);
 
                             if is_valid_delim {
                                 self.mode = LexerMode::ExpectDelimiter;

--- a/crates/perl-parser-core/tests/fix_qw_space_delimiter.rs
+++ b/crates/perl-parser-core/tests/fix_qw_space_delimiter.rs
@@ -36,6 +36,26 @@ fn qw_space_squote_double_in_call() {
     assert_clean_parse(r#"f(qw 'A B', qw 'C D');"#);
 }
 
+/// my $x = [qw /A B/]; my $y = 1 — slash delimiters after whitespace must not
+/// swallow the closing bracket or following statement. This is the
+/// Regexp::Common::zip corpus shape behind the current unclosed_bracket bucket.
+#[test]
+fn qw_space_slash_inside_array_preserves_following_tokens() {
+    let ast = parse(
+        r#"my $x = ['zip', 'Australia' => qw /-prefix= -country= -lax=/];
+my $y = 1;"#,
+    );
+    let sexp = ast.to_sexp();
+    assert!(
+        sexp.contains("(variable $ y)"),
+        "expected parser to continue after slash-delimited qw list, got: {sexp}"
+    );
+    assert_clean_parse(
+        r#"my $x = ['zip', 'Australia' => qw /-prefix= -country= -lax=/];
+my $y = 1;"#,
+    );
+}
+
 // ── Statement-level (already works — non-regression baseline) ────────────────
 
 /// my @x = qw 'A B' — at statement level. This worked before; must remain


### PR DESCRIPTION
Problem: Spaced slash-delimited `qw /.../` lists fell through quote-op delimiter handling and could leave Regexp::Common::zip in the `unclosed_bracket` corpus bucket.
Fix: Treat spaced `/` as a quote delimiter for non-`s` quote operators, while preserving the `s /.../` filetest ambiguity guard, and add a corpus-shaped regression proving tokens after the list remain visible.
Verification: `cargo test -p perl-parser-core --test fix_qw_space_delimiter --profile agent --locked -- --nocapture`; `cargo test -p perl-lexer --profile agent --locked quote -- --nocapture`; one-file `parser-corpus-sweep` of Regexp::Common::zip is clean; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `cargo clippy --locked -p perl-lexer -p perl-parser-core --profile agent -- -D warnings -A missing_docs`.

Addresses one concrete delimiter bucket under #6487; does not close the broader issue.