### PR TITLE
docs(tooling): align native tooling defaults (#8432)

### DIFF
--- a/crates/perl-lsp-perltidy/README.md
+++ b/crates/perl-lsp-perltidy/README.md
@@ -1,17 +1,20 @@
 # perl-lsp-perltidy
 
-Standalone SRP microcrate for Perl formatting integration. The existing
-`PerlTidyFormatter` remains a subprocess-backed compatibility adapter; the
-`native` module defines the Rust-native formatter contract for the native-first
-replacement lane.
+Standalone SRP microcrate for Perl formatting integration. The `native` module
+contains the Rust-native formatter used by the default LSP formatting path.
+`PerlTidyFormatter` remains available as an explicit subprocess-backed
+compatibility adapter for projects that still need exact `perltidy` behavior.
 
 ## Features
 
 - `PerlFormatter` trait and native `FormatResult` / edit / diagnostic model
-- `FormatDoc` document IR for deterministic native pretty-printing
+- `NativeFormatter` and `FormatDoc` document IR for deterministic native
+  pretty-printing
 - `PerlTidyConfig` for serializable formatter configuration
-- `PerlTidyFormatter` for subprocess-backed formatting with memoized results
-- `BuiltInFormatter` fallback for environments without `perltidy`
+- `PerlTidyFormatter` for explicit subprocess-backed compatibility formatting
+  with memoized results
+- `BuiltInFormatter` legacy fallback for direct crate consumers that still opt
+  into the old adapter path without `perltidy`
 - Range formatting and simple formatting suggestion generation
 - Argument-injection-safe file formatting via `--` separator
 

--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -1,8 +1,11 @@
-//! Perltidy integration for code formatting.
+//! Native-first Perl formatting with optional `perltidy` compatibility.
 //!
 //! This crate isolates Perl formatting concerns behind a small API so the
 //! broader tooling crate can focus on composition rather than formatter
-//! implementation details.
+//! implementation details. The default LSP formatter uses the Rust-native
+//! [`NativeFormatter`]; [`PerlTidyFormatter`] remains an explicit
+//! subprocess-backed compatibility adapter for projects that still require
+//! exact `perltidy` behavior.
 
 #![deny(unsafe_code)]
 #![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]

--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -1,9 +1,9 @@
 //! Native formatter contract types.
 //!
-//! This module defines the Rust-native formatter API that future formatter
-//! engines should implement. It intentionally lives beside the existing
-//! subprocess-backed `PerlTidyFormatter` adapter so consumers can start moving
-//! toward native formatting without changing the current runtime path.
+//! This module defines the Rust-native formatter API and default formatter
+//! implementation. It intentionally lives beside the subprocess-backed
+//! `PerlTidyFormatter` adapter so consumers can keep an explicit legacy
+//! compatibility path while the LSP runtime uses native formatting by default.
 
 use serde::{Deserialize, Serialize};
 

--- a/docs/how-to/FEATURE_SELECTION.md
+++ b/docs/how-to/FEATURE_SELECTION.md
@@ -164,19 +164,25 @@ args = ["--stdio", "--feature-profile", "production"]
 
 ---
 
-## Runtime Feature Gating: Perltidy
+## Runtime Feature Gating: Native Formatting
 
-Formatting capabilities (`lsp.formatting`, `lsp.range_formatting`, `lsp.on_type_formatting`) depend on an external tool. The server checks at startup whether Perltidy is available on `PATH`.
+Formatting capabilities (`lsp.formatting`, `lsp.range_formatting`,
+`lsp.on_type_formatting`) are backed by the native formatter by default. The
+server no longer removes document/range formatting just because Perltidy is not
+available on `PATH`; Perltidy only matters when explicit external compatibility
+mode is selected.
 
 | Profile | No Perltidy | Perltidy present |
 |---------|-------------|------------------|
 | `ga-lock` | Formatting enabled (static) | Formatting enabled |
-| `production` | Formatting disabled | Formatting enabled |
+| `production` | Formatting enabled | Formatting enabled |
 | `all` | Formatting enabled (static) | Formatting enabled |
 
-In `production` mode without Perltidy the server still starts and all other features remain active; only the formatting capability is removed from the `initialize` response.
+In `production` mode without Perltidy the server still starts and advertises
+native formatting. If explicit external Perltidy compatibility mode is selected,
+formatting errors include guidance for installing the external tool.
 
-To install Perltidy:
+To install Perltidy for explicit compatibility mode:
 
 ```bash
 cpanm Perl::Tidy

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -348,9 +348,9 @@ RUST_TEST_THREADS=4 cargo test -p perl-lsp-rs              # High-performance de
 
 **LSP test environment**:
 ```bash
-# Optional external dependencies for enhanced features
-export PERLTIDY_PATH="/usr/local/bin/perltidy"    # Custom perltidy location
-export PERLCRITIC_PATH="/usr/local/bin/perlcritic" # Custom perlcritic location
+# Optional external dependencies for compatibility adapters
+export PERLTIDY_PATH="/usr/local/bin/perltidy"      # explicit external formatter mode
+export PERLCRITIC_PATH="/usr/local/bin/perlcritic"  # explicit legacy critic mode
 
 # Override adaptive test timeouts
 LSP_TEST_TIMEOUT_MS=20000 cargo test -p perl-lsp-rs
@@ -362,18 +362,17 @@ LSP_TEST_ECHO_STDERR=1 cargo test -p perl-lsp-rs -- --nocapture
 
 ### LSP executeCommand Integration (*Diataxis: How-to Guide* - Execute command usage)
 
-The LSP server supports `workspace/executeCommand` with integrated perlcritic analysis and advanced code actions.
+The LSP server supports `workspace/executeCommand` with native critic analysis,
+legacy perlcritic compatibility, and advanced code actions.
 
 #### perl.runCritic Command Usage
 
 **Dual Analyzer Strategy Overview** (*Diataxis: Explanation* - Architecture design):
 
-The `perl.runCritic` command implements a sophisticated dual analyzer strategy ensuring 100% availability:
-
-1. **Primary**: External perlcritic (full policy coverage, configurable)
-2. **Fallback**: Built-in analyzer (always available, comprehensive basic policies)
-3. **Seamless Transition**: Automatic fallback with no user intervention required
-4. **Performance Target**: <2s execution time for typical Perl files
+The normal diagnostic path uses the native critic engine by default. The
+`perl.runCritic` execute command still supports legacy compatibility behavior,
+but external `perlcritic` should be treated as an explicit adapter rather than
+the default editor path.
 
 **Basic Usage** (*Diataxis: Tutorial* - Getting started with code quality analysis):
 ```bash
@@ -383,7 +382,7 @@ cargo test -p perl-lsp-rs --test lsp_behavioral_tests -- test_execute_command_pe
 # Test executeCommand protocol compliance
 cargo test -p perl-lsp-rs --test lsp_execute_command_tests
 
-# Test with dual analyzer strategy (external + built-in fallback)
+# Test legacy dual analyzer compatibility behavior
 cargo test -p perl-lsp-rs --test lsp_execute_command_tests -- test_perlcritic_dual_analyzer
 
 # Test built-in analyzer specifically
@@ -393,11 +392,22 @@ cargo test -p perl-parser --test execute_command_tests -- test_execute_command_r
 cargo test -p perl-parser --test execute_command_tests -- test_execute_command_run_critic_missing_file
 ```
 
-**Advanced Configuration** (*Diataxis: How-to Guide* - Optimizing perlcritic integration):
+**Advanced Configuration** (*Diataxis: How-to Guide* - Optimizing critic integration):
 
-**External Perlcritic Setup**:
+**Native Critic Setup**:
+```toml
+[diagnostics]
+perlcritic = true
+perlcritic_severity = 3
+
+[critic]
+engine = "native"
+profile = "recommended"
+```
+
+**External Perlcritic Compatibility Setup**:
 ```bash
-# Install perlcritic for enhanced analysis
+# Install perlcritic only when exact legacy policy output is required
 sudo apt-get install perlcritic         # Ubuntu/Debian
 brew install perl-critic                # macOS
 cpan Perl::Critic                      # CPAN installation
@@ -410,12 +420,13 @@ perlcritic --version                    # Check version
 cargo test -p perl-parser --test execute_command_tests -- test_command_exists_behavior
 ```
 
-**Built-in Analyzer Capabilities** (*Diataxis: Reference* - Policy coverage):
+**Native Critic Capabilities** (*Diataxis: Reference* - Policy coverage):
 ```rust
-// Built-in analyzer policies (always available)
+// Native critic policies (always available)
 - RequireUseStrict: "Missing 'use strict' pragma"
 - RequireUseWarnings: "Missing 'use warnings' pragma"
 - Syntax::ParseError: "Comprehensive syntax error detection"
+- Stable native rule IDs, suppressions, and code actions
 - Performance optimized: ~100µs analysis time for typical files
 - Parse-error resilient: Continues analysis even with syntax errors
 ```
@@ -423,21 +434,21 @@ cargo test -p perl-parser --test execute_command_tests -- test_command_exists_be
 **Performance Specifications** (*Diataxis: Reference* - Timing requirements):
 | Analyzer Type | File Size | Analysis Time | Policy Coverage | Availability |
 |---------------|-----------|---------------|-----------------|--------------|
-| External perlcritic | <10KB | <0.5s | 150+ policies | Requires installation |
-| External perlcritic | <100KB | <1.5s | 150+ policies | Configurable severity |
-| Built-in analyzer | <10KB | <0.1s | Core policies | 100% availability |
-| Built-in analyzer | <100KB | <0.3s | Core policies | Parse-error resilient |
+| Native critic | <10KB | <0.1s | Recommended native profile | 100% availability |
+| Native critic | <100KB | <0.3s | Recommended native profile | Parse-error resilient |
+| External perlcritic | <10KB | <0.5s | Legacy policy catalog | Explicit compatibility mode |
+| External perlcritic | <100KB | <1.5s | Legacy policy catalog | Configurable severity |
 
 **Troubleshooting** (*Diataxis: How-to Guide* - Common issues and solutions):
 
-**Issue: External perlcritic not found**
+**Issue: External perlcritic not found in legacy mode**
 ```bash
-# Problem: LSP falls back to built-in analyzer always
-# Solution: Install perlcritic and verify PATH
+# Problem: explicit legacy compatibility mode cannot launch perlcritic
+# Solution: use native critic, or install perlcritic and verify PATH
 which perlcritic || echo "perlcritic not found in PATH"
 echo $PATH | grep -o '/usr/local/bin\|/usr/bin\|/opt/perl/bin'
 
-# Alternative: Use built-in analyzer explicitly (always works)
+# Alternative: use the native critic path
 cargo test -p perl-parser --test execute_command_tests -- test_execute_command_run_critic_builtin
 ```
 

--- a/docs/reference/CONFIGURATION_SCHEMA.md
+++ b/docs/reference/CONFIGURATION_SCHEMA.md
@@ -95,8 +95,14 @@ The perl-lsp server configuration is hierarchical, with all settings nested unde
         "testRunner": {
           "$ref": "#/definitions/testRunner"
         },
+        "formatting": {
+          "$ref": "#/definitions/formatting"
+        },
         "perlcritic": {
           "$ref": "#/definitions/perlcritic"
+        },
+        "critic": {
+          "$ref": "#/definitions/critic"
         },
         "telemetry": {
           "$ref": "#/definitions/telemetry"
@@ -201,18 +207,77 @@ The perl-lsp server configuration is hierarchical, with all settings nested unde
       },
       "additionalProperties": false
     },
