### PR TITLE
docs(evidence): correct ripr framing — shifts mutation signal earlier and cheaper (#8672)

### DIFF
--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -1,5 +1,11 @@
 # ripr — Static Oracle-Gap Detection
 
+> **Doctrine**: `ripr` is static mutation-exposure analysis. It catches the
+> same class of findings mutation testing catches — weak test/oracle
+> exposure — but earlier and cheaper because it is static and PR-time.
+> Mutation testing remains the slower runtime backstop for findings that
+> static analysis cannot predict. `ripr` shifts mutation signal left.
+
 `ripr` adds **mutation-testing-lite oracle-gap detection at static-analysis prices**. It
 sits between coverage and runtime mutation testing on the verification ladder: more
 oracle-aware than coverage, far cheaper than mutation testing.

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -31,11 +31,11 @@ warrant different cadences:
 | `ripr` (static oracle-gap) | every Rust-diff PR | Cheap static substitute that surfaces "this changed line is not exercised by any test that could discriminate behavior." Advisory only. |
 | Coverage | push to `master`, label-gated PR (`coverage`), workflow_dispatch | Codecov upload is push-billed; on-demand for PRs. |
 
-The doctrine, repeated from sibling-repo CI economics:
+The doctrine, from [`ripr.md`](ripr.md):
 
-> **`ripr` is the PR-time static oracle-exposure filter; it is not a
-> replacement for mutation testing. Mutation remains runtime evidence
-> for targeted PRs, nightly lanes, and release readiness.**
+> `ripr` shifts mutation signal left — static, per-PR, and cheaper than
+> runtime mutation testing, which remains the backstop for what static analysis
+> cannot predict. See [`docs/ci/ripr.md`](ripr.md) for the canonical framing.
 
 ## Lane shapes
 

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -17,10 +17,9 @@
 >
 > Umbrella for this consolidation: **#8663**.
 
-> Doctrine, repeated from the cross-repo CI economics plan:
-> **`ripr` is the PR-time static oracle-exposure filter; it is not a
-> replacement for mutation testing. Mutation remains runtime evidence
-> for targeted PRs, nightly lanes, and release readiness.**
+> Doctrine: `ripr` shifts mutation signal left — static, per-PR, and cheaper than
+> runtime mutation testing, which remains the backstop for what static analysis
+> cannot predict. See [`docs/ci/ripr.md`](../ci/ripr.md) for the canonical framing.
 
 The doc has four sections:
 

--- a/docs/releases/0.14.0-readiness.md
+++ b/docs/releases/0.14.0-readiness.md
@@ -73,7 +73,7 @@ Each row is a builder-ready issue that a sonnet builder can pick up.
 - [ ] No-panic exact-identity plan/spec present (#8567 design issue)
 - [ ] File-policy inventory + advisory check/propose at least planned (#8566/#8568)
 - [ ] Codecov claim boundary docs aligned (per rail #8646; Cov-1/3/5/6 ladder rows)
-- [ ] ripr-vs-mutation doctrine explicit (per merged PR #8617 rollout)
+- [x] ripr-vs-mutation doctrine explicit — shift-left framing canonical in [`docs/ci/ripr.md`](../ci/ripr.md) (#8672)
 
 ### Devex
 - [ ] Freshness-check spec merged (PR #8556 = merged); implementation issue (#8619) filed


### PR DESCRIPTION
## Current truth

`ripr` is static mutation-exposure analysis. It catches the same class of findings mutation testing catches — weak test/oracle exposure — but earlier and cheaper because it is static and PR-time. Mutation testing remains the slower runtime backstop for findings that static analysis cannot predict. `ripr` shifts mutation signal left.

This PR removes the propagated wrong framing ("ripr is not a replacement for mutation testing; mutation remains runtime evidence") from docs and replaces it with the canonical shift-left doctrine in `docs/ci/ripr.md`, with cross-links from other docs.

**Files changed:**

| File | Change |
|---|---|
| `docs/ci/ripr.md` | Added canonical doctrine block at top — this is now the authoritative source |
| `docs/ci/test-evidence-lanes.md` | Replaced wrong parallel-lanes blockquote with cross-link to `ripr.md` |
| `docs/development/RUST_1_95_ROLLOUT.md` | Replaced wrong doctrine block with cross-link to `ripr.md` |
| `docs/releases/0.14.0-readiness.md` | Marked `ripr-vs-mutation doctrine` checklist item done |

## Acceptance

```bash
# Wrong phrasings should be GONE (empty result expected):
rtk grep -rni "not a replacement.*mutation\|parallel evidence lane\|separate evidence lane\|oracle.exposure filter" docs/

# Verified empty on this branch. Only allowed exceptions:
# - issue body for EffortlessMetrics/perl-lsp#8672 itself (GitHub API, not in docs/)
# - git history from prior merged PRs
```

## Claim boundary

Docs precision only. No `.rs` or `.toml` files touched. CI configs and gate policies are unchanged. Pipeline ordering is unchanged — only the framing of why `ripr` and mutation testing relate as they do.

## Do not combine

- Not bundled with EffortlessMetrics/perl-lsp#8673 (industrialized-AI link) — that issue has a sequencing dependency on this one landing first.
- Not bundled with EffortlessMetrics/perl-lsp-swarm#1831 (Codecov Test Analytics receipt).

Closes EffortlessMetrics/perl-lsp#8672