### PR TITLE
docs(tooling): align feature reference native tooling guidance (#8435)

### DIFF
--- a/docs/how-to/FEATURE_SELECTION.md
+++ b/docs/how-to/FEATURE_SELECTION.md
@@ -10,7 +10,7 @@ This guide explains how to choose and configure the feature profile for perl-lsp
   - [production](#production-profile)
   - [all](#all-profile)
 - [Selecting a Profile at Runtime](#selecting-a-profile-at-runtime)
-- [Runtime Feature Gating: Perltidy](#runtime-feature-gating-perltidy)
+- [Runtime Feature Gating: Native Formatting](#runtime-feature-gating-native-formatting)
 - [Verifying the Active Profile](#verifying-the-active-profile)
 - [Feature Catalog and Compliance](#feature-catalog-and-compliance)
 - [Per-Feature Reference](#per-feature-reference)
@@ -65,7 +65,7 @@ The default profile for normal runtime operation. This is what the server uses u
 
 **What changes vs. ga-lock:**
 - `lsp.inline_value` is enabled (DAP debugging shows inline variable values)
-- `lsp.formatting` and `lsp.range_formatting` require Perltidy to be installed at runtime; if Perltidy is absent the server disables these capabilities dynamically
+- `lsp.formatting` and `lsp.range_formatting` use the native formatter by default; explicit external Perltidy compatibility mode is opt-in
 
 ---
 
@@ -80,7 +80,7 @@ Every in-tree capability is enabled. This profile is primarily intended for test
 - Generating the complete feature grid JSON for documentation tooling
 - Verifying LSP compliance against the full feature catalog
 
-**Caution:** Because formatting is unconditionally enabled, clients that attempt formatting without a Perltidy installation may receive error responses. Use this profile intentionally.
+**Caution:** Because every in-tree capability is enabled, this profile can expose experimental surfaces intended for test matrices. Native formatting does not require Perltidy, but explicit external compatibility mode still requires the external tool.
 
 ---
 
@@ -245,7 +245,7 @@ The `features.toml` file is the canonical definition. The Rust code in `perl-lsp
 
 ## Per-Feature Reference
 
-The table below summarizes which features each profile enables. "Dynamic" means the feature depends on a runtime availability check (Perltidy).
+The table below summarizes which features each profile enables. "Dynamic" means the feature depends on runtime configuration or an availability check; native formatting is enabled by default and does not require Perltidy.
 
 | Feature ID | ga-lock | production | all |
 |---|---|---|---|
@@ -322,5 +322,5 @@ The `features.toml` file feeds into `perl-lsp-feature-contracts` at build time v
 - [features.toml](../../features.toml) - Complete feature catalog
 - [PERFORMANCE_TUNING.md](PERFORMANCE_TUNING.md) - Workspace and hardware tuning
 - [EDITOR_SETUP.md](EDITOR_SETUP.md) - Editor-specific setup
-- [INSTALLATION.md](INSTALLATION.md) - Installation and Perltidy setup
+- [INSTALLATION.md](INSTALLATION.md) - Installation and setup
 - [CURRENT_STATUS.md](../project/CURRENT_STATUS.md) - Current feature coverage metrics

--- a/docs/reference/ARCHITECTURE_OVERVIEW.md
+++ b/docs/reference/ARCHITECTURE_OVERVIEW.md
@@ -35,12 +35,12 @@ The following microcrates were extracted to enforce single-responsibility bounda
 | `perl-dap-config` | Launch/attach configuration parsing and validation | DAP |
 | `perl-lsp-code-actions` | LSP code actions provider (extracted from `perl-lsp-providers`) | LSP |
 | `perl-lsp-critic-parser` | Perl::Critic output line parsing (extracted from diagnostics) | LSP |
-| `perl-lsp-perltidy` | Perltidy-based formatting integration (extracted from formatting) | LSP |
+| `perl-lsp-perltidy` | Native-first formatting with explicit Perltidy compatibility (extracted from formatting) | LSP |
 | `perl-lsp-type-hierarchy` | Type hierarchy navigation | LSP |
 | `perl-workspace-index-monitoring` | Monitoring, limits, and lifecycle instrumentation for workspace indexing | Workspace |
 | `perl-ts-statement-tracker` | Statement boundary and heredoc context tracking | Tree-sitter |
 
-The `perl-lsp-code-actions`, `perl-lsp-critic-parser`, and `perl-lsp-perltidy` extractions are part of a broader modularization effort that split monolithic LSP providers into focused microcrates -- each owning a single concern (code actions, Perl::Critic parsing, and perltidy integration respectively).
+The `perl-lsp-code-actions`, `perl-lsp-critic-parser`, and `perl-lsp-perltidy` extractions are part of a broader modularization effort that split monolithic LSP providers into focused microcrates -- each owning a single concern (code actions, Perl::Critic parsing, and native-first formatting with Perltidy compatibility respectively).
 
 ### Internal/Unpublished
 - **`/tree-sitter-perl/`**: Original C implementation (benchmarking only)

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -536,7 +536,7 @@ cargo test -p perl-lsp-rs --test lsp_behavioral_tests -- test_execute_command_de
 - ✅ `perl.runFile` - Execute single Perl file with output capture
 - ✅ `perl.runTestSub` - Execute specific test subroutine with isolation
 - ✅ `perl.debugTests` - Debug test execution with breakpoint support
-- ✅ `perl.runCritic` - Perl::Critic analysis with dual analyzer strategy (external + built-in fallback)
+- ✅ `perl.runCritic` - Native critic analysis with explicit Perl::Critic compatibility
 
 ### Advanced Code Actions Testing (*Diataxis: How-to Guide* - Code action workflows)
 

--- a/docs/reference/LSP_FEATURES_OVERVIEW.md
+++ b/docs/reference/LSP_FEATURES_OVERVIEW.md
@@ -97,8 +97,8 @@ first to validate the rename and get the default placeholder text.
 
 | Feature | ID | Notes |
 |---|---|---|
-| Document formatting | `lsp.formatting` | Delegates to Perl::Tidy |
-| Range formatting | `lsp.range_formatting` | Single range |
+| Document formatting | `lsp.formatting` | Native formatter by default; Perl::Tidy compatibility is explicit opt-in |
+| Range formatting | `lsp.range_formatting` | Native single-range edits |
 | Multi-range formatting | `lsp.ranges_formatting` | `textDocument/rangesFormatting` (@proposed) |
 | On-type formatting | `lsp.on_type_formatting` | Auto-indent on `{`, `}`, `;` |
 | Format on save | `lsp.will_save_wait_until` | Via willSaveWaitUntil |

--- a/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
+++ b/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
@@ -1969,9 +1969,9 @@ The Perl LSP server has achieved **100% user-visible coverage (53/53)** and **10
 | `textDocument/documentSymbol` | ✅ Complete | <80ms | Comprehensive symbol tree |
 | `workspace/symbol` | ✅ Complete | <100ms | Workspace-wide indexing |
 | `textDocument/rename` | ✅ Complete | <200ms | Cross-file workspace refactoring |
-| `textDocument/formatting` | ✅ Complete | <2s | Perltidy integration with fallback |
+| `textDocument/formatting` | ✅ Complete | <2s | Native formatter with explicit Perltidy compatibility |
 | `textDocument/codeAction` | ✅ Complete | <50ms | **NEW**: Advanced refactoring operations |
-| `workspace/executeCommand` | ✅ Complete | <2s | **NEW**: perl.runCritic with dual analyzer |
+| `workspace/executeCommand` | ✅ Complete | <2s | **NEW**: perl.runCritic with native critic and legacy compatibility |
 | `textDocument/publishDiagnostics` | ✅ Complete | <100ms | Integrated with executeCommand workflow |
 | `textDocument/semanticTokens` | ✅ Complete | <15ms | Thread-safe with 2.826µs average |
 
@@ -2004,7 +2004,7 @@ The Perl LSP server has achieved **100% user-visible coverage (53/53)** and **10
 | `perl.runFile` | ✅ Complete | Native | <2s | Execution with output capture |
 | `perl.runTestSub` | ✅ Complete | Native | <2s | Subroutine isolation |
 | `perl.debugTests` | ✅ Complete | Native | <1s | Debug adapter preparation |
-| `perl.runCritic` | ✅ Complete | Dual strategy | <2s | External perlcritic + built-in fallback |
+| `perl.runCritic` | ✅ Complete | Native + compatibility | <2s | Native critic with explicit Perl::Critic compatibility |
 
 ### Code Action Categories (*Diataxis: Reference* - Refactoring capabilities)
 | Category | Operations | Status | Performance | Cross-file Support |
@@ -5188,21 +5188,25 @@ them to perltidy command-line arguments:
 - `insertSpaces: true` → `-et=4 -i=4` (expand tabs, indent size)
 - `insertSpaces: false` → `-dt -i=4` (use tabs, tab size)
 
-**Configuration File**: `.perltidyrc` files are automatically detected and applied:
-- Workspace-specific configuration takes precedence
-- Falls back to user home directory configuration
-- Uses built-in defaults when no configuration found
+**Configuration File**: Native formatting uses perl-lsp formatting settings by
+default. `.perltidyrc` files are compatibility inputs for explicit external
+Perltidy mode and for compatibility reporting:
+- Workspace-specific compatibility configuration takes precedence
+- Falls back to user home directory compatibility configuration
+- Uses native defaults when no compatibility configuration is selected
 
 ### Performance Characteristics (*Diataxis: Reference*)
 
 **Formatting Speed**: 
-- Small files (< 1KB): < 100ms including perltidy startup
+- Small files (< 1KB): < 100ms on the native path
 - Medium files (1-10KB): 100-500ms  
 - Large files (> 10KB): Proportional to content size
 
-**Memory Usage**: Minimal overhead beyond perltidy process execution
+**Memory Usage**: Minimal overhead on the native path; external compatibility
+mode adds the subprocess overhead of the selected adapter
 
-**Error Recovery**: Fast fallback with immediate user feedback for missing tools
+**Error Recovery**: Native formatting reports unsupported or preserved syntax
+directly; explicit external compatibility mode reports missing-tool guidance
 
 ## Agent-Driven Feature Development
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -233,7 +233,7 @@ perllsp provides:
 | **Definition** | Jump to where symbols are defined |
 | **References** | Find all uses of a symbol |
 | **Rename** | Safely rename variables across files |
-| **Formatting** | Format code with Perl::Tidy |
+| **Formatting** | Format code with the native formatter |
 | **Folding** | Collapse functions, blocks, POD |
 | **Symbols** | Document outline and workspace search |
 


### PR DESCRIPTION
## Summary
- update feature-selection and feature overview docs so formatting is described as native-first, not Perltidy-gated
- refresh getting-started, command, architecture, and LSP implementation references to frame Perltidy/Perl::Critic as explicit compatibility adapters
- leave the larger execute-command configuration guide rewrite for a separate focused docs pass

## Proof packet

Changed surfaces:
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed locally

- [x] cargo xtask check-devex-docs
  - why: guards contributor and command-doc drift
  - evidence: command passed locally

- [x] cargo xtask native-tooling check-defaults
  - why: verifies docs still align with native formatter/critic defaults and explicit legacy adapters
  - evidence: command passed locally

- [x] cargo xtask check-memory-lifecycle-policy
  - why: standard retained-state policy proof
  - evidence: command passed locally

- [x] cargo xtask check-memory-retained-owner-drift --base origin/master
  - why: confirms this docs-only branch did not introduce retained-owner drift
  - evidence: command passed locally

- [x] cargo xtask devex pr-body --base origin/master
  - why: generated the local proof packet routing
  - evidence: command passed locally

- [x] cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json
  - why: emitted the structured local proof receipt
  - evidence: command passed locally

- [x] git diff --check
  - why: guards final patch whitespace
  - evidence: command exits cleanly

## Notes
This is docs-only. It does not change formatter, critic, runtime config, CI behavior, parser behavior, or native-tooling policy.
