### PR TITLE
test(semantic-tokens): add runtime quality receipts (#8483)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/mod.rs
@@ -42,6 +42,8 @@ mod refactor_runtime_blocker_receipts;
 mod refactor_runtime_blocker_tests;
 
 #[cfg(test)]
+mod semantic_tokens_runtime_quality_tests;
+#[cfg(test)]
 mod symbols_runtime_quality_tests;
 
 #[cfg(feature = "workspace")]

--- a/crates/perl-lsp-rs/src/runtime/language/semantic_tokens.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/semantic_tokens.rs
@@ -82,6 +82,45 @@ impl LspServer {
         })))
     }
 
+    /// Semantic tokens runtime quality receipt.
+    ///
+    /// Calls the live `textDocument/semanticTokens/full` handler and captures the result in a
+    /// typed receipt for quality proof. This does not change live semantic token behavior —
+    /// parser/HIR token classifications remain the live provider source.
+    ///
+    /// The receipt records token count, shadow state, and notes confirming no behavior change.
+    /// Compiler-fact candidates are pending staged cutover and are not yet wired.
+    #[cfg(any(test, feature = "expose_lsp_test_api"))]
+    pub(crate) fn semantic_tokens_runtime_quality_receipt(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        let live_provider_result = self.handle_semantic_tokens(params)?;
+
+        // Each LSP semantic token encodes as 5 consecutive u32 values in the flat data array.
+        let live_token_count = live_provider_result
+            .as_ref()
+            .and_then(|v| v.get("data"))
+            .and_then(|d| d.as_array())
+            .map(|arr| arr.len() / 5)
+            .unwrap_or(0);
+
+        Ok(Some(json!({
+            "provider": "semantic_tokens",
+            "live_provider_result": live_provider_result,
+            "live_provider_count": live_token_count,
+            "shadow_state": "shadowed",
+            "compiler_receipt": null,
+            "no_live_behavior_change": true,
+            "notes": format!(
+                "semantic_tokens runtime proof: token_count={live_token_count}; \
+                 parser/HIR classifications remain live provider; \
+                 compiler-fact candidates pending staged cutover; \
+                 no live behavior change"
+            )
+        })))
+    }
+
     /// Handle semantic tokens range request
     pub(crate) fn handle_semantic_tokens_range(
         &self,

--- a/crates/perl-lsp-rs/src/runtime/language/semantic_tokens_runtime_quality_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/semantic_tokens_runtime_quality_tests.rs
@@ -1,0 +1,315 @@
+//! Semantic tokens runtime quality receipts — BDD tests.
+//!
+//! Exercises the `textDocument/semanticTokens/full` handler through the receipt
+//! API, verifying that the runtime quality proof captures the live provider
+//! result without changing any live behavior.
+//!
+//! These tests advance the cutover matrix state for semantic tokens from
+//! "shadowed" toward "runtime integration proof" by confirming that:
+//!   - The live handler is called and its result is recorded in the receipt.
+//!   - Token count in the receipt matches the actual live provider count.
+//!   - `no_live_behavior_change` is always `true`.
+//!   - `shadow_state` is "shadowed".
+//!   - `compiler_receipt` is `null` (no compiler-fact cutover yet).
+//!   - `notes` carry a human-readable proof trail.
+
+use crate::runtime::LspServer;
+use parking_lot::Mutex;
+use perl_tdd_support::{must, must_some};
+use serde_json::{Value, json};
+use std::io::Cursor;
+use std::sync::Arc;
+
+const DOC_URI: &str = "file:///workspace/lib/Tokens.pm";
+
+/// A realistic Perl module with packages, subs, variables, and string literals
+/// to produce a non-trivial token stream.
+const PERL_MODULE: &str = r#"package Tokens::Example;
+use strict;
+use warnings;
+
+my $CONSTANT = 42;
+my @items    = (1, 2, 3);
+my %mapping  = (key => "value");
+
+sub process {
+    my ($self, $input) = @_;
+    my $result = $input * $CONSTANT;
+    return $result;
+}
+
+sub describe {
+    my $self = shift;
+    return "Tokens::Example instance";
+}
+
+1;
+"#;
+
+/// Empty Perl file — no declarations at all.
+const EMPTY_PERL: &str = r#"1;
+"#;
+
+/// Perl with only a comment and package declaration.
+const MINIMAL_PERL: &str = r#"# This is a comment
+package Minimal;
+1;
+"#;
+
+fn create_server() -> LspServer {
+    let output =
+        Arc::new(Mutex::new(Box::new(Cursor::new(Vec::new())) as Box<dyn std::io::Write + Send>));
+    LspServer::with_output(output)
+}
+
+fn open_document(server: &LspServer, uri: &str, text: &str) {
+    must(server.test_handle_did_open(Some(json!({
+        "textDocument": {
+            "uri": uri,
+            "text": text,
+            "languageId": "perl",
+            "version": 1
+        }
+    }))));
+}
+
+/// Count LSP semantic tokens from a `{ "data": [...] }` response.
+/// Each token is encoded as 5 consecutive u32 values.
+fn token_count(value: Option<&Value>) -> usize {
+    value
+        .and_then(|v| v.get("data"))
+        .and_then(|d| d.as_array())
+        .map(|arr| arr.len() / 5)
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// Receipt field correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_has_correct_provider_field() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": DOC_URI}
+        })))));
+
+    assert_eq!(
+        receipt.get("provider").and_then(Value::as_str),
+        Some("semantic_tokens"),
+        "provider field must be 'semantic_tokens'"
+    );
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_reports_no_live_behavior_change() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": DOC_URI}
+        })))));
+
+    assert_eq!(
+        receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "no_live_behavior_change must be true — receipt must not alter live token behavior"
+    );
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_shadow_state_is_shadowed() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": DOC_URI}
+        })))));
+
+    assert_eq!(
+        receipt.get("shadow_state").and_then(Value::as_str),
+        Some("shadowed"),
+        "shadow_state must be 'shadowed' — semantic tokens are not yet in partial-live cutover"
+    );
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_compiler_receipt_is_null() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": DOC_URI}
+        })))));
+
+    assert!(
+        receipt.get("compiler_receipt").map(Value::is_null).unwrap_or(false),
+        "compiler_receipt must be null — compiler-fact candidates are not yet wired"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Live provider result capture
+// ---------------------------------------------------------------------------
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_count_matches_live_result() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let params = json!({ "textDocument": {"uri": DOC_URI} });
+
+    let live_result = must(server.test_handle_semantic_tokens(Some(params.clone())));
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(params))));
+
+    let live_count = token_count(live_result.as_ref());
+    let receipt_count =
+        must_some(receipt.get("live_provider_count").and_then(Value::as_u64).map(|n| n as usize));
+
+    assert_eq!(
+        receipt_count, live_count,
+        "receipt live_provider_count must equal the actual live token count"
+    );
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_live_result_matches_handler() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let params = json!({ "textDocument": {"uri": DOC_URI} });
+
+    let live_result = must(server.test_handle_semantic_tokens(Some(params.clone())));
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(params))));
+
+    assert_eq!(
+        receipt.get("live_provider_result"),
+        live_result.as_ref(),
+        "live_provider_result in receipt must exactly match the live handler output"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Notes quality proof
+// ---------------------------------------------------------------------------
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_notes_record_quality_proof() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": DOC_URI}
+        })))));
+
+    let notes = must_some(receipt.get("notes").and_then(Value::as_str));
+
+    assert!(
+        notes.contains("semantic_tokens runtime proof"),
+        "notes must contain 'semantic_tokens runtime proof'; got: {notes}"
+    );
+    assert!(
+        notes.contains("no live behavior change"),
+        "notes must confirm no live behavior change; got: {notes}"
+    );
+    assert!(notes.contains("token_count="), "notes must include token_count metric; got: {notes}");
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_handles_empty_document() {
+    let server = create_server();
+    let empty_uri = "file:///workspace/lib/Empty.pm";
+    open_document(&server, empty_uri, EMPTY_PERL);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": empty_uri}
+        })))));
+
+    assert_eq!(receipt.get("provider").and_then(Value::as_str), Some("semantic_tokens"),);
+    assert_eq!(receipt.get("no_live_behavior_change").and_then(Value::as_bool), Some(true),);
+    // An effectively empty file may produce zero tokens — that is valid.
+    let count = receipt.get("live_provider_count").and_then(Value::as_u64).unwrap_or(u64::MAX);
+    assert!(
+        count < u64::MAX,
+        "live_provider_count must be a valid number even for an empty document"
+    );
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_handles_minimal_document() {
+    let server = create_server();
+    let minimal_uri = "file:///workspace/lib/Minimal.pm";
+    open_document(&server, minimal_uri, MINIMAL_PERL);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": minimal_uri}
+        })))));
+
+    assert_eq!(receipt.get("shadow_state").and_then(Value::as_str), Some("shadowed"),);
+    assert!(
+        receipt.get("compiler_receipt").map(Value::is_null).unwrap_or(false),
+        "compiler_receipt must remain null for minimal document"
+    );
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_module_with_subs_produces_tokens() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": DOC_URI}
+        })))));
+
+    let count = must_some(receipt.get("live_provider_count").and_then(Value::as_u64));
+
+    // A module with packages, subs, and variables should produce at least one token.
+    assert!(
+        count > 0,
+        "a Perl module with subs and variables should produce at least one semantic token; \
+         got {count}"
+    );
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_result_has_data_field() {
+    let server = create_server();
+    open_document(&server, DOC_URI, PERL_MODULE);
+
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(json!({
+            "textDocument": {"uri": DOC_URI}
+        })))));
+
+    let live_result = must_some(receipt.get("live_provider_result"));
+
+    assert!(
+        live_result.get("data").is_some(),
+        "live_provider_result must contain a 'data' field (LSP SemanticTokens shape)"
+    );
+
+    let data = must_some(live_result.get("data").and_then(Value::as_array));
+    // The flat array length must be divisible by 5 (each token = 5 u32 values).
+    assert_eq!(
+        data.len() % 5,
+        0,
+        "semantic token data array length must be a multiple of 5; got {} values",
+        data.len()
+    );
+}

