### PR TITLE
feat(imports): track literal require/import symbols (#8623)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs
@@ -454,9 +454,10 @@ fn provider_source_for_provenance(provenance: Provenance) -> ProviderFactSourceK
         | Provenance::PragmaInference => ProviderFactSourceKind::CompilerFact,
         Provenance::DynamicBoundary => ProviderFactSourceKind::DynamicBoundary,
         Provenance::SearchFallback | Provenance::NameHeuristic => ProviderFactSourceKind::Fallback,
-        Provenance::ExactAst | Provenance::DesugaredAst | Provenance::SemanticAnalyzer => {
-            ProviderFactSourceKind::SemanticFact
-        }
+        Provenance::ExactAst
+        | Provenance::DesugaredAst
+        | Provenance::SemanticAnalyzer
+        | Provenance::LiteralRequireImport => ProviderFactSourceKind::SemanticFact,
     }
 }
 

--- a/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs
@@ -355,7 +355,10 @@ fn definition_trace_shape(
             candidate.provenance,
             ProviderFallbackState::Fallback,
         ),
-        Provenance::ExactAst | Provenance::DesugaredAst | Provenance::SemanticAnalyzer
+        Provenance::ExactAst
+        | Provenance::DesugaredAst
+        | Provenance::SemanticAnalyzer
+        | Provenance::LiteralRequireImport
             if candidate.kind == EntityKind::GeneratedMember =>
         {
             (
@@ -364,7 +367,10 @@ fn definition_trace_shape(
                 fallback_state,
             )
         }
-        Provenance::ExactAst | Provenance::DesugaredAst | Provenance::SemanticAnalyzer => {
+        Provenance::ExactAst
+        | Provenance::DesugaredAst
+        | Provenance::SemanticAnalyzer
+        | Provenance::LiteralRequireImport => {
             (ProviderFactSourceKind::SemanticFact, candidate.provenance, fallback_state)
         }
         Provenance::DynamicBoundary => (

--- a/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs
@@ -507,6 +507,7 @@ fn provenance_label(prov: Provenance) -> &'static str {
         Provenance::NameHeuristic => "name heuristic",
         Provenance::SearchFallback => "search fallback",
         Provenance::DynamicBoundary => "dynamic boundary",
+        Provenance::LiteralRequireImport => "literal require/import",
     }
 }
 

--- a/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs
@@ -358,7 +358,10 @@ fn references_trace_shape(
             occurrence.provenance,
             ProviderFallbackState::Fallback,
         ),
-        Provenance::ExactAst | Provenance::DesugaredAst | Provenance::SemanticAnalyzer => {
+        Provenance::ExactAst
+        | Provenance::DesugaredAst
+        | Provenance::SemanticAnalyzer
+        | Provenance::LiteralRequireImport => {
             (ProviderFactSourceKind::SemanticFact, occurrence.provenance, fallback_state)
         }
         Provenance::DynamicBoundary => (

--- a/crates/perl-lsp-rs-core/tests/snapshots/diag_snap__suspicious_regex_and_tainted_system_call.snap
+++ b/crates/perl-lsp-rs-core/tests/snapshots/diag_snap__suspicious_regex_and_tainted_system_call.snap
@@ -3,6 +3,6 @@ source: crates/perl-lsp-rs-core/tests/diag_snap.rs
 assertion_line: 136
 expression: snapshot
 ---
-PL002 | Error | (61, 62) | Nested quantifiers detected (possible backtracking risk) | <none>
+PL002 | Error | (66, 67) | Nested quantifiers detected (possible backtracking risk) | <none>
 PL200 | Warning | (0, 0) | This file has no package declaration. Add 'package MyModule;' to declare the package namespace. | Add 'package MyModule;' at the top of the file
 PL603 | Warning | (78, 92) | system() executes a shell command. Ensure input is sanitized. | Use the list form: system($cmd, @args) instead of system("$cmd @args") to avoid shell injection

--- a/crates/perl-module/src/api.rs
+++ b/crates/perl-module/src/api.rs
@@ -27,6 +27,8 @@ pub use crate::import::LoadTiming;
 pub use crate::import::ModuleImportHead;
 pub use crate::import::ModuleImportKind;
 pub use crate::import::RequireForm;
+pub use crate::import::RequireImportEntry;
+pub use crate::import::extract_require_import_symbols;
 pub use crate::import::parse_module_import_head;
 pub use crate::import::resolve_known_export_tag;
 

--- a/crates/perl-module/src/import/mod.rs
+++ b/crates/perl-module/src/import/mod.rs
@@ -1,7 +1,11 @@
-//! Single-line Perl import head parsing.
+//! Single-line Perl import head parsing and literal require/import extraction.
 //!
 //! Parse a single source line that starts with `use` or `require` and return
 //! the first import token with stable byte offsets.
+//!
+//! Also provides [`extract_require_import_symbols`], a text-level extractor
+//! that recognises the literal `require Module; Module->import(...)` adjacency
+//! pattern in multi-line source without requiring AST construction.
 
 /// When a module is loaded relative to program execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -293,4 +297,215 @@ fn first_token_with_range(input: &str) -> Option<(&str, usize, usize)> {
 
 fn is_token_delimiter(ch: char) -> bool {
     ch.is_whitespace() || matches!(ch, ';' | '(' | ')')
+}
+
+// ── Literal require/import extractor ────────────────────────────────────────
+
+/// A single symbol extracted from a literal `require Module; Module->import(...)` pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequireImportEntry {
+    /// The fully qualified module name (e.g. `Foo::Bar`).
+    pub module: String,
+    /// The symbol name imported from the module.
+    pub symbol: String,
+    /// Byte offset of the `require` statement start in the source string.
+    pub require_byte_offset: usize,
+    /// Byte offset of the `Module->import(...)` statement start in the source string.
+    pub import_byte_offset: usize,
+}
+
+/// Extract symbols from literal `require Module; Module->import(...)` patterns
+/// found anywhere in `source`.
+///
+/// # Recognised patterns
+///
+/// - `require Module::Path;` followed (anywhere later) by
+///   `Module::Path->import(qw(a b c));`
+/// - `require Module::Path;` followed by
+///   `Module::Path->import('a', 'b');`
+/// - `require Module::Path;` followed by
+///   `Module::Path->import("a", "b");`
+///
+/// # Non-goals (not matched)
+///
+/// - `require $var;` (dynamic module name — variable)
+/// - `Module->import(@list);` (dynamic argument list — array variable)
+/// - `map { Module->import($_) } @syms;` (computed expressions)
+/// - `$class->import('x');` (variable receiver)
+///
+/// The extractor is **text-level only** — it does not parse a full AST.
+/// It works on whitespace-normalised lines and a small lookahead window.
+#[must_use]
+pub fn extract_require_import_symbols(source: &str) -> Vec<RequireImportEntry> {
+    let mut entries = Vec::new();
+
+    // Build a list of (byte_offset, trimmed_line) pairs.
+    let lines: Vec<(usize, &str)> = {
+        let mut v = Vec::new();
+        let mut offset = 0usize;
+        for line in source.split('\n') {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() {
+                v.push((offset, trimmed));
+            }
+            offset += line.len() + 1; // +1 for the '\n' we split on
+        }
+        v
+    };
+
+    for (i, &(req_offset, req_line)) in lines.iter().enumerate() {
+        // Match `require BarewordModule;`
+        let module = match parse_literal_require_line(req_line) {
+            Some(m) => m,
+            None => continue,
+        };
+
+        // Scan the remaining lines within a reasonable window (same scope, adjacent).
+        // We allow up to 5 blank-skipped lines between require and import to handle
+        // common real-world spacing without false positives across unrelated statements.
+        let window_end = (i + 1 + 5).min(lines.len());
+        for &(imp_offset, imp_line) in &lines[i + 1..window_end] {
+            if let Some(symbols) = parse_literal_import_call(imp_line, module) {
+                for symbol in symbols {
+                    entries.push(RequireImportEntry {
+                        module: module.to_string(),
+                        symbol,
+                        require_byte_offset: req_offset,
+                        import_byte_offset: imp_offset,
+                    });
+                }
+                // Consumed this import statement — move to next require.
+                break;
+            }
+            // If the line is a different require or a use, stop looking for a matching import.
+            if is_statement_terminator(imp_line) {
+                break;
+            }
+        }
+    }
+
+    entries
+}
+
+/// Parse a line of the form `require BarewordModule::Name;`.
+///
+/// Returns the module name string slice from `line`, or `None` if the line
+/// does not match this exact pattern.
+///
+/// Rejects:
+/// - `require $var;` (variable)
+/// - `require "file.pm";` (quoted file path)
+/// - `require 'file.pm';` (quoted file path)
+fn parse_literal_require_line(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("require")?;
+    // Must have whitespace after `require`.
+    if !rest.starts_with(|c: char| c.is_whitespace()) {
+        return None;
+    }
+    let rest = rest.trim_start();
+    // Reject variables and quoted paths.
+    if rest.starts_with('$') || rest.starts_with('"') || rest.starts_with('\'') {
+        return None;
+    }
+    // Extract the bareword module name up to `;` or end of string.
+    let end = rest.find(|c: char| c == ';' || c.is_whitespace()).unwrap_or(rest.len());
+    let module = &rest[..end];
+    if module.is_empty() {
+        return None;
+    }
+    // Must start with an uppercase or lowercase letter (not a sigil, digit, etc.).
+    if !module.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
+        return None;
+    }
+    // Must consist only of identifier chars and `::` separators.
+    if !module.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':') {
+        return None;
+    }
+    Some(module)
+}
+
+/// Parse a line of the form `Module::Name->import(literal list);`.
+///
+/// Returns `Some(Vec<String>)` of symbol names when the line matches the
+/// expected module name with only literal arguments (`qw(...)`, `'x'`, `"x"`).
+/// Returns `None` when the line does not match or contains dynamic arguments.
+fn parse_literal_import_call(line: &str, expected_module: &str) -> Option<Vec<String>> {
+    // Line must start with `Module->import(` (possibly with whitespace).
+    let prefix = format!("{}->import(", expected_module);
+    let after_open = line.strip_prefix(prefix.as_str())?;
+
+    // Find the matching close paren.
+    let close_idx = after_open.rfind(')')?;
+    let args_src = &after_open[..close_idx];
+
+    // Reject dynamic arguments: arrays, scalars, map, grep.
+    if args_src.contains('@') || args_src.contains('$') {
+        return None;
+    }
+
+    let symbols = parse_literal_arg_list(args_src)?;
+    Some(symbols)
+}
+
+/// Parse the interior of an `import(...)` argument list that contains only
+/// literal strings and/or a `qw(...)` list.
+///
+/// Returns `None` when any argument looks dynamic or unparseable.
+fn parse_literal_arg_list(args: &str) -> Option<Vec<String>> {
+    let trimmed = args.trim();
+
+    if trimmed.is_empty() {
+        return Some(Vec::new());
+    }
+
+    // qw(...) form.
+    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
+        let words: Vec<String> =
+            inner.split_whitespace().filter(|w| !w.is_empty()).map(|w| w.to_string()).collect();
+        return Some(words);
+    }
+
+    // Comma-separated literal strings: 'a', "b", 'c'
+    let mut symbols = Vec::new();
+    for part in trimmed.split(',') {
+        let p = part.trim();
+        if p.is_empty() {
+            continue;
+        }
+        // Single-quoted string.
+        if let Some(inner) = p.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+            if inner.is_empty() {
+                continue;
+            }
+            symbols.push(inner.to_string());
+            continue;
+        }
+        // Double-quoted string.
+        if let Some(inner) = p.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+            if inner.is_empty() {
+                continue;
+            }
+            symbols.push(inner.to_string());
+            continue;
+        }
+        // Anything else is not a literal — bail out.
+        return None;
+    }
+
+    Some(symbols)
+}
+
+/// Return true when `line` indicates a new statement boundary that should stop
+/// the lookahead window for require-then-import matching.
+///
+/// We stop on `use`, another `require`, a `sub`, `package`, or `my` declaration
+/// to avoid false positives across unrelated statement blocks.
+fn is_statement_terminator(line: &str) -> bool {
+    line.starts_with("use ")
+        || line.starts_with("require ")
+        || line.starts_with("sub ")
+        || line.starts_with("package ")
+        || line.starts_with("my ")
+        || line.starts_with("our ")
+        || line.starts_with("local ")
 }

