### PR TITLE
chore(clippy): remove assertions_on_constants workspace allow (#8559)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,7 +376,6 @@ collapsible_match = { level = "allow", priority = 1 }
 manual_range_contains = { level = "allow", priority = 1 }
 useless_vec = { level = "allow", priority = 1 }
 vec_init_then_push = { level = "allow", priority = 1 }
-assertions_on_constants = { level = "allow", priority = 1 }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)', 'cfg(feature, values("slow_tests"))'] }


### PR DESCRIPTION
Closes EffortlessMetrics/perl-lsp-swarm#2725. Part of the EffortlessMetrics/perl-lsp#8508 clippy-cleanup rollout.

## Summary

Remove `clippy::assertions_on_constants = allow` from `Cargo.toml` (workspace lints). Zero call sites on master; the allow is dead weight.

## Verification

```bash
cargo clippy --workspace --all-targets --quiet -- -D clippy::assertions_on_constants -A clippy::all
# exit 0, no warnings

cargo clippy --workspace --all-targets   # still clean after the allow removal
```

## Claim boundary

Mechanical lint-allow removal. No behavior change, no logic change, no test change.

## Test plan

- [x] `cargo clippy --workspace --all-targets` clean.
- [x] `cargo xtask fmt` clean (no formatting touched).
- [x] No code files changed.

## Remaining allows after this lands

- `collapsible_match`
- `manual_range_contains`
- `useless_vec`
- `vec_init_then_push`

Each is a separate PR (do-not-combine — adjacent-line conflicts).