### PR TITLE
docs(tooling): update editor native tooling guidance (#8434)

### DIFF
--- a/docs/EDITORS/COC_NEOVIM_SETUP.md
+++ b/docs/EDITORS/COC_NEOVIM_SETUP.md
@@ -419,11 +419,9 @@ Reduce result caps:
 
 ### Formatting does not work
 
-Confirm `perltidy` is installed:
-
-```bash
-perltidy --version
-```
+Native formatting does not require `perltidy`. Check `:CocCommand workspace.showOutput`
+or the server log for native formatting diagnostics. Install `perltidy` only
+when using explicit external formatting compatibility mode.
 
 Then run:
 

--- a/docs/EDITORS/EMACS_SETUP.md
+++ b/docs/EDITORS/EMACS_SETUP.md
@@ -351,11 +351,9 @@ Or pass Emacs-specific startup options through Eglot `:initializationOptions` or
 
 ### Formatting does not work
 
-Install `perltidy` and confirm it is visible to Emacs:
-
-```bash
-perltidy --version
-```
+Native formatting does not require `perltidy`. Check the Eglot or lsp-mode
+server log for native formatting diagnostics. Install `perltidy` only when
+using explicit external formatting compatibility mode.
 
 Then try:
 

--- a/docs/EDITORS/HELIX_SETUP.md
+++ b/docs/EDITORS/HELIX_SETUP.md
@@ -211,11 +211,9 @@ Inside Helix:
 ## Formatting
 
 Helix uses the language server for `:format` unless you configure an external
-formatter. If formatting fails, confirm `perltidy` is installed:
-
-```bash
-perltidy --version
-```
+formatter. Native LSP formatting does not require `perltidy`; if formatting
+returns no edits, check the language-server log for native formatting
+diagnostics.
 
 To use an external formatter instead of LSP formatting:
 

--- a/docs/EDITORS/NEOVIM_SETUP.md
+++ b/docs/EDITORS/NEOVIM_SETUP.md
@@ -13,8 +13,8 @@ Optional:
 - `nvim-lspconfig`, if you already use it for other language servers
 - `nvim-cmp`, if you prefer cmp-based completion
 - `telescope.nvim`, for picker-based symbol/reference navigation
-- `perltidy`, for formatting
-- `perlcritic`, only if Perl::Critic diagnostics are enabled
+- `perltidy`, only if explicit external formatting compatibility is enabled
+- `perlcritic`, only if explicit legacy Perl::Critic compatibility is enabled
 
 Verify `perllsp` before changing Neovim configuration:
 

--- a/docs/EDITORS/SUBLIME_SETUP.md
+++ b/docs/EDITORS/SUBLIME_SETUP.md
@@ -14,8 +14,8 @@ package.
 Optional:
 
 - Perl, for running project code, tests, and system `@INC` probing
-- `perltidy`, for formatting
-- `perlcritic`, only if Perl::Critic diagnostics are enabled
+- `perltidy`, only if explicit external formatting compatibility is enabled
+- `perlcritic`, only if explicit legacy Perl::Critic compatibility is enabled
 
 Verify `perllsp` before changing Sublime settings:
 
@@ -369,11 +369,9 @@ Or pass Sublime-specific initialization options:
 
 ### Formatting does not work
 
-Install `perltidy` and confirm it is available:
-
-```bash
-perltidy --version
-```
+Native formatting does not require `perltidy`. If formatting returns no edits,
+check the Sublime LSP output panel for native formatting diagnostics. Install
+`perltidy` only when using explicit external formatting compatibility mode.
 
 Then run:
 

--- a/docs/EDITORS/VS_CODE_SETUP.md
+++ b/docs/EDITORS/VS_CODE_SETUP.md
@@ -29,7 +29,7 @@ server installation is only required for offline/pinned deployments or when
 ### Optional but Recommended
 
 - **Perl** 5.10 or later (for syntax validation)
-- **perltidy** (for code formatting)
+- **perltidy** only if you select explicit external formatting compatibility
 
 ---
 
@@ -190,15 +190,15 @@ settings.
 | `perl-lsp.includePaths` | array | `["lib", ".", "local/lib/perl5"]` | Additional library paths to search for Perl modules. |
 | `perl-lsp.enableDiagnostics` | boolean | `true` | Enable real-time syntax diagnostics. |
 | `perl-lsp.enableSemanticTokens` | boolean | `true` | Enable semantic syntax highlighting. |
-| `perl-lsp.perltidyConfig` | string | `""` | Path to `.perltidyrc` configuration file. |
-| `perl-lsp.enableFormatting` | boolean | `true` | Enable document formatting using `perltidy`. |
+| `perl-lsp.perltidyConfig` | string | `""` | Path to `.perltidyrc` compatibility file. Native formatting is the default path. |
+| `perl-lsp.enableFormatting` | boolean | `true` | Enable native document formatting. |
 | `perl-lsp.formatOnSave` | boolean | `false` | Format document on save. |
 | `perl-lsp.enableRefactoring` | boolean | `true` | Enable refactoring-related code actions. |
 | `perl-lsp.enableTestIntegration` | boolean | `true` | Enable `Test::More` and `Test2` integration. |
 | `perl-lsp.autoPopulateNewFiles` | boolean | `true` | Auto-populate new `.pm` and `.t` files with boilerplate. |
-| `perl-lsp.perlcritic.enabled` | boolean | `false` | Enable external `perlcritic` diagnostics. |
-| `perl-lsp.perlcritic.severity` | number | `3` | Perl::Critic minimum severity, from `1` to `5`. |
-| `perl-lsp.perlcritic.profile` | string | `""` | Path to `.perlcriticrc` profile file. |
+| `perl-lsp.perlcritic.enabled` | boolean | `true` | Enable native critic diagnostics. |
+| `perl-lsp.perlcritic.severity` | number | `3` | Critic minimum severity, from `1` to `5`. |
+| `perl-lsp.perlcritic.profile` | string | `""` | Path to `.perlcriticrc` compatibility profile file. |
 | `perl-lsp.featureProfile` | string | `"auto"` | Runtime capability profile. Keep `auto` unless you need a specific compatibility profile. |
 | `perl-lsp.disabledFeatures` | array | `[]` | Disable selected server features at client startup. |
 | `perl-lsp.autoUpdate` | boolean | `false` | Automatically download and install a new `perllsp` binary when available. |
@@ -314,7 +314,7 @@ Rename symbols across the workspace:
 
 ### Formatting
 
-Format Perl code using perltidy:
+Format Perl code using the native formatter:
 
 - **Keyboard**: `Shift+Alt+F` (Shift+Option+F on macOS)
 - **Command**: Format Document
@@ -487,27 +487,7 @@ Example:
 
 **Solutions**:
 
-1. **Install perltidy**:
-   ```bash
-   # macOS
-   brew install perltidy
-
-   # Ubuntu/Debian
-   sudo apt-get install perltidy
-
-   # CentOS/RHEL
-   sudo yum install perl-Perl-Tidy
-
-   # Windows (via Strawberry Perl)
-   ppm install Perl-Tidy
-   ```
-
-2. **Check perltidy works**:
-   ```bash
-   perltidy --version
-   ```
-
-3. **Verify formatting enabled**:
+1. **Verify formatting enabled**:
    ```json
    {
      "perl-lsp.enableFormatting": true,
@@ -515,11 +495,21 @@ Example:
    }
    ```
 
-4. **Set perltidy config path** (optional):
+2. **Check server logs**:
+   Open the "Perl Language Server" output channel and look for native formatting
+   diagnostics. Unsupported literal-preserve regions return no edits rather
+   than unsafe rewrites.
+
+3. **Set a compatibility profile path** (optional):
    ```json
    {
      "perl-lsp.perltidyConfig": "/path/to/.perltidyrc"
    }
+   ```
+
+4. **Install perltidy only for explicit external compatibility mode**:
+   ```bash
+   perltidy --version
    ```
 
 ### Extension Conflicts

--- a/docs/EXTENSION.md
+++ b/docs/EXTENSION.md
@@ -40,7 +40,7 @@ The Marketplace package is designed to work with `PATH`, `serverPath`, or runtim
 | `perl-lsp.enableFormatting` | `true` | Enable formatting integration. |
 | `perl-lsp.formatOnSave` | `false` | Request formatting on save. |
 | `perl-lsp.enableRefactoring` | `true` | Enable server-supplied refactoring code actions where supported. |
-| `perl-lsp.perltidyConfig` | `""` | Path to a `.perltidyrc` file. |
+| `perl-lsp.perltidyConfig` | `""` | Path to a `.perltidyrc` compatibility file. Native formatting is the default path. |
 | `perl-lsp.includePaths` | `["lib", "local/lib/perl5"]` | Additional Perl include paths passed to the server. |
 | `perl-lsp.enableTestIntegration` | `true` | Enable test integration for `.t` and runnable `.pl` files. |
 | `perl-lsp.autoPopulateNewFiles` | `true` | Auto-populate new `.pm` files with a `package` declaration and new `.t` files with `Test::More` boilerplate. Set to `false` to disable. |

--- a/docs/articles/FEATURE_CATALOG.md
+++ b/docs/articles/FEATURE_CATALOG.md
@@ -74,7 +74,7 @@ Diagnostics report problems in your code as you edit.
 
 **Code Actions** (`lsp.code_action`) / **Code Action Resolve** (`lsp.code_action_resolve`) — context-sensitive suggestions for fixing or improving code. Examples: organize imports, add missing `use` statements, modernize old Perl idioms, apply quick fixes for diagnostics. `resolve` fetches the full edit for a code action when selected.
 
-**Formatting** (`lsp.formatting`) — formats the entire document using Perl::Tidy. Produces consistently formatted Perl code.
+**Formatting** (`lsp.formatting`) — formats the entire document using the native Rust formatter, with explicit Perl::Tidy compatibility available for projects that need legacy output.
 
 **Range Formatting** (`lsp.range_formatting`) — formats a selected range rather than the entire file.
 
@@ -124,7 +124,7 @@ These features maintain the server's view of open files in sync with the editor.
 
 **Workspace Edit** (`lsp.workspace_edit`) — applies multi-file edits. Used by rename and other refactoring operations that touch multiple files.
 
-**Execute Command** (`lsp.execute_command`) — runs server-side commands from the editor. Used for invoking Perl::Critic on the current file, running custom Perl tools, and triggering workspace operations that do not fit the standard request/response model.
+**Execute Command** (`lsp.execute_command`) — runs server-side commands from the editor. Used for native critic analysis, legacy Perl::Critic compatibility, custom Perl tools, and workspace operations that do not fit the standard request/response model.
 
 **Configuration** (`lsp.configuration`) / **Did Change Configuration** (`lsp.did_change_configuration`) / **Did Change Watched Files** (`lsp.did_change_watched_files`) — manages server configuration. The server can request specific configuration from the client. The client notifies the server when configuration or watched files change.
 


### PR DESCRIPTION
## Summary

Update editor-facing native-tooling guidance so normal setup no longer tells users to install `perltidy` or `perlcritic` for the default path.

- refresh VS Code, Neovim, Sublime, Coc, Emacs, Helix, extension, and feature-catalog docs to describe native formatting and native critic as the normal path
- keep `perltidy` and `perlcritic` framed as explicit compatibility adapters for projects that need legacy behavior
- update formatting troubleshooting to point at native diagnostics/logs before external-tool installation

## Proof packet

Changed surfaces:
- docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask native-tooling check-defaults`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Receipt:
- `target/devex/local-proof.json`