-    "perlcritic": {
+    "formatting": {
       "type": "object",
-      "description": "Perl::Critic static analysis integration",
+      "description": "Native-first formatter configuration. The default engine is native; external perltidy is explicit compatibility mode.",
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Enable perlcritic diagnostics (opt-in; requires perlcritic installed)",
+          "description": "Enable LSP formatting requests",
+          "default": true
+        },
+        "engine": {
+          "type": "string",
+          "description": "Formatter engine: native, compat/perltidy-compat, external-perltidy/external-legacy/perltidy, or off",
+          "enum": ["native", "compat", "perltidy-compat", "external-perltidy", "external-legacy", "perltidy", "off"],
+          "default": "native"
+        },
+        "perltidy_profile": {
+          "type": "string",
+          "description": "Path to a .perltidyrc profile used for compatibility reporting or explicit external mode"
+        },
+        "perltidy_maximum_line_length": {
+          "type": "integer",
+          "description": "Maximum native formatter line width",
+          "minimum": 20,
+          "default": 80
+        },
+        "perltidy_indent_columns": {
+          "type": "integer",
+          "description": "Indent width in spaces",
+          "minimum": 1,
+          "default": 4
+        },
+        "perltidy_tabs": {
+          "type": "boolean",
+          "description": "Use tabs for indentation where supported",
           "default": false
+        },
+        "perltidy_opening_brace_on_new_line": {
+          "type": "boolean",
+          "description": "Place supported opening braces on a new line",
+          "default": false
+        },
+        "perltidy_cuddled_else": {
+          "type": "boolean",
+          "description": "Use cuddled else/elsif layout for supported blocks",
+          "default": true
+        },
+        "perltidy_space_after_keyword": {
+          "type": "boolean",
+          "description": "Insert a space between supported control-flow keywords and their condition",
+          "default": true
+        },
+        "perltidy_add_trailing_commas": {
+          "type": "boolean",
+          "description": "Add trailing commas in supported multi-line lists and hashes",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "perlcritic": {
+      "type": "object",
+      "description": "Critic diagnostics compatibility settings. Native critic is the default engine; legacy Perl::Critic is explicit compatibility mode.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable critic diagnostics",
+          "default": true
         },
         "severity": {
           "type": "integer",
-          "description": "Minimum severity to report: 1 (least severe, reports everything) to 5 (most severe, reports less)",
+          "description": "Minimum critic severity to report: 1 (least severe, reports everything) to 5 (most severe, reports less)",
           "minimum": 1,
           "maximum": 5,
           "default": 3
@@ -220,6 +285,25 @@ The perl-lsp server configuration is hierarchical, with all settings nested unde
         "profile": {
           "type": "string",
           "description": "Path to a .perlcriticrc profile file"
+        }
+      },
+      "additionalProperties": false
+    },
+    "critic": {
+      "type": "object",
+      "description": "Native critic engine selection and profile settings",
+      "properties": {
+        "engine": {
+          "type": "string",
+          "description": "Critic engine: native, legacy, external, or perlcritic",
+          "enum": ["native", "legacy", "external", "perlcritic"],
+          "default": "native"
+        },
+        "profile": {
+          "type": "string",
+          "description": "Native critic profile",
+          "enum": ["recommended", "strict"],
+          "default": "recommended"
         }
       },
       "additionalProperties": false

--- a/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
+++ b/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
@@ -1691,17 +1691,23 @@ pub static SUPPORTED_COMMANDS: &[&str] = &[
 
 #### perl.runCritic Command Integration
 
-**Dual Analyzer Strategy** (*Diataxis: How-to* - Using perlcritic with fallback):
+**Native critic with legacy compatibility** (*Diataxis: How-to* - Using critic diagnostics):
 ```rust
-// Comprehensive perlcritic integration with fallback
+// Native critic is the default diagnostics path. perl.runCritic keeps a
+// compatibility route for projects comparing against legacy Perl::Critic.
 impl ExecuteCommandProvider {
     pub fn execute_perl_critic(&self, file_path: &str) -> Result<CriticResult, String> {
-        // Try external perlcritic first
+        // Use native critic unless explicit legacy compatibility is requested.
+        if self.critic_engine == CriticEngine::Native {
+            return self.run_native_critic(file_path);
+        }
+
+        // Explicit legacy compatibility path.
         if let Ok(external_result) = self.run_external_perlcritic(file_path) {
             return Ok(CriticResult::External(external_result));
         }
 
-        // Fallback to built-in analyzer for 100% availability
+        // Legacy fallback for compatibility command behavior.
         let builtin_analyzer = BuiltInAnalyzer::new();
         let ast = self.parser.parse_file(file_path)?;
         let violations = builtin_analyzer.analyze(&ast, &file_content);
@@ -5059,9 +5065,15 @@ caps.document_range_formatting_provider = Some(OneOf::Left(true));
 
 The server **always** advertises formatting capabilities, independent of external tool detection.
 
-#### External Tool Integration
+#### Native Formatter and Compatibility Adapter
 
-**Primary Formatter**: `perltidy` integration with comprehensive configuration support:
+**Primary formatter**: native Rust formatting through the configured formatter
+engine. The server keeps formatting capabilities advertised even when
+`perltidy` is not installed because the default path does not shell out.
+
+**Compatibility adapter**: explicit `external-perltidy` / `external-legacy`
+mode can still shell out to `perltidy` for projects that require exact legacy
+output:
 
 ```rust
 // Find perltidy in multiple locations
@@ -5075,7 +5087,9 @@ let perltidy_cmd = self.find_perltidy_command();
 // - ~/.perlbrew/perls/current/bin/perltidy
 ```
 
-**Configuration File Support**: Automatic `.perltidyrc` detection with workspace traversal:
+**Configuration File Support**: `.perltidyrc` is now primarily a compatibility
+input. Native compatibility reports classify common options against native
+support, and explicit external mode can still pass a profile to `perltidy`:
 
 ```rust
 // Searches in order:
@@ -5086,7 +5100,10 @@ let perltidy_cmd = self.find_perltidy_command();
 
 #### Error Handling and User Guidance (*Diataxis: How-to*)
 
-When `perltidy` is unavailable, the server provides comprehensive installation guidance:
+When the native formatter cannot safely rewrite a construct, it returns no edits
+and emits a native formatting diagnostic. When explicit external mode is
+selected and `perltidy` is unavailable, the server provides installation
+guidance:
 
 ```
 perltidy not found: No such file or directory
@@ -5121,15 +5138,17 @@ if let Some(res) = result {
 
 #### Development Workflow Impact
 
-**Local Development**: Formatting works seamlessly when `perltidy` is installed
-**CI/CD Environments**: Tests pass without external dependencies  
-**Production Deployments**: Clear error messages guide users to install required tools
+**Local Development**: Native formatting works without external tools
+**CI/CD Environments**: Tests pass without external dependencies
+**Production Deployments**: External-tool errors are limited to explicit
+compatibility mode
 
 ### Future Enhancements (*Diataxis: Explanation*)
 
 The architecture supports planned enhancements:
 
-**Built-in Formatter**: `BuiltInFormatter` struct exists for fallback formatting:
+**Legacy fallback**: `BuiltInFormatter` still exists for direct crate consumers
+that opt into the old adapter path without `perltidy`:
 
 ```rust
 pub struct BuiltInFormatter {
@@ -5144,7 +5163,8 @@ impl BuiltInFormatter {
 }
 ```
 
-**Integration Path**: Future versions can seamlessly add built-in formatting without changing capability advertising or client expectations.
+**Integration Path**: New formatter coverage should extend the native formatter
+and its receipts, not the legacy fallback.
 
 ### Configuration Options (*Diataxis: Reference*)
 
@@ -5160,9 +5180,11 @@ impl BuiltInFormatter {
 }
 ```
 
-#### Perltidy Integration
+#### Native Formatting and Perltidy Compatibility
 
-**Standard Options**: Automatically converted to perltidy command-line arguments:
+**Standard Options**: Common perltidy-style options are mapped onto native
+formatter configuration where supported; explicit external mode still converts
+them to perltidy command-line arguments:
 - `insertSpaces: true` → `-et=4 -i=4` (expand tabs, indent size)
 - `insertSpaces: false` → `-dt -i=4` (use tabs, tab size)
 

--- a/docs/specs/NATIVE_FORMATTER_CRITIC_REPLACEMENT.md
+++ b/docs/specs/NATIVE_FORMATTER_CRITIC_REPLACEMENT.md
@@ -1,11 +1,12 @@
 # Native Formatter and Critic Replacement Contract
 
-**Status**: Draft
+**Status**: Implemented native-first baseline; active hardening and
+compatibility reporting continue.
 **Scope**: native replacement contract for `perltidy` and `perlcritic`
-**Current adapter state**: `perl-lsp-perltidy` shells out to `perltidy` through
-`perl-subprocess-runtime` and keeps a small built-in fallback; `perl.runCritic`
-is an existing execute-command surface; `perl-diagnostics` is the canonical
-diagnostic model.
+**Current adapter state**: the default LSP formatter and critic diagnostics use
+native Rust engines. `PerlTidyFormatter` and legacy `perlcritic` integration
+remain explicit compatibility adapters; `perl.runCritic` remains an
+execute-command surface; `perl-diagnostics` is the canonical diagnostic model.
 
 ---
 
@@ -53,9 +54,6 @@ compat            native behavior tuned toward common perltidy/perlcritic profil
 external-legacy   explicit opt-in shell-out to traditional tools
 off               disabled
 ```
-
-Initial implementation may keep the existing external behavior as the default,
-but every PR in this lane should move toward this final state:
 
 ```text
 default editor path: native
@@ -319,14 +317,15 @@ severity = "info"
 max = 12
 ```
 
-Configuration import commands should be explicit and report gaps:
+Compatibility reports should classify existing legacy profiles against native
+support:
 
 ```bash
-perllsp config import-perltidy .perltidyrc
-perllsp config import-perlcritic .perlcriticrc
+cargo xtask native-format perltidy-compat --profile .perltidyrc
+cargo xtask native-tooling perlcritic-compat --profile .perlcriticrc
 ```
 
-Import output must classify every setting:
+Report output must classify every setting:
 
 ```text
 supported

--- a/docs/tutorials/EXECUTE_COMMAND_TUTORIAL.md
+++ b/docs/tutorials/EXECUTE_COMMAND_TUTORIAL.md
@@ -108,25 +108,30 @@ cargo test -p perl-parser --test execute_command_tests -- test_execute_command_r
 }
 ```
 
-### Step 4: Understanding the Dual Analyzer Strategy
+### Step 4: Understanding Native Critic and Legacy Compatibility
 
-The perl.runCritic command implements a sophisticated dual strategy:
+The normal editor diagnostic path uses the native critic engine by default.
+`perl.runCritic` remains a compatibility-oriented execute command for projects
+that still compare against legacy Perl::Critic output.
 
-1. **Primary Path**: External perlcritic (if installed)
-2. **Fallback Path**: Built-in analyzer (always available)
-3. **Seamless Transition**: Automatic fallback with no user intervention
+1. **Default Path**: Native critic recommended profile
+2. **Compatibility Path**: External `perlcritic` when explicitly selected
+3. **Migration Support**: Compatibility receipts map legacy policies to native
+   rules
 
 **Test the Strategy**:
 ```bash
-# Test dual analyzer behavior
+# Test legacy dual analyzer compatibility behavior
 cargo test -p perl-lsp-rs --test lsp_execute_command_tests -- test_perlcritic_dual_analyzer
 ```
 
-**Learning Goal**: Understand that you always get analysis results, regardless of external tool availability.
+**Learning Goal**: Understand that native diagnostics do not depend on external
+tool availability, while the legacy command path remains available for
+compatibility testing.
 
-### Step 5: Install External Perlcritic (Optional Enhancement)
+### Step 5: Install External Perlcritic (Optional Compatibility)
 
-For more comprehensive analysis, install external perlcritic:
+Install external perlcritic only when you need exact legacy policy behavior:
 
 ```bash
 # Ubuntu/Debian
@@ -143,11 +148,10 @@ which perlcritic
 perlcritic --version
 ```
 
-**Benefits of External Perlcritic**:
-- 150+ policy checks (vs basic policies in built-in)
-- Configurable severity levels
-- Custom policy configuration support
-- Industry-standard Perl best practices
+**When to use External Perlcritic**:
+- a project requires exact Perl::Critic policy output
+- a `.perlcriticrc` policy is classified as external-only
+- a team is comparing native findings with a legacy baseline during migration
 
 ### Step 6: LSP Protocol Integration
 

--- a/docs/tutorials/LSP_DEVELOPMENT_GUIDE.md
+++ b/docs/tutorials/LSP_DEVELOPMENT_GUIDE.md
@@ -713,20 +713,26 @@ impl ExecuteCommandProvider {
 }
 ```
 
-**Dual Analyzer Strategy Pattern** (*Diataxis: How-to* - Tool integration with fallback):
+**Native Critic and Legacy Compatibility Pattern** (*Diataxis: How-to* - Tool integration with compatibility):
 ```rust
-// perl.runCritic implementation with graceful degradation
+// The normal diagnostics path uses native critic. perl.runCritic keeps
+// compatibility behavior for teams comparing against legacy Perl::Critic.
 impl ExecuteCommandProvider {
     fn execute_perl_critic(&self, arguments: Vec<Value>) -> Result<Value, JsonRpcError> {
         let file_path = self.extract_file_path(&arguments)?;
 
-        // Try external perlcritic first (preferred)
+        // Use native critic unless explicit legacy compatibility is requested.
+        if self.critic_engine == CriticEngine::Native {
+            return self.run_native_critic(&file_path);
+        }
+
+        // Legacy compatibility path.
         match self.run_external_perlcritic(&file_path) {
             Ok(external_result) => {
                 Ok(serde_json::to_value(CriticResult::External(external_result))?)
             },
             Err(_) => {
-                // Fallback to built-in analyzer for 100% availability
+                // Legacy fallback for compatibility command behavior
                 let builtin_result = self.run_builtin_analyzer(&file_path)?;
                 Ok(serde_json::to_value(CriticResult::Builtin(builtin_result))?)
             }


### PR DESCRIPTION
## Summary

Align native-tooling docs with the current native-first formatter and critic defaults.

- update the perltidy crate docs and native formatter module docs to describe `NativeFormatter` as the default LSP path and `PerlTidyFormatter` as explicit compatibility
- refresh the native replacement contract from draft/external-first language to the current native-first baseline and receipt/reporting workflow
- update configuration, command, LSP, feature-selection, and execute-command docs so external `perltidy` / `perlcritic` are compatibility adapters rather than operational dependencies

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code
- docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo xtask native-tooling check-defaults`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `cargo xtask devex cockpit --base origin/master`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
