### PR TITLE
test(parser-core): clean recovery len-zero lint (#7900)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/error_recovery_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/error_recovery_tests.rs
@@ -500,7 +500,7 @@ fn test_recovery_unclosed_qw() {
     assert!(result.is_ok(), "Parser should recover from unclosed qw()");
     let ast = must(result);
     if let NodeKind::Program { statements } = &ast.kind {
-        assert!(statements.len() >= 1, "Should have recovered statements after unclosed qw");
+        assert!(!statements.is_empty(), "Should have recovered statements after unclosed qw");
     }
     assert!(!parser.errors().is_empty(), "Should record unclosed delimiter error");
 }
@@ -513,7 +513,7 @@ fn test_recovery_unclosed_q_brace() {
     assert!(result.is_ok(), "Parser should recover from unclosed q braces");
     let ast = must(result);
     if let NodeKind::Program { statements } = &ast.kind {
-        assert!(statements.len() >= 1, "Should have recovered statements");
+        assert!(!statements.is_empty(), "Should have recovered statements");
     }
     assert!(!parser.errors().is_empty(), "Should record unclosed brace error");
 }


### PR DESCRIPTION
Problem: parser-core lib tests still had `len() >= 1` assertions, leaving the broad parser-core test clippy gate blocked by `clippy::len_zero`.
Fix: Replace the recovery assertions with `!statements.is_empty()` while preserving the same expectations.
Verification: `cargo test -p perl-parser-core --lib --profile agent --locked test_recovery_unclosed -- --nocapture`; `cargo clippy -p perl-parser-core --tests --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`.

Refs #7900.