### PR TITLE
test(symbols): add runtime quality receipts (#8197)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/mod.rs
@@ -41,6 +41,9 @@ mod refactor_runtime_blocker_receipts;
 #[cfg(test)]
 mod refactor_runtime_blocker_tests;
 
+#[cfg(test)]
+mod symbols_runtime_quality_tests;
+
 #[cfg(feature = "workspace")]
 fn to_workspace_sym_kind(kind: perl_parser::index::SymKind) -> crate::workspace_index::SymKind {
     match kind {

--- a/crates/perl-lsp-rs/src/runtime/language/symbols.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/symbols.rs
@@ -463,3 +463,42 @@ fn document_symbol_priority(symbol: &crate::symbol::Symbol) -> u8 {
 fn offset_to_line(content: &str, offset: usize) -> usize {
     content[..offset.min(content.len())].chars().filter(|&c| c == '\n').count()
 }
+
+impl LspServer {
+    /// Document symbol runtime quality receipt — shadow-only proof.
+    ///
+    /// Calls the live `textDocument/documentSymbol` handler and wraps the result
+    /// in a typed receipt that can be used for staged cutover proof. Document symbols
+    /// is in `shadowed` state: the live provider is the source of truth; compiler-fact
+    /// candidates are not yet promoted to the runtime path.
+    ///
+    /// Does not change live provider behavior (`no_live_behavior_change: true`).
+    #[cfg(any(test, feature = "expose_lsp_test_api"))]
+    pub(crate) fn document_symbols_runtime_quality_receipt(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        let live_provider_result = self.handle_document_symbol(params)?;
+        let live_provider_count = match live_provider_result.as_ref() {
+            Some(Value::Array(items)) => items.len(),
+            _ => 0,
+        };
+
+        Ok(Some(json!({
+            "provider": "document_symbols",
+            "live_provider_result": live_provider_result,
+            "live_provider_count": live_provider_count,
+            "shadow_state": "shadowed",
+            "compiler_receipt": null,
+            "no_live_behavior_change": true,
+            "notes": [
+                format!(
+                    "document-symbol runtime quality receipt: live_provider_count={}; \
+                     compiler-fact candidates pending staged cutover; \
+                     no live document-symbol behavior change",
+                    live_provider_count
+                )
+            ]
+        })))
+    }
+}

--- a/crates/perl-lsp-rs/src/runtime/language/symbols_runtime_quality_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/symbols_runtime_quality_tests.rs
@@ -1,0 +1,416 @@
+use crate::runtime::LspServer;
+use parking_lot::Mutex;
+use serde_json::{Value, json};
+use std::io::Cursor;
+use std::sync::Arc;
+
+const MODULE_URI: &str = "file:///workspace/lib/Symbols/Quality.pm";
+const SCRIPT_URI: &str = "file:///workspace/script.pl";
+
+const MODULE: &str = r#"package Symbols::Quality;
+use strict;
+use warnings;
+
+=head1 NAME
+
+Symbols::Quality - Runtime quality receipt test fixture
+
+=head1 METHODS
+
+=head2 new
+
+Constructor.
+
+=cut
+
+sub new {
+    my ($class, %args) = @_;
+    return bless { name => $args{name} }, $class;
+}
+
+sub name {
+    my ($self) = @_;
+    return $self->{name};
+}
+
+sub greet {
+    my ($self) = @_;
+    return "Hello, " . $self->name();
+}
+
+1;
+"#;
+
+const SCRIPT: &str = r#"use strict;
+use warnings;
+use lib 'lib';
+use Symbols::Quality;
+
+my $obj = Symbols::Quality->new(name => 'World');
+print $obj->greet(), "\n";
+"#;
+
+fn create_server() -> LspServer {
+    let output =
+        Arc::new(Mutex::new(Box::new(Cursor::new(Vec::new())) as Box<dyn std::io::Write + Send>));
+    LspServer::with_output(output)
+}
+
+fn open_document(
+    server: &LspServer,
+    uri: &str,
+    text: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    server.test_handle_did_open(Some(json!({
+        "textDocument": {
+            "uri": uri,
+            "text": text,
+            "languageId": "perl",
+            "version": 1
+        }
+    })))?;
+    Ok(())
+}
+
+fn open_symbol_workspace(server: &LspServer) -> Result<(), Box<dyn std::error::Error>> {
+    open_document(server, MODULE_URI, MODULE)?;
+    open_document(server, SCRIPT_URI, SCRIPT)?;
+    Ok(())
+}
+
+fn symbol_count(value: Option<&Value>) -> usize {
+    match value {
+        Some(Value::Array(items)) => items.len(),
+        _ => 0,
+    }
+}
+
+fn receipt_notes(receipt: &Value) -> Result<Vec<&str>, Box<dyn std::error::Error>> {
+    let notes = receipt.get("notes").and_then(Value::as_array).ok_or("missing notes")?;
+    Ok(notes.iter().filter_map(Value::as_str).collect())
+}
+
+// --- document symbol runtime quality receipt tests ---
+
+#[test]
+fn document_symbols_runtime_quality_receipt_has_correct_provider_field()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"textDocument": {"uri": MODULE_URI}});
+
+    let receipt = server
+        .test_document_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing document symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("provider").and_then(Value::as_str),
+        Some("document_symbols"),
+        "provider field must identify the document_symbols surface"
+    );
+    Ok(())
+}
+
+#[test]
+fn document_symbols_runtime_quality_receipt_reports_no_live_behavior_change()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"textDocument": {"uri": MODULE_URI}});
+
+    let receipt = server
+        .test_document_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing document symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "receipt must confirm no live behavior change"
+    );
+    Ok(())
+}
+
+#[test]
+fn document_symbols_runtime_quality_receipt_count_matches_live_result()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"textDocument": {"uri": MODULE_URI}});
+
+    let live_result = server.test_handle_document_symbols(Some(params.clone()))?;
+    let expected_count = symbol_count(live_result.as_ref());
+
+    let receipt = server
+        .test_document_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing document symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("live_provider_count").and_then(Value::as_u64),
+        Some(u64::try_from(expected_count)?),
+        "live_provider_count must match the actual live document symbol count"
+    );
+    // live_provider_result is captured in a single internal call; its count must
+    // match live_provider_count (symbol ordering is non-deterministic across calls)
+    let receipt_result_count = symbol_count(receipt.get("live_provider_result"));
+    assert_eq!(
+        receipt_result_count, expected_count,
+        "receipt live_provider_result item count must match live_provider_count"
+    );
+    Ok(())
+}
+
+#[test]
+fn document_symbols_runtime_quality_receipt_finds_symbols_in_module_with_subs()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"textDocument": {"uri": MODULE_URI}});
+
+    let receipt = server
+        .test_document_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing document symbols receipt")?;
+
+    let count =
+        receipt.get("live_provider_count").and_then(Value::as_u64).ok_or("missing count")?;
+
+    assert!(count > 0, "module with package and subs must have at least one document symbol");
+    Ok(())
+}
+
+#[test]
+fn document_symbols_runtime_quality_receipt_shadow_state_is_shadowed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"textDocument": {"uri": MODULE_URI}});
+
+    let receipt = server
+        .test_document_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing document symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("shadow_state").and_then(Value::as_str),
+        Some("shadowed"),
+        "document symbols must report shadowed state (not yet partial live)"
+    );
+    Ok(())
+}
+
+#[test]
+fn document_symbols_runtime_quality_receipt_notes_record_quality_proof()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"textDocument": {"uri": MODULE_URI}});
+
+    let receipt = server
+        .test_document_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing document symbols receipt")?;
+
+    let notes = receipt_notes(&receipt)?;
+    assert!(!notes.is_empty(), "document symbol receipt must include quality proof notes");
+    assert!(
+        notes.iter().any(|note| note.contains("document-symbol runtime quality receipt")),
+        "notes must identify this as a document-symbol runtime quality receipt: {notes:?}"
+    );
+    assert!(
+        notes.iter().any(|note| note.contains("no live document-symbol behavior change")),
+        "notes must confirm no live behavior change: {notes:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn document_symbols_runtime_quality_receipt_handles_unknown_uri_gracefully()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    let params = json!({"textDocument": {"uri": "file:///nonexistent/file.pm"}});
+
+    let receipt = server
+        .test_document_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing document symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "receipt must report no live behavior change even for unknown URIs"
+    );
+    assert_eq!(
+        receipt.get("live_provider_count").and_then(Value::as_u64),
+        Some(0),
+        "unknown URI must yield zero symbols"
+    );
+    Ok(())
+}
+
+// --- workspace symbol runtime quality receipt tests ---
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_has_correct_provider_field()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"query": "new"});
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing workspace symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("provider").and_then(Value::as_str),
+        Some("workspace_symbols"),
+        "provider field must identify the workspace_symbols surface"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_reports_no_live_behavior_change()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"query": "greet"});
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing workspace symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "receipt must confirm no live behavior change"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_count_matches_live_result()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"query": "name"});
+
+    let live_result = server.test_handle_workspace_symbols(Some(params.clone()))?;
+    let expected_count = symbol_count(live_result.as_ref());
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing workspace symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("live_provider_count").and_then(Value::as_u64),
+        Some(u64::try_from(expected_count)?),
+        "live_provider_count must match the actual live workspace symbol count"
+    );
+    assert_eq!(
+        receipt.get("live_provider_result"),
+        live_result.as_ref(),
+        "live_provider_result must equal the live handler result"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_echoes_query_field()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"query": "greet"});
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing workspace symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("query").and_then(Value::as_str),
+        Some("greet"),
+        "receipt must echo the query field for traceability"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_shadow_state_is_shadowed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"query": ""});
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing workspace symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("shadow_state").and_then(Value::as_str),
+        Some("shadowed"),
+        "workspace symbols must report shadowed state (not yet partial live)"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_notes_record_quality_proof()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"query": "Quality"});
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing workspace symbols receipt")?;
+
+    let notes = receipt_notes(&receipt)?;
+    assert!(!notes.is_empty(), "workspace symbol receipt must include quality proof notes");
+    assert!(
+        notes.iter().any(|note| note.contains("workspace-symbol runtime quality receipt")),
+        "notes must identify this as a workspace-symbol runtime quality receipt: {notes:?}"
+    );
+    assert!(
+        notes.iter().any(|note| note.contains("no live workspace-symbol behavior change")),
+        "notes must confirm no live behavior change: {notes:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_handles_empty_query()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"query": ""});
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing workspace symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "receipt must report no live behavior change for empty query"
+    );
+    Ok(())
+}
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_handles_no_match_query()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_symbol_workspace(&server)?;
+    let params = json!({"query": "zzz_no_such_symbol_xyzzy"});
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing workspace symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("live_provider_count").and_then(Value::as_u64),
+        Some(0),
+        "unmatched query must yield zero symbols"
+    );
+    assert_eq!(
+        receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "receipt must report no live behavior change for zero-result queries"
+    );
+    Ok(())
+}

