### PR TITLE
feat(tooling): expose native compatibility reports (#8476)

### DIFF
--- a/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/launcher/mod.rs
@@ -264,6 +264,14 @@ pub struct LspArgs {
     #[arg(long)]
     pub features_json: bool,
 
+    /// Report how a .perltidyrc profile maps to native formatting
+    #[arg(long, value_name = "PROFILE", conflicts_with = "perlcritic_compat_report")]
+    pub perltidy_compat_report: Option<String>,
+
+    /// Report how a .perlcriticrc profile maps to native critic rules
+    #[arg(long, value_name = "PROFILE", conflicts_with = "perltidy_compat_report")]
+    pub perlcritic_compat_report: Option<String>,
+
     /// Set feature profile
     #[arg(long)]
     pub feature_profile: Option<String>,
@@ -333,6 +341,16 @@ pub enum LaunchAction {
     Version,
     /// Print profile-scoped feature catalog JSON.
     FeaturesJson,
+    /// Classify a `.perltidyrc` profile against native formatter support.
+    PerltidyCompatReport {
+        /// Profile path to classify.
+        profile: String,
+    },
+    /// Classify a `.perlcriticrc` profile against native critic support.
+    PerlcriticCompatReport {
+        /// Profile path to classify.
+        profile: String,
+    },
     /// Print CLI help output.
     Help,
 }
@@ -466,6 +484,10 @@ where
                 LaunchAction::Completion { shell }
             } else if parsed_args.features_json {
                 LaunchAction::FeaturesJson
+            } else if let Some(profile) = parsed_args.perltidy_compat_report {
+                LaunchAction::PerltidyCompatReport { profile }
+            } else if let Some(profile) = parsed_args.perlcritic_compat_report {
+                LaunchAction::PerlcriticCompatReport { profile }
             } else {
                 LaunchAction::Run
             };
@@ -611,6 +633,10 @@ pub fn help_text() -> String {
     out.push_str("Tool options:\n");
     out.push_str("  --check <files...>   Validate Perl files and report parse errors\n");
     out.push_str("  --check-project [dir] Scan project directory for parsability report\n");
+    out.push_str("  --perltidy-compat-report <profile>\n");
+    out.push_str("                       Report native formatter compatibility for .perltidyrc\n");
+    out.push_str("  --perlcritic-compat-report <profile>\n");
+    out.push_str("                       Report native critic compatibility for .perlcriticrc\n");
     out.push_str("  --completion <shell> Generate shell completions (bash, zsh, fish)\n");
     out.push_str("  --help               Show this help message\n");
     out.push('\n');
@@ -622,6 +648,8 @@ pub fn help_text() -> String {
     out.push_str("  perllsp --stdio --feature-profile=prod  # production profile\n");
     out.push_str("  perllsp --check lib/MyModule.pm         # syntax check\n");
     out.push_str("  perllsp --check-project lib/             # project scan\n");
+    out.push_str("  perllsp --perltidy-compat-report .perltidyrc\n");
+    out.push_str("  perllsp --perlcritic-compat-report .perlcriticrc\n");
     out.push_str("  perllsp --info                          # server information\n");
     out.push_str("  perllsp --completion bash >> ~/.bashrc   # install completions\n");
     out.push('\n');
@@ -652,7 +680,7 @@ const BASH_COMPLETION: &str = r#"_perl_lsp() {
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--stdio --mcp --socket --port --log --health --info --check --check-project --version --features-json --feature-profile --completion --help"
+    opts="--stdio --mcp --socket --port --log --health --info --check --check-project --version --features-json --perltidy-compat-report --perlcritic-compat-report --feature-profile --completion --help"
 
     case "${prev}" in
         --port)
@@ -664,6 +692,10 @@ const BASH_COMPLETION: &str = r#"_perl_lsp() {
             ;;
         --completion)
             COMPREPLY=( $(compgen -W "bash zsh fish powershell" -- "${cur}") )
+            return 0
+            ;;
+        --perltidy-compat-report|--perlcritic-compat-report)
+            COMPREPLY=( $(compgen -f -- "${cur}") )
             return 0
             ;;
         --check)
