### PR TITLE
docs(rail/freshness): add stale-binary failure mode (#8660)

### DIFF
--- a/docs/development/FRESHNESS_RAIL.md
+++ b/docs/development/FRESHNESS_RAIL.md
@@ -53,6 +53,65 @@ Exit status zero means: the working tree is at or ahead of `origin/master` withi
 - Adjacent rails:
   - All other rails depend on freshness for correct issue-spec discipline; this rail is foundational, not parallel
 
+## Stale binary resolution (test-harness)
+
+Source-tree staleness is one failure class — but test harnesses can be stale in
+a different way: the binary they invoke may be from a different SHA than the
+current build.
+
+### Symptom
+
+A test passes or fails unrelated to the current code state because the harness
+resolves a binary from an older build. The test is real; the binary is
+historical.
+
+### Canonical incident — #8624
+
+`scenario_14_no_lib_cancellation` failed on every PR branch and on master.
+Root cause was NOT a regression in `no lib` semantics. It was in the test
+harness:
+
+> `resolve_binary()` in `crates/perl-lsp-ux-tests/src/lib.rs` mishandled
+> `CARGO_TARGET_DIR`, treating it as a workspace root and looking under
+> `CARGO_TARGET_DIR/target/debug/perl-lsp`. That path never existed in agent
+> worktrees, so resolution fell through to a stale v0.13.1 binary in the main
+> checkout. The v0.13.1 binary predated the position-aware `no lib`
+> cancellation fix (#8525), so it correctly-for-itself but incorrectly-for-the-test
+> resolved `GoneModule`, fired PL700 instead of PL701, and failed the strict
+> assertions.
+
+Fix: **#8659** — `resolve_binary()` now looks in `CARGO_TARGET_DIR/debug/` directly.
+
+### Detection
+
+- Pre-test hook: assert `target/debug/perl-lsp` mtime is newer than the
+  workspace SHA's commit time, OR build it explicitly before any harness run.
+- `cargo xtask freshness-check --binaries` (future extension to the existing
+  freshness-check command per **#8619**) — out of scope for this rail doc;
+  tracked there.
+
+### Mitigation
+
+`resolve_binary()` in `crates/perl-lsp-ux-tests/src/lib.rs` must NEVER fall
+through to a binary outside the current build's `target/` tree:
+
+- Respect `CARGO_TARGET_DIR` if set: look in `$CARGO_TARGET_DIR/debug/perl-lsp`.
+- If `CARGO_TARGET_DIR` is unset, use the workspace's `target/debug/` only
+  when it was just built in this session.
+- Refuse fallback to ancestor / parent workspace binaries — they are
+  almost always stale.
+
+### Related
+
+- **#8624** — the regression issue.
+- **#8659** — the fix PR.
+- **#8546** — umbrella freshness tooling.
+- **#8619** — `cargo xtask freshness-check` implementation (covers the
+  `--binaries` extension as a follow-up).
+- **#8485** — sibling stale-source-checkout incident.
+
+---
+
 ## Do not combine
 
 Do **not** roll this rail's PRs into:

--- a/docs/devex/freshness-check.md
+++ b/docs/devex/freshness-check.md
@@ -146,6 +146,20 @@ an issue, the reason should appear in the issue body.
 - **`feedback_issue_correction_record.md`** + **#8554** — downstream
   remediation rule for when a stale claim slips through anyway.
 
+## Sibling failure mode: stale binary resolution
+
+Source-staleness is one class of frozen-artifact failure. Test-harness binary
+resolution is another: a test invokes a binary from an older build and asserts
+against ancient product code.
+
+See `docs/development/FRESHNESS_RAIL.md` "Stale binary resolution (test-harness)"
+for the canonical example (#8624 / #8659) and detection patterns.
+
+The `cargo xtask freshness-check --binaries` extension (tracked in **#8619**)
+will detect this class of failure once the base `freshness-check` command lands.
+
+---
+
 ## Claim boundary
 
 This document describes the freshness-check surfaces, not their


### PR DESCRIPTION
## Summary

- Extends `docs/development/FRESHNESS_RAIL.md` with a **"Stale binary resolution (test-harness)"** section — symptom, canonical incident (#8624), detection, and mitigation triad.
- Cross-links from `docs/devex/freshness-check.md` so the two sibling failure modes (stale source checkout, stale binary resolution) are discoverable from both docs.

## Changes

**`docs/development/FRESHNESS_RAIL.md`** (+59 lines): New section placed before "Do not combine", documenting the failure mode uncovered by EffortlessMetrics/perl-lsp#8624 and fixed by EffortlessMetrics/perl-lsp#8659. Covers `resolve_binary()` in `crates/perl-lsp-ux-tests/src/lib.rs`, `CARGO_TARGET_DIR` mishandling, and the detection/mitigation pattern. Cross-links EffortlessMetrics/perl-lsp#8624, EffortlessMetrics/perl-lsp#8659, EffortlessMetrics/perl-lsp-swarm#1819, EffortlessMetrics/perl-lsp#8619, EffortlessMetrics/perl-lsp#8485.

**`docs/devex/freshness-check.md`** (+14 lines): Brief "Sibling failure mode" subsection before "Claim boundary", pointing to the rail doc's canonical example and the planned `--binaries` extension in EffortlessMetrics/perl-lsp#8619.

## Test plan

- [ ] Both files exist on branch with the new sections
- [ ] `cargo xtask fmt --check` passes (docs-only, no .rs touched — no-op)
- [ ] Cross-links resolve: `docs/development/FRESHNESS_RAIL.md` exists (merged via EffortlessMetrics/perl-lsp#8642), `docs/devex/freshness-check.md` exists (merged via EffortlessMetrics/perl-lsp#8556)
- [ ] No code changes — `resolve_binary()` fix is already landed in EffortlessMetrics/perl-lsp#8659

Closes EffortlessMetrics/perl-lsp#8660