### PR TITLE
feat(critic): route native critic filters through config (#8478)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -92,6 +92,12 @@ pub struct ServerConfig {
     /// can select `strict` for the full native rule surface.
     pub native_critic_profile: String,
 
+    /// Native critic rule IDs to include. Empty means use the selected profile.
+    pub native_critic_include: Vec<String>,
+
+    /// Native critic rule IDs to exclude from the selected profile.
+    pub native_critic_exclude: Vec<String>,
+
     /// Whether LSP formatting is enabled.
     ///
     /// Kept as `perltidy_enabled` for compatibility with older internal call sites
@@ -227,6 +233,8 @@ impl Default for ServerConfig {
             perlcritic_theme: None,
             critic_engine: CriticEngine::Native,
             native_critic_profile: "recommended".to_string(),
+            native_critic_include: Vec::new(),
+            native_critic_exclude: Vec::new(),
             perltidy_enabled: true,
             formatting_engine: FormatterMode::Native,
             perltidy_profile: None,
@@ -317,6 +325,14 @@ impl ServerConfig {
             && let Some(profile) = parse_native_critic_profile(profile)
         {
             self.native_critic_profile = profile.to_string();
+        }
+        if let Some(critic) = settings.get("critic") {
+            if let Some(include) = string_array(critic.get("include")) {
+                self.native_critic_include = include;
+            }
+            if let Some(exclude) = string_array(critic.get("exclude")) {
+                self.native_critic_exclude = exclude;
+            }
         }
 
         if let Some(formatting) = settings.get("formatting") {
@@ -553,6 +569,29 @@ fn dedupe_preserve_order<'a>(paths: impl Iterator<Item = &'a str>) -> Vec<String
     result
 }
 
+fn normalize_string_list(values: &[String]) -> Vec<String> {
+    let mut result = Vec::new();
+    for value in values {
+        let trimmed = value.trim();
+        if trimmed.is_empty() || result.iter().any(|existing| existing == trimmed) {
+            continue;
+        }
+        result.push(trimmed.to_string());
+    }
+    result
+}
+
+fn string_array(value: Option<&serde_json::Value>) -> Option<Vec<String>> {
+    value.and_then(|value| value.as_array()).map(|values| {
+        normalize_string_list(
+            &values
+                .iter()
+                .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+                .collect::<Vec<_>>(),
+        )
+    })
+}
+
 impl WorkspaceConfig {
     /// Parse a `PERL5LIB` environment variable value into a list of paths.
     ///
@@ -765,6 +804,10 @@ pub struct ProjectCriticConfig {
     pub engine: Option<String>,
     /// Native critic profile (`recommended` or `strict`).
     pub profile: Option<String>,
+    /// Native critic rule IDs to include. Empty means use the selected profile.
+    pub include: Option<Vec<String>>,
+    /// Native critic rule IDs to exclude from the selected profile.
+    pub exclude: Option<Vec<String>>,
 }
 
 /// `[features]` section of `.perl-lsp.toml`.
@@ -945,6 +988,12 @@ impl ProjectConfig {
             && let Some(profile) = parse_native_critic_profile(profile)
         {
             config.native_critic_profile = profile.to_string();
+        }
+        if let Some(ref include) = self.critic.include {
+            config.native_critic_include = normalize_string_list(include);
+        }
+        if let Some(ref exclude) = self.critic.exclude {
+            config.native_critic_exclude = normalize_string_list(exclude);
         }
         if let Some(ref profile) = self.formatting.perltidy_profile {
             config.perltidy_profile = Some(profile.clone());
@@ -1197,6 +1246,47 @@ profile = "recommended"
     }
 
     #[test]
+    fn server_config_accepts_native_critic_include_and_exclude_filters() {
+        let mut config = ServerConfig::default();
+
+        config.update_from_value(&serde_json::json!({
+            "critic": {
+                "include": [
+                    "native.testing.require_use_strict",
+                    "",
+                    "native.testing.require_use_warnings"
+                ],
+                "exclude": [
+                    "native.common.assignment_in_condition"
+                ]
+            }
+        }));
+
+        assert_eq!(
+            config.native_critic_include,
+            vec![
+                "native.testing.require_use_strict".to_string(),
+                "native.testing.require_use_warnings".to_string()
+            ]
+        );
+        assert_eq!(
+            config.native_critic_exclude,
+            vec!["native.common.assignment_in_condition".to_string()]
+        );
+
+        config.update_from_value(&serde_json::json!({
+            "critic": {
+                "include": []
+            }
+        }));
+        assert!(config.native_critic_include.is_empty());
+        assert_eq!(
+            config.native_critic_exclude,
+            vec!["native.common.assignment_in_condition".to_string()]
+        );
+    }
+
+    #[test]
     fn project_config_applies_formatter_engine() {
         let mut config = ServerConfig::default();
         let mut project = ProjectConfig::default();
@@ -1232,11 +1322,25 @@ profile = "recommended"
         let mut project = ProjectConfig::default();
         project.critic.engine = Some("native".to_string());
         project.critic.profile = Some("recommended".to_string());
+        project.critic.include = Some(vec![
+            "native.testing.require_use_strict".to_string(),
+            " ".to_string(),
+            "native.testing.require_use_strict".to_string(),
+        ]);
+        project.critic.exclude = Some(vec!["native.common.assignment_in_condition".to_string()]);
 
         project.apply_to_server_config(&mut config);
 
         assert_eq!(config.critic_engine, CriticEngine::Native);
         assert_eq!(config.native_critic_profile, "recommended");
+        assert_eq!(
+            config.native_critic_include,
+            vec!["native.testing.require_use_strict".to_string()]
+        );
+        assert_eq!(
+            config.native_critic_exclude,
+            vec!["native.common.assignment_in_condition".to_string()]
+        );
     }
 
     #[test]

--- a/crates/perl-lsp-rs-core/src/tooling/native_compat.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/native_compat.rs
@@ -460,7 +460,7 @@ fn classify_perlcritic_setting(name: &str, value: Option<String>) -> PerlcriticC
             value,
             "native_equivalent",
             None,
-            "maps to native critic include/exclude rule filtering for native rule IDs",
+            "native critic supports include/exclude filters; map policy names to native rule IDs before configuring them",
         ),
         "theme" => classify_perlcritic_theme_setting(value),
         "profile-strictness" => perlcritic_item(

--- a/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
+++ b/crates/perl-lsp-rs/src/features/diagnostics/pull.rs
@@ -52,6 +52,10 @@ pub struct PullDiagnosticsContext {
     pub critic_engine: CriticEngine,
     /// Native critic profile used when `critic_engine` is native.
     pub native_critic_profile: String,
+    /// Native critic rule IDs to include. Empty means use the selected profile.
+    pub native_critic_include: Vec<String>,
+    /// Native critic rule IDs to exclude from the selected profile.
+    pub native_critic_exclude: Vec<String>,
     /// Workspace root for .perlcriticrc discovery
     pub workspace_root: Option<PathBuf>,
     /// @INC paths for module resolution
@@ -72,6 +76,8 @@ impl PullDiagnosticsContext {
             perlcritic_profile: None,
             critic_engine: CriticEngine::Native,
             native_critic_profile: "recommended".to_string(),
+            native_critic_include: Vec::new(),
+            native_critic_exclude: Vec::new(),
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -89,6 +95,8 @@ impl PullDiagnosticsContext {
             perlcritic_profile: profile,
             critic_engine: CriticEngine::Legacy,
             native_critic_profile: "recommended".to_string(),
+            native_critic_include: Vec::new(),
+            native_critic_exclude: Vec::new(),
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -108,6 +116,8 @@ impl PullDiagnosticsContext {
             perlcritic_profile: None,
             critic_engine: CriticEngine::Native,
             native_critic_profile: "recommended".to_string(),
+            native_critic_include: Vec::new(),
+            native_critic_exclude: Vec::new(),
             workspace_root: None,
             include_paths: Vec::new(),
             markup_message_support: false,
@@ -124,6 +134,8 @@ impl std::fmt::Debug for PullDiagnosticsContext {
             .field("perlcritic_profile", &self.perlcritic_profile)
             .field("critic_engine", &self.critic_engine)
             .field("native_critic_profile", &self.native_critic_profile)
+            .field("native_critic_include", &self.native_critic_include)
+            .field("native_critic_exclude", &self.native_critic_exclude)
             .field("workspace_root", &self.workspace_root)
             .field("include_paths", &self.include_paths)
             .field("markup_message_support", &self.markup_message_support)
@@ -492,6 +504,8 @@ impl PullDiagnosticsProvider {
         let critic_config = CriticConfig {
             severity: context.perlcritic_severity.clamp(1, 5) as u8,
             profile: context.perlcritic_profile.clone(),
+            include: context.native_critic_include.clone(),
+            exclude: context.native_critic_exclude.clone(),
             ..CriticConfig::default()
         };
         let critic_context = CriticContext::new(content, ast.as_ref(), &critic_config);
@@ -1837,6 +1851,53 @@ mod tests {
                 )
             }),
             "recommended native critic profile should omit broader variable findings: {items:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn native_critic_runtime_context_honors_include_and_exclude_filters()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let provider = PullDiagnosticsProvider::new();
+        let uri: Uri = "file:///test.pl".parse()?;
+        let mut context = PullDiagnosticsContext::new();
+        context.critic_engine = CriticEngine::Native;
+        context.native_critic_profile = "recommended".to_string();
+        context.native_critic_include = vec!["native.testing.require_use_strict".to_string()];
+        context.native_critic_exclude = vec!["native.common.assignment_in_condition".to_string()];
+
+        let items = get_full_items(provider.get_document_diagnostics_with_context(
+            &uri,
+            "my $cond = 0;\nif ($cond = 1) { print $cond; }\n",
+            None,
+            &context,
+            None,
+        ));
+
+        assert!(
+            items.iter().any(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.testing.require_use_strict"),
+                )
+            }),
+            "native include should keep selected strict rule: {items:?}"
+        );
+        assert!(
+            !items.iter().any(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.common.assignment_in_condition"),
+                )
+            }),
+            "native include/exclude filters should suppress assignment rule: {items:?}"
+        );
+        assert!(
+            !items.iter().any(|diag| {
+                diag.code.as_ref().is_some_and(
+                    |code| matches!(code, NumberOrString::String(value) if value == "native.testing.require_use_warnings"),
+                )
+            }),
+            "native include should suppress non-included warning rule: {items:?}"
         );
 
         Ok(())

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -100,6 +100,8 @@ impl PullDiagnosticsOrchestrator {
             perlcritic_profile,
             critic_engine,
             native_critic_profile,
+            native_critic_include,
+            native_critic_exclude,
         ) = {
             let cfg = server.config.lock();
             (
@@ -108,6 +110,8 @@ impl PullDiagnosticsOrchestrator {
                 cfg.perlcritic_profile.clone(),
                 cfg.critic_engine,
                 cfg.native_critic_profile.clone(),
+                cfg.native_critic_include.clone(),
+                cfg.native_critic_exclude.clone(),
             )
         };
 
@@ -143,6 +147,8 @@ impl PullDiagnosticsOrchestrator {
             perlcritic_profile: profile,
             critic_engine,
             native_critic_profile,
+            native_critic_include,
+            native_critic_exclude,
             workspace_root,
             include_paths,
             markup_message_support,
@@ -1402,13 +1408,15 @@ impl LspServer {
         doc_text: &str,
         diagnostics: &mut Vec<InternalDiagnostic>,
     ) {
-        let (critic_engine, severity, profile, native_profile) = {
+        let (critic_engine, severity, profile, native_profile, native_include, native_exclude) = {
             let cfg = self.config.lock();
             (
                 cfg.critic_engine,
                 cfg.perlcritic_severity,
                 cfg.perlcritic_profile.clone(),
                 cfg.native_critic_profile.clone(),
+                cfg.native_critic_include.clone(),
+                cfg.native_critic_exclude.clone(),
             )
         };
         if critic_engine != perl_lsp_rs_core::config::CriticEngine::Native {
@@ -1418,6 +1426,8 @@ impl LspServer {
         let critic_config = crate::perl_critic::CriticConfig {
             severity: severity.clamp(1, 5),
             profile,
+            include: native_include,
+            exclude: native_exclude,
             ..crate::perl_critic::CriticConfig::default()
         };
         let critic_context =
@@ -2061,6 +2071,47 @@ mod tests {
         assert!(
             !text.contains("native.variables.unused_lexical"),
             "recommended native critic profile should omit broader variable-noise findings; got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn native_critic_push_diagnostics_honor_include_and_exclude_filters() {
+        let (server, buf) = make_server_with_capture();
+        server.test_configure_critic_engine(perl_lsp_rs_core::config::CriticEngine::Native);
+        server.test_configure_native_critic_profile("recommended");
+        server.test_configure_native_critic_filters(
+            vec!["native.testing.require_use_strict".to_string()],
+            vec!["native.common.assignment_in_condition".to_string()],
+        );
+        let uri = "file:///native_critic_filtered_push_test.pl";
+        server
+            .test_handle_did_open(Some(json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": "my $cond = 0;\nif ($cond = 1) { print $cond; }\n"
+                }
+            })))
+            .unwrap();
+
+        server.publish_diagnostics(uri);
+        drop(server);
+        std::thread::sleep(Duration::from_millis(50));
+
+        let bytes = buf.lock().clone();
+        let text = String::from_utf8(bytes).unwrap_or_default();
+        assert!(
+            text.contains("native.testing.require_use_strict"),
+            "native include should keep selected strict rule; got: {text:?}"
+        );
+        assert!(
+            !text.contains("native.common.assignment_in_condition"),
+            "native exclude should suppress assignment rule; got: {text:?}"
+        );
+        assert!(
+            !text.contains("native.testing.require_use_warnings"),
+            "native include should suppress non-included warning rule; got: {text:?}"
         );
     }
 

--- a/crates/perl-lsp-rs/src/runtime/test_api.rs
+++ b/crates/perl-lsp-rs/src/runtime/test_api.rs
@@ -325,6 +325,13 @@ impl LspServer {
         }
     }
 
+    /// Configure native critic include/exclude filters directly for test purposes.
+    pub fn test_configure_native_critic_filters(&self, include: Vec<String>, exclude: Vec<String>) {
+        let mut cfg = self.config.lock();
+        cfg.native_critic_include = include;
+        cfg.native_critic_exclude = exclude;
+    }
+
     /// Test-only entrypoint for LSP `textDocument/inlineCompletion`.
     ///
     /// Exercises inline completion functionality in tests.

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -702,11 +702,35 @@ impl LspServer {
                             )
                             .map(|profile| profile.as_str().to_string())
                             .unwrap_or_else(|| cfg.native_critic_profile.clone());
+                        let new_native_include = perl
+                            .get("critic")
+                            .and_then(|v| v.get("include"))
+                            .and_then(|v| v.as_array())
+                            .map(|values| {
+                                values
+                                    .iter()
+                                    .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_else(|| cfg.native_critic_include.clone());
+                        let new_native_exclude = perl
+                            .get("critic")
+                            .and_then(|v| v.get("exclude"))
+                            .and_then(|v| v.as_array())
+                            .map(|values| {
+                                values
+                                    .iter()
+                                    .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_else(|| cfg.native_critic_exclude.clone());
                         new_enabled != cfg.perlcritic_enabled
                             || new_severity != cfg.perlcritic_severity
                             || new_profile != cfg.perlcritic_profile
                             || new_theme != cfg.perlcritic_theme
                             || new_native_profile != cfg.native_critic_profile
+                            || new_native_include != cfg.native_critic_include
+                            || new_native_exclude != cfg.native_critic_exclude
                     };
 
                     // Update server config (inlay hints, test runner)

--- a/docs/how-to/NATIVE_TOOLING_MIGRATION.md
+++ b/docs/how-to/NATIVE_TOOLING_MIGRATION.md
@@ -115,6 +115,7 @@ perlcritic_severity = 3
 [critic]
 engine = "native"
 profile = "recommended"
+exclude = ["native.documentation.require_pod_sections"]
 ```
 
 Use native critic diagnostics when:
@@ -123,6 +124,11 @@ Use native critic diagnostics when:
 - suppressions and severity filtering match the project policy
 - editor diagnostics should expose stable rule IDs, precise spans, and code
   actions
+
+Native critic include/exclude filters use native rule IDs, not Perl::Critic
+policy names. During migration, map supported policies from the compatibility
+report to their native IDs before adding them to `[critic].include` or
+`[critic].exclude`.
 
 Keep external `perlcritic` compatibility when:
 

--- a/docs/reference/CONFIG.md
+++ b/docs/reference/CONFIG.md
@@ -581,6 +581,28 @@ Native-critic rule bundle used when `perl.critic.engine = "native"`.
 `recommended` selects the lower-noise security/common-mistake/testing profile.
 `strict` enables the full native rule surface.
 
+#### `perl.critic.include`
+
+| Property | Value |
+|---|---|
+| Type | `string[]` |
+| Default | `[]` |
+
+Native critic rule IDs to include. When non-empty, only listed native rule IDs
+run inside the selected profile. Use native IDs such as
+`native.testing.require_use_strict`, not Perl::Critic policy names.
+
+#### `perl.critic.exclude`
+
+| Property | Value |
+|---|---|
+| Type | `string[]` |
+| Default | `[]` |
+
+Native critic rule IDs to suppress from the selected profile. This is useful
+when migrating a project to the native recommended profile while deferring one
+specific rule.
+
 ```json
 {
   "perl": {
@@ -591,7 +613,8 @@ Native-critic rule bundle used when `perl.critic.engine = "native"`.
     },
     "critic": {
       "engine": "native",
-      "profile": "recommended"
+      "profile": "recommended",
+      "exclude": ["native.documentation.require_pod_sections"]
     }
   }
 }

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -313,6 +313,7 @@ perlcritic_severity = 3
 [critic]
 engine = "native"
 profile = "recommended"
+exclude = ["native.documentation.require_pod_sections"]
 ```
 
 **Enable via editor settings** (personal preference):
@@ -326,11 +327,17 @@ profile = "recommended"
     },
     "critic": {
       "engine": "native",
-      "profile": "recommended"
+      "profile": "recommended",
+      "exclude": ["native.documentation.require_pod_sections"]
     }
   }
 }
 ```
+
+Native critic `include` and `exclude` lists use native rule IDs such as
+`native.testing.require_use_strict`; they do not use Perl::Critic policy names.
+When `include` is non-empty, only listed native IDs run inside the selected
+profile. `exclude` removes native IDs from the selected profile.
 
 **Use a custom `.perlcriticrc` profile**:
 


### PR DESCRIPTION
## Summary

- routes native critic `include` / `exclude` filters through `ServerConfig`, `.perl-lsp.toml`, LSP settings, pull diagnostics, and push/workspace diagnostics
- adds focused coverage proving native include/exclude filters affect pull and push diagnostics while preserving the existing native profile path
- documents `perl.critic.include` / `perl.critic.exclude` as native-rule-ID filters and clarifies the perlcritic compatibility report wording

## Scope

This does not add native critic rules, change formatter behavior, change default engines, or invoke `perlcritic`. It closes the config-routing gap between existing native registry filtering and user/project configuration.

## Proof packet

- `cargo xtask fmt`
- `cargo test -p perl-lsp-rs-core native_compat --profile agent --locked -- --nocapture`
- `cargo test -p perl-lsp-rs-core native_critic --profile agent --locked -- --nocapture`
- `cargo test -p perl-lsp-rs native_critic_runtime_context_honors_include_and_exclude_filters --profile agent --locked --lib -- --nocapture`
- `cargo test -p perl-lsp-rs native_critic_push_diagnostics_honor_include_and_exclude_filters --profile agent --locked --lib -- --nocapture`
- `cargo test -p perl-lsp-rs native_critic_engine --profile agent --locked --lib -- --nocapture`
- `cargo test -p perl-lsp-rs diagnostics --profile agent --locked --lib -- --nocapture`
- `cargo clippy --locked -p perl-lsp-rs-core -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`
- `cargo xtask check-devex-docs`
- `cargo xtask check-memory-lifecycle-policy`
- `cargo xtask check-memory-retained-owner-drift --base origin/master`
- `cargo xtask devex pr-body --base origin/master`
- `cargo xtask devex receipt --base origin/master --output target/devex/local-proof.json`
- `git diff --check`
