### PR TITLE
fix(lexer): parse split adjacent single-quote strings (#6487)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1706,6 +1706,15 @@ impl<'a> PerlLexer<'a> {
     }
 
     #[inline]
+    fn apostrophe_starts_legacy_package_segment(&self, position: usize) -> bool {
+        let next_position = position + '\''.len_utf8();
+        self.input
+            .get(next_position..)
+            .and_then(|suffix| suffix.chars().next())
+            .is_some_and(is_perl_identifier_start)
+    }
+
+    #[inline]
     fn try_identifier_or_keyword(&mut self) -> Option<Token> {
         let start = self.position;
         let ch = self.current_char()?;
@@ -1744,12 +1753,19 @@ impl<'a> PerlLexer<'a> {
             // Fast ASCII path for identifier continuation.
             while self.position < len {
                 let byte = bytes[self.position];
-                if byte == b'\'' && is_quote_op_word_prefix(&bytes[start..self.position]) {
-                    // Keep apostrophe for quote-operator parsing in cases like q'...'.
-                    break;
+                if byte == b'\'' {
+                    if is_quote_op_word_prefix(&bytes[start..self.position])
+                        || !self.apostrophe_starts_legacy_package_segment(self.position)
+                    {
+                        // Keep apostrophe for quote/string parsing in cases like q'...'
+                        // and split' ', while still accepting Foo'Bar package spelling.
+                        break;
+                    }
+                    self.position += 1;
+                    continue;
                 }
 
-                if byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'\'' {
+                if byte.is_ascii_alphanumeric() || byte == b'_' {
                     self.position += 1;
                     continue;
                 }
@@ -1784,7 +1800,15 @@ impl<'a> PerlLexer<'a> {
                 self.advance();
                 while self.position < len {
                     let byte = bytes[self.position];
-                    if byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'\'' {
+                    if byte == b'\'' {
+                        if !self.apostrophe_starts_legacy_package_segment(self.position) {
+                            break;
+                        }
+                        self.position += 1;
+                        continue;
+                    }
+
+                    if byte.is_ascii_alphanumeric() || byte == b'_' {
                         self.position += 1;
                         continue;
                     }

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -51,6 +51,42 @@ fn assert_terminates(input: &str) {
     );
 }
 
+#[test]
+fn split_adjacent_single_quote_pattern_keeps_quote_for_string() -> R {
+    let sig = significant("@names = split' ', $val;");
+
+    let split = sig.iter().find(|token| token.text.as_ref() == "split").ok_or("missing split")?;
+    assert!(
+        matches!(&split.token_type, TokenType::Keyword(keyword) if keyword.as_ref() == "split"),
+        "split should remain a keyword, got {:?}",
+        split.token_type
+    );
+    assert!(
+        sig.iter().any(|token| matches!(token.token_type, TokenType::StringLiteral)
+            && token.text.as_ref() == "' '"),
+        "adjacent single quote should start the split pattern string: {sig:?}"
+    );
+    assert!(
+        !sig.iter().any(|token| token.text.as_ref() == "split'"),
+        "apostrophe should not be consumed into split identifier: {sig:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn legacy_apostrophe_package_separator_stays_identifier() -> R {
+    let first = first_significant("Foo'Bar::baz").ok_or("missing identifier")?;
+    assert!(
+        matches!(&first.token_type, TokenType::Identifier(identifier) if identifier.as_ref() == "Foo'Bar::baz"),
+        "legacy package separator should remain one identifier, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), "Foo'Bar::baz");
+
+    Ok(())
+}
+
 // ===========================================================================
 // 1. Heredoc variants
 // ===========================================================================

--- a/crates/perl-parser-core/tests/fix_unexpected_rparen_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rparen_expr.rs
@@ -470,3 +470,8 @@ fn test_subst_double_quoted_replacement_no_delimiter() {
     // The quotes are treated as literal chars in the replacement
     assert_no_errors(r#"$x =~ s/old/"new_replacement"/;"#);
 }
+
+#[test]
+fn test_split_single_quote_string_without_space() {
+    assert_no_errors(r#"@names = split' ', $val;"#);
+}


### PR DESCRIPTION
Problem: Perl allows `split' ', $val`, but the lexer consumed the apostrophe into `split'` as a legacy package separator and produced parser recovery noise in Perl core samples.
Fix: Only treat apostrophe as an identifier continuation when it starts a legacy package segment such as `Foo'Bar`; otherwise leave it for quote/string parsing.
Verification: `cargo test -p perl-lexer --profile agent --locked -- --nocapture`, `cargo test -p perl-parser-core --test fix_unexpected_rparen_expr --profile agent --locked -- --nocapture`, parser accuracy/status/ratchet checks, semantic scorecard/shadow checks, `cargo check`, `cargo clippy`, `cargo xtask fmt --check`, and `git diff --check` passed. Sampled Perl core sweep dropped ERROR nodes from 17 to 15. Broad `cargo test -p perl-parser-core` still fails on the pre-existing `fix_subst_unusual_delimiters_2732` baseline, reproduced on clean `origin/master`.