### PR TITLE
chore(clippy): use checked rate math in semantic scorecard (#8508)

### DIFF
--- a/xtask/src/tasks/semantic_scorecard.rs
+++ b/xtask/src/tasks/semantic_scorecard.rs
@@ -1143,32 +1143,18 @@ fn build_readiness_rows(
         + measurement.reference_edges
         + measurement.package_graph_edges;
     let fixture_rate = if fixture_count == 0 { "0%" } else { "100%" };
-    let method_candidate_rate = if measurement.method_candidate_fixture_total == 0 {
-        "0%".to_string()
-    } else {
-        format!(
-            "{}%",
-            measurement.method_candidate_fixture_passes * 100
-                / measurement.method_candidate_fixture_total
-        )
-    };
-    let rename_plan_rate = if measurement.rename_plan_fixture_total == 0 {
-        "0%".to_string()
-    } else {
-        format!(
-            "{}%",
-            measurement.rename_plan_fixture_passes * 100 / measurement.rename_plan_fixture_total
-        )
-    };
-    let safe_delete_plan_rate = if measurement.safe_delete_plan_fixture_total == 0 {
-        "0%".to_string()
-    } else {
-        format!(
-            "{}%",
-            measurement.safe_delete_plan_fixture_passes * 100
-                / measurement.safe_delete_plan_fixture_total
-        )
-    };
+    let method_candidate_rate = percentage_rate(
+        measurement.method_candidate_fixture_passes,
+        measurement.method_candidate_fixture_total,
+    );
+    let rename_plan_rate = percentage_rate(
+        measurement.rename_plan_fixture_passes,
+        measurement.rename_plan_fixture_total,
+    );
+    let safe_delete_plan_rate = percentage_rate(
+        measurement.safe_delete_plan_fixture_passes,
+        measurement.safe_delete_plan_fixture_total,
+    );
 
     BTreeMap::from([
         (
@@ -1315,6 +1301,12 @@ fn build_readiness_rows(
             },
         ),
     ])
+}
+
+fn percentage_rate(passes: usize, total: usize) -> String {
+    let percent =
+        passes.checked_mul(100).and_then(|numerator| numerator.checked_div(total)).unwrap_or(0);
+    format!("{percent}%")
 }
 
 fn serialize_json(artifact: &Artifact) -> Result<String> {


### PR DESCRIPTION
Problem: After the manual_checked_ops lint policy landed, xtask clippy flags semantic scorecard percentage calculations.\nFix: Route the pass-rate math through checked_mul and checked_div while preserving the existing 0% fallback.\nVerification: \cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs\, \cargo check -p xtask --profile agent --locked\, \cargo xtask semantic-scorecard --check\, parser accuracy/status/ratchet checks, fmt check, and git diff check pass.