### PR TITLE
fix(parser): parse substitution in hash subscript (#6487)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2874,13 +2874,13 @@ impl<'a> PerlLexer<'a> {
                 && Self::is_quote_delim(repl_delim)
             {
                 self.advance();
-                let (_replacement, closed) = self.read_delimited_body(repl_delim);
+                let (_replacement, closed) = self.read_substitution_replacement_body(repl_delim);
                 replacement_closed = closed;
             } else {
                 replacement_closed = false;
             }
         } else {
-            let (_replacement, closed) = self.read_delimited_body(delimiter);
+            let (_replacement, closed) = self.read_substitution_replacement_body(delimiter);
             replacement_closed = closed;
         }
 
@@ -2906,6 +2906,107 @@ impl<'a> PerlLexer<'a> {
         };
 
         Some(Token { token_type, text: Arc::from(text), start, end: self.position })
+    }
+
+    fn read_substitution_replacement_body(&mut self, delim: char) -> (String, bool) {
+        if quote_handler::paired_close(delim).is_some() {
+            return self.read_delimited_body(delim);
+        }
+
+        self.read_unpaired_substitution_replacement_body(delim)
+    }
+
+    fn read_unpaired_substitution_replacement_body(&mut self, delim: char) -> (String, bool) {
+        let mut body = String::new();
+        let mut escaped = false;
+
+        while let Some(ch) = self.current_char() {
+            if escaped {
+                body.push(ch);
+                self.advance();
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' => {
+                    body.push(ch);
+                    self.advance();
+                    escaped = true;
+                }
+                '"' | '\'' if ch != delim => {
+                    if let Some((string_end, true)) =
+                        self.scan_inner_string_for_delimiter(self.position, ch, delim)
+                    {
+                        if let Some(string_text) = self.input.get(self.position..string_end) {
+                            body.push_str(string_text);
+                            self.position = string_end;
+                        } else {
+                            body.push(ch);
+                            self.advance();
+                        }
+                    } else {
+                        body.push(ch);
+                        self.advance();
+                    }
+                }
+                c if c == delim => {
+                    self.advance();
+                    return (body, true);
+                }
+                _ => {
+                    body.push(ch);
+                    self.advance();
+                }
+            }
+        }
+
+        (body, false)
+    }
+
+    fn scan_inner_string_for_delimiter(
+        &self,
+        start: usize,
+        quote: char,
+        delim: char,
+    ) -> Option<(usize, bool)> {
+        let mut pos = start.checked_add(quote.len_utf8())?;
+        let mut escaped = false;
+        let mut contains_delim = false;
+
+        while let Some(ch) = self.input.get(pos..).and_then(|text| text.chars().next()) {
+            if matches!(ch, '\n' | '\r') {
+                return None;
+            }
+
+            if escaped {
+                if ch == delim {
+                    contains_delim = true;
+                }
+                pos += ch.len_utf8();
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' => {
+                    pos += ch.len_utf8();
+                    escaped = true;
+                }
+                c if c == quote => {
+                    return Some((pos + ch.len_utf8(), contains_delim));
+                }
+                c if c == delim => {
+                    contains_delim = true;
+                    pos += ch.len_utf8();
+                }
+                _ => {
+                    pos += ch.len_utf8();
+                }
+            }
+        }
+
+        None
     }
 
     fn parse_transliteration(&mut self, start: usize) -> Option<Token> {

--- a/crates/perl-parser-core/src/engine/parser/expressions/quotes.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/quotes.rs
@@ -260,15 +260,95 @@ impl<'a> Parser<'a> {
                 ))
             }
             "s" => {
-                // Substitution operator shouldn't reach here - handled by TokenKind::Substitution
-                // This is kept for defensive programming
-                Err(ParseError::syntax(
-                    "Substitution operator should be handled by TokenKind::Substitution",
-                    start,
+                let replacement = self.parse_quote_operator_substitution_replacement(
+                    opening_delim,
+                    closing_delim,
+                )?;
+                let modifiers = self.parse_quote_operator_substitution_modifiers()?;
+                let has_embedded_code = self.analyze_regex_body_for_ast(&content, start)?;
+                end = self.previous_position();
+
+                Ok(Node::new(
+                    NodeKind::Substitution {
+                        expr: Box::new(Node::new(
+                            NodeKind::Identifier { name: String::from("$_") },
+                            SourceLocation { start, end: start },
+                        )),
+                        pattern: content,
+                        replacement,
+                        modifiers,
+                        has_embedded_code,
+                        negated: false,
+                    },
+                    SourceLocation { start, end },
                 ))
             }
             _ => Err(ParseError::syntax(format!("Unknown quote operator: {}", op), start)),
         }
+    }
+
+    fn parse_quote_operator_substitution_replacement(
+        &mut self,
+        pattern_open_delim: char,
+        pattern_close_delim: char,
+    ) -> ParseResult<String> {
+        if pattern_open_delim != pattern_close_delim {
+            return Err(ParseError::syntax(
+                "Paired-delimiter substitution should be handled by TokenKind::Substitution",
+                self.current_position(),
+            ));
+        }
+
+        self.collect_quote_operator_unpaired_body(pattern_close_delim)
+    }
+
+    fn collect_quote_operator_unpaired_body(&mut self, close_delim: char) -> ParseResult<String> {
+        let mut content = String::new();
+
+        while !self.tokens.is_eof() {
+            let token = self.consume_token()?;
+            if token.kind != TokenKind::String && token.text.contains(close_delim) {
+                let pos = token.text.find(close_delim).ok_or_else(|| {
+                    ParseError::syntax("Closing delimiter not found in token", token.start)
+                })?;
+                content.push_str(&token.text[..pos]);
+                break;
+            }
+            content.push_str(&token.text);
+        }
+
+        Ok(content)
+    }
+
+    fn parse_quote_operator_substitution_modifiers(&mut self) -> ParseResult<String> {
+        let mut modifiers = String::new();
+
+        while let Ok(token) = self.tokens.peek() {
+            if token.kind != TokenKind::Identifier || token.text.len() != 1 {
+                break;
+            }
+
+            let ch = token.text.chars().next().ok_or_else(|| {
+                ParseError::syntax("Empty identifier token", token.start)
+            })?;
+            if !ch.is_ascii_alphabetic() {
+                break;
+            }
+            if !matches!(ch, 'g' | 'i' | 'm' | 's' | 'x' | 'o' | 'e' | 'r') {
+                return Err(ParseError::syntax(
+                    format!(
+                        "Invalid substitution modifier '{}'. Valid modifiers are: g, i, m, s, x, o, e, r",
+                        ch
+                    ),
+                    token.start,
+                ));
+            }
+
+            modifiers.push(ch);
+            self.tokens.next()?;
+        }
+
+        Ok(modifiers)
     }
 
     /// After having consumed the `qw` identifier, parse `qw<delim>...<close>`

