### PR TITLE
test(format): prove native default tab-size formatting e2e (#8449)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_formatting_e2e.rs
+++ b/crates/perl-lsp-rs/tests/lsp_formatting_e2e.rs
@@ -136,35 +136,15 @@ return$x;
 }
 
 #[test]
-
-fn formatting_with_custom_config() -> Result<(), Box<dyn std::error::Error>> {
-    // Skip test if perltidy is not available
-    if std::process::Command::new("perltidy").arg("--version").output().is_err() {
-        eprintln!("Skipping test: perltidy not installed");
-        return Ok(());
-    }
-
-    // Create a temporary perltidyrc for testing
-    let config_content = r#"
-# Test configuration
--i=2    # 2-space indentation
--pt=2   # tight parentheses
--bt=2   # tight braces
--sbt=2  # tight square brackets
-"#;
-
-    std::fs::write("/tmp/test.perltidyrc", config_content)?;
-
+fn native_default_formatting_honors_lsp_tab_size() -> Result<(), Box<dyn std::error::Error>> {
     let bin = env!("CARGO_BIN_EXE_perl-lsp");
     let mut client = LspClient::spawn(bin)?;
-    let uri = "file:///custom.pl";
+    let uri = "file:///tab-size.pl";
 
-    let source = "sub test { my @array = ( 1, 2, 3 ); return \\@array; }\n";
+    let source = "sub test{my$x=1;return$x;}\n";
 
     client.did_open(uri, "perl", source)?;
 
-    // Note: The LSP server would need to support custom config paths
-    // This test demonstrates the structure but may need server-side support
     let response = client.request(
         "textDocument/formatting",
         json!({
@@ -176,19 +156,12 @@ fn formatting_with_custom_config() -> Result<(), Box<dyn std::error::Error>> {
     let edits =
         response["result"].as_array().ok_or("formatting should return an array of edits")?;
 
-    if !edits.is_empty() {
-        let edit_text =
-            edits.first().ok_or("edits array should have at least one element")?["newText"]
-                .as_str()
-                .ok_or("Edit should have newText")?;
+    assert!(!edits.is_empty(), "native default formatting should return edits");
+    let edit_text = edits.first().ok_or("edits array should have at least one element")?["newText"]
+        .as_str()
+        .ok_or("Edit should have newText")?;
 
-        // Check for some formatting (exact format depends on perltidy version)
-        assert!(edit_text.contains("sub test"), "Should contain formatted subroutine");
-        assert!(edit_text.contains("@array"), "Should contain array variable");
-    }
-
-    // Clean up
-    let _ = std::fs::remove_file("/tmp/test.perltidyrc");
+    assert!(edit_text.contains("sub test {\n  my $x = 1;\n  return $x;\n}"));
 
     client.shutdown()?;
     Ok(())


### PR DESCRIPTION
## Summary
- Converts the custom formatting E2E from a fake `.perltidyrc`/legacy adapter proof to a native-default LSP formatting-options proof.
- Removes the stale `perltidy` availability skip and temporary `.perltidyrc` file.
- Asserts `tabSize: 2` reaches native formatting and produces two-space indentation.

## Why
Native formatting should be config-aware through the LSP formatting path without relying on perltidy/perltidyrc. This test now fails if native default formatting stops honoring LSP tab-size options.

## Scope
Test-only. No formatter behavior, runtime config, default-mode, critic, receipt, or CI behavior changes.

## Proof packet
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs native_default_formatting_honors_lsp_tab_size --test lsp_formatting_e2e --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-tooling check-defaults`
- [x] `cargo xtask native-format check` - native formatter fixtures: 40/40 passed
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Note: the focused E2E still emits pre-existing dead-code warnings from shared test support; the renamed native-default tab-size test passes.
