### PR TITLE
chore(clippy): replace sort_by with sort_by_key (#8508)

### DIFF
--- a/crates/perl-parser/src/refactor/inline.rs
+++ b/crates/perl-parser/src/refactor/inline.rs
@@ -623,7 +623,7 @@ fn split_args(args_str: &str) -> Vec<String> {
 fn substitute_params(body: &str, sub_map: &HashMap<String, String>) -> String {
     let mut result = body.to_string();
     let mut pairs: Vec<(&String, &String)> = sub_map.iter().collect();
-    pairs.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    pairs.sort_by_key(|p| std::cmp::Reverse(p.0.len()));
 
     for (param, arg) in pairs {
         let var = format!("${}", param);

--- a/crates/perl-parser/src/refactor/refactoring.rs
+++ b/crates/perl-parser/src/refactor/refactoring.rs
@@ -1506,7 +1506,7 @@ impl RefactoringEngine {
         }
 
         // Sort by start position descending for safe removal from source
-        elements_to_move.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+        elements_to_move.sort_by_key(|e| std::cmp::Reverse(e.location.start));
 
         let mut modified_source = source_content.clone();
 
@@ -1527,7 +1527,7 @@ impl RefactoringEngine {
         }
 
         // Sort by start position ascending for correct append order
-        elements_to_move.sort_by(|a, b| a.location.start.cmp(&b.location.start));
+        elements_to_move.sort_by_key(|e| e.location.start);
 
         // Construct moved content
         let mut moved_content = String::new();
@@ -1822,7 +1822,7 @@ impl RefactoringEngine {
             // Clone and sort edits by start position in descending order to apply them safely
             // (applying from end to start preserves earlier byte positions)
             let mut edits = file_edit.edits.clone();
-            edits.sort_by(|a, b| b.start.cmp(&a.start));
+            edits.sort_by_key(|e| std::cmp::Reverse(e.start));
 
             // Clone content for comparison after modifications
             let mut new_content = content.clone();

--- a/crates/perl-parser/src/refactor/workspace_rename.rs
+++ b/crates/perl-parser/src/refactor/workspace_rename.rs
@@ -569,7 +569,7 @@ impl WorkspaceRename {
         let file_edits: Vec<FileEdit> = edits_by_file
             .into_iter()
             .map(|(file_path, mut edits)| {
-                edits.sort_by(|a, b| b.start.cmp(&a.start));
+                edits.sort_by_key(|e| std::cmp::Reverse(e.start));
                 FileEdit { file_path, edits }
             })
             .collect();

--- a/crates/perl-refactoring/src/refactor/inline.rs
+++ b/crates/perl-refactoring/src/refactor/inline.rs
@@ -664,7 +664,7 @@ fn split_args(args_str: &str) -> Vec<String> {
 fn substitute_params(body: &str, sub_map: &HashMap<String, String>) -> String {
     let mut result = body.to_string();
     let mut pairs: Vec<(&String, &String)> = sub_map.iter().collect();
-    pairs.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    pairs.sort_by_key(|p| std::cmp::Reverse(p.0.len()));
 
     for (param, arg) in pairs {
         let var = format!("${}", param);

--- a/crates/perl-refactoring/src/refactor/refactoring.rs
+++ b/crates/perl-refactoring/src/refactor/refactoring.rs
@@ -1529,7 +1529,7 @@ impl RefactoringEngine {
         }
 
         // Sort by start position descending for safe removal from source
-        elements_to_move.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+        elements_to_move.sort_by_key(|e| std::cmp::Reverse(e.location.start));
 
         let mut modified_source = source_content.clone();
 
@@ -1550,7 +1550,7 @@ impl RefactoringEngine {
         }
 
         // Sort by start position ascending for correct append order
-        elements_to_move.sort_by(|a, b| a.location.start.cmp(&b.location.start));
+        elements_to_move.sort_by_key(|e| e.location.start);
 
         // Construct moved content
         let mut moved_content = String::new();
@@ -1882,7 +1882,7 @@ impl RefactoringEngine {
             // Clone and sort edits by start position in descending order to apply them safely
             // (applying from end to start preserves earlier byte positions)
             let mut edits = file_edit.edits.clone();
-            edits.sort_by(|a, b| b.start.cmp(&a.start));
+            edits.sort_by_key(|e| std::cmp::Reverse(e.start));
 
             // Clone content for comparison after modifications
             let mut new_content = content.clone();

--- a/crates/perl-refactoring/src/refactor/workspace_rename.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_rename.rs
@@ -564,7 +564,7 @@ impl WorkspaceRename {
         let file_edits: Vec<FileEdit> = edits_by_file
             .into_iter()
             .map(|(file_path, mut edits)| {
-                edits.sort_by(|a, b| b.start.cmp(&a.start));
+                edits.sort_by_key(|e| std::cmp::Reverse(e.start));
                 FileEdit { file_path, edits }
             })
             .collect();


### PR DESCRIPTION
## Summary

Fixes the 10 `clippy::unnecessary_sort_by` sites that surface under Rust 1.95-bundled clippy. Refs #8508 (Rust 1.95 upgrade) — this is follow-up B1 of the cleanup plan.

All ten are single-key comparisons that map mechanically:

| Pattern | Replacement |
|---|---|
| `v.sort_by(\|a, b\| a.key.cmp(&b.key))` | `v.sort_by_key(\|x\| x.key)` |
| `v.sort_by(\|a, b\| b.key.cmp(&a.key))` | `v.sort_by_key(\|x\| std::cmp::Reverse(x.key))` |

Behavior-preserving — `sort_by_key` returns the same order as the explicit `cmp` form for these patterns.

## Sites fixed (10 total)

- `crates/perl-refactoring/src/refactor/inline.rs:667`
- `crates/perl-refactoring/src/refactor/refactoring.rs:1532, 1553, 1885`
- `crates/perl-refactoring/src/refactor/workspace_rename.rs:567`
- `crates/perl-parser/src/refactor/inline.rs:626`
- `crates/perl-parser/src/refactor/refactoring.rs:1509, 1530, 1825`
- `crates/perl-parser/src/refactor/workspace_rename.rs:572`

## Sites left alone (intentional)

- `crates/perl-parser/src/incremental/incremental_edit.rs:167, 198, 231`
- `crates/perl-parser/src/ide/lsp_compat/code_actions.rs:251`
- `crates/perl-parser/src/ide/lsp_compat/workspace_symbols.rs:262`

These are multi-key composite comparisons (`a.x.cmp(&b.x).then(b.y.cmp(&a.y))` etc.) that clippy correctly does NOT flag.

## Follow-up

Once all allow-listed lints from #8509 have cleanup PRs landed, the `unnecessary_sort_by = { level = "allow", priority = 1 }` entry in `[workspace.lints.clippy]` can be removed. Tracking the full cleanup in #8508.

## Test plan

- [x] `cargo check -p perl-parser -p perl-refactoring --lib` — clean
- [x] `cargo test -p perl-parser --lib` — 140 passed
- [x] `cargo test -p perl-refactoring --lib` — 115 passed
- [x] `cargo xtask fmt`

## References

- Refs #8508 (PR B1 — `unnecessary_sort_by` cleanup)
- Independent of #8509 (Rust 1.95 toolchain) — these fixes work on any recent Rust version. The corresponding workspace allow can be removed after both this PR and #8509 land.
