### PR TITLE
docs(imports): specify literal require/import closeout (#8616)

### DIFF
--- a/docs/project/status/module_resolution.md
+++ b/docs/project/status/module_resolution.md
@@ -145,3 +145,47 @@ Backlog (pre-existing, not part of the @INC rail closure):
 - `inc_nested_use_lib` — `use lib` inside `BEGIN` block
 - `inc_qw_use_lib` — `use lib qw(lib t/lib)` multi-path form
 - Cross-scorecard: add `expected.json` diagnostic sidecars to all `inc_*` fixtures
+
+## Literal `require` / `import`
+
+Spec lane tracked under [#4280](https://github.com/EffortlessMetrics/perl-lsp/issues/4280)
+(umbrella) and [#8616](https://github.com/EffortlessMetrics/perl-lsp/issues/8616)
+(this spec). All literal-form resolution **must** flow through
+`EffectiveIncContext` (the same filter introduced by [#8544](https://github.com/EffortlessMetrics/perl-lsp/pull/8544)
+for workspace-symbol lookups). No consumer may bypass active `@INC` state to
+resolve a literal `require` or `import` form.
+
+### Consumer × form matrix
+
+| Form | PL701 diagnostic | completion | goto-definition | hover |
+|---|---|---|---|---|
+| `require Foo;` (bareword) | resolve via `EffectiveIncContext` | suggest from prefix scan, filtered by context | jump to module file | show module summary |
+| `require "Foo.pm";` (literal, single-segment) | resolve same as bareword `Foo` | suggest matching `.pm` paths under context roots | jump to module file | show module summary |
+| `require "Foo/Bar.pm";` (literal, multi-segment) | resolve same as bareword `Foo::Bar` | suggest matching nested `.pm` paths | jump to module file | show module summary |
+| `import Foo;` (static bareword) | treat as `use Foo;` for resolution purposes | suggest from prefix scan | jump to module file | show module summary |
+| `Foo->import;` (static method call on bareword) | resolve `Foo`, do not interpret import list | suggest the bareword target | jump to `Foo` | show `Foo` summary |
+
+### Boundary table
+
+| In scope | Out of scope |
+|---|---|
+| `require Foo;` (bareword) | `eval STRING` where STRING contains `use`/`require` |
+| `require "Foo.pm";` (string literal, single segment) | `require $module;` (variable holds the path) |
+| `require "Foo/Bar.pm";` (string literal, multi segment) | `require "${prefix}::Foo";` (string interpolation) |
+| `import Foo;` (static, no list) | Runtime `import` with computed module names |
+| `Foo->import;` (static method call) | Plugin frameworks that synthesize module names at runtime |
+
+Out-of-scope forms remain explicitly unresolved — diagnostics may flag them
+as "dynamic; cannot statically resolve" but must not guess.
+
+### Acceptance test path (when impl lands)
+
+- New fixtures under `crates/perl-lsp-ux-tests/tests/fixtures/literal_require/`.
+- Consumer harness reused from Scenario 14 (`@INC` conformance).
+- Boundary table out-of-scope rows MUST produce a documented "unresolved (dynamic)" outcome — not a panic, not a stale hit, not a false positive.
+
+Receipts:
+
+- [#4280](https://github.com/EffortlessMetrics/perl-lsp/issues/4280) — umbrella ux-journey
+- [#8616](https://github.com/EffortlessMetrics/perl-lsp/issues/8616) — this spec
+- [#8544](https://github.com/EffortlessMetrics/perl-lsp/pull/8544) — `EffectiveIncContext` filter that literal forms must reuse

--- a/docs/reference/LANGUAGE_SUPPORT.md
+++ b/docs/reference/LANGUAGE_SUPPORT.md
@@ -1,0 +1,53 @@
+# Perl Language Support
+
+This page documents the Perl language constructs perl-lsp understands across
+its four primary consumers (PL701 diagnostic, completion, goto-definition,
+hover). It is a user-facing reference; authoritative definitions of behavior
+live in the linked status documents.
+
+> **Rule**: Indexes provide candidates. Context determines authority.
+>
+> If this page and a status doc disagree, the status doc wins.
+
+## Module resolution
+
+The full consumer-consistency matrix and `@INC` rail status live in
+[`docs/project/status/module_resolution.md`](../project/status/module_resolution.md).
+
+Summary: `use Foo;`, `use lib '...';`, `no lib '...';`, `FindBin`-relative
+includes, `PERL5LIB`, and interpreter-startup `@INC` are all supported across
+the four consumers, gated by `usePerl5lib` and `useSystemInc` workspace flags.
+
+## Literal `require` and `import`
+
+Tracked under spec issue
+[#8616](https://github.com/EffortlessMetrics/perl-lsp/issues/8616) (umbrella
+ux-journey: [#4280](https://github.com/EffortlessMetrics/perl-lsp/issues/4280)).
+
+All literal-form resolution flows through `EffectiveIncContext` (introduced by
+[#8544](https://github.com/EffortlessMetrics/perl-lsp/pull/8544)). Forms in
+the in-scope column are resolved by every consumer; forms in the out-of-scope
+column are flagged as "dynamic; cannot statically resolve" but never guessed.
+
+### Supported forms
+
+| Form | Example | Resolution |
+|---|---|---|
+| Bareword `require` | `require Foo;` | resolve `Foo` via `EffectiveIncContext` |
+| Literal single-segment | `require "Foo.pm";` | resolve same as bareword `Foo` |
+| Literal multi-segment | `require "Foo/Bar.pm";` | resolve same as bareword `Foo::Bar` |
+| Static `import` | `import Foo;` | resolve same as `use Foo;` |
+| Static method-call import | `Foo->import;` | resolve `Foo` only; do not interpret import list |
+
+### Boundary table
+
+| In scope | Out of scope |
+|---|---|
+| `require Foo;` (bareword) | `eval STRING` containing `use`/`require` |
+| `require "Foo.pm";` | `require $module;` (variable path) |
+| `require "Foo/Bar.pm";` | `require "${prefix}::Foo";` (string interpolation) |
+| `import Foo;` (static, no list) | Runtime `import` with computed module names |
+| `Foo->import;` (static method call) | Plugin frameworks synthesizing module names at runtime |
+
+Authoritative behavior matrix:
+[`docs/project/status/module_resolution.md` → "Literal `require` / `import`"](../project/status/module_resolution.md#literal-require--import).


### PR DESCRIPTION
## Summary

Spec-only docs PR for the literal `require` / `import` closeout under umbrella EffortlessMetrics/perl-lsp-swarm#2960. No production code.

- `docs/project/status/module_resolution.md` — new section with consumer-by-form matrix, in/out-of-scope boundary table, acceptance test path. All literal forms flow through `EffectiveIncContext` (filter from EffortlessMetrics/perl-lsp#8544).
- `docs/reference/LANGUAGE_SUPPORT.md` — new user-facing reference page anchoring the boundary table.

## Closes

Closes EffortlessMetrics/perl-lsp#8616 (cross-link EffortlessMetrics/perl-lsp-swarm#2960)

## Boundary

Spec only. Implementation lands under a follow-up issue.

## Test plan

- [ ] `git diff --stat` shows only the two doc files.
- [ ] Cross-links to EffortlessMetrics/perl-lsp-swarm#2960, EffortlessMetrics/perl-lsp#8544 resolve on GitHub.