### PR TITLE
docs(crate): prefix-vs-exact fixture rule + `.`-wildcard inc-root semantics (#8552)

### DIFF
--- a/crates/perl-lsp-rs/CLAUDE.md
+++ b/crates/perl-lsp-rs/CLAUDE.md
@@ -18,3 +18,29 @@ cargo fmt --all
 cargo clippy -p perl-lsp-rs --tests
 RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs -- --test-threads=2
 ```
+
+## Include-root semantics: `.` is a wildcard, not a path
+
+When filtering workspace-symbol candidates through `EffectiveIncContext`, treat the
+workspace-root `.` entry distinctly from configured-relative or lexical-`use lib`
+entries. If `.` is treated like any other include root, almost every workspace file
+becomes reachable and the filter cannot reject e.g. `lib/GoneModule.pm` after
+`no lib 'lib'`.
+
+Sources of include roots — semantically distinct, do NOT collapse to "path roots":
+
+- `WorkspaceDefaultDot` — `.` from the workspace folder. Acts as a wildcard for
+  everything under the workspace; not subject to `no lib` cancellation.
+- `WorkspaceConfiguredRelative` — explicit `additionalIncPaths` entries from
+  config (e.g. `lib`, `t/lib`).
+- `LexicalUseLib` — `use lib '...'` from the source under analysis. Position-
+  scoped; subject to `no lib '...'` cancellation downstream of the cancel point.
+- `Perl5LibEnv` — `PERL5LIB` from the LSP process / `usePerl5lib` config.
+- `InterpreterStartup` — output of the `perl -e 'print @INC'` probe (via the
+  subprocess oracle contract — see #8551).
+
+When implementing a new filter or routing decision over include roots, branch on
+the kind, not on the path. The wildcard `.` is the most common source of
+false-positives in workspace-symbol filtering.
+
+Related: `crates/perl-lsp-rs/src/runtime/lifecycle/inc_context.rs`.

--- a/crates/perl-lsp-ux-tests/CLAUDE.md
+++ b/crates/perl-lsp-ux-tests/CLAUDE.md
@@ -1,0 +1,59 @@
+# perl-lsp-ux-tests
+
+End-to-end UX scenarios that exercise multiple LSP consumers (completion,
+diagnostics, goto-definition, hover, code-actions) against the same fixture.
+
+## Test Threading
+
+```bash
+RUST_TEST_THREADS=2 cargo test -p perl-lsp-ux-tests -- --test-threads=2
+```
+
+## Verify
+
+```bash
+cargo fmt --all
+cargo clippy -p perl-lsp-ux-tests --tests
+RUST_TEST_THREADS=2 cargo test -p perl-lsp-ux-tests -- --test-threads=2
+```
+
+## Fixture shape: prefix vs exact, by consumer
+
+A UX scenario typically asserts multiple LSP consumers see the same logical
+state. **Consumer parity does NOT mean identical source text** — it means
+semantically equivalent fixture intent, with the right source form for each
+consumer.
+
+| Consumer        | Valid fixture shape                                      |
+| --------------- | -------------------------------------------------------- |
+| completion      | prefix form, cursor inside the prefix: `use Gre<cursor>` |
+| PL701 diagnostic| exact module form, fully resolved: `use GreetModule;`    |
+| goto-definition | exact module form: `use GreetModule;`                    |
+| hover           | exact module form: `use GreetModule;`                    |
+| document-link   | exact module form                                        |
+| code-actions    | exact module form (action triggers off resolved symbol)  |
+
+**Why**: completion-fixture text is incomplete by design — the prefix is what
+the user has typed *so far*. Asking goto-definition or PL701 to resolve a
+prefix is a category error; the symbol isn't named yet. The two fixture
+shapes must coexist in the scenario, not collapse to one.
+
+**Tell that a fixture is miscategorized**: an ignored test or `#[ignore]` with
+a FIXME pointing to "completion returns no result" while the assertion is on
+goto-definition. That's the symptom of mixing prefix-form source with an
+exact-symbol consumer. The fix is two fixtures (one prefix-cursor, one exact),
+not one tortured fixture.
+
+**Historical**: `scenario_14` removed a `#[ignore]`'d test in #8524 for exactly
+this reason — it asserted goto-definition on `use Gre`. See
+`tests/ux_scenario_14_inc_conformance.rs` for the current pattern: separate
+`*_COMPLETION_SOURCE` and `*_SOURCE` constants per fixture.
+
+## After a scenario change, run scenario-14 specifically
+
+```bash
+RUST_TEST_THREADS=2 cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance
+```
+
+This scenario is the @INC strictness conformance grid — touches completion,
+PL701, goto-def, hover. Most fixture-shape regressions surface here first.

--- a/docs/project/status/module_resolution.md
+++ b/docs/project/status/module_resolution.md
@@ -107,6 +107,34 @@ environment when `usePerl5lib=false` to prevent cross-flag leakage.
 The two flags are independent: `usePerl5lib` controls PERL5LIB; `useSystemInc`
 controls interpreter startup roots. Setting one does not imply the other.
 
+## Include-Root Classification
+
+When filtering workspace-symbol candidates through `EffectiveIncContext`,
+include roots are NOT equivalent paths — they have semantically distinct
+sources that affect cancellation, reachability, and filter behavior.
+
+| Kind | Source | Subject to `no lib` cancellation? | Notes |
+|---|---|---|---|
+| `WorkspaceDefaultDot` | `.` from the workspace folder | No | **Wildcard-like** — matches almost any workspace file; do NOT treat as an ordinary library root for reachability filters |
+| `WorkspaceConfiguredRelative` | `includePaths: ["lib", "t/lib"]` config | No | Explicit operator intent; persists for the workspace lifetime |
+| `WorkspaceConfiguredAbsolute` | `includePaths: ["/abs/path"]` config | No | Same as Relative but absolute |
+| `LexicalUseLib` | `use lib '...'` in the source under analysis | **Yes** (position-scoped) | Cancelled by a downstream `no lib '...'` at the cancel-point offset |
+| `LexicalNoLibCancellation` | `no lib '...'` cancellation marker | n/a — the cancel itself | Removes a `LexicalUseLib` entry from the position-scoped active set |
+| `Perl5LibEnv` | `PERL5LIB`, gated by `usePerl5lib` | No | Inherited from the LSP process environment; stripped from subprocess oracles per #8551 |
+| `InterpreterStartup` | `perl -e 'print @INC'`, gated by `useSystemInc` | No | Output of the subprocess seam — see [perl-subprocess-seams.md](../../architecture/perl-subprocess-seams.md) (#8555) |
+| `FindBinDerived` | `use FindBin; use lib "$FindBin::Bin/..."` | Yes (position-scoped) | `$FindBin::Bin` derived per analyzed file |
+| `RuntimeDerived` | Other lexical paths derived at runtime | Yes (position-scoped) | Currently rare; reserved for future use |
+
+**Why this matters**: if `.` (the workspace default) is treated like any
+other configured include root, reachability filters incorrectly conclude
+that nearly every workspace file is reachable, which defeats checks like
+"after `no lib 'lib'`, `lib/GoneModule.pm` should NOT resolve." Filters
+must branch on the kind, not the path.
+
+See `crates/perl-lsp-rs/src/runtime/lifecycle/inc_context.rs` for the
+runtime implementation and `crates/perl-lsp-rs/CLAUDE.md` for the per-crate
+rule.
+
 ## Implementation Notes
 
 - Position-aware resolution is implemented in `crates/perl-module/src/resolution/use_lib.rs`.


### PR DESCRIPTION
Closes EffortlessMetrics/perl-lsp#8552.

## Summary

Two crate-level CLAUDE.md additions encoding domain-specific rules from the 2026-05-11 reflections:

- `crates/perl-lsp-rs/CLAUDE.md` (append): `IncRootKind` distinction — `.` is a wildcard, not a path; do not collapse it with configured-relative / lexical-use-lib / PERL5LIB / interpreter-startup roots when filtering workspace-symbol candidates.
- `crates/perl-lsp-ux-tests/CLAUDE.md` (new): consumer parity ≠ identical source text. Completion uses prefix-cursor form; PL701 / goto-def / hover use exact module form. Two fixture constants per scenario.

## Claim boundary

Docs only. No code, no test, no behavior change.

## Test plan

- [x] No code changes; CI runs fmt/clippy/markdown lint as usual.
- [x] Files match existing crate-CLAUDE.md style.

## Related

- EffortlessMetrics/perl-lsp#8552 — tracking issue
- PR EffortlessMetrics/perl-lsp#8550 — session forensics doc
- EffortlessMetrics/perl-lsp-swarm#2726 — perl-oracle subprocess env contract (deeper @INC trap)
- EffortlessMetrics/perl-lsp-swarm#1819 — stale-checkout warning hook + xtask
- EffortlessMetrics/perl-lsp#8524 — historical: the `#[ignore]`'d test removed for fixture miscategorization