### PR TITLE
chore(clippy): remove useless_conversion workspace allow (#8508)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,6 @@ dbg_macro = "deny"
 # crate `lib.rs` files declare.
 collapsible_match = { level = "allow", priority = 1 }
 manual_checked_ops = { level = "allow", priority = 1 }
-useless_conversion = { level = "allow", priority = 1 }
 while_let_loop = { level = "allow", priority = 1 }
 manual_range_contains = { level = "allow", priority = 1 }
 useless_vec = { level = "allow", priority = 1 }


### PR DESCRIPTION
## Summary

Removes `useless_conversion = { level = "allow", priority = 1 }` from `[workspace.lints.clippy]`. The lint is back to its clippy::style default (warn → deny under `-D warnings` in CI).

Refs #8508 (Rust 1.95 cleanup plan), follow-up B3. Stacks behind #8520 (`unnecessary_sort_by` allow removal, follow-up B2).

## Why

After Rust 1.95 landed on master via #8509 and the single surfaced `useless_conversion` site was fixed in `crates/perl-parser-core/src/engine/parser/heredoc.rs:179` (also in #8509), a workspace survey under Rust 1.95 confirms zero remaining hits:

- `cargo clippy --workspace --lib --no-deps -- -D warnings` — clean
- `cargo clippy --workspace --tests --no-deps -- -D warnings -A missing_docs` — clean for `useless_conversion`; only pre-existing perl-ci-hygiene `expect_used`/`manual_range_contains` failures (also present on master, not introduced by this PR).

## What stays

After this lands (stacked behind #8520), the workspace allow set will be 7 lints from the original Rust 1.95 allowlist:

- `collapsible_match` (3 lib sites)
- `while_let_loop` (1 lib site, `selection_range.rs:96`)
- `manual_checked_ops` (1 lib site)
- `manual_range_contains` (perl-ci-hygiene tests/bin, pre-existing)
- `useless_vec` (test code)
- `vec_init_then_push` (test code)
- `assertions_on_constants` (test code)

Each will get its own cleanup PR.

## Test plan

- [x] `cargo clippy --workspace --lib --no-deps -- -D warnings` — clean
- [x] `cargo xtask fmt` — no diff

## References

- Refs #8508 (Rust 1.95 cleanup)
- Stacks behind: #8520 (`unnecessary_sort_by` allow removal)
- Builds on: #8509 (toolchain), #8511 (sort_by cleanup), both merged.
