### PR TITLE
test(format): prove native default LSP 3.17 formatting (#8455)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_3_17_formatting_tests.rs
@@ -15,9 +15,9 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 fn test_formatting_3_17() -> TestResult {
     let mut harness = LspHarness::new();
     harness.initialize(None)?;
-    harness.open("file:///test.pl", "my$x=1;print$x;")?;
+    harness.open("file:///test.pl", "sub test{my$x=1;return$x;}\n")?;
 
-    let response = harness.request(
+    let result = harness.request(
         "textDocument/formatting",
         json!({
             "textDocument": { "uri": "file:///test.pl" },
@@ -29,22 +29,12 @@ fn test_formatting_3_17() -> TestResult {
                 "trimFinalNewlines": true
             }
         }),
-    );
+    )?;
 
-    // Handle both success and error cases - this is a protocol compliance test
-    match response {
-        Ok(result) => {
-            // Success: should return null or array of edits
-            assert!(result.is_null() || result.is_array());
-        }
-        Err(_) => {
-            // Error is acceptable when perltidy is not available
-            // This maintains LSP protocol compliance
-            eprintln!(
-                "Formatting failed (perltidy may not be installed) - this is acceptable for protocol compliance"
-            );
-        }
-    }
+    let edits = result.as_array().ok_or("formatting should return an edit array")?;
+    assert!(!edits.is_empty(), "native default formatting should return edits");
+    let edit_text = edits[0]["newText"].as_str().ok_or("formatting edit should include newText")?;
+    assert!(edit_text.contains("sub test {\n    my $x = 1;\n    return $x;\n}"));
     Ok(())
 }
 
@@ -54,7 +44,7 @@ fn test_range_formatting_3_17() -> TestResult {
     harness.initialize(None)?;
     harness.open("file:///test.pl", "my$x=1;\nprint$x;")?;
 
-    let response = harness.request(
+    let result = harness.request(
         "textDocument/rangeFormatting",
         json!({
             "textDocument": { "uri": "file:///test.pl" },
@@ -67,22 +57,11 @@ fn test_range_formatting_3_17() -> TestResult {
                 "insertSpaces": true
             }
         }),
-    );
+    )?;
 
-    // Handle both success and error cases - this is a protocol compliance test
-    match response {
-        Ok(result) => {
-            // Success: should return null or array of edits
-            assert!(result.is_null() || result.is_array());
-        }
-        Err(_) => {
-            // Error is acceptable when perltidy is not available
-            // This maintains LSP protocol compliance
-            eprintln!(
-                "Range formatting failed (perltidy may not be installed) - this is acceptable for protocol compliance"
-            );
-        }
-    }
+    let edits = result.as_array().ok_or("rangeFormatting should return an edit array")?;
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0]["newText"], "my $x = 1;");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Tightens the LSP 3.17 document-formatting contract test to require native-default formatting edits.
- Tightens the LSP 3.17 range-formatting contract test to require the native range edit for the selected line.
- Removes stale branches that accepted formatter errors because external `perltidy` might be missing.

## Why
Native formatting is the normal path now. The LSP 3.17 formatting contract tests should prove native edit behavior instead of treating missing external `perltidy` as an acceptable formatting outcome.

## Scope
Test-only. No formatter behavior, runtime config, default-mode, critic, receipt, or CI behavior changes.

## Proof packet
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs formatting_3_17 --test lsp_3_17_formatting_tests --profile agent --locked -- --nocapture`
- [x] `cargo xtask native-tooling check-defaults`
- [x] `cargo xtask native-format check` - native formatter fixtures: 40/40 passed
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`

Note: the focused test emits pre-existing dead-code warnings from shared test support; the tightened native-default LSP 3.17 formatting tests pass.
