### PR TITLE
fix(@INC): warn when startup @INC probe times out or fails (#8515)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -743,7 +743,34 @@ impl WorkspaceConfig {
             Ok(out) if out.status.success() => {
                 Self::parse_perl_inc_output(&String::from_utf8_lossy(&out.stdout))
             }
-            _ => Vec::new(),
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                tracing::warn!(
+                    target: "perl_lsp::config::system_inc",
+                    status = ?out.status,
+                    stderr = %stderr.trim(),
+                    "startup @INC probe exited non-zero; caching empty result"
+                );
+                Vec::new()
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::TimedOut => {
+                tracing::warn!(
+                    target: "perl_lsp::config::system_inc",
+                    timeout_ms = SYSTEM_INC_PROBE_TIMEOUT.as_millis() as u64,
+                    "startup @INC probe timed out; caching empty result. \
+                     Set perl.workspace.useSystemInc=false to disable probing, \
+                     or pin a faster perl interpreter."
+                );
+                Vec::new()
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "perl_lsp::config::system_inc",
+                    error = %err,
+                    "startup @INC probe failed to spawn perl; caching empty result"
+                );
+                Vec::new()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #8515.

The bounded `output_with_timeout` wrapper from #8497 prevents the probe from stalling the LSP, but its error branch silently returned `Vec::new()`. A slow/hung/missing `perl` interpreter therefore looked identical to a truly-empty interpreter `@INC` — users had no signal to investigate when startup-`@INC` resolution mysteriously stopped working.

## Change

In `crates/perl-lsp-rs-core/src/config/mod.rs::fetch_perl_inc`, the catch-all `_ => Vec::new()` arm is replaced with three discriminated warns:

| Branch | Warning content |
|---|---|
| `Err(err)` where `err.kind() == TimedOut` | `"startup @INC probe timed out; caching empty result. Set perl.workspace.useSystemInc=false to disable probing, or pin a faster perl interpreter."` |
| `Ok(out)` where `!out.status.success()` | exit status + trimmed stderr |
| `Err(err)` (other) | the `io::Error` |

All three keep the existing cache-empty behavior, so the warning fires **at most once per cache invalidation cycle** (i.e. once per `useSystemInc` / `usePerl5lib` toggle). No re-spawn on subsequent requests.

## Tracing target

All three warns use `target: "perl_lsp::config::system_inc"` so users can filter precisely (e.g. `RUST_LOG=perl_lsp::config::system_inc=warn`).

## Test plan

- [x] `cargo check -p perl-lsp-rs-core --tests`
- [x] `cargo test -p perl-lsp-rs-core --lib config::tests` — 29 passed (existing `get_system_inc_does_not_stall_on_slow_interpreter` integration test still passes; that test exercises the `TimedOut` path)
- [x] `cargo xtask fmt`

No new test added. A tracing-subscriber capture test would add significant test-infra complexity for a single observability hook; the existing module-resolution.rs:362 comment ("we do not capture tracing output here because tracing-test adds a...") is the project's stated precedent.

## References

- Closes #8515
- Builds on #8497 (closed via PR #8497 → master).
- Part of the @INC rail follow-up triplet (#8514, #8515, #8516) tracked in the rail-completion status doc PR #8517.
