### PR TITLE
test(format): prove literal preserves through LSP (#8428)

### DIFF
--- a/crates/perl-lsp-rs/tests/formatting_test.rs
+++ b/crates/perl-lsp-rs/tests/formatting_test.rs
@@ -151,6 +151,27 @@ fn test_range_formatting_preserves_simple_block_trailing_comment() {
 }
 
 #[test]
+fn test_formatting_returns_no_edits_for_literal_preserve_regions() {
+    let formatter = CodeFormatter::new();
+    let options = FormattingOptions {
+        tab_size: 4,
+        insert_spaces: true,
+        trim_trailing_whitespace: None,
+        insert_final_newline: None,
+        trim_final_newlines: None,
+    };
+
+    for code in [
+        "my $matched = $text =~ /needle/i;\n",
+        "print <<'EOF';\nraw { text }\nEOF\n",
+        "=pod\n\n=head1 NAME\n\n=cut\n\nmy $x = 1;\n",
+    ] {
+        let edits = must(formatter.format_document(code, &options));
+        assert!(edits.is_empty(), "literal-preserve source should not produce edits: {code:?}");
+    }
+}
+
+#[test]
 fn test_empty_document() {
     let formatter = CodeFormatter::new();
     let options = FormattingOptions {

--- a/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
@@ -141,6 +141,34 @@ fn test_range_formatting_preserves_simple_block_trailing_comment_3_17() -> TestR
 }
 
 #[test]
+fn test_formatting_returns_no_edits_for_literal_preserve_regions_3_17() -> TestResult {
+    for (uri, source) in [
+        ("file:///regex-format.pl", "my $matched = $text =~ /needle/i;\n"),
+        ("file:///heredoc-format.pl", "print <<'EOF';\nraw { text }\nEOF\n"),
+        ("file:///pod-format.pl", "=pod\n\n=head1 NAME\n\n=cut\n\nmy $x = 1;\n"),
+    ] {
+        let mut harness = LspHarness::new();
+        harness.initialize(None)?;
+        harness.open(uri, source)?;
+
+        let result = harness.request(
+            "textDocument/formatting",
+            json!({
+                "textDocument": { "uri": uri },
+                "options": {
+                    "tabSize": 4,
+                    "insertSpaces": true
+                }
+            }),
+        )?;
+
+        let edits = result.as_array().ok_or("formatting should return an edit array")?;
+        assert!(edits.is_empty(), "literal-preserve source should not produce edits: {source:?}");
+    }
+    Ok(())
+}
+
+#[test]
 fn test_on_type_formatting_3_17() -> TestResult {
     let mut harness = LspHarness::new();
     harness.initialize(None)?;


### PR DESCRIPTION
## Summary

Adds LSP-facing proof that native formatter literal-preserve regions return no formatting edits.

This covers dangerous formatter surfaces that are intentionally preserved rather than rewritten today:
- regex literal
- heredoc
- POD

## Scope

- Direct `CodeFormatter` no-edit proof for literal-preserve inputs
- LSP 3.17 `textDocument/formatting` no-edit proof for the same inputs
- No formatter behavior changes
- No runtime/config/default changes

## Proof packet

Changed surfaces:
- LSP formatting tests

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs --test formatting_test literal_preserve --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests literal_preserve --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Note: `lsp_3_17_formatting_tests` still emits the existing unused support-helper warnings.
