### PR TITLE
docs(tooling): regenerate native tooling readiness counts (#8472)

### DIFF
--- a/docs/project/status/native_tooling_readiness.md
+++ b/docs/project/status/native_tooling_readiness.md
@@ -11,14 +11,14 @@
 | Area | Criterion | Status | Required | Evidence | Next |
 | --- | --- | --- | --- | --- | --- |
 | formatter | native formatter default | ready | true | engine=native, external_adapter_requested=false | regenerate `cargo xtask native-format config` and keep external adapter opt-in |
-| formatter | fixture suite passes | ready | true | passed=38/38 failed=0 | run `cargo xtask native-format check` and fix any fixture failures |
+| formatter | fixture suite passes | ready | true | passed=40/40 failed=0 | run `cargo xtask native-format check` and fix any fixture failures |
 | formatter | corpus idempotent and parse-preserving | ready | true | files=65 idempotence=65/65 parse_preservation=65/65 passed=true | run `cargo xtask native-format corpus` and investigate non-idempotent or non-preserved files |
 | formatter | corpus unsupported formatter diagnostics are cleared | warning | false | unsupported_diagnostics=10 literal_bailouts=24 diagnostics=34 | triage unsupported formatter diagnostics before claiming broad format-on-save coverage |
-| formatter | dangerous surfaces visible | ready | true | expected_diagnostic_fixtures=8 literal_preserve_fixtures=8 bailout_count=8 | expand literal/comment preservation fixtures before treating format-on-save as broad coverage |
+| formatter | dangerous surfaces visible | ready | true | expected_diagnostic_fixtures=9 literal_preserve_fixtures=9 bailout_count=9 | expand literal/comment preservation fixtures before treating format-on-save as broad coverage |
 | formatter | perltidy compatibility has no external-only gaps | ready | true | options=8 supported=7 approximated=0 external_only=0 | map, approximate, or document remaining external-only perltidy options |
 | critic | native critic default | ready | true | default perlcritic_enabled=true critic_engine=Native profile=recommended | keep default critic path on the low-noise native recommended profile |
 | critic | native rule surface has LSP and bridge coverage | ready | true | rules=28 pull=28 push=28 workspace=28 bridge=28 | route every recommended rule through pull, push, workspace diagnostics, and violation bridge |
 | critic | native critic check receipt is parse-clean | ready | true | profile=recommended files=65 parse_errors=0 findings=112 fixable=110 | run `cargo xtask native-critic check` and fix parse errors before relying on critic receipts |
-| critic | native critic false-positive fixtures are clean | ready | true | files=6 parse_errors=0 findings=0 suppressed=0 | run the native critic false-positive fixture receipt and fix any emitted finding |
+| critic | native critic false-positive fixtures are clean | ready | true | files=11 parse_errors=0 findings=0 suppressed=0 | run the native critic false-positive fixture receipt and fix any emitted finding |
 | critic | native critic has fixes and suppression coverage | ready | true | rules=28 suppression=28 fixes=14 | add suppression/config/fix tests for new rules before enabling them in recommended profile |
 | critic | perlcritic compatibility has no external-only gaps | ready | true | items=12 equivalent=5 superset=2 approximated=3 external_only=0 | map high-value perlcritic policies or keep external mode documented for remaining policies |


### PR DESCRIPTION
## Summary

- regenerate `docs/project/status/native_tooling_readiness.md` from current native-tooling receipts after #8471 merged
- restore the live formatter fixture / dangerous-surface / false-positive fixture counts while preserving the new provisional warning

## Proof

- [x] `cargo xtask native-tooling readiness --markdown docs/project/status/native_tooling_readiness.md`
- [x] `git diff --check`
