### PR TITLE
chore(rust): upgrade workspace to Rust 1.95 toolchain + MSRV (#8508)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 [workspace.package]
 version = "0.13.4"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.95"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
 description = "Perl parser, LSP, and DAP ecosystem in Rust"
 license = "MIT OR Apache-2.0"
@@ -368,6 +368,19 @@ panic = "deny"
 todo = "deny"
 unimplemented = "deny"
 dbg_macro = "deny"
+# Newly-stabilised in Rust 1.94/1.95. Each has a cluster of pre-existing
+# call sites; opt into them once the cleanup follow-ups land (see #8508).
+# `priority = 1` overrides `#![warn(clippy::all)]` (priority 0) that several
+# crate `lib.rs` files declare.
+collapsible_match = { level = "allow", priority = 1 }
+manual_checked_ops = { level = "allow", priority = 1 }
+unnecessary_sort_by = { level = "allow", priority = 1 }
+useless_conversion = { level = "allow", priority = 1 }
+while_let_loop = { level = "allow", priority = 1 }
+manual_range_contains = { level = "allow", priority = 1 }
+useless_vec = { level = "allow", priority = 1 }
+vec_init_then_push = { level = "allow", priority = 1 }
+assertions_on_constants = { level = "allow", priority = 1 }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)', 'cfg(feature, values("slow_tests"))'] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 # clippy.toml
 # Keep pedantic on, but chill some noisy lints for a parser project.
 # warn-on-all-wildcard-imports = false
-msrv = "1.93"
+msrv = "1.95"
 
 # Common pedantic relaxations for parser projects
 allow-private-module-inception = true

--- a/crates/perl-diagnostics/src/lib.rs
+++ b/crates/perl-diagnostics/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 //! Unified diagnostic codes, types, and catalog for Perl LSP.
 //!

--- a/crates/perl-incremental-parsing/src/lib.rs
+++ b/crates/perl-incremental-parsing/src/lib.rs
@@ -13,7 +13,6 @@
 #![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 #[doc(inline)]
 pub use perl_parser::edit;

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -113,7 +113,6 @@
 //! let ast = parser.parse().expect("should parse");
 //! ```
 
-#![warn(clippy::all)]
 #![allow(
     // Core allows for lexer code
     clippy::too_many_lines,

--- a/crates/perl-line-index/src/lib.rs
+++ b/crates/perl-line-index/src/lib.rs
@@ -6,7 +6,6 @@
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 /// Line index for byte <-> (line, col) mapping.
 #[derive(Clone, Debug)]

--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -11,7 +11,6 @@
 #![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 use perl_subprocess_runtime::SubprocessRuntime;
 use serde::{Deserialize, Serialize};

--- a/crates/perl-lsp-rs-core/src/providers/code_lens/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_lens/mod.rs
@@ -23,7 +23,6 @@
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 use perl_parser_core::ast::{Node, NodeKind};
 use perl_position_tracking::{WirePosition, WireRange};

--- a/crates/perl-lsp-rs-core/src/providers/formatting_types/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/formatting_types/mod.rs
@@ -3,7 +3,6 @@
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/perl-lsp-rs/src/runtime/workspace_folder.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace_folder.rs
@@ -5,7 +5,6 @@
 //! workspace support.
 
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 use std::path::PathBuf;
 

--- a/crates/perl-parser-core/src/engine/parser/heredoc.rs
+++ b/crates/perl-parser-core/src/engine/parser/heredoc.rs
@@ -176,7 +176,7 @@ impl<'a> Parser<'a> {
         );
 
         // Zip 1:1 in order (collector preserves input order)
