### PR TITLE
test(parser-core): remove bare-call lint debt (#7900)

### DIFF
--- a/crates/perl-parser-core/tests/bare_call_binding_regression_tests.rs
+++ b/crates/perl-parser-core/tests/bare_call_binding_regression_tests.rs
@@ -1,41 +1,61 @@
 mod cpan_test_helpers;
 
 use cpan_test_helpers::{assert_clean_parse, parse};
-use perl_parser_core::NodeKind;
+use perl_parser_core::{Node, NodeKind};
 
-fn program_statements(source: &str) -> Vec<perl_parser_core::Node> {
+fn program_statements(source: &str) -> Result<Vec<Node>, String> {
     let ast = parse(source);
     match ast.kind {
-        NodeKind::Program { statements } => statements,
-        other => {
-            assert!(false, "expected Program node, got {:?}", other);
-            Vec::new()
-        }
+        NodeKind::Program { statements } => Ok(statements),
+        other => Err(format!("expected Program node, got {other:?}")),
     }
 }
 
+fn statement_at<'a>(
+    statements: &'a [Node],
+    index: usize,
+    context: &str,
+) -> Result<&'a Node, String> {
+    statements.get(index).ok_or_else(|| format!("expected statement {index} for {context}"))
+}
+
+fn expression_statement<'a>(statement: &'a Node, context: &str) -> Result<&'a Node, String> {
+    let NodeKind::ExpressionStatement { expression } = &statement.kind else {
+        return Err(format!(
+            "expected ExpressionStatement for {context}, got {:?}",
+            statement.kind
+        ));
+    };
+    Ok(expression.as_ref())
+}
+
+fn variable_initializer<'a>(statement: &'a Node, context: &str) -> Result<&'a Node, String> {
+    let NodeKind::VariableDeclaration { initializer, .. } = &statement.kind else {
+        return Err(format!(
+            "expected VariableDeclaration for {context}, got {:?}",
+            statement.kind
+        ));
+    };
+    initializer.as_deref().ok_or_else(|| format!("expected declaration initializer for {context}"))
+}
+
+fn function_call<'a>(node: &'a Node, context: &str) -> Result<(&'a str, &'a [Node]), String> {
+    let NodeKind::FunctionCall { name, args } = &node.kind else {
+        return Err(format!("expected FunctionCall for {context}, got {:?}", node.kind));
+    };
+    Ok((name.as_str(), args))
+}
+
 #[test]