--- a/crates/perl-parser-core/tests/fix_substitution_misparse_2395.rs
+++ b/crates/perl-parser-core/tests/fix_substitution_misparse_2395.rs
@@ -54,6 +54,18 @@ fn test_subst_e_hash_lookup() {
     assert_clean_parse(source);
 }
 
+#[test]
+fn test_subst_e_biber_imatch_array_index_replacement() {
+    let source = r#"$newkey =~ s/(?<!\\)\$(\d)/$imatches[$1-1]/ge;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_subst_r_empty_replacement_inside_hash_subscript_condition() {
+    let source = r#"unless ($nps{$npn =~ s/-i$//r} or $npn eq 'id') { next; }"#;
+    assert_clean_parse(source);
+}
+
 /// Template Toolkit style: replacement is a full conditional expression
 #[test]
 fn test_subst_e_template_toolkit_style() {


### PR DESCRIPTION
Problem: A Biber corpus sample hit `substitution_misparse` because slash-delimited replacements and hash-subscript-suppressed `s///` tokens were split before the parser could build a substitution node.
Fix: Scan substitution replacements without treating delimiters inside quoted strings as terminators, and parse the suppressed non-paired `s///` fallback into a `Substitution` node.
Verification: `cargo test -p perl-parser-core --test fix_substitution_misparse_2395 --profile agent --locked -- --nocapture`; `cargo test -p perl-lexer --profile agent --locked`; `cargo xtask parser-corpus-sweep --roots $env:TEMP\perl-lsp-corpus-biber-bibtex --verbose --output $env:TEMP\perl-lsp-corpus-biber-bibtex\sweep-after.json`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo check --locked -p perl-lexer -p perl-parser-core --all-targets --profile agent`; `cargo clippy --locked -p perl-lexer -p perl-parser-core --profile agent -- -D warnings -A missing_docs`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`
