### PR TITLE
docs(tooling): update execute command native critic guide (#8436)

### DIFF
--- a/docs/explanation/EXECUTE_COMMAND_CONFIGURATION_GUIDE.md
+++ b/docs/explanation/EXECUTE_COMMAND_CONFIGURATION_GUIDE.md
@@ -1,505 +1,458 @@
 # ExecuteCommand Configuration and Troubleshooting Guide (*Diataxis: How-to Guide* - Problem-oriented executeCommand solutions)
 
-*Comprehensive guide for configuring, troubleshooting, and optimizing executeCommand functionality in Perl LSP server. This guide provides solutions for common problems and advanced configuration scenarios.*
+*Practical guidance for configuring, troubleshooting, and validating `workspace/executeCommand` operations in perl-lsp.*
 
 ## Overview
 
-This guide addresses specific problems you may encounter when using executeCommand functionality (Issue #145) in production environments. Each section provides step-by-step solutions for real-world challenges.
+`workspace/executeCommand` exposes server-side commands such as `perl.runTests`,
+`perl.runFile`, `perl.runTestSub`, `perl.debugTests`, and `perl.runCritic`.
+`perl.runCritic` now uses the native critic path by default. The native path
+shares perl-lsp parser, semantic, diagnostic, suppression, severity, code-action,
+and receipt surfaces with normal editor diagnostics.
+
+External `perlcritic` remains available only as an explicit compatibility
+adapter for migration, comparison, or custom policy stacks that are not native
+yet. You do not need to install `perlcritic` for the default native critic
+workflow.
 
 ## Configuration Problems and Solutions
 
-### Problem: Setting Up External Perlcritic
+### Problem: Selecting the Critic Engine
 
-**Scenario**: You want to use external perlcritic for enhanced policy coverage but encounter installation or path issues.
+**Scenario**: You want to confirm whether `perl.runCritic` uses the native critic
+or the explicit legacy adapter.
 
 **Solution Steps**:
 
-1. **Install perlcritic using your system package manager**:
+1. **Use the native engine for normal development**:
+
+```toml
+[critic]
+engine = "native"
+profile = "recommended"
+```
+
+2. **Select explicit external compatibility only when needed**:
+
+```toml
+[critic]
+engine = "legacy"
+```
+
+3. **Verify the native default policy guard**:
+
+```bash
+cargo xtask native-tooling check-defaults
+```
+
+This check confirms native critic defaults do not silently shell out to
+`perlcritic`.
+
+### Problem: Configuring Native Critic Rules
+
+**Scenario**: You want to tune which native critic rules run and how findings are
+reported.
+
+**Solution Steps**:
+
+1. **Set a profile and severity floor**:
+
+```toml
+[critic]
+engine = "native"
+profile = "recommended"
+
+[diagnostics]
+perlcritic = true
+perlcritic_severity = 3
+```
+
+2. **Use profiles for normal rule selection**:
+
+```toml
+[critic]
+engine = "native"
+profile = "recommended" # or "strict"
+```
+
+3. **Use compatibility reports for existing include/exclude lists**:
+
+```bash
+cargo xtask native-tooling perlcritic-compat \
+  --profile .perlcriticrc \
+  --receipt target/receipts/native-tooling/perlcritic-compat.json \
+  --summary target/receipts/native-tooling/perlcritic-compat.md
+```
+
+4. **Suppress intentional findings inline**:
+
+```perl
+## no perl-lsp-critic native.variables.unused_lexical -- kept for API parity
+my $unused;
+```
+
+Native suppressions are structured: they preserve the rule ID, scope, line, and
+optional reason so diagnostics, code actions, and receipts agree.
+
+### Problem: Understanding `.perlcriticrc` Compatibility
+
+**Scenario**: You already have a `.perlcriticrc` and need to know what the native
+critic can cover.
+
+**Solution Steps**:
+
+1. **Generate a compatibility receipt**:
+
+```bash
+cargo xtask native-tooling perlcritic-compat \
+  --profile .perlcriticrc \
+  --receipt target/receipts/native-tooling/perlcritic-compat.json \
+  --summary target/receipts/native-tooling/perlcritic-compat.md
+```
+
+2. **Review classifications**:
+
+- `native-equivalent` - native rule covers the Perl::Critic policy directly
+- `native-superset` - native rule covers the policy and adds parser/LSP context
+- `approximated` - native behavior is close but not identical
+- `unsupported-safe` - unsupported policy has no required runtime effect
+- `external-only` - keep explicit legacy compatibility for this policy
+
+3. **Check dashboard status**:
+
+```bash
+cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md
+```
+
+The dashboard rolls formatter, critic, and compatibility receipt counts into a
+single status surface.
+
+### Problem: Performance Optimization
+
+**Scenario**: `perl.runCritic` is slow for large files or causes editor timeouts.
+
+**Solution Steps**:
+
+1. **Prefer native critic for editor workflows**:
+
+```bash
+cargo xtask native-tooling check-defaults
+```
+
+The native path avoids process startup and parser-output translation overhead
+from the legacy adapter.
+
+2. **Use focused runtime tests for diagnostics behavior**:
+
+```bash
+cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture
+cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture
+```
+
+3. **Use fewer rules for large or noisy projects**:
+
+```toml
+[critic]
+engine = "native"
+profile = "recommended"
+
+[diagnostics]
+perlcritic_severity = 4
+```
+
+4. **Keep legacy compatibility out of the editor hot path**:
+
+Use `engine = "legacy"` only for migration checks, custom Perl::Critic
+policy stacks, or parity investigations.
+
+## Troubleshooting Common Issues
+
+### Problem: `perlcritic` Is Missing
+
+**Scenario**: You selected external legacy compatibility and the command fails
+because `perlcritic` is not available.
+
+**Diagnostic Steps**:
+
+```bash
+which perlcritic || echo "perlcritic not found in PATH"
+perlcritic --version
+env PATH="$PATH" which perlcritic
+```
+
+**Solutions**:
+
+- Prefer native critic by removing the explicit external legacy setting.
+- Install `perlcritic` only if you intentionally need compatibility mode.
+- Ensure the editor process inherits the same `PATH` that can find `perlcritic`.
+
+Example compatibility install commands:
+
 ```bash
 # Ubuntu/Debian
 sudo apt-get update
 sudo apt-get install perlcritic
 
-# CentOS/RHEL/Fedora
-sudo dnf install perl-Perl-Critic  # or sudo yum install perl-Perl-Critic
-
 # macOS with Homebrew
 brew install perl-critic
 
-# Arch Linux
-sudo pacman -S perl-critic
-```
-
-2. **Alternative: Install via CPAN**:
-```bash
-# Install via CPAN (works on all platforms)
+# CPAN
 cpan Perl::Critic
-
-# Or using cpanminus
-cpanm Perl::Critic
-
-# For system-wide installation
-sudo cpan Perl::Critic
 ```
 
-3. **Verify installation and PATH**:
-```bash
-# Check installation
-which perlcritic
-perlcritic --version
+### Problem: Analysis Results Are Missing or Incomplete
 
-# Test on sample file
-echo 'print "hello"' > /tmp/test.pl
-perlcritic /tmp/test.pl
-rm /tmp/test.pl
-```
-
-4. **Configure PATH if needed**:
-```bash
-# Find perlcritic location
-find /usr -name perlcritic 2>/dev/null
-find /opt -name perlcritic 2>/dev/null
-find $HOME -name perlcritic 2>/dev/null
-
-# Add to PATH in your shell profile
-echo 'export PATH="/usr/local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
-source ~/.bashrc
-```
-
-5. **Test LSP integration**:
-```bash
-# Verify LSP server can find perlcritic
-cargo test -p perl-parser --test execute_command_tests -- test_command_exists_behavior
-```
-
-### Problem: Configuring Perlcritic Policies
-
-**Scenario**: You want to customize which policies perlcritic checks and their severity levels.
-
-**Solution Steps**:
-
-1. **Create a .perlcriticrc configuration file**:
-```bash
-# Create in your project root or home directory
-cat > ~/.perlcriticrc << 'EOF'
-# Perlcritic configuration for LSP integration
-severity = 3
-theme = core
-verbose = %f:%l:%c: %m. %e. (%p)\n
-
-# Enable/disable specific policies
-[BuiltinFunctions::ProhibitVoidGrep]
-severity = 5
-
-[InputOutput::RequireCheckedSyscalls]
-functions = :builtins
-
-[Variables::ProhibitPunctuationVars]
-severity = 4
-EOF
-```
-
-2. **Test configuration**:
-```bash
-# Test perlcritic with custom config
-perlcritic --profile ~/.perlcriticrc /path/to/test.pl
-
-# Verify different severity levels
-perlcritic --severity 1 /path/to/test.pl  # Show all
-perlcritic --severity 5 /path/to/test.pl  # Show only brutal
-```
-
-3. **Project-specific configuration**:
-```bash
-# Create project-specific .perlcriticrc
-cat > .perlcriticrc << 'EOF'
-# Project-specific perlcritic settings
-severity = 2
-theme = bugs + maintenance + complexity
-
-# Disable specific policies for this project
-[-Subroutines::ProhibitExplicitReturnUndef]
-[-InputOutput::RequireBriefOpen]
-EOF
-```
-
-4. **Validate LSP integration with custom config**:
-```bash
-# Test that LSP server respects configuration
-cargo test -p perl-lsp-rs --test lsp_execute_command_tests -- test_perlcritic_dual_analyzer
-```
-
-### Problem: Performance Optimization
-
-**Scenario**: perl.runCritic is too slow for large files or causes LSP timeouts.
-
-**Solution Steps**:
-
-1. **Identify performance bottlenecks**:
-```bash
-# Test file size impact
-ls -lh your_large_file.pl
-wc -l your_large_file.pl
-
-# Time external perlcritic directly
-time perlcritic your_large_file.pl
-
-# Compare with built-in analyzer
-cargo test -p perl-parser --test execute_command_tests -- test_run_builtin_critic_with_valid_file
-```
-
-2. **Optimize perlcritic configuration for speed**:
-```bash
-cat > .perlcriticrc << 'EOF'
-# Performance-optimized configuration
-severity = 4          # Check only important and brutal issues
-theme = core          # Focus on core policies
-verbose = %f:%l:%c: %m\n  # Minimal output format
-
-# Disable slow policies
-[-Documentation::RequirePodSections]
-[-Miscellanea::RequireRcsKeywords]
-[-BuiltinFunctions::ProhibitComplexMappings]
-EOF
-```
-
-3. **Use built-in analyzer for large files**:
-```bash
-# Built-in analyzer is optimized for speed
-# Test performance characteristics
-cargo test -p perl-parser --test execute_command_tests -- test_run_builtin_critic_arithmetic_mutations
-
-# Validate <300ms performance target for files <100KB
-cargo test -p perl-lsp-rs --test lsp_performance_tests -- test_execute_command_latency
-```
-
-4. **Configure LSP timeouts**:
-```bash
-# Test with extended timeouts for large files
-LSP_TEST_TIMEOUT_MS=10000 cargo test -p perl-lsp-rs --test lsp_execute_command_tests
-
-# Use adaptive threading for better performance
-RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs -- --test-threads=2
-```
-
-## Troubleshooting Common Issues
-
-### Problem: "perlcritic not found" Error
-
-**Scenario**: LSP server always uses built-in analyzer despite perlcritic being installed.
+**Scenario**: `perl.runCritic` returns no findings for code where you expected a
+diagnostic.
 
 **Diagnostic Steps**:
 
-1. **Verify perlcritic in PATH**:
+1. **Check the source parses cleanly enough for native analysis**:
+
 ```bash
-# Check current PATH
-echo $PATH
-
-# Test perlcritic accessibility
-which perlcritic || echo "perlcritic not found in PATH"
-
-# Test from same environment as LSP server
-env PATH="$PATH" which perlcritic
-```
-
-2. **Check LSP server environment**:
-```bash
-# Start LSP server with environment logging
-env PATH="$PATH" perllsp --stdio --log
-
-# Test command detection logic
-cargo test -p perl-parser --test execute_command_tests -- test_command_exists_behavior
-```
-
-3. **Debug command existence check**:
-```bash
-# Test the exact command existence logic
-echo '#!/bin/bash
-command -v perlcritic && echo "Found via command -v"
-which perlcritic && echo "Found via which"
-type perlcritic && echo "Found via type"' > /tmp/debug_perlcritic.sh
-chmod +x /tmp/debug_perlcritic.sh
-/tmp/debug_perlcritic.sh
-```
-
-**Solutions**:
-
-- **Fix PATH**: Ensure perlcritic location is in PATH before starting LSP server
-- **Symlink**: Create symlink in standard location: `sudo ln -s /full/path/to/perlcritic /usr/local/bin/`
-- **Use built-in**: Built-in analyzer provides reliable alternative with core policies
-
-### Problem: Analysis Results Missing or Incomplete
-
-**Scenario**: perl.runCritic returns no violations for file with obvious issues.
-
-**Diagnostic Steps**:
-
-1. **Test file syntax**:
-```bash
-# Check if file has syntax errors
 perl -c your_file.pl
-
-# Test with minimal example
-echo '#!/usr/bin/perl
-my $var = 42;
-print $var;' > /tmp/test_minimal.pl
-
-# Run analysis on minimal file
-cargo test -p perl-parser --test execute_command_tests -- test_execute_command_run_critic_builtin
 ```
 
-2. **Verify policy configuration**:
-```bash
-# Test with default configuration
-perlcritic --noprofile /tmp/test_minimal.pl
+2. **Confirm the active critic profile and filters**:
 
-# Check current configuration
-perlcritic --profile-strictness /tmp/test_minimal.pl
+```toml
+[critic]
+engine = "native"
+profile = "recommended"
 ```
 
-3. **Test built-in analyzer specifically**:
-```bash
-# Test built-in analyzer detection
-cargo test -p perl-parser --test execute_command_tests -- test_execute_command_run_critic_builtin
+3. **Check whether the rule is below the severity floor or outside the selected profile**:
 
-# Verify specific policy detection
-cargo test -p perl-parser --test execute_command_tests -- test_format_violation_structure
+```toml
+[critic]
+profile = "strict"
+
+[diagnostics]
+perlcritic_severity = 1
+```
+
+4. **Run focused diagnostics tests when changing the implementation**:
+
+```bash
+cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture
+cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture
 ```
 
 **Solutions**:
 
-- **Fix syntax errors**: Address Perl syntax issues before running analysis
-- **Adjust severity**: Lower perlcritic severity threshold to show more issues
-- **Check configuration**: Ensure .perlcriticrc doesn't disable relevant policies
+- Fix syntax errors before analysis.
+- Lower the severity floor if you intentionally want lower-severity findings.
+- Remove accidental excludes.
+- Generate a compatibility report if you expected a Perl::Critic policy that has
+  not been mapped to a native rule yet.
+
+### Problem: Suppressions Do Not Apply
+
+**Scenario**: A native critic diagnostic remains visible after adding a
+suppression comment.
+
+**Diagnostic Steps**:
+
+1. **Use the native rule ID exactly**:
+
+```perl
+## no critic native.security.two_arg_open -- legacy open form is deliberate
+open(FH, $path);
+```
+
+or:
+
+```perl
+## no perl-lsp-critic native.security.two_arg_open -- migration shim
+open(FH, $path);
+```
+
+2. **Verify the suppression is in the intended scope**:
+
+Line-local suppressions apply to nearby findings; file- or block-wide behavior
+depends on the suppression form supported by the rule path.
+
+3. **Run focused suppression tests when changing rule behavior**:
+
+```bash
+cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture
+```
+
+**Solutions**:
+
+- Use the stable native rule ID from the diagnostic.
+- Keep suppression comments close to the relevant code.
+- Include a reason so future triage can distinguish intentional debt from a
+  stale suppression.
 
 ### Problem: LSP Client Integration Issues
 
-**Scenario**: executeCommand doesn't appear in your editor or returns errors.
+**Scenario**: `workspace/executeCommand` does not appear in your editor or
+returns errors.
 
 **Diagnostic Steps**:
 
 1. **Verify server capabilities**:
-```bash
-# Test capability advertisement
-cargo test -p perl-lsp-rs --test lsp_behavioral_tests -- test_execute_command_capabilities
 
-# Manual LSP protocol test
-echo -e 'Content-Length: 58\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | perllsp --stdio
+```bash
+cargo test -p perl-lsp-rs --test lsp_behavioral_tests -- test_execute_command_capabilities
 ```
 
 2. **Test JSON-RPC protocol directly**:
+
 ```bash
-# Create test request
 cat > /tmp/test_request.json << 'EOF'
 Content-Length: 140
 
 {"jsonrpc":"2.0","id":1,"method":"workspace/executeCommand","params":{"command":"perl.runCritic","arguments":["/tmp/test.pl"]}}
 EOF
 
-# Test with LSP server
 perllsp --stdio < /tmp/test_request.json
 ```
 
 3. **Check editor-specific integration**:
 
-**VSCode**:
-- Verify Perl extension is installed and enabled
-- Check Output panel for LSP errors
-- Restart LSP server via Command Palette
+**VS Code**:
+
+- Verify the Perl extension is installed and enabled.
+- Check the Output panel for LSP errors.
+- Restart the LSP server from the Command Palette.
 
 **Neovim**:
-```lua
--- Debug LSP client status
-:lua print(vim.inspect(vim.lsp.get_active_clients()))
 
--- Test command execution directly
+```lua
+:lua print(vim.inspect(vim.lsp.get_active_clients()))
 :lua vim.lsp.buf.execute_command({command="perl.runCritic", arguments={vim.fn.expand("%:p")}})
 ```
 
 **Emacs**:
-```elisp
-;; Check LSP server status
-(lsp-describe-session)
 
-;; Test command execution
+```elisp
+(lsp-describe-session)
 (lsp-execute-command "perl.runCritic" (list (buffer-file-name)))
 ```
 
 ### Problem: Permission and Security Issues
 
-**Scenario**: executeCommand fails due to file permissions or security restrictions.
+**Scenario**: `executeCommand` fails due to file permissions or path security
+restrictions.
 
 **Diagnostic Steps**:
 
-1. **Check file permissions**:
 ```bash
-# Verify file is readable
 ls -la your_file.pl
-
-# Test file access
 cat your_file.pl > /dev/null && echo "File readable" || echo "File not readable"
-```
-
-2. **Test with known-good file**:
-```bash
-# Create test file with proper permissions
-echo '#!/usr/bin/perl
-use strict;
-use warnings;
-print "hello world\n";' > /tmp/test_permissions.pl
-chmod 644 /tmp/test_permissions.pl
-
-# Test analysis
-cargo test -p perl-parser --test execute_command_tests -- test_execute_command_run_critic_builtin
-```
-
-3. **Validate path normalization**:
-```bash
-# Test URI path handling
-cargo test -p perl-parser --test execute_command_tests -- test_normalize_file_path_uri_handling
-
-# Test path traversal prevention
 cargo test -p perl-parser --test file_completion_tests -- basic_security_test_rejects_path_traversal
 ```
 
 **Solutions**:
 
-- **Fix permissions**: `chmod 644 your_file.pl`
-- **Use absolute paths**: Avoid relative paths that might resolve incorrectly
-- **Verify workspace security**: Ensure LSP server has access to project directories
+- Fix permissions with `chmod 644 your_file.pl`.
+- Use absolute paths when testing direct command calls.
+- Verify the LSP server has workspace access to the target project.
 
 ## Advanced Configuration Scenarios
 
 ### Scenario: CI/CD Integration
 
-**Problem**: Need to run perl.runCritic in automated CI/CD pipelines.
+**Problem**: You want automated quality analysis that matches editor behavior.
 
 **Solution**:
 
-1. **Docker container setup**:
-```dockerfile
-# Dockerfile for Perl LSP with perlcritic
-FROM rust:latest
-RUN apt-get update && apt-get install -y perlcritic perl
-COPY . /workspace
-WORKDIR /workspace
-RUN cargo build --release -p perl-lsp-rs
-CMD ["./target/release/perllsp", "--stdio"]
-```
+1. **Use native critic proof commands in CI**:
 
-2. **GitHub Actions integration**:
 ```yaml
-name: Perl Quality Analysis
+name: Perl Native Critic
 on: [push, pull_request]
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - name: Install perlcritic
-      run: sudo apt-get install -y perlcritic
-    - name: Test executeCommand
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Native critic diagnostics
       run: |
-        RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --test lsp_execute_command_tests -- --test-threads=2
+        cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture
+        cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture
 ```
 
-3. **Jenkins pipeline**:
-```groovy
-pipeline {
-    agent any
-    stages {
-        stage('Setup') {
-            steps {
-                sh 'apt-get update && apt-get install -y perlcritic'
-            }
-        }
-        stage('Analyze') {
-            steps {
-                sh 'cargo test -p perl-lsp-rs --test lsp_execute_command_tests'
-            }
-        }
-    }
-}
+2. **Attach compatibility receipts for migration PRs**:
+
+```bash
+cargo xtask native-tooling perlcritic-compat \
+  --profile .perlcriticrc \
+  --receipt target/receipts/native-tooling/perlcritic-compat.json \
+  --summary target/receipts/native-tooling/perlcritic-compat.md
 ```
+
+3. **Use external compatibility only for parity checks**:
+
+Install `perlcritic` in CI only when a job intentionally exercises the legacy
+adapter or compares native coverage against a `.perlcriticrc`.
 
 ### Scenario: Multiple Project Configuration
 
-**Problem**: Different projects need different perlcritic configurations.
+**Problem**: Different projects need different critic policies.
 
 **Solution**:
 
-1. **Project-specific .perlcriticrc files**:
-```bash
-# Legacy project - lenient settings
-cat > legacy_project/.perlcriticrc << 'EOF'
-severity = 4
-theme = core
-[-Subroutines::RequireExplicitReturnUndef]
-[-Variables::ProhibitPunctuationVars]
-EOF
+1. **Project-specific native profiles**:
 
-# New project - strict settings
-cat > new_project/.perlcriticrc << 'EOF'
-severity = 2
-theme = core + bugs + maintenance
-verbose = %f:%l:%c: [%p] %m\n
-EOF
+```toml
+# legacy_project/.perl-lsp.toml
+[critic]
+engine = "native"
+profile = "recommended"
+
+[diagnostics]
+perlcritic_severity = 4
+
+# new_project/.perl-lsp.toml
+[critic]
+engine = "native"
+profile = "strict"
+
+[diagnostics]
+perlcritic_severity = 2
 ```
 
-2. **Environment-based configuration**:
+2. **Migration compatibility receipts**:
+
 ```bash
-# Development environment
-export PERLCRITIC_PROFILE="$HOME/.perlcriticrc.dev"
-
-# Production environment
-export PERLCRITIC_PROFILE="$HOME/.perlcriticrc.prod"
-
-# Test configuration switching
-perlcritic --profile "$PERLCRITIC_PROFILE" test_file.pl
+cargo xtask native-tooling perlcritic-compat \
+  --profile legacy_project/.perlcriticrc \
+  --receipt target/receipts/native-tooling/legacy-perlcritic-compat.json \
+  --summary target/receipts/native-tooling/legacy-perlcritic-compat.md
 ```
 
-### Scenario: Custom Policy Integration
+### Scenario: Custom Perl::Critic Policy Integration
 
-**Problem**: Need to integrate custom Perl::Critic policies with executeCommand.
+**Problem**: You still depend on custom Perl::Critic policies.
 
 **Solution**:
 
-1. **Install custom policies**:
-```bash
-# Install custom policy modules
-cpanm Perl::Critic::Policy::Custom::MyPolicy
+1. **Keep custom policies in explicit external legacy mode**:
 
-# Verify installation
-perl -MPerl::Critic::Policy::Custom::MyPolicy -e 'print "Custom policy loaded\n"'
+```toml
+[critic]
+engine = "legacy"
 ```
 
-2. **Configure custom policies**:
-```bash
-cat > .perlcriticrc << 'EOF'
-# Custom policy configuration
-[Custom::MyPolicy]
-severity = 3
-enabled = 1
-custom_option = value
+2. **Document the gap in the compatibility report**:
 
-# Built-in policies
-severity = 3
-theme = core + custom
-EOF
+```bash
+cargo xtask native-tooling perlcritic-compat \
+  --profile .perlcriticrc \
+  --receipt target/receipts/native-tooling/perlcritic-compat.json \
+  --summary target/receipts/native-tooling/perlcritic-compat.md
 ```
 
-3. **Test integration**:
-```bash
-# Test custom policies
-perlcritic --profile .perlcriticrc test_file.pl
+3. **Promote high-value custom policies into native rules deliberately**:
 
-# Validate LSP integration
-cargo test -p perl-lsp-rs --test lsp_execute_command_tests -- test_perlcritic_dual_analyzer
-```
+New native rules should have stable rule IDs, precise spans, suppression tests,
+severity/config coverage, diagnostics coverage, and code-action coverage when a
+fix is safe.
 
 ## Monitoring and Maintenance
 
@@ -507,78 +460,40 @@ cargo test -p perl-lsp-rs --test lsp_execute_command_tests -- test_perlcritic_du
 
 **Set up performance monitoring**:
 
-1. **Enable performance metrics**:
 ```bash
-# Test performance benchmarks
 cargo test -p perl-lsp-rs --test lsp_performance_tests -- test_execute_command_latency
-
-# Monitor memory usage
-cargo test -p perl-parser --test execute_command_tests -- test_run_builtin_critic_arithmetic_mutations
-```
-
-2. **Log analysis timing**:
-```bash
-# Enable detailed logging
-RUST_LOG=debug cargo test -p perl-lsp-rs --test lsp_execute_command_tests -- --nocapture
-
-# Monitor specific timing thresholds
-LSP_TEST_TIMEOUT_MS=20000 cargo test -p perl-lsp-rs
+RUST_LOG=debug cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture
 ```
 
 ### Health Checks
 
 **Regular validation procedures**:
 
-1. **Automated health check script**:
 ```bash
 #!/bin/bash
-# health_check_executecommand.sh
+set -euo pipefail
 
-echo "Testing executeCommand health..."
+echo "Testing executeCommand and native critic health..."
 
-# Test 1: Basic functionality
-if cargo test -p perl-parser --test execute_command_tests --quiet; then
-    echo "✅ Basic executeCommand: PASS"
-else
-    echo "❌ Basic executeCommand: FAIL"
-    exit 1
-fi
+cargo xtask native-tooling check-defaults
+cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture
+cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture
+cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture
 
-# Test 2: Performance validation
-if cargo test -p perl-lsp-rs --test lsp_performance_tests --quiet; then
-    echo "✅ Performance validation: PASS"
-else
-    echo "❌ Performance validation: FAIL"
-    exit 1
-fi
-
-# Test 3: Integration tests
-if RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --test lsp_execute_command_tests --quiet; then
-    echo "✅ Integration tests: PASS"
-else
-    echo "❌ Integration tests: FAIL"
-    exit 1
-fi
-
-echo "All executeCommand health checks passed!"
-```
-
-2. **Cron job for regular validation**:
-```bash
-# Add to crontab for daily validation
-0 2 * * * /path/to/health_check_executecommand.sh >> /var/log/perl_lsp_health.log 2>&1
+echo "Native executeCommand health checks passed."
 ```
 
 ## Summary
 
-This guide provides comprehensive solutions for:
+This guide covers:
 
-✅ **Installation and Configuration**: Setting up external perlcritic with custom policies
-✅ **Performance Optimization**: Tuning for large files and production environments
-✅ **Troubleshooting**: Diagnosing and fixing common issues
-✅ **Security**: Handling permissions and path validation
-✅ **CI/CD Integration**: Automated quality analysis in build pipelines
-✅ **Advanced Scenarios**: Multi-project and custom policy configurations
-✅ **Monitoring**: Health checks and performance validation
+- Native `perl.runCritic` configuration and profiles
+- Compatibility reporting for existing `.perlcriticrc` files
+- Explicit external `perlcritic` adapter troubleshooting
+- Suppressions, severity filters, and missing-result triage
+- CI patterns that match editor diagnostics
+- Maintenance checks for native tooling defaults
 
-The executeCommand functionality provides robust code quality analysis with comprehensive configuration options and reliability patterns.
+The default executeCommand critic path is native. External `perlcritic` is a
+compatibility adapter for migration and custom policy stacks, not an operational
+dependency for normal perl-lsp editing or CI proof.


### PR DESCRIPTION
## Summary
- rewrite the execute-command configuration guide around native `perl.runCritic` as the default path
- move external `perlcritic` guidance into explicit legacy compatibility, migration, and custom-policy scenarios
- refresh troubleshooting, CI, suppression, profile, and compatibility receipt examples to match the native critic/defaults model

## Proof packet

Changed surfaces:
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed locally

- [x] cargo xtask check-devex-docs
  - why: guards contributor and command-doc drift
  - evidence: command passed locally

- [x] cargo xtask native-tooling check-defaults
  - why: verifies docs still align with native formatter/critic defaults and explicit legacy adapters
  - evidence: command passed locally

- [x] cargo xtask check-memory-lifecycle-policy
  - why: standard retained-state policy proof
  - evidence: command passed locally

- [x] cargo xtask check-memory-retained-owner-drift --base origin/master
  - why: confirms this docs-only branch did not introduce retained-owner drift
  - evidence: command passed locally

- [x] cargo xtask devex pr-body --base origin/master
  - why: generated the local proof packet routing
  - evidence: command passed locally

- [x] cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json
  - why: emitted the structured local proof receipt
  - evidence: command passed locally

- [x] git diff --check
  - why: guards final patch whitespace
  - evidence: command exits cleanly

## Notes
This is docs-only. It does not change execute-command behavior, critic rules, formatter behavior, runtime config, CI behavior, parser behavior, or native-tooling policy.
