### PR TITLE
chore(clippy): remove while_let_loop workspace allow (#8508)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,7 +373,6 @@ dbg_macro = "deny"
 # `priority = 1` overrides `#![warn(clippy::all)]` (priority 0) that several
 # crate `lib.rs` files declare.
 collapsible_match = { level = "allow", priority = 1 }
-while_let_loop = { level = "allow", priority = 1 }
 manual_range_contains = { level = "allow", priority = 1 }
 useless_vec = { level = "allow", priority = 1 }
 vec_init_then_push = { level = "allow", priority = 1 }

--- a/crates/perl-lsp-rs-core/src/providers/lsp_compat/selection_range.rs
+++ b/crates/perl-lsp-rs-core/src/providers/lsp_compat/selection_range.rs
@@ -93,11 +93,7 @@ pub fn selection_chain(
 
     let mut current_ptr = leaf as *const Node;
     let mut first = true;
-    loop {
-        let Some(node) = node_lookup.get(&current_ptr).copied() else {
-            break;
-        };
-
+    while let Some(node) = node_lookup.get(&current_ptr).copied() {
         // For the *first* (deepest) node, inject any synthetic sub-ranges
         // that contain the offset.  This handles the case where the cursor
         // sits on a subroutine name or signature: those areas are not
@@ -131,11 +127,10 @@ pub fn selection_chain(
             }
         }
 
-        // Move to parent
-        if let Some(&parent_ptr) = parent_map.get(&current_ptr) {
-            current_ptr = parent_ptr;
-        } else {
-            break;
+        // Move to parent; if there is no parent, exit the loop.
+        match parent_map.get(&current_ptr) {
+            Some(&parent_ptr) => current_ptr = parent_ptr,
+            None => break,
         }
     }
 


### PR DESCRIPTION
## Summary

Refactors the single `while_let_loop` site that surfaced under Rust 1.95 clippy and removes the workspace allow. Refs #8508 — follow-up B5.

## The fix

`crates/perl-lsp-rs-core/src/providers/lsp_compat/selection_range.rs:96` originally had:

```rust
loop {
    let Some(node) = node_lookup.get(&current_ptr).copied() else {
        break;
    };
    // ... use node ...
    if let Some(&parent_ptr) = parent_map.get(&current_ptr) {
        current_ptr = parent_ptr;
    } else {
        break;
    }
}
```

The first break is exactly what clippy wants converted; the second is structural. Restructured to:

```rust
while let Some(node) = node_lookup.get(&current_ptr).copied() {
    // ... use node ...
    match parent_map.get(&current_ptr) {
        Some(&parent_ptr) => current_ptr = parent_ptr,
        None => break,
    }
}
```

Same set of nodes visited in the same order.

## Test plan

- [x] `cargo clippy --workspace --lib --no-deps -- -D warnings` — clean
- [x] `cargo test -p perl-lsp-rs-core --lib selection_range` — 6 passed
- [x] `cargo xtask fmt` — no diff

## References

- Refs #8508 (Rust 1.95 cleanup)
- Follow-up B5: builds on #8511, #8520, #8521, #8522
- Workspace allow set: 6 → 5 remaining (`collapsible_match`, `manual_range_contains`, `useless_vec`, `vec_init_then_push`, `assertions_on_constants`)