### PR TITLE
test(parser-core): remove object-pad lint debt (#7900)

### DIFF
--- a/crates/perl-parser-core/tests/object_pad_adjust_tests.rs
+++ b/crates/perl-parser-core/tests/object_pad_adjust_tests.rs
@@ -2,10 +2,9 @@ mod cpan_test_helpers;
 
 use cpan_test_helpers::*;
 use perl_parser_core::NodeKind;
-use perl_tdd_support::must_some;
 
 #[test]
-fn object_pad_adjust_block_parses_cleanly() -> Result<(), Box<dyn std::error::Error>> {
+fn object_pad_adjust_block_parses_cleanly() -> Result<(), String> {
     let source = r#"
 use Object::Pad;
 
@@ -20,28 +19,31 @@ class Config {
 
     let ast = parse(source);
     let NodeKind::Program { statements } = &ast.kind else {
-        panic!("expected program node, got {}", ast.kind.kind_name());
+        return Err(format!("expected program node, got {}", ast.kind.kind_name()));
     };
 
-    let class_stmt = statements
-        .iter()
-        .find(|statement| matches!(statement.kind, NodeKind::Class { .. }))
-        .expect("expected Object::Pad class statement");
+    let Some(class_stmt) =
+        statements.iter().find(|statement| matches!(statement.kind, NodeKind::Class { .. }))
+    else {
+        return Err("expected Object::Pad class statement".to_string());
+    };
 
     let NodeKind::Class { body, .. } = &class_stmt.kind else {
-        panic!("expected class node, got {}", class_stmt.kind.kind_name());
+        return Err(format!("expected class node, got {}", class_stmt.kind.kind_name()));
     };
 
     let NodeKind::Block { statements } = &body.kind else {
-        panic!("expected class body block, got {}", body.kind.kind_name());
+        return Err(format!("expected class body block, got {}", body.kind.kind_name()));
     };
 
-    let adjust_stmt = must_some(statements.first());
+    let Some(adjust_stmt) = statements.first() else {
+        return Err("expected ADJUST block statement".to_string());
+    };
     let NodeKind::Method { name, signature, attributes, .. } = &adjust_stmt.kind else {
-        panic!(
+        return Err(format!(
             "expected ADJUST block to parse as a method-like node, got {}",
             adjust_stmt.kind.kind_name()
-        );
+        ));
     };
 
     assert_eq!(name, "ADJUST");


### PR DESCRIPTION
Problem: `object_pad_adjust_tests.rs` still used `panic!(...)` and `expect(...)` assertion branches, keeping parser-core test clippy debt in the way of a clean test-lint baseline.
Fix: Convert the Object::Pad ADJUST regression test to `Result<(), String>` errors with explicit AST-shape checks.
Verification: `cargo test -p perl-parser-core --test object_pad_adjust_tests --profile agent --locked -- --nocapture`; `cargo clippy -p perl-parser-core --test object_pad_adjust_tests --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`.

Known gap: the broader `cargo clippy -p perl-parser-core --tests --profile agent --locked -- -D warnings -A missing_docs` gate now advances to the remaining parser-core lib-test `len_zero` assertions in `error_recovery_tests.rs`. This PR only clears the object-pad slice.

Refs #7900.