### PR TITLE
test(parser-core): remove proto-plus lint debt (#7900)

### DIFF
--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_proto_plus_2835.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_proto_plus_2835.rs
@@ -100,19 +100,20 @@ fn test_named_sub_attr_then_plus_proto() {
 }
 
 #[test]
-fn test_proto_then_attr_correct_order() {
+fn test_proto_then_attr_correct_order() -> Result<(), String> {
     let ast = parse("sub foo (+) : lvalue { $_[0] }");
     let NodeKind::Program { statements } = &ast.kind else {
-        panic!("expected program node, got: {:?}", ast.kind);
+        return Err(format!("expected program node, got: {:?}", ast.kind));
     };
     let Some(first) = statements.first() else {
-        panic!("expected a subroutine statement");
+        return Err("expected a subroutine statement".to_string());
     };
     let NodeKind::Subroutine { prototype, attributes, .. } = &first.kind else {
-        panic!("expected subroutine node, got: {:?}", first.kind);
+        return Err(format!("expected subroutine node, got: {:?}", first.kind));
     };
     assert!(prototype.is_some(), "expected prototype for sub foo (+)");
     assert_eq!(attributes, &vec!["lvalue".to_string()]);
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Problem: `fix_unexpected_rbrace_proto_plus_2835.rs` still used `panic!(...)` assertion branches, keeping parser-core test clippy debt in the way of a clean test-lint baseline.
Fix: Convert the proto-plus structural assertion test to return `Result<(), String>` and report unexpected AST shapes as explicit errors.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_rbrace_proto_plus_2835 --profile agent --locked -- --nocapture`; `cargo clippy -p perl-parser-core --test fix_unexpected_rbrace_proto_plus_2835 --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`.

Known gap: the broader `cargo clippy -p perl-parser-core --tests --profile agent --locked -- -D warnings -A missing_docs` gate now advances to remaining pre-existing debt in `object_pad_adjust_tests.rs` and parser-core lib-test `len_zero` assertions. This PR only clears the proto-plus slice.

Refs #7900.