### PR TITLE
docs: cross-link initial and post-landing Rust 1.95 rollout maps (#8543)

### DIFF
--- a/docs/ci/perl-lsp-rust-1.95-rollout.md
+++ b/docs/ci/perl-lsp-rust-1.95-rollout.md
@@ -1,5 +1,12 @@
 # Rust 1.95 / 0.14.0 rollout map
 
+> **Status (2026-05-11):** This is the **initial rollout plan**, filed when
+> the workspace was still on Rust 1.93. The MSRV / toolchain / `clippy.toml`
+> bumps have since **landed** (#8509). The historical framing below is
+> preserved as the original plan-of-record. For the **post-landing
+> improvement ladder** — what remains, in agent-actionable form — see
+> [`docs/development/RUST_1_95_ROLLOUT.md`](../development/RUST_1_95_ROLLOUT.md).
+
 This document is the control map for moving `perl-lsp` from the current Rust
 1.93 line to Rust 1.95.0 and preparing the next minor release, 0.14.0. It is
 intentionally documentation-only: no MSRV, toolchain, workflow, lint, baseline,

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -1,5 +1,13 @@
 # Rust 1.95 / Next-Minor Rollout
 
+> **Companion to** [`docs/ci/perl-lsp-rust-1.95-rollout.md`](../ci/perl-lsp-rust-1.95-rollout.md).
+> That doc is the **initial rollout plan** (historical, planned-from-1.93
+> framing). This doc is the **post-landing improvement spec** — what's
+> remaining now that MSRV / toolchain / `clippy.toml`-msrv have shipped
+> (#8509). Each row in the ladder below is an agent-actionable spec; a
+> haiku scout can file it as a GitHub issue and a sonnet builder can
+> implement it without re-discovering the call sites.
+
 Continuation of the Rust 1.93 → 1.95 quality control plane. This doc tracks
 both the ratchet (what already landed) and the remaining ladder (what's
 next), so subsequent PRs do **one thing**.


### PR DESCRIPTION
Layered docs, reciprocal banners between `docs/ci/perl-lsp-rust-1.95-rollout.md` (historical) and `docs/development/RUST_1_95_ROLLOUT.md` (post-landing). +15 lines, no content rewrites. Closes #8543.