### PR TITLE
chore(ci): enable --check-lane-whitelist in workflow-policy lint (#8166)

### DIFF
--- a/.github/workflows/workflow-policy.yml
+++ b/.github/workflows/workflow-policy.yml
@@ -32,7 +32,12 @@ jobs:
         with:
           toolchain: stable
       - name: Run workflow policy lint
-        run: cargo xtask workflow-policy-lint --receipt target/receipts/workflow-policy.json
+        # `--check-lane-whitelist` enables the policy/ci-lane-whitelist.toml
+        # gate (was opt-in per PR #8154). All currently-flagged workflows
+        # either have a whitelist entry or an allowlist exemption, so this
+        # is a no-op for the existing tree and a guard against future drift.
+        # See #8166 ("CI economics rollout: deferred follow-ups").
+        run: cargo xtask workflow-policy-lint --check-lane-whitelist --receipt target/receipts/workflow-policy.json
       - name: Upload workflow policy receipt
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Enables `--check-lane-whitelist` in the `workflow-policy-lint` CI job. Was opt-in since PR EffortlessMetrics/perl-lsp#8154; EffortlessMetrics/perl-lsp-swarm#2742 tracked this as a deferred follow-up of the CI economics rollout.

## Verified locally

```
$ cargo xtask workflow-policy-lint --check-lane-whitelist
Workflow policy lint passed (0 error(s), 4 warning(s))
```

The 4 warnings are unrelated `UNPINNED_ACTION` complaints already present on master. No new errors surface, so this is a no-op for the existing tree and a guard against future workflow drift.

## References

- Refs EffortlessMetrics/perl-lsp-swarm#2742 (CI economics rollout — deferred follow-ups)
- Precedent: PR EffortlessMetrics/perl-lsp#8154 introduced the flag as opt-in