### PR TITLE
fix(ci): pin ripr advisory install to MSRV-compatible release (#8500)

### DIFF
--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -38,6 +38,8 @@ jobs:
     # Advisory only in this PR. Failures do not block.
     continue-on-error: true
     if: github.event.pull_request.draft != true
+    env:
+      RIPR_VERSION: "0.4.0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,11 +54,11 @@ jobs:
         with:
           cache-on-failure: true
           cache-all-crates: true
-          shared-key: ripr-${{ hashFiles('Cargo.lock') }}
+          shared-key: ripr-${{ env.RIPR_VERSION }}-${{ hashFiles('Cargo.lock') }}
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
 
       - name: Install ripr
-        run: cargo install ripr --locked
+        run: cargo install ripr --version "$RIPR_VERSION" --locked
 
       - name: Run ripr (doctor)
         run: ripr doctor

--- a/docs/ci/perl-lsp-rust-1.95-rollout.md
+++ b/docs/ci/perl-lsp-rust-1.95-rollout.md
@@ -108,6 +108,9 @@ expansion.
 normal PRs during this rollout. The target is better routing: skip docs-only and
 test-fixture-only changes unless a label forces analysis, keep artifacts
 consistent, and reserve mutation testing for targeted, nightly, or release lanes.
+While the repo remains pinned to Rust 1.93.1, the workflow pins `ripr` to the
+0.4.x line; the Rust 1.95 toolchain bump is the point where that install can move
+to a newer `ripr` release.
 
 ### CI economics
 

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -94,15 +94,17 @@ ripr is **never** used as proof; it is used as a **prompt**.
 
 ## Toolchain
 
-`rust-toolchain.toml` pins `1.93.1`, which satisfies `ripr`'s `>= 1.93` MSRV. The workflow
-uses the toolchain pinned in the repo and installs `ripr` via `cargo install ripr --locked`.
+`rust-toolchain.toml` pins `1.93.1`. While the repository is on that toolchain,
+the workflow installs `ripr` `0.4.0`, the latest compatible advisory version for
+the Rust 1.93 line. The Rust 1.95 rollout can unpin or bump this after the repo
+toolchain moves.
 
 ---
 
 ## Running locally
 
 ```bash
-cargo install ripr --locked
+cargo install ripr --version 0.4.0 --locked
 ripr doctor
 ripr check --base origin/master
 ripr check --base origin/master --json > target/ripr/ripr.json


### PR DESCRIPTION
Problem: `ripr static exposure` installs latest `ripr` under the repo-pinned Rust 1.93.1 toolchain, but `ripr 0.5.0` now requires Rust 1.95.
Fix: Pin the advisory workflow to `ripr 0.4.0`, include the pinned version in the cache key, and update the ripr/Rust 1.95 rollout docs.
Verification: `git diff --check`; `cargo xtask fmt --check`; `cargo xtask workflow-policy-lint --check-lane-whitelist`; `cargo xtask workflow-trigger-lint`; `cargo xtask devex plan --base origin/master`; `cargo info ripr@0.4.0`; `cargo install ripr --version 0.4.0 --locked --root $env:TEMP\perl-lsp-ripr-0.4.0-proof --force`; temp-root `ripr doctor` passes.