@@ -695,6 +727,8 @@ _perl-lsp() {
         '--check-project[Scan project directory for parsability report]:dir:_directories' \
         '--version[Show version information]' \
         '--features-json[Output features catalog as JSON]' \
+        '--perltidy-compat-report[Report native formatter compatibility for .perltidyrc]:profile:_files' \
+        '--perlcritic-compat-report[Report native critic compatibility for .perlcriticrc]:profile:_files' \
         '--feature-profile[Set feature profile]:profile:(ga-lock ga prod production all auto)' \
         '--completion[Generate shell completions]:shell:(bash zsh fish powershell)' \
         '--help[Show help message]' \
@@ -715,6 +749,8 @@ complete -c perl-lsp -l check -F -d 'Validate Perl files'
 complete -c perl-lsp -l check-project -d 'Scan project directory for parsability report'
 complete -c perl-lsp -l version -d 'Show version information'
 complete -c perl-lsp -l features-json -d 'Output features catalog as JSON'
+complete -c perl-lsp -l perltidy-compat-report -F -d 'Report native formatter compatibility for .perltidyrc'
+complete -c perl-lsp -l perlcritic-compat-report -F -d 'Report native critic compatibility for .perlcriticrc'
 complete -c perl-lsp -l feature-profile -x -a 'ga-lock ga prod production all auto' -d 'Set feature profile'
 complete -c perl-lsp -l completion -x -a 'bash zsh fish powershell' -d 'Generate shell completions'
 complete -c perl-lsp -l help -d 'Show help message'
@@ -735,6 +771,8 @@ const POWERSHELL_COMPLETION: &str = r#"Register-ArgumentCompleter -Native -Comma
         [CompletionResult]::new('--check-project', '--check-project', 'ParameterName', 'Scan project directory for parsability report')
         [CompletionResult]::new('--version', '--version', 'ParameterName', 'Show version information')
         [CompletionResult]::new('--features-json', '--features-json', 'ParameterName', 'Output features catalog as JSON')
+        [CompletionResult]::new('--perltidy-compat-report', '--perltidy-compat-report', 'ParameterName', 'Report native formatter compatibility for .perltidyrc')
+        [CompletionResult]::new('--perlcritic-compat-report', '--perlcritic-compat-report', 'ParameterName', 'Report native critic compatibility for .perlcriticrc')
         [CompletionResult]::new('--feature-profile', '--feature-profile', 'ParameterName', 'Set feature profile')
         [CompletionResult]::new('--completion', '--completion', 'ParameterName', 'Generate shell completions')
         [CompletionResult]::new('--help', '--help', 'ParameterName', 'Show help message')

--- a/crates/perl-lsp-rs-core/src/tooling/mod.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/mod.rs
@@ -15,6 +15,9 @@ pub mod performance {
 /// Perl::Critic integration for code quality analysis.
 pub mod perl_critic;
 
+/// Native formatter and critic compatibility reports for legacy profiles.
+pub mod native_compat;
+
 /// Perltidy integration for code formatting.
 pub mod perltidy {
     pub use perl_lsp_perltidy::*;

--- a/crates/perl-lsp-rs-core/src/tooling/native_compat.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/native_compat.rs
@@ -1,0 +1,626 @@
+//! Native tooling compatibility reports for user-facing migration commands.
+//!
+//! These helpers classify legacy `perltidy` and `perlcritic` profile files
+//! against the Rust-native formatter and critic surfaces without invoking the
+//! external tools. Developer receipt commands in `xtask` render richer CI
+//! artifacts; this module provides the small stable report model needed by the
+//! installed `perllsp` binary.
+
+use super::perl_critic::NativeCriticRegistry;
+use serde::Serialize;
+use std::collections::BTreeSet;
+
+/// Native formatter compatibility report for a `.perltidyrc` profile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PerltidyCompatReport {
+    /// Number of perltidy options found in the profile.
+    pub option_count: usize,
+    /// Options that map directly to native formatter config.
+    pub supported_count: usize,
+    /// Options approximated by current native formatter behavior.
+    pub approximated_count: usize,
+    /// Execution/output options that are safe to ignore for native formatting.
+    pub unsupported_safe_count: usize,
+    /// Options that still require external perltidy compatibility mode.
+    pub external_only_count: usize,
+    /// Per-option classifications in source order.
+    pub options: Vec<PerltidyCompatOption>,
+}
+
+/// Per-option compatibility classification for a `.perltidyrc` entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PerltidyCompatOption {
+    /// Raw perltidy option token, such as `-l`.
+    pub option: String,
+    /// Optional value associated with the option.
+    pub value: Option<String>,
+    /// Classification: supported, approximated, unsupported_safe, or external_only.
+    pub classification: &'static str,
+    /// Native formatter config field when the option maps directly.
+    pub native_field: Option<&'static str>,
+    /// Human explanation for the classification.
+    pub note: &'static str,
+}
+
+/// Native critic compatibility report for a `.perlcriticrc` profile.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PerlcriticCompatReport {
+    /// Number of settings and policy sections found in the profile.
+    pub item_count: usize,
+    /// Items with direct native critic equivalents.
+    pub native_equivalent_count: usize,
+    /// Items where native critic behavior is broader or more precise.
+    pub native_superset_count: usize,
+    /// Items approximated by the current native recommended profile.
+    pub approximated_count: usize,
+    /// Settings that are safe to ignore for structured native diagnostics.
+    pub unsupported_safe_count: usize,
+    /// Items that still require external perlcritic compatibility mode.
+    pub external_only_count: usize,
+    /// Per-item classifications in source order.
+    pub items: Vec<PerlcriticCompatItem>,
+}
+
+/// Per-setting or per-policy compatibility classification for `.perlcriticrc`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PerlcriticCompatItem {
+    /// Item kind: setting or policy.
+    pub kind: &'static str,
+    /// Setting name or policy name.
+    pub name: String,
+    /// Setting value, when present.
+    pub value: Option<String>,
+    /// Classification: native_equivalent, native_superset, approximated,
+    /// unsupported_safe, or external_only.
+    pub classification: &'static str,
+    /// Native rule ID when the item maps to a rule.
+    pub native_rule: Option<&'static str>,
+    /// Human explanation for the classification.
+    pub note: &'static str,
+}
+
+/// Classify a `.perltidyrc`-style profile against native formatter support.
+#[must_use]
+pub fn classify_perltidy_profile(raw: &str) -> PerltidyCompatReport {
+    let options = tokenize_perltidy_profile(raw)
+        .iter()
+        .map(|(option, value)| classify_perltidy_option(option, value.clone()))
+        .collect::<Vec<_>>();
+    PerltidyCompatReport {
+        option_count: options.len(),
+        supported_count: perltidy_count(&options, "supported"),
+        approximated_count: perltidy_count(&options, "approximated"),
+        unsupported_safe_count: perltidy_count(&options, "unsupported_safe"),
+        external_only_count: perltidy_count(&options, "external_only"),
+        options,
+    }
+}
+
+/// Classify a `.perlcriticrc`-style profile against native critic support.
+#[must_use]
+pub fn classify_perlcritic_profile(raw: &str) -> PerlcriticCompatReport {
+    let native_rules = NativeCriticRegistry::recommended()
+        .rule_ids()
+        .into_iter()
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>();
+    let mut items = Vec::new();
+
+    for line in raw.lines() {
+        let line = strip_perlcritic_comment(line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(policy) = parse_perlcritic_policy_section(line) {
+            items.push(classify_perlcritic_policy(&policy, &native_rules));
+            continue;
+        }
+
+        if let Some((name, value)) = line.split_once('=') {
+            items.push(classify_perlcritic_setting(name.trim(), Some(value.trim().to_string())));
+            continue;
+        }
+
+        items.push(perlcritic_item(
+            "setting",
+            line,
+            None,
+            "external_only",
+            None,
+            "unrecognized perlcritic profile line is not applied by native critic",
+        ));
+    }
+
+    PerlcriticCompatReport {
+        item_count: items.len(),
+        native_equivalent_count: perlcritic_count(&items, "native_equivalent"),
+        native_superset_count: perlcritic_count(&items, "native_superset"),
+        approximated_count: perlcritic_count(&items, "approximated"),
+        unsupported_safe_count: perlcritic_count(&items, "unsupported_safe"),
+        external_only_count: perlcritic_count(&items, "external_only"),
+        items,
+    }
+}
+
+/// Render a human-readable Markdown summary for a perltidy compatibility report.
+#[must_use]
+pub fn render_perltidy_compat_markdown(profile: &str, report: &PerltidyCompatReport) -> String {
+    let mut markdown = String::new();
+    markdown.push_str("# Native Format Perltidy Compatibility\n\n");
+    markdown.push_str(&format!("- Profile: `{profile}`\n"));
+    markdown.push_str(&format!("- Options checked: {}\n", report.option_count));
+    markdown.push_str(&format!("- Supported: {}\n", report.supported_count));
+    markdown.push_str(&format!("- Approximated: {}\n", report.approximated_count));
+    markdown.push_str(&format!("- Unsupported safe: {}\n", report.unsupported_safe_count));
+    markdown.push_str(&format!("- External-only: {}\n\n", report.external_only_count));
+    markdown.push_str("| Option | Value | Classification | Native field | Note |\n");
+    markdown.push_str("| --- | --- | --- | --- | --- |\n");
+    for option in &report.options {
+        markdown.push_str(&format!(
+            "| `{}` | {} | {} | {} | {} |\n",
+            option.option,
+            option.value.as_deref().unwrap_or(""),
+            option.classification,
+            option.native_field.unwrap_or(""),
+            option.note
+        ));
+    }
+    markdown
+}
+
+/// Render a human-readable Markdown summary for a perlcritic compatibility report.
+#[must_use]
+pub fn render_perlcritic_compat_markdown(profile: &str, report: &PerlcriticCompatReport) -> String {
+    let mut markdown = String::new();
+    markdown.push_str("# Native Critic Perlcritic Compatibility\n\n");
+    markdown.push_str(&format!("- Profile: `{profile}`\n"));
+    markdown.push_str(&format!("- Items checked: {}\n", report.item_count));
+    markdown.push_str(&format!("- Native equivalent: {}\n", report.native_equivalent_count));
+    markdown.push_str(&format!("- Native superset: {}\n", report.native_superset_count));
+    markdown.push_str(&format!("- Approximated: {}\n", report.approximated_count));
+    markdown.push_str(&format!("- Unsupported safe: {}\n", report.unsupported_safe_count));
+    markdown.push_str(&format!("- External-only: {}\n\n", report.external_only_count));
+    markdown.push_str("| Kind | Name | Value | Classification | Native rule | Note |\n");
+    markdown.push_str("| --- | --- | --- | --- | --- | --- |\n");
+    for item in &report.items {
+        markdown.push_str(&format!(
+            "| {} | `{}` | {} | {} | {} | {} |\n",
+            item.kind,
+            item.name,
+            item.value.as_deref().unwrap_or(""),
+            item.classification,
+            item.native_rule.unwrap_or(""),
+            item.note
+        ));
+    }
+    markdown
+}
+
+fn tokenize_perltidy_profile(raw: &str) -> Vec<(String, Option<String>)> {
+    let tokens = raw
+        .lines()
+        .filter_map(|line| line.split('#').next())
+        .flat_map(str::split_whitespace)
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let mut options = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        if !token.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        if let Some((option, value)) = token.split_once('=') {
+            options.push((option.to_string(), Some(value.to_string())));
+            index += 1;
+            continue;
+        }
+        if perltidy_option_requires_value(token)
+            && tokens.get(index + 1).is_some_and(|value| !value.starts_with('-'))
+        {
+            options.push((token.to_string(), tokens.get(index + 1).cloned()));
+            index += 2;
+            continue;
+        }
+        options.push((token.to_string(), None));
+        index += 1;
+    }
+    options
+}
+
+fn perltidy_option_requires_value(option: &str) -> bool {
+    matches!(
+        option,
+        "-l" | "--maximum-line-length"
+            | "-i"
+            | "--indent-columns"
+            | "-ci"
+            | "--block-comment-indentation"
+    )
+}
+
+fn classify_perltidy_option(option: &str, value: Option<String>) -> PerltidyCompatOption {
+    match option {
+        "-l" | "--maximum-line-length" => perltidy_option(
+            option,
+            value,
+            "supported",
+            Some("format.line_width"),
+            "maps directly to the native formatter line width",
+        ),
+        "-i" | "--indent-columns" => perltidy_option(
+            option,
+            value,
+            "supported",
+            Some("format.indent_width"),
+            "maps directly to native formatter indentation width",
+        ),
+        "-t" | "--tabs" | "-nt" | "--notabs" => perltidy_option(
+            option,
+            value,
+            "supported",
+            Some("format.use_tabs"),
+            "maps directly to native formatter tab indentation",
+        ),
+        "-ce" | "--cuddled-else" | "-nce" | "--nocuddled-else" => perltidy_option(
+            option,
+            value,
+            "supported",
+            Some("format.else_placement"),
+            "maps to native formatter else placement for supported simple block layouts",
+        ),
+        "-sok" | "--space-after-keyword" | "-nsok" | "--nospace-after-keyword" => perltidy_option(
+            option,
+            value,
+            "supported",
+            Some("format.keyword_spacing"),
+            "maps to native formatter keyword spacing for supported simple control-flow headers",
+        ),
+        "-bl" | "--opening-brace-on-new-line" | "-bar" | "--opening-brace-always-on-right" => {
+            perltidy_option(
+                option,
+                value,
+                "supported",
+                Some("format.brace_placement"),
+                "maps to native formatter brace placement for supported simple block layouts",
+            )
+        }
+        "-atc" | "--add-trailing-commas" | "-natc" | "--no-add-trailing-commas" => perltidy_option(
+            option,
+            value,
+            "supported",
+            Some("format.trailing_comma"),
+            "maps to native formatter trailing comma policy for wrapped calls, lists, and hashes",
+        ),
+        "-ci" | "--block-comment-indentation" => perltidy_option(
+            option,
+            value,
+            "external_only",
+            None,
+            "comment-aware native formatting is not yet configurable",
+        ),
+        "-val" | "--vertical-alignment" | "-nval" | "--novertical-alignment" => perltidy_option(
+            option,
+            value,
+            "external_only",
+            None,
+            "native formatter intentionally avoids alignment policy today",
+        ),
+        "-pbp" | "--perl-best-practices" | "-gnu" | "--gnu-style" => perltidy_option(
+            option,
+            value,
+            "approximated",
+            None,
+            "native formatter can map individual style settings but not full preset profiles yet",
+        ),
+        "-q" | "--quiet" | "-st" | "--standard-output" | "-se" | "--standard-error-output" => {
+            perltidy_option(
+                option,
+                value,
+                "unsupported_safe",
+                None,
+                "perltidy execution/output flag does not affect native formatting style",
+            )
+        }
+        _ => perltidy_option(
+            option,
+            value,
+            "external_only",
+            None,
+            "unknown style option is not applied by native formatter and may require external compatibility mode",
+        ),
+    }
+}
+
+fn perltidy_option(
+    option: &str,
+    value: Option<String>,
+    classification: &'static str,
+    native_field: Option<&'static str>,
+    note: &'static str,
+) -> PerltidyCompatOption {
+    PerltidyCompatOption { option: option.to_string(), value, classification, native_field, note }
+}
+
+fn strip_perlcritic_comment(line: &str) -> &str {
+    line.split('#').next().unwrap_or_default()
+}
+
+fn parse_perlcritic_policy_section(line: &str) -> Option<String> {
+    let inner = line.strip_prefix('[')?.strip_suffix(']')?.trim();
+    let policy = inner.strip_prefix('-').unwrap_or(inner).trim();
+    if policy.is_empty() { None } else { Some(policy.to_string()) }
+}
+
+fn classify_perlcritic_policy(
+    policy: &str,
+    native_rules: &BTreeSet<String>,
+) -> PerlcriticCompatItem {
+    match perlcritic_policy_native_mapping(policy) {
+        Some((native_rule, classification, note)) if native_rules.contains(native_rule) => {
+            perlcritic_item("policy", policy, None, classification, Some(native_rule), note)
+        }
+        Some((native_rule, _, _)) => perlcritic_item(
+            "policy",
+            policy,
+            None,
+            "external_only",
+            Some(native_rule),
+            "mapped native rule is not currently present in the recommended registry",
+        ),
+        None => perlcritic_item(
+            "policy",
+            policy,
+            None,
+            "external_only",
+            None,
+            "perlcritic policy does not yet have a native rule mapping",
+        ),
+    }
+}
+
+fn perlcritic_policy_native_mapping(
+    policy: &str,
+) -> Option<(&'static str, &'static str, &'static str)> {
+    match policy {
+        "TestingAndDebugging::RequireUseStrict" => Some((
+            "native.testing.require_use_strict",
+            "native_equivalent",
+            "native critic emits the same strict-pragmas policy with LSP spans",
+        )),
+        "TestingAndDebugging::RequireUseWarnings" => Some((
+            "native.testing.require_use_warnings",
+            "native_equivalent",
+            "native critic emits the same warnings-pragmas policy with LSP spans",
+        )),
+        "InputOutput::ProhibitTwoArgOpen" => Some((
+            "native.io.two_arg_open",
+            "native_equivalent",
+            "native critic detects two-argument open and exposes the existing safe fix",
+        )),
+        "InputOutput::ProhibitBarewordFileHandles" => Some((
+            "native.io.bareword_filehandle",
+            "native_equivalent",
+            "native critic detects bareword filehandles and exposes the existing safe fix",
+        )),
+        "InputOutput::RequireCheckedOpen" => Some((
+            "native.io.unchecked_open_close",
+            "native_superset",
+            "native critic covers unchecked open and close result handling",
+        )),
+        "BuiltinFunctions::ProhibitStringyEval" => Some((
+            "native.security.string_eval",
+            "native_equivalent",
+            "native critic detects parser-confirmed string eval without shelling out",
+        )),
+        "InputOutput::ProhibitBacktickOperators" => Some((
+            "native.security.backtick_exec",
+            "native_superset",
+            "native critic splits backticks and qx/readpipe into precise native rules",
+        )),
+        "BuiltinFunctions::ProhibitSystemCalls" => Some((
+            "native.security.system_exec",
+            "native_equivalent",
+            "native critic reports system and exec command execution without an automatic fix",
+        )),
+        "Variables::ProhibitUnusedVariables" => Some((
+            "native.variables.unused_lexical",
+            "native_superset",
+            "native critic uses semantic scope facts and sigil-aware quick fixes",
+        )),
+        "Variables::ProhibitReusedNames" => Some((
+            "native.variables.duplicate_lexical",
+            "approximated",
+            "native critic has duplicate and shadowing rules but not a single combined perlcritic policy",
+        )),
+        "Documentation::RequirePodSections" => Some((
+            "native.documentation.require_pod_sections",
+            "approximated",
+            "native critic checks required NAME/DESCRIPTION sections when a file already contains POD",
+        )),
+        _ => None,
+    }
+}
+
+fn classify_perlcritic_setting(name: &str, value: Option<String>) -> PerlcriticCompatItem {
+    match name {
+        "severity" => perlcritic_item(
+            "setting",
+            name,
+            value,
+            "native_equivalent",
+            None,
+            "maps to native critic minimum severity filtering",
+        ),
+        "include" | "exclude" => perlcritic_item(
+            "setting",
+            name,
+            value,
+            "native_equivalent",
+            None,
+            "maps to native critic include/exclude rule filtering for native rule IDs",
+        ),
+        "theme" => classify_perlcritic_theme_setting(value),
+        "profile-strictness" => perlcritic_item(
+            "setting",
+            name,
+            value,
+            "unsupported_safe",
+            None,
+            "perlcritic loader strictness has no runtime effect on native critic rules",
+        ),
+        "color" => perlcritic_item(
+            "setting",
+            name,
+            value,
+            "unsupported_safe",
+            None,
+            "perlcritic terminal color setting has no effect on structured native diagnostics",
+        ),
+        _ => perlcritic_item(
+            "setting",
+            name,
+            value,
+            "external_only",
+            None,
+            "perlcritic setting is not yet applied by native critic",
+        ),
+    }
+}
+
+fn classify_perlcritic_theme_setting(value: Option<String>) -> PerlcriticCompatItem {
+    let Some(theme) = value.as_deref() else {
+        return perlcritic_item(
+            "setting",
+            "theme",
+            value,
+            "unsupported_safe",
+            None,
+            "empty perlcritic theme does not change native critic rule selection",
+        );
+    };
+    let known_themes = [
+        "bugs",
+        "certrec",
+        "certrule",
+        "core",
+        "cosmetic",
+        "maintenance",
+        "pbp",
+        "performance",
+        "security",
+        "tests",
+        "unicode",
+    ];
+    if known_themes.contains(&theme.trim()) {
+        perlcritic_item(
+            "setting",
+            "theme",
+            value,
+            "approximated",
+            None,
+            "native critic recommended profile approximates common perlcritic themes with currently implemented native rules",
+        )
+    } else {
+        perlcritic_item(
+            "setting",
+            "theme",
+            value,
+            "external_only",
+            None,
+            "unrecognized perlcritic theme is not expanded by native critic",
+        )
+    }
+}
+
+fn perlcritic_item(
+    kind: &'static str,
+    name: &str,
+    value: Option<String>,
+    classification: &'static str,
+    native_rule: Option<&'static str>,
+    note: &'static str,
+) -> PerlcriticCompatItem {
+    PerlcriticCompatItem { kind, name: name.to_string(), value, classification, native_rule, note }
+}
+
+fn perltidy_count(options: &[PerltidyCompatOption], classification: &str) -> usize {
+    options.iter().filter(|option| option.classification == classification).count()
+}
+
+fn perlcritic_count(items: &[PerlcriticCompatItem], classification: &str) -> usize {
+    items.iter().filter(|item| item.classification == classification).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        classify_perlcritic_profile, classify_perltidy_profile, render_perlcritic_compat_markdown,
+        render_perltidy_compat_markdown,
+    };
+
+    #[test]
+    fn perltidy_profile_classifies_native_supported_options() {
+        let report = classify_perltidy_profile(
+            "# common profile\n-l=100\n-i 2\n-nt\n-ce\n-nsok\n-q\n-atc\n-bl\n",
+        );
+
+        assert_eq!(report.option_count, 8);
+        assert_eq!(report.supported_count, 7);
+        assert_eq!(report.approximated_count, 0);
+        assert_eq!(report.unsupported_safe_count, 1);
+        assert_eq!(report.external_only_count, 0);
+        assert_eq!(report.options[0].native_field, Some("format.line_width"));
+        assert_eq!(report.options[4].native_field, Some("format.keyword_spacing"));
+        assert_eq!(report.options[6].native_field, Some("format.trailing_comma"));
+
+        let markdown = render_perltidy_compat_markdown(".perltidyrc", &report);
+        assert!(markdown.contains("# Native Format Perltidy Compatibility"));
+        assert!(markdown.contains("| `-l` | 100 | supported | format.line_width |"));
+    }
+
+    #[test]
+    fn perltidy_profile_keeps_unknown_options_external_only() {
+        let report = classify_perltidy_profile("--unknown-style\n");
+
+        assert_eq!(report.option_count, 1);
+        assert_eq!(report.external_only_count, 1);
+        assert_eq!(report.options[0].option, "--unknown-style");
+        assert_eq!(report.options[0].classification, "external_only");
+    }
+
+    #[test]
+    fn perlcritic_profile_classifies_common_policy_surface() {
+        let report = classify_perlcritic_profile(
+            r#"# common policy profile
+severity = 3
+include = TestingAndDebugging::RequireUseStrict
+exclude = Documentation::RequirePodSections
+profile-strictness = quiet
+[TestingAndDebugging::RequireUseStrict]
+[-InputOutput::ProhibitTwoArgOpen]
+[InputOutput::RequireCheckedOpen]
+[Variables::ProhibitUnusedVariables]
+[Variables::ProhibitReusedNames]
+[Documentation::RequirePodSections]
+theme = core
+color = 1
+"#,
+        );
+
+        assert_eq!(report.item_count, 12);
+        assert_eq!(report.native_equivalent_count, 5);
+        assert_eq!(report.native_superset_count, 2);
+        assert_eq!(report.approximated_count, 3);
+        assert_eq!(report.unsupported_safe_count, 2);
+        assert_eq!(report.external_only_count, 0);
+        assert_eq!(report.items[5].native_rule, Some("native.io.two_arg_open"));
+        assert_eq!(report.items[6].native_rule, Some("native.io.unchecked_open_close"));
+
+        let markdown = render_perlcritic_compat_markdown(".perlcriticrc", &report);
+        assert!(markdown.contains("# Native Critic Perlcritic Compatibility"));
+        assert!(markdown.contains("| policy | `InputOutput::RequireCheckedOpen` |  | native_superset | native.io.unchecked_open_close |"));
+    }
+}

