### PR TITLE
docs(roadmap): map remaining Rust 1.95 to 0.14.0 rollout (#8663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documented the Rust 1.95 / 0.14.0 rollout sequence before implementation: compatibility spike first, then MSRV/toolchain, lint, no-panic, file-policy, CI routing, and release-prep lanes.
 - Added the proactive CI integrity guards rail ([`docs/development/RUST_1_95_PROACTIVE_GUARDS.md`](docs/development/RUST_1_95_PROACTIVE_GUARDS.md)) as a sibling rollout. Six guard PRs (PG-1 through PG-6) covering label enforcement, risk-pack referential integrity, lane mapping with matrix expansion, net-new workflow-allowlist ledger, CI Actuals emitter + subscription coverage check, and broad-glob justification tightening. Each row mirrors a sibling-repo proven shape.
+- Consolidated the remaining Rust 1.95 → 0.14.0 work into a single canonical roadmap: rewrote [`docs/development/RUST_1_95_ROLLOUT.md`](docs/development/RUST_1_95_ROLLOUT.md) into a post-landing source of truth (already landed / remaining implementation ladder / per-rail acceptance contracts / Claude-Codex operating contract); slimmed [`docs/ci/perl-lsp-rust-1.95-rollout.md`](docs/ci/perl-lsp-rust-1.95-rollout.md) to a historical pointer; added [`docs/ci/test-evidence-lanes.md`](docs/ci/test-evidence-lanes.md) defining the five evidence-lane shapes (PR-fast required / PR-targeted / nightly cron / release-only / advisory) with risk-pack auto-routing, skipped-by-policy receipts, and LEM cost framing. Umbrella tracking: **#8663**.
 
 ## [0.13.4] - 2026-05-07
 

--- a/docs/ci/perl-lsp-rust-1.95-rollout.md
+++ b/docs/ci/perl-lsp-rust-1.95-rollout.md
@@ -1,203 +1,32 @@
-# Rust 1.95 / 0.14.0 rollout map
+# Rust 1.95 / 0.14.0 rollout map (historical)
 
-> **Status (2026-05-11):** This is the **initial rollout plan**, filed when
-> the workspace was still on Rust 1.93. The MSRV / toolchain / `clippy.toml`
-> bumps have since **landed** (#8509). The historical framing below is
-> preserved as the original plan-of-record. For the **post-landing
-> improvement ladder** — what remains, in agent-actionable form — see
-> [`docs/development/RUST_1_95_ROLLOUT.md`](../development/RUST_1_95_ROLLOUT.md).
+> **This doc is now a pointer.**
+>
+> When this file was first written, the workspace was on Rust 1.93 and
+> the 0.14.0 line had not been planned. The MSRV / toolchain /
+> `clippy.toml`-msrv bumps have since shipped (#8509), and the rollout
+> has moved on. The **current, canonical post-landing roadmap** lives at:
+>
+> **[`../development/RUST_1_95_ROLLOUT.md`](../development/RUST_1_95_ROLLOUT.md)**
+>
+> That doc carries:
+>
+> 1. Already-landed state (current-state facts + ratchet table).
+> 2. Remaining implementation ladder (single canonical PR list).
+> 3. Per-rail acceptance contracts (one per row).
+> 4. Claude / Codex operating contract.
+>
+> Sibling rails:
+>
+> - [`../development/STRONG_CLIPPY_LINTS_ROLLOUT.md`](../development/STRONG_CLIPPY_LINTS_ROLLOUT.md)
+>   — strong-clippy-lints activation rail (umbrella #8590).
+> - [`../development/RUST_1_95_PROACTIVE_GUARDS.md`](../development/RUST_1_95_PROACTIVE_GUARDS.md)
+>   — proactive CI integrity guards rail (umbrella #8662).
+>
+> Umbrella tracking for the consolidation that produced this pointer:
+> **#8663**.
 
-This document is the control map for moving `perl-lsp` from the current Rust
-1.93 line to Rust 1.95.0 and preparing the next minor release, 0.14.0. It is
-intentionally documentation-only: no MSRV, toolchain, workflow, lint, baseline,
-or version changes happen in this PR.
-
-Truth sources for rollout facts are the repository files, not this document:
-
-- Workspace edition, MSRV, package version, and active workspace lints:
-  [`Cargo.toml`](../../Cargo.toml).
-- Pinned toolchain: [`rust-toolchain.toml`](../../rust-toolchain.toml).
-- Clippy runtime configuration: [`clippy.toml`](../../clippy.toml).
-- Governed lint ledger and planned Rust-version flips:
-  [`policy/clippy-lints.toml`](../../policy/clippy-lints.toml).
-- CI lane, risk-pack, LEM, and actuals policy:
-  [`policy/ci-lanes.toml`](../../policy/ci-lanes.toml),
-  [`policy/ci-risk-packs.toml`](../../policy/ci-risk-packs.toml), and
-  [`policy/ci-budget.toml`](../../policy/ci-budget.toml).
-
-## Current and target state
-
-| Layer | Current | Target | Status |
-|---|---:|---:|---|
-| Edition | 2024 | 2024 | done |
-| MSRV | 1.93 | 1.95.0 | planned |
-| Toolchain | 1.93.1 | 1.95.0 | planned |
-| Release line | 0.13.4 | 0.14.0 | planned |
-| Clippy panic-family | partly active | strict + no test carveouts | partial |
-| `collapsible_if` | broad allow | debt ledger / cleanup | todo |
-| Rust 1.93 rustc lints | planned/tracked | active | todo |
-| Rust 1.95 Clippy lints | planned | active or ratcheted | todo |
-| No-panic allowlist | missing/incomplete | exact counted no-new-debt | todo |
-| Non-Rust allowlist | missing/incomplete | blocking file policy | todo |
-| ripr | advisory, installed in workflow | advisory + better routing | partial |
-| CI economics | LEM/risk packs exist | tuned + actuals-backed | partial |
-
-## Why Rust 1.95 matters for `perl-lsp`
-
-| Rust 1.95 item | Repo-specific value |
-|---|---|
-| `if let` guards | Parser/AST walkers, semantic extraction, import visibility, refactor preconditions, LSP provider routing. |
-| `Vec::push_mut` / `insert_mut` | Diagnostic/report builders, semantic facts, scorecards, CI receipts, LSP response builders. |
-| Atomic `update` / `try_update` | Session/cache counters, memory-pressure counters, cancellation or stream-state metrics. |
-| `cfg_select!` | Windows/Unix path behavior, subprocess handling, VS Code install surfaces, native/virtual URI handling. |
-| `cold_path` | Parser recovery, malformed URI/path handling, failed subprocess/perlcritic paths, policy failure reporting. |
-| Clippy 1.95 | `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, and future `disallowed_fields`. |
-
-The AST-heavy parts of this repository are the main beneficiary: `if let` guards
-let semantic walkers keep the branch shape and the semantic precondition in the
-same expression, which reduces review load and helps keep parser/provider paths
-from drifting into panic-prone precondition checks.
-
-## Operating rule
-
-The first implementation PR after this documentation PR is a Rust 1.95
-compatibility spike. No MSRV bump, lint activation, no-panic baseline reset,
-release bump, or API cleanup happens in the same PR.
-
-## Queue control
-
-The Rust 1.95 rollout is separate from unrelated product and test PRs. If draft
-or in-flight work such as UX diagnostic lifecycle fixes or native critic rules is
-open, keep it separate: start rollout PRs from a clean `master` snapshot and
-rebase after those PRs merge rather than folding Rust 1.95 work into them.
-
-## Policy surfaces to watch
-
-### Clippy policy
-
-- `Cargo.toml` currently carries the active hard bans for
-  `unwrap_used`, `expect_used`, `panic`, `todo`, `unimplemented`, and
-  `dbg_macro`.
-- `clippy.toml` still has `allow-unwrap-in-tests = true` while
-  `policy/clippy-lints.toml` says tests should be panic-free. Removing that
-  carveout is a later policy PR, not part of the compatibility spike or MSRV
-  bump.
-- `collapsible_if = "allow"` is current debt. It should move through a debt
-  ledger and behavior-preserving cleanup rather than being flipped while
-  changing the toolchain.
-- Rust 1.93 rustc lints and Rust 1.94/1.95 Clippy lints are already tracked in
-  `policy/clippy-lints.toml`; they should be activated only in their dedicated
-  lint-floor and ratchet PRs.
-
-### No-panic policy
-
-The target posture is exact, counted, no-new-debt policy:
-
-1. Match panic-family findings by path, family, selector kind, selector callee,
-   snippet, and count.
-2. Consume exact allowlist counts first.
-3. Consume baseline counts second, except in blocking mode.
-4. Report anything left as new debt.
-
-Do not reset or add a no-panic baseline until exact counted identity exists.
-
-### Non-Rust and file policy
-
-Rust and `xtask` remain the default implementation surfaces. Non-Rust files are
-legitimate for Perl corpus fixtures, tree-sitter/native parser bindings, VS Code
-extension code, workflows, CI scripts, generated status artifacts, and release
-metadata, but the target is receipt-backed allowlisting rather than anonymous
-expansion.
-
-### ripr
-
-`ripr` is advisory static oracle-gap detection. It should remain non-blocking for
-normal PRs during this rollout. The target is better routing: skip docs-only and
-test-fixture-only changes unless a label forces analysis, keep artifacts
-consistent, and reserve mutation testing for targeted, nightly, or release lanes.
-While the repo remains pinned to Rust 1.93.1, the workflow pins `ripr` to the
-0.4.x line; the Rust 1.95 toolchain bump is the point where that install can move
-to a newer `ripr` release.
-
-### CI economics
-
-LEM budgets, CI risk packs, CI lane policy, PR smoke, merge-gate shards, UX tests,
-memory smoke, Windows guardrails, CI actuals, and advisory `ripr` already exist.
-This rollout should tune that control plane; it should not replace it or add a
-new parallel process. Learned estimates should be actuals-backed and must not
-hard-enforce below the existing 125 LEM ceiling before calibration.
-
-## PR ladder and acceptance gates
-
-Some gates below are current commands; others are command surfaces introduced
-by earlier steps in this same rollout. A row that creates a new checker should
-prove existing `xtask` health first, then smoke/test the new command after the
-row adds it. Later rows that reference no-panic, file-policy, or policy-report
-checks depend on those earlier command-introduction rows having landed.
-
-| Step | Branch | Objective | Acceptance gate |
-|---:|---|---|---|
-| 1 | `docs/rust-1.95-rollout` | Map the rollout, docs only. | `cargo check -p xtask --locked`; `cargo xtask check-lint-policy`; `git diff --check` |
-| 2 | `probe/rust-1.95-compat` | Run current repo under Rust 1.95.0 before declaring MSRV. | fmt, workspace checks, clippy, tests, lint policy, pr-fast receipt, diff check |
-| 3 | `chore/msrv-rust-1.95` | Raise MSRV/toolchain/config/workflow pins to Rust 1.95.0; no release bump. | Rust 1.95 override, fmt, workspace check, lint policy, pr-fast receipt, diff check |
-| 4 | `policy/rust-1.95-lints` | Activate the Rust compiler lint floor. | workspace check, lint policy, pr-fast receipt |
-| 5 | `policy/clippy-rust-1.95-ratchets` | Measure and activate clean or cheap Rust 1.94/1.95 Clippy ratchets. | lint policy and workspace clippy without global `-D warnings` until debt is receipted |
-| 6 | `policy/no-test-clippy-carveouts` | Remove Clippy test unwrap carveout and add fallible test helper path. | targeted checks for the touched helper crate plus lint policy |
-| 7 | `policy/no-panic-exact-identity` | Harden no-panic matching by exact counted identity and introduce the no-panic checker command. | Existing proof: `cargo check -p xtask --locked`, `cargo test -p xtask --locked`, `git diff --check`; new proof after this step adds it: exact no-panic matcher tests plus `cargo xtask check-no-panic-family` smoke |
-| 8 | `policy/no-panic-baseline` | Add generated no-panic baseline and no-new-debt mode. | baseline reset, no-panic family check, xtask no-panic tests, diff check |
-| 9 | `policy/no-panic-diagnostics` | Improve no-panic diagnostics. | xtask no-panic tests, no-panic family check, report existence |
-| 10 | `policy/non-rust-file-ledger` | Add non-Rust file allowlist ledger; no enforcement yet. | TOML parse check and `cargo check -p xtask --locked` |
-| 11 | `policy/check-file-policy` | Add inventory, proposal, and file-policy checker commands. | Existing proof: `cargo check -p xtask --locked`, `cargo test -p xtask --locked`, `git diff --check`; new proof after this step adds them: file-policy tests plus inventory, proposal, and advisory checker smoke |
-| 12 | `policy/file-companion-ledgers` | Add generated, executable, dependency, workflow, process, and network ledgers. | advisory companion policy checks and `policy-report` |
-| 13 | `ci/policy-gate-wiring` | Wire policy checks into gate receipts. | file-policy gate receipt and receipt validation |
-| 14 | `ci/ripr-and-mutation-routing` | Tune ripr routing and keep mutation off normal PRs. | CI plan dry run where available and diff check |
-| 15 | `refactor/rust-1.95-ast-cleanups` | Apply targeted Rust 1.95 API cleanup in AST/LSP paths. | targeted parser, semantic, LSP tests; targeted clippy; no-panic family; diff check |
-| 16 | `policy/clippy-default-surface-cleanup` | Clean strict lint debt in parser, semantic, and LSP default surface. | lint policy, clippy exceptions, workspace clippy |
-| 17 | `policy/no-panic-first-burndown` | Burn down one narrow no-panic owner lane. | touched-crate tests, no-panic family check, baseline refresh that only drops disappeared entries |
-| 18 | `ci/learned-lem-estimates` | Use CI actuals to calibrate PR Plan LEM estimates. | plan JSON shows `estimate_source`, summaries compare static vs learned, static fallback remains |
-| 19 | `release/0.14.0-prep-rust-1.95` | Prepare 0.14.0 release surfaces. | workspace check, lint/file/no-panic policy checks, pr-fast receipt, diff check |
-| 20 | `release/0.14.0-dry-run` | Prove package/publish readiness before tagging. | package dry run, pr-fast receipt, policy checks, release readiness docs |
-
-## Bot, CI, and self-review loop
-
-For each PR, inspect the current check and review state before claiming green:
-
-```bash
-gh pr view <PR> --json statusCheckRollup,reviewDecision,mergeStateStatus
-gh pr checks <PR> --watch
-```
-
-If CI fails:
-
-```bash
-gh run view <run-id> --log-failed
-```
-
-Then identify the first real failing command, reproduce locally if possible, fix
-only that failure, rerun the matching local gate, push, and check bot comments
-again. Bot comments should be treated as follows: fix real defects, answer false
-positives with evidence, fix cheap in-scope style comments, defer out-of-scope
-requests with a follow-up, and mark stale comments only after verifying current
-HEAD.
-
-Every rollout PR should self-review before it is marked ready:
-
-```markdown
-## Self-review
-
-- Scope matches PR title:
-- Files touched are expected:
-- No unrelated cleanup:
-- Policy changes are intentional:
-- No Clippy test carveouts added:
-- No bare `#[allow(clippy::...)]` added:
-- No-panic baseline handling is scoped:
-- Non-Rust allowlist changes are narrow:
-- CI/ripr/LEM behavior matches docs:
-- Local validation:
-- CI status:
-- Bot comments addressed:
-- Follow-ups:
-```
-
-If any item is not true, do not merge.
+The original 20-step Rust-1.93-framed ladder previously hosted at this
+path has been folded into the canonical roadmap with current branch /
+issue / objective / acceptance-contract data per row. If you arrived
+here via an older commit hash or stale link, follow the link above.

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -1,0 +1,201 @@
+# Test Evidence Lanes
+
+Defines the **evidence-lane shapes** that perl-lsp's CI organises tests
+into: which kinds of tests run on which trigger, with what bound, and
+why. The point is to make the cost / signal trade-off explicit so a
+contributor can predict which lane fires for their change without
+reading every workflow YAML.
+
+This doc pairs with:
+
+- [`ci-lane-map.md`](ci-lane-map.md) — the per-workflow inventory.
+- [`../../policy/ci-lanes.toml`](../../policy/ci-lanes.toml) — the
+  machine-readable lane policy.
+- [`../../policy/ci-risk-packs.toml`](../../policy/ci-risk-packs.toml)
+  — path-pattern → label/lane auto-routing.
+- [`lem-budgeting.md`](lem-budgeting.md) — cost model.
+- [`ripr.md`](ripr.md) — the static oracle-gap detector that sits
+  between coverage and runtime mutation testing.
+
+## Doctrine
+
+Test evidence is a spend-vs-signal trade. Different test families
+warrant different cadences:
+
+| Test family | Default cadence | Why |
+|---|---|---|
+| Unit + workspace lib tests | every PR | Cheapest signal per minute. Catch most regressions. |
+| Bounded smoke (acceptance-flavoured but capped) | every PR | Constant-cost-per-PR signal that the user-flow surface still works end-to-end. Specifically *not* a full sweep. |
+| Broad acceptance / property / fuzz / BDD matrix | label-gated **or** nightly cron | Real evidence but expensive; only fire when a reviewer explicitly asks (`bdd`, `property-tests`, `fuzz`, `full-ci`) or on the scheduled cron. |
+| Mutation testing | targeted PR (`mutation` label) **or** nightly cron **or** release readiness | High-cost runtime evidence; never default-PR. |
+| `ripr` (static oracle-gap) | every Rust-diff PR | Cheap static substitute that surfaces "this changed line is not exercised by any test that could discriminate behavior." Advisory only. |
+| Coverage | push to `master`, label-gated PR (`coverage`), workflow_dispatch | Codecov upload is push-billed; on-demand for PRs. |
+
+The doctrine, repeated from sibling-repo CI economics:
+
+> **`ripr` is the PR-time static oracle-exposure filter; it is not a
+> replacement for mutation testing. Mutation remains runtime evidence
+> for targeted PRs, nightly lanes, and release readiness.**
+
+## Lane shapes
+
+### 1. PR-fast required
+
+Runs on every PR. Blocks merge. Constant per-PR cost.
+
+Includes (this set evolves; consult `ci-lane-map.md` for the current
+inventory):
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --lib --no-deps -- -D warnings`
+- `cargo clippy --workspace --all-targets --no-deps -- -D warnings -A missing_docs`
+- Workspace unit + lib tests for at least `perl-lsp-rs --lib`.
+- The bounded UX scenario smoke (e.g. `ux_scenario_14_inc_conformance`).
+- `cargo xtask check-lint-policy` and any other `cargo xtask check-*`
+  ledger gates that have shipped at the time of the PR (the
+  per-checker set grows as ledger PRs land; see
+  [`../development/RUST_1_95_PROACTIVE_GUARDS.md`](../development/RUST_1_95_PROACTIVE_GUARDS.md)
+  for the planned guards rail).
+- `cargo deny check` (if wired into the canonical CI workflow).
+- `ripr` advisory lane.
+
+The bound matters as much as the inclusion: PR-fast lanes have a
+**capped** cost. A 30-minute property sweep does not belong here; a
+30-second bounded smoke does.
+
+### 2. PR-targeted (label-gated)
+
+Runs only when a reviewer applies the routing label. The matching
+risk-pack in [`../../policy/ci-risk-packs.toml`](../../policy/ci-risk-packs.toml)
+may auto-apply the label based on changed paths (e.g. `parsers-serde`
+risk-pack auto-applies `fuzz` when a fuzz target or `*_parse.rs` file
+changes).
+
+| Label | Lane it activates |
+|---|---|
+| `bdd` | broader BDD scenarios in `bdd-testing.yml` (full matrix). |
+| `property-tests` | broad property sweep in `property-testing.yml` (high case-count). |
+| `fuzz` | quick-fuzz across all parser surfaces in `fuzzing.yml`. |
+| `mutation` | targeted mutation testing in `mutation-testing.yml` (scoped to touched risk-pack). |
+| `coverage` | `coverage.yml` Codecov upload on PR. |
+| `security-audit` | standalone `cargo-deny` in `ci-security.yml` (also fires on push-main + weekly cron). |
+| `full-ci` | "spend authorization": activates every label-gated lane on a single PR. Reviewer signs off on the cost. |
+
+### 3. Nightly cron
+
+Runs on schedule regardless of PRs. Full sweeps, expensive evidence,
+canary lanes.
+
+- Full property-test sweep (256+ cases per crate).
+- Full fuzz matrix at extended budget.
+- Full mutation sweep across trust surfaces.
+- Coverage on `master` (`coverage.yml`).
+- `ci-nightly.yml` for any other long-running canary.
+
+The point of nightly: surface regressions that the bounded PR-fast
+smoke misses, without billing every PR for the full sweep.
+
+### 4. Release-only (tag-triggered)
+
+Runs only when a `v*` tag is pushed or `release.yml` is dispatched.
+
+- Multi-platform release builds (Linux / macOS x86_64 + arm64 / Windows).
+- `cargo package --locked` proof.
+- `cargo publish --dry-run` on the foundation crate (the rest of the
+  publish chain dry-runs interleaved with the actual publish, since
+  each non-foundation crate needs the prior crate on crates.io before
+  its dry-run resolves).
+- Install-smoke against the published artifact.
+- Crates.io publish in dependency order (owner-gated).
+
+See [`../release/RUNBOOK.md`](../release/RUNBOOK.md) for the
+end-to-end release execution flow.
+
+### 5. Advisory
+
+Lanes that emit signal but **never block merge**. A reviewer reads
+their findings and treats them as input to judgement.
+
+- `ripr` (static oracle-gap detection).
+- Bot review lanes: `droid-review`, `tokmd`, `CodeRabbit` if active.
+- `pr-plan` LEM forecast.
+- `methodology-gate` (currently advisory pending its own ratchet).
+
+The reviewer's job is to weight advisory output against the change's
+risk surface and the matching risk-pack. A `ripr` finding on a
+parser-touching PR is more load-bearing than the same finding on a
+docs-only PR.
+
+## Risk-pack auto-routing
+
+Risk packs in [`../../policy/ci-risk-packs.toml`](../../policy/ci-risk-packs.toml)
+map changed-path patterns to labels and lanes. Applying a label is a
+human reviewer's job; the *suggestion* of which label to apply comes
+from the matching risk pack(s).
+
+Example: a PR touching `crates/perl-parser-pest/` matches the
+hypothetical `parsers-serde` risk-pack, which surfaces `fuzz` as the
+recommended label. The reviewer can:
+
+- Apply `fuzz` → activates the quick-fuzz lane.
+- Apply `full-ci` → activates every recommended lane plus the broad ones.
+- Apply nothing → the PR runs only PR-fast required lanes.
+
+The risk-pack model is **advisory** at the PR level. The
+[`RUST_1_95_PROACTIVE_GUARDS.md`](../development/RUST_1_95_PROACTIVE_GUARDS.md)
+rail row PG-2 introduces a checker that verifies risk-pack references
+resolve to real lanes and real labels (currently unchecked).
+
+## Skipped-by-policy receipts
+
+When a lane skips for a particular PR, the lane must say **why** via
+the GitHub Actions step summary or the lane's emitted receipt JSON.
+Categories:
+
+| Category | When |
+|---|---|
+| `docs-only` | PR matches the docs-only risk pack and no other. |
+| `no-matching-risk-pack` | The lane is opt-in via risk pack; no risk pack on this PR selects it. |
+| `label-absent` | Lane is opt-in via label; the label is not present. |
+| `nightly-only` | Lane runs only on cron. |
+| `release-only` | Lane runs only on tag push. |
+| `ripr-waived` | A `ripr-waive` label suppressed advisory output for this PR (when wired). |
+| `duplicate` | The lane's intent is already produced by another lane on this PR (e.g. standalone `cargo-deny` when `ci.yml` already ran it). |
+
+The PG-5 row in
+[`RUST_1_95_PROACTIVE_GUARDS.md`](../development/RUST_1_95_PROACTIVE_GUARDS.md)
+adds a CI Actuals emitter that records skip categories in a
+machine-readable receipt.
+
+## Cost framing
+
+LEM (Linux Equivalent Minutes) is the unit; see
+[`lem-budgeting.md`](lem-budgeting.md) for the model. The PR plan
+([`pr-plan.yml`](../../.github/workflows/pr-plan.yml) +
+[`../../policy/ci-budget.toml`](../../policy/ci-budget.toml)) forecasts
+the spend for each lane the PR would activate.
+
+Tiers:
+
+- `preferred_default_lem` — the spend a docs-only or fixture-only PR
+  expects.
+- `default_limit_lem` — soft ceiling for a normal PR; the plan warns
+  past this without `ci-budget-ack`.
+- `elevated_limit_lem` — ceiling for label-elevated PRs; requires
+  `ci-budget-override`.
+- `hard_limit_lem` — emergency ceiling; requires `full-ci` (which
+  implies override).
+
+These are advisory in the current rollout. Hard enforcement is the
+C-LL row in
+[`../development/RUST_1_95_ROLLOUT.md`](../development/RUST_1_95_ROLLOUT.md)
+(learned LEM, actuals-backed calibration).
+
+## See also
+
+- [`ci-lane-map.md`](ci-lane-map.md) — per-workflow inventory.
+- [`../development/RUST_1_95_ROLLOUT.md`](../development/RUST_1_95_ROLLOUT.md) — the remaining-roadmap canonical doc.
+- [`../development/RUST_1_95_PROACTIVE_GUARDS.md`](../development/RUST_1_95_PROACTIVE_GUARDS.md) — proactive integrity guards rail (PG-1..PG-6 includes the lane mapping + actuals coverage checkers that keep this doc honest).
+- [`lem-budgeting.md`](lem-budgeting.md) — LEM cost model.
+- [`ripr.md`](ripr.md) — `ripr` static oracle-gap lane doctrine.
+- [`../release/RUNBOOK.md`](../release/RUNBOOK.md) — release execution.

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -1,104 +1,340 @@
-# Rust 1.95 / Next-Minor Rollout
+# Rust 1.95 → 0.14.0 Remaining Roadmap
 
-> **Companion to** [`docs/ci/perl-lsp-rust-1.95-rollout.md`](../ci/perl-lsp-rust-1.95-rollout.md).
-> That doc is the **initial rollout plan** (historical, planned-from-1.93
-> framing). This doc is the **post-landing improvement spec** — what's
-> remaining now that MSRV / toolchain / `clippy.toml`-msrv have shipped
-> (#8509). Each row in the ladder below is an agent-actionable spec; a
-> haiku scout can file it as a GitHub issue and a sonnet builder can
-> implement it without re-discovering the call sites.
-
-Continuation of the Rust 1.93 → 1.95 quality control plane. This doc tracks
-both the ratchet (what already landed) and the remaining ladder (what's
-next), so subsequent PRs do **one thing**.
+> **Canonical post-landing source of truth** for the Rust 1.95 / 0.14.0
+> quality rollout. The MSRV / toolchain / `clippy.toml`-msrv bumps have
+> shipped (#8509); this doc tracks what remains from here to the 0.14.0
+> release tag.
+>
+> The historical Rust-1.93-framed plan lives at
+> [`docs/ci/perl-lsp-rust-1.95-rollout.md`](../ci/perl-lsp-rust-1.95-rollout.md)
+> and now delegates to this doc.
+>
+> Sibling rails:
+> - [`STRONG_CLIPPY_LINTS_ROLLOUT.md`](STRONG_CLIPPY_LINTS_ROLLOUT.md) —
+>   strong-clippy-lints activation rail (umbrella #8590).
+> - [`RUST_1_95_PROACTIVE_GUARDS.md`](RUST_1_95_PROACTIVE_GUARDS.md) —
+>   proactive CI integrity guards rail (umbrella #8662).
+>
+> Umbrella for this consolidation: **#8663**.
 
 > Doctrine, repeated from the cross-repo CI economics plan:
 > **`ripr` is the PR-time static oracle-exposure filter; it is not a
 > replacement for mutation testing. Mutation remains runtime evidence
 > for targeted PRs, nightly lanes, and release readiness.**
 
-## Current vs target
+The doc has four sections:
 
-| Layer                        |                         Current |                          Target | Status                 |
-| ---------------------------- | ------------------------------: | ------------------------------: | ---------------------- |
-| Edition                      |                       Rust 2024 |                       Rust 2024 | done                   |
-| Workspace MSRV               |                          1.95.0 |                          1.95.0 | done (#8509)           |
-| Toolchain                    |                          1.95.0 |                          1.95.0 | done (#8509)           |
-| `clippy.toml` `msrv`         |                            1.95 |                            1.95 | done (#8509)           |
-| Workspace clippy allow set   |                       5 entries |                       0 entries | in flight (#8538 +)    |
-| `clippy.toml` test carveouts | `allow-unwrap-in-tests = true`  |                         removed | todo (PR T-1 below)    |
-| Workspace lints — rustc      | `unsafe_op_in_unsafe_fn = deny` |       broader 1.95 lint floor   | partial (PR R-1 below) |
-| No-panic policy infra        |                          absent |     exact-identity baseline     | todo (PR N-series)     |
-| Non-Rust file policy         |    `policy/non-rust-allowlist.toml` present, broad |        tightened + reviewed     | partial                |
-| CI lane whitelist / LEM      |                         present |             Rust 1.95 budgeted  | partial                |
-| Release line                 |                          0.13.4 |             next minor (TBD)    | planned (PR R-prep)    |
+1. [Already landed](#1-already-landed) — the current state facts and what shipped.
+2. [Remaining implementation ladder](#2-remaining-implementation-ladder) — single canonical PR list.
+3. [Per-rail acceptance contracts](#3-per-rail-acceptance-contracts) — objective / files / commands / forbidden / merge rule / follow-up per row.
+4. [Claude / Codex operating contract](#4-claude--codex-operating-contract) — how each PR in this rollout is shaped.
 
-## What already landed
+---
 
-The `@INC` rail wrapped up while the Rust 1.95 bump was being staged. The
-ratchet so far:
+## 1. Already landed
 
-| PR    | Effect |
-| ----- | ------ |
-| #8509 | Toolchain → 1.95.0; MSRV → 1.95; `clippy.toml` msrv → 1.95; nine 1.94/1.95 lints added to workspace allowlist with `priority = 1`. |
+### Current state facts (truth sources)
+
+| Surface | Live value | Source file |
+|---|---|---|
+| Workspace edition | `2024` | [`Cargo.toml`](../../Cargo.toml) |
+| Workspace MSRV (`rust-version`) | `1.95` | [`Cargo.toml`](../../Cargo.toml) |
+| Workspace version | `0.13.4` | [`Cargo.toml`](../../Cargo.toml) |
+| Pinned toolchain channel | `1.95.0` | [`rust-toolchain.toml`](../../rust-toolchain.toml) |
+| `clippy.toml` `msrv` | `"1.95"` | [`clippy.toml`](../../clippy.toml) |
+| `clippy.toml` `allow-unwrap-in-tests` | `true` ← **debt** | [`clippy.toml`](../../clippy.toml) |
+| `policy/clippy-lints.toml` `msrv` | `"1.93"` ← **stale, see M-1** | [`policy/clippy-lints.toml`](../../policy/clippy-lints.toml) |
+| Workspace clippy allow set | 5 entries (`collapsible_match`, `manual_range_contains`, `useless_vec`, `vec_init_then_push`, `assertions_on_constants`) | `[workspace.lints]` in [`Cargo.toml`](../../Cargo.toml) |
+| `ripr` lane | advisory; never blocking on PR | [`.github/workflows/ripr.yml`](../../.github/workflows/ripr.yml) + [`docs/ci/ripr.md`](../ci/ripr.md) |
+| Mutation testing | targeted / nightly / release only; **not** default-PR | [`.github/workflows/`](../../.github/workflows/) + LEM ledgers |
+| Release line | `0.13.4`, with `0.14.0` reserved as the **quality posture release vehicle** (not just MSRV bump) | [`CHANGELOG.md`](../../CHANGELOG.md) |
+
+### Ratchet so far
+
+The `@INC` rail wrapped up while the Rust 1.95 bump was being staged.
+The lint-debt burn-down progressed in parallel:
+
+| PR | Effect |
+| --- | ------ |
+| #8509 | Toolchain → 1.95.0; MSRV → 1.95; `clippy.toml` msrv → 1.95; nine 1.94 / 1.95 lints added to workspace allowlist with `priority = 1`. |
 | #8511 | Cleaned 10 `unnecessary_sort_by` sites in `perl-{parser,refactoring}`. |
 | #8520 | Removed `unnecessary_sort_by` workspace allow; fixed remaining site in `perl-lsp-rs/cli.rs`. |
 | #8521 | Removed `useless_conversion` workspace allow. |
 | #8522 | Removed `manual_checked_ops` workspace allow; fix in `runtime/workspace_progress.rs` (`checked_div`). |
-| #8523 | Fixed `unnecessary_sort_by` in xtask `parser_stats.rs` (caught after #8511's lib-only survey). |
-| #8538 | Removes `while_let_loop` workspace allow; refactored `selection_range.rs` `loop` → `while let`. |
+| #8523 | Fixed `unnecessary_sort_by` in xtask `parser_stats.rs`. |
+| #8538 | Removed `while_let_loop` workspace allow; refactored `selection_range.rs` `loop` → `while let`. |
+| #8590 | Strong-clippy-lints umbrella issue (rows #8601–#8611). |
+| #8657 / #8658 | NON_RUST_LADDER doc; file-policy companion docs. |
+| #8661 | Proactive-guards rail doc (#8662 umbrella). |
+| #8663 | This consolidation (current PR). |
 
-After #8538 lands, the workspace allow set is **5 entries**: `collapsible_match`,
-`manual_range_contains`, `useless_vec`, `vec_init_then_push`, `assertions_on_constants`.
+### Existing policy / CI substrate (don't rebuild)
 
-## Remaining PR ladder
+- `policy/ci-lanes.toml`, `policy/ci-risk-packs.toml`, `policy/ci-budget.toml`, `policy/ci-exceptions.toml`, `policy/ci-lane-whitelist.toml`, `policy/ci-non-rust-allowlist.toml` — CI policy ledgers.
+- `policy/clippy-lints.toml`, `policy/clippy-debt.toml` — Clippy ledgers.
+- `xtask check-lint-policy` — Clippy ledger gate.
+- 39 GitHub workflows under `.github/workflows/` covering PR plan, methodology gate, ripr advisory, ci-gate-self-tests, post-merge ratchets, droid review, release orchestration, etc.
 
-Each row is one PR. Branch from clean `origin/master`. Do **not** combine.
+---
 
-| #     | Tracking                          | Branch                                          | Title                                                            | Notes                                                 |
-| ----- | --------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------- |
-| C-1   | [#8561](https://github.com/EffortlessMetrics/perl-lsp/issues/8561) | `chore/clippy-collapsible-match`                | `chore(clippy): clean collapsible_match` + remove workspace allow | 3 lib sites (`perl-regex`, `perl-pragma`, `perl-parser-pest`) |
-| C-2   | [#8562](https://github.com/EffortlessMetrics/perl-lsp/issues/8562) + [#8559](https://github.com/EffortlessMetrics/perl-lsp/issues/8559) | `chore/clippy-test-only-allows`                 | `chore(clippy): remove useless_vec / vec_init_then_push / assertions_on_constants allows` | Test-code cleanup; replaces `assert!(false, …)` with `panic!(…)` in test files that already allow `clippy::panic`. #8559 covers the `assertions_on_constants` subset; #8562 covers `useless_vec` + `vec_init_then_push`. |
-| C-3   | [#8563](https://github.com/EffortlessMetrics/perl-lsp/issues/8563) | `chore/clippy-manual-range-contains`            | `chore(clippy): clean manual_range_contains in perl-ci-hygiene`  | The single remaining surface; may also need `expect_used` cleanup in the same crate |
-| T-1   | [#8564](https://github.com/EffortlessMetrics/perl-lsp/issues/8564) | `policy/clippy-test-carveout`                   | `policy(clippy): remove allow-unwrap-in-tests carveout`          | `clippy.toml` removes `allow-unwrap-in-tests = true`; verify tests already use `must_some` / fallible helpers |
-| R-1   | [#8565](https://github.com/EffortlessMetrics/perl-lsp/issues/8565) | `policy/rust-1.95-rustc-floor`                  | `policy(rust): tighten workspace rustc lint floor`               | Promote `unexpected_cfgs` to `warn`, add `unused_must_use = "deny"` (verify it's not already), survey other 1.95 stabilizations worth denying. Clippy lint activations beyond 1.95 deweighting are split into the **strong-clippy-lints** rail — see [`STRONG_CLIPPY_LINTS_ROLLOUT.md`](STRONG_CLIPPY_LINTS_ROLLOUT.md) (umbrella #8590, rows #8601-#8611). |
-| N-1   | [#8567](https://github.com/EffortlessMetrics/perl-lsp/issues/8567) | `policy/no-panic-design`                        | `docs/policy(panic): design no-panic exact-identity baseline`    | Docs-only — defines `path + family + selector_kind + selector_callee + snippet + count` identity; describes baseline file format + matching rules. No code yet. |
-| N-2   | [#8569](https://github.com/EffortlessMetrics/perl-lsp/issues/8569) | `feat/no-panic-xtask`                           | `feat(xtask): no-panic baseline + check command`                 | `cargo xtask check-no-panic-family` reads `policy/no-panic-baseline.toml` + `policy/no-panic-allowlist.toml`; advisory mode first |
-| N-3   | [#8571](https://github.com/EffortlessMetrics/perl-lsp/issues/8571) | `policy/no-panic-baseline-init`                 | `policy(panic): generate no-new-debt baseline`                   | Run once from clean `master`; `mode = "no-new-debt"`; `.gitattributes` marks baseline `linguist-generated`; **only baseline PR** |
-| F-1   | [#8574](https://github.com/EffortlessMetrics/perl-lsp/issues/8574) | `policy/file-allowlist-tightening`              | `policy(files): narrow non-rust-allowlist coverage`              | Remove stale entries; narrow broad globs; add `review_after` where supported; surface shader/FFI/WASM explicitly |
-| RP-1  | [#8576](https://github.com/EffortlessMetrics/perl-lsp/issues/8576) | `release/next-minor-prep`                       | `release: prepare next minor for Rust 1.95`                      | Version decision (see below); CHANGELOG; release evidence doc |
-| RP-2  | [#8579](https://github.com/EffortlessMetrics/perl-lsp/issues/8579) | `release/next-minor-dry-run`                    | `release: validate publish readiness`                            | `cargo package --locked`, `cargo publish --dry-run`, evidence receipt under `docs/release/` |
+## 2. Remaining implementation ladder
 
-## Version decision (for PR RP-1)
+Each row is one PR. Branch from clean `origin/master`. **Do not combine.**
+Rows are independent unless a `Depends on` cell says otherwise.
 
-Current package version is `0.13.4`. The full project Cargo.toml lineage
-suggests the next user-facing release after the MSRV bump should be a
-**minor** bump (semver: raising MSRV is user-visible).
+| # | Issue | Branch | Title | Lane |
+|---|---|---|---|---|
+| M-1 | (file new) | `policy/clippy-lints-msrv-reconcile` | `policy(clippy): reconcile policy/clippy-lints.toml msrv to 1.95` | reconcile-toolchain (one-line fix; unblocks `cargo xtask check-lint-policy` on `master`) |
+| C-1 | [#8561](https://github.com/EffortlessMetrics/perl-lsp/issues/8561) | `chore/clippy-collapsible-match` | `chore(clippy): clean collapsible_match` + remove workspace allow | clippy allow-set burn-down |
+| C-2 | [#8562](https://github.com/EffortlessMetrics/perl-lsp/issues/8562) + [#8559](https://github.com/EffortlessMetrics/perl-lsp/issues/8559) | `chore/clippy-test-only-allows` | `chore(clippy): remove useless_vec / vec_init_then_push / assertions_on_constants allows` | clippy allow-set burn-down |
+| C-3 | [#8563](https://github.com/EffortlessMetrics/perl-lsp/issues/8563) | `chore/clippy-manual-range-contains` | `chore(clippy): clean manual_range_contains in perl-ci-hygiene` | clippy allow-set burn-down |
+| T-1 | [#8564](https://github.com/EffortlessMetrics/perl-lsp/issues/8564) | `policy/clippy-test-carveout` | `policy(clippy): remove allow-unwrap-in-tests carveout` | no-test-carveouts |
+| R-1 | [#8565](https://github.com/EffortlessMetrics/perl-lsp/issues/8565) | `policy/rust-1.95-rustc-floor` | `policy(rust): tighten workspace rustc lint floor` | rustc-floor |
+| SCL-* | [#8601–#8611](https://github.com/EffortlessMetrics/perl-lsp/issues/8590) | (per-lint branches) | strong-clippy-lint activations (Tier 1–3) | strong-clippy (sibling rail; see `STRONG_CLIPPY_LINTS_ROLLOUT.md`) |
+| DF-1 | (file new) | `docs/clippy-disallowed-fields-seams` | `docs(clippy): define protected-field seams for disallowed_fields` | disallowed-fields prep (mirrors sibling-repo doc pattern) |
+| DF-2 | (file new) | `policy/clippy-protected-fields-scaffold` | `policy(clippy): add policy/clippy-protected-fields.toml ledger` | disallowed-fields prep |
+| DF-3 | (file new) | `refactor/cache-internals-accessors` | `refactor(cache): introduce accessors for the cache-internals seam` | disallowed-fields prep (smallest-class refactor) |
+| DF-4 | (file new) | `policy/clippy-disallowed-fields-activate-cache` | `policy(clippy): activate disallowed_fields for cache-internals seam` | first disallowed-fields slice |
+| N-1 | [#8567](https://github.com/EffortlessMetrics/perl-lsp/issues/8567) | `policy/no-panic-design` | `docs/policy(panic): design no-panic exact-identity baseline` | no-panic |
+| N-2 | [#8569](https://github.com/EffortlessMetrics/perl-lsp/issues/8569) | `feat/no-panic-xtask` | `feat(xtask): no-panic baseline + check command` | no-panic |
+| N-3 | [#8571](https://github.com/EffortlessMetrics/perl-lsp/issues/8571) | `policy/no-panic-baseline-init` | `policy(panic): generate no-new-debt baseline` | no-panic |
+| F-1 | [#8574](https://github.com/EffortlessMetrics/perl-lsp/issues/8574) | `policy/file-allowlist-tightening` | `policy(files): narrow non-rust-allowlist coverage` | file-policy |
+| PG-1..PG-6 | [#8662](https://github.com/EffortlessMetrics/perl-lsp/issues/8662) | (per-row branches) | proactive integrity guards (label enforcement, risk-pack referential integrity, lane mappings, workflow-allowlist, ci-actuals coverage, broad-glob justification) | proactive-guards (sibling rail; see `RUST_1_95_PROACTIVE_GUARDS.md`) |
+| C-CI | (file new) | `ci/policy-gate-wiring` | `ci: wire policy checkers into a Policy gates job` | ci-policy-wiring (consolidates all the `cargo xtask check-*` calls into one CI job) |
+| C-RM | (file new) | `ci/ripr-and-mutation-routing` | `ci: tighten ripr routing + confirm mutation off normal PRs` | ci-routing |
+| C-AC | (file new) | `refactor/rust-1.95-ast-ast-cleanups` | `refactor(rust-1.95): targeted API cleanup in AST / LSP paths` | rust-1.95-api-cleanup (behavior-preserving only) |
+| C-LL | (file new) | `ci/learned-lem-estimates` | `ci: use CI actuals to calibrate PR Plan LEM` | lem-calibration |
+| RP-1 | [#8576](https://github.com/EffortlessMetrics/perl-lsp/issues/8576) | `release/0.14.0-prep` | `release: prepare 0.14.0` | release-prep |
+| RP-2 | [#8579](https://github.com/EffortlessMetrics/perl-lsp/issues/8579) | `release/0.14.0-dry-run` | `release: validate publish readiness` | release-prep |
 
-Two cases:
+**Sequencing recommendation** (smallest-first; surface the easy wins):
 
-| Case                                                | Version move          |
-| --------------------------------------------------- | --------------------- |
-| `0.14.x` has not actually shipped                   | `0.13.4 → 0.14.0`     |
-| `0.14.0` already shipped or is reserved             | `0.13.4 → 0.15.0`     |
+```text
+M-1 → T-1 (or one of C-1/C-2/C-3) → PG-6 → R-1 → C-CI → N-1 → DF-1
+   → (then mid-weight rows) PG-1/PG-2/PG-3 → N-2 → DF-2
+   → (heavier rows)         PG-4/PG-5 → DF-3 → DF-4 → N-3 → F-1
+   → C-RM → C-AC → C-LL → RP-1 → RP-2
+```
 
-Reconcile against `CHANGELOG.md` and any git tag named `v0.14.*` before
-choosing. Document the decision in the PR body.
+Adjust as issues are triaged. The point is **no row blocks the next**
+unless its acceptance contract explicitly says so.
 
-## What Rust 1.95 buys us in this repo
+---
 
-| Rust 1.95 item                  | perl-lsp use                                                                                                |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `if let` guards                 | Provider dispatch, parser route selection, `EffectiveIncContext` lane selection, completion fixture routing |
-| `Vec::push_mut` / `insert_mut`  | Receipt builders, diagnostic vec builders, status/scorecard report assembly                                 |
-| Atomic `update` / `try_update`  | Runtime metrics, once-warn counters, cancellation flags                                                     |
-| `cfg_select!`                   | Platform-specific paths in `perl-uri`, `perl-subprocess-runtime`, Windows-vs-POSIX in `fetch_perl_inc`      |
-| `cold_path`                     | Diagnostic-emit paths, `unreachable!` substitutes, parser error-recovery branches                           |
-| Clippy 1.95                     | `manual_checked_ops` (done), `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, others surveyed in #8508 |
+## 3. Per-rail acceptance contracts
 
-Use these where they reduce review load or close a small lint debt. **Behavior-preserving only** in this rollout — feature-bearing uses get their own PR per usual.
+Each contract has the same six fields. Where a contract is identical
+to a sibling-rail doc, the contract cell references that doc.
 
-## Acceptance gates (every PR)
+### M-1: reconcile policy/clippy-lints.toml msrv
+
+| Slot | Value |
+|---|---|
+| Objective | Fix `cargo xtask check-lint-policy` failing on `master` (`workspace.package.rust-version (1.95) must match policy/clippy-lints.toml msrv (1.93)`). |
+| Files expected | `policy/clippy-lints.toml` (one-line bump). |
+| Commands | `cargo xtask check-lint-policy`; `git diff --check`. |
+| Forbidden scope | Cargo.toml, rust-toolchain.toml, clippy.toml, workflows, Rust source. |
+| Merge rule | Green CI; one-line diff; no review needed beyond title check. |
+| Follow-up | None. After this lands, the lint policy gate proves itself on every subsequent PR. |
+
+### C-1, C-2, C-3: clippy allow-set burn-down
+
+| Slot | Value |
+|---|---|
+| Objective | Remove one workspace clippy allow entry per PR by fixing the call sites it suppresses. |
+| Files expected | One or more `crates/perl-*/src/**/*.rs` files; `Cargo.toml` allow-set entry removal. |
+| Commands | `cargo clippy --workspace --lib --no-deps -- -D warnings`; `cargo test` for touched crates; `git diff --check`. |
+| Forbidden scope | Multiple lints in one PR; unrelated cleanup; new `#[allow(clippy::*)]` (use `#[expect(..., reason = "policy:...")]` if absolutely needed). |
+| Merge rule | Green CI; one lint per PR; no allow-entry resurrection. |
+| Follow-up | Next C-* row. |
+
+### T-1: remove allow-unwrap-in-tests carveout
+
+| Slot | Value |
+|---|---|
+| Objective | Remove `allow-unwrap-in-tests = true` from `clippy.toml`. Verify tests already use `must_some` / fallible helpers (any remaining `.unwrap()` in tests is a finding to fix in this PR). |
+| Files expected | `clippy.toml`; possibly tests where `.unwrap()` needs replacement. |
+| Commands | `cargo clippy --workspace --all-targets --no-deps -- -D warnings -A missing_docs`; `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib`. |
+| Forbidden scope | New test carveouts; broad refactor in tests beyond `.unwrap()` → fallible replacement. |
+| Merge rule | Green CI; `clippy.toml` shows the carveout removed. |
+| Follow-up | Strong-clippy rail can now include test-targeted lints. |
+
+### R-1: tighten workspace rustc lint floor
+
+| Slot | Value |
+|---|---|
+| Objective | Promote `unexpected_cfgs` to `warn`; add `unused_must_use = "deny"` if not already; survey other 1.95 stabilizations worth denying. |
+| Files expected | `Cargo.toml` `[workspace.lints]` block. |
+| Commands | `cargo clippy --workspace --lib --no-deps -- -D warnings`; full CI. |
+| Forbidden scope | Clippy lint activations beyond 1.95 deweighting (those belong to the strong-clippy rail). |
+| Merge rule | Green CI. |
+| Follow-up | Sibling strong-clippy rail rows (#8601–#8611). |
+
+### SCL-*: strong-clippy lint activations
+
+Defer to [`STRONG_CLIPPY_LINTS_ROLLOUT.md`](STRONG_CLIPPY_LINTS_ROLLOUT.md) — that doc has per-row acceptance contracts.
+
+### DF-1: define protected-field seams
+
+| Slot | Value |
+|---|---|
+| Objective | Document the protected field classes that `clippy::disallowed_fields` will eventually enforce (redaction internals, bundle paths, trust receipts, source opaque IDs, cache internals, policy ledger metadata) with invariant / boundary / today's surface / failure-mode per class. Doc only; no lint activation. |
+| Files expected | `docs/CLIPPY_PROTECTED_FIELDS.md` (new); `docs/CLIPPY_POLICY.md` (See-also cross-link); `policy/clippy-lints.toml` `[[planned]] disallowed_fields` `reason` field update. |
+| Commands | `cargo xtask check-lint-policy`; `cargo xtask check-policy-schemas` (if available); `git diff --check`. |
+| Forbidden scope | `clippy.toml` change; `[lints]` workspace block change; Rust source change. |
+| Merge rule | Green CI; doc reviewable as a design anchor. |
+| Follow-up | DF-2 scaffolds the policy ledger; DF-3 refactors the first seam; DF-4 activates the lint for that one class. |
+
+### DF-2: scaffold policy/clippy-protected-fields.toml
+
+| Slot | Value |
+|---|---|
+| Objective | Add the policy ledger that lists protected fields per class, without yet wiring into `clippy.toml`. `cargo xtask check-policy-schemas` (or equivalent) accepts the new ledger header. |
+| Files expected | `policy/clippy-protected-fields.toml` (new); brief cross-link from `docs/CLIPPY_PROTECTED_FIELDS.md`. |
+| Commands | `cargo check -p xtask --locked`; `cargo xtask check-lint-policy`. |
+| Forbidden scope | `clippy.toml disallowed-fields` wiring; Rust accessor refactor. |
+| Merge rule | Green CI; ledger header validated. |
+| Follow-up | DF-3 picks the smallest class (cache internals) and adds accessors. |
+
+### DF-3, DF-4: first-class refactor + activation
+
+| Slot | Value |
+|---|---|
+| Objective | DF-3 introduces accessors for the smallest protected class (likely cache internals); DF-4 activates `clippy::disallowed_fields` for that one class via `clippy.toml`. |
+| Files expected | DF-3: `crates/shiplog-cache/...` or the local equivalent (any private-to-pub-accessor swap), focused tests asserting the accessor invariant. DF-4: `clippy.toml` disallowed-fields list; possibly `policy/clippy-exceptions.toml` if any expected sites need policy-ID'd suppressions. |
+| Commands | DF-3: `cargo clippy --workspace`; `cargo test` for touched crate; `git diff --check`. DF-4: full Clippy gate + lint policy. |
+| Forbidden scope | Activating multiple classes in one PR; bypassing the accessor refactor. |
+| Merge rule | Green CI; first run of `disallowed_fields` on this class must be `no findings` on `master`. |
+| Follow-up | Repeat for next class (redaction internals, bundle paths, etc.). |
+
+### N-1, N-2, N-3: no-panic ladder
+
+| Slot | Value |
+|---|---|
+| Objective | N-1 defines the exact-identity scheme. N-2 introduces `cargo xtask check-no-panic-family` in advisory mode reading `policy/no-panic-baseline.toml` + `policy/no-panic-allowlist.toml`. N-3 generates the no-new-debt baseline once on clean `master`. |
+| Files expected | N-1: docs only. N-2: `xtask/src/tasks/no_panic*.rs`, ledger TOMLs, tests. N-3: `policy/no-panic-baseline.toml` (generated) marked `linguist-generated` in `.gitattributes`. |
+| Commands | N-1: `cargo xtask check-lint-policy`. N-2: `cargo test -p xtask`; `cargo xtask check-no-panic-family --mode advisory`. N-3: baseline-generation command in advisory; commit baseline; rerun `--mode blocking` returns clean. |
+| Forbidden scope | Baseline reset outside N-3. Lint activation that surfaces new debt without baseline. |
+| Merge rule | N-1 + N-2 advisory must ship before N-3. |
+| Follow-up | Per-crate panic burn-downs are individual PRs after N-3. |
+
+### F-1: non-rust-allowlist tightening
+
+| Slot | Value |
+|---|---|
+| Objective | Remove stale entries from `policy/ci-non-rust-allowlist.toml`; narrow broad globs; add `review_after` where supported; surface shader/FFI/WASM explicitly. |
+| Files expected | `policy/ci-non-rust-allowlist.toml`. |
+| Commands | `cargo xtask check-lint-policy`; whatever non-rust-allowlist checker exists (advisory first). |
+| Forbidden scope | New companion ledgers (those are PG-4 territory); Rust source. |
+| Merge rule | Green CI; live file inventory still satisfied. |
+| Follow-up | PG-4 net-new workflow-allowlist ledger; PG-6 broad-glob tightening. |
+
+### PG-1 .. PG-6: proactive integrity guards
+
+Defer to [`RUST_1_95_PROACTIVE_GUARDS.md`](RUST_1_95_PROACTIVE_GUARDS.md) — that doc has per-row acceptance contracts.
+
+### C-CI: wire policy checkers into a Policy gates job
+
+| Slot | Value |
+|---|---|
+| Objective | Consolidate every `cargo xtask check-*` call into a single `Policy gates` job in `ci.yml` (or whichever workflow is canonical) so a contributor sees one pass/fail for policy compliance. Mirrors the sibling-repo pattern. |
+| Files expected | `.github/workflows/<canonical>.yml` adding a new job. |
+| Commands | `cargo xtask check-lint-policy`; any other live `check-*` commands at the time of this PR (the set grows as guard rows land). |
+| Forbidden scope | New checkers (those belong to PG-* rows); routing changes for other jobs. |
+| Merge rule | Green CI; new job reports `no findings`. |
+| Follow-up | Each subsequent guard PR adds a step to this job. |
+
+### C-RM: ripr routing + mutation lane confirmation
+
+| Slot | Value |
+|---|---|
+| Objective | Confirm `ripr.yml` triggers route docs-only / fixture-only PRs around the lane; confirm mutation testing remains gated off normal PRs (label / nightly / release only). Adjust `policy/ci-lanes.toml` and workflow `if:` blocks as needed. |
+| Files expected | `policy/ci-lanes.toml`, `policy/ci-risk-packs.toml`, `.github/workflows/ripr.yml`, `.github/workflows/mutation-testing*.yml`. |
+| Commands | `cargo xtask check-lint-policy`; PG-* guards if landed; lane-map review. |
+| Forbidden scope | Making `ripr` blocking; putting mutation on default PR. |
+| Merge rule | Green CI; ripr still advisory; mutation still off-default. |
+| Follow-up | PG-3 (lane mappings) + PG-5 (actuals coverage) keep this honest. |
+
+### C-AC: Rust 1.95 API cleanup in AST / LSP paths
+
+| Slot | Value |
+|---|---|
+| Objective | Apply behavior-preserving Rust 1.95 idioms (`if let` guards, `push_mut`, `cold_path`, etc.) in AST / parser / provider / LSP paths where they materially reduce review load. **Behavior-preserving only.** |
+| Files expected | `crates/perl-ast*/...`, `crates/perl-parser*/...`, `crates/perl-lsp-rs*/...` (focused; no broad sweep). |
+| Commands | `cargo clippy --workspace --lib --no-deps -- -D warnings`; targeted tests for touched crates; UX scenarios; `git diff --check`. |
+| Forbidden scope | Feature-bearing changes; broad refactor; combined with any policy / lint activation PR. |
+| Merge rule | Green CI; explicit "behavior preserved" claim in PR body. |
+| Follow-up | None mandatory; further cleanups are individual PRs. |
+
+### C-LL: learned LEM estimates
+
+| Slot | Value |
+|---|---|
+| Objective | Have the PR plan emit `estimate_source = "learned"` (or `"static"`) and use actuals-backed numbers when available; static fallback remains. |
+| Files expected | `xtask/src/tasks/pr_plan*.rs` (or equivalent), `policy/ci-budget.toml` if new fields. |
+| Commands | `cargo test -p xtask`; sample PR plan JSON shows the new field; CI plan dry-run if available. |
+| Forbidden scope | Hard-enforce LEM below the existing 125 LEM ceiling before calibration. |
+| Merge rule | Green CI; static fallback still works on a fresh checkout with no actuals. |
+| Follow-up | None mandatory; per-lane calibration in subsequent PRs as actuals accumulate. |
+
+### RP-1, RP-2: 0.14.0 release-prep
+
+| Slot | Value |
+|---|---|
+| Objective | RP-1 prepares 0.14.0: version bump, CHANGELOG finalization, release readiness doc. RP-2 proves `cargo package` + `cargo publish --dry-run` on all publishable crates in dependency order. |
+| Files expected | RP-1: `Cargo.toml` version bump (workspace + members as needed); `CHANGELOG.md`; `docs/release/0.14.0-readiness.md`. RP-2: dry-run receipts; release evidence doc updates. |
+| Commands | RP-1: package-version audit (whatever the local equivalent is); CHANGELOG matches version. RP-2: `cargo package --locked` per crate; `cargo publish -p <crate> --dry-run` for the foundation crate; subsequent crates need their internal deps to be on crates.io before their dry-run resolves (interleaved publish, not pre-tag gate — see `docs/release/RUNBOOK.md` and sibling-repo experience for the same constraint). |
+| Forbidden scope | Tagging; pushing crates; CI routing changes. |
+| Merge rule | RP-1: green CI + readiness doc complete. RP-2: green CI + dry-run receipts committed. |
+| Follow-up | Owner-gated: `git tag v0.14.0`; `release.yml` builds artifacts; install-smoke; crates.io publish in dependency order. |
+
+---
+
+## 4. Claude / Codex operating contract
+
+Every PR in this rollout obeys the following rules. Deviation is a
+review-blocker, not a debate.
+
+### One PR per objective
+
+- Each ladder row above is one PR. Do not bundle a lint activation
+  with a baseline reset, a release bump with an API cleanup, or a
+  policy schema change with a workflow routing change. If a row's
+  acceptance contract names two surfaces (e.g. DF-1 touches the doc
+  and the `[[planned]]` `reason` field), that's the *narrow* allowed
+  scope — anything else is a different row.
+
+### Draft first; self-review before "ready for review"
+
+- Every rollout PR opens as a **draft**.
+- Post the self-review template (below) as a PR comment **before**
+  marking ready.
+- Marking ready before CI is green is fine if the PR is awaiting bot
+  review; marking ready while a real check fails is not.
+
+### Forbidden cross-pollination
+
+- **No provider-cutover, native-tooling, Codecov, or rail-doc PRs
+  mixed in.** If your branch off `origin/master` was clean and your
+  diff stayed within the row's `Files expected` cell, this is
+  automatic.
+- **No Dependabot mixing.** Dependabot PRs land separately; they are
+  not auto-rebased into this rollout.
+- **No bare `#[allow(clippy::*)]`.** Use
+  `#[expect(..., reason = "policy:<id>")]` per
+  [`docs/CLIPPY_POLICY.md`](../CLIPPY_POLICY.md). Scoped temporary
+  debt goes in `policy/clippy-debt.toml` with `expires`.
+- **No test carveouts.** The `allow-unwrap-in-tests = true` carveout
+  is being removed in T-1; do not add new ones.
+- **No no-panic baseline reset** except in the dedicated N-3 PR.
+  Burn-down PRs may *only* drop entries that disappeared from source;
+  they do not regenerate the baseline.
+- **`ripr` advisory only.** No row in this rollout makes `ripr`
+  branch-protection blocking. Real mutation evidence lives in
+  targeted / nightly / release lanes per the doctrine quoted at the
+  top of this doc.
+
+### Acceptance gate (every PR)
 
 ```bash
 cargo fmt --all -- --check
@@ -107,36 +343,27 @@ cargo clippy --workspace --all-targets --no-deps -- -D warnings -A missing_docs
 RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib -- --test-threads=2
 RUST_TEST_THREADS=2 cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance -- --test-threads=1
 cargo xtask fmt
+cargo xtask check-lint-policy
 git diff --check
 ```
 
-Per-PR additions (e.g. policy reports) follow the existing xtask command
-names; see `xtask --help` for the current command surface.
+Per-row additions (e.g. `cargo xtask check-no-panic-family --mode advisory`
+for the N-* rows, or `cargo xtask <new-check> --mode advisory` for any
+PG-* row that adds a checker) follow the existing `xtask --help`
+surface.
 
-## Do not (per cross-repo rollout doctrine)
-
-- Combine MSRV bump, lint activation, no-panic baseline, release bump, or
-  code cleanup into one PR.
-- Weaken schemas or policy to satisfy CI.
-- Add `#[allow(clippy::...)]` suppressions without a debt-policy entry.
-- Reset a no-panic baseline outside its dedicated PR.
-- Make `ripr` branch-protection blocking.
-- Replace mutation testing with `ripr`.
-- Put full mutation on ordinary PRs.
-- Hide skipped lanes as passed.
-
-## Self-review template (every PR)
+### Self-review template (post as a comment before marking ready)
 
 ```markdown
 ## Self-review
 
 - Scope matches PR title:
-- Files touched are expected:
+- Files touched are expected (per the row's acceptance contract):
 - No unrelated cleanup:
 - Policy changes are intentional:
 - No `clippy::*` test carveouts added:
 - No bare `#[allow(clippy::...)]` added:
-- No-panic baseline handling is scoped:
+- No-panic baseline handling is scoped (only N-3 may reset it):
 - File-policy changes are narrow:
 - CI lanes are risk-pack appropriate:
 - `ripr` vs mutation boundary preserved:
@@ -146,20 +373,61 @@ names; see `xtask --help` for the current command surface.
 - Follow-ups:
 ```
 
+### Bot / review loop
+
+For each PR, inspect the current check and review state before
+claiming green:
+
+```bash
+gh pr view <PR> --json statusCheckRollup,reviewDecision,mergeStateStatus
+gh pr checks <PR> --watch
+```
+
+If CI fails, identify the first real failing command, reproduce
+locally if possible, fix only that failure, rerun the matching local
+gate, push, and check bot comments again. Bot comments:
+
+- Fix real defects.
+- Answer false positives with evidence.
+- Fix cheap, in-scope style comments.
+- Defer out-of-scope requests with a follow-up.
+- Mark stale comments only after verifying current HEAD.
+
+### "Done" definition for the whole rollout
+
+The 0.14.0 release is the vehicle for the *completed quality posture*,
+not merely the MSRV bump that already shipped in #8509. The rollout is
+done when:
+
+- Workspace clippy allow-set is at 0 entries (C-1/C-2/C-3 + sibling
+  strong-clippy rail).
+- `allow-unwrap-in-tests` is removed (T-1).
+- `cargo xtask check-no-panic-family` runs in `no-new-debt` mode on
+  every PR (N-1 + N-2 + N-3).
+- `policy/ci-non-rust-allowlist.toml` is tightened with explicit
+  receipts and reviewed entries (F-1).
+- Proactive integrity guards PG-1..PG-6 are live in the `Policy gates`
+  job (`RUST_1_95_PROACTIVE_GUARDS.md`).
+- Strong-clippy rail Tier 1–3 lints are active (`STRONG_CLIPPY_LINTS_ROLLOUT.md`).
+- `disallowed_fields` is active for at least the first protected class
+  (DF-1..DF-4).
+- RP-1 + RP-2 complete; owner tags `v0.14.0` and runs
+  `release.yml` + install-smoke + crates.io publish per
+  [`docs/release/RUNBOOK.md`](../release/RUNBOOK.md).
+
+---
+
 ## References
 
-- Cross-repo doctrine: this rollout follows the same pattern as the
-  Rust 1.95 quality wave in adjacent repos (BitNet-rs, etc.).
-- [`STRONG_CLIPPY_LINTS_ROLLOUT.md`](STRONG_CLIPPY_LINTS_ROLLOUT.md) —
-  the strong-clippy-lints activation rail (sibling rollout).
-- [`RUST_1_95_PROACTIVE_GUARDS.md`](RUST_1_95_PROACTIVE_GUARDS.md) —
-  the proactive CI integrity guards rail (sibling rollout). Six guard
-  PRs (PG-1 through PG-6) covering label enforcement, risk-pack
-  referential integrity, lane mapping, workflow allowlist coverage, CI
-  Actuals emitter + subscription coverage, and broad-glob justification
-  tightening.
-- `docs/ci/codecov-rollout.md` — the parallel CI/Codecov cleanup ladder.
-- `docs/project/status/module_resolution.md` — the `@INC` rail summary
-  that this rollout sits on top of.
-- `policy/clippy-lints.toml`, `policy/clippy-debt.toml` — the live
-  policy ledgers.
+- [`../ci/perl-lsp-rust-1.95-rollout.md`](../ci/perl-lsp-rust-1.95-rollout.md) — historical Rust-1.93-framed plan; now a pointer to this doc.
+- [`STRONG_CLIPPY_LINTS_ROLLOUT.md`](STRONG_CLIPPY_LINTS_ROLLOUT.md) — strong-clippy lint activation rail (sibling, umbrella #8590).
+- [`RUST_1_95_PROACTIVE_GUARDS.md`](RUST_1_95_PROACTIVE_GUARDS.md) — proactive CI integrity guards rail (sibling, umbrella #8662).
+- [`../CLIPPY_POLICY.md`](../CLIPPY_POLICY.md) — Clippy doctrine, suppression style, `check-lint-policy` flow.
+- [`../NO_PANIC_POLICY.md`](../NO_PANIC_POLICY.md) — no-panic policy and baseline shape.
+- [`../FILE_POLICY.md`](../FILE_POLICY.md) — non-Rust file policy and allowlist semantics.
+- [`../POLICY_ALLOWLISTS.md`](../POLICY_ALLOWLISTS.md) — common header schema across policy ledgers.
+- [`../ci/ripr.md`](../ci/ripr.md) — `ripr` lane doctrine and Rust 1.95 rollout note.
+- [`../ci/lem-budgeting.md`](../ci/lem-budgeting.md) — LEM cost model and runner multipliers.
+- [`../ci/test-evidence-lanes.md`](../ci/test-evidence-lanes.md) — evidence-lane shapes (PR fast / broad / nightly / label-gated).
+- [`../release/RUNBOOK.md`](../release/RUNBOOK.md) — release execution runbook.
+- `policy/clippy-lints.toml`, `policy/clippy-debt.toml` — live policy ledgers.


### PR DESCRIPTION
## Summary

Consolidate the remaining Rust 1.95 → 0.14.0 quality work into a single canonical post-landing roadmap, so the next implementation PR branches from written source of truth instead of synthesizing one each time.

Tracking: **#8663**.

## Per-PR acceptance contract

**Scope**
docs-only. Consolidates three docs into one canonical roadmap; adds a sibling lane-shape doc; updates CHANGELOG `[Unreleased] / Planned`.

**Files expected**
- `docs/development/RUST_1_95_ROLLOUT.md` — rewritten as the canonical post-landing source of truth.
- `docs/ci/perl-lsp-rust-1.95-rollout.md` — slimmed to a brief pointer at the new canonical doc.
- `docs/ci/test-evidence-lanes.md` — new; defines the five evidence-lane shapes (PR-fast required / PR-targeted label-gated / nightly cron / release-only / advisory), risk-pack auto-routing, skipped-by-policy receipts, and LEM cost framing.
- `CHANGELOG.md` — `[Unreleased] / Planned` entry referencing umbrella EffortlessMetrics/perl-lsp#8663.

**Behavior change**
None. Documentation only.

**Advisory vs blocking**
N/A — no policy enforcement changes. Every row in the ladder still arrives as its own PR with its own acceptance contract.

**New artifacts**
- One new doc: `docs/ci/test-evidence-lanes.md`.
- No new policy ledgers, no new workflows, no new xtask checkers.

**Validation commands**
- `git diff --check` — clean.
- (Pre-existing finding, not introduced here) `cargo xtask check-lint-policy` fails on `master` because `policy/clippy-lints.toml msrv = \"1.93\"` doesn't match `Cargo.toml rust-version = \"1.95\"`. That mismatch is the M-1 row in the ladder this PR consolidates. Out of scope for this docs PR; landed by M-1.

**Rollback path**
Single revert of this commit restores the three docs to their pre-consolidation state. No data migrations, no policy changes.

**Follow-up PR**
M-1 (one-line `policy/clippy-lints.toml msrv` reconcile to `1.95`). This unblocks `cargo xtask check-lint-policy` on `master`.

## Canonical doc — section structure

Four sections in `docs/development/RUST_1_95_ROLLOUT.md`:

1. **Already landed** — current-state facts (truth-source table covering edition, MSRV, toolchain, `clippy.toml`, policy ledgers, allow set, ripr/mutation lane posture, release line) and the ratchet log from EffortlessMetrics/perl-lsp#8509 through EffortlessMetrics/perl-lsp#8661.
2. **Remaining implementation ladder** — single canonical PR list, one row per PR. Covers `M-1` (msrv reconcile), `C-1`..`C-3` (clippy allow-set burn-down), `T-1` (no test carveouts), `R-1` (rustc lint floor), `SCL-*` (strong-clippy activations under sibling rail EffortlessMetrics/perl-lsp-swarm#1796), `DF-1`..`DF-4` (`disallowed_fields` ladder), `N-1`..`N-3` (no-panic), `F-1` (non-Rust allowlist tightening), `PG-1`..`PG-6` (proactive integrity guards, sibling rail EffortlessMetrics/perl-lsp-swarm#2699), `C-CI`, `C-RM`, `C-AC`, `C-LL` (CI economics rails), `RP-1`, `RP-2` (release readiness + cut).
3. **Per-rail acceptance contracts** — objective / files / commands / forbidden / merge rule / follow-up, one block per ladder row.
4. **Claude / Codex operating contract** — branching rules, draft-PR cadence, no test carveouts, no bare `#[allow]`, advisory-vs-blocking framing, mutation-vs-ripr economics.

## Sibling rails (still load-bearing, not consolidated here)

- `docs/development/STRONG_CLIPPY_LINTS_ROLLOUT.md` — umbrella **#8590**.
- `docs/development/RUST_1_95_PROACTIVE_GUARDS.md` — umbrella **#8662**.

## Doctrine

> `ripr` is the PR-time static oracle-exposure filter; it is not a replacement for mutation testing. Mutation remains runtime evidence for targeted PRs, nightly lanes, and release readiness.