### PR TITLE
docs(tooling): update lsp guide native critic examples (#8439)

### DIFF
--- a/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
+++ b/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
@@ -1685,7 +1685,7 @@ pub static SUPPORTED_COMMANDS: &[&str] = &[
     "perl.runFile",            // Execute single Perl file
     "perl.runTestSub",         // Execute specific test subroutine
     "perl.debugTests",         // Debug test execution
-    "perl.runCritic",          // ⭐ NEW: Perl::Critic analysis
+    "perl.runCritic",          // ⭐ NEW: Native critic analysis
 ];
 ```
 
@@ -1707,12 +1707,7 @@ impl ExecuteCommandProvider {
             return Ok(CriticResult::External(external_result));
         }
 
-        // Legacy fallback for compatibility command behavior.
-        let builtin_analyzer = BuiltInAnalyzer::new();
-        let ast = self.parser.parse_file(file_path)?;
-        let violations = builtin_analyzer.analyze(&ast, &file_content);
-
-        Ok(CriticResult::Builtin(violations))
+        Err("Legacy Perl::Critic compatibility requested but perlcritic is unavailable".into())
     }
 }
 ```
@@ -1723,7 +1718,7 @@ impl ExecuteCommandProvider {
 pub struct CriticCommandResult {
     pub success: bool,                    // Execution status
     pub violations: Vec<Violation>,       // Policy violations found
-    pub analyzer_used: String,            // "external" | "builtin"
+    pub analyzer_used: String,            // "native" | "legacy-perlcritic"
     pub execution_time: Duration,         // Performance metrics
     pub file_path: String,               // Analyzed file path
 }
@@ -1903,20 +1898,21 @@ impl RefactoringOperations {
 
 #### Error Handling and Tool Integration
 
-**Graceful Degradation Strategy**:
+**Native-first error handling**:
 ```rust
 // Robust error handling with user-friendly feedback
 impl ExecuteCommandProvider {
     fn handle_tool_unavailable_error(&self, command: &str, error: &str) -> JsonRpcError {
         match command {
             "perl.runCritic" => {
-                // Provide actionable error message with fallback information
+                // The default native critic path does not require perlcritic.
+                // Missing-tool guidance only applies to explicit legacy mode.
                 JsonRpcError::new(
                     -32603, // Internal error
-                    format!("Perlcritic unavailable, using built-in analyzer: {}", error),
+                    format!("Legacy Perl::Critic compatibility unavailable: {}", error),
                     Some(json!({
-                        "fallback_available": true,
-                        "suggestion": "Install perlcritic for enhanced analysis"
+                        "native_available": true,
+                        "suggestion": "Use the native critic engine or install perlcritic for explicit legacy compatibility"
                     }))
                 )
             },
@@ -1933,7 +1929,7 @@ impl ExecuteCommandProvider {
 # Comprehensive test suite for executeCommand and code actions
 cargo test -p perl-lsp-rs --test lsp_execute_command_tests        # Execute command protocol compliance
 cargo test -p perl-lsp-rs --test lsp_code_actions_tests          # Code action workflows
-cargo test -p perl-lsp-rs --test lsp_behavioral_tests -- test_execute_command_perlcritic  # End-to-end validation
+cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture  # Native critic validation
 
 # Performance validation with adaptive threading
 RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs -- --test-threads=2  # Optimized thread configuration

--- a/docs/tutorials/LSP_DEVELOPMENT_GUIDE.md
+++ b/docs/tutorials/LSP_DEVELOPMENT_GUIDE.md
@@ -731,11 +731,14 @@ impl ExecuteCommandProvider {
             Ok(external_result) => {
                 Ok(serde_json::to_value(CriticResult::External(external_result))?)
             },
-            Err(_) => {
-                // Legacy fallback for compatibility command behavior
-                let builtin_result = self.run_builtin_analyzer(&file_path)?;
-                Ok(serde_json::to_value(CriticResult::Builtin(builtin_result))?)
-            }
+            Err(error) => Err(JsonRpcError::new(
+                -32603,
+                format!("Legacy Perl::Critic compatibility unavailable: {error}"),
+                Some(json!({
+                    "native_available": true,
+                    "suggestion": "Use native critic or install perlcritic for explicit legacy compatibility"
+                }))
+            )),
         }
     }
 
@@ -751,13 +754,13 @@ impl ExecuteCommandProvider {
         self.parse_perlcritic_output(&output.stdout)
     }
 
-    fn run_builtin_analyzer(&self, file_path: &str) -> Result<Vec<Violation>, String> {
-        // Built-in analyzer using AST parsing
+    fn run_native_critic(&self, file_path: &str) -> Result<Vec<Violation>, String> {
+        // Native critic uses parser/semantic facts and stable native rule IDs.
         let content = std::fs::read_to_string(file_path)?;
         let ast = self.parser.parse(&content)?;
 
-        let analyzer = BuiltInCriticAnalyzer::new();
-        analyzer.analyze(&ast, &content)
+        let registry = NativeCriticRegistry::recommended();
+        registry.check(&CriticContext::new(&content, &ast, &self.critic_config))
     }
 }
 ```
@@ -772,10 +775,10 @@ impl ExecuteCommandProvider {
                 -32603, // Internal error
                 format!("Code analysis failed: {}", error),
                 Some(json!({
-                    "fallback_available": true,
-                    "suggestion": "Ensure perlcritic is installed or use built-in analyzer",
+                    "native_available": true,
+                    "suggestion": "Use native critic, or install perlcritic only for explicit legacy compatibility",
                     "command": command,
-                    "recovery_action": "install_perlcritic"
+                    "recovery_action": "select_native_or_install_legacy_perlcritic"
                 }))
             ),
             "perl.runTests" => JsonRpcError::new(
@@ -2181,7 +2184,7 @@ impl DiagnosticAnalyzer {
 
 #### Phase 6: Execute ⭐ **NEW: Issue #145** (*Diataxis: Reference* - Command execution)
 ```rust
-// Enhanced executeCommand with dual analyzer strategy
+// Enhanced executeCommand with native critic and explicit legacy compatibility
 pub struct ExecuteCommandProvider {
     parser: Arc<EnhancedParser>,
     workspace_index: Arc<WorkspaceIndexer>,
@@ -2195,18 +2198,12 @@ impl ExecuteCommandProvider {
             "perl.runCritic" => {
                 let file_path = self.extract_file_path(&arguments)?;
 
-                // Dual analyzer strategy: external perlcritic + built-in fallback
-                if self.command_exists("perlcritic") {
-                    match self.run_external_critic(file_path) {
-                        Ok(result) => return Ok(result),
-                        Err(_) => {
-                            // Seamless fallback to built-in analyzer
-                        }
-                    }
+                if self.critic_engine == CriticEngine::Native {
+                    return self.run_native_critic(file_path);
                 }
 
-                // Built-in analyzer provides 100% availability
-                self.run_builtin_critic(file_path)
+                // Explicit legacy compatibility path.
+                self.run_external_critic(file_path)
             },
             "perl.runTests" => self.execute_test_runner(&arguments),
             "perl.runFile" => self.execute_perl_file(&arguments),


### PR DESCRIPTION
## Summary
- update LSP implementation/development guide execute-command examples from the old external-plus-built-in critic model to native critic with explicit legacy compatibility
- replace missing-`perlcritic` recovery text with native-available / legacy-adapter guidance
- refresh the critic response-format comment to use `native` / `legacy-perlcritic`

## Proof packet

Changed surfaces:
- docs

Required proof:
- [x] cargo xtask fmt
  - why: keeps formatting deterministic before any other proof
  - evidence: command passed locally

- [x] cargo xtask check-devex-docs
  - why: guards contributor and command-doc drift
  - evidence: command passed locally

- [x] cargo xtask native-tooling check-defaults
  - why: verifies docs still align with native formatter/critic defaults and explicit legacy adapters
  - evidence: command passed locally

- [x] cargo xtask check-memory-lifecycle-policy
  - why: standard retained-state policy proof
  - evidence: command passed locally

- [x] cargo xtask check-memory-retained-owner-drift --base origin/master
  - why: confirms this docs-only branch did not introduce retained-owner drift
  - evidence: command passed locally

- [x] cargo xtask devex pr-body --base origin/master
  - why: generated the local proof packet routing
  - evidence: command passed locally

- [x] cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json
  - why: emitted the structured local proof receipt
  - evidence: command passed locally

- [x] git diff --check
  - why: guards final patch whitespace
  - evidence: command exits cleanly

## Notes
This is docs-only. It does not change execute-command behavior, critic rules, formatter behavior, runtime config, CI behavior, parser behavior, or native-tooling policy.