--- a/crates/perl-lsp-rs-core/tests/runtime_launcher_comprehensive.rs
+++ b/crates/perl-lsp-rs-core/tests/runtime_launcher_comprehensive.rs
@@ -324,6 +324,28 @@ fn parse_version_flag_produces_version_action() {
     assert_eq!(plan.action, perl_lsp_rs_core::runtime::launcher::LaunchAction::Version);
 }
 
+#[test]
+fn parse_perltidy_compat_report_produces_report_action() {
+    let plan = must(parse_args(["perl-lsp", "--perltidy-compat-report", ".perltidyrc"]));
+    assert_eq!(
+        plan.action,
+        perl_lsp_rs_core::runtime::launcher::LaunchAction::PerltidyCompatReport {
+            profile: ".perltidyrc".to_string()
+        }
+    );
+}
+
+#[test]
+fn parse_perlcritic_compat_report_produces_report_action() {
+    let plan = must(parse_args(["perl-lsp", "--perlcritic-compat-report", ".perlcriticrc"]));
+    assert_eq!(
+        plan.action,
+        perl_lsp_rs_core::runtime::launcher::LaunchAction::PerlcriticCompatReport {
+            profile: ".perlcriticrc".to_string()
+        }
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Module: parse_args — feature profile variants
 // ---------------------------------------------------------------------------
@@ -556,6 +578,13 @@ fn help_text_mentions_health() {
 }
 
 #[test]
+fn help_text_mentions_native_compat_reports() {
+    let text = help_text();
+    assert!(text.contains("--perltidy-compat-report"));
+    assert!(text.contains("--perlcritic-compat-report"));
+}
+
+#[test]
 fn help_text_includes_examples_section() {
     let text = help_text();
     assert!(text.contains("Examples:"));
@@ -626,6 +655,8 @@ fn launch_action_variants_are_distinct() {
         LaunchAction::Completion { shell: "bash".to_string() },
         LaunchAction::Version,
         LaunchAction::FeaturesJson,
+        LaunchAction::PerltidyCompatReport { profile: ".perltidyrc".to_string() },
+        LaunchAction::PerlcriticCompatReport { profile: ".perlcriticrc".to_string() },
         LaunchAction::Help,
     ];
     for (i, a) in actions.iter().enumerate() {

--- a/crates/perl-lsp-rs/src/cli.rs
+++ b/crates/perl-lsp-rs/src/cli.rs
@@ -11,6 +11,10 @@ use perl_lsp_rs_core::runtime::launcher::{
     logging_filter, parse_args, port_in_use_message, shell_completion, should_enable_logging,
     should_use_ansi_stdout,
 };
+use perl_lsp_rs_core::tooling::native_compat::{
+    classify_perlcritic_profile, classify_perltidy_profile, render_perlcritic_compat_markdown,
+    render_perltidy_compat_markdown,
+};
 use std::env;
 use std::path::Path;
 use std::process;
@@ -83,6 +87,10 @@ where
             println!("{}", launch_plan.config.features_json());
             0
         }
+        LaunchAction::PerltidyCompatReport { ref profile } => run_perltidy_compat_report(profile),
+        LaunchAction::PerlcriticCompatReport { ref profile } => {
+            run_perlcritic_compat_report(profile)
+        }
         LaunchAction::Help => {
             println!("{}", render_help_text(&command_name));
             0
@@ -106,6 +114,34 @@ fn render_help_text(command_name: &str) -> String {
 fn render_shell_completion(script: &str, command_name: &str) -> String {
     let function_name = command_name.replace('-', "_");
     script.replace("_perl_lsp", &format!("_{function_name}")).replace("perl-lsp", command_name)
+}
+
+fn run_perltidy_compat_report(profile: &str) -> i32 {
+    let raw = match std::fs::read_to_string(profile) {
+        Ok(raw) => raw,
+        Err(error) => {
+            eprintln!("{profile}: error reading perltidy profile: {error}");
+            return 1;
+        }
+    };
+
+    let report = classify_perltidy_profile(&raw);
+    print!("{}", render_perltidy_compat_markdown(profile, &report));
+    0
+}
+
+fn run_perlcritic_compat_report(profile: &str) -> i32 {
+    let raw = match std::fs::read_to_string(profile) {
+        Ok(raw) => raw,
+        Err(error) => {
+            eprintln!("{profile}: error reading perlcritic profile: {error}");
+            return 1;
+        }
+    };
+
+    let report = classify_perlcritic_profile(&raw);
+    print!("{}", render_perlcritic_compat_markdown(profile, &report));
+    0
 }
 
 /// Spawn a blocking reader thread that reads LSP messages from `reader` and

--- a/crates/perl-lsp-rs/tests/cli_smoke.rs
+++ b/crates/perl-lsp-rs/tests/cli_smoke.rs
@@ -19,7 +19,7 @@ fn version_shows_git_tag() {
 #[test]
 fn help_prints_to_stdout() {
     let mut cmd = cargo_bin_cmd!("perl-lsp");
-    cmd.arg("--help").assert().success().stdout(predicates::str::contains("Usage: perl-lsp"));
+    cmd.arg("--help").assert().success().stdout(predicates::str::contains("Usage:"));
 }
 
 #[test]
@@ -76,6 +76,41 @@ fn completion_zsh_produces_output() {
         .assert()
         .success()
         .stdout(predicates::str::contains("compdef"));
+}
+
+#[test]
+fn perltidy_compat_report_prints_native_mapping() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let profile = dir.path().join(".perltidyrc");
+    std::fs::write(&profile, "-l=100\n-nsok\n-q\n")?;
+
+    let mut cmd = cargo_bin_cmd!("perl-lsp");
+    cmd.args(["--perltidy-compat-report", profile.to_str().ok_or("non-UTF-8 temp path")?])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("# Native Format Perltidy Compatibility"))
+        .stdout(predicates::str::contains("format.line_width"))
+        .stdout(predicates::str::contains("format.keyword_spacing"));
+    Ok(())
+}
+
+#[test]
+fn perlcritic_compat_report_prints_native_mapping() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let profile = dir.path().join(".perlcriticrc");
+    std::fs::write(
+        &profile,
+        "severity = 3\n[TestingAndDebugging::RequireUseStrict]\n[InputOutput::RequireCheckedOpen]\n",
+    )?;
+
+    let mut cmd = cargo_bin_cmd!("perl-lsp");
+    cmd.args(["--perlcritic-compat-report", profile.to_str().ok_or("non-UTF-8 temp path")?])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("# Native Critic Perlcritic Compatibility"))
+        .stdout(predicates::str::contains("native.testing.require_use_strict"))
+        .stdout(predicates::str::contains("native.io.unchecked_open_close"));
+    Ok(())
 }
 
 #[test]

--- a/docs/how-to/NATIVE_TOOLING_MIGRATION.md
+++ b/docs/how-to/NATIVE_TOOLING_MIGRATION.md
@@ -50,6 +50,15 @@ cargo xtask native-critic check
 For compatibility reporting, run:
 
 ```bash
+perllsp --perltidy-compat-report .perltidyrc
+perllsp --perlcritic-compat-report .perlcriticrc
+```
+
+Those installed-binary commands print the same native-support classification a
+team needs during migration without requiring a checkout of the `xtask`
+developer tooling. For receipt-backed repository proof, run:
+
+```bash
 cargo xtask native-format perltidy-compat \
   --profile .perltidyrc \
   --receipt target/receipts/format/native-format-perltidy-compat.json \

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -94,6 +94,7 @@ perl-dap --stdio  # Standard DAP transport
 | Release/version surfaces touched | `just version-check` then `just release-check` | Verifies version sync and the release-prep gate before tagging/publishing. |
 | Native tooling defaults touched | `cargo xtask native-tooling check-defaults` | Verifies native formatter and native critic default paths do not silently shell out. |
 | Native tooling cutover status touched | `cargo xtask native-tooling readiness --markdown docs/project/status/native_tooling_readiness.md` | Renders explicit native formatter/critic default-readiness criteria from existing receipts. |
+| User migration check | `perllsp --perltidy-compat-report .perltidyrc` / `perllsp --perlcritic-compat-report .perlcriticrc` | Classifies legacy profiles against native formatter and critic support without requiring external tools. |
 | Native critic touched | `cargo xtask native-critic check` | Runs native critic rules and emits check receipts for findings, suppressions, and fixability. |
 | DevEx docs touched | `cargo xtask check-devex-docs` | Verifies toolchain wording and documented command references stay current. |
 | Need a terminal summary | `just quick-ref` | Prints the short command decision tree. |

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -454,7 +454,10 @@ The TOML parser also accepts compatibility aliases such as `perltidy-compat`,
 | Default | (none) |
 
 Path to a `.perltidyrc` profile. This is used by the external perltidy adapter
-and by native-tooling compatibility reports.
+and by native-tooling compatibility reports. Run
+`perllsp --perltidy-compat-report .perltidyrc` for an installed-binary
+migration check, or `cargo xtask native-format perltidy-compat --profile
+.perltidyrc` when you need a JSON/Markdown receipt in this repository.
 
 #### `perl.formatting.maximumLineLength`
 
@@ -489,8 +492,9 @@ The server also accepts:
 - `perl.formatting.timeoutSecs`
 
 Some options are native compatibility hints; others only affect the external
-perltidy adapter. Use the native-tooling compatibility reports to classify a
-specific `.perltidyrc` before switching a project.
+perltidy adapter. Use `perllsp --perltidy-compat-report .perltidyrc` or the
+receipt-backed native-tooling compatibility reports to classify a specific
+`.perltidyrc` before switching a project.
 
 ```json
 {

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -351,8 +351,9 @@ profile = "recommended"
 
 When `profile` is not set, the legacy engine lets perlcritic auto-discover
 `.perlcriticrc` in the workspace root. Use
-`cargo xtask native-tooling perlcritic-compat --profile .perlcriticrc` to
-classify a profile against native critic rule coverage before migrating.
+`perllsp --perlcritic-compat-report .perlcriticrc` for an installed-binary
+migration check, or `cargo xtask native-tooling perlcritic-compat --profile
+.perlcriticrc` when you need a JSON/Markdown receipt in this repository.
 
 **Severity levels**:
 


### PR DESCRIPTION
## Summary

- add shared native compatibility report classifiers in `perl-lsp-rs-core`
- expose installed `perllsp --perltidy-compat-report <profile>` and `--perlcritic-compat-report <profile>` commands
- document the installed-binary migration checks alongside receipt-backed `xtask` commands

This is reporting-only. It does not invoke `perltidy` or `perlcritic`, change native/default formatter or critic behavior, alter LSP diagnostics, or modify runtime config semantics.

## Proof packet

Changed surfaces:
- memory_sensitive_runtime
- retained_owner_candidate
- rust_code
- docs

Validation:
- [x] `cargo xtask fmt`
- [x] `cargo test -p perl-lsp-rs-core native_compat --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs-core --test runtime_launcher_comprehensive --profile agent --locked -- --nocapture`
- [x] `cargo test -p perl-lsp-rs --test cli_smoke --profile agent --locked -- --nocapture`
- [x] `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- [x] real `perllsp --perltidy-compat-report` sample invocation
- [x] real `perllsp --perlcritic-compat-report` sample invocation
- [x] `cargo xtask check-devex-docs`
- [x] `cargo xtask check-memory-lifecycle-policy`
- [x] `cargo xtask check-memory-retained-owner-drift --base origin/master`
- [x] `cargo xtask devex pr-body --base origin/master`
- [x] `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- [x] `git diff --check`
