### PR TITLE
chore(clippy): replace xtask sort_by with sort_by_key (#8508)

### DIFF
--- a/xtask/src/tasks/metrics/parser_stats.rs
+++ b/xtask/src/tasks/metrics/parser_stats.rs
@@ -105,7 +105,7 @@ fn find_latest_benchmark_json(root: &Path) -> Result<PathBuf> {
         })
         .collect();
 
-    candidates.sort_by(|a, b| b.0.cmp(&a.0)); // newest first
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.0)); // newest first
 
     candidates.into_iter().map(|(_, p)| p).next().ok_or_else(|| {
         color_eyre::eyre::eyre!("no *.json files found in {}", results_dir.display())


### PR DESCRIPTION
Problem: Rust 1.95 clippy flags an xtask parser-stats sort as unnecessary_sort_by.\nFix: Use sort_by_key with Reverse while preserving newest-first ordering.\nVerification: \cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs\, \cargo check -p xtask --profile agent --locked\, parser accuracy/status/ratchet checks, fmt check, and git diff check pass.