### PR TITLE
test(format): prove native default comment formatting e2e (#8444)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_formatting_e2e.rs
+++ b/crates/perl-lsp-rs/tests/lsp_formatting_e2e.rs
@@ -118,14 +118,7 @@ sub second{my$b=2;return$b;}
 }
 
 #[test]
-
-fn formatting_preserves_comments() -> Result<(), Box<dyn std::error::Error>> {
-    // Skip test if perltidy is not available
-    if std::process::Command::new("perltidy").arg("--version").output().is_err() {
-        eprintln!("Skipping test: perltidy not installed");
-        return Ok(());
-    }
-
+fn native_default_formatting_preserves_comments() -> Result<(), Box<dyn std::error::Error>> {
     let bin = env!("CARGO_BIN_EXE_perl-lsp");
     let mut client = LspClient::spawn(bin)?;
     let uri = "file:///comments.pl";
@@ -154,26 +147,19 @@ return$x;
     let edits =
         response["result"].as_array().ok_or("formatting should return an array of edits")?;
 
-    if !edits.is_empty() {
-        let edit_text =
-            edits.first().ok_or("edits array should have at least one element")?["newText"]
-                .as_str()
-                .ok_or("Edit should have newText")?;
+    assert!(!edits.is_empty(), "native default formatting should return comment-safe edits");
+    let edit_text = edits.first().ok_or("edits array should have at least one element")?["newText"]
+        .as_str()
+        .ok_or("Edit should have newText")?;
 
-        // Check that comments are preserved
-        assert!(edit_text.contains("# Main script comment"), "Should preserve main comment");
-        assert!(edit_text.contains("# Function comment"), "Should preserve function comment");
-        assert!(edit_text.contains("# Inner comment"), "Should preserve inner comment");
-        assert!(edit_text.contains("# Inline comment"), "Should preserve inline comment");
+    assert!(edit_text.contains("# Main script comment"), "Should preserve main comment");
+    assert!(edit_text.contains("# Function comment"), "Should preserve function comment");
+    assert!(edit_text.contains("# Inner comment"), "Should preserve inner comment");
+    assert!(edit_text.contains("# Inline comment"), "Should preserve inline comment");
 
-        // Check that code is still formatted
-        assert!(edit_text.contains("use strict"), "Should format use statements");
-        assert!(edit_text.contains("use warnings"), "Should separate use statements");
-        assert!(
-            edit_text.contains("sub test") && edit_text.contains("{"),
-            "Should format subroutine"
-        );
-    }
+    assert!(edit_text.contains("use strict"), "Should format use statements");
+    assert!(edit_text.contains("use warnings"), "Should separate use statements");
+    assert!(edit_text.contains("sub test") && edit_text.contains("{"), "Should format subroutine");
 
     client.shutdown()?;
     Ok(())


### PR DESCRIPTION
## Summary

- Updates the LSP formatting E2E comment-preservation test to exercise the native default path directly.
- Removes the stale `perltidy` availability skip from that test.
- Requires the server to return a real comment-safe formatting edit instead of accepting an empty edit set.

## Why

`perl-lsp` now defaults to native formatting, with external `perltidy` isolated behind the explicit legacy adapter path. This E2E was still shaped like the old adapter-first world, so it could silently skip the native comment-preservation proof when `perltidy` was unavailable.

## Scope

Test-only. No formatter behavior, runtime config, default-mode, critic, receipt, or CI behavior changes.

## Proof packet

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs native_default_formatting_preserves_comments --test lsp_formatting_e2e --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-tooling check-defaults`
- [x] `cargo xtask native-format check` — native formatter fixtures: 40/40 passed
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Note: the focused E2E still emits pre-existing dead-code warnings from shared test support; the renamed test passes.