--- a/crates/perl-lsp-rs/src/runtime/test_api.rs
+++ b/crates/perl-lsp-rs/src/runtime/test_api.rs
@@ -424,6 +424,38 @@ impl LspServer {
         cfg.ai_completion.fallback = fallback;
     }
 
+    /// Test-only entrypoint for LSP `textDocument/semanticTokens/full`.
+    ///
+    /// Exercises semantic token generation in tests. Returns the full semantic
+    /// token data for the document as a flat encoded array.
+    ///
+    /// # Parameters
+    /// - `params`: JSON-RPC params with `textDocument.uri`.
+    ///
+    /// # Returns
+    /// - `Ok(Some({"data": [...]}))`: Semantic token data (flat u32 array, 5 values per token).
+    ///
+    /// # Errors
+    /// Returns [`JsonRpcError`] if params are invalid or the document is not open.
+    pub fn test_handle_semantic_tokens(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        self.handle_semantic_tokens(params)
+    }
+
+    /// Test-only receipt for semantic tokens runtime quality proof.
+    ///
+    /// Calls the live `textDocument/semanticTokens/full` handler and captures the
+    /// result in a typed receipt. The receipt records token count, shadow state,
+    /// and a quality proof note. This does not change live semantic token behavior.
+    pub fn test_semantic_tokens_runtime_quality_receipt(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Option<Value>, JsonRpcError> {
+        self.semantic_tokens_runtime_quality_receipt(params)
+    }
+
     /// Returns `true` if a document with the given URI is currently in the
     /// document store.
     ///

--- a/docs/project/status/provider_cutover.md
+++ b/docs/project/status/provider_cutover.md
@@ -65,6 +65,12 @@ fallback behavior and rollback proof.
   parser/HIR classifications, compiler-backed classifications,
   dynamic-boundary blockers, and stale compiler facts. These receipts do not
   broaden live semantic-token behavior.
+- Semantic tokens now have runtime integration quality receipts
+  (`semantic_tokens_runtime_quality_receipt`) that exercise the live
+  `textDocument/semanticTokens/full` handler and capture token count, shadow
+  state, and a quality-proof note. Nine BDD tests confirm receipt correctness,
+  no-live-behavior-change invariant, and token-count parity with the live
+  handler. Compiler-fact candidates remain pending staged cutover.
 - Other provider surfaces remain trace/proof infrastructure only until their
   own cutover proof lands.
 
@@ -97,7 +103,7 @@ the relevant receipt command.
 | Safe delete | `boundary-shadowed` | Safe-delete receipts trace exact static allow decisions, dynamic-boundary blockers, framework-generated blockers, stale compiler facts, runtime blocker UX notes, and live-vs-compiler exact-static receipt data before any live compiler-backed refactor behavior | Real-workspace unsafe-delete receipts and explicit blocker UX in live safe-delete surfaces before any broader refactor migration |
 | Workspace symbols | `shadowed` | Existing workspace index remains the live provider source; semantic-shadow fixtures trace fresh compiler, generated, dynamic-boundary, stale fact, and real-workspace quality candidates; runtime quality receipts capture live provider counts/results without changing live behavior | Real-workspace workspace-symbol quality receipts ([#8378](https://github.com/EffortlessMetrics/perl-lsp/issues/8378)) before any live cutover |
 | Document symbols | `shadowed` | Existing document-symbol provider remains the live source; semantic-shadow fixtures trace explicit syntax, generated, dynamic-boundary, and stale fact candidates; runtime quality receipts capture live provider counts/results without changing live behavior | Real-workspace document-symbol quality receipts before any live cutover |
-| Semantic tokens | `shadowed` | Existing parser/token provider remains the live source; semantic-shadow fixtures trace parser/HIR, compiler-backed, dynamic-boundary, and stale fact candidates | Runtime integration and token/span invariant receipts before any live cutover |
+| Semantic tokens | `shadowed` | Existing parser/token provider remains the live source; semantic-shadow fixtures trace parser/HIR, compiler-backed, dynamic-boundary, and stale fact candidates; runtime quality receipts capture live token count and shadow state without changing live behavior | Token/span invariant receipts and real-workspace token quality before any live cutover |
 
 ## Cutover Rules
 


### PR DESCRIPTION
Problem: semantic-token provider cutover needed runtime integration receipts before any live compiler-backed token behavior change.
Fix: add a test-only semantic-token receipt endpoint and focused tests that capture live token counts/results while keeping parser/HIR token behavior unchanged.
Verification: `cargo test -p perl-lsp-rs --lib --profile agent --locked semantic_tokens_runtime_quality -- --nocapture --test-threads=2`, `cargo xtask semantic-shadow-compare --check`, `cargo xtask semantic-scorecard --check`, `cargo xtask metrics parser-accuracy --check`, `cargo xtask update-status --only parser --check`, `cargo xtask metrics ratchet-check parser_accuracy`, `cargo xtask fmt --check`, `cargo clippy --locked --lib -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`, `git diff --check` pass.