### PR TITLE
test(parser-core): remove scoped-sub lint debt (#7900)

### DIFF
--- a/crates/perl-parser-core/tests/fix_scoped_sub_declarations.rs
+++ b/crates/perl-parser-core/tests/fix_scoped_sub_declarations.rs
@@ -30,7 +30,7 @@ fn parses_scoped_sub_forward_declarations() {
 }
 
 #[test]
-fn recovers_after_scoped_sub_missing_name() {
+fn recovers_after_scoped_sub_missing_name() -> Result<(), String> {
     let mut parser = Parser::new("my sub { 1 }; my $x = 2;");
     let output = parser.parse_with_recovery();
     let sexp = output.ast.to_sexp();
@@ -51,13 +51,13 @@ fn recovers_after_scoped_sub_missing_name() {
         "scoped sub recovery should preserve an anonymous-sub structure: {sexp}"
     );
 
-    if let NodeKind::Program { statements } = &output.ast.kind {
-        assert!(
-            statements.len() >= 2,
-            "parser should recover and keep following statement, got {} items",
-            statements.len()
-        );
-    } else {
-        panic!("expected Program root, got {:?}", output.ast.kind);
-    }
+    let NodeKind::Program { statements } = &output.ast.kind else {
+        return Err(format!("expected Program root, got {:?}", output.ast.kind));
+    };
+    assert!(
+        statements.len() >= 2,
+        "parser should recover and keep following statement, got {} items",
+        statements.len()
+    );
+    Ok(())
 }


### PR DESCRIPTION
Problem: `fix_scoped_sub_declarations.rs` still used a `panic!(...)` failure branch, keeping parser-core test clippy debt in the way of a clean test-lint baseline.
Fix: Convert the scoped-sub recovery assertion to return `Result<(), String>` and report the unexpected root node as an explicit error.
Verification: `cargo test -p perl-parser-core --test fix_scoped_sub_declarations --profile agent --locked -- --nocapture`; `cargo clippy -p perl-parser-core --test fix_scoped_sub_declarations --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`.

Known gap: the broader `cargo clippy -p perl-parser-core --tests --profile agent --locked -- -D warnings -A missing_docs` gate now advances to remaining pre-existing debt in `fix_unexpected_rbrace_proto_plus_2835.rs`, `object_pad_adjust_tests.rs`, and parser-core lib-test `len_zero` assertions. This PR only clears the scoped-sub slice.

Refs #7900.