### PR TITLE
test(format): prove native DAP nonregression edits (#8466)

### DIFF
--- a/crates/perl-lsp-rs/tests/dap_non_regression_tests.rs
+++ b/crates/perl-lsp-rs/tests/dap_non_regression_tests.rs
@@ -22,7 +22,7 @@ fn test_lsp_features_unaffected_by_dap() -> Result<()> {
     initialize_lsp(&server);
 
     let uri = "file:///ac1_comprehensive.pl";
-    let text = "package TestPkg;\nsub test_sub { my $var = 1; }\n1;\n";
+    let text = "package TestPkg;\nsub test_sub{my$var=1;return$var;}\n1;\n";
     send_notification(
         &server,
         json!({
@@ -116,7 +116,7 @@ fn test_lsp_features_unaffected_by_dap() -> Result<()> {
         "Workspace symbol response should be present with DAP feature enabled"
     );
 
-    // AC1: formatting (null result is acceptable, response must arrive)
+    // AC1: formatting returns native default edits while DAP is enabled.
     let formatting_id = 104;
     send_request_no_wait(
         &server,
@@ -130,9 +130,30 @@ fn test_lsp_features_unaffected_by_dap() -> Result<()> {
             }
         }),
     );
+    let formatting_response =
+        read_response_matching_i64(&server, formatting_id, Duration::from_secs(5)).ok_or_else(
+            || anyhow::anyhow!("Formatting response should be present with DAP feature enabled"),
+        )?;
+    let edits = formatting_response["result"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Formatting result should be an edit array"))?;
     assert!(
-        read_response_matching_i64(&server, formatting_id, Duration::from_secs(5)).is_some(),
-        "Formatting response should be present with DAP feature enabled"
+        !edits.is_empty(),
+        "Native default formatting should return edits with DAP feature enabled"
+    );
+    let new_text = edits[0]["newText"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Formatting edit should include newText"))?;
+    assert_eq!(
+        new_text,
+        concat!(
+            "package TestPkg;\n",
+            "sub test_sub {\n",
+            "    my $var = 1;\n",
+            "    return $var;\n",
+            "}\n",
+            "1;\n",
+        )
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- tightens the DAP/LSP non-regression formatting check from “response arrives, null acceptable” to concrete native-default formatting edits
- uses a supported messy Perl fixture and asserts the formatted edit text while DAP integration is enabled
- leaves DAP behavior, formatter defaults, and external compatibility adapters unchanged

## Proof

- `cargo xtask fmt`
- `cargo test -p perl-lsp-rs --test dap_non_regression_tests --profile agent --locked -- --nocapture`
- `cargo xtask native-tooling check-defaults`
- `cargo xtask native-format check`
- `cargo xtask check-memory-lifecycle-policy`
- `cargo xtask check-memory-retained-owner-drift --base origin/master`
- `cargo xtask devex pr-body --base origin/master`
- `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- `git diff --check`
