### PR TITLE
chore(clippy): remove manual_checked_ops workspace allow (#8508)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,7 +373,6 @@ dbg_macro = "deny"
 # `priority = 1` overrides `#![warn(clippy::all)]` (priority 0) that several
 # crate `lib.rs` files declare.
 collapsible_match = { level = "allow", priority = 1 }
-manual_checked_ops = { level = "allow", priority = 1 }
 while_let_loop = { level = "allow", priority = 1 }
 manual_range_contains = { level = "allow", priority = 1 }
 useless_vec = { level = "allow", priority = 1 }

--- a/crates/perl-lsp-rs/src/runtime/workspace_progress.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace_progress.rs
@@ -46,7 +46,7 @@ pub(super) fn send_progress_begin(outbound: &OutboundSender) {
 
 #[cfg(feature = "workspace")]
 pub(super) fn send_progress_report(outbound: &OutboundSender, indexed: usize, total: usize) {
-    let percentage = if total > 0 { (indexed * 100 / total).min(99) as u32 } else { 0 };
+    let percentage = (indexed * 100).checked_div(total).unwrap_or(0).min(99) as u32;
     let message = format!("Indexed {} of {} files", indexed, total);
     if let Err(e) = outbound.send_notification(
         "$/progress",


### PR DESCRIPTION
## Summary

Removes `manual_checked_ops = { level = "allow", priority = 1 }` from `[workspace.lints.clippy]`. The lint is back to its clippy::style default. Refs #8508 follow-up B4 — stacks behind #8520 (sort_by) and #8521 (useless_conversion).

## The one fix

`crates/perl-lsp-rs/src/runtime/workspace_progress.rs:49`:

```diff
-    let percentage = if total > 0 { (indexed * 100 / total).min(99) as u32 } else { 0 };
+    let percentage = (indexed * 100).checked_div(total).unwrap_or(0).min(99) as u32;
```

Semantically identical: `total == 0` returns 0; otherwise the quotient capped at 99. Uses `unwrap_or(default)` (allowed) rather than `unwrap()` (denied workspace-wide).

## Test plan

- [x] `cargo clippy --workspace --lib --no-deps -- -D warnings` — clean
- [x] `cargo xtask fmt` — no diff
- [x] Behavior preserved: the function returns 0 when `total == 0`, otherwise `min((indexed * 100) / total, 99)` cast to `u32`.

## What's still allow-listed

After #8520, #8521, and this PR land, 5 of the 9 original 1.95 allow entries remain:

- `collapsible_match` (3 lib sites — non-trivial restructure)
- `unnecessary_sort_by` — being removed in #8520
- `while_let_loop` (1 lib site, multi-break loop)
- `useless_conversion` — being removed in #8521
- `manual_range_contains` (test-only, perl-ci-hygiene)
- `useless_vec`, `vec_init_then_push`, `assertions_on_constants` (test-only)

## References

- Refs #8508 (Rust 1.95 cleanup plan)
- Stacks behind: #8520, #8521
