### PR TITLE
fix(format): keep literal preserves no-edit through whitespace options (#8429)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting/formatting.rs
@@ -288,18 +288,7 @@ fn native_format_document(
         };
     }
 
-    let formatted = apply_lsp_whitespace_options(content, options);
-    if formatted == content {
-        FormattedDocument { text: content.to_string(), edits: vec![] }
-    } else {
-        FormattedDocument {
-            text: formatted.clone(),
-            edits: vec![FormatTextEdit {
-                range: FormatRange::whole_document(content),
-                new_text: formatted,
-            }],
-        }
-    }
+    FormattedDocument { text: content.to_string(), edits: vec![] }
 }
 
 fn native_format_range(
@@ -328,7 +317,7 @@ fn native_format_range(
         };
     }
 
-    whitespace_range_fallback(content, range, options)
+    FormattedDocument { text: content.to_string(), edits: vec![] }
 }
 
 fn native_format_config(
@@ -654,7 +643,7 @@ mod tests {
     }
 
     #[test]
-    fn format_document_falls_back_to_lsp_whitespace_when_native_declines() -> Result<()> {
+    fn format_document_returns_empty_edits_when_native_reports_literal_preserve() -> Result<()> {
         let provider = FormattingProvider::new(MissingPerltidyRuntime);
         let options = FormattingOptions {
             tab_size: 4,
@@ -665,8 +654,27 @@ mod tests {
         };
 
         let formatted = provider.format_document("=pod\n\n=cut\n\nmy $x = 1;   \n", &options)?;
-        assert_eq!(formatted.edits.len(), 1);
-        assert_eq!(formatted.edits[0].new_text, "=pod\n\n=cut\n\nmy $x = 1;\n");
+        assert!(formatted.edits.is_empty());
+        assert_eq!(formatted.text, "=pod\n\n=cut\n\nmy $x = 1;   \n");
+        Ok(())
+    }
+
+    #[test]
+    fn format_range_returns_empty_edits_when_native_reports_literal_preserve() -> Result<()> {
+        let provider = FormattingProvider::new(MissingPerltidyRuntime);
+        let options = FormattingOptions {
+            tab_size: 4,
+            insert_spaces: true,
+            trim_trailing_whitespace: Some(true),
+            insert_final_newline: Some(false),
+            trim_final_newlines: None,
+        };
+        let range = FormatRange::new(FormatPosition::new(0, 0), FormatPosition::new(0, 31));
+
+        let formatted =
+            provider.format_range("my $matched = $text =~ /needle/i;   \n", &range, &options)?;
+
+        assert!(formatted.edits.is_empty());
         Ok(())
     }
 

--- a/crates/perl-lsp-rs/tests/formatting_test.rs
+++ b/crates/perl-lsp-rs/tests/formatting_test.rs
@@ -156,15 +156,15 @@ fn test_formatting_returns_no_edits_for_literal_preserve_regions() {
     let options = FormattingOptions {
         tab_size: 4,
         insert_spaces: true,
-        trim_trailing_whitespace: None,
-        insert_final_newline: None,
+        trim_trailing_whitespace: Some(true),
+        insert_final_newline: Some(true),
         trim_final_newlines: None,
     };
 
     for code in [
-        "my $matched = $text =~ /needle/i;\n",
-        "print <<'EOF';\nraw { text }\nEOF\n",
-        "=pod\n\n=head1 NAME\n\n=cut\n\nmy $x = 1;\n",
+        "my $matched = $text =~ /needle/i;   \n",
+        "print <<'EOF';   \nraw { text }\nEOF\n",
+        "=pod\n\n=head1 NAME   \n\n=cut\n\nmy $x = 1;   \n",
     ] {
         let edits = must(formatter.format_document(code, &options));
         assert!(edits.is_empty(), "literal-preserve source should not produce edits: {code:?}");

--- a/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
@@ -143,9 +143,9 @@ fn test_range_formatting_preserves_simple_block_trailing_comment_3_17() -> TestR
 #[test]
 fn test_formatting_returns_no_edits_for_literal_preserve_regions_3_17() -> TestResult {
     for (uri, source) in [
-        ("file:///regex-format.pl", "my $matched = $text =~ /needle/i;\n"),
-        ("file:///heredoc-format.pl", "print <<'EOF';\nraw { text }\nEOF\n"),
-        ("file:///pod-format.pl", "=pod\n\n=head1 NAME\n\n=cut\n\nmy $x = 1;\n"),
+        ("file:///regex-format.pl", "my $matched = $text =~ /needle/i;   \n"),
+        ("file:///heredoc-format.pl", "print <<'EOF';   \nraw { text }\nEOF\n"),
+        ("file:///pod-format.pl", "=pod\n\n=head1 NAME   \n\n=cut\n\nmy $x = 1;   \n"),
     ] {
         let mut harness = LspHarness::new();
         harness.initialize(None)?;
@@ -157,7 +157,9 @@ fn test_formatting_returns_no_edits_for_literal_preserve_regions_3_17() -> TestR
                 "textDocument": { "uri": uri },
                 "options": {
                     "tabSize": 4,
-                    "insertSpaces": true
+                    "insertSpaces": true,
+                    "trimTrailingWhitespace": true,
+                    "insertFinalNewline": true
                 }
             }),
         )?;


### PR DESCRIPTION
## Summary

Native formatter diagnostics are now a hard no-edit boundary in the LSP formatting provider. When the native formatter reports a literal-preserve diagnostic for risky surfaces such as POD, heredoc, or regex literals, the provider no longer applies LSP whitespace fallback edits like trim trailing whitespace or insert final newline.

This keeps literal-preserve regions truly no-edit through both full-document and range formatting. Clean native results without diagnostics still keep the existing whitespace-option behavior.

## Scope

- Provider/LSP formatting behavior only
- No native formatter syntax expansion
- No runtime default or config changes
- No perltidy compatibility changes

## Proof packet

Changed surfaces:
- rust_code

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command exited cleanly

- [x] git diff --check
  - why: guards against whitespace errors in the final patch
  - evidence: command exited cleanly after all edits

Additional focused proof:
- [x] cargo test -p perl-lsp-rs-core format_document_returns_empty_edits_when_native_reports_literal_preserve --profile agent --locked -- --nocapture
- [x] cargo test -p perl-lsp-rs-core format_range_returns_empty_edits_when_native_reports_literal_preserve --profile agent --locked -- --nocapture
- [x] cargo test -p perl-lsp-rs-core formatting::formatting::tests --profile agent --locked -- --nocapture
- [x] cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture
- [x] cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture
- [x] cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs
- [x] cargo xtask native-format check
- [x] cargo xtask check-memory-lifecycle-policy
- [x] cargo xtask check-memory-retained-owner-drift --base origin/master
- [x] cargo xtask devex pr-body --base origin/master
- [x] cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json

Receipt:
- target/devex/local-proof.json