### PR TITLE
docs(format): refresh native tooling overview wording (#8469)

### DIFF
--- a/docs/articles/ZERO_PANIC.md
+++ b/docs/articles/ZERO_PANIC.md
@@ -56,7 +56,7 @@ background. When that process panics, the user's experience degrades silently:
 - **Diagnostics go stale** -- errors from three edits ago persist on screen.
 - **Navigation breaks** -- goto-definition returns nothing, so the user opens
   `grep` instead.
-- **Formatting fails** -- the user assumes perltidy is broken.
+- **Formatting fails** -- the user assumes the language server or formatting configuration is broken.
 
 The editor may restart the server, but restart is not instant. There's a gap
 where the developer has no language intelligence at all. If the panic was

--- a/docs/articles/drafts/PERL_DESERVES_BETTER_TOOLING.md
+++ b/docs/articles/drafts/PERL_DESERVES_BETTER_TOOLING.md
@@ -61,7 +61,7 @@ The feature list is not a promise — it is tracked in `features.toml` with test
 - **Navigation**: go to definition, find references, call hierarchy, type hierarchy, workspace symbols
 - **Completion**: 150+ built-in Perl functions, workspace symbols across all project files, module names
 - **Diagnostics**: static analysis, undefined subroutine detection, variable scope problems
-- **Editing**: rename across the workspace, code actions, formatting (via Perl::Tidy integration), inlay hints
+- **Editing**: rename across the workspace, code actions, native formatting with optional Perl::Tidy compatibility, inlay hints
 - **Semantic tokens**: syntax highlighting with semantic context (not just regex-based tokenization)
 - **Code lens**: inline contextual information without cluttering the source view
 - **Debugging**: a bundled DAP (Debug Adapter Protocol) server for step debugging

--- a/docs/how-to/PERFORMANCE_TUNING.md
+++ b/docs/how-to/PERFORMANCE_TUNING.md
@@ -828,7 +828,7 @@ Key metrics to monitor:
 1. **Module resolution** - Slow filesystem, network latency
 2. **Symbol indexing** - Large workspaces, deep nesting
 3. **Completion** - Too many items, complex resolution
-4. **Formatting** - External tool (perltidy) overhead
+4. **Formatting** - Native formatting cost, or external tool overhead when explicit compatibility mode is enabled
 5. **Diagnostics** - Complex syntax analysis
 
 ---

--- a/docs/project/CRATE_DEPENDENCY_TIERS.md
+++ b/docs/project/CRATE_DEPENDENCY_TIERS.md
@@ -163,8 +163,8 @@ This tier contains the parser core engine and LSP transport layer.
 | `perl-parser-core` | `perl-lexer`, `perl-ast`, `perl-quote`, `perl-pragma`, `perl-edit`, `perl-builtins`, `perl-regex`, `perl-heredoc`, `perl-error`, `perl-tokenizer` | Core parser engine for perl-parser |
 | `perl-tdd-support` | `perl-parser-core` | Test-driven development helpers for the Perl LSP ecosystem |
 | `perl-lsp-transport` | `perl-lsp-protocol`, `perl-content-length-framing` | LSP transport layer with Content-Length message framing |
-| `perl-lsp-tooling` | `perl-subprocess-runtime`, `perl-parser-core`, `perl-symbol-index`, `perl-lsp-performance`, `perl-lsp-critic-parser` | Tooling integration (perltidy, perlcritic, subprocess) |
-| `perl-lsp-formatting` | `perl-lsp-tooling`, `perl-lsp-formatting-types` | LSP formatting provider with perltidy integration |
+| `perl-lsp-tooling` | `perl-subprocess-runtime`, `perl-parser-core`, `perl-symbol-index`, `perl-lsp-performance`, `perl-lsp-critic-parser` | Native tooling integration plus explicit perltidy/perlcritic compatibility adapters |
+| `perl-lsp-formatting` | `perl-lsp-tooling`, `perl-lsp-formatting-types` | LSP formatting provider with native-first formatting and Perltidy compatibility |
 | `perl-lsp-diagnostics` | `perl-lsp-diagnostic-types`, `perl-parser-core`, `perl-semantic-analyzer`, `perl-workspace-index`, `perl-pragma` | LSP diagnostics provider |
 | `perl-lsp-semantic-tokens` | `perl-parser-core`, `perl-lexer`, `perl-semantic-analyzer` | LSP semantic tokens provider |
 | `perl-lsp-inlay-hints` | `perl-semantic-analyzer`, `perl-position-tracking`, `perl-parser-core` | LSP inlay hints provider |

--- a/docs/project/LSP_IMPLEMENTATION_STORY.md
+++ b/docs/project/LSP_IMPLEMENTATION_STORY.md
@@ -161,9 +161,9 @@ As the project matured, more sophisticated features were added:
 
 ### Formatting and Diagnostics
 
-- **Document formatting**: Integration with Perl::Tidy via a subprocess runtime
-  abstraction. The `FormattingProvider` wraps perltidy execution behind a generic
-  `SubprocessRuntime` trait, supporting full-document formatting, range
+- **Document formatting**: Native Rust formatting is the default path, with
+  explicit Perl::Tidy compatibility available for projects that require legacy
+  output. The `FormattingProvider` supports full-document formatting, range
   formatting, and the LSP 3.18 multi-range formatting proposal.
 - **On-type formatting**: Auto-indentation on keystroke, extracted into its own
   `perl-lsp-on-type-formatting` SRP microcrate.
@@ -338,8 +338,8 @@ capabilities are advertised, compiled, and reported:
    `features.toml` and produces a Rust module with all feature metadata.
 
 4. **`perl-lsp-feature-policy`**: Maps high-level profile decisions to runtime
-   `BuildFlags`. Handles runtime tooling checks (e.g., formatting is only
-   advertised if perltidy is installed).
+   `BuildFlags`. Native formatting capabilities are deterministic; external
+   tool detection only affects explicit compatibility adapters.
 
 5. **`perl-lsp-feature-profile`**: Profile name parsing and normalization.
    Handles aliases (`ga`, `ga-lock`, `ga_lock` all resolve to `GaLock`).

--- a/docs/project/PERL_LSP_VISION.md
+++ b/docs/project/PERL_LSP_VISION.md
@@ -315,7 +315,7 @@ What must happen:
 | **Diagnostics** | Syntax + parse errors | GA | 80% | Missing: perlcritic, dead code, use warnings |
 | **Navigation** | Go-to-def, references, rename | GA | 85% | Missing: cross-inheritance, @INC resolution |
 | **Completion** | Symbols, builtins, keywords | GA | 80% | Missing: CPAN module completion |
-| **Formatting** | Perl::Tidy integration | GA | 90% | Missing: config-per-project |
+| **Formatting** | Native formatter with explicit Perl::Tidy compatibility | GA | 90% | Missing: broader corpus coverage |
 | **Semantics** | Workspace symbol index | GA | 70% | Missing: Moose/Moo intelligence |
 | **Debugging** | DAP native adapter | GA | 80% | Missing: expression evaluation, locals |
 | **Perl-specific** | Test runner, perldoc, @INC | Preview | 20% | All missing |

--- a/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
+++ b/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
@@ -301,6 +301,6 @@ secret-check preflight and `PUBLISHING_ROADMAP.md` for the release-day sequence.
 - [ ] **Record the 3 walkthrough GIFs** using `scripts/marketing/render-walkthrough-gif.py`. These improve the in-extension first-run experience, not the marketplace listing itself.
 - [ ] **Delete the stale `perl-lsp-rs-0.12.0.vsix`** from `vscode-extension/`. It does not block publishing but bloats git history.
 - [ ] **Verify icon at 28px** — confirm it reads at sidebar icon size.
-- [ ] **Add perltidy/perlcritic as an explicit "Requirements" section** in README.md.
+- [ ] **Clarify native tooling requirements** in README.md, with perltidy/perlcritic documented only as optional compatibility adapters.
 - [ ] **Resolve the `Shift+Alt+F` footnote** in the keyboard shortcuts table.
 - [ ] **Consider root `LICENSE` file** — the repo root has no LICENSE file (only `vscode-extension/LICENSE`). GitHub shows the license badge from the root. Worth adding a root `LICENSE` or symlink.


### PR DESCRIPTION
## Summary
- update architecture/vision docs from Perl::Tidy-led formatting to native-first formatting with explicit compatibility adapters
- refresh performance and marketplace wording so perltidy/perlcritic are optional compatibility tools, not normal-path requirements
- adjust article wording where users would otherwise infer formatting failure means perltidy failure

## Proof
- `cargo xtask fmt`
- `cargo xtask check-devex-docs`
- `cargo xtask devex pr-body --base origin/master`
- `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- `git diff --check`