### PR TITLE
chore(ci): whitelist aggregate lane history workflow (#8166)

### DIFF
--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -22,7 +22,7 @@ schema_version = 1
 policy = "ci-lane-whitelist"
 owner = "EffortlessMetrics"
 status = "advisory"
-updated = "2026-05-07"
+updated = "2026-05-11"
 
 # =============================================================================
 # Frontdoor / control lanes
@@ -703,6 +703,27 @@ expensive = false
 duplicate_of = []
 review_after = "2026-06-07"
 expires = "2026-11-07"
+
+[[lane]]
+id = "aggregate_ci_lane_history"
+workflow = ".github/workflows/aggregate-ci-lane-history.yml"
+job = "aggregate"
+tier = "nightly"
+kind = "visibility"
+blocking = false
+default_pr = false
+runner = "ubuntu_24_04"
+base_lem = 2
+owner = "ci"
+intent = "Aggregate recent ci-actuals artifacts into learned lane-history estimates."
+failure_mode = "Planner keeps using static LEM floors or stale learned lane estimates."
+proof_obligation = "Download recent ci-actuals artifacts and run scripts/ci/aggregate_lane_history.py."
+evidence = [".ci/metrics/ci-lane-history.json", "ci-lane-history-* artifact"]
+allowed_triggers = ["schedule", "workflow_dispatch"]
+expensive = false
+duplicate_of = []
+review_after = "2026-06-11"
+expires = "2026-11-11"
 
 [[lane]]
 id = "pipeline_labels"


### PR DESCRIPTION
Problem: #8510 added the scheduled CI lane-history aggregator workflow, but the advisory lane-whitelist linter still reported it as missing from policy/ci-lane-whitelist.toml.\nFix: Add the aggregate-ci-lane-history workflow to the CI lane whitelist with schedule/dispatch triggers and learned-history proof obligations.\nVerification: \cargo xtask workflow-policy-lint --check-lane-whitelist\, \cargo xtask fmt --check\, \git diff --check\, \cargo xtask metrics parser-accuracy --check\, \cargo xtask update-status --only parser --check\, and \cargo xtask metrics ratchet-check parser_accuracy\ pass.