### PR TITLE
docs(rollout): cross-link tracking issues for CI economics ladder rows (#8670)

### DIFF
--- a/docs/ci/codecov-rollout.md
+++ b/docs/ci/codecov-rollout.md
@@ -43,16 +43,18 @@ Codecov does **not** answer:
 
 Each row is one PR. Branch from clean `origin/master`. Do **not** combine.
 
-| #     | Branch                                  | Title                                                          | Notes                                                                                   |
-| ----- | --------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| Cov-1 | `ci/codecov-config`                     | `ci(codecov): quiet and scope coverage statuses`               | Replace `codecov.yml`: comments off, informational project/patch, single `parser-branch` flag |
-| Cov-2 | `ci/coverage-receipt`                   | `ci(coverage): add parser branch coverage receipt`             | `ci-nightly.yml::test-coverage` — change flag to `parser-branch`, harden upload condition (token detection + `continue-on-error`), emit `coverage-receipt.json`, write step summary |
-| Cov-3 | `docs/codecov-lane`                     | `docs(ci): document Codecov coverage lane boundary`            | Create `docs/ci/codecov.md` with claim boundary; reference from `docs/how-to/COVERAGE.md` if/when that doc exists |
-| Cov-4 | `docs/readme-codecov-badge`             | `docs(readme): clarify Codecov badge scope`                    | `alt="code coverage"` → `alt="Codecov parser branch coverage"`; MSRV badge `1.93` → `1.95` |
-| Cov-5 | `ci/codecov-test-analytics-docs`        | `ci(codecov): document receipt-backed test analytics`          | Adds a table that separates coverage vs Test Analytics vs branch ratchet (none blocking) |
-| Cov-6 | `policy/codecov-files`                  | `policy(ci): register Codecov coverage surfaces`               | Add entries for `codecov.yml`, `.github/workflows/ci-nightly.yml`, `.ci/coverage-baseline.txt` to `policy/non-rust-allowlist.toml` |
-| Cov-7 | `ci/coverage-workflow` *(optional, late)* | `ci(coverage): extract parser coverage into dedicated workflow` | Move `test-coverage` job out of `ci-nightly.yml` into `.github/workflows/coverage.yml`; remove the old job |
-| Cov-8 | `ci/codecov-ratchet` *(optional, late)* | `ci(codecov): calibrate parser coverage ratchet`               | Only after several stable runs; tune `.ci/coverage-baseline.txt` baseline/drop conservatively |
+| #     | Branch                                  | Title                                                          | Tracking      | Notes                                                                                   |
+| ----- | --------------------------------------- | -------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------- |
+| Cov-1 | `ci/codecov-config`                     | `ci(codecov): quiet and scope coverage statuses`               | #8578         | Replace `codecov.yml`: comments off, informational project/patch, single `parser-branch` flag |
+| Cov-2 | `ci/coverage-receipt`                   | `ci(coverage): add parser branch coverage receipt`             | #8582         | `ci-nightly.yml::test-coverage` — change flag to `parser-branch`, harden upload condition (token detection + `continue-on-error`), emit `coverage-receipt.json`, write step summary |
+| Cov-3 | `docs/codecov-lane`                     | `docs(ci): document Codecov coverage lane boundary`            | #8586         | Create `docs/ci/codecov.md` with claim boundary; reference from `docs/how-to/COVERAGE.md` if/when that doc exists |
+| Cov-4 | `docs/readme-codecov-badge`             | `docs(readme): clarify Codecov badge scope`                    | merged #8541  | `alt="code coverage"` → `alt="Codecov parser branch coverage"`; MSRV badge `1.93` → `1.95` |
+| Cov-5 | `ci/codecov-test-analytics-docs`        | `ci(codecov): document receipt-backed test analytics`          | #8588         | Adds a table that separates coverage vs Test Analytics vs branch ratchet (none blocking) |
+| Cov-6 | `policy/codecov-files`                  | `policy(ci): register Codecov coverage surfaces`               | #8594         | Add entries for `codecov.yml`, `.github/workflows/ci-nightly.yml`, `.ci/coverage-baseline.txt` to `policy/non-rust-allowlist.toml` |
+| Cov-7 | `ci/coverage-workflow` *(optional, late)* | `ci(coverage): extract parser coverage into dedicated workflow` | #8668         | Move `test-coverage` job out of `ci-nightly.yml` into `.github/workflows/coverage.yml`; remove the old job |
+| Cov-8 | `ci/codecov-ratchet` *(optional, late)* | `ci(codecov): calibrate parser coverage ratchet`               | #8669         | Only after several stable runs; tune `.ci/coverage-baseline.txt` baseline/drop conservatively |
+
+> Tracking issues filed 2026-05-11. Cross-link added via #8670.
 
 ## PR Cov-1 — `codecov.yml` shape
 

--- a/docs/ci/perl-lsp-ci-policy-rollout.md
+++ b/docs/ci/perl-lsp-ci-policy-rollout.md
@@ -12,6 +12,8 @@ as one of its pr-fast checks.
 
 ## Order
 
+> Tracking: PRs 3–11 are scoped together in #8174. PRs 01–02 already merged (#8158, #8159). Cross-link added via #8670.
+
 | PR | Name | Purpose | Mode introduced |
 |---:|---|---|---|
 | 01 | File-policy doctrine | Document `FILE_POLICY.md`, `NON_RUST_POLICY.md`, `POLICY_ALLOWLISTS.md`, this rollout. | n/a |

--- a/docs/ci/perl-lsp-rollout-plan.md
+++ b/docs/ci/perl-lsp-rollout-plan.md
@@ -13,28 +13,30 @@ replace the conveyor — it adds the missing economics layer.
 
 ## Order and status
 
-| PR | Name | Purpose | Status |
-|---:|---|---|---|
-| 01 | CI economics docs | Encode verification economics doctrine and contributor framing. | landed |
-| 02 | Policy TOML ledgers | Map every CI item to intent, cost, trigger, owner. | landed |
-| 03 | CI inventory | Inventory current workflows; flag duplicates and gaps. | landed |
-| 04 | PR Plan advisory | Emit per-PR LEM estimate and selected lanes. | landed |
-| 05 | Cache save-only-master | Stop PR cache write churn. | landed |
-| 06 | `ripr` advisory | Add static oracle-gap signal. | landed |
-| 07 | PR Plan: `ripr` + LEM wiring | Make planner aware of `ripr` and risk packs. | landed |
-| 08 | `ci-actuals` | Convert receipts into cost telemetry. | landed (upload wiring deferred) |
-| 09 | LEM in gate policy | Cross-reference `.ci/gate-policy.yaml` with lane economics. | landed |
-| 10 | Risk-pack routing metadata | Parser/LSP/workspace/DAP/security/memory risk packs. | landed |
-| 11 | Workflow policy lint | Lint workflows against `policy/ci-lane-whitelist.toml`. | landed |
-| 12 | `xtask ci plan` | Move PR Plan from Python to Rust. | deferred |
-| 13 | Soft LEM warnings | Warn above 35 / 75 LEM, hard guard above 125. | landed |
-| 14 | External AI review tuning | Make Droid review advisory and LEM-visible. | landed |
-| 15 | UX ownership clarification | Resolve `ci.yml` UX vs `ux-regression-gate.yml` overlap. | landed |
-| 16 | Learned estimate scaffolding | Use observed actuals for LEM estimates. | landed |
-| 17 | Conditional lane cleanup | Tune Windows / memory / UX / external review after actuals. | data-gated |
-| 18 | `ripr` soft-gate promotion | Require acknowledgement for high-confidence new gaps. | data-gated |
+| PR | Name | Purpose | Status | Tracking |
+|---:|---|---|---|---|
+| 01 | CI economics docs | Encode verification economics doctrine and contributor framing. | landed | #8134 |
+| 02 | Policy TOML ledgers | Map every CI item to intent, cost, trigger, owner. | landed | #8135 |
+| 03 | CI inventory | Inventory current workflows; flag duplicates and gaps. | landed | #8136 |
+| 04 | PR Plan advisory | Emit per-PR LEM estimate and selected lanes. | landed | #8137 |
+| 05 | Cache save-only-master | Stop PR cache write churn. | landed | #8138 |
+| 06 | `ripr` advisory | Add static oracle-gap signal. | landed | #8139 |
+| 07 | PR Plan: `ripr` + LEM wiring | Make planner aware of `ripr` and risk packs. | landed | #8142 |
+| 08 | `ci-actuals` | Convert receipts into cost telemetry. | landed (upload wiring deferred) | #8143 (wiring → #8166) |
+| 09 | LEM in gate policy | Cross-reference `.ci/gate-policy.yaml` with lane economics. | landed | #8144 |
+| 10 | Risk-pack routing metadata | Parser/LSP/workspace/DAP/security/memory risk packs. | landed | #8153 |
+| 11 | Workflow policy lint | Lint workflows against `policy/ci-lane-whitelist.toml`. | landed | #8154 |
+| 12 | `xtask ci plan` | Move PR Plan from Python to Rust. | deferred | #8166 |
+| 13 | Soft LEM warnings | Warn above 35 / 75 LEM, hard guard above 125. | landed | #8145 |
+| 14 | External AI review tuning | Make Droid review advisory and LEM-visible. | landed | #8146 |
+| 15 | UX ownership clarification | Resolve `ci.yml` UX vs `ux-regression-gate.yml` overlap. | landed | #8147 |
+| 16 | Learned estimate scaffolding | Use observed actuals for LEM estimates. | landed | #8155 |
+| 17 | Conditional lane cleanup | Tune Windows / memory / UX / external review after actuals. | data-gated | #8166 |
+| 18 | `ripr` soft-gate promotion | Require acknowledgement for high-confidence new gaps. | data-gated | #8166 |
 
 End-of-rollout retrospective: [`rollout-summary.md`](rollout-summary.md).
+
+> Tracking-column "landed" PR numbers are the audit-trail PRs from the retrospective; deferred rows (12, 17, 18 + actuals wiring) are tracked together in #8166. Cross-link added via #8670.
 
 ---
 

--- a/docs/ci/rollout-summary.md
+++ b/docs/ci/rollout-summary.md
@@ -139,6 +139,28 @@ Once data is available, gate promotion lands as a one-line change in `ripr.toml`
 
 ---
 
+## Follow-up tracking
+
+GitHub issues for every remaining row in the CI economics + Codecov + file-policy ladders (filed 2026-05-11 via #8670):
+
+| Ladder | Row | Issue |
+|---|---|---|
+| CI economics | PR 12, 17, 18 + actuals wiring (deferred cluster) | #8166 |
+| Codecov | Cov-1 (`codecov.yml` shape) | #8578 |
+| Codecov | Cov-2 (test-coverage receipt) | #8582 |
+| Codecov | Cov-3 (`docs/ci/codecov.md`) | #8586 |
+| Codecov | Cov-4 (README) | merged #8541 |
+| Codecov | Cov-5 (Test Analytics table) | #8588 |
+| Codecov | Cov-6 (policy registration) | #8594 |
+| Codecov | Cov-7 (dedicated workflow, optional/late) | #8668 |
+| Codecov | Cov-8 (ratchet calibration, data-gated) | #8669 |
+| File-policy | PRs 3–11 (xtask, companion ledgers, gate wiring) | #8174 |
+| Cross-link | this doc-update PR | #8670 |
+
+Coworker agents reading the ladders should open the corresponding tracking issue before starting work on a row.
+
+---
+
 ## Operational reminders
 
 - **PR Plan failure does not block merges.** The workflow is intentionally not a


### PR DESCRIPTION
## Summary

Adds a `Tracking` column / footnote to each CI economics + Codecov + file-policy ladder doc so coworker agents (codex, factory-droid, codex-burst) can navigate from a ladder row straight to its GitHub tracking issue.

## Docs touched

- `docs/ci/codecov-rollout.md` — `Tracking` column for Cov-1..Cov-8.
- `docs/ci/perl-lsp-rollout-plan.md` — `Tracking` column for rows 01-18 (audit-trail PRs + EffortlessMetrics/perl-lsp-swarm#2742 for the data-gated deferred cluster).
- `docs/ci/rollout-summary.md` — new `Follow-up tracking` table consolidating CI-economics + Codecov + file-policy + cross-link issues.
- `docs/ci/perl-lsp-ci-policy-rollout.md` — one-line note pointing at EffortlessMetrics/perl-lsp-swarm#2741 above the order table.

## Tracking issues filed 2026-05-11

- **Codecov ladder** — EffortlessMetrics/perl-lsp-swarm#2710 (Cov-1), EffortlessMetrics/perl-lsp-swarm#1827 (Cov-2), EffortlessMetrics/perl-lsp-swarm#1829 (Cov-3), EffortlessMetrics/perl-lsp-swarm#1831 (Cov-5), EffortlessMetrics/perl-lsp-swarm#1798 (Cov-6), EffortlessMetrics/perl-lsp-swarm#2698 (Cov-7), EffortlessMetrics/perl-lsp-swarm#2697 (Cov-8). Cov-4 already merged in EffortlessMetrics/perl-lsp#8541.
- **CI economics deferred cluster** (PR 12, 17, 18 + actuals wiring) — EffortlessMetrics/perl-lsp-swarm#2742 (pre-existing).
- **File-policy rollout PRs 3-11** — EffortlessMetrics/perl-lsp-swarm#2741 (pre-existing).
- **This doc-update PR** — EffortlessMetrics/perl-lsp#8670.

## Claim boundary

Docs-only PR. No code, workflow, policy TOML, or branch-protection changes. Does not change which ladder rows exist or what they require — only lowers the navigation cost for contributors and agents.

## Test plan

- [x] `git diff --check` clean
- [x] Tracking entries match filed-issue numbers above
- [ ] CI green (auto)

Closes EffortlessMetrics/perl-lsp#8670