-        for (decl, body) in pending.into_iter().zip(out.contents.into_iter()) {
+        for (decl, body) in pending.into_iter().zip(out.contents) {
             let mut attached = self.try_attach_heredoc_at_node(root, decl.decl_span, &body);
             if !attached {
                 // Fallback: when statement recovery mutates span boundaries, the exact

--- a/crates/perl-parser-core/src/lib.rs
+++ b/crates/perl-parser-core/src/lib.rs
@@ -49,7 +49,6 @@
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
 #![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
-#![warn(clippy::all)]
 #![allow(
     clippy::too_many_lines,
     clippy::module_name_repetitions,

--- a/crates/perl-parser-core/src/syntax/text_line.rs
+++ b/crates/perl-parser-core/src/syntax/text_line.rs
@@ -7,7 +7,6 @@
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 /// Return the byte span of the line containing `cursor_pos`.
 ///

--- a/crates/perl-parser/src/lib.rs
+++ b/crates/perl-parser/src/lib.rs
@@ -299,7 +299,6 @@
 // NOTE: missing_docs enabled with baseline enforcement (Issue #197)
 // Baseline enforced via ci/missing_docs_baseline.txt
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 #![allow(
     // Core allows for parser/lexer code
     clippy::too_many_lines,

--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -6,7 +6,6 @@
 #![deny(unsafe_code)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 use std::collections::HashMap;
 use std::io;

--- a/crates/perl-refactoring/src/lib.rs
+++ b/crates/perl-refactoring/src/lib.rs
@@ -8,7 +8,6 @@
 #![deny(unreachable_pub)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 #![allow(
     clippy::too_many_lines,
     clippy::module_name_repetitions,

--- a/crates/perl-semantic-analyzer/src/lib.rs
+++ b/crates/perl-semantic-analyzer/src/lib.rs
@@ -20,7 +20,6 @@
 )]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 #![allow(
     clippy::too_many_lines,
     clippy::module_name_repetitions,

--- a/crates/perl-subprocess-runtime/src/lib.rs
+++ b/crates/perl-subprocess-runtime/src/lib.rs
@@ -7,7 +7,6 @@
 #![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 mod error;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/perl-tdd-support/src/lib.rs
+++ b/crates/perl-tdd-support/src/lib.rs
@@ -25,7 +25,6 @@
 #![deny(unreachable_pub)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 // This crate provides test helpers that intentionally panic on failure.
 // The must/must_some/must_err helpers are designed to panic in tests.
 #![allow(clippy::panic)]

--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -3,8 +3,6 @@
 //! This module centralizes URI helpers that are frequently reused by LSP-facing
 //! crates while keeping filesystem URI conversion concerns in `perl-uri`.
 
-#![warn(clippy::all)]
-
 use url::Url;
 
 /// Normalize a URI to a consistent key for lookups.

--- a/crates/perl-workspace/src/lib.rs
+++ b/crates/perl-workspace/src/lib.rs
@@ -17,7 +17,6 @@
 #![cfg_attr(test, allow(clippy::panic, clippy::unwrap_used, clippy::expect_used))]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 #![allow(
     clippy::too_many_lines,
     clippy::module_name_repetitions,

--- a/crates/tree-sitter-perl-rs/src/lib.rs
+++ b/crates/tree-sitter-perl-rs/src/lib.rs
@@ -44,7 +44,6 @@
 #![deny(clippy::print_stdout)]
 #![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Rust toolchain configuration for perl-lsp
-# MSRV: 1.93 (for OpenAI Codex compatibility)
+# MSRV: 1.95 (latest stable; tracks current CI Rust)
 [toolchain]
-channel = "1.93.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Toolchain + MSRV bump from 1.93 to 1.95. Closes #8508.

| File | Before | After |
|---|---|---|
| `rust-toolchain.toml` channel | `1.93.1` | `1.95.0` |
| `Cargo.toml` `rust-version` | `1.93` | `1.95` |
| `clippy.toml` `msrv` | `1.93` | `1.95` |

## Side effects

### New / promoted clippy lints

Running 1.95-bundled clippy surfaces these previously-unstabilised or newly-promoted lints:

- `collapsible_match`
- `manual_checked_ops`
- `unnecessary_sort_by`
- `useless_conversion`
- `while_let_loop`
- `manual_range_contains`
- `useless_vec`
- `vec_init_then_push`
- `assertions_on_constants`

Each has a cluster of pre-existing call sites. Rather than fix in one go, this PR opts out at the workspace level via `[workspace.lints.clippy]` with `priority = 1`. Cleanup follow-ups (PR B in #8508's plan) will land separately so they can be reviewed by category.

### Redundant `#![warn(clippy::all)]` removed

19 crate-root files declared `#![warn(clippy::all)]`. That attribute was redundant (`clippy::all` is warn-by-default), but it blocked the workspace `[lints]` allows above from taking effect because source attributes win over Cargo.toml inheritance. Removing the redundant attributes lets workspace lints work as intended.

### One real code fix

`crates/perl-parser-core/src/engine/parser/heredoc.rs:179`:

```rust
// before
for (decl, body) in pending.into_iter().zip(out.contents.into_iter()) {
// after
for (decl, body) in pending.into_iter().zip(out.contents) {
```

The second `.into_iter()` was redundant since `Iterator::zip` accepts any `IntoIterator`. Couldn't be silenced at the workspace level due to crate-local precedence, so fix-forward.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --lib --no-deps -- -D warnings` — clean
- [x] `cargo test -p perl-parser --lib` — 140 passed
- [x] `cargo xtask fmt` — no diff
- [x] `rustc --version` reports 1.95.0

## Out of scope

`cargo clippy --workspace --all-targets -- -Dwarnings` still fails for `perl-ci-hygiene` (`expect_used`, `manual_range_contains` in `version_sync/mod.rs` and `main.rs`). **These failures also exist on `master`** — they're not regressions from this PR. The CI gate `clippy_scoped` only checks touched packages, so they don't block merges; they'll be cleaned up when the team next touches that crate.

## References

- Closes #8508
- Follow-ups: PR B (clean up allow-listed lints, by category), PR C (adopt 1.95-stable features in production code if any are worth touching)
