### PR TITLE
test(format): include native formatting in feature snapshot (#8467)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_features_snapshot_test.rs
+++ b/crates/perl-lsp-rs/tests/lsp_features_snapshot_test.rs
@@ -22,15 +22,10 @@ fn test_advertised_features_match_capabilities() -> Result<(), Box<dyn std::erro
 
     // Get features from capabilities and catalog
     let mut from_caps = feature_ids_from_caps(&caps);
-    from_caps.retain(|feature| !matches!(*feature, "lsp.formatting" | "lsp.range_formatting"));
     from_caps.sort();
 
     let mut from_catalog: Vec<_> = advertised_features().to_vec();
     from_catalog.sort();
-
-    // Formatting capabilities depend on runtime tool availability (for example
-    // whether perltidy is installed in CI), so keep the snapshot focused on
-    // deterministic capability coverage.
 
     // Create snapshot data
     let snapshot_data = json!({

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_features_snapshot_test__advertised_vs_caps.snap
@@ -15,6 +15,7 @@ caps:
   - lsp.document_symbol
   - lsp.execute_command
   - lsp.folding_range
+  - lsp.formatting
   - lsp.hover
   - lsp.implementation
   - lsp.inlay_hint
@@ -24,6 +25,7 @@ caps:
   - lsp.notebook_document_sync
   - lsp.on_type_formatting
   - lsp.pull_diagnostics
+  - lsp.range_formatting
   - lsp.references
   - lsp.rename
   - lsp.selection_range
@@ -32,16 +34,31 @@ caps:
   - lsp.type_definition
   - lsp.workspace_symbol
 catalog:
+  - dap.breakpoint_locations
   - dap.breakpoints.basic
+  - dap.breakpoints.function
   - dap.breakpoints.hit_condition
   - dap.breakpoints.logpoints
+  - dap.cancel
   - dap.completions
   - dap.core
   - dap.exceptions.die
   - dap.exceptions.warn
+  - dap.goto
+  - dap.goto_targets
   - dap.inline_values
+  - dap.loaded_sources
   - dap.modules
+  - dap.pause
+  - dap.restart
+  - dap.restart_frame
+  - dap.set_expression
+  - dap.source
+  - dap.step_in_targets
+  - dap.terminate_threads
+  - dap.threads
   - dap.watchpoints
+  - experimental.perlInlineCompletionStream
   - lsp.apply_edit
   - lsp.call_hierarchy
   - lsp.cancel_request
@@ -58,6 +75,11 @@ catalog:
   - lsp.configuration
   - lsp.declaration
   - lsp.definition
+  - lsp.diagnostic.markup_message_support
+  - lsp.diagnostic.missing_strict
+  - lsp.diagnostic.missing_warnings
+  - lsp.diagnostic.phase_scoped_pragmas
+  - lsp.diagnostic.unreachable_code
   - lsp.diagnostic.unused_variable
   - lsp.diagnostic_refresh
   - lsp.did_change_configuration
@@ -99,6 +121,7 @@ catalog:
   - lsp.pull_diagnostics
   - lsp.range_formatting
   - lsp.ranges_formatting
+  - lsp.refactoring
   - lsp.references
   - lsp.rename
   - lsp.selection_range


### PR DESCRIPTION
## Summary
- removes the old perltidy-availability filter from the LSP feature snapshot
- records native `lsp.formatting` and `lsp.range_formatting` as deterministic initialized capabilities
- refreshes the advertised feature catalog snapshot entries that had drifted since the last regeneration

## Proof
- `cargo xtask fmt`
- `cargo test -p perl-lsp-rs --test lsp_features_snapshot_test --profile agent --locked -- --nocapture`
- `cargo xtask native-tooling check-defaults`
- `cargo xtask native-format check` - native formatter fixtures: 40/40 passed
- `cargo xtask check-memory-lifecycle-policy`
- `cargo xtask check-memory-retained-owner-drift --base origin/master`
- `cargo xtask devex pr-body --base origin/master`
- `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- `git diff --check`