### PR TITLE
test(format): expand literal preserve matrix (#8431)

### DIFF
--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/transliteration_literal_preserve.expected-diagnostics.txt
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/transliteration_literal_preserve.expected-diagnostics.txt
@@ -1,0 +1,1 @@
+native.format.literal_preserve_region

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/transliteration_literal_preserve.expected.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/transliteration_literal_preserve.expected.pl
@@ -1,0 +1,2 @@
+$text =~ tr/a-z/A-Z/;
+print $text;

--- a/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/transliteration_literal_preserve.pl
+++ b/crates/perl-lsp-perltidy/tests/fixtures/native_formatter/transliteration_literal_preserve.pl
@@ -1,0 +1,2 @@
+$text =~ tr/a-z/A-Z/;
+print $text;

--- a/crates/perl-lsp-perltidy/tests/native_formatter_parse_gate_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_parse_gate_tests.rs
@@ -142,6 +142,20 @@ fn native_formatter_refuses_substitution_until_preservation_pass_exists() {
 }
 
 #[test]
+fn native_formatter_refuses_transliteration_until_preservation_pass_exists() {
+    let formatter = NativeFormatter::new();
+    let source = "$text =~ tr/a-z/A-Z/;\n";
+    let config = FormatConfig { final_newline: FinalNewline::Trim, ..FormatConfig::default() };
+
+    let result = formatter.format_document(source, &config);
+
+    assert!(!result.changed);
+    assert_eq!(result.formatted, source);
+    assert_eq!(result.diagnostics[0].code, "native.format.literal_preserve_region");
+    assert!(result.diagnostics[0].message.contains("transliteration operator"));
+}
+
+#[test]
 fn native_formatter_refuses_quote_like_until_preservation_pass_exists() {
     let formatter = NativeFormatter::new();
     let source = "my @words = qw(alpha beta gamma);\n";

--- a/crates/perl-lsp-rs/tests/formatting_test.rs
+++ b/crates/perl-lsp-rs/tests/formatting_test.rs
@@ -163,7 +163,13 @@ fn test_formatting_returns_no_edits_for_literal_preserve_regions() {
 
     for code in [
         "my $matched = $text =~ /needle/i;   \n",
+        "$text =~ s/foo/bar/g;   \n",
+        "$text =~ tr/a-z/A-Z/;   \n",
+        "my @words = qw(alpha beta gamma);   \n",
         "print <<'EOF';   \nraw { text }\nEOF\n",
+        "my $x = 1;   \n__DATA__\nraw fixture bytes\n",
+        "my $x = 1;   \n__END__\nraw fixture bytes\n",
+        "format STDOUT =\n@<<<<\n$name\n.\nwrite;   \n",
         "=pod\n\n=head1 NAME   \n\n=cut\n\nmy $x = 1;   \n",
     ] {
         let edits = must(formatter.format_document(code, &options));

--- a/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
@@ -144,7 +144,13 @@ fn test_range_formatting_preserves_simple_block_trailing_comment_3_17() -> TestR
 fn test_formatting_returns_no_edits_for_literal_preserve_regions_3_17() -> TestResult {
     for (uri, source) in [
         ("file:///regex-format.pl", "my $matched = $text =~ /needle/i;   \n"),
+        ("file:///substitution-format.pl", "$text =~ s/foo/bar/g;   \n"),
+        ("file:///transliteration-format.pl", "$text =~ tr/a-z/A-Z/;   \n"),
+        ("file:///quote-like-format.pl", "my @words = qw(alpha beta gamma);   \n"),
         ("file:///heredoc-format.pl", "print <<'EOF';   \nraw { text }\nEOF\n"),
+        ("file:///data-format.pl", "my $x = 1;   \n__DATA__\nraw fixture bytes\n"),
+        ("file:///end-format.pl", "my $x = 1;   \n__END__\nraw fixture bytes\n"),
+        ("file:///format-body-format.pl", "format STDOUT =\n@<<<<\n$name\n.\nwrite;   \n"),
         ("file:///pod-format.pl", "=pod\n\n=head1 NAME   \n\n=cut\n\nmy $x = 1;   \n"),
     ] {
         let mut harness = LspHarness::new();

--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -6,9 +6,9 @@
 
 | Metric | Value |
 | --- | ---: |
-| Fixture count | 39 |
-| Expected diagnostic fixtures | 8 |
-| Literal-preserve bailout fixtures | 8 |
+| Fixture count | 40 |
+| Expected diagnostic fixtures | 9 |
+| Literal-preserve bailout fixtures | 9 |
 | Corpus files checked | 65 |
 | Corpus files changed | 2 |
 | Corpus idempotence | 65/65 |


### PR DESCRIPTION
## Summary

Expands native formatter literal-preserve coverage for risky Perl syntax.

- adds a transliteration fixture with expected `native.format.literal_preserve_region` diagnostics
- adds a focused parse-gate unit test for transliteration preservation
- broadens direct and LSP 3.17 no-edit tests to cover substitution, transliteration, quote-like operators, DATA/END sections, and format bodies under whitespace cleanup options
- regenerates `docs/project/status/native_tooling.md` so the native formatter status reports 40 fixtures and 9 literal-preserve bailout fixtures

## Scope

- Test/status coverage only
- No formatter syntax expansion
- No runtime default or config changes
- No critic changes

## Proof packet

Changed surfaces:
- generated_status_docs
- rust_code
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command exited cleanly

- [ ] just status-check
  - note: attempted; failed on pre-existing generated status drift in `tests.md`, `parser.md`, `quality.md`, and `dap.md`; this PR only updates `native_tooling.md`, which was regenerated with `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`

- [x] git diff --check
  - why: guards against whitespace errors in the final patch
  - evidence: command exited cleanly after all edits

Additional focused proof:
- [x] cargo test -p perl-lsp-perltidy native_formatter_refuses_transliteration_until_preservation_pass_exists --profile agent --locked -- --nocapture
- [x] cargo test -p perl-lsp-perltidy native_formatter --profile agent --locked -- --nocapture
- [x] cargo xtask native-format check (40/40 fixtures passed)
- [x] cargo test -p perl-lsp-rs --test formatting_test literal_preserve --profile agent --locked -- --nocapture
- [x] cargo test -p perl-lsp-rs --test formatting_test --profile agent --locked -- --nocapture
- [x] cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests literal_preserve --profile agent --locked -- --nocapture
- [x] cargo test -p perl-lsp-rs --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture
- [x] cargo test -p xtask native_tooling -- --nocapture
- [x] cargo clippy --locked -p perl-lsp-perltidy -p perl-lsp-rs -p xtask --profile agent -- -D warnings -A missing_docs
- [x] cargo xtask check-memory-lifecycle-policy
- [x] cargo xtask check-memory-retained-owner-drift --base origin/master
- [x] cargo xtask devex pr-body --base origin/master
- [x] cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json

Receipt:
- target/devex/local-proof.json