### PR TITLE
feat(diagnostics): use effective include context for PL701 (#8490)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
@@ -23,6 +23,7 @@ use super::lints::eval_error_flow::check_eval_error_flow;
 use super::lints::ffi_checklib::check_ffi_checklib;
 use super::lints::goto_label::check_goto_labels;
 use super::lints::loop_control_label::check_loop_control_labels;
+use super::lints::missing_module::ModuleSearchPathDisplay;
 use super::lints::package_subroutine::{
     check_duplicate_package, check_duplicate_subroutine, check_missing_package_declaration,
 };
@@ -171,6 +172,33 @@ impl DiagnosticsProvider {
             source,
             module_resolver,
             module_search_paths,
+            None,
+            source_path,
+            FileId(0),
+            &NullSemanticQueries,
+        )
+    }
+
+    /// Generate diagnostics with labeled module-search context for PL701.
+    ///
+    /// This preserves the legacy resolver and source-path behavior while using
+    /// labeled search roots for missing-module messages and suggestions.
+    pub fn get_diagnostics_with_search_context(
+        &self,
+        ast: &std::sync::Arc<Node>,
+        parse_errors: &[ParseError],
+        source: &str,
+        module_resolver: Option<&dyn Fn(&str) -> bool>,
+        module_search_context: &[ModuleSearchPathDisplay],
+        source_path: Option<&Path>,
+    ) -> Vec<Diagnostic> {
+        self.get_diagnostics_with_path_and_semantics_impl(
+            ast,
+            parse_errors,
+            source,
+            module_resolver,
+            &[],
+            Some(module_search_context),
             source_path,
             FileId(0),
             &NullSemanticQueries,
@@ -205,6 +233,36 @@ impl DiagnosticsProvider {
             source,
             module_resolver,
             module_search_paths,
+            None,
+            source_path,
+            file_id,
+            semantic_queries,
+        )
+    }
+
+    /// Generate semantic-aware diagnostics with labeled module-search context.
+    ///
+    /// Callers should use this when they have both workspace semantic queries
+    /// and labeled `@INC` roots from the runtime include-context builder.
+    #[allow(clippy::too_many_arguments)]
+    pub fn get_diagnostics_with_search_context_and_semantics<Q: SemanticQueries>(
+        &self,
+        ast: &std::sync::Arc<Node>,
+        parse_errors: &[ParseError],
+        source: &str,
+        module_resolver: Option<&dyn Fn(&str) -> bool>,
+        module_search_context: &[ModuleSearchPathDisplay],
+        source_path: Option<&Path>,
+        file_id: FileId,
+        semantic_queries: &Q,
+    ) -> Vec<Diagnostic> {
+        self.get_diagnostics_with_path_and_semantics_impl(
+            ast,
+            parse_errors,
+            source,
+            module_resolver,
+            &[],
+            Some(module_search_context),
             source_path,
             file_id,
             semantic_queries,
@@ -223,6 +281,7 @@ impl DiagnosticsProvider {
         source: &str,
         module_resolver: Option<&dyn Fn(&str) -> bool>,
         module_search_paths: &[String],
+        module_search_context: Option<&[ModuleSearchPathDisplay]>,
         source_path: Option<&Path>,
         file_id: FileId,
         semantic_queries: &Q,
@@ -326,13 +385,23 @@ impl DiagnosticsProvider {
 
         // Missing module lint (PL701) — only when a resolver is provided
         if let Some(resolver) = module_resolver {
-            super::lints::missing_module::check_missing_modules(
-                ast,
-                source,
-                resolver,
-                module_search_paths,
-                &mut diagnostics,
-            );
+            if let Some(search_context) = module_search_context {
+                super::lints::missing_module::check_missing_modules_with_search_context(
+                    ast,
+                    source,
+                    resolver,
+                    search_context,
+                    &mut diagnostics,
+                );
+            } else {
+                super::lints::missing_module::check_missing_modules(
+                    ast,
+                    source,
+                    resolver,
+                    module_search_paths,
+                    &mut diagnostics,
+                );
+            }
         }
 
         // Remove duplicate diagnostics before returning

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -483,11 +483,10 @@ impl LspServer {
             let resolver = |module: &str| {
                 self.resolve_module_to_path_with_doc(module, Some(&text), Some(uri)).is_some()
             };
-            let search_paths: Vec<String> = self
-                .include_paths_for_doc(uri)
-                .into_iter()
-                .map(|p| p.to_string_lossy().into_owned())
-                .collect();
+            let search_context = self
+                .effective_inc_context_for_doc(Some(uri), Some(&text), None)
+                .map(|context| context.search_display_paths())
+                .unwrap_or_default();
             let source_path = source_path_from_uri(uri);
 
             // Wire semantic queries when workspace data is available for this URI.
@@ -497,12 +496,12 @@ impl LspServer {
             let mut diagnostics = {
                 let semantic_diags = self.workspace_index().and_then(|workspace_index| {
                     workspace_index.with_semantic_queries_for_uri(uri, |file_id, queries| {
-                        provider.get_diagnostics_with_path_and_semantics(
+                        provider.get_diagnostics_with_search_context_and_semantics(
                             ast,
                             &parse_errors,
                             &text,
                             Some(&resolver),
-                            &search_paths,
+                            &search_context,
                             source_path.as_deref(),
                             file_id,
                             &queries,
@@ -510,23 +509,23 @@ impl LspServer {
                     })
                 });
                 semantic_diags.unwrap_or_else(|| {
-                    provider.get_diagnostics_with_path(
+                    provider.get_diagnostics_with_search_context(
                         ast,
                         &parse_errors,
                         &text,
                         Some(&resolver),
-                        &search_paths,
+                        &search_context,
                         source_path.as_deref(),
                     )
                 })
             };
             #[cfg(not(all(feature = "workspace", not(target_arch = "wasm32"))))]
-            let mut diagnostics = provider.get_diagnostics_with_path(
+            let mut diagnostics = provider.get_diagnostics_with_search_context(
                 ast,
                 &parse_errors,
                 &text,
                 Some(&resolver),
-                &search_paths,
+                &search_context,
                 source_path.as_deref(),
             );
 
@@ -1112,11 +1111,10 @@ impl LspServer {
                     self.resolve_module_to_path_with_doc(module, Some(&doc.text), Some(uri_str))
                         .is_some()
                 };
-                let search_paths: Vec<String> = self
-                    .include_paths_for_doc(uri_str)
-                    .into_iter()
-                    .map(|p| p.to_string_lossy().into_owned())
-                    .collect();
+                let search_context = self
+                    .effective_inc_context_for_doc(Some(uri_str), Some(&doc.text), None)
+                    .map(|context| context.search_display_paths())
+                    .unwrap_or_default();
                 let source_path = source_path_from_uri(uri_str);
 
                 // Wire semantic queries when workspace data is available for this URI.
@@ -1126,12 +1124,12 @@ impl LspServer {
                         workspace_index.with_semantic_queries_for_uri(
                             uri_str,
                             |file_id, queries| {
-                                provider.get_diagnostics_with_path_and_semantics(
+                                provider.get_diagnostics_with_search_context_and_semantics(
                                     ast,
                                     &doc.parse_errors,
                                     &doc.text,
                                     Some(&resolver),
-                                    &search_paths,
+                                    &search_context,
                                     source_path.as_deref(),
                                     file_id,
                                     &queries,
@@ -1140,23 +1138,23 @@ impl LspServer {
                         )
                     });
                     semantic_diags.unwrap_or_else(|| {
-                        provider.get_diagnostics_with_path(
+                        provider.get_diagnostics_with_search_context(
                             ast,
                             &doc.parse_errors,
                             &doc.text,
                             Some(&resolver),
-                            &search_paths,
+                            &search_context,
                             source_path.as_deref(),
                         )
                     })
                 };
                 #[cfg(not(all(feature = "workspace", not(target_arch = "wasm32"))))]
-                let mut diagnostics = provider.get_diagnostics_with_path(
+                let mut diagnostics = provider.get_diagnostics_with_search_context(
                     ast,
                     &doc.parse_errors,
                     &doc.text,
                     Some(&resolver),
-                    &search_paths,
+                    &search_context,
                     source_path.as_deref(),
                 );
 
@@ -2145,6 +2143,58 @@ mod tests {
             !text.contains("native.testing.require_use_strict"),
             "explicit legacy critic engine should not publish native policy IDs; got: {text:?}"
         );
+    }
+
+    #[test]
+    fn push_pl701_uses_effective_inc_context_labels() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(workspace.join("lib"))?;
+        let script = workspace.join("script.pl");
+        let uri = url::Url::from_file_path(&script)
+            .map_err(|()| "failed to build script URI")?
+            .to_string();
+        let folder_uri = url::Url::from_directory_path(&workspace)
+            .map_err(|()| "failed to build workspace URI")?
+            .to_string();
+
+        let (server, buf) = make_server_with_capture();
+        *server.root_path.lock() = Some(workspace.clone());
+        let mut config = perl_lsp_rs_core::config::WorkspaceConfig::default();
+        config.include_paths = vec!["lib".to_string()];
+        config.use_system_inc = false;
+        config.use_perl5lib = false;
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(folder_uri)
+                .with_path(workspace.clone())
+                .with_effective_workspace_config(config),
+        );
+
+        server.test_handle_did_open(Some(json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": "use Missing::From::Lib;\n"
+            }
+        })))?;
+
+        server.publish_diagnostics(&uri);
+        drop(server);
+        std::thread::sleep(Duration::from_millis(50));
+
+        let bytes = buf.lock().clone();
+        let text = String::from_utf8(bytes)?;
+        assert!(text.contains("PL701"), "missing module should publish PL701; got: {text:?}");
+        assert!(
+            text.contains("Searched @INC"),
+            "PL701 should include searched @INC context; got: {text:?}"
+        );
+        assert!(
+            text.contains("workspace includePaths"),
+            "PL701 should label the include root source; got: {text:?}"
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Problem: PL701 runtime diagnostics still passed bare @INC path strings after the labeled EffectiveIncContext builder landed.
Fix: Add backward-compatible diagnostics-provider overloads for labeled search context and route push/workspace PL701 diagnostics through EffectiveIncContext::search_display_paths().
Verification: `cargo test -p perl-lsp-rs --lib --profile agent --locked push_pl701_uses_effective_inc_context_labels -- --nocapture --test-threads=1`, `cargo test -p perl-lsp-rs-core --lib --profile agent --locked missing_module -- --nocapture --test-threads=2`, `cargo test -p perl-lsp-rs --lib --profile agent --locked diagnostics -- --nocapture --test-threads=2`, `cargo test -p perl-lsp-rs-core --lib --profile agent --locked diagnostics -- --nocapture --test-threads=2`, `cargo clippy --locked --lib -p perl-lsp-rs-core --profile agent -- -D warnings -A missing_docs`, `cargo clippy --locked --lib -p perl-lsp-rs --profile agent -- -D warnings -A missing_docs`, semantic freshness, parser accuracy/status/ratchet, `cargo xtask fmt --check`, and `git diff --check` pass.