### PR TITLE
docs(release): 0.14.0 readiness queue + lock criteria (#8647)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -98,6 +98,7 @@ Background material that explains why the system is designed the way it is (unde
 Decision records, project status, and planning documents.
 
 - [ADR Index](adr/README.md) — chronological index plus a topic guide for parser, runtime, DAP, security, and swarm decisions
+- [0.14.0 Readiness Queue](releases/0.14.0-readiness.md) — current-release meta-roadmap: drain queue + implementation phase + release lock
 - [Project Roadmap](project/ROADMAP.md)
 - [Compiler-Backed LSP Roadmap](project/COMPILER_BACKED_LSP_ROADMAP.md)
 - [Project Milestones](project/MILESTONES.md)

--- a/docs/releases/0.14.0-readiness.md
+++ b/docs/releases/0.14.0-readiness.md
@@ -1,0 +1,109 @@
+# 0.14.0 Readiness
+
+> **Substrate (already built)**: Rust 1.95 MSRV/toolchain (#8509); @INC strictness rail (#8544, #8540); rollout docs (#8539, #8545); forensics doc (#8550); freshness-check spec (#8556); rail meta (#8636).
+> **Connector gap**: drain open docs/spec queue, implement product/release connectors, lock release criteria.
+> **0.14.0 upside**: the substrate becomes a tagged release.
+
+This page is the single answer to "what's left for 0.14.0?". It tracks the queue and the lock criteria. It does NOT duplicate per-rail content — follow the cross-links for that.
+
+## Phase 1 — Drain docs/spec PR queue
+
+Strict ordering. Rebase any PR with stale base; merge when CI green and gates clean.
+
+| # | PR | Status | Title | Blocked? |
+|---|---|---|---|---|
+| 1 | #8581 | open | docs(@INC): record final no-lib workspace-index strictness | — |
+| 2 | #8557 | open | docs(devex): issue body = current truth; comments = research log | #8624 |
+| 3 | #8558 | open | docs(architecture): Perl subprocess ambient-input contracts | #8624 |
+| 4 | #8636 | open | docs(project): rail burndown template + active rails index | — |
+| 5 | #8638 | open | docs(rail): module completion latency burndown | — |
+| 6 | #8639 | open | docs(rail): literal require/import imports burndown | — |
+| 7 | #8640 | open | docs(rail): real-workspace provider baseline burndown | — |
+| 8 | #8641 | open | docs(rail): DAP module journey burndown | — |
+| 9 | #8642 | open | docs(rail): freshness / issue-spec discipline burndown | — |
+| 10 | #8643 | open | docs(rail): Perl-oracle subprocess environment burndown | — |
+| 11 | #8644 | open | docs(rail): file-policy rollout burndown — non-rust | — |
+| 12 | #8645 | open | docs(rail): CI contributor UX burndown | — |
+| 13 | #8646 | open | docs(rail): Codecov / evidence claim boundaries burndown | — |
+
+**Already merged into substrate** (do not re-track):
+
+| PR | Merged | Title |
+|---|---|---|
+| #8591 | `8f895312` | docs(ux): add UX closeout index |
+| #8598 | `12941e58` | docs(ux): add UX closeout spec template |
+| #8612 | `4c4f5938` | docs(agents): add implementation plan and builder brief templates |
+| #8553 | `02a45310` | docs(crate): prefix-vs-exact + `.`-wildcard rules |
+| #8618 | `dd1e02fc` | docs(imports): literal require/import closeout |
+| #8595 | `cb8cedef` | docs(rollout): Rust 1.95 ladder cross-links |
+| #8617 | `cb592063` | docs(clippy): strong clippy lints rollout |
+| #8556 | `9a28a438` | tooling(devex): freshness-check spec |
+
+## Phase 2 — Implementation connectors (priority order)
+
+Each row is a builder-ready issue that a sonnet builder can pick up.
+
+| # | Issue | Builder-ready? | Title | Lane | Receipt |
+|---|---|---|---|---|---|
+| 1 | #8514 | yes | perf(completion): runtime-owned TTL cache for prefix module scans | builder | `cargo test -p perl-lsp-rs-core --lib completion` |
+| 2 | #8622 | yes | feat(perl-oracle): PerlOracleEnv v1 + startup @INC probe migration | builder | poisoned-env tests in `config::tests` |
+| 3 | #8623 | yes | feat(imports): track literal require/import symbols | builder | `cargo test -p perl-module --locked` + scorecard |
+| 4 | #8637 | yes | test(editor): real-workspace provider expectations | builder | `cargo test -p perl-lsp-rs --lib real_workspace` |
+| 5 | #8621 | yes | test(dap): module-resolution debug smoke | builder | `cargo test -p perl-dap --test dap_module_resolution_smoke` |
+| 6 | #8566 | no  | policy(files): advisory non-rust file policy checker | factory-droid | `cargo xtask check-file-policy --mode advisory` |
+| 7 | #8568 | no  | policy(files): propose non-rust allowlist entries | factory-droid | `cargo xtask non-rust propose` |
+| 8 | #4825 | yes | ci: PR sticky CI summary | builder | `cargo xtask ci pr-summary --dry-run` |
+| 9 | #4826 | yes | ci: local ci-doctor | builder | `cargo xtask ci doctor` |
+
+(Builder-ready column reflects presence of `builder-ready` label per `gh api` as of 2026-05-11. #8566/#8568 have only the `non-rust-policy` lane label, so they are factory-droid candidates and not yet builder-ready.)
+
+## Phase 3 — Release lock
+
+### Product / user-facing
+- [ ] @INC strictness status doc merged after #8540/#8544 (= PR #8581 lands)
+- [ ] scenario_14 green; no ignored tests (blocked on #8624)
+- [ ] Completion TTL cache implemented OR explicitly deferred to 0.14.x
+- [ ] Literal require/import spec merged (PR #8618 = merged); implementation completed OR deferred (#8623)
+- [ ] Real-workspace provider baseline completed OR deferred (#8637)
+- [ ] DAP module smoke completed OR deferred (#8621)
+
+### Release-control
+- [ ] Rust 1.95 MSRV/toolchain confirmed (#8509 = merged)
+- [ ] Remaining clippy allows listed with issue numbers (Rust 1.95 ladder, including #8561 collapsible_match)
+- [ ] No-panic exact-identity plan/spec present (#8567 design issue)
+- [ ] File-policy inventory + advisory check/propose at least planned (#8566/#8568)
+- [ ] Codecov claim boundary docs aligned (per rail #8646; Cov-1/3/5/6 ladder rows)
+- [ ] ripr-vs-mutation doctrine explicit (per merged PR #8617 rollout)
+
+### Devex
+- [ ] Freshness-check spec merged (PR #8556 = merged); implementation issue (#8619) filed
+- [ ] Issue-body current-truth doc merged (PR #8557, blocked on #8624)
+- [ ] Builder brief / spec templates merged (PR #8612 = merged)
+- [ ] PR summary + ci-doctor implemented OR deferred (#4825/#4826)
+
+## Phase 4 — Release cut
+
+| # | Issue | Title |
+|---|---|---|
+| RP-1 | #8576 | release: prepare next minor for Rust 1.95 |
+| RP-2 | #8579 | release: validate publish readiness (cargo package + dry-run) |
+
+## Exit criteria
+
+A 0.14.0 release tag may be cut when ALL Phase 3 boxes are checked AND Phase 4 items are merged AND CI on master is green AND no `needs-*` labels remain on the merge candidate commit.
+
+## Claim boundary
+
+This doc is the queue + lock criteria. It does NOT contain rail-level implementation detail (see per-rail burndown docs under `docs/development/*_RAIL.md` and `docs/development/RUST_1_95_ROLLOUT.md`).
+
+## Related
+
+- Rails index: `docs/project/RAILS_INDEX.md` (PR #8636, pending merge)
+- Rail template: `docs/project/RAIL_TEMPLATE.md` (PR #8636, pending merge)
+- Rust 1.95 rollout: `docs/development/RUST_1_95_ROLLOUT.md`
+- Codecov rollout: `docs/ci/codecov-rollout.md`
+- Forensics: `docs/forensics/2026-05-11-autonomous-session-learnings.md`
+
+## Do not combine
+
+This doc tracks queue state only. PRs that update Phase 1/2/3/4 status should update this doc as part of their commit. Do not let it drift from reality.


### PR DESCRIPTION
## Summary

Adds the single page that answers "what is left for 0.14.0?" — a meta-roadmap covering the docs/spec drain queue, implementation connectors, release lock criteria, and the release cut itself.

Tracks #8647.

## What this PR adds

- `docs/releases/0.14.0-readiness.md` — the queue + lock doc, organized as:
  - **Phase 1** — drain open docs/spec PRs (13 open, 8 merged into substrate)
  - **Phase 2** — 9 implementation-connector issues, priority-ordered, with builder/factory-droid lanes and acceptance receipts
  - **Phase 3** — release lock checklists (product / release-control / devex)
  - **Phase 4** — release cut (#8576, #8579)
- `docs/INDEX.md` — single link to the new doc under "Project / ADR / Specs"

## Claim boundary

Docs-only. No production code change. This doc is the queue tracker; it does not duplicate per-rail content (cross-links only to `docs/development/*_RAIL.md`, `RUST_1_95_ROLLOUT.md`, `codecov-rollout.md`, and the 2026-05-11 forensics doc).

Every PR/issue number was verified via `gh api` against live GitHub state at filing time. Discrepancies vs. the original spec are documented in the "already merged into substrate" sub-table.

## Test plan

- [ ] `git diff --stat` shows only `docs/releases/0.14.0-readiness.md` and `docs/INDEX.md`.
- [ ] Markdown links resolve (especially the substrate-merged PRs).

## Do not combine

This PR is the doc itself. Subsequent PRs that move queue state should update this doc in the same commit; do not let it drift.

Closes #8647