### PR TITLE
test(format): lock native range comment attachment (#8442)

### DIFF
--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -440,6 +440,21 @@ fn native_range_formatter_preserves_trailing_comment_on_selected_simple_statemen
 }
 
 #[test]
+fn native_range_formatter_keeps_neighboring_leading_comment_outside_selected_line() {
+    let formatter = NativeFormatter::new();
+    let source = "# applies to next declaration\nmy$x=1;\nmy$y=2;\n";
+    let range = TextRange::new(TextPosition::new(1, 0), TextPosition::new(1, 7));
+
+    let result = formatter.format_range(source, range, &FormatConfig::default());
+
+    assert!(result.changed);
+    assert_eq!(result.formatted, "# applies to next declaration\nmy $x = 1;\nmy$y=2;\n");
+    assert_eq!(result.edits.len(), 1);
+    assert_eq!(result.edits[0].range, range);
+    assert_eq!(result.edits[0].new_text, "my $x = 1;");
+}
+
+#[test]
 fn native_range_formatter_formats_selected_simple_lexical_declaration_list_line() {
     let formatter = NativeFormatter::new();
     let source = "my($x,$y)=($a,$b);\nmy$z=1;\n";

--- a/crates/perl-lsp-rs/tests/formatting_test.rs
+++ b/crates/perl-lsp-rs/tests/formatting_test.rs
@@ -132,6 +132,27 @@ fn test_range_formatting_preserves_trailing_comment() {
 }
 
 #[test]
+fn test_range_formatting_keeps_neighboring_leading_comment_outside_selected_line() {
+    let formatter = CodeFormatter::new();
+    let options = FormattingOptions {
+        tab_size: 4,
+        insert_spaces: true,
+        trim_trailing_whitespace: None,
+        insert_final_newline: None,
+        trim_final_newlines: None,
+    };
+    let code = "# applies to next declaration\nmy$x=1;\nmy$y=2;\n";
+    let range = WireRange { start: WirePosition::new(1, 0), end: WirePosition::new(1, 7) };
+
+    let edits = must(formatter.format_range(code, &range, &options));
+
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "my $x = 1;");
+    assert_eq!(edits[0].range.start.line, 1);
+    assert_eq!(edits[0].range.end.line, 1);
+}
+
+#[test]
 fn test_range_formatting_preserves_simple_block_trailing_comment() {
     let formatter = CodeFormatter::new();
     let options = FormattingOptions {

--- a/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
@@ -114,6 +114,37 @@ fn test_range_formatting_preserves_trailing_comment_3_17() -> TestResult {
 }
 
 #[test]
+fn test_range_formatting_keeps_neighboring_leading_comment_outside_selected_line_3_17() -> TestResult
+{
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness
+        .open("file:///leading-comment.pl", "# applies to next declaration\nmy$x=1;\nmy$y=2;")?;
+
+    let result = harness.request(
+        "textDocument/rangeFormatting",
+        json!({
+            "textDocument": { "uri": "file:///leading-comment.pl" },
+            "range": {
+                "start": { "line": 1, "character": 0 },
+                "end": { "line": 1, "character": 7 }
+            },
+            "options": {
+                "tabSize": 4,
+                "insertSpaces": true
+            }
+        }),
+    )?;
+
+    let edits = result.as_array().ok_or("rangeFormatting should return an edit array")?;
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0]["range"]["start"]["line"], 1);
+    assert_eq!(edits[0]["range"]["end"]["line"], 1);
+    assert_eq!(edits[0]["newText"], "my $x = 1;");
+    Ok(())
+}
+
+#[test]
 fn test_range_formatting_preserves_simple_block_trailing_comment_3_17() -> TestResult {
     let mut harness = LspHarness::new();
     harness.initialize(None)?;


### PR DESCRIPTION
## Summary

- Adds native formatter range coverage proving a neighboring leading comment outside the selected line is not included in the edit.
- Mirrors the same contract through `CodeFormatter` integration and LSP 3.17 range-formatting tests.
- Keeps this as test coverage only: no formatter behavior, config, runtime default, critic, or receipt schema changes.

## Why

The native formatter already has trailing-comment preservation coverage. This locks the next comment-safety edge for range formatting: selected-line formatting must not pull in or move a leading comment from the adjacent line.

## Proof packet

Changed surfaces:
- rust_code

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-perltidy native_range_formatter_keeps_neighboring_leading_comment_outside_selected_line --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs test_range_formatting_keeps_neighboring_leading_comment_outside_selected_line --test formatting_test --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs test_range_formatting_keeps_neighboring_leading_comment_outside_selected_line_3_17 --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-format check` — native formatter fixtures: 40/40 passed
- [x] `cargo xtask native-tooling check-defaults`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Note: the LSP 3.17 focused test emits pre-existing dead-code warnings from shared test support; the new test passes.