--- a/crates/perl-lsp-rs/src/runtime/test_api.rs
+++ b/crates/perl-lsp-rs/src/runtime/test_api.rs
@@ -204,6 +204,30 @@ impl LspServer {
         self.handle_workspace_symbols_v2(params)
     }
 
+    /// Test-only receipt for document symbol runtime quality proof.
+    ///
+    /// Calls the live `textDocument/documentSymbol` handler and returns a typed
+    /// quality receipt. Document symbols is in `shadowed` state — the receipt
+    /// captures live provider results without changing live behavior.
+    pub fn test_document_symbols_runtime_quality_receipt(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        self.document_symbols_runtime_quality_receipt(params)
+    }
+
+    /// Test-only receipt for workspace symbol runtime quality proof.
+    ///
+    /// Calls the live `workspace/symbol` handler and returns a typed quality
+    /// receipt. Workspace symbols is in `shadowed` state — the receipt captures
+    /// live provider results without changing live behavior.
+    pub fn test_workspace_symbols_runtime_quality_receipt(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        self.workspace_symbols_runtime_quality_receipt(params)
+    }
+
     /// Test-only entrypoint for LSP `textDocument/documentColor`.
     ///
     /// Exercises document color detection functionality in tests.

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -354,6 +354,51 @@ impl LspServer {
         Ok(Some(json!(all_symbols)))
     }
 
