### PR TITLE
chore(clippy): remove unnecessary_sort_by workspace allow (#8508)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,6 @@ dbg_macro = "deny"
 # crate `lib.rs` files declare.
 collapsible_match = { level = "allow", priority = 1 }
 manual_checked_ops = { level = "allow", priority = 1 }
-unnecessary_sort_by = { level = "allow", priority = 1 }
 useless_conversion = { level = "allow", priority = 1 }
 while_let_loop = { level = "allow", priority = 1 }
 manual_range_contains = { level = "allow", priority = 1 }

--- a/crates/perl-lsp-rs/src/cli.rs
+++ b/crates/perl-lsp-rs/src/cli.rs
@@ -313,7 +313,7 @@ fn run_check_project(dir: &str) -> i32 {
 
     if !category_counts.is_empty() {
         let mut cats: Vec<_> = category_counts.into_iter().collect();
-        cats.sort_by(|a, b| b.1.cmp(&a.1));
+        cats.sort_by_key(|c| std::cmp::Reverse(c.1));
         println!("Top issue categories:");
         for (cat, count) in &cats {
             println!("  {cat}: {count}");


### PR DESCRIPTION
## Summary

Removes `unnecessary_sort_by = { level = "allow", priority = 1 }` from `[workspace.lints.clippy]`. The lint is back to its clippy::style default (warn → deny under `-D warnings` in CI).

Refs #8508 (Rust 1.95 cleanup plan), follow-up B2.

## Why

PR #8511 cleaned the 10 originally-surveyed sort_by sites (5 in `perl-refactoring/`, 5 in `perl-parser/`). After Rust 1.95 landed on master (#8509), clippy surfaces one more site that wasn't in the lib scope of the original survey:

- `crates/perl-lsp-rs/src/cli.rs:316` — `cats.sort_by(|a, b| b.1.cmp(&a.1))` → `cats.sort_by_key(|c| std::cmp::Reverse(c.1))`

With that fixed, the allow entry is no longer needed.

## What's still allow-listed

The other 8 lints from PR #8509's allow set stay until their respective follow-up PRs land:

- `collapsible_match`
- `manual_checked_ops`
- `useless_conversion`
- `while_let_loop`
- `manual_range_contains`
- `useless_vec`
- `vec_init_then_push`
- `assertions_on_constants`

## Test plan

- [x] `cargo clippy --workspace --lib --no-deps -- -D warnings` — clean
- [x] `cargo xtask fmt` — no diff
- [x] `cargo build --workspace` — clean

`--all-targets` still surfaces the pre-existing `perl-ci-hygiene` `expect_used`/`manual_range_contains` violations (also present on master). The `clippy_scoped` CI gate runs scoped to touched packages, so they don't block.

## References

- Refs #8508 (Rust 1.95 cleanup)
- Builds on: #8509 (toolchain bump, merged), #8511 (initial sort_by cleanup, merged)
- Follow-up category: strong clippy lints rollout
