### PR TITLE
fix(@INC): suppress unused-import hint for missing modules (#8624)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics.rs
@@ -113,7 +113,7 @@ impl SemanticQueries for NullSemanticQueries {
 #[allow(unused_imports)]
 pub use super::internal_types::{Diagnostic, RelatedInformation};
 #[allow(unused_imports)]
-pub use perl_diagnostics::codes::DiagnosticSeverity;
+pub use perl_diagnostics::codes::{DiagnosticCode, DiagnosticSeverity};
 
 /// Diagnostics provider
 ///
@@ -404,11 +404,30 @@ impl DiagnosticsProvider {
             }
         }
 
+        suppress_unused_imports_for_missing_modules(&mut diagnostics);
+
         // Remove duplicate diagnostics before returning
         deduplicate_diagnostics(&mut diagnostics);
 
         diagnostics
     }
+}
+
+fn suppress_unused_imports_for_missing_modules(diagnostics: &mut Vec<Diagnostic>) {
+    let missing_module_ranges: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| diag.code.as_deref() == Some(DiagnosticCode::ModuleNotFound.as_str()))
+        .map(|diag| diag.range)
+        .collect();
+
+    if missing_module_ranges.is_empty() {
+        return;
+    }
+
+    diagnostics.retain(|diag| {
+        diag.code.as_deref() != Some(DiagnosticCode::UnusedImport.as_str())
+            || !missing_module_ranges.contains(&diag.range)
+    });
 }
 
 fn format_found_token(found: &str) -> String {

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -2670,8 +2670,12 @@ print \"unreachable\\n\";\n";
             "PL701 MUST fire: 'no lib' cancelled the path, GoneModule must not be found.\n\
              Published: {text:?}"
         );
-        // PL700 (unused import hint) is orthogonal and may also fire — it does not indicate
-        // the module was found. What matters is that PL701 fires (resolver returned false).
+        assert!(
+            !text.contains("PL700"),
+            "PL700 must not fire after 'no lib' cancels the path; that would mean \
+             the missing module was still treated as resolved.\n\
+             Published: {text:?}"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Problem: #8659 locked PL701 for `no lib` cancellation, but the same unresolved import could still publish the PL700 unused-import hint.
Fix: Suppress PL700 when PL701 exists for the same `use` range, and tighten the scenario_14 regression guard to assert PL700 is absent.
Verification: `cargo test -p perl-lsp-rs --lib --profile agent --locked push_pl701_fires_after_no_lib_cancels_default_include_path -- --nocapture`; `cargo test -p perl-lsp-rs-core --test diag_snap --profile agent --locked snapshot_missing_module_import -- --nocapture`; `cargo test -p perl-lsp-rs-core --profile agent --locked unused_import -- --nocapture`; `cargo test -p perl-lsp-ux-tests --test ux_scenario_14_inc_conformance --profile agent --locked -- --nocapture --test-threads=1`; parser/semantic freshness checks pass.