### PR TITLE
docs(readme): clarify Codecov badge scope and sync MSRV to 1.95 (#8508)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 </p>
 
 <p align="center">
-  <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp"><img src="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="code coverage" /></a>
-  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.93-blue" alt="MSRV" /></a>
+  <a href="https://codecov.io/gh/EffortlessMetrics/perl-lsp"><img src="https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg" alt="Codecov parser branch coverage" /></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/MSRV-1.95-blue" alt="MSRV" /></a>
   <a href="LICENSE-MIT"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
 </p>
 


### PR DESCRIPTION
## Summary

Cov-4 of the Codecov rollout (per `docs/ci/codecov-rollout.md` from #8539):

- README MSRV badge said `MSRV-1.93` while `master` has been on Rust 1.95 since #8509. Synced to `MSRV-1.95`.
- Codecov badge `alt="code coverage"` overclaimed. Replaced with `alt="Codecov parser branch coverage"`, matching what is actually scoped (`parser-branch` flag against parser/lexer/AST sources) and what `.ci/coverage-baseline.txt` ratchets.

Two-line docs-only fix.

## Test plan

- [x] `git diff --check` clean
- [x] Diff stat: 1 file changed, 2 insertions(+), 2 deletions(-)

## References

- Refs #8508 (Rust 1.95 / next-minor rollout umbrella)
- Implements step Cov-4 in [`docs/ci/codecov-rollout.md`](https://github.com/EffortlessMetrics/perl-lsp/blob/master/docs/ci/codecov-rollout.md) (landed in #8539)