### PR TITLE
perf(completion): runtime-owned TTL cache for module prefix scans (#8514)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion.rs
@@ -115,6 +115,7 @@ pub use self::methods::get_dbi_method_documentation;
 pub use self::test_more::get_test_more_documentation;
 pub use self::xs_api::{add_xs_api_completions_for_prefix, get_xs_api_documentation, is_xs_source};
 
+use crate::providers::completion::module_scan_cache::ModuleCompletionScanCache;
 use perl_parser_core::ast::Node;
 use perl_semantic_analyzer::class_model::{ClassModel, ClassModelBuilder, Framework};
 use perl_semantic_analyzer::semantic::{BuiltinDoc, get_moose_type_documentation};
@@ -180,6 +181,13 @@ pub struct CompletionProvider {
     include_paths: Vec<PathBuf>,
     system_inc_paths: Vec<PathBuf>,
     include_system_inc: bool,
+    /// Optional runtime-owned scan cache (issue #8514).
+    ///
+    /// When `Some`, repeated `use Module::Prefix|` completions within 1 second
+    /// avoid re-scanning the same include root subdirectory. The cache is owned
+    /// by `LspServer` and survives across requests; this field holds a cheap
+    /// `Arc` clone valid for the lifetime of this provider instance.
+    scan_cache: Option<Arc<ModuleCompletionScanCache>>,
 }
 
 impl CompletionProvider {
@@ -301,7 +309,17 @@ impl CompletionProvider {
             include_paths,
             system_inc_paths,
             include_system_inc,
+            scan_cache: None,
         }
+    }
+
+    /// Attach a runtime-owned scan cache to this provider.
+    ///
+    /// Called by `LspServer` after construction to wire the server-level cache
+    /// into the per-request provider without changing the public constructor API.
+    pub fn with_scan_cache(mut self, cache: Arc<ModuleCompletionScanCache>) -> Self {
+        self.scan_cache = Some(cache);
+        self
     }
 
     fn extract_symbol_table(ast: &Node, source: &str) -> SymbolTable {
@@ -532,13 +550,15 @@ impl CompletionProvider {
             );
         } else if context.in_use_statement && !context.prefix.starts_with('$') {
             // Module name completion after `use` or `require`
-            workspace::add_use_module_completions(
+            workspace::add_use_module_completions_with_cache(
                 &mut completions,
                 &context,
                 &self.workspace_index,
                 &self.include_paths,
                 &self.system_inc_paths,
                 self.include_system_inc,
+                self.scan_cache.as_deref(),
+                is_cancelled,
             );
         } else if self.is_has_type_value_context(source, position) {
             self.add_has_type_completions(&mut completions, &context);

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -9,6 +9,7 @@ use super::{
     context::CompletionContext,
     items::{CompletionItem, CompletionItemKind},
 };
+use crate::providers::completion::module_scan_cache::{ModuleCompletionScanCache, ScanCacheKey};
 use perl_module::path::module_name_to_path;
 use perl_parser_core::SourceLocation;
 use perl_semantic_analyzer::{
@@ -524,6 +525,12 @@ fn normalized_path_key(path: &Path) -> String {
     if cfg!(windows) { key.to_ascii_lowercase() } else { key }
 }
 
+/// Add module name completions for `use` and `require` statements.
+///
+/// Thin backward-compatible wrapper around [`add_use_module_completions_with_cache`]
+/// that passes `None` for the cache.  Prefer the `_with_cache` variant when a
+/// runtime-owned [`ModuleCompletionScanCache`] is available.
+#[allow(dead_code)] // Public backward-compatibility API; callers in perl-lsp-rs use _with_cache
 pub fn add_use_module_completions(
     completions: &mut Vec<CompletionItem>,
     context: &CompletionContext,
@@ -531,6 +538,43 @@ pub fn add_use_module_completions(
     include_paths: &[PathBuf],
     system_inc_paths: &[PathBuf],
     include_system_inc: bool,
+) {
+    add_use_module_completions_with_cache(
+        completions,
+        context,
+        workspace_index,
+        include_paths,
+        system_inc_paths,
+        include_system_inc,
+        None,
+        &|| false,
+    );
+}
+
+/// Add module name completions for `use` and `require` statements, optionally
+/// using a runtime-owned TTL cache to avoid repeated filesystem scans on each
+/// keystroke (issue #8514).
+///
+/// ## Cache contract
+///
+/// - When `scan_cache` is `Some`, each
+///   `(canonical_root, prefix_dir, full_module_prefix)` tuple is looked up before
+///   scanning. On a miss the scan proceeds normally and the result is stored in
+///   the cache. On a hit the cached `Vec<String>` is used directly.
+/// - `is_cancelled` is checked **before returning any cached hit** so that a
+///   cancelled LSP request does not deliver results to the editor.
+/// - The workspace-index path is not cached — it is already in-memory.
+/// - Cache population uses the canonical form of the root path when available
+///   (`std::fs::canonicalize`); falls back to the raw path on error.
+pub fn add_use_module_completions_with_cache(
+    completions: &mut Vec<CompletionItem>,
+    context: &CompletionContext,
+    workspace_index: &Option<Arc<WorkspaceIndex>>,
+    include_paths: &[PathBuf],
+    system_inc_paths: &[PathBuf],
+    include_system_inc: bool,
+    scan_cache: Option<&ModuleCompletionScanCache>,
+    is_cancelled: &dyn Fn() -> bool,
 ) {
     let mut seen: HashSet<String> = HashSet::new();
     let mut active_module_roots: Vec<&Path> = include_paths.iter().map(PathBuf::as_path).collect();
@@ -586,9 +630,61 @@ pub fn add_use_module_completions(
         }
     }
 
-    let mut add_external_modules = |roots: &[PathBuf], detail: &str| {
+    // Helper: resolve the canonical form of `root` for use as a cache key.
+    // Falls back to the raw path when canonicalization fails (e.g. non-existent dir).
+    let canonical_root = |root: &Path| -> PathBuf {
+        std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf())
+    };
+
+    // Helper: build the ScanCacheKey for (root, prefix).
+    //
+    // The prefix_dir is the subdirectory that the scan starts from
+    // (e.g. `Mojo/` for prefix `Mojo::Controller`). Using a relative
+    // path under the canonical root keeps the key stable across callers
+    // that might pass in slightly different root representations. The full
+    // prefix is part of the key because cached values are prefix-filtered.
+    let cache_key = |root: &Path| -> ScanCacheKey {
+        let (scan_dir, _, _) = root_and_leaf_prefix(root, &context.prefix);
+        let prefix_dir = scan_dir.strip_prefix(root).unwrap_or(&scan_dir).to_path_buf();
+        ScanCacheKey {
+            canonical_root: canonical_root(root),
+            prefix_dir,
+            module_prefix: context.prefix.clone(),
+        }
+    };
+
+    let mut add_external_modules = |roots: &[PathBuf], detail: &str| -> bool {
         for root in roots.iter().take(MAX_MODULE_SCAN_ROOTS) {
-            for name in scan_directory_for_modules(root, &context.prefix) {
+            if is_cancelled() {
+                return false;
+            }
+
+            let modules = match scan_cache {
+                Some(cache) => {
+                    let key = cache_key(root);
+                    if let Some(cached) = cache.get(&key) {
+                        // Cancellation check before returning cached result.
+                        if is_cancelled() {
+                            return false;
+                        }
+                        cached
+                    } else {
+                        let scanned = scan_directory_for_modules(root, &context.prefix);
+                        if is_cancelled() {
+                            return false;
+                        }
+                        cache.insert(key, scanned.clone());
+                        scanned
+                    }
+                }
+                None => scan_directory_for_modules(root, &context.prefix),
+            };
+
+            if is_cancelled() {
+                return false;
+            }
+
+            for name in modules {
                 if !seen.insert(name.clone()) {
                     continue;
                 }
@@ -608,11 +704,14 @@ pub fn add_use_module_completions(
                 });
             }
         }
+        true
     };
 
-    add_external_modules(include_paths, "external module");
+    if !add_external_modules(include_paths, "external module") {
+        return;
+    }
     if include_system_inc {
-        add_external_modules(system_inc_paths, "system module");
+        let _ = add_external_modules(system_inc_paths, "system module");
     }
 }
 

--- a/crates/perl-lsp-rs-core/src/providers/completion/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/mod.rs
@@ -21,6 +21,8 @@
 mod completion;
 /// Completion visibility shadow compare path (semantic migration).
 pub mod completion_shadow;
+/// Short-TTL cache for module prefix directory scans (issue #8514).
+pub mod module_scan_cache;
 
 pub use completion::{
     CompletionContext, CompletionItem, CompletionItemKind, CompletionProvider,

--- a/crates/perl-lsp-rs-core/src/providers/completion/module_scan_cache.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/module_scan_cache.rs
@@ -1,0 +1,212 @@
+//! Short-TTL cache for module prefix directory scans.
+//!
+//! Typing a multi-segment `use` prefix such as `use Mojo::Cont|` re-scans
+//! `root/Mojo/` on every keystroke.  With a 1 second TTL and 128 capacity the
+//! repeated keystrokes within a typing burst hit the cache rather than the
+//! filesystem, eliminating the hot-loop I/O regression identified in issue #8514.
+//!
+//! ## Design
+//!
+//! - Owner: `LspServer` (runtime-owned state, survives across requests).
+//!   `CompletionProvider` is reconstructed per request and cannot hold persistent
+//!   state; the cache must be held at a longer-lived layer.
+//! - Key: `(canonical_include_root, prefix_dir_relative, full_module_prefix)` —
+//!   the include root after path canonicalization, the subdirectory that the
+//!   prefix-directed scan starts from (e.g. `Mojo/` for prefix
+//!   `Mojo::Controller`), and the full typed module prefix.
+//! - Value: `Vec<String>` of module names returned by the prefix-filtered scan.
+//! - TTL: [`MODULE_COMPLETION_CACHE_TTL_MS`] (1000 ms by default).
+//! - Capacity: [`MODULE_COMPLETION_CACHE_MAX_ENTRIES`] (128 entries).  When full
+//!   `moka` evicts the least-recently-used entry automatically.
+//! - Thread safety: `moka::sync::Cache` — concurrent, lock-free reads.
+//! - Cancellation: callers **must** check the cancellation predicate **before**
+//!   returning a cached hit so that a cancelled request does not deliver stale
+//!   results to the editor.
+
+use moka::sync::Cache;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Default TTL for a scan cache entry (1 second).
+pub const MODULE_COMPLETION_CACHE_TTL_MS: u64 = 1000;
+
+/// Maximum number of entries retained in the cache.
+pub const MODULE_COMPLETION_CACHE_MAX_ENTRIES: u64 = 128;
+
+/// Cache key: (canonical include root, relative prefix directory, full prefix).
+///
+/// Using the canonical form of the include root avoids spurious misses from
+/// symlink or case differences on case-insensitive filesystems.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ScanCacheKey {
+    /// Canonicalized include root (e.g. `/home/user/proj/lib`).
+    pub canonical_root: PathBuf,
+    /// Relative path from the root to the prefix scan directory
+    /// (e.g. `Mojo` for the prefix `Mojo::Controller`).
+    /// Empty path when the prefix has no `::` namespace segments.
+    pub prefix_dir: PathBuf,
+    /// Full typed module prefix used to filter the scan result.
+    ///
+    /// This keeps prefix-filtered cache entries from satisfying another leaf
+    /// prefix under the same directory, such as `Mojo::C` vs. `Mojo::L`.
+    pub module_prefix: String,
+}
+
+/// Runtime-owned short-TTL cache for `scan_directory_for_modules` results.
+///
+/// Constructed once during `LspServer::new()` and shared across all completion
+/// requests via the server's `Arc`.
+pub struct ModuleCompletionScanCache {
+    inner: Cache<ScanCacheKey, Vec<String>>,
+}
+
+impl ModuleCompletionScanCache {
+    /// Create a new cache with the default TTL and capacity.
+    pub fn new() -> Self {
+        Self::with_ttl_ms(MODULE_COMPLETION_CACHE_TTL_MS)
+    }
+
+    /// Create a cache with an explicit TTL in milliseconds (useful for tests).
+    pub fn with_ttl_ms(ttl_ms: u64) -> Self {
+        let inner = Cache::builder()
+            .max_capacity(MODULE_COMPLETION_CACHE_MAX_ENTRIES)
+            .time_to_live(Duration::from_millis(ttl_ms))
+            .build();
+        Self { inner }
+    }
+
+    /// Look up a cached scan result for `key`.
+    ///
+    /// Returns `Some(modules)` when an unexpired entry exists.
+    /// **Callers must check cancellation before acting on the returned value.**
+    pub fn get(&self, key: &ScanCacheKey) -> Option<Vec<String>> {
+        self.inner.get(key)
+    }
+
+    /// Store `modules` for `key`.  TTL is applied automatically by `moka`.
+    pub fn insert(&self, key: ScanCacheKey, modules: Vec<String>) {
+        self.inner.insert(key, modules);
+    }
+
+    /// Return the approximate number of live entries currently in the cache.
+    /// Used by tests; exact count may lag due to moka's background eviction.
+    #[cfg(test)]
+    pub fn entry_count(&self) -> u64 {
+        self.inner.entry_count()
+    }
+}
+
+impl Default for ModuleCompletionScanCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn key(root: &str, prefix_dir: &str, module_prefix: &str) -> ScanCacheKey {
+        ScanCacheKey {
+            canonical_root: PathBuf::from(root),
+            prefix_dir: PathBuf::from(prefix_dir),
+            module_prefix: module_prefix.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_empty_cache_returns_none() -> Result<(), Box<dyn std::error::Error>> {
+        let cache = ModuleCompletionScanCache::new();
+        assert!(
+            cache.get(&key("/lib", "Mojo", "Mojo::C")).is_none(),
+            "empty cache must return None"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_insert_then_get_returns_modules() -> Result<(), Box<dyn std::error::Error>> {
+        let cache = ModuleCompletionScanCache::new();
+        let k = key("/lib", "Mojo", "Mojo::C");
+        cache.insert(k.clone(), vec!["Mojo::Controller".to_string(), "Mojo::Lite".to_string()]);
+        let result = cache.get(&k).ok_or("expected hit after insert")?;
+        assert_eq!(result, vec!["Mojo::Controller", "Mojo::Lite"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_different_prefix_dir_is_a_miss() -> Result<(), Box<dyn std::error::Error>> {
+        let cache = ModuleCompletionScanCache::new();
+        cache.insert(key("/lib", "Mojo", "Mojo::C"), vec!["Mojo::Controller".to_string()]);
+        assert!(
+            cache.get(&key("/lib", "Catalyst", "Catalyst::C")).is_none(),
+            "different prefix_dir must be a cache miss"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_different_module_prefix_is_a_miss() -> Result<(), Box<dyn std::error::Error>> {
+        let cache = ModuleCompletionScanCache::new();
+        cache.insert(key("/lib", "Mojo", "Mojo::C"), vec!["Mojo::Controller".to_string()]);
+        assert!(
+            cache.get(&key("/lib", "Mojo", "Mojo::L")).is_none(),
+            "different leaf prefix under the same prefix_dir must be a cache miss"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_different_root_is_a_miss() -> Result<(), Box<dyn std::error::Error>> {
+        let cache = ModuleCompletionScanCache::new();
+        cache.insert(key("/lib", "Mojo", "Mojo::C"), vec!["Mojo::Controller".to_string()]);
+        assert!(
+            cache.get(&key("/vendor/lib", "Mojo", "Mojo::C")).is_none(),
+            "different canonical root must be a cache miss"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_expired_entry_returns_none() -> Result<(), Box<dyn std::error::Error>> {
+        // Use a tiny TTL so we don't sleep long.
+        let cache = ModuleCompletionScanCache::with_ttl_ms(10);
+        let k = key("/lib", "Mojo", "Mojo::C");
+        cache.insert(k.clone(), vec!["Mojo::Controller".to_string()]);
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(cache.get(&k).is_none(), "entry past TTL must be a miss");
+        Ok(())
+    }
+
+    #[test]
+    fn test_overwrite_updates_existing_entry() -> Result<(), Box<dyn std::error::Error>> {
+        let cache = ModuleCompletionScanCache::new();
+        let k = key("/lib", "Foo", "Foo::O");
+        cache.insert(k.clone(), vec!["Foo::One".to_string()]);
+        cache.insert(k.clone(), vec!["Foo::One".to_string(), "Foo::Two".to_string()]);
+        let result = cache.get(&k).ok_or("expected hit")?;
+        assert_eq!(result.len(), 2, "overwrite must replace old entry");
+        Ok(())
+    }
+
+    #[test]
+    fn test_capacity_enforced() -> Result<(), Box<dyn std::error::Error>> {
+        let cache = ModuleCompletionScanCache::new();
+        // Insert more entries than capacity.
+        for i in 0..200u64 {
+            let prefix = format!("Ns{i}::M");
+            cache.insert(key("/lib", &format!("Ns{i}"), &prefix), vec![format!("Ns{i}::Mod")]);
+        }
+        // moka's entry_count is approximate; the important thing is that it's bounded.
+        // Give moka time to run its background eviction.
+        std::thread::sleep(Duration::from_millis(20));
+        // It must not have grown unboundedly past capacity * 2.
+        assert!(
+            cache.entry_count() <= MODULE_COMPLETION_CACHE_MAX_ENTRIES * 2,
+            "cache must be bounded; got entry_count={}",
+            cache.entry_count()
+        );
+        Ok(())
+    }
+}

--- a/crates/perl-lsp-rs/src/runtime/constructors.rs
+++ b/crates/perl-lsp-rs/src/runtime/constructors.rs
@@ -57,6 +57,9 @@ impl LspServer {
             parse_cancel_flags: Arc::new(Mutex::new(HashMap::new())),
             pull_diagnostics_orchestrator: super::diagnostics::PullDiagnosticsOrchestrator::new(),
             semantic_analyzer_cache: Arc::new(Mutex::new(HashMap::new())),
+            module_scan_cache: Arc::new(
+                perl_lsp_rs_core::providers::completion::module_scan_cache::ModuleCompletionScanCache::new(),
+            ),
             #[cfg(feature = "workspace")]
             indexing_in_progress: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "workspace")]
@@ -167,6 +170,9 @@ impl LspServer {
             parse_cancel_flags: Arc::new(Mutex::new(HashMap::new())),
             pull_diagnostics_orchestrator: super::diagnostics::PullDiagnosticsOrchestrator::new(),
             semantic_analyzer_cache: Arc::new(Mutex::new(HashMap::new())),
+            module_scan_cache: Arc::new(
+                perl_lsp_rs_core::providers::completion::module_scan_cache::ModuleCompletionScanCache::new(),
+            ),
             #[cfg(feature = "workspace")]
             indexing_in_progress: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "workspace")]
@@ -240,6 +246,9 @@ impl LspServer {
             parse_cancel_flags: Arc::new(Mutex::new(HashMap::new())),
             pull_diagnostics_orchestrator: super::diagnostics::PullDiagnosticsOrchestrator::new(),
             semantic_analyzer_cache: Arc::new(Mutex::new(HashMap::new())),
+            module_scan_cache: Arc::new(
+                perl_lsp_rs_core::providers::completion::module_scan_cache::ModuleCompletionScanCache::new(),
+            ),
             #[cfg(feature = "workspace")]
             indexing_in_progress: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "workspace")]

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -502,7 +502,8 @@ impl LspServer {
                         include_paths,
                         system_inc_paths,
                         include_system_inc,
-                    );
+                    )
+                    .with_scan_cache(Arc::clone(&self.module_scan_cache));
 
                     #[cfg(not(feature = "workspace"))]
                     let provider = CompletionProvider::new_with_index_and_source_and_paths(
@@ -512,7 +513,8 @@ impl LspServer {
                         include_paths,
                         system_inc_paths,
                         include_system_inc,
-                    );
+                    )
+                    .with_scan_cache(Arc::clone(&self.module_scan_cache));
 
                     let mut base_completions =
                         provider.get_completions_with_path(&doc.text, offset, Some(uri));
@@ -776,7 +778,8 @@ impl LspServer {
                         include_paths,
                         system_inc_paths,
                         include_system_inc,
-                    );
+                    )
+                    .with_scan_cache(Arc::clone(&self.module_scan_cache));
                     #[cfg(not(feature = "workspace"))]
                     let provider = CompletionProvider::new_with_index_and_source_and_paths(
                         ast,
@@ -785,7 +788,8 @@ impl LspServer {
                         include_paths,
                         system_inc_paths,
                         include_system_inc,
-                    );
+                    )
+                    .with_scan_cache(Arc::clone(&self.module_scan_cache));
 
                     // Use cancellable provider method
                     provider.get_completions_with_path_cancellable(
@@ -1740,5 +1744,305 @@ mod tests {
             "required Foo",
             "required Foo".len()
         ));
+    }
+
+    // =========================================================================
+    // Module scan cache integration tests (issue #8514)
+    // =========================================================================
+
+    /// First call for a given root+prefix triggers a scan (cache miss).
+    /// Second call within TTL returns the cached result (no new scan).
+    #[test]
+    fn test_scan_cache_second_call_within_ttl_does_not_rescan()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use perl_lsp_rs_core::providers::completion::module_scan_cache::{
+            ModuleCompletionScanCache, ScanCacheKey,
+        };
+        use std::path::PathBuf;
+
+        let temp = tempfile::TempDir::new()?;
+        let lib = temp.path().join("lib");
+        let mojo_dir = lib.join("Mojo");
+        std::fs::create_dir_all(&mojo_dir)?;
+        std::fs::write(mojo_dir.join("Controller.pm"), "package Mojo::Controller;\n1;\n")?;
+
+        let cache = ModuleCompletionScanCache::new();
+        let canonical = std::fs::canonicalize(&lib).unwrap_or_else(|_| lib.clone());
+        let key = ScanCacheKey {
+            canonical_root: canonical.clone(),
+            prefix_dir: PathBuf::from("Mojo"),
+            module_prefix: "Mojo::".to_string(),
+        };
+
+        // First: miss — nothing in cache yet
+        assert!(cache.get(&key).is_none(), "cache must be cold initially");
+
+        // Manually populate as the scan would
+        cache.insert(key.clone(), vec!["Mojo::Controller".to_string()]);
+
+        // Second within TTL: hit
+        let hit = cache.get(&key).ok_or("expected cache hit on second call")?;
+        assert!(hit.contains(&"Mojo::Controller".to_string()), "cached result must match scan");
+
+        Ok(())
+    }
+
+    /// Different prefix dir produces a cache miss.
+    #[test]
+    fn test_scan_cache_different_prefix_dir_misses() -> Result<(), Box<dyn std::error::Error>> {
+        use perl_lsp_rs_core::providers::completion::module_scan_cache::{
+            ModuleCompletionScanCache, ScanCacheKey,
+        };
+        use std::path::PathBuf;
+
+        let cache = ModuleCompletionScanCache::new();
+        cache.insert(
+            ScanCacheKey {
+                canonical_root: PathBuf::from("/lib"),
+                prefix_dir: PathBuf::from("Mojo"),
+                module_prefix: "Mojo::C".to_string(),
+            },
+            vec!["Mojo::Controller".to_string()],
+        );
+
+        // Different prefix_dir — must miss
+        let miss = cache.get(&ScanCacheKey {
+            canonical_root: PathBuf::from("/lib"),
+            prefix_dir: PathBuf::from("Catalyst"),
+            module_prefix: "Catalyst::C".to_string(),
+        });
+        assert!(miss.is_none(), "different prefix_dir must be a cache miss");
+
+        Ok(())
+    }
+
+    /// After TTL expires the cache returns None.
+    #[test]
+    fn test_scan_cache_after_ttl_misses() -> Result<(), Box<dyn std::error::Error>> {
+        use perl_lsp_rs_core::providers::completion::module_scan_cache::{
+            ModuleCompletionScanCache, ScanCacheKey,
+        };
+        use std::path::PathBuf;
+        use std::time::Duration;
+
+        let cache = ModuleCompletionScanCache::with_ttl_ms(10);
+        let key = ScanCacheKey {
+            canonical_root: PathBuf::from("/lib"),
+            prefix_dir: PathBuf::from("Mojo"),
+            module_prefix: "Mojo::C".to_string(),
+        };
+        cache.insert(key.clone(), vec!["Mojo::Controller".to_string()]);
+
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(cache.get(&key).is_none(), "expired entry must be a cache miss");
+
+        Ok(())
+    }
+
+    /// Cancellation token is checked before returning a cached hit.
+    #[test]
+    fn test_scan_cache_cancellation_checked_before_returning_hit()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use perl_lsp_rs_core::providers::completion::CompletionProvider;
+        use perl_lsp_rs_core::providers::completion::module_scan_cache::{
+            ModuleCompletionScanCache, ScanCacheKey,
+        };
+        use perl_parser::Parser;
+        use std::path::PathBuf;
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        };
+
+        let temp = tempfile::TempDir::new()?;
+        let lib = temp.path().join("lib");
+        let mojo_dir = lib.join("Mojo");
+        std::fs::create_dir_all(&mojo_dir)?;
+        std::fs::write(mojo_dir.join("Controller.pm"), "package Mojo::Controller;\n1;\n")?;
+
+        // Pre-populate the cache as if a prior call had scanned.
+        let cache = Arc::new(ModuleCompletionScanCache::new());
+        let canonical = std::fs::canonicalize(&lib).unwrap_or_else(|_| lib.clone());
+        let key = ScanCacheKey {
+            canonical_root: canonical.clone(),
+            prefix_dir: PathBuf::from("Mojo"),
+            module_prefix: "Mojo::".to_string(),
+        };
+        cache.insert(key, vec!["Mojo::Controller".to_string()]);
+
+        // Construct a provider with the pre-populated cache and a cancellation flag already set.
+        let source = "use Mojo::";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse().map_err(|e| format!("parse error: {e:?}"))?;
+
+        let cancelled = Arc::new(AtomicBool::new(true));
+        let cancel_fn = {
+            let c = Arc::clone(&cancelled);
+            move || c.load(Ordering::Relaxed)
+        };
+
+        let provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            source,
+            None,
+            vec![lib.clone()],
+            vec![],
+            false,
+        )
+        .with_scan_cache(Arc::clone(&cache));
+
+        // With cancellation flag set, completions must be empty even though cache has a hit.
+        let completions =
+            provider.get_completions_with_path_cancellable(source, source.len(), None, &cancel_fn);
+
+        // Either the request was cancelled entirely (empty) or the cancellation check
+        // at the cache-hit path caused an early return.  Either way, the contract is
+        // that a cancelled request does not return results.
+        assert!(
+            completions.is_empty(),
+            "cancelled request must not return completions; got {completions:?}"
+        );
+
+        Ok(())
+    }
+
+    /// Prefix-filtered cache entries must not satisfy a different leaf prefix
+    /// under the same namespace directory.
+    #[test]
+    fn test_scan_cache_full_prefix_prevents_cross_prefix_hits()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use perl_lsp_rs_core::providers::completion::CompletionProvider;
+        use perl_lsp_rs_core::providers::completion::module_scan_cache::{
+            ModuleCompletionScanCache, ScanCacheKey,
+        };
+        use perl_parser::Parser;
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let temp = tempfile::TempDir::new()?;
+        let lib = temp.path().join("lib");
+        let mojo_dir = lib.join("Mojo");
+        std::fs::create_dir_all(&mojo_dir)?;
+        std::fs::write(mojo_dir.join("Controller.pm"), "package Mojo::Controller;\n1;\n")?;
+        std::fs::write(mojo_dir.join("Lite.pm"), "package Mojo::Lite;\n1;\n")?;
+
+        // Simulate an earlier `Mojo::C` request. A later `Mojo::L` request
+        // scans the same prefix_dir (`Mojo`) but must not reuse this filtered hit.
+        let cache = Arc::new(ModuleCompletionScanCache::new());
+        let canonical = std::fs::canonicalize(&lib).unwrap_or_else(|_| lib.clone());
+        cache.insert(
+            ScanCacheKey {
+                canonical_root: canonical,
+                prefix_dir: PathBuf::from("Mojo"),
+                module_prefix: "Mojo::C".to_string(),
+            },
+            vec!["Mojo::Controller".to_string()],
+        );
+
+        let source = "use Mojo::L";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse().map_err(|e| format!("parse error: {e:?}"))?;
+        let provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            source,
+            None,
+            vec![lib.clone()],
+            vec![],
+            false,
+        )
+        .with_scan_cache(Arc::clone(&cache));
+
+        let labels: Vec<String> = provider
+            .get_completions_with_path(source, source.len(), None)
+            .into_iter()
+            .map(|item| item.label)
+            .collect();
+
+        assert!(
+            labels.contains(&"Mojo::Lite".to_string()),
+            "different leaf prefix should miss the stale filtered hit and scan Lite; labels={labels:?}"
+        );
+        assert!(
+            !labels.contains(&"Mojo::Controller".to_string()),
+            "cached Mojo::C result must not leak into Mojo::L completions; labels={labels:?}"
+        );
+
+        Ok(())
+    }
+
+    /// Cached and uncached completions produce the same labels.
+    #[test]
+    fn test_scan_cache_cached_and_uncached_labels_match() -> Result<(), Box<dyn std::error::Error>>
+    {
+        use perl_lsp_rs_core::providers::completion::CompletionProvider;
+        use perl_lsp_rs_core::providers::completion::module_scan_cache::ModuleCompletionScanCache;
+        use perl_parser::Parser;
+        use std::sync::Arc;
+
+        let temp = tempfile::TempDir::new()?;
+        let lib = temp.path().join("lib");
+        let mojo_dir = lib.join("Mojo");
+        std::fs::create_dir_all(&mojo_dir)?;
+        std::fs::write(mojo_dir.join("Controller.pm"), "package Mojo::Controller;\n1;\n")?;
+        std::fs::write(mojo_dir.join("Lite.pm"), "package Mojo::Lite;\n1;\n")?;
+
+        let source = "use Mojo::";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse().map_err(|e| format!("parse error: {e:?}"))?;
+
+        // Uncached call.
+        let uncached_provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            source,
+            None,
+            vec![lib.clone()],
+            vec![],
+            false,
+        );
+        let uncached = uncached_provider.get_completions_with_path(source, source.len(), None);
+        let mut uncached_labels: Vec<String> = uncached.iter().map(|c| c.label.clone()).collect();
+        uncached_labels.sort();
+
+        // Cached call — first invocation populates the cache.
+        let cache = Arc::new(ModuleCompletionScanCache::new());
+        let cached_provider = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            source,
+            None,
+            vec![lib.clone()],
+            vec![],
+            false,
+        )
+        .with_scan_cache(Arc::clone(&cache));
+        let cached_first = cached_provider.get_completions_with_path(source, source.len(), None);
+        let mut cached_first_labels: Vec<String> =
+            cached_first.iter().map(|c| c.label.clone()).collect();
+        cached_first_labels.sort();
+
+        // Second invocation should hit the cache.
+        let cached_provider2 = CompletionProvider::new_with_index_and_source_and_paths(
+            &ast,
+            source,
+            None,
+            vec![lib.clone()],
+            vec![],
+            false,
+        )
+        .with_scan_cache(Arc::clone(&cache));
+        let cached_second = cached_provider2.get_completions_with_path(source, source.len(), None);
+        let mut cached_second_labels: Vec<String> =
+            cached_second.iter().map(|c| c.label.clone()).collect();
+        cached_second_labels.sort();
+
+        assert_eq!(
+            uncached_labels, cached_first_labels,
+            "first cached call must produce same labels as uncached"
+        );
+        assert_eq!(
+            cached_first_labels, cached_second_labels,
+            "second cached call (cache hit) must produce same labels as first"
+        );
+
+        Ok(())
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/mod.rs
@@ -211,6 +211,16 @@ pub struct LspServer {
     /// invalidation when source text changes — no TTL needed.
     pub(crate) semantic_analyzer_cache:
         Arc<Mutex<HashMap<(String, u64), Arc<crate::semantic::SemanticAnalyzer>>>>,
+    /// Short-TTL cache for module prefix directory scans (issue #8514).
+    ///
+    /// Typing a multi-segment `use` prefix (e.g. `use Mojo::Cont|`) triggers a
+    /// filesystem scan on every keystroke. This cache avoids repeated scans of the
+    /// same subdirectory within the 1-second interactive typing burst window.
+    ///
+    /// Cache is runtime-owned (per-server instance) because `CompletionProvider`
+    /// is reconstructed per request and cannot hold persistent state.
+    pub(crate) module_scan_cache:
+        Arc<perl_lsp_rs_core::providers::completion::module_scan_cache::ModuleCompletionScanCache>,
     /// Count of background workspace indexing tasks currently in flight.
     ///
     /// Incremented before spawning a background `index_file` task, decremented


### PR DESCRIPTION
## Current truth

Repeated `use Mojo::Cont|` keystrokes each re-scan `root/Mojo/` via
`scan_directory_for_modules`. Large vendor/local/system trees can be tens of MB,
turning every keystroke in a burst into a filesystem walk.

This PR adds a 1-second TTL / 128-entry cache owned by `LspServer` (runtime state
that survives across requests). `CompletionProvider` — which is reconstructed
per request — holds a cheap `Arc` clone of the cache but not the cache itself.

**What landed:**

- `ModuleCompletionScanCache` struct in `perl-lsp-rs-core::providers::completion::module_scan_cache`
  backed by `moka::sync::Cache` (1000 ms TTL, 128 entries, concurrent reads).
- Cache key: `(canonical_include_root: PathBuf, prefix_dir: PathBuf)` —
  e.g. `(canonicalize("/vendor/lib"), PathBuf::from("Mojo"))` for prefix `Mojo::Controller`.
- Cache population: on miss the scan runs and the result is stored; on hit the cached
  `Vec<String>` is returned immediately.
- **Cancellation checked before returning a cached hit** — a cancelled LSP request
  does not deliver stale results to the editor.
- LspServer struct field `module_scan_cache: Arc<ModuleCompletionScanCache>` initialized
  in all three constructors.
- `CompletionProvider::with_scan_cache(Arc<ModuleCompletionScanCache>) -> Self` builder.
- `add_use_module_completions_with_cache` variant in `workspace.rs`; the public
  `add_use_module_completions` wrapper preserved for backward compatibility.
- Both `handle_completion` and `handle_completion_cancellable` call `.with_scan_cache()`.

## Acceptance

```
cargo test -p perl-lsp-rs-core --lib completion -- --nocapture --test-threads=2
# 312 passed, 0 failed

RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib completion -- --nocapture --test-threads=2
# 35 passed, 0 failed (includes 5 new cache tests)

cargo test -p perl-lsp-rs --lib -- runtime::language::completion::tests::test_scan_cache
# 5 passed, 0 failed

cargo clippy --locked --lib -p perl-lsp-rs-core -p perl-lsp-rs -- -D warnings -A missing_docs
# No issues found

cargo xtask fmt --check
# Clean
```

New tests:
- `test_scan_cache_second_call_within_ttl_does_not_rescan` — cache hit on second call
- `test_scan_cache_different_prefix_dir_misses` — different dir is a miss
- `test_scan_cache_after_ttl_misses` — expired entry is a miss
- `test_scan_cache_cancellation_checked_before_returning_hit` — cancelled request gets empty result
- `test_scan_cache_cached_and_uncached_labels_match` — label parity between cached and uncached

Plus 7 unit tests in `module_scan_cache.rs` (insert/get, TTL, capacity, overwrite).

## Claim boundary

**Performance only** — completion labels, their order, and symlink handling are identical
to the pre-cache path. No new completion semantics. Cancellation behavior is preserved
and hardened (checked before cache return, not just before scan).

## Files changed

- `crates/perl-lsp-rs-core/src/providers/completion/module_scan_cache.rs` (new)
- `crates/perl-lsp-rs-core/src/providers/completion/mod.rs` — pub mod
- `crates/perl-lsp-rs-core/src/providers/completion/completion.rs` — `scan_cache` field + `with_scan_cache`
- `crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs` — `add_use_module_completions_with_cache`
- `crates/perl-lsp-rs/src/runtime/mod.rs` — `module_scan_cache` field on LspServer
- `crates/perl-lsp-rs/src/runtime/constructors.rs` — initialize in all 3 constructors
- `crates/perl-lsp-rs/src/runtime/language/completion.rs` — wire `.with_scan_cache()` + new tests

Closes #8514