### PR TITLE
docs(format): remove stale perltidy formatting gate wording (#8468)

### DIFF
--- a/docs/project/CLEAN_CODE_SHOWCASE.md
+++ b/docs/project/CLEAN_CODE_SHOWCASE.md
@@ -131,18 +131,18 @@ impl BuildFlags {
 The policy layer bridges user-facing CLI arguments to concrete flag sets:
 
 ```rust
-pub fn runtime_flags(self, has_perltidy: bool) -> BuildFlags {
-    let mut flags = self.build_flags();
-    if has_perltidy {
-        flags.formatting = true;
-        flags.range_formatting = true;
-    }
-    flags
+pub fn runtime_flags(self, _has_perltidy: bool) -> BuildFlags {
+    // Native formatting is built into the server. Perltidy availability is
+    // still detected for the external compatibility adapter, but it no longer
+    // gates whether formatting capabilities can be advertised.
+    self.build_flags()
 }
 ```
 
-This means formatting is only advertised when `perltidy` is actually installed --
-the capability set adapts to the runtime environment.
+This means native formatting is advertised deterministically from the selected
+feature profile. External `perltidy` availability is still useful for projects
+that opt into the legacy compatibility adapter, but it is not part of default
+capability selection.
 
 The grid layer produces JSON reports showing exactly which features are enabled
 for each profile, with compliance percentages. Tests verify that the feature ID

--- a/docs/project/FEATURE_GOVERNANCE.md
+++ b/docs/project/FEATURE_GOVERNANCE.md
@@ -100,7 +100,7 @@ and the computed compliance percentage.
 | `perl-lsp-feature-flags` | `crates/perl-lsp-feature-flags/` | Defines `BuildFlags` (per-feature booleans for compile-time selection) and `AdvertisedFeatures` (runtime projection). Provides preset constructors: `production()`, `ga_lock()`, `all()`. Converts flags to feature ID vectors. |
 | `perl-lsp-feature-contracts` | `crates/perl-lsp-feature-contracts/` | Runs a `build.rs` that compiles `features.toml` into `feature_contracts.rs` constants via `perl-feature-catalog`. Defines `FeatureProfileKind` (GaLock, Production, All) and `BddFeatureRow` for reporting. Exposes `all_features()`, `has_feature()`, `compliance_percent()`. |
 | `perl-lsp-feature-profile` | `crates/perl-lsp-feature-profile/` | Parses raw CLI profile tokens (`"ga-lock"`, `"prod"`, `"all"`, `"auto"`) into `FeatureProfileKind`. Handles normalization (trimming, case folding, underscore-to-hyphen). |
-| `perl-lsp-feature-policy` | `crates/perl-lsp-feature-policy/` | Defines `FeatureProfile` and resolves it into `BuildFlags`. Handles runtime environment effects (e.g. enabling formatting when `perltidy` is available). Provides `catalog_advertised_feature_ids()` which intersects profile flags with the catalog. |
+| `perl-lsp-feature-policy` | `crates/perl-lsp-feature-policy/` | Defines `FeatureProfile` and resolves it into `BuildFlags`. Keeps native formatting capabilities deterministic; external `perltidy` availability is only relevant to the explicit compatibility adapter. Provides `catalog_advertised_feature_ids()` which intersects profile flags with the catalog. |
 | `perl-lsp-feature-grid` | `crates/perl-lsp-feature-grid/` | Assembles the BDD feature grid JSON payload. Computes per-profile compliance percentages. Consumed by `xtask`, CI reporting, and the server's feature catalog endpoint. |
 | `perl-lsp-feature-profile-cli` | `crates/perl-lsp-feature-profile-cli/` | Parses `--feature-profile` CLI arguments. Returns structured `UnsupportedFeatureProfileError` with the supported token list for user diagnostics. |
 | `perl-lsp-feature-governance` | `crates/perl-lsp-feature-governance/` | Facade crate that re-exports the public API surface from all governance sub-crates. The LSP server binary and launcher depend on this single crate rather than each sub-crate individually. |
@@ -113,7 +113,7 @@ profiles are defined:
 | Profile | Constructor | Description |
 |---------|------------|-------------|
 | `ga-lock` | `BuildFlags::ga_lock()` | Conservative set. Excludes `inline_values`. Includes formatting. Intended for stable API guarantees. |
-| `production` | `BuildFlags::production()` | Standard runtime set. Excludes formatting (enabled dynamically when `perltidy` is detected). All other GA features enabled. |
+| `production` | `BuildFlags::production()` | Standard runtime set. Includes native full-document and range formatting. All other GA features enabled. |
 | `all` | `BuildFlags::all()` | Every in-tree feature enabled. Used for testing, snapshots, and CI matrices. |
 
 Profile selection happens through:
@@ -126,9 +126,10 @@ Profile selection happens through:
    `ga-lock`, `ga_lock`, `prod`, `production`, `all`, or `auto` (which falls
    back to the compiled default).
 
-3. **Runtime adaptation:** `FeatureProfile::runtime_flags()` checks for external
-   tool availability. For example, formatting is enabled only when `perltidy` is
-   installed, regardless of the base profile.
+3. **Runtime adaptation:** `FeatureProfile::runtime_flags()` preserves the
+   selected profile's native formatting flags. External tool detection still
+   exists for compatibility adapters, but it no longer gates whether formatting
+   capabilities are advertised.
 
 ## Contracts and Compliance
 

--- a/docs/reference/PERFORMANCE_SLO.md
+++ b/docs/reference/PERFORMANCE_SLO.md
@@ -24,7 +24,7 @@ This document defines the Service Level Objectives (SLOs) for the Perl LSP serve
 | `textDocument/references` | 100ms | 250ms | 500ms | Multi-phase search |
 | `textDocument/documentSymbol` | 25ms | 50ms | 100ms | Single file parsing |
 | `textDocument/semanticTokens` | 50ms | 100ms | 200ms | Full semantic analysis |
-| `textDocument/formatting` | 500ms | 1000ms | 2000ms | External perltidy |
+| `textDocument/formatting` | 500ms | 1000ms | 2000ms | Native formatter default; external perltidy only in compatibility mode |
 | `textDocument/rename` | 250ms | 500ms | 1000ms | Cross-file workspace |
 | `textDocument/codeAction` | 50ms | 100ms | 200ms | Code action generation |
 | `textDocument/codeLens` | 50ms | 100ms | 200ms | Reference counting |

--- a/docs/specs/PACKAGING_INSTALL_SPEC.md
+++ b/docs/specs/PACKAGING_INSTALL_SPEC.md
@@ -332,15 +332,18 @@ Note: Configuration is nested under `perl.inlayHints.*` and `perl.workspace.*` s
 3. Verify workspace folder is correctly set
 4. Check `maxFiles` limit isn't exceeded
 
-### perltidy/perlcritic Not Working
+### External perltidy/perlcritic Compatibility Not Working
 
-**Symptoms**: Formatting doesn't work, or no linting diagnostics
+**Symptoms**: Explicit external formatting compatibility doesn't work, or no
+legacy perlcritic diagnostics
 
 **Solutions**:
-1. Verify tools are installed: `which perltidy`, `which perlcritic`
+1. Verify external compatibility tools are installed: `which perltidy`, `which perlcritic`
 2. Check paths in configuration
-3. Formatting works without perltidy (built-in fallback)
-4. perlcritic requires explicit installation
+3. Native formatting works without perltidy; install perltidy only for explicit
+   external compatibility mode
+4. Native critic diagnostics work without perlcritic; install perlcritic only
+   for explicit legacy compatibility mode
 
 ### Multi-Root Workspace Issues
 


### PR DESCRIPTION
## Summary
- update feature governance docs so native formatting is deterministic instead of perltidy-gated
- refresh the clean-code showcase runtime_flags example to match the current native-default policy
- update performance/install docs to describe external perltidy/perlcritic as explicit compatibility adapters

## Proof
- `cargo xtask fmt`
- `cargo xtask check-devex-docs`
- `cargo xtask devex pr-body --base origin/master`
- `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- `git diff --check`

Note: `cargo xtask check-doc-index` and `cargo xtask markdown-links` are not recognized subcommands in this checkout; `check-devex-docs` is the available docs drift guard.