-fn bare_call_condition_stays_outside_ternary() {
+fn bare_call_condition_stays_outside_ternary() -> Result<(), String> {
     let source = "sub is_ready { 1 }; my $x = is_ready $obj ? 1 : 0;";
     assert_clean_parse(source);
 
-    let statements = program_statements(source);
+    let statements = program_statements(source)?;
     assert!(statements.len() >= 2, "expected at least 2 statements");
 
-    let second = &statements[1];
-    let initializer = match &second.kind {
-        NodeKind::VariableDeclaration { initializer, .. } => match initializer.as_deref() {
-            Some(node) => node,
-            None => {
-                assert!(false, "expected declaration initializer");
-                return;
-            }
-        },
-        other => {
-            assert!(false, "expected VariableDeclaration, got {:?}", other);
-            return;
-        }
-    };
+    let second = statement_at(&statements, 1, "bare call ternary assignment")?;
+    let initializer = variable_initializer(second, "bare call ternary assignment")?;
 
     match &initializer.kind {
         NodeKind::Ternary { condition, .. } => match &condition.kind {
@@ -43,58 +63,54 @@ fn bare_call_condition_stays_outside_ternary() {
                 assert_eq!(name, "is_ready");
                 assert_eq!(args.len(), 1, "expected one bare-call argument");
             }
-            other => assert!(false, "expected FunctionCall condition, got {:?}", other),
+            other => return Err(format!("expected FunctionCall condition, got {other:?}")),
         },
-        other => assert!(false, "expected Ternary initializer, got {:?}", other),
+        other => return Err(format!("expected Ternary initializer, got {other:?}")),
     }
+    Ok(())
 }
 
 #[test]
-fn bare_call_stops_before_word_or_rhs() {
+fn bare_call_stops_before_word_or_rhs() -> Result<(), String> {
     let source = "do_thing @args or die;";
     assert_clean_parse(source);
 
-    let statements = program_statements(source);
-    let expr = match &statements[0].kind {
-        NodeKind::ExpressionStatement { expression } => expression.as_ref(),
-        other => {
-            assert!(false, "expected ExpressionStatement, got {:?}", other);
-            return;
-        }
-    };
+    let statements = program_statements(source)?;
+    let expr = expression_statement(
+        statement_at(&statements, 0, "bare call or expression")?,
+        "bare call or expression",
+    )?;
 
     match &expr.kind {
         NodeKind::Binary { op, left, right } => {
             assert_eq!(op, "or");
             match &right.kind {
                 NodeKind::FunctionCall { name, .. } => assert_eq!(name, "die"),
-                other => assert!(false, "expected die FunctionCall rhs, got {:?}", other),
+                other => return Err(format!("expected die FunctionCall rhs, got {other:?}")),
             }
             match &left.kind {
                 NodeKind::FunctionCall { name, args } => {
                     assert_eq!(name, "do_thing");
                     assert_eq!(args.len(), 1);
                 }
-                other => assert!(false, "expected left FunctionCall, got {:?}", other),
+                other => return Err(format!("expected left FunctionCall, got {other:?}")),
             }
         }
-        other => assert!(false, "expected Binary(or), got {:?}", other),
+        other => return Err(format!("expected Binary(or), got {other:?}")),
     }
+    Ok(())
 }
 
 #[test]
-fn bare_call_stops_before_word_and_rhs() {
+fn bare_call_stops_before_word_and_rhs() -> Result<(), String> {
     let source = "do_thing $x and return;";
     assert_clean_parse(source);
 
-    let statements = program_statements(source);
-    let expr = match &statements[0].kind {
-        NodeKind::ExpressionStatement { expression } => expression.as_ref(),
-        other => {
-            assert!(false, "expected ExpressionStatement, got {:?}", other);
-            return;
-        }
-    };
+    let statements = program_statements(source)?;
+    let expr = expression_statement(
+        statement_at(&statements, 0, "bare call and expression")?,
+        "bare call and expression",
+    )?;
 
     match &expr.kind {
         NodeKind::Binary { op, left, right } => {
@@ -102,58 +118,42 @@ fn bare_call_stops_before_word_and_rhs() {
             assert!(matches!(right.kind, NodeKind::Return { .. }));
             assert!(matches!(left.kind, NodeKind::FunctionCall { .. }));
         }
-        other => assert!(false, "expected Binary(and), got {:?}", other),
+        other => return Err(format!("expected Binary(and), got {other:?}")),
     }
+    Ok(())
 }
 
 #[test]
-fn bare_call_stops_before_defined_or() {
+fn bare_call_stops_before_defined_or() -> Result<(), String> {
     let source = "my $v = transform $x // $fallback;";
     assert_clean_parse(source);
 
-    let statements = program_statements(source);
-    let initializer = match &statements[0].kind {
-        NodeKind::VariableDeclaration { initializer, .. } => match initializer.as_deref() {
-            Some(node) => node,
-            None => {
-                assert!(false, "expected declaration initializer");
-                return;
-            }
-        },
-        other => {
-            assert!(false, "expected VariableDeclaration, got {:?}", other);
-            return;
-        }
-    };
+    let statements = program_statements(source)?;
+    let initializer = variable_initializer(
+        statement_at(&statements, 0, "defined-or assignment")?,
+        "defined-or assignment",
+    )?;
 
     match &initializer.kind {
         NodeKind::Binary { op, left, .. } => {
             assert_eq!(op, "//");
             assert!(matches!(left.kind, NodeKind::FunctionCall { .. }));
         }
-        other => assert!(false, "expected Binary(//), got {:?}", other),
+        other => return Err(format!("expected Binary(//), got {other:?}")),
     }
+    Ok(())
 }
 
 #[test]
-fn nested_bare_call_ternary_inside_larger_expression() {
+fn nested_bare_call_ternary_inside_larger_expression() -> Result<(), String> {
     let source = "my $z = 1 + (is_ready $obj ? 1 : 0);";
     assert_clean_parse(source);
 
-    let statements = program_statements(source);
-    let initializer = match &statements[0].kind {
-        NodeKind::VariableDeclaration { initializer, .. } => match initializer.as_deref() {
-            Some(node) => node,
-            None => {
-                assert!(false, "expected declaration initializer");
-                return;
-            }
-        },
-        other => {
-            assert!(false, "expected VariableDeclaration, got {:?}", other);
-            return;
-        }
-    };
+    let statements = program_statements(source)?;
+    let initializer = variable_initializer(
+        statement_at(&statements, 0, "nested ternary assignment")?,
+        "nested ternary assignment",
+    )?;
 
     match &initializer.kind {
         NodeKind::Binary { op, right, .. } => {
@@ -162,11 +162,12 @@ fn nested_bare_call_ternary_inside_larger_expression() {
                 NodeKind::Ternary { condition, .. } => {
                     assert!(matches!(condition.kind, NodeKind::FunctionCall { .. }));
                 }
-                other => assert!(false, "expected ternary rhs, got {:?}", other),
+                other => return Err(format!("expected ternary rhs, got {other:?}")),
             }
         }
-        other => assert!(false, "expected Binary(+), got {:?}", other),
+        other => return Err(format!("expected Binary(+), got {other:?}")),
     }
+    Ok(())
 }
 
 /// When a sort (or other builtin) is immediately followed by `?` it should parse
@@ -186,38 +187,26 @@ fn builtin_directly_before_ternary_no_args() {
 ///   grep { ... } @arr ? 1 : 0
 /// must parse as: grep(BLOCK, @arr ? 1 : 0)  — ternary binds tighter than list op
 #[test]
-fn block_list_func_absorbs_ternary_arg_after_array() {
+fn block_list_func_absorbs_ternary_arg_after_array() -> Result<(), String> {
     let source = "my $r = grep { $_ > 0 } @arr ? 1 : 0;";
     assert_clean_parse(source);
-    let statements = program_statements(source);
-    let initializer = match &statements[0].kind {
-        NodeKind::VariableDeclaration { initializer, .. } => match initializer.as_deref() {
-            Some(node) => node,
-            None => {
-                assert!(false, "expected declaration initializer");
-                return;
-            }
-        },
-        other => {
-            assert!(false, "expected VariableDeclaration, got {:?}", other);
-            return;
-        }
-    };
+    let statements = program_statements(source)?;
+    let initializer = variable_initializer(
+        statement_at(&statements, 0, "grep ternary assignment")?,
+        "grep ternary assignment",
+    )?;
     // Correct Perl semantics: ternary binds tighter than list operators, so
     // grep collects the ternary expression as its list argument.
-    match &initializer.kind {
-        NodeKind::FunctionCall { name, args } => {
-            assert_eq!(name, "grep");
-            assert_eq!(args.len(), 2, "expected block + one list arg");
-            // second arg should be the ternary @arr ? 1 : 0
-            assert!(
-                matches!(args[1].kind, NodeKind::Ternary { .. }),
-                "expected Ternary second arg, got {:?}",
-                args[1].kind.kind_name()
-            );
-        }
-        other => assert!(false, "expected FunctionCall(grep), got {:?}", other),
-    }
+    let (name, args) = function_call(initializer, "grep initializer")?;
+    assert_eq!(name, "grep");
+    assert_eq!(args.len(), 2, "expected block + one list arg");
+    let second_arg = args.get(1).ok_or_else(|| "expected grep ternary list arg".to_string())?;
+    assert!(
+        matches!(second_arg.kind, NodeKind::Ternary { .. }),
+        "expected Ternary second arg, got {:?}",
+        second_arg.kind.kind_name()
+    );
+    Ok(())
 }
 
 /// When `?` follows immediately after a block (no list argument in between),
@@ -235,23 +224,14 @@ fn bare_block_directly_before_ternary_no_error() {
 /// must parse as: (foo $x) ? ($a ? $b : $c) : $d
 /// i.e. the outer ternary's condition is FunctionCall(foo, [$x]).
 #[test]
-fn bare_call_nested_ternary_outside_call() {
+fn bare_call_nested_ternary_outside_call() -> Result<(), String> {
     let source = "my $r = is_ready $obj ? 1 ? 2 : 3 : 4;";
     assert_clean_parse(source);
-    let statements = program_statements(source);
-    let initializer = match &statements[0].kind {
-        NodeKind::VariableDeclaration { initializer, .. } => match initializer.as_deref() {
-            Some(node) => node,
-            None => {
-                assert!(false, "expected declaration initializer");
-                return;
-            }
-        },
-        other => {
-            assert!(false, "expected VariableDeclaration, got {:?}", other);
-            return;
-        }
-    };
+    let statements = program_statements(source)?;
+    let initializer = variable_initializer(
+        statement_at(&statements, 0, "nested bare-call ternary")?,
+        "nested bare-call ternary",
+    )?;
     match &initializer.kind {
         NodeKind::Ternary { condition, then_expr, else_expr } => {
             // Outer condition must be the bare call
@@ -273,6 +253,7 @@ fn bare_call_nested_ternary_outside_call() {
                 else_expr.kind.kind_name()
             );
         }
-        other => assert!(false, "expected outer Ternary, got {:?}", other),
+        other => return Err(format!("expected outer Ternary, got {other:?}")),
     }
+    Ok(())
 }


### PR DESCRIPTION
Problem: `bare_call_binding_regression_tests.rs` used `assert!(false, ...)` failure paths, keeping parser-core test clippy debt in the way of a clean test-lint baseline.
Fix: Convert the bare-call regression assertions to `Result<(), String>` helpers with explicit error returns and no `assert!(false)` in the file.
Verification: `cargo test -p perl-parser-core --test bare_call_binding_regression_tests --profile agent --locked -- --nocapture`; `cargo clippy -p perl-parser-core --test bare_call_binding_regression_tests --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`.

Known gap: the broader `cargo clippy -p perl-parser-core --tests --profile agent --locked -- -D warnings -A missing_docs` gate now advances to pre-existing debt in `expected_module_name_tests.rs`; this PR only clears the bare-call slice.

Refs #7900.