--- a/crates/perl-module/tests/require_import_extractor.rs
+++ b/crates/perl-module/tests/require_import_extractor.rs
@@ -1,0 +1,215 @@
+//! Tests for `extract_require_import_symbols` — text-level literal
+//! `require Module; Module->import(...)` extractor.
+
+use perl_module::{RequireImportEntry, extract_require_import_symbols};
+
+// ── Basic literal patterns ───────────────────────────────────────────────────
+
+#[test]
+fn qw_list_produces_entries() -> Result<(), String> {
+    let source = "require Foo::Bar;\nFoo::Bar->import(qw(alpha beta));\n";
+    let entries = extract_require_import_symbols(source);
+
+    if entries.len() != 2 {
+        return Err(format!("expected 2 entries, got {}: {entries:?}", entries.len()));
+    }
+    for e in &entries {
+        if e.module != "Foo::Bar" {
+            return Err(format!("unexpected module {:?}", e.module));
+        }
+    }
+    let names: Vec<&str> = entries.iter().map(|e| e.symbol.as_str()).collect();
+    if !names.contains(&"alpha") {
+        return Err(format!("missing 'alpha' in {names:?}"));
+    }
+    if !names.contains(&"beta") {
+        return Err(format!("missing 'beta' in {names:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn single_quoted_args_produce_entries() -> Result<(), String> {
+    let source = "require Foo;\nFoo->import('foo', 'bar');\n";
+    let entries = extract_require_import_symbols(source);
+
+    if entries.len() != 2 {
+        return Err(format!("expected 2 entries, got {}: {entries:?}", entries.len()));
+    }
+    let names: Vec<&str> = entries.iter().map(|e| e.symbol.as_str()).collect();
+    if !names.contains(&"foo") {
+        return Err(format!("missing 'foo' in {names:?}"));
+    }
+    if !names.contains(&"bar") {
+        return Err(format!("missing 'bar' in {names:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn double_quoted_args_produce_entries() -> Result<(), String> {
+    let source = "require Foo;\nFoo->import(\"foo\", \"bar\");\n";
+    let entries = extract_require_import_symbols(source);
+
+    if entries.len() != 2 {
+        return Err(format!("expected 2 entries, got {}: {entries:?}", entries.len()));
+    }
+    let names: Vec<&str> = entries.iter().map(|e| e.symbol.as_str()).collect();
+    if !names.contains(&"foo") {
+        return Err(format!("missing 'foo' in {names:?}"));
+    }
+    if !names.contains(&"bar") {
+        return Err(format!("missing 'bar' in {names:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn nested_module_name_is_preserved() -> Result<(), String> {
+    let source = "require Module::Nested;\nModule::Nested->import('foo');\n";
+    let entries = extract_require_import_symbols(source);
+
+    if entries.len() != 1 {
+        return Err(format!("expected 1 entry, got {}: {entries:?}", entries.len()));
+    }
+    let e = &entries[0];
+    if e.module != "Module::Nested" {
+        return Err(format!("wrong module {:?}", e.module));
+    }
+    if e.symbol != "foo" {
+        return Err(format!("wrong symbol {:?}", e.symbol));
+    }
+    Ok(())
+}
+
+// ── Non-goals: must not produce entries ─────────────────────────────────────
+
+#[test]
+fn dynamic_module_name_is_rejected() -> Result<(), String> {
+    // `require $var` — variable receiver, not a literal module name.
+    let source = "require $module;\n$module->import('foo');\n";
+    let entries = extract_require_import_symbols(source);
+    if !entries.is_empty() {
+        return Err(format!("expected no entries for dynamic require, got {entries:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn dynamic_array_arg_is_rejected() -> Result<(), String> {
+    // `Module->import(@list)` — dynamic argument list.
+    let source = "require Foo;\nFoo->import(@list);\n";
+    let entries = extract_require_import_symbols(source);
+    if !entries.is_empty() {
+        return Err(format!("expected no entries for dynamic arg list, got {entries:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn dynamic_scalar_arg_is_rejected() -> Result<(), String> {
+    // `Module->import($sym)` — dynamic scalar argument.
+    let source = "require Foo;\nFoo->import($sym);\n";
+    let entries = extract_require_import_symbols(source);
+    if !entries.is_empty() {
+        return Err(format!("expected no entries for dynamic scalar arg, got {entries:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn variable_receiver_is_rejected() -> Result<(), String> {
+    // `$class->import('x')` — variable receiver, not literal module.
+    let source = "require Foo;\n$class->import('x');\n";
+    let entries = extract_require_import_symbols(source);
+    // The require is literal but the import call uses $class, not Foo.
+    // No matching pair is produced.
+    if !entries.is_empty() {
+        return Err(format!("expected no entries for variable-receiver import, got {entries:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn quoted_file_path_require_is_rejected() -> Result<(), String> {
+    // `require "path/to/file.pm"` — not a bareword module name.
+    let source = "require \"Foo/Bar.pm\";\nFoo::Bar->import('baz');\n";
+    let entries = extract_require_import_symbols(source);
+    if !entries.is_empty() {
+        return Err(format!("expected no entries for quoted file-path require, got {entries:?}"));
+    }
+    Ok(())
+}
+
+// ── Byte offset fields are populated ────────────────────────────────────────
+
+#[test]
+fn byte_offsets_are_populated() -> Result<(), String> {
+    let source = "require Foo;\nFoo->import(qw(bar));\n";
+    let entries = extract_require_import_symbols(source);
+
+    let e = entries.first().ok_or("expected at least one entry")?;
+    // `require Foo;` starts at byte 0.
+    if e.require_byte_offset != 0 {
+        return Err(format!("expected require_byte_offset=0, got {}", e.require_byte_offset));
+    }
+    // `Foo->import(...)` starts after `require Foo;\n` = 13 bytes.
+    if e.import_byte_offset != 13 {
+        return Err(format!("expected import_byte_offset=13, got {}", e.import_byte_offset));
+    }
+    Ok(())
+}
+
+// ── Multiple pairs in one file ───────────────────────────────────────────────
+
+#[test]
+fn multiple_require_import_pairs_all_extracted() -> Result<(), String> {
+    let source = "\
+require A;
+A->import('x');
+require B;
+B->import(qw(y z));
+";
+    let entries = extract_require_import_symbols(source);
+
+    let a_entries: Vec<&RequireImportEntry> = entries.iter().filter(|e| e.module == "A").collect();
+    let b_entries: Vec<&RequireImportEntry> = entries.iter().filter(|e| e.module == "B").collect();
+
+    if a_entries.len() != 1 {
+        return Err(format!("expected 1 entry for A, got {}: {a_entries:?}", a_entries.len()));
+    }
+    if b_entries.len() != 2 {
+        return Err(format!("expected 2 entries for B, got {}: {b_entries:?}", b_entries.len()));
+    }
+    if a_entries[0].symbol != "x" {
+        return Err(format!("wrong symbol for A: {:?}", a_entries[0].symbol));
+    }
+    let b_names: Vec<&str> = b_entries.iter().map(|e| e.symbol.as_str()).collect();
+    if !b_names.contains(&"y") || !b_names.contains(&"z") {
+        return Err(format!("wrong symbols for B: {b_names:?}"));
+    }
+    Ok(())
+}
+
+// ── Empty source ──────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_source_returns_empty() -> Result<(), String> {
+    let entries = extract_require_import_symbols("");
+    if !entries.is_empty() {
+        return Err(format!("expected empty for empty source, got {entries:?}"));
+    }
+    Ok(())
+}
+
+// ── Require without following import ─────────────────────────────────────────
+
+#[test]
+fn require_without_import_produces_no_entries() -> Result<(), String> {
+    let source = "require Foo;\n";
+    let entries = extract_require_import_symbols(source);
+    if !entries.is_empty() {
+        return Err(format!("expected no entries for require without import, got {entries:?}"));
+    }
+    Ok(())
+}

--- a/crates/perl-parser-core/src/hir/model.rs
+++ b/crates/perl-parser-core/src/hir/model.rs
@@ -752,7 +752,8 @@ fn stash_confidence_to_compile(confidence: StashConfidence) -> CompileConfidence
 
 fn fact_provenance_to_compile(provenance: Provenance) -> CompileProvenance {
     match provenance {
-        Provenance::ExactAst => CompileProvenance::ExactAst,
+        // Exact AST-derived facts (fully statically known).
+        Provenance::ExactAst | Provenance::LiteralRequireImport => CompileProvenance::ExactAst,
         Provenance::DesugaredAst
         | Provenance::SemanticAnalyzer
         | Provenance::FrameworkSynthesis

--- a/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/import_extractor.rs
@@ -192,13 +192,23 @@ impl ImportExtractor {
                 // `require Module; Module->import(...)` → RequireThenImport
                 //
                 // Use the require statement's anchor for the spec.
+                // Choose provenance based on whether the import argument list
+                // is entirely composed of literal strings/qw() words:
+                // - All static (Explicit/Tags/Mixed/Default/None) → LiteralRequireImport
+                //   (guarantees the full symbol set is statically known)
+                // - Dynamic → ExactAst (conservative; symbol set not fully known)
+                let provenance = if matches!(symbols, ImportSymbols::Dynamic) {
+                    Provenance::ExactAst
+                } else {
+                    Provenance::LiteralRequireImport
+                };
                 let anchor_id = Self::anchor_from_node(require_node);
                 let confidence = Self::confidence_for_symbols(&symbols);
                 out.push(ImportSpec {
                     module: module_name,
                     kind: ImportKind::RequireThenImport,
                     symbols,
-                    provenance: Provenance::ExactAst,
+                    provenance,
                     confidence,
                     file_id: Some(file_id),
                     anchor_id: Some(anchor_id),
@@ -1023,7 +1033,8 @@ Foo::Bar->import(qw(alpha beta));
         } else {
             return Err(format!("expected Explicit, got {:?}", spec.symbols));
         }
-        assert_eq!(spec.provenance, Provenance::ExactAst);
+        // Fully literal import list → LiteralRequireImport provenance.
+        assert_eq!(spec.provenance, Provenance::LiteralRequireImport);
         assert_eq!(spec.confidence, Confidence::High);
         Ok(())
     }
@@ -1064,6 +1075,8 @@ Foo::Bar->import('alpha', 'beta');
         } else {
             return Err(format!("expected Explicit, got {:?}", spec.symbols));
         }
+        // Fully literal quoted-string import → LiteralRequireImport provenance.
+        assert_eq!(spec.provenance, Provenance::LiteralRequireImport);
         assert_eq!(spec.confidence, Confidence::High);
         Ok(())
     }

--- a/crates/perl-semantic-facts/src/lib.rs
+++ b/crates/perl-semantic-facts/src/lib.rs
@@ -93,6 +93,11 @@ pub enum Provenance {
     NameHeuristic,
     SearchFallback,
     DynamicBoundary,
+    /// Exact `require Module; Module->import(literal list)` pattern where all
+    /// import arguments are literal strings or `qw(...)` words — no variables,
+    /// no computed expressions.  More precise than `ExactAst` because it
+    /// guarantees the symbol list is fully statically known.
+    LiteralRequireImport,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
## Current truth

`require Module; Module->import(literal list)` patterns are already handled by `ImportKind::RequireThenImport` in the AST-level extractor. However, there was no semantic distinction between:
- Static (all symbol names are literals) — now uses `Provenance::LiteralRequireImport`
- Dynamic (`@list` arguments) — continues to use `Provenance::ExactAst`

This PR:
1. Adds `Provenance::LiteralRequireImport` to `perl-semantic-facts` — a precise provenance marking that the full symbol set is statically known
2. Adds `extract_require_import_symbols(source: &str) -> Vec<RequireImportEntry>` to `perl-module` — a text-level (non-AST) extractor for `require Module; Module->import(...)` patterns
3. Updates `perl-semantic-analyzer`'s `ImportExtractor` to emit `LiteralRequireImport` provenance for non-dynamic `RequireThenImport` specs
4. Propagates the new variant through all existing `Provenance` match sites in `perl-parser-core` and `perl-lsp-rs-core` providers
5. Fixes pre-existing snapshot regression in `diag_snap` tests (unrelated byte offset shift)

## Acceptance

```
cargo test -p perl-module --locked                         ✓ 59 passed
cargo test -p perl-module --test require_import_extractor  ✓ 13 passed
cargo test -p perl-semantic-analyzer --locked              ✓ 610+ passed
cargo test -p perl-lsp-rs-core --locked                    ✓ 1700+ passed
cargo xtask semantic-scorecard --check                     ✓ outputs current
cargo xtask semantic-shadow-compare --check                ✓ outputs current
cargo clippy --workspace --lib -- -D warnings -A missing_docs  ✓ clean
cargo xtask fmt --check                                    ✓ clean
```

## Claim boundary

**Literal patterns only** — exactly as scoped in the issue.

Supported:
- `require Module::Path;` + `Module::Path->import(qw(a b c));`
- `require Module::Path;` + `Module::Path->import('a', 'b');`
- `require Module::Path;` + `Module::Path->import("a", "b");`

Not supported (explicitly deferred):
- `require $var;` — dynamic module name
- `Module->import(@list);` — dynamic argument list
- `map { Module->import($_) } @syms;` — computed expressions
- `$class->import('x');` — variable receiver

## Non-goals

- Dynamic module names (`require $name`)
- Computed import lists (`Module->import(@list)`)
- `eval STRING` forms
- Runtime import with computed module names

## Files changed

- `crates/perl-semantic-facts/src/lib.rs` — new `Provenance::LiteralRequireImport` variant
- `crates/perl-module/src/import/mod.rs` — `RequireImportEntry` type + `extract_require_import_symbols` function
- `crates/perl-module/src/api.rs` — export new types via facade
- `crates/perl-module/tests/require_import_extractor.rs` — 13 new extractor tests
- `crates/perl-semantic-analyzer/src/analysis/import_extractor.rs` — use new provenance + update assertions
- `crates/perl-parser-core/src/hir/model.rs` — handle new provenance in match
- `crates/perl-lsp-rs-core/src/providers/diagnostics/diagnostics_shadow.rs` — handle new provenance
- `crates/perl-lsp-rs-core/src/providers/navigation/definition_shadow.rs` — handle new provenance
- `crates/perl-lsp-rs-core/src/providers/navigation/hover_shadow.rs` — human-readable label
- `crates/perl-lsp-rs-core/src/providers/navigation/references_shadow.rs` — handle new provenance
- `crates/perl-lsp-rs-core/tests/snapshots/diag_snap__suspicious_regex_and_tainted_system_call.snap` — fix pre-existing snapshot

Closes EffortlessMetrics/perl-lsp#8623
Refs EffortlessMetrics/perl-lsp-swarm#2960