### PR TITLE
fix(@INC): block workspace-index no-lib consumer leaks (#8516)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs
@@ -3052,10 +3052,12 @@ fn test_use_completion_workspace_first_and_dedupes_external()
     let include_root = temp.path().join("external");
     let module_file = include_root.join("DBI.pm");
     fs::create_dir_all(module_file.parent().ok_or("missing parent")?)?;
-    fs::write(module_file, "package DBI;\n1;\n")?;
+    fs::write(&module_file, "package DBI;\n1;\n")?;
 
     let index = Arc::new(WorkspaceIndex::new());
-    index.index_file(Url::parse("file:///workspace/lib/DBI.pm")?, "package DBI;\n1;\n".into())?;
+    let module_uri =
+        Url::from_file_path(&module_file).map_err(|()| "failed to build module file URI")?;
+    index.index_file(module_uri, "package DBI;\n1;\n".into())?;
 
     let code = "use DB";
     let mut parser = Parser::new(code);
@@ -3072,6 +3074,41 @@ fn test_use_completion_workspace_first_and_dedupes_external()
     let dbi_items: Vec<_> = completions.iter().filter(|c| c.label == "DBI").collect();
     assert_eq!(dbi_items.len(), 1, "DBI should be deduplicated across workspace/external");
     assert_eq!(dbi_items[0].detail.as_deref(), Some("module"));
+    Ok(())
+}
+
+#[test]
+fn test_use_completion_filters_workspace_module_by_active_include_roots()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let workspace = temp.path();
+    let suppressed_module = workspace.join("lib").join("GoneModule.pm");
+    let active_root = workspace.join("t").join("lib");
+    fs::create_dir_all(suppressed_module.parent().ok_or("missing suppressed module parent")?)?;
+    fs::create_dir_all(&active_root)?;
+    fs::write(&suppressed_module, "package GoneModule;\n1;\n")?;
+
+    let index = Arc::new(WorkspaceIndex::new());
+    let suppressed_uri =
+        Url::from_file_path(&suppressed_module).map_err(|()| "failed to build module URI")?;
+    index.index_file(suppressed_uri, "package GoneModule;\n1;\n".into())?;
+
+    let code = "use Gon";
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let provider = CompletionProvider::new_with_index_and_source_and_paths(
+        &ast,
+        code,
+        Some(index),
+        vec![active_root],
+        Vec::new(),
+        false,
+    );
+    let completions = provider.get_completions(code, code.len());
+    assert!(
+        !completions.iter().any(|c| c.label == "GoneModule"),
+        "workspace package modules outside active @INC roots must not leak into use-completion"
+    );
     Ok(())
 }
 
@@ -3801,14 +3838,22 @@ fn test_use_module_completion_unchanged_with_empty_inc_vectors()
     Ok(())
 }
 
-/// Phase 1 contract: non-empty inc_paths are stored but do NOT alter completions
-/// (no filesystem scanning until phase 2). If this test breaks it means someone
-/// started using the paths without adding scan logic — a regression, not a feature.
+/// Include roots constrain workspace-index module candidates, but they do not
+/// trigger filesystem scans. A workspace-indexed package under an active root
+/// remains visible; packages outside active roots are covered by the negative
+/// filter test.
 #[test]