+    /// Workspace symbol runtime quality receipt — shadow-only proof.
+    ///
+    /// Calls the live `workspace/symbol` handler and wraps the result in a typed
+    /// receipt for staged cutover proof. Workspace symbols is in `shadowed` state:
+    /// the live workspace index remains the source of truth; compiler-fact candidates
+    /// are not yet promoted to the runtime path.
+    ///
+    /// Does not change live provider behavior (`no_live_behavior_change: true`).
+    #[cfg(any(test, feature = "expose_lsp_test_api"))]
+    pub(crate) fn workspace_symbols_runtime_quality_receipt(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        let query = params
+            .as_ref()
+            .and_then(|p| p.get("query"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+
+        let live_provider_result = self.handle_workspace_symbols_v2(params)?;
+        let live_provider_count = match live_provider_result.as_ref() {
+            Some(Value::Array(items)) => items.len(),
+            _ => 0,
+        };
+
+        Ok(Some(json!({
+            "provider": "workspace_symbols",
+            "query": query,
+            "live_provider_result": live_provider_result,
+            "live_provider_count": live_provider_count,
+            "shadow_state": "shadowed",
+            "compiler_receipt": null,
+            "no_live_behavior_change": true,
+            "notes": [
+                format!(
+                    "workspace-symbol runtime quality receipt: query={:?}; live_provider_count={}; \
+                     compiler-fact candidates pending staged cutover; \
+                     no live workspace-symbol behavior change",
+                    query, live_provider_count
+                )
+            ]
+        })))
+    }
+
     /// Search open documents for symbols (non-workspace stub)
     #[cfg(not(feature = "workspace"))]
     fn search_open_documents_for_symbols(

--- a/docs/project/status/provider_cutover.md
+++ b/docs/project/status/provider_cutover.md
@@ -52,6 +52,15 @@ fallback behavior and rollback proof.
 - Document symbols now have source/freshness shadow proof for explicit syntax
   facts, framework-generated candidates, dynamic-boundary blockers, and stale
   compiler facts. These receipts do not broaden live document-symbol behavior.
+- Document symbols and workspace symbols now have runtime quality receipts that
+  call the live `textDocument/documentSymbol` and `workspace/symbol` handlers
+  and capture live provider counts and results without changing live behavior.
+  Seven BDD receipt tests cover document symbols (provider field,
+  no-live-behavior-change, count integrity, symbol presence, shadow state, notes
+  proof, unknown-URI graceful handling) and eight tests cover workspace symbols
+  (provider field, no-live-behavior-change, count integrity, query echo, shadow
+  state, notes proof, empty-query, no-match query). These receipts complete the
+  runtime integration proof step for both surfaces.
 - Semantic tokens now have source/freshness shadow proof for explicit
   parser/HIR classifications, compiler-backed classifications,
   dynamic-boundary blockers, and stale compiler facts. These receipts do not
@@ -86,8 +95,8 @@ the relevant receipt command.
 | References | `ranked-shadowed` | Reference shadow compare tracks imported, generated, dynamic-boundary, low-confidence fallback, stale fact, and real-workspace quality occurrence traces before live migration. Runtime quality receipts compare the live `textDocument/references` result with the compiler cutover receipt without changing live behavior. | Narrow live cutover proof for exact/imported high-confidence occurrences before any broader navigation migration |
 | Rename | `boundary-shadowed` | Rename plan receipts trace exact static edits, dynamic-boundary blockers, stale compiler facts, low-confidence ambiguity, runtime blocker UX notes, and live-vs-compiler exact-static receipt data before any live compiler-backed refactor behavior | Real-workspace unsafe-edit receipts and a narrow lexical/package rename live-cutover proof before any broader refactor migration |
 | Safe delete | `boundary-shadowed` | Safe-delete receipts trace exact static allow decisions, dynamic-boundary blockers, framework-generated blockers, stale compiler facts, runtime blocker UX notes, and live-vs-compiler exact-static receipt data before any live compiler-backed refactor behavior | Real-workspace unsafe-delete receipts and explicit blocker UX in live safe-delete surfaces before any broader refactor migration |
-| Workspace symbols | `shadowed` | Existing workspace index remains the live provider source; semantic-shadow fixtures trace fresh compiler, generated, dynamic-boundary, stale fact, and real-workspace quality candidates | Runtime integration and live-provider workspace-symbol quality receipts before any live cutover |
-| Document symbols | `shadowed` | Existing document-symbol provider remains the live source; semantic-shadow fixtures trace explicit syntax, generated, dynamic-boundary, and stale fact candidates | Runtime integration and real-workspace document-symbol quality receipts before any live cutover |
+| Workspace symbols | `shadowed` | Existing workspace index remains the live provider source; semantic-shadow fixtures trace fresh compiler, generated, dynamic-boundary, stale fact, and real-workspace quality candidates; runtime quality receipts capture live provider counts/results without changing live behavior | Real-workspace workspace-symbol quality receipts ([#8378](https://github.com/EffortlessMetrics/perl-lsp/issues/8378)) before any live cutover |
+| Document symbols | `shadowed` | Existing document-symbol provider remains the live source; semantic-shadow fixtures trace explicit syntax, generated, dynamic-boundary, and stale fact candidates; runtime quality receipts capture live provider counts/results without changing live behavior | Real-workspace document-symbol quality receipts before any live cutover |
 | Semantic tokens | `shadowed` | Existing parser/token provider remains the live source; semantic-shadow fixtures trace parser/HIR, compiler-backed, dynamic-boundary, and stale fact candidates | Runtime integration and token/span invariant receipts before any live cutover |
 
 ## Cutover Rules


### PR DESCRIPTION
Problem: document/workspace symbol provider cutover needed runtime quality receipts before any live compiler-backed behavior change.
Fix: add test-only receipt endpoints and focused tests that compare live symbol outputs while keeping provider behavior unchanged.
Verification: `cargo test -p perl-lsp-rs --lib --profile agent --locked symbols_runtime_quality -- --nocapture --test-threads=2`, `cargo xtask semantic-shadow-compare --check`, `cargo xtask semantic-scorecard --check`, `cargo xtask metrics parser-accuracy --check`, `cargo xtask update-status --only parser --check`, `cargo xtask metrics ratchet-check parser_accuracy`, `cargo xtask fmt --check`, `cargo clippy --locked --lib -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`, `git diff --check` pass.