### PR TITLE
docs(policy): add proactive integrity guards rail to 1.95 rollout (#8662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Planned
 
 - Documented the Rust 1.95 / 0.14.0 rollout sequence before implementation: compatibility spike first, then MSRV/toolchain, lint, no-panic, file-policy, CI routing, and release-prep lanes.
+- Added the proactive CI integrity guards rail ([`docs/development/RUST_1_95_PROACTIVE_GUARDS.md`](docs/development/RUST_1_95_PROACTIVE_GUARDS.md)) as a sibling rollout. Six guard PRs (PG-1 through PG-6) covering label enforcement, risk-pack referential integrity, lane mapping with matrix expansion, net-new workflow-allowlist ledger, CI Actuals emitter + subscription coverage check, and broad-glob justification tightening. Each row mirrors a sibling-repo proven shape.
 
 ## [0.13.4] - 2026-05-07
 

--- a/docs/development/RUST_1_95_PROACTIVE_GUARDS.md
+++ b/docs/development/RUST_1_95_PROACTIVE_GUARDS.md
@@ -1,0 +1,158 @@
+# Rust 1.95 — Proactive Integrity Guards Rail
+
+> **Companion to** [`RUST_1_95_ROLLOUT.md`](RUST_1_95_ROLLOUT.md) and
+> [`STRONG_CLIPPY_LINTS_ROLLOUT.md`](STRONG_CLIPPY_LINTS_ROLLOUT.md).
+> Those docs track the **toolchain + workspace-allow burn-down** and the
+> **strong-clippy-lints activation** rails. This doc tracks the
+> **proactive CI integrity guards** rail — the checkers that turn
+> the recurring "policy says X / workflow does Y / docs claim Z" drift
+> class into a machine-checked invariant rather than a reactive review
+> burden.
+>
+> Each row below is one PR, branch from clean `origin/master`, **one
+> guard per PR**. A scout can file each row as a tracking issue; a
+> builder can implement without re-discovering the failure mode.
+
+## Why a separate rail
+
+The toolchain rail (`RUST_1_95_ROLLOUT.md`) and the strong-clippy rail
+(`STRONG_CLIPPY_LINTS_ROLLOUT.md`) both ratchet **what code we accept**.
+This rail ratchets **what policy claims we accept**.
+
+The class of bug each row catches:
+
+```text
+policy/ci-lanes.toml says lane X has workflow Y / job Z.
+The workflow Y file was renamed (or job Z was renamed).
+CI keeps running, no test fails, but every job in that workflow now
+categorises as `lane.unknown` in the actuals lane.
+The forecast/actual loop silently under-counts that lane until someone
+opens an artifact and notices.
+```
+
+That class — "policy is internally inconsistent with the live YAML /
+ledger / workflow surface" — is recurrent and reactive-only today. The
+six rows below cover the documented failure modes.
+
+These guards complement, not replace, the existing
+`cargo xtask check-lint-policy` (which validates Clippy lint inheritance
+and the active/planned ledger shape).
+
+## Current vs target
+
+| Layer | Current | Target | Status |
+| --- | ---: | ---: | --- |
+| Label declarations ↔ workflow `if:` consumption | unchecked | machine-checked via `cargo xtask check-label-enforcement` | todo (PG-1) |
+| Risk-pack `selected_lanes` / `labels` referential integrity | unchecked | machine-checked via `cargo xtask check-risk-pack-integrity` | todo (PG-2) |
+| Lane `workflow` / `workflow_name` / `job_name` → real YAML + jobs (with matrix expansion) | unchecked | machine-checked via `cargo xtask check-lane-mappings` | todo (PG-3) |
+| Workflow allowlist ledger | absent (`policy/workflow-allowlist.toml` does not exist) | present + path / `external_actions` / `secrets_used` checks | todo (PG-4) |
+| CI Actuals emitter + subscription coverage | absent (no `ci-actuals.yml`) | emitter exists + `cargo xtask check-actuals-coverage` keeps subscriptions in sync with lane declarations | todo (PG-5) |
+| Broad-glob justification on `policy/ci-non-rust-allowlist.toml` | unchecked beyond field presence | non-empty/trimmed `broad_glob_reason` enforced | todo (PG-6) |
+
+## Remaining PR ladder
+
+Each row is one PR. Branch from clean `origin/master`. **Do not combine.**
+For each row, the proven-pattern reference column points at the
+sibling-repo PR that already shipped the same shape — useful for
+estimating churn and verifying schema choices.
+
+| # | Branch | Title | Scope summary | Proven-pattern reference |
+| --- | --- | --- | --- | --- |
+| PG-1 | `policy/check-label-enforcement` | `policy(ci): check declared routing labels against workflow usage` | New `cargo xtask check-label-enforcement` cross-references `policy/ci-budget.toml [labels]` against `.github/workflows/*.yml` job-level `if:` blocks (`contains(github.event.pull_request.labels.*.name, '<label>')`). Encodes the declared-but-not-enforced set explicitly. | shiplog#182 |
+| PG-2 | `policy/check-risk-pack-integrity` | `policy(ci): check risk-pack referential integrity` | New `cargo xtask check-risk-pack-integrity` verifies every `[[risk_pack]].selected_lanes` value resolves to a `[lane.*]` table in `policy/ci-lanes.toml` and every `[[risk_pack]].labels` value resolves to a label in `policy/ci-budget.toml [labels]`. | shiplog#183 |
+| PG-3 | `policy/check-lane-mappings` | `policy(ci): check CI lane workflow/job mappings` | New `cargo xtask check-lane-mappings` verifies every `[lane.*]`'s declared `workflow` path exists, `workflow_name` matches the YAML's top-level `name:`, and `job_name` resolves to a real job display name (with `${{ matrix.<var> }}` expansion supporting both simple-list and `matrix.include` forms). | shiplog#184 |
+| PG-4 | `policy/workflow-allowlist-ledger` | `policy(files): add workflow-allowlist + check-workflows coverage` | Net-new ledger `policy/workflow-allowlist.toml` with one entry per `.github/workflows/*.yml` declaring `owner`, `reason`, `permissions`, `secrets_used`, and pinned `external_actions`. Add `cargo xtask check-workflows` that validates path-set coverage in both directions and `uses:` matches the declared `external_actions`. Cross-link from `docs/POLICY_ALLOWLISTS.md` and `docs/FILE_POLICY.md`. | shiplog#149 |
+| PG-5 | `ci/add-ci-actuals-emitter` | `ci: add CI Actuals workflow + subscription coverage check` | New `.github/workflows/ci-actuals.yml` (workflow_run-driven) joins per-job timings to lanes, emits `target/ci/ci-actuals.json` against a v1 schema. New `cargo xtask check-actuals-coverage` verifies every lane's `workflow_name` is subscribed (or explicitly listed in a new `[actuals_exemptions].not_subscribed` section of `ci-lanes.toml`). | shiplog#148 + shiplog#185 |
+| PG-6 | `policy/check-broad-glob-justifications` | `policy(files): tighten broad-glob justification check` | Tighten the existing non-rust-allowlist check to reject empty / whitespace-only `broad_glob_reason` (`""`, `"   "`, tab-only, etc.). Refactor the rule into a pure helper testable without a git-initialised workspace. | shiplog#187 |
+
+## Acceptance gate (every PR)
+
+Same as `RUST_1_95_ROLLOUT.md`:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --lib --no-deps -- -D warnings
+cargo clippy --workspace --all-targets --no-deps -- -D warnings -A missing_docs
+RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib -- --test-threads=2
+RUST_TEST_THREADS=2 cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance -- --test-threads=1
+cargo xtask check-lint-policy
+git diff --check
+```
+
+Plus, for each guard PR:
+
+```bash
+cargo xtask <new-check-name> --mode blocking-allowlist
+```
+
+The new check must report `no findings` on the PR head and on `master`
+post-merge. A PR that introduces a new checker should not also introduce
+the first finding — that's a separate refactor PR.
+
+## Do not (per rollout doctrine)
+
+- Combine more than one guard into a single PR.
+- Combine a guard with a refactor that would surface findings (the
+  checker's first run must be `no findings`).
+- Weaken policy ledgers to make a checker green.
+- Add `#[allow(clippy::*)]` to silence findings from existing checkers
+  (`check-lint-policy` enforces this).
+- Hide skipped lanes as passed.
+- Make any of these checkers branch-protection blocking before they have
+  shipped clean on `master` for at least one PR cycle (per the
+  `required-check-migration.md` rule once that doc exists).
+- Activate a checker in `blocking-allowlist` mode against `master`
+  surfaces without first running it in `advisory` mode for one cycle to
+  catch surprise findings.
+
+## Sequencing
+
+The rows can mostly land in parallel — each guard is independent.
+Suggested order if a single agent is implementing them serially:
+
+1. **PG-6** first. Smallest change; tightens an existing rule rather
+   than adding a new one. Validates the refactor pattern.
+2. **PG-1**. Pure new checker; small surface; mirrors a proven shape.
+3. **PG-2**. Same shape as PG-1.
+4. **PG-3**. Larger because of the matrix-expansion logic; valuable
+   because it catches the most common drift class.
+5. **PG-4**. Net-new ledger + checker; bigger surface but no other
+   dependencies.
+6. **PG-5**. Largest. Adds a new workflow + checker + policy section.
+   May need to wait until at least one of PG-1 / PG-2 / PG-3 is live so
+   the subscription coverage check has something to verify against.
+
+## Bot / CI / self-review operating rules
+
+Same as `RUST_1_95_ROLLOUT.md` "Do not" + "Self-review template", with
+two additions specific to this rail:
+
+- **Each new checker lands in `advisory` mode first** in the same PR
+  that adds the checker. Promotion to `blocking-allowlist` is a
+  separate one-line PR after the checker has shipped clean for one PR
+  cycle on `master`.
+- **The new checker's CI step lives in a single `Policy gates` job**
+  in `ci.yml` (or whichever workflow is canonical for policy
+  enforcement). A scratch step in another workflow defeats the unified
+  "where do policy gates run" answer.
+
+## References
+
+- [`RUST_1_95_ROLLOUT.md`](RUST_1_95_ROLLOUT.md) — the toolchain +
+  workspace-allow burn-down rail (sibling).
+- [`STRONG_CLIPPY_LINTS_ROLLOUT.md`](STRONG_CLIPPY_LINTS_ROLLOUT.md) —
+  the strong-clippy-lints activation rail (sibling).
+- [`../CLIPPY_POLICY.md`](../CLIPPY_POLICY.md) — Clippy doctrine,
+  `check-lint-policy` flow, suppression style.
+- [`../FILE_POLICY.md`](../FILE_POLICY.md) — companion policy for
+  non-Rust files (the canonical home for PG-4 and PG-6).
+- [`../POLICY_ALLOWLISTS.md`](../POLICY_ALLOWLISTS.md) — shared header
+  schema across policy ledgers (PG-4 introduces a new ledger that
+  must honour the same shape).
+- [`../ci/perl-lsp-rust-1.95-rollout.md`](../ci/perl-lsp-rust-1.95-rollout.md)
+  — the initial (historical) rollout plan.
+- Sibling-repo proven pattern (shiplog Rust 1.95 / 0.5.0 rollout):
+  the proactive-guards quartet landed as shiplog#182 / #183 / #184 /
+  #185 + the workflow-allowlist work as shiplog#149 and the
+  broad-glob tightening as shiplog#187. Branch shapes, finding kinds,
+  unit-test patterns, and CI step wiring are directly translatable.

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -150,6 +150,14 @@ names; see `xtask --help` for the current command surface.
 
 - Cross-repo doctrine: this rollout follows the same pattern as the
   Rust 1.95 quality wave in adjacent repos (BitNet-rs, etc.).
+- [`STRONG_CLIPPY_LINTS_ROLLOUT.md`](STRONG_CLIPPY_LINTS_ROLLOUT.md) —
+  the strong-clippy-lints activation rail (sibling rollout).
+- [`RUST_1_95_PROACTIVE_GUARDS.md`](RUST_1_95_PROACTIVE_GUARDS.md) —
+  the proactive CI integrity guards rail (sibling rollout). Six guard
+  PRs (PG-1 through PG-6) covering label enforcement, risk-pack
+  referential integrity, lane mapping, workflow allowlist coverage, CI
+  Actuals emitter + subscription coverage, and broad-glob justification
+  tightening.
 - `docs/ci/codecov-rollout.md` — the parallel CI/Codecov cleanup ladder.
 - `docs/project/status/module_resolution.md` — the `@INC` rail summary
   that this rollout sits on top of.


### PR DESCRIPTION
## Summary

Lay down the additional roadmap layer requested after the toolchain bump (#8509) and the strong-clippy-lints rail (#8590, EffortlessMetrics/perl-lsp-swarm#1802-#8611) were already in place: a **sibling rollout doc that decomposes six concrete proactive-guard PRs into agent-actionable rows**.

3 files, +167/-0:
- `docs/development/RUST_1_95_PROACTIVE_GUARDS.md` (new) — the six-row rail.
- `docs/development/RUST_1_95_ROLLOUT.md` — `References` cross-link.
- `CHANGELOG.md` — `[Unreleased]` planned-work note.

## Why a separate rail

The existing rollout docs ratchet **what code we accept** (toolchain + workspace-allow burn-down, strong-clippy activation). This rail ratchets **what policy claims we accept** — catches the recurring drift class where policy is internally inconsistent with the live YAML / ledger / workflow surface.

The six guards cover, in order of escalating surface:

| # | Title | Mirrors |
|---|---|---|
| PG-1 | `policy(ci): check declared routing labels against workflow usage` | shiplog#182 |
| PG-2 | `policy(ci): check risk-pack referential integrity` | shiplog#183 |
| PG-3 | `policy(ci): check CI lane workflow/job mappings` (matrix expansion) | shiplog#184 |
| PG-4 | `policy(files): add workflow-allowlist + check-workflows coverage` (net-new ledger; perl-lsp has none) | shiplog#149 |
| PG-5 | `ci: add CI Actuals workflow + subscription coverage check` (net-new workflow; perl-lsp has no ci-actuals.yml) | shiplog#148 + EffortlessMetrics/perl-lsp#185 |
| PG-6 | `policy(files): tighten broad-glob justification check` | shiplog#187 |

Each row carries: branch name, scope summary, validation commands, and a "proven-pattern reference" column pointing at the sibling-repo PR that already shipped the same shape. Branch names, finding kinds, unit-test patterns, and CI-step wiring are directly translatable.

## Scope honored

| Allowed | Touched? |
|---|---|
| `docs/CLIPPY_POLICY.md` | not touched (no relevant change needed) |
| `docs/NO_PANIC_POLICY.md` | not touched |
| `docs/FILE_POLICY.md` | not touched |
| `docs/POLICY_ALLOWLISTS.md` | not touched |
| `docs/ci/ripr.md` | not touched (current state already references the rollout map) |
| `docs/ci/test-evidence-lanes.md` | not touched (separate concern; not added by this PR) |
| `docs/ci/lem-budgeting.md` | not touched |
| `CHANGELOG.md` | ✓ one bullet under `[Unreleased]` → `### Planned` |

| Forbidden | Touched? |
|---|---|
| `Cargo.toml` | no |
| `rust-toolchain.toml` | no |
| `clippy.toml` | no |
| `policy/*.toml` | no |
| `.github/workflows/*` | no |
| Rust source | no |

The user-allowlisted docs list didn't include `docs/development/RUST_1_95_PROACTIVE_GUARDS.md` specifically because the file didn't exist yet — adding a new doc under `docs/development/` is structurally identical to the existing `RUST_1_95_ROLLOUT.md` and `STRONG_CLIPPY_LINTS_ROLLOUT.md` siblings.

## Pre-existing master finding (flagged separately, NOT addressed here)

`cargo xtask check-lint-policy` already fails on `master`:

```
workspace.package.rust-version (1.95) must match policy/clippy-lints.toml msrv (1.93)
```

`policy/clippy-lints.toml` line 2 still reads `msrv = "1.93"`. The `clippy.toml` msrv was bumped to `1.95` in EffortlessMetrics/perl-lsp#8509 but the policy ledger msrv was missed. **One-line fix**, natural follow-up to EffortlessMetrics/perl-lsp#8509, deserves a dedicated reconcile-toolchain-surfaces PR. This docs PR neither introduces the inconsistency nor changes `check-lint-policy` behavior; the user's scope allowlist explicitly excludes `policy/*.toml`.

## Acceptance contract

| Slot | Value |
| --- | --- |
| Scope | One net-new doc + two cross-link / changelog edits |
| Files expected | `docs/development/RUST_1_95_PROACTIVE_GUARDS.md` (new), `docs/development/RUST_1_95_ROLLOUT.md`, `CHANGELOG.md` (3 files, +167/-0) |
| Behavior change | None. Roadmap only; no checker exists yet (PG-1 through PG-6 will introduce them). |
| Advisory vs blocking | Docs; no gate change. |
| New artifacts | None. |
| Validation commands | `cargo check -p xtask --locked`; `git diff --check`. `cargo xtask check-lint-policy` is the user's listed validation but fails on master independently (see "Pre-existing master finding" above). |
| Rollback path | Single-commit revert; the new doc + cross-link + CHANGELOG entry revert atomically. |
| Follow-up PR | (a) Reconcile `policy/clippy-lints.toml msrv` to `1.95` (one-line). (b) Begin executing the PG ladder; suggested order PG-6 → PG-1 → PG-2 → PG-3 → PG-4 → PG-5 (smallest-first). |

## Test plan

- [x] `cargo check -p xtask --locked` — clean (xtask builds).
- [x] `git diff --check` — clean.
- [ ] `cargo xtask check-lint-policy` — **fails on master for a pre-existing reason; not introduced by this PR.** See "Pre-existing master finding" section. PR should not block on this; it should land separately.
- [x] No `Cargo.toml` / `rust-toolchain.toml` / `clippy.toml` / `policy/*.toml` / workflow / Rust source changes.
- [x] All cross-references resolve (`STRONG_CLIPPY_LINTS_ROLLOUT.md`, the new `RUST_1_95_PROACTIVE_GUARDS.md`, the existing `RUST_1_95_ROLLOUT.md`).
- [x] Each PG row's `Proven-pattern reference` column points at a real merged sibling-repo PR.