### PR TITLE
docs(agents): add implementation plan and builder brief templates (#8600)

### DIFF
--- a/docs/project/templates/BUILDER_BRIEF.md
+++ b/docs/project/templates/BUILDER_BRIEF.md
@@ -1,0 +1,66 @@
+# Builder Brief Template
+
+> **Rule**: Indexes provide candidates. Context determines authority.
+>
+> This template renders structure. The issue spec owns content.
+> If the brief and the issue disagree, the issue wins.
+
+Used by spec-planner to hand off to a builder agent. Copy into
+`.spec/<issue-or-lane>/BUILDER_BRIEF.md` and fill each section.
+
+---
+
+## 1. Goal
+
+One paragraph. What is the builder being asked to do? Reference the issue.
+
+## 2. Branch / worktree
+
+Already set up by spec-planner. The builder checks out and runs from here.
+
+- **Branch**: `<type>/<short-slug>`
+- **Worktree**: `H:\Code\Rust2\wt-<slug>`
+
+## 3. Existing artifacts
+
+| File | Role |
+|---|---|
+| `.spec/<lane>/IMPLEMENTATION_PLAN.md` | the plan to follow |
+| `crates/.../tests/red_<name>.rs` | red test from red-tdd; must turn green |
+| `tests/fixtures/<name>.pm` | fixture the red test depends on |
+
+## 4. Implementation map
+
+Pointer to the section of the spec or implementation plan the builder follows.
+Example: `IMPLEMENTATION_PLAN.md` §5 (Tests) and §3 (Files touched).
+
+## 5. Acceptance
+
+Exact commands the builder must run before pushing.
+
+```bash
+cargo test -p <crate> --test <test_file>
+cargo clippy --workspace --lib
+just pr-fast
+```
+
+PR body must include receipts that downstream agents (green-tdd, reviewer,
+diff-auditor) will consume.
+
+## 6. Out of scope
+
+Explicit list of work the builder must **not** do. If the builder hits one of
+these while implementing, bump back to spec-planner with a comment — don't
+expand scope silently.
+
+- Item one (rationale)
+- Item two (rationale)
+
+## 7. Receipts to capture
+
+What to include in the PR body so downstream agents don't have to re-research:
+
+- Commands run and their exit status
+- New test names and crates
+- Status doc updated (which row)
+- Any deviation from the implementation plan, with rationale

--- a/docs/project/templates/IMPLEMENTATION_PLAN.md
+++ b/docs/project/templates/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,63 @@
+# Implementation Plan Template
+
+> **Rule**: Indexes provide candidates. Context determines authority.
+>
+> This template renders structure. The issue spec owns content.
+> If the plan and the issue disagree, the issue wins.
+
+Used by spec-planner agents to translate an approved issue into a concrete
+ordered plan. Copy into `.spec/<issue-or-lane>/IMPLEMENTATION_PLAN.md` and
+fill each section.
+
+---
+
+## 1. Objective
+
+One paragraph. Restate the issue's goal in implementation terms. Reference
+the issue number explicitly.
+
+## 2. Branch and worktree
+
+- **Branch**: `<type>/<short-slug>` (e.g. `fix/inc-no-lib-strictness`)
+- **Worktree**: `H:\Code\Rust2\wt-<slug>`
+- **Base**: `origin/master` at SHA `<short SHA>`
+
+## 3. Files touched
+
+| Path | Change type | Rationale |
+|---|---|---|
+| `crates/.../foo.rs` | modify | adds the lookup-boundary filter |
+| `crates/.../tests/bar.rs` | add | regression test for the filter |
+
+## 4. Sequence
+
+Ordered checklist of steps. Each step should be reversible in isolation.
+
+1. [ ] Step one
+2. [ ] Step two
+3. [ ] Step three
+
+## 5. Tests added or modified
+
+| Path | Scenario | Expected outcome |
+|---|---|---|
+| `crates/.../tests/foo.rs::test_name` | description | pass after step 2 |
+
+## 6. Validation matrix
+
+| Gate | Command | Passing criterion |
+|---|---|---|
+| Unit tests | `cargo test -p <crate>` | all green |
+| Workspace lint | `cargo clippy --workspace --lib` | no new warnings |
+| PR-fast | `just pr-fast` | exits 0 |
+
+## 7. Status update
+
+- **File**: `docs/project/status/<file>.md`
+- **Section**: `## Closeouts` (or the specific subsection)
+- **Row content**: one-line summary plus receipt PR number
+
+## 8. Rollback plan
+
+- What reverts cleanly with `git revert <PR-merge-SHA>` and no downstream effects.
+- What does **not** revert cleanly (e.g. data migration, schema change, label change) and what the manual fix-up is.


### PR DESCRIPTION
## Summary

Adds two spec-planner/builder handoff templates under `docs/project/templates/`:

- `IMPLEMENTATION_PLAN.md` — eight sections (objective, branch/worktree, files-touched, sequence, tests, validation matrix, status update, rollback).
- `BUILDER_BRIEF.md` — seven sections (goal, branch/worktree, existing artifacts, implementation map, acceptance, out of scope, receipts).

Docs-only, two files. Both headers carry the candidate/authority rule.

## Closes

Closes #8600

## Test plan

- [ ] Both files render correctly on GitHub.
- [ ] `git diff --stat` shows only the two template files.