### PR TITLE
fix(perl-oracle): honor startup probe timeout (#8622)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/mod.rs
+++ b/crates/perl-lsp-rs-core/src/config/mod.rs
@@ -724,10 +724,11 @@ impl WorkspaceConfig {
             Some(o) => o,
             None => return Vec::new(),
         };
+        let timeout = oracle.timeout;
         let mut command = oracle.into_command();
         command.args(perl_args);
         command.args(["-e", "print join(\"\\n\", @INC)"]);
-        let output = output_with_timeout(command, SYSTEM_INC_PROBE_TIMEOUT);
+        let output = output_with_timeout(command, timeout);
 
         match output {
             Ok(out) if out.status.success() => {
@@ -746,7 +747,7 @@ impl WorkspaceConfig {
             Err(err) if err.kind() == std::io::ErrorKind::TimedOut => {
                 tracing::warn!(
                     target: "perl_lsp::config::system_inc",
-                    timeout_ms = SYSTEM_INC_PROBE_TIMEOUT.as_millis() as u64,
+                    timeout_ms = timeout.as_millis() as u64,
                     "startup @INC probe timed out; caching empty result. \
                      Set perl.workspace.useSystemInc=false to disable probing, \
                      or pin a faster perl interpreter."

--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -37,6 +37,8 @@ use std::process::Command;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
+#[cfg(not(target_arch = "wasm32"))]
+use super::SYSTEM_INC_PROBE_TIMEOUT;
 use super::WorkspaceConfig;
 
 /// Controlled subprocess environment for a single Perl oracle seam.
@@ -182,7 +184,7 @@ impl PerlOracleEnv {
         Some(Self {
             perl_binary,
             cwd,
-            timeout: Duration::from_millis(1000),
+            timeout: SYSTEM_INC_PROBE_TIMEOUT,
             allow_perl5lib: config.use_perl5lib,
             allow_perl5opt: false,
             allow_local_lib: false,
@@ -263,6 +265,8 @@ mod tests {
         let env = PerlOracleEnv::for_startup_inc_probe(&config);
         if let Some(e) = env {
             assert!(!e.allow_perl5lib, "allow_perl5lib should be false when use_perl5lib=false");
+            assert!(!e.allow_perl5opt, "allow_perl5opt must always be false for startup probe");
+            assert!(!e.allow_local_lib, "allow_local_lib must always be false for startup probe");
         }
     }
 


### PR DESCRIPTION
Problem: PerlOracleEnv exposed a startup probe timeout that fetch_perl_inc did not consume, and one constructor test missed two false-branch deny flags.
Fix: fetch_perl_inc now uses oracle.timeout for execution and logging, the constructor shares SYSTEM_INC_PROBE_TIMEOUT, and the false branch asserts all deny flags.
Verification: cargo test -p perl-lsp-rs-core --lib --profile agent --locked for_startup_inc_probe -- --nocapture; cargo test -p perl-lsp-rs-core --lib --profile agent --locked output_with_timeout -- --nocapture; cargo test -p perl-lsp-rs-core --lib --profile agent --locked get_system_inc_does_not_stall -- --nocapture; cargo check -p perl-lsp-rs-core --all-targets --profile agent --locked; cargo clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs; cargo xtask fmt --check; git diff --check