-fn test_non_empty_inc_paths_do_not_change_phase1_completions()
+fn test_non_empty_inc_paths_keep_workspace_module_under_active_root()
 -> Result<(), Box<dyn std::error::Error>> {
+    let temp = TempDir::new()?;
+    let active_root = temp.path().join("lib");
+    let module_path = active_root.join("MyApp.pm");
+    fs::create_dir_all(&active_root)?;
+    fs::write(&module_path, "package MyApp;\n1;\n")?;
+
     let index = Arc::new(WorkspaceIndex::new());
-    let module_uri = Url::parse("file:///workspace/MyApp.pm")?;
+    let module_uri =
+        Url::from_file_path(&module_path).map_err(|()| "failed to build module URI")?;
     index.index_file(module_uri, "package MyApp;\n1;\n".to_string())?;
 
     let code = "use MyA";
@@ -3819,13 +3864,16 @@ fn test_non_empty_inc_paths_do_not_change_phase1_completions()
         CompletionProvider::new_with_index_and_source(&ast, code, Some(Arc::clone(&index)))
             .get_completions_with_path(code, code.len(), None);
 
-    // Non-empty inc paths: completions must still be identical to workspace-only baseline.
+    // Non-empty inc paths: completions keep workspace-indexed modules that live
+    // under an active @INC root.
+    let inactive_root = temp.path().join("inactive-inc-root");
+    let inactive_system_root = temp.path().join("inactive-system-inc-root");
     let with_inc = CompletionProvider::new_with_index_and_source_and_paths(
         &ast,
         code,
         Some(index),
-        vec![PathBuf::from("/usr/local/lib/perl5"), PathBuf::from("t/lib")],
-        vec![PathBuf::from("/usr/lib/perl5/5.38")],
+        vec![active_root, inactive_root],
+        vec![inactive_system_root],
         false,
     )
     .get_completions_with_path(code, code.len(), None);
@@ -3837,7 +3885,7 @@ fn test_non_empty_inc_paths_do_not_change_phase1_completions()
 
     assert_eq!(
         baseline_labels, with_inc_labels,
-        "non-empty include paths must not change completions in phase 1 (no filesystem scanning yet)"
+        "non-empty include paths must keep workspace package completions under active @INC roots"
     );
     Ok(())
 }

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -9,6 +9,7 @@ use super::{
     context::CompletionContext,
     items::{CompletionItem, CompletionItemKind},
 };
