### PR TITLE
fix(parser): parse paren block filehandle print (#6487)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -610,6 +610,13 @@ impl<'a> Parser<'a> {
             let first_is_scalar = s.tokens.peek().is_ok_and(|t| {
                 t.text.starts_with('$') && t.text.len() > 1
             });
+            let first_is_filehandle_block = s
+                .tokens
+                .peek()
+                .is_ok_and(|t| t.kind == TokenKind::LeftBrace)
+                && s.tokens.peek_second().is_ok_and(|t| {
+                    t.text.starts_with('$') || t.text.starts_with('*')
+                });
             let second_is_not_separator = s.tokens.peek_second().is_ok_and(|t| {
                 !matches!(
                     t.kind,
@@ -617,9 +624,9 @@ impl<'a> Parser<'a> {
                 )
             });
 
-            if first_is_scalar && second_is_not_separator {
-                // Filehandle form: parse $fh as first argument, then remaining args
-                // without requiring a comma separator.
+            if (first_is_scalar && second_is_not_separator) || first_is_filehandle_block {
+                // Filehandle form: parse `$fh` or `{ *FH }` as first argument,
+                // then remaining args without requiring a comma separator.
                 let mut args = Vec::new();
                 let filehandle = s.parse_assignment_or_declaration()?;
                 args.push(filehandle);

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -868,6 +868,12 @@ fn print_parens_filehandle_list() {
 }
 
 #[test]
+fn print_parens_block_filehandle_typeglob_deref() {
+    // From Dpkg::Source::Archive: print({ *$self->{tar_input} } "$file\0")
+    assert_clean_parse(r#"print({ *$self->{tar_input} } "$file\0") or die "write failed";"#);
+}
+
+#[test]
 fn undef_in_return_expr() {
     // return undef — undef at statement boundary, no sigil follows
     assert_clean_parse(r#"sub f { return undef; }"#);


### PR DESCRIPTION
Problem: `print({ *$self->{tar_input} } "$file\0")` in Dpkg::Source::Archive hit the `unclosed_paren` corpus bucket because explicit-parens print handling only recognized scalar filehandles, not block-form filehandles.
Fix: Treat `{ $fh }` / `{ *FH }` as the first filehandle argument in parenthesized print/say/printf/send argument parsing, then continue collecting the message args without a comma.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test cpan_misc_idioms --profile agent --locked -- --nocapture`; one-file `parser-corpus-sweep` of Dpkg::Source::Archive is clean; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `cargo clippy --locked -p perl-parser-core --profile agent -- -D warnings -A missing_docs`.

Addresses one concrete `unclosed_paren` corpus bucket under #6487; does not close the broader issue.