### PR TITLE
docs(tooling): refresh native tooling readiness status (#8441)

### DIFF
--- a/docs/project/status/native_tooling_readiness.md
+++ b/docs/project/status/native_tooling_readiness.md
@@ -11,9 +11,9 @@
 | Area | Criterion | Status | Required | Evidence | Next |
 | --- | --- | --- | --- | --- | --- |
 | formatter | native formatter default | ready | true | engine=native, external_adapter_requested=false | regenerate `cargo xtask native-format config` and keep external adapter opt-in |
-| formatter | fixture suite passes | ready | true | passed=38/38 failed=0 | run `cargo xtask native-format check` and fix any fixture failures |
+| formatter | fixture suite passes | ready | true | passed=40/40 failed=0 | run `cargo xtask native-format check` and fix any fixture failures |
 | formatter | corpus idempotent and parse-preserving | ready | true | files=65 idempotence=65/65 parse_preservation=65/65 passed=true | run `cargo xtask native-format corpus` and investigate non-idempotent or non-preserved files |
-| formatter | dangerous surfaces visible | ready | true | expected_diagnostic_fixtures=8 literal_preserve_fixtures=8 bailout_count=8 | expand literal/comment preservation fixtures before treating format-on-save as broad coverage |
+| formatter | dangerous surfaces visible | ready | true | expected_diagnostic_fixtures=9 literal_preserve_fixtures=9 bailout_count=9 | expand literal/comment preservation fixtures before treating format-on-save as broad coverage |
 | formatter | perltidy compatibility has no external-only gaps | ready | true | options=8 supported=7 approximated=0 external_only=0 | map, approximate, or document remaining external-only perltidy options |
 | critic | native critic default | ready | true | default perlcritic_enabled=true critic_engine=Native profile=recommended | keep default critic path on the low-noise native recommended profile |
 | critic | native rule surface has LSP and bridge coverage | ready | true | rules=28 pull=28 push=28 workspace=28 bridge=28 | route every recommended rule through pull, push, workspace diagnostics, and violation bridge |


### PR DESCRIPTION
## Summary

Refresh the generated native tooling readiness snapshot so it matches the current formatter receipt evidence.

## What changed

- Update formatter fixture readiness evidence from `38/38` to `40/40`.
- Update dangerous-surface readiness evidence from `8` expected diagnostic / literal-preserve bailout fixtures to `9`.

## Proof packet

- `cargo xtask fmt`
- `cargo xtask native-format check`
- `cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md`
- `cargo xtask native-tooling readiness --markdown docs/project/status/native_tooling_readiness.md`
- `cargo xtask native-tooling check-defaults`
- `cargo xtask check-devex-docs`
- `just status-update`
- `just status-check`
- `cargo xtask devex pr-body --base origin/master`
- `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- `git diff --check`
