### PR TITLE
test(format): prove native default document formatting e2e (#8446)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_formatting_e2e.rs
+++ b/crates/perl-lsp-rs/tests/lsp_formatting_e2e.rs
@@ -6,20 +6,12 @@ mod support;
 use support::lsp_client::LspClient;
 
 #[test]
-
-fn document_formatting_with_perltidy() -> Result<(), Box<dyn std::error::Error>> {
-    // Skip test if perltidy is not available
-    if std::process::Command::new("perltidy").arg("--version").output().is_err() {
-        eprintln!("Skipping test: perltidy not installed");
-        return Ok(());
-    }
-
+fn native_default_document_formatting() -> Result<(), Box<dyn std::error::Error>> {
     let bin = env!("CARGO_BIN_EXE_perl-lsp");
     let mut client = LspClient::spawn(bin)?;
     let uri = "file:///fmt.pl";
 
-    // Intentionally poorly formatted code
-    let source = "sub test{my$x=1;return$x;}sub another{print'hello';}\n";
+    let source = "sub test{my$x=1;return$x;}\nsub another{return 2;}\n";
 
     client.did_open(uri, "perl", source)?;
 
@@ -36,13 +28,10 @@ fn document_formatting_with_perltidy() -> Result<(), Box<dyn std::error::Error>>
 
     assert!(!edits.is_empty(), "Should return formatting edits");
 
-    // The server typically returns a single edit that replaces the whole document
     let edit_text = edits.first().ok_or("edits array should have at least one element")?["newText"]
         .as_str()
         .ok_or("Edit should have newText")?;
 
-    // Check that formatting improved the code
-    // perltidy may add varying amounts of whitespace depending on version and config
     assert!(
         edit_text.contains("sub test") && edit_text.contains("{"),
         "Should format subroutine declaration, got: {}",


### PR DESCRIPTION
## Summary

- Converts the document-formatting E2E from an adapter-first `perltidy` proof to a native-default proof.
- Removes the stale `perltidy` availability skip.
- Uses supported native safe-subset syntax and still requires an actual formatting edit from the server.

## Why

The normal formatter path is native now. This test should prove the server can format a document through the native default path, instead of skipping whenever the legacy adapter is absent.

## Scope

Test-only. No formatter behavior, runtime config, default-mode, critic, receipt, or CI behavior changes.

## Proof packet

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs native_default_document_formatting --test lsp_formatting_e2e --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-tooling check-defaults`
- [x] `cargo xtask native-format check` — native formatter fixtures: 40/40 passed
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Note: the focused E2E still emits pre-existing dead-code warnings from shared test support; the renamed test passes.
