### PR TITLE
chore(@INC): post-rail polish — remove #7570 test, clarify @INC wording, pin perl5libPrecedence policy (#8485)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -1530,6 +1530,74 @@ profile = "recommended"
         assert_eq!(paths, vec!["local/lib", "vendor/lib", "lib"]);
     }
 
+    /// Precedence audit: when the SAME path appears in both `PERL5LIB` and
+    /// `include_paths`, `Prepend` resolves it from PERL5LIB's slot (early in
+    /// the search list) and `Append` resolves it from `include_paths`' slot.
+    ///
+    /// This pins the policy decision flagged in the 2026-05-11 @INC
+    /// checkpoint: `perl5libPrecedence=prepend` is **Perl-faithful**
+    /// (PERL5LIB shadows workspace `includePaths` for overlapping modules).
+    /// `Append` makes workspace `includePaths` win over PERL5LIB. The
+    /// resolver iterates in the returned order and picks the first hit, so
+    /// the asserted index is the resolution outcome.
+    #[test]
+    fn perl5lib_precedence_pins_shadow_order_for_overlapping_paths() {
+        let shared = "shared/lib".to_string();
+        let perl5lib = vec![shared.clone()];
+        let workspace = vec![shared.clone()];
+
+        let prepend_config = WorkspaceConfig {
+            include_paths: workspace.clone(),
+            perl5lib_precedence: Perl5LibPrecedence::Prepend,
+            ..WorkspaceConfig::default()
+        };
+        let prepend = prepend_config.effective_include_paths(&perl5lib);
+        assert_eq!(prepend.len(), 1, "dedup must collapse to one entry");
+        // With prepend, the overlapping path is contributed by PERL5LIB
+        // first and the workspace copy is deduped. The kept entry is
+        // conceptually the PERL5LIB one — which matches Perl's runtime
+        // behaviour where `-I` / PERL5LIB precedes the default `@INC`.
+
+        let append_config = WorkspaceConfig {
+            include_paths: workspace,
+            perl5lib_precedence: Perl5LibPrecedence::Append,
+            ..WorkspaceConfig::default()
+        };
+        let append = append_config.effective_include_paths(&perl5lib);
+        assert_eq!(append.len(), 1, "dedup must collapse to one entry");
+        // Symmetric: with append, the workspace `includePaths` entry comes
+        // first; the PERL5LIB duplicate is deduped after it.
+
+        // Multi-path overlap: shared appears in both lists, plus distinct
+        // entries on each side. Prepend interleaves PERL5LIB-first.
+        let prepend_multi_config = WorkspaceConfig {
+            include_paths: vec!["workspace_only".into(), shared.clone()],
+            perl5lib_precedence: Perl5LibPrecedence::Prepend,
+            ..WorkspaceConfig::default()
+        };
+        let prepend_multi =
+            prepend_multi_config.effective_include_paths(&["env_only".into(), shared.clone()]);
+        // PERL5LIB entries first → env_only then shared (from env). The
+        // workspace's `shared` is deduped. workspace_only follows.
+        #[cfg(windows)]
+        assert_eq!(prepend_multi, vec!["env_only", "shared\\lib", "workspace_only"]);
+        #[cfg(not(windows))]
+        assert_eq!(prepend_multi, vec!["env_only", "shared/lib", "workspace_only"]);
+
+        // And append flips it: workspace entries first, then env-only.
+        let append_multi_config = WorkspaceConfig {
+            include_paths: vec!["workspace_only".into(), shared.clone()],
+            perl5lib_precedence: Perl5LibPrecedence::Append,
+            ..WorkspaceConfig::default()
+        };
+        let append_multi =
+            append_multi_config.effective_include_paths(&["env_only".into(), shared.clone()]);
+        #[cfg(windows)]
+        assert_eq!(append_multi, vec!["workspace_only", "shared\\lib", "env_only"]);
+        #[cfg(not(windows))]
+        assert_eq!(append_multi, vec!["workspace_only", "shared/lib", "env_only"]);
+    }
+
     #[test]
     fn effective_include_paths_dedupes_with_append_precedence() {
         let config = WorkspaceConfig {

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
@@ -272,10 +272,12 @@ impl LspServer {
     ///    - Custom paths from workspace configuration
     ///    - Relative paths are resolved against each workspace folder
     ///
-    /// 4. **System @INC** (opt-in only)
+    /// 4. **Interpreter startup `@INC`** (opt-in only)
     ///    - Disabled by default (network filesystem concern)
     ///    - Enable via `workspace.useSystemInc: true` in settings
     ///    - Filtered to exclude `.` (current directory) for security
+    ///    - Distinct from `PERL5LIB`, which is governed by
+    ///      `workspace.usePerl5lib` and merged with `includePaths` (see #8493).
     ///
     /// ## Performance Characteristics
     /// - Timeout: Configurable (default 50ms) to prevent blocking

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
@@ -266,72 +266,15 @@ fn scenario_14_relative_include_path() {
     harness.assert_no_crash();
 }
 
-// FIXME(#7570): goto-definition does not agree with completion when
-// `includePaths` is configured — completion finds the module but defs is empty.
-// Tracked in #7570; ignored to unblock master CI Gate. The bug shape and
-// repro live in the issue.
-#[test]
-#[ignore = "FIXME(#7570): goto-def returns empty under includePaths completion"]
-fn scenario_14_include_path_completion_external_module() {
-    if !binary_available() {
-        eprintln!(
-            "SKIP scenario_14_include_path_completion_external_module: perl-lsp binary not found"
-        );
-        return;
-    }
-
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-            .with_file("fixture.pl", RELATIVE_INCLUDE_COMPLETION_SOURCE)
-            .with_file("lib/GreetModule.pm", RELATIVE_INCLUDE_MODULE),
-    )
-    .expect("Failed to create UX harness");
-
-    send_include_paths(&harness, &["lib"]);
-    harness
-        .open_file("fixture.pl", RELATIVE_INCLUDE_COMPLETION_SOURCE)
-        .expect("didOpen should succeed");
-    std::thread::sleep(Duration::from_millis(500));
-
-    let completions = harness.completion("fixture.pl", 2, 7).expect("completion must not error");
-    let completion_has_greet = completion_has_module(&completions, "GreetModule");
-
-    let defs = harness.definition("fixture.pl", 2, 4).expect("definition must not error");
-    let def_resolves = !defs.is_empty();
-
-    let hover_result = harness.hover("fixture.pl", 2, 4).expect("hover must not error");
-
-    assert!(
-        completion_has_greet,
-        "Expected completion to include GreetModule via includePaths=['lib']; labels={:?}",
-        completion_labels(&completions)
-    );
-    assert!(
-        def_resolves,
-        "Expected goto-definition to resolve GreetModule from completion scenario; defs={:?}",
-        defs
-    );
-    if hover_result.is_some() {
-        assert!(
-            def_resolves,
-            "Consumer inconsistency (completion_external_module): hover resolved while goto-definition did not.\n\
-             hover={:?}\n\
-             defs={:?}",
-            hover_result, defs
-        );
-    }
-    assert_eq!(
-        completion_has_greet,
-        def_resolves,
-        "Consumer inconsistency (completion_external_module): completion and goto-definition disagree.\n\
-         labels={:?}\n\
-         defs={:?}",
-        completion_labels(&completions),
-        defs
-    );
-
-    harness.assert_no_crash();
-}
+// Removed `scenario_14_include_path_completion_external_module` (was the
+// FIXME(#7570) ignored test). The test asserted goto-definition would
+// resolve on an incomplete prefix `use Gre` — that is not a valid parity
+// assertion: completion works on prefixes; PL701, goto-definition, and
+// hover work on resolved/exact symbols. The post-rail conformance harness
+// (PR #8495) covers the intended parity correctly via separate prefix-
+// completion and exact-module fixtures in `scenario_14_relative_include_path`
+// and `scenario_14_perl5lib_completion_gating_matrix`. #7570 closed
+// 2026-05-07.
 
 // =============================================================================
 // Fixture 2: lexical use lib in source


### PR DESCRIPTION
## Summary

Three small post-rail @INC items. Behaviour-preserving except where noted.

### 1. Remove the ignored `#7570` test

`scenario_14_include_path_completion_external_module` was kept ignored after PR #8495 redesigned the conformance harness. The test asserted goto-definition would resolve on an incomplete prefix `use Gre` — **that's not a valid parity assertion**: completion works on prefixes; PL701, goto-def, and hover work on resolved/exact symbols. PR #8495 already covers the intended parity via separate prefix-completion and exact-module fixtures in:

- `scenario_14_relative_include_path` (exact source, all consumers)
- `scenario_14_perl5lib_completion_gating_matrix` (prefix completion across 4-cell flag matrix)

Issue #7570 itself was closed 2026-05-07. The ignored test no longer adds value and is misleading — confirmed by running it locally with the binary built (it fails on the wrong assertion). Scenario 14 goes from "12 passed, 1 ignored" → "12 passed, 0 ignored".

### 2. Clarify "System @INC" → "Interpreter startup `@INC`"

The doc-comment on `resolve_module_to_path` in `runtime/lifecycle/module_resolution.rs` still called the 4th resolution phase "System @INC", which post-#8493 is ambiguous between `PERL5LIB` and interpreter startup `@INC`. Renamed and added a note that the two are distinct. Matches the terminology already used in `docs/project/status/module_resolution.md` and `docs/reference/CONFIGURATION_SCHEMA.md`.

### 3. Pin `perl5libPrecedence` shadow-order policy

New unit test `perl5lib_precedence_pins_shadow_order_for_overlapping_paths` in `WorkspaceConfig::tests`. Documents the policy flagged in the 2026-05-11 @INC checkpoint:

> `perl5libPrecedence=prepend` is **Perl-faithful** — PERL5LIB shadows workspace `includePaths` for overlapping modules. `Append` makes workspace `includePaths` win.

The existing dedupe-with-{prepend,append} tests cover ordering mechanics; this one captures the user-visible intent for overlapping module paths. The resolver iterates the returned slice and picks the first hit, so the asserted index IS the resolution outcome.

## Test plan

- [x] `cargo check -p perl-lsp-ux-tests --tests` — clean
- [x] `cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance` — 12 passed, 0 failed, 0 ignored
- [x] `cargo test -p perl-lsp-rs-core --lib perl5lib_precedence_pins` — 1 passed
- [x] `cargo xtask fmt` — no diff

## References

- Part of post-rail polish per the 2026-05-11 @INC checkpoint
- Related: PR #8495 (conformance matrix), PR #8493 (PERL5LIB gating fix), #7570 (closed)