+use perl_module::path::module_name_to_path;
 use perl_parser_core::SourceLocation;
 use perl_semantic_analyzer::{
     semantic::SemanticModel,
@@ -31,7 +32,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::hash::{Hash, Hasher};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 /// Add workspace symbol completions for functions and variables
@@ -492,6 +493,37 @@ pub fn scan_directory_for_modules(root: &Path, prefix: &str) -> Vec<String> {
 /// workspace index. This enables discovering available modules as you type.
 ///
 /// For example, typing `use My` will suggest `MyApp`, `MyApp::Config`, etc.
+fn workspace_module_symbol_matches_roots(symbol: &WorkspaceSymbol, active_roots: &[&Path]) -> bool {
+    if active_roots.is_empty() {
+        return true;
+    }
+
+    let Some(symbol_path) = perl_workspace::workspace_index::uri_to_fs_path(&symbol.uri) else {
+        return false;
+    };
+    let module_path = module_name_to_path(&symbol.name);
+    let symbol_key = normalized_path_key(&symbol_path);
+
+    active_roots.iter().any(|root| {
+        let candidate = root.join(&module_path);
+        normalized_path_key(&candidate) == symbol_key
+    })
+}
+
+fn normalized_path_key(path: &Path) -> String {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        if component == Component::CurDir {
+            continue;
+        }
+        normalized.push(component.as_os_str());
+    }
+
+    let path = if normalized.as_os_str().is_empty() { PathBuf::from(".") } else { normalized };
+    let key = path.to_string_lossy().replace('\\', "/").trim_end_matches('/').to_string();
+    if cfg!(windows) { key.to_ascii_lowercase() } else { key }
+}
+
 pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
@@ -501,6 +533,10 @@ pub fn add_use_module_completions(
     include_system_inc: bool,
 ) {
     let mut seen: HashSet<String> = HashSet::new();
+    let mut active_module_roots: Vec<&Path> = include_paths.iter().map(PathBuf::as_path).collect();
+    if include_system_inc {
+        active_module_roots.extend(system_inc_paths.iter().map(PathBuf::as_path));
+    }
 
     if let Some(index) = workspace_index
         && index.has_symbols()
@@ -519,6 +555,10 @@ pub fn add_use_module_completions(
 
             // Match against the module name prefix
             if !context.prefix.is_empty() && !symbol.name.starts_with(&context.prefix) {
+                continue;
+            }
+
+            if !workspace_module_symbol_matches_roots(&symbol, &active_module_roots) {
                 continue;
             }
 

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -215,6 +215,43 @@ impl LspServer {
         }
     }
 
+    fn is_module_import_completion_context(doc_text: &str, offset: usize) -> bool {
+        if !doc_text.is_char_boundary(offset) {
+            return false;
+        }
+        let before = &doc_text[..offset];
+        let line_start = before.rfind('\n').map(|position| position + 1).unwrap_or(0);
+        let line = before[line_start..].trim_start();
+
+        if let Some(rest) = line.strip_prefix("use") {
+            if rest.chars().next().is_some_and(|c| !c.is_whitespace()) {
+                return false;
+            }
+            let rest = rest.trim_start();
+            if rest.contains(';') || rest.contains('(') || rest.contains("qw") {
+                return false;
+            }
+            let first_char = rest.chars().next();
+            return first_char.is_none() || first_char.is_some_and(|c| c.is_ascii_uppercase());
+        }
+
+        if let Some(rest) = line.strip_prefix("require") {
+            if rest.chars().next().is_some_and(|c| !c.is_whitespace()) {
+                return false;
+            }
+            let rest = rest.trim_start();
+            if rest.contains(';') {
+                return false;
+            }
+            let Some(first_char) = rest.chars().next() else {
+                return true;
+            };
+            return !matches!(first_char, '0'..='9' | '\'' | '"' | '`' | '.' | '/' | '\\');
+        }
+
+        false
+    }
+
     fn add_runtime_workspace_completions(
         &self,
         completions: &mut Vec<crate::completion::CompletionItem>,
@@ -224,6 +261,10 @@ impl LspServer {
         workspace_mode: &IndexAccessMode,
         cap: usize,
     ) {
+        if Self::is_module_import_completion_context(doc_text, offset) {
+            return;
+        }
+
         match workspace_mode {
             IndexAccessMode::Full(coordinator) => {
                 let index = coordinator.index();
@@ -1685,5 +1726,19 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn module_import_completion_context_accepts_perl_whitespace_only_after_keyword() {
+        assert!(LspServer::is_module_import_completion_context("use\tFoo", "use\tFoo".len()));
+        assert!(LspServer::is_module_import_completion_context(
+            "require\tFoo",
+            "require\tFoo".len()
+        ));
+        assert!(!LspServer::is_module_import_completion_context("useful Foo", "useful Foo".len()));
+        assert!(!LspServer::is_module_import_completion_context(
+            "required Foo",
+            "required Foo".len()
+        ));
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -1274,9 +1274,12 @@ impl LspServer {
             });
         }
 
-        // Try filesystem resolution as fallback
-        if let Some(path) =
-            self.resolve_module_path_with_uri(module_name, Some(doc_text), Some(doc_uri))
+        // Try filesystem resolution as a legacy fallback only when the caller
+        // has no position. Position-aware callers must not bypass active
+        // `@INC` state such as `no lib` cancellation.
+        if doc_offset.is_none()
+            && let Some(path) =
+                self.resolve_module_path_with_uri(module_name, Some(doc_text), Some(doc_uri))
         {
             let pod_section = self.format_pod_for_hover(&path);
             let display = path.display().to_string();

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/module_resolution.rs
@@ -329,7 +329,11 @@ impl LspServer {
 
         let open_document_uris: Vec<String> = {
             let documents = self.documents.lock();
-            documents.keys().cloned().collect()
+            documents
+                .keys()
+                .filter(|uri| doc_offset.is_none() || context.symbol_uri_reachable(uri))
+                .cloned()
+                .collect()
         };
 
         match resolve_module_uri_with_effective_inc(
@@ -353,6 +357,7 @@ impl LspServer {
 mod tests {
     use super::*;
     use crate::runtime::workspace_folder::WorkspaceFolderState;
+    use crate::state::DocumentState;
     use perl_module::resolution::IncRootKind;
     use perl_module::resolution::build_effective_inc_roots;
     use std::fs;
@@ -851,6 +856,74 @@ use Overlay::Live;
         assert!(
             resolved_after.is_none(),
             "expected module to stop resolving after no lib at end-of-doc"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_position_aware_resolution_filters_open_docs_by_effective_inc() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        let custom_dir = workspace.join("custom");
+        let module_file = custom_dir.join("Overlay").join("OpenDoc.pm");
+        fs::create_dir_all(module_file.parent().ok_or("no parent")?)?;
+        fs::write(&module_file, "package Overlay::OpenDoc; 1;")?;
+
+        let server = LspServer::new();
+        *server.root_path.lock() = Some(workspace.clone());
+        {
+            let mut folders = server.workspace_folders.lock();
+            folders.push(
+                WorkspaceFolderState::new(format!(
+                    "file://{}",
+                    workspace.to_string_lossy().replace('\\', "/")
+                ))
+                .with_path(workspace.clone())
+                .with_name("workspace".to_string()),
+            );
+        }
+        {
+            let mut config = server.workspace_config.lock();
+            config.include_paths = vec![];
+        }
+
+        let module_uri =
+            url::Url::from_file_path(&module_file).map_err(|()| "failed module URI")?.to_string();
+        server
+            .documents
+            .lock()
+            .insert(module_uri.clone(), DocumentState::new("package Overlay::OpenDoc; 1;", 1));
+
+        let doc_uri = format!("file://{}/main.pl", workspace.to_string_lossy().replace('\\', "/"));
+        let doc_text = "use lib 'custom';
+no lib 'custom';
+use Overlay::OpenDoc;
+";
+        let before_no_lib = doc_text.find("no lib").ok_or("missing no lib")?;
+
+        let resolved_before = server
+            .resolve_module_to_path_with_doc_at_offset(
+                "Overlay::OpenDoc",
+                Some(doc_text),
+                Some(&doc_uri),
+                Some(before_no_lib),
+            )
+            .ok_or("expected open document under active @INC root to resolve")?;
+        assert_eq!(
+            resolved_before, module_uri,
+            "open document should still resolve while its include root is active"
+        );
+
+        let resolved_after = server.resolve_module_to_path_with_doc_at_offset(
+            "Overlay::OpenDoc",
+            Some(doc_text),
+            Some(&doc_uri),
+            Some(doc_text.len()),
+        );
+        assert!(
+            resolved_after.is_none(),
+            "open document under a cancelled include root must not bypass position-aware @INC"
         );
 
         Ok(())

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
@@ -70,6 +70,34 @@ fn has_pl701(diags: &[serde_json::Value]) -> bool {
     })
 }
 
+fn hover_is_not_resolved(hover: &Option<serde_json::Value>) -> bool {
+    let Some(hover) = hover else {
+        return true;
+    };
+
+    let Some(contents) = hover.get("contents") else {
+        return false;
+    };
+    let text = match contents {
+        serde_json::Value::String(value) => value.clone(),
+        serde_json::Value::Object(map) => {
+            map.get("value").and_then(|value| value.as_str()).unwrap_or("").to_string()
+        }
+        serde_json::Value::Array(items) => items
+            .iter()
+            .filter_map(|item| {
+                item.as_str().map(str::to_owned).or_else(|| {
+                    item.get("value").and_then(|value| value.as_str()).map(str::to_owned)
+                })
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    };
+
+    text.contains("Not found in workspace") && !text.contains("[Go to module]")
+}
+
 /// Configure the server to use `includePaths` via workspace/didChangeConfiguration.
 fn send_include_paths(harness: &UxHarness, paths: &[&str]) {
     let paths_json: Vec<serde_json::Value> = paths.iter().map(|p| json!(*p)).collect();
@@ -547,10 +575,10 @@ fn scenario_14_no_lib_cancellation() {
     let def_empty = defs.is_empty();
 
     let hover_result = harness.hover("fixture.pl", 4, 4).expect("hover must not error");
+    let hover_not_resolved = hover_is_not_resolved(&hover_result);
 
     // Completion check (negative): `GoneModule` should NOT appear since `no lib`
-    // cancelled the path. Consumer-divergence is acceptable here — completion
-    // may not fully enforce `no lib` semantics.
+    // cancelled the path.
     harness
         .change_file_full("fixture.pl", NO_LIB_CANCEL_COMPLETION_SOURCE)
         .expect("didChange to completion fixture should succeed");
@@ -562,10 +590,10 @@ fn scenario_14_no_lib_cancellation() {
 
     print_conformance(
         "no_lib_cancellation",
-        pl701_fires,            // "ok" for negative = PL701 fired
-        completion_ok,          // "ok" for negative = module absent from completion
-        def_empty,              // "ok" for negative = definition returned empty
-        hover_result.is_none(), // "ok" for negative = hover returned null
+        pl701_fires,        // "ok" for negative = PL701 fired
+        completion_ok,      // "ok" for negative = module absent from completion
+        def_empty,          // "ok" for negative = definition returned empty
+        hover_not_resolved, // "ok" for negative = hover returned null/not-resolved
     );
 
     // Strict enforcement for PL701: the push-diagnostic resolver must honor
@@ -604,6 +632,11 @@ fn scenario_14_no_lib_cancellation() {
          EffectiveIncContext at the use-site offset.\n\
          completions (labels): {:?}",
         completion_labels(&completions)
+    );
+    assert!(
+        hover_not_resolved,
+        "hover MUST NOT resolve GoneModule after 'no lib' cancellation; got {:?}",
+        hover_result
     );
 
     harness.assert_no_crash();

--- a/docs/project/status/module_resolution.md
+++ b/docs/project/status/module_resolution.md
@@ -23,7 +23,7 @@ PL701, goto-definition, and hover use exact-module fixtures (`use GreetModule;`)
 | Workspace `includePaths` | + | + | + | + | Config-driven: `includePaths: ["lib"]` |
 | Absolute `includePaths` | + | + | + | + | Config-driven: absolute path entry |
 | Lexical `use lib` | + | + | + | + | In-source pragma extraction |
-| `no lib` cancellation | + | - | - | - | PL701 enforced (#8516); goto-def/completion/hover bypass via workspace index — follow-up |
+| `no lib` cancellation | + | + | + | + | Position-aware negative; all four consumers enforce #8516 |
 | FindBin-relative | + | + | + | + | `$FindBin::Bin/lib` pattern |
 | PERL5LIB env | + | + | + | + | `usePerl5lib=true` gates PERL5LIB |
 | interpreter startup `@INC` | + | + | + | + | `useSystemInc=true` gates interpreter startup paths |
@@ -47,7 +47,7 @@ The cross-consumer `@INC` rail landed across `#8493 → #8506`:
 
 Known follow-ups (each tracked as its own issue, not blocking rail closure):
 
-- Pull-diagnostics path (`features/diagnostics/pull.rs`) now also honors per-use-statement `no lib` cancellation — resolved in the follow-up commit to #8516.
+- Pull-diagnostics path (`features/diagnostics/pull.rs`) and workspace-index-backed consumers now honor per-use-statement `no lib` cancellation — resolved in the follow-up commit to #8516.
 - Runtime-owned short TTL cache for prefix module scans — split out of #8491 after PR 7a (scan-only) landed in #8498.
 
 ## Resolution Mode Details
@@ -137,7 +137,7 @@ provider behavior.
 
 Tracked follow-ups from the @INC rail completion (each its own issue):
 
-- **Position-aware `no lib` cancellation for PL701** — landed in [#8516](https://github.com/EffortlessMetrics/perl-lsp/issues/8516). The PL701 diagnostic resolver now correctly fires for modules whose path was cancelled by `no lib`. goto-def, completion, and hover still surface workspace-indexed modules regardless of `no lib` because the workspace indexer bypasses `@INC` — tracked as a follow-up.
+- **Position-aware `no lib` cancellation** — landed in [#8516](https://github.com/EffortlessMetrics/perl-lsp/issues/8516). PL701, pull diagnostics, completion, goto-definition, and hover now reject modules whose path was cancelled by `no lib`; workspace-index-backed consumers are filtered so they cannot bypass active `@INC` state.
 - **Runtime-owned TTL cache for module-completion scans** — see [#8514](https://github.com/EffortlessMetrics/perl-lsp/issues/8514). Builds on the prefix-directed scan in #8498.
 
 Backlog (pre-existing, not part of the @INC rail closure):


### PR DESCRIPTION
Problem: #8525 merged before the workspace-index consumer follow-up landed, leaving completion, goto-definition, and hover able to surface modules that active `no lib` state had cancelled.
Fix: Filter module completions by active @INC roots, block generic workspace completion/navigation fallbacks in module-import contexts, and keep position-aware hover from bypassing @INC with the legacy filesystem fallback.
Verification: `cargo build -p perl-lsp-rs --bin perl-lsp --locked`; `cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance scenario_14_no_lib_cancellation --profile agent --locked -- --nocapture`; `cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance --profile agent --locked -- --nocapture`; `cargo test -p perl-lsp-rs-core --lib --profile agent --locked test_use_completion -- --nocapture`; `cargo test -p perl-lsp-rs --lib --profile agent --locked completion -- --nocapture`; `cargo test -p perl-lsp-rs --lib --profile agent --locked hover -- --nocapture`; `cargo test -p perl-lsp-rs --lib --profile agent --locked navigation -- --nocapture`; `cargo test -p perl-lsp-rs-core --lib --profile agent --locked missing_module -- --nocapture`; `cargo test -p perl-lsp-rs --lib --profile agent --locked module_resolution -- --nocapture`; `cargo clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check origin/master..HEAD`.