### PR TITLE
fix(@INC): repair scenario_14 conformance regression (#8624)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -2601,4 +2601,77 @@ mod tests {
         );
         Ok(())
     }
+
+    /// Regression guard for scenario_14_no_lib_cancellation:
+    ///
+    /// When `use lib 'lib'` is followed by `no lib 'lib'` and then `use GoneModule`,
+    /// push diagnostics must emit PL701 (missing module) for GoneModule, NOT PL700
+    /// (unused import). PL700 would mean the resolver found the module, which would
+    /// be wrong — the `no lib` should have cancelled the path.
+    ///
+    /// This test uses the DEFAULT WorkspaceConfig (include_paths = ["lib", ".", ...])
+    /// to match the UX harness scenario where no explicit includePaths are configured.
+    #[test]
+    fn push_pl701_fires_after_no_lib_cancels_default_include_path()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(workspace.join("lib"))?;
+        // Create GoneModule.pm in lib/ so that without no-lib it WOULD be found.
+        std::fs::write(
+            workspace.join("lib").join("GoneModule.pm"),
+            "package GoneModule;\nsub gone { 1 }\n1;\n",
+        )?;
+        let script = workspace.join("fixture.pl");
+        let uri = url::Url::from_file_path(&script)
+            .map_err(|()| "failed to build script URI")?
+            .to_string();
+        let folder_uri = url::Url::from_directory_path(&workspace)
+            .map_err(|()| "failed to build workspace URI")?
+            .to_string();
+
+        let (server, buf) = make_server_with_capture();
+        *server.root_path.lock() = Some(workspace.clone());
+        // Use default config — include_paths = ["lib", ".", "local/lib/perl5"], use_perl5lib = true.
+        // This matches the UX harness startup state (no workspace/didChangeConfiguration sent).
+        let config = perl_lsp_rs_core::config::WorkspaceConfig::default();
+        server.workspace_folders.lock().push(
+            crate::runtime::workspace_folder::WorkspaceFolderState::new(folder_uri)
+                .with_path(workspace.clone())
+                .with_effective_workspace_config(config),
+        );
+
+        let source = "use strict;\n\
+use warnings;\n\
+use lib 'lib';\n\
+no lib 'lib';\n\
+use GoneModule;\n\
+\n\
+print \"unreachable\\n\";\n";
+
+        server.test_handle_did_open(Some(serde_json::json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "perl",
+                "version": 1,
+                "text": source
+            }
+        })))?;
+
+        server.publish_diagnostics(&uri);
+        drop(server);
+        std::thread::sleep(Duration::from_millis(50));
+
+        let bytes = buf.lock().clone();
+        let text = String::from_utf8(bytes)?;
+
+        assert!(
+            text.contains("PL701"),
+            "PL701 MUST fire: 'no lib' cancelled the path, GoneModule must not be found.\n\
+             Published: {text:?}"
+        );
+        // PL700 (unused import hint) is orthogonal and may also fire — it does not indicate
+        // the module was found. What matters is that PL701 fires (resolver returned false).
+        Ok(())
+    }
 }

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -981,10 +981,17 @@ pub fn resolve_binary() -> Result<String> {
 
     // 3. CARGO_TARGET_DIR — if set, look directly in its debug/release subdirs.
     //    This covers custom target directories (e.g. agent worktrees using
-    //    CARGO_TARGET_DIR=/tmp/agent-...).
+    //    CARGO_TARGET_DIR=/tmp/agent-...). Note: CARGO_TARGET_DIR is the target
+    //    directory itself (not a workspace root), so we look in
+    //    CARGO_TARGET_DIR/debug/ and CARGO_TARGET_DIR/release/ directly.
     if let Ok(target_dir) = std::env::var("CARGO_TARGET_DIR") {
-        if let Some(binary) = find_binary_in_target(std::path::Path::new(&target_dir)) {
-            return Ok(binary);
+        let target_path = std::path::Path::new(&target_dir);
+        let bin_name = if cfg!(windows) { "perl-lsp.exe" } else { "perl-lsp" };
+        for profile in ["debug", "release"] {
+            let candidate = target_path.join(profile).join(bin_name);
+            if candidate.exists() {
+                return Ok(candidate.to_string_lossy().into_owned());
+            }
         }
     }
 


### PR DESCRIPTION
Closes #8624

## Root cause

`resolve_binary()` in `perl-lsp-ux-tests` had a bug in step 3 (CARGO_TARGET_DIR handling): it called `find_binary_in_target(CARGO_TARGET_DIR)` which looks for `CARGO_TARGET_DIR/target/debug/perl-lsp` — treating CARGO_TARGET_DIR as a workspace root. That path never exists. So the function fell through to step 4 (CARGO_MANIFEST_DIR), which walked up to the workspace root `H:/Code/Rust2/perl-lsp/` and found the **stale binary** at `target/debug/perl-lsp` (v0.13.1, pre-#8525).

The stale v0.13.1 binary doesn't have the position-aware `no lib` cancellation (added in #8525). So when the scenario_14 no_lib_cancellation tests ran, the server found `GoneModule` despite `no lib 'lib'` (using whole-file @INC scan), fired PL700 (unused import) instead of PL701 (missing module), and the strict assertions from #8525 and #8540 failed.

## Failing assertion
```
PL701 MUST fire for GoneModule: 'no lib' cancelled the earlier 'use lib'
diagnostics: [{"code": "PL700", "message": "Module 'GoneModule' appears to be unused"}]
```

## Fix

Fix `resolve_binary()` step 3: when `CARGO_TARGET_DIR` is set, look directly in `CARGO_TARGET_DIR/debug/perl-lsp` and `CARGO_TARGET_DIR/release/perl-lsp` — not `CARGO_TARGET_DIR/target/debug/perl-lsp`. The comment already said "look directly in its debug/release subdirs" but the implementation was wrong.

Also adds a regression guard unit test `push_pl701_fires_after_no_lib_cancels_default_include_path` that verifies PL701 fires at the push-diagnostics level when `no lib` cancels the default include path.

## Acceptance receipt

```
RUST_TEST_THREADS=2 cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance -- --nocapture
test result: ok. 14 passed; 0 failed

cargo clippy -p perl-lsp-ux-tests --tests  # clean
cargo xtask fmt --check                    # clean (exit 0)
```