### PR TITLE
test(parser-core): remove expected-module lint debt (#7900)

### DIFF
--- a/crates/perl-parser-core/tests/expected_module_name_tests.rs
+++ b/crates/perl-parser-core/tests/expected_module_name_tests.rs
@@ -2,6 +2,24 @@ mod cpan_test_helpers;
 use cpan_test_helpers::*;
 use perl_parser_core::NodeKind;
 
+fn assert_use_module_preserved(source: &str, expected: &str) -> Result<(), String> {
+    let ast = parse(source);
+    let NodeKind::Program { statements } = &ast.kind else {
+        return Err(format!("expected Program node, got {:?}", ast.kind));
+    };
+    assert_eq!(statements.len(), 1);
+
+    let Some(statement) = statements.first() else {
+        return Err("expected one top-level statement".to_string());
+    };
+    let NodeKind::Use { module, .. } = &statement.kind else {
+        return Err(format!("expected top-level Use node, got {:?}", statement.kind));
+    };
+
+    assert_eq!(module, expected);
+    Ok(())
+}
+
 // --- VString version directives in `use` ---
 
 #[test]
@@ -104,33 +122,13 @@ use warnings;
 }
 
 #[test]
-fn test_use_vstring_preserves_full_version_segment() {
-    let ast = parse("use v5.38;");
-    if let NodeKind::Program { statements } = &ast.kind {
-        assert_eq!(statements.len(), 1);
-        if let NodeKind::Use { module, .. } = &statements[0].kind {
-            assert_eq!(module, "v5.38");
-        } else {
-            panic!("expected top-level Use node");
-        }
-    } else {
-        panic!("expected Program node");
-    }
+fn test_use_vstring_preserves_full_version_segment() -> Result<(), String> {
+    assert_use_module_preserved("use v5.38;", "v5.38")
 }
 
 #[test]
-fn test_use_vstring_three_part_preserves_patch_segment() {
-    let ast = parse("use v5.12.0;");
-    if let NodeKind::Program { statements } = &ast.kind {
-        assert_eq!(statements.len(), 1);
-        if let NodeKind::Use { module, .. } = &statements[0].kind {
-            assert_eq!(module, "v5.12.0");
-        } else {
-            panic!("expected top-level Use node");
-        }
-    } else {
-        panic!("expected Program node");
-    }
+fn test_use_vstring_three_part_preserves_patch_segment() -> Result<(), String> {
+    assert_use_module_preserved("use v5.12.0;", "v5.12.0")
 }
 
 #[test]


### PR DESCRIPTION
Problem: `expected_module_name_tests.rs` still used `panic!(...)` assertion branches, keeping parser-core test clippy debt in the way of a clean test-lint baseline.
Fix: Add a small `Result<(), String>` helper for preserved `use` module names and return explicit errors instead of panicking.
Verification: `cargo test -p perl-parser-core --test expected_module_name_tests --profile agent --locked -- --nocapture`; `cargo clippy -p perl-parser-core --test expected_module_name_tests --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`.

Known gap: the broader `cargo clippy -p perl-parser-core --tests --profile agent --locked -- -D warnings -A missing_docs` gate now advances to remaining pre-existing debt in `fix_scoped_sub_declarations.rs`, `object_pad_adjust_tests.rs`, `fix_unexpected_rbrace_proto_plus_2835.rs`, and parser-core lib-test `len_zero` assertions. This PR only clears the expected-module slice.

Refs #7900.