### PR TITLE
docs(tooling): clarify native tooling requirements (#8475)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ These are behavioral and corpus-backed signals, not feature-inventory counts. Pr
 | Workspace stale-index defects | 0 / 7 tested scenarios |
 | Multi-root workspace tests | 8 / 8 |
 | Memory-control closeout | Known retained-state/session-creep class closed with guardrails ([closeout](docs/large-workspaces/MEMORY_CONTROL_CLOSEOUT.md)) |
+| Native tooling readiness | Native formatter and native critic are default-ready; `perltidy` / `perlcritic` remain explicit compatibility adapters ([status](docs/project/status/native_tooling.md)) |
 
 See [project status](docs/project/status/index.md), [parser status](docs/project/status/parser.md), [workspace status](docs/project/status/workspace.md), and [quality metrics](docs/project/status/quality.md) for generated details.
 
@@ -74,6 +75,10 @@ Current public install artifacts are public alpha. Verify the binary before
 wiring it into shared editor or CI configuration.
 
 The VS Code extension downloads the matching `perllsp` binary automatically. Other editors use the `perllsp --stdio` server command after installing a release binary.
+
+Native formatting and native critic diagnostics do not require `perltidy` or
+`perlcritic`. Install those tools only when a project explicitly opts into
+external compatibility behavior or needs legacy output comparison.
 
 Do not install `perl-lsp` from crates.io; that is a different project.
 

--- a/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
+++ b/docs/project/VSCODE_MARKETPLACE_PUNCH_LIST.md
@@ -301,6 +301,6 @@ secret-check preflight and `PUBLISHING_ROADMAP.md` for the release-day sequence.
 - [ ] **Record the 3 walkthrough GIFs** using `scripts/marketing/render-walkthrough-gif.py`. These improve the in-extension first-run experience, not the marketplace listing itself.
 - [ ] **Delete the stale `perl-lsp-rs-0.12.0.vsix`** from `vscode-extension/`. It does not block publishing but bloats git history.
 - [ ] **Verify icon at 28px** — confirm it reads at sidebar icon size.
-- [ ] **Clarify native tooling requirements** in README.md, with perltidy/perlcritic documented only as optional compatibility adapters.
+- [x] **Clarify native tooling requirements** in README.md, with perltidy/perlcritic documented only as optional compatibility adapters.
 - [ ] **Resolve the `Shift+Alt+F` footnote** in the keyboard shortcuts table.
 - [ ] **Consider root `LICENSE` file** — the repo root has no LICENSE file (only `vscode-extension/LICENSE`). GitHub shows the license badge from the root. Worth adding a root `LICENSE` or symlink.


### PR DESCRIPTION
## Summary

- surface native tooling readiness in the README status table
- state that native formatting and native critic diagnostics do not require `perltidy` or `perlcritic`
- mark the matching VS Code marketplace punch-list item complete

## Proof

- cargo xtask fmt
- cargo xtask check-devex-docs
- just version-check
- cargo xtask devex pr-body --base origin/master
- cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json
- git diff --check

## Notes

- `cargo xtask markdown-links` and `cargo xtask check-doc-index` are not available commands in this repo.
- `just release-check` currently stops on an unrelated CI spend audit finding: `policy-validators.yml:validate` runs ungated. This PR leaves that policy workflow debt untouched.