### PR TITLE
feat(format): split corpus unsupported diagnostics (#8473)

### DIFF
--- a/docs/project/status/native_tooling.md
+++ b/docs/project/status/native_tooling.md
@@ -13,8 +13,10 @@
 | Corpus files changed | 2 |
 | Corpus idempotence | 65/65 |
 | Corpus parse preservation | 65/65 |
-| Corpus literal bailouts | 24 |
-| Corpus unsupported diagnostics | 10 |
+| Corpus literal bailouts | 25 |
+| Corpus unsupported diagnostics | 9 |
+| Corpus unsupported parse-clean diagnostics | 0 |
+| Corpus parse-error diagnostics | 9 |
 | Corpus passed | true |
 | Perltidy compatibility options | 8 |
 | Perltidy compatibility supported | 7 |

--- a/docs/project/status/native_tooling_readiness.md
+++ b/docs/project/status/native_tooling_readiness.md
@@ -13,7 +13,7 @@
 | formatter | native formatter default | ready | true | engine=native, external_adapter_requested=false | regenerate `cargo xtask native-format config` and keep external adapter opt-in |
 | formatter | fixture suite passes | ready | true | passed=40/40 failed=0 | run `cargo xtask native-format check` and fix any fixture failures |
 | formatter | corpus idempotent and parse-preserving | ready | true | files=65 idempotence=65/65 parse_preservation=65/65 passed=true | run `cargo xtask native-format corpus` and investigate non-idempotent or non-preserved files |
-| formatter | corpus unsupported formatter diagnostics are cleared | warning | false | unsupported_diagnostics=10 literal_bailouts=24 diagnostics=34 | triage unsupported formatter diagnostics before claiming broad format-on-save coverage |
+| formatter | corpus unsupported formatter diagnostics are cleared | warning | false | unsupported_diagnostics=9 parse_clean_unsupported=0 parse_error_diagnostics=9 literal_bailouts=25 diagnostics=34 | triage parse-clean unsupported diagnostics first; parse-error diagnostics are recovery fixtures |
 | formatter | dangerous surfaces visible | ready | true | expected_diagnostic_fixtures=9 literal_preserve_fixtures=9 bailout_count=9 | expand literal/comment preservation fixtures before treating format-on-save as broad coverage |
 | formatter | perltidy compatibility has no external-only gaps | ready | true | options=8 supported=7 approximated=0 external_only=0 | map, approximate, or document remaining external-only perltidy options |
 | critic | native critic default | ready | true | default perlcritic_enabled=true critic_engine=Native profile=recommended | keep default critic path on the low-noise native recommended profile |

--- a/xtask/src/tasks/native_format.rs
+++ b/xtask/src/tasks/native_format.rs
@@ -90,6 +90,8 @@ struct NativeFormatCorpusReceipt {
     parse_preserved_count: usize,
     literal_bailout_count: usize,
     unsupported_patterns_count: usize,
+    unsupported_parse_clean_count: usize,
+    parse_error_count: usize,
     diagnostics_count: usize,
     passed: bool,
     files: Vec<NativeFormatCorpusFileResult>,
@@ -107,6 +109,8 @@ struct NativeFormatCorpusFileResult {
     parse_preserved: bool,
     literal_bailout: bool,
     unsupported_pattern: bool,
+    unsupported_parse_clean: bool,
+    parse_error: bool,
     passed: bool,
 }
 
@@ -319,6 +323,11 @@ pub fn corpus(config: NativeFormatCorpusConfig) -> Result<()> {
             .iter()
             .filter(|result| result.unsupported_pattern)
             .count(),
+        unsupported_parse_clean_count: results
+            .iter()
+            .filter(|result| result.unsupported_parse_clean)
+            .count(),
+        parse_error_count: results.iter().filter(|result| result.parse_error).count(),
         diagnostics_count: results.iter().map(|result| result.diagnostic_codes.len()).sum(),
         passed,
         files: results,
@@ -747,6 +756,8 @@ fn check_corpus_file(
         && diagnostic_codes.iter().any(|code| code == "native.format.literal_preserve_region");
     let unsupported_pattern =
         diagnostic_codes.iter().any(|code| code != "native.format.literal_preserve_region");
+    let parse_error = diagnostic_codes.iter().any(|code| code == "native.format.parse_error");
+    let unsupported_parse_clean = unsupported_pattern && source_parse_clean;
     let passed = idempotent && parse_preserved;
 
     Ok(NativeFormatCorpusFileResult {
@@ -760,6 +771,8 @@ fn check_corpus_file(
         parse_preserved,
         literal_bailout,
         unsupported_pattern,
+        unsupported_parse_clean,
+        parse_error,
         passed,
     })
 }
@@ -926,6 +939,11 @@ fn write_corpus_summary(path: &Path, receipt: &NativeFormatCorpusReceipt) -> Res
     markdown.push_str(&format!("- Literal bailouts: {}\n", receipt.literal_bailout_count));
     markdown
         .push_str(&format!("- Unsupported diagnostics: {}\n", receipt.unsupported_patterns_count));
+    markdown.push_str(&format!(
+        "- Unsupported diagnostics on parse-clean files: {}\n",
+        receipt.unsupported_parse_clean_count
+    ));
+    markdown.push_str(&format!("- Parse-error diagnostics: {}\n", receipt.parse_error_count));
     markdown.push_str(&format!("- Passed: {}\n\n", receipt.passed));
     markdown.push_str("| File | Changed | Idempotent | Parse Preserved | Diagnostics |\n");
     markdown.push_str("| --- | --- | --- | --- | --- |\n");
@@ -939,6 +957,22 @@ fn write_corpus_summary(path: &Path, receipt: &NativeFormatCorpusReceipt) -> Res
             "| `{}` | {} | {} | {} | {} |\n",
             file.path, file.changed, file.idempotent, file.parse_preserved, diagnostics
         ));
+    }
+    let unsupported_files =
+        receipt.files.iter().filter(|file| file.unsupported_pattern).collect::<Vec<_>>();
+    if !unsupported_files.is_empty() {
+        markdown.push_str("\n## Unsupported Diagnostics\n\n");
+        markdown.push_str("| File | Source Parse Clean | Parse Error | Diagnostics |\n");
+        markdown.push_str("| --- | --- | --- | --- |\n");
+        for file in unsupported_files {
+            markdown.push_str(&format!(
+                "| `{}` | {} | {} | {} |\n",
+                file.path,
+                file.source_parse_clean,
+                file.parse_error,
+                file.diagnostic_codes.join(", ")
+            ));
+        }
     }
     fs::write(path, markdown).wrap_err_with(|| format!("failed to write {}", path.display()))
 }
@@ -1098,12 +1132,16 @@ mod tests {
         assert_eq!(receipt["idempotence_passed_count"], 2);
         assert_eq!(receipt["parse_preserved_count"], 2);
         assert_eq!(receipt["literal_bailout_count"], 1);
+        assert_eq!(receipt["unsupported_parse_clean_count"], 0);
+        assert_eq!(receipt["parse_error_count"], 0);
         assert_eq!(receipt["passed"], true);
 
         let summary = fs::read_to_string(receipts.join("native-format-corpus-summary.md"))?;
         assert!(summary.contains("# Native Format Corpus"));
         assert!(summary.contains("Files checked: 2"));
         assert!(summary.contains("Literal bailouts: 1"));
+        assert!(summary.contains("Unsupported diagnostics on parse-clean files: 0"));
+        assert!(summary.contains("Parse-error diagnostics: 0"));
 
         Ok(())
     }

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -131,6 +131,8 @@ struct FormatterStatus {
     corpus_parse_preserved_count: Option<usize>,
     corpus_literal_bailout_count: Option<usize>,
     corpus_unsupported_patterns_count: Option<usize>,
+    corpus_unsupported_parse_clean_count: Option<usize>,
+    corpus_parse_error_count: Option<usize>,
     corpus_diagnostics_count: Option<usize>,
     corpus_passed: Option<bool>,
     format_perltidy_compat_receipt: String,
@@ -439,9 +441,17 @@ fn build_readiness_receipt(
         formatter.format_corpus_receipt_present,
         false,
         format!(
-            "unsupported_diagnostics={} literal_bailouts={} diagnostics={}",
+            "unsupported_diagnostics={} parse_clean_unsupported={} parse_error_diagnostics={} literal_bailouts={} diagnostics={}",
             optional_metric(
                 formatter.corpus_unsupported_patterns_count,
+                formatter.format_corpus_receipt_present,
+            ),
+            optional_metric(
+                formatter.corpus_unsupported_parse_clean_count,
+                formatter.format_corpus_receipt_present,
+            ),
+            optional_metric(
+                formatter.corpus_parse_error_count,
                 formatter.format_corpus_receipt_present,
             ),
             optional_metric(
@@ -453,7 +463,7 @@ fn build_readiness_receipt(
                 formatter.format_corpus_receipt_present
             )
         ),
-        "triage unsupported formatter diagnostics before claiming broad format-on-save coverage",
+        "triage parse-clean unsupported diagnostics first; parse-error diagnostics are recovery fixtures",
     ));
     criteria.push(readiness_criterion(
         "formatter",
@@ -843,6 +853,11 @@ fn formatter_status(
             &corpus_receipt,
             "unsupported_patterns_count",
         ),
+        corpus_unsupported_parse_clean_count: optional_usize(
+            &corpus_receipt,
+            "unsupported_parse_clean_count",
+        ),
+        corpus_parse_error_count: optional_usize(&corpus_receipt, "parse_error_count"),
         corpus_diagnostics_count: optional_usize(&corpus_receipt, "diagnostics_count"),
         corpus_passed: optional_bool(&corpus_receipt, "passed"),
         format_perltidy_compat_receipt: format_perltidy_compat_receipt.display().to_string(),
@@ -1080,6 +1095,14 @@ fn render_markdown(receipt: &NativeToolingStatusReceipt) -> String {
         formatter.corpus_unsupported_patterns_count,
         formatter.format_corpus_receipt_present,
     );
+    let corpus_unsupported_parse_clean = optional_metric(
+        formatter.corpus_unsupported_parse_clean_count,
+        formatter.format_corpus_receipt_present,
+    );
+    let corpus_parse_errors = optional_metric(
+        formatter.corpus_parse_error_count,
+        formatter.format_corpus_receipt_present,
+    );
     let corpus_passed =
         formatter.corpus_passed.map(|passed| passed.to_string()).unwrap_or_else(|| {
             if formatter.format_corpus_receipt_present {
@@ -1230,6 +1253,8 @@ fn render_markdown(receipt: &NativeToolingStatusReceipt) -> String {
 | Corpus parse preservation | {} |
 | Corpus literal bailouts | {} |
 | Corpus unsupported diagnostics | {} |
+| Corpus unsupported parse-clean diagnostics | {} |
+| Corpus parse-error diagnostics | {} |
 | Corpus passed | {} |
 | Perltidy compatibility options | {} |
 | Perltidy compatibility supported | {} |
@@ -1293,6 +1318,8 @@ Fixable native rules:
         corpus_parse_preservation,
         corpus_literal_bailouts,
         corpus_unsupported_diagnostics,
+        corpus_unsupported_parse_clean,
+        corpus_parse_errors,
         corpus_passed,
         perltidy_compat_options,
         perltidy_compat_supported,
@@ -1722,6 +1749,8 @@ mod tests {
   "parse_preserved_count": 2,
   "literal_bailout_count": 1,
   "unsupported_patterns_count": 0,
+  "unsupported_parse_clean_count": 0,
+  "parse_error_count": 0,
   "diagnostics_count": 1,
   "passed": true
 }
@@ -1833,6 +1862,8 @@ mod tests {
         assert_eq!(value["formatter"]["corpus_parse_preserved_count"], 2);
         assert_eq!(value["formatter"]["corpus_literal_bailout_count"], 1);
         assert_eq!(value["formatter"]["corpus_unsupported_patterns_count"], 0);
+        assert_eq!(value["formatter"]["corpus_unsupported_parse_clean_count"], 0);
+        assert_eq!(value["formatter"]["corpus_parse_error_count"], 0);
         assert_eq!(value["formatter"]["corpus_passed"], true);
         assert_eq!(value["formatter"]["format_perltidy_compat_receipt_present"], true);
         assert_eq!(value["formatter"]["perltidy_compat_option_count"], 9);
@@ -1898,6 +1929,8 @@ mod tests {
         assert!(markdown.contains("| Corpus parse preservation | 2/2 |"));
         assert!(markdown.contains("| Corpus literal bailouts | 1 |"));
         assert!(markdown.contains("| Corpus unsupported diagnostics | 0 |"));
+        assert!(markdown.contains("| Corpus unsupported parse-clean diagnostics | 0 |"));
+        assert!(markdown.contains("| Corpus parse-error diagnostics | 0 |"));
         assert!(markdown.contains("| Corpus passed | true |"));
         assert!(markdown.contains("| Perltidy compatibility options | 9 |"));
         assert!(markdown.contains("| Perltidy compatibility supported | 7 |"));
@@ -2052,6 +2085,8 @@ color = 1
                 corpus_parse_preserved_count: Some(3),
                 corpus_literal_bailout_count: Some(1),
                 corpus_unsupported_patterns_count: Some(2),
+                corpus_unsupported_parse_clean_count: Some(0),
+                corpus_parse_error_count: Some(2),
                 corpus_diagnostics_count: Some(1),
                 corpus_passed: Some(true),
                 format_perltidy_compat_receipt: "native-format-perltidy-compat.json".to_string(),


### PR DESCRIPTION
## Summary

- split native-format corpus unsupported diagnostics into parse-clean unsupported and parse-error buckets
- surface the new breakdown in native-tooling status and readiness evidence
- regenerate native tooling status/readiness docs to show the current warning is 0 parse-clean unsupported diagnostics and 9 parse-error recovery diagnostics

## Proof

- cargo xtask fmt
- cargo test -p xtask native_format_corpus -- --nocapture
- cargo test -p xtask native_tooling -- --nocapture
- cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs
- cargo xtask native-format corpus
- cargo xtask native-tooling status --markdown docs/project/status/native_tooling.md
- cargo xtask native-tooling readiness --markdown docs/project/status/native_tooling_readiness.md
- cargo xtask check-memory-lifecycle-policy
- cargo xtask check-memory-retained-owner-drift --base origin/master
- cargo xtask devex pr-body --base origin/master
- cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json
- git diff --check

## Notes

- This is reporting/status only. It does not change formatter runtime behavior.
- `just status-check` still reports unrelated generated status drift in tests/parser/quality/dap docs; this PR intentionally leaves those files untouched.