### PR TITLE
docs(ci): link Industrialized-AI framework as CI design rationale (#8673)

### DIFF
--- a/docs/ci/ci-actuals.md
+++ b/docs/ci/ci-actuals.md
@@ -1,5 +1,7 @@
 # CI Actuals
 
+> **Context**: This document is part of perl-lsp's [Industrialized AI](why-industrialized.md) CI architecture. The choices here are responses to operating at 1000+ PRs/day, not premature optimization.
+
 `ci-actuals.json` records what each gate actually spent in CI. It is the actuals
 counterpart to [`ci-plan.json`](pr-plan.md): the plan forecasts cost; the actuals
 record what was spent. Together they let later PRs derive learned LEM estimates.

--- a/docs/ci/codecov-rollout.md
+++ b/docs/ci/codecov-rollout.md
@@ -1,5 +1,7 @@
 # Codecov Rollout
 
+> **Context**: This document is part of perl-lsp's [Industrialized AI](why-industrialized.md) CI architecture. The choices here are responses to operating at 1000+ PRs/day, not premature optimization.
+
 Tightens Codecov's posture in perl-lsp so it accurately reflects what's
 actually uploaded, stays out of branch-protection theater, and remains
 useful alongside the other evidence lanes.

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -1,5 +1,7 @@
 # CI Cost and Verification Policy
 
+> **Context**: This document is part of perl-lsp's [Industrialized AI](why-industrialized.md) CI architecture. The choices here are responses to operating at 1000+ PRs/day, not premature optimization.
+
 This repository targets CI cost per ordinary PR far below common high-volume agentic
 defaults. The goal is **not** lighter verification. The goal is stronger verification per
 CI minute.

--- a/docs/ci/gate-policy-economics.md
+++ b/docs/ci/gate-policy-economics.md
@@ -1,5 +1,7 @@
 # Gate Policy ↔ Lane Economics Cross-Reference
 
+> **Context**: This document is part of perl-lsp's [Industrialized AI](why-industrialized.md) CI architecture. The choices here are responses to operating at 1000+ PRs/day, not premature optimization.
+
 `.ci/gate-policy.yaml` defines **what executes**; `policy/ci-lanes.toml` defines **what
 it costs and why**. This doc is the cross-reference between the two. The mapping
 itself lives in `scripts/ci/validate_gate_lane_mapping.py` so it can be checked by

--- a/docs/ci/lem-budgeting.md
+++ b/docs/ci/lem-budgeting.md
@@ -1,5 +1,7 @@
 # Linux-Equivalent Minutes (LEM)
 
+> **Context**: This document is part of perl-lsp's [Industrialized AI](why-industrialized.md) CI architecture. The choices here are responses to operating at 1000+ PRs/day, not premature optimization.
+
 LEM is a normalized cost unit for CI lanes. It lets every lane and every PR be compared
 on the same axis regardless of which runner type or OS the work runs on.
 

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -1,5 +1,7 @@
 # ripr — Static Oracle-Gap Detection
 
+> **Context**: This document is part of perl-lsp's [Industrialized AI](why-industrialized.md) CI architecture. The choices here are responses to operating at 1000+ PRs/day, not premature optimization.
+
 > **Doctrine**: `ripr` is static mutation-exposure analysis. It catches the
 > same class of findings mutation testing catches — weak test/oracle
 > exposure — but earlier and cheaper because it is static and PR-time.

--- a/docs/ci/why-industrialized.md
+++ b/docs/ci/why-industrialized.md
@@ -1,0 +1,36 @@
+# Why this CI architecture exists
+
+perl-lsp operates in **Industrialized AI mode** (the fourth step of the
+four-mode AI-development progression).
+
+| Mode | Who writes | Who reviews | PR size | Daily volume |
+|---|---|---|---|---|
+| Suggestions | Human | Human | ~76 lines | A few |
+| Assisted | AI | Human | ~500 lines | Dozens |
+| Native | AI | AI | 2,000–20,000 lines | Hundreds |
+| **Industrialized** | AI | AI | Continuous | **1,000+ PRs** |
+
+Reference: [Assisted, Native, Industrialized](https://effortlesssteven.com/assisted-native-industrialized/).
+
+At ~1000+ PRs/day with agents on both sides, verification cost is
+already higher than LLM cost. The CI architecture in this repo is a
+direct response to that operating mode:
+
+| Choice | What it's responding to |
+|---|---|
+| Scoped per-crate / per-domain gates | Full-workspace builds × 1000 PRs/day are infeasible |
+| LEM (Learned Estimate Model) budgeting | Predictive cost-per-PR is how the CI budget gets spent intelligently at scale |
+| ripr as static mutation-exposure analysis | Shift-left the same signal mutation testing catches; mutation as runtime backstop on the residual |
+| Claim boundaries on every evidence lane | Ambiguous claims compound into systemic mistrust faster at industrialized volume |
+| Rail-burndown docs + builder-ready issue ladders | Coworker agents need specs, not chat history; specs-for-agents > prose-for-humans |
+| Coworker-agent lanes (codex / factory-droid / claude / aider) | Orchestration depends on each agent having queued builder-ready work |
+
+Without the framework, these choices look like over-engineering. With it,
+they're the only sustainable architecture for this throughput.
+
+## Related
+
+- [`ripr.md`](ripr.md) — static mutation-exposure analysis doctrine
+- [`codecov-rollout.md`](codecov-rollout.md) — coverage claim boundaries
+- [`gate-policy-economics.md`](gate-policy-economics.md) — scoped gate policy
+- [`lem-budgeting.md`](lem-budgeting.md) — Learned Estimate Model

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -1,5 +1,7 @@
 # Rust 1.95 → 0.14.0 Remaining Roadmap
 
+> **Context**: This document is part of perl-lsp's [Industrialized AI](../ci/why-industrialized.md) CI architecture. The choices here are responses to operating at 1000+ PRs/day, not premature optimization.
+
 > **Canonical post-landing source of truth** for the Rust 1.95 / 0.14.0
 > quality rollout. The MSRV / toolchain / `clippy.toml`-msrv bumps have
 > shipped (#8509); this doc tracks what remains from here to the 0.14.0

--- a/docs/releases/0.14.0-readiness.md
+++ b/docs/releases/0.14.0-readiness.md
@@ -1,5 +1,7 @@
 # 0.14.0 Readiness
 
+> **Context**: This document is part of perl-lsp's [Industrialized AI](../ci/why-industrialized.md) CI architecture. The choices here are responses to operating at 1000+ PRs/day, not premature optimization.
+
 > **Substrate (already built)**: Rust 1.95 MSRV/toolchain (#8509); @INC strictness rail (#8544, #8540); rollout docs (#8539, #8545); forensics doc (#8550); freshness-check spec (#8556); rail meta (#8636).
 > **Connector gap**: drain open docs/spec queue, implement product/release connectors, lock release criteria.
 > **0.14.0 upside**: the substrate becomes a tagged release.


### PR DESCRIPTION
## Current truth

- New canonical doc `docs/ci/why-industrialized.md` — single source explaining why perl-lsp's CI choices (scoped gates, LEM budgeting, ripr, claim boundaries) follow from Industrialized AI mode (~1000+ PRs/day, agents on both sides).
- Context cross-link added to 8 existing docs immediately after their title.

## Acceptance

```bash
# All listed docs reference the canonical:
grep -rl "industrialized" docs/ci/ docs/development/ docs/releases/

# Docs-only — no Rust touched:
git diff --name-only origin/master | grep -v '\.md$'  # should be empty
```

## Claim boundary

Docs precision only. Does NOT change CI behavior, gate policies, LEM budgets, or any code. The architecture is unchanged; only the explanatory framing changes so external readers (humans, agents, future maintainers) have the operating-mode context.

Closes #8673