### PR TITLE
fix(parser-core): restore malformed quote-op diagnostics (#7899)

### DIFF
--- a/crates/perl-parser-core/src/tokens/token_stream.rs
+++ b/crates/perl-parser-core/src/tokens/token_stream.rs
@@ -432,15 +432,34 @@ impl<'a> TokenStream<'a> {
                     // Unclosed quote-like operator from the lexer (e.g. "unclosed qq delimiter '{'").
                     // Map to the corresponding quote token kind so the parser's quote-handler
                     // produces a proper "Unclosed delimiter" diagnostic rather than the generic
-                    // "expected expression, found unknown token" error.  Only q/qq/qw have
-                    // unclosed-detection in their primary-expression arms; other operators
-                    // (qr, qx, m, s, tr, y) fall through to Unknown so they keep the current
-                    // behaviour until dedicated recovery is added.
+                    // "expected expression, found unknown token" error. q/qq/qw have
+                    // unclosed-detection in their primary-expression arms. Substitution
+                    // also has strict parser-side validation, as do transliteration
+                    // operators, so route malformed `s///`, `tr///`, and `y///`
+                    // tokens there instead of losing the lexer diagnostic as Unknown.
+                    // Other operators (qr, qx, m) still fall through to Unknown until
+                    // dedicated recovery is added.
                     let text = token.text.as_ref();
                     if text.starts_with("qq") {
                         TokenKind::QuoteDouble
                     } else if text.starts_with("qw") {
                         TokenKind::QuoteWords
+                    } else if text
+                        .strip_prefix('s')
+                        .and_then(|rest| rest.chars().next())
+                        .is_some_and(|ch| !ch.is_ascii_alphanumeric() && ch != '_')
+                    {
+                        TokenKind::Substitution
+                    } else if text
+                        .strip_prefix("tr")
+                        .and_then(|rest| rest.chars().next())
+                        .is_some_and(|ch| !ch.is_ascii_alphanumeric() && ch != '_')
+                        || text
+                            .strip_prefix('y')
+                            .and_then(|rest| rest.chars().next())
+                            .is_some_and(|ch| !ch.is_ascii_alphanumeric() && ch != '_')
+                    {
+                        TokenKind::Transliteration
                     } else if text
                         .strip_prefix('q')
                         .and_then(|rest| rest.chars().next())

--- a/docs/project/status/parser_accuracy_failure_packets.json
+++ b/docs/project/status/parser_accuracy_failure_packets.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "commit": "1db620b99",
+  "commit": "4c6b59170",
   "cadence": "pr",
   "generated_by": "cargo xtask metrics parser-accuracy --export-status-receipts",
   "failure_packet_count": 0,

--- a/xtask/src/tasks/metrics/parser_accuracy.rs
+++ b/xtask/src/tasks/metrics/parser_accuracy.rs
@@ -1382,9 +1382,13 @@ fn quote_like_parse_error_location(error: &ParseError) -> Option<usize> {
 }
 
 fn is_unclosed_quote_like_diagnostic(message: &str) -> bool {
-    message.starts_with("Unclosed ")
+    (message.starts_with("Unclosed ")
         && (message.contains(" delimiter in string operator ")
-            || message.starts_with("Unclosed qw() delimiter"))
+            || message.starts_with("Unclosed qw() delimiter")))
+        || message.starts_with("Missing replacement in substitution")
+        || message.starts_with("Missing closing delimiter in substitution")
+        || message.starts_with("Missing replacement list in transliteration")
+        || message.starts_with("Missing closing delimiter in transliteration")
 }
 
 fn line_tag_for_node(node: &Node) -> Option<LineTag> {
@@ -7680,6 +7684,9 @@ sub dynamic_boundary_case {
             ("q", "package Accuracy::Unclosed;\n\nmy $message = q{still open\n"),
             ("qq", "package Accuracy::Unclosed;\n\nmy $message = qq{still open\n"),
             ("qw", "package Accuracy::Unclosed;\n\nmy @words = qw{still open\n"),
+            ("s", "package Accuracy::Unclosed;\n\nmy $pattern = s/unterminated/foo;\n"),
+            ("tr", "package Accuracy::Unclosed;\n\nmy $table = tr/a/b;\n"),
+            ("y", "package Accuracy::Unclosed;\n\nmy $table = y/a/b;\n"),
         ] {
             let actual_by_line = extract_line_tags(source);
             let line_tags = actual_by_line
@@ -7688,7 +7695,9 @@ sub dynamic_boundary_case {
             let expected = tags(&[LineTag::ParseError]);
 
             assert!(line_tags.contains(&LineTag::ParseError));
-            assert!(line_tags.contains(&LineTag::VariableDecl));
+            if matches!(operator, "q" | "qq" | "qw") {
+                assert!(line_tags.contains(&LineTag::VariableDecl));
+            }
             assert_eq!(comparable_actual_line_tags(&expected, line_tags), expected);
         }
 


### PR DESCRIPTION
Problem: malformed `s///`, `tr///`, and `y///` lexer error tokens were converted to `Unknown`, so parser-core emitted generic unknown-token diagnostics and parser accuracy could miss the parse-error line.
Fix: route malformed substitution/transliteration unclosed lexer errors through the strict parser handlers, and normalize those strict diagnostics as parser-accuracy parse-error line tags.
Verification: `cargo test -p perl-parser-core --test fix_subst_unusual_delimiters_2732 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_transliteration_strict_parsing --profile agent --locked -- --nocapture`; `cargo test -p xtask --profile agent --locked parser_accuracy -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; changed-crate check/clippy for `perl-parser-core` and `xtask`; `git diff --check`.

Known gap: the full `cargo test -p perl-parser-core --profile agent --locked` suite still fails `parser_panic_mode_recovery::parser_ac3_prevent_recursive_recovery`; I reproduced that same failure on clean `origin/master`, so it is outside this PR.

Refs #7899.