### PR TITLE
tooling(devex): implement cargo xtask freshness-check (#8619)

### DIFF
--- a/scripts/githooks/warn-stale-checkout.sh
+++ b/scripts/githooks/warn-stale-checkout.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# warn-stale-checkout.sh — opt-in git hook for stale checkout warnings.
+#
+# Calls `cargo xtask freshness-check --mode warn` and parses the JSON receipt.
+# When `safe_for_code_state_claims == false`, prints a one-line warning to
+# stderr with the `behind_by` count and the remediation command.
+#
+# Always exits 0 — this is a warning hook, not a blocking hook.
+#
+# Installation (opt-in):
+#   bash scripts/install-githooks.sh
+#
+# Or link manually:
+#   ln -sf ../../scripts/githooks/warn-stale-checkout.sh .git/hooks/post-checkout
+#
+# Reference: docs/devex/freshness-check.md
+
+set -euo pipefail
+
+# Locate cargo — fall back gracefully if not available.
+if ! command -v cargo &>/dev/null; then
+    exit 0
+fi
+
+# Run the freshness check in warn mode, capturing JSON output.
+RECEIPT="$(cargo xtask freshness-check --mode warn --no-fetch 2>/dev/null)" || {
+    # If xtask itself fails (not built yet, etc.), silently skip.
+    exit 0
+}
+
+# Parse the receipt. Prefer jq; fall back to python; fall back to grep.
+if command -v jq &>/dev/null; then
+    SAFE="$(printf '%s' "$RECEIPT" | jq -r '.safe_for_code_state_claims')"
+    BEHIND="$(printf '%s' "$RECEIPT" | jq -r '.behind_by')"
+    BASE_REF="$(printf '%s' "$RECEIPT" | jq -r '.base_ref')"
+elif command -v python3 &>/dev/null; then
+    SAFE="$(printf '%s' "$RECEIPT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(str(d['safe_for_code_state_claims']).lower())")"
+    BEHIND="$(printf '%s' "$RECEIPT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['behind_by'])")"
+    BASE_REF="$(printf '%s' "$RECEIPT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['base_ref'])")"
+elif command -v python &>/dev/null; then
+    SAFE="$(printf '%s' "$RECEIPT" | python -c "import sys,json; d=json.load(sys.stdin); print(str(d['safe_for_code_state_claims']).lower())")"
+    BEHIND="$(printf '%s' "$RECEIPT" | python -c "import sys,json; d=json.load(sys.stdin); print(d['behind_by'])")"
+    BASE_REF="$(printf '%s' "$RECEIPT" | python -c "import sys,json; d=json.load(sys.stdin); print(d['base_ref'])")"
+else
+    # Cannot parse JSON — skip the warning silently.
+    exit 0
+fi
+
+if [ "$SAFE" = "false" ]; then
+    echo "⚠  stale checkout: HEAD is ${BEHIND} commit(s) behind ${BASE_REF}" >&2
+    echo "   run: git pull --rebase" >&2
+fi
+
+exit 0

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1412,6 +1412,38 @@ enum Commands {
         #[command(subcommand)]
         command: NonRustCommand,
     },
+
+    /// Check whether the current checkout is behind origin/master.
+    ///
+    /// Emits a JSON receipt (schema_version 1) with staleness metadata.
+    /// Use --mode block to fail when stale; default is warn (exit 0 always).
+    ///
+    /// Example: `cargo xtask freshness-check --base origin/master --mode block`
+    FreshnessCheck {
+        /// Base git reference to compare HEAD against.
+        #[arg(long, default_value = "origin/master")]
+        base: String,
+
+        /// Operating mode: warn (default, exit 0) or block (exit 1 when stale).
+        #[arg(long, value_enum, default_value = "warn")]
+        mode: FreshnessCheckMode,
+
+        /// Write the JSON receipt to this file path instead of stdout.
+        #[arg(long)]
+        json: Option<PathBuf>,
+
+        /// Skip the `git fetch` step.
+        #[arg(long)]
+        no_fetch: bool,
+
+        /// Accept a stale checkout for historical/archaeology work. Requires --reason.
+        #[arg(long, requires = "reason")]
+        allow_historical: bool,
+
+        /// Reason text for the historical override (required with --allow-historical).
+        #[arg(long)]
+        reason: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1580,6 +1612,13 @@ enum GatePolicyCommand {
 enum GateReceiptsFormat {
     Human,
     Json,
+}
+
+/// CLI-facing mode enum for freshness-check (maps to `tasks::freshness_check::FreshnessMode`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum FreshnessCheckMode {
+    Warn,
+    Block,
 }
 
 #[derive(Subcommand)]
@@ -2852,6 +2891,21 @@ fn main() -> Result<()> {
                 tasks::file_policy::non_rust_inventory(&root)
             }
         },
+        Commands::FreshnessCheck { base, mode, json, no_fetch, allow_historical, reason } => {
+            use tasks::freshness_check::{FreshnessCheckConfig, FreshnessMode};
+            let mode = match mode {
+                FreshnessCheckMode::Warn => FreshnessMode::Warn,
+                FreshnessCheckMode::Block => FreshnessMode::Block,
+            };
+            tasks::freshness_check::run(FreshnessCheckConfig {
+                base,
+                mode,
+                json_output: json,
+                no_fetch,
+                allow_historical,
+                reason,
+            })
+        }
     }
 }
 

--- a/xtask/src/tasks/freshness_check.rs
+++ b/xtask/src/tasks/freshness_check.rs
@@ -1,0 +1,270 @@
+//! `cargo xtask freshness-check` — source-tree staleness guard.
+//!
+//! Detects whether the current checkout is behind `origin/master` (or another
+//! base ref) and emits a JSON receipt that downstream tools and hooks can
+//! consume.
+//!
+//! # Exit codes
+//! - `0` — always in warn mode (default).
+//! - `0` — block mode AND `safe_for_code_state_claims == true`.
+//! - `1` — block mode AND stale (unless `--allow-historical` was passed).
+//!
+//! # JSON receipt (schema_version 1)
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "base_ref": "origin/master",
+//!   "head": "abc1234",
+//!   "base_head": "def5678",
+//!   "behind_by": 5,
+//!   "fetch_age_seconds": 3600,
+//!   "worktree_dirty": false,
+//!   "safe_for_code_state_claims": false,
+//!   "mode": "warn",
+//!   "allow_historical": false,
+//!   "bypass_reason": null
+//! }
+//! ```
+
+use color_eyre::eyre::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
+
+/// Operating mode for the freshness check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FreshnessMode {
+    /// Warn mode: always exit 0, emit receipt.
+    Warn,
+    /// Block mode: exit 1 when stale (unless `--allow-historical` was passed).
+    Block,
+}
+
+impl std::fmt::Display for FreshnessMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FreshnessMode::Warn => write!(f, "warn"),
+            FreshnessMode::Block => write!(f, "block"),
+        }
+    }
+}
+
+/// Configuration for the freshness check subcommand.
+pub struct FreshnessCheckConfig {
+    /// Base git reference to compare HEAD against. Default: `origin/master`.
+    pub base: String,
+    /// Operating mode (warn or block).
+    pub mode: FreshnessMode,
+    /// If `Some(path)`, write the JSON receipt to this file instead of stdout.
+    pub json_output: Option<PathBuf>,
+    /// Skip the `git fetch` step.
+    pub no_fetch: bool,
+    /// Bypass block mode for historical work. Requires `reason` to be `Some`.
+    pub allow_historical: bool,
+    /// Reason string required when `allow_historical` is true.
+    pub reason: Option<String>,
+}
+
+/// The JSON receipt schema emitted by freshness-check.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FreshnessReceipt {
+    /// Always 1 for this schema generation.
+    pub schema_version: u32,
+    /// The base git ref used for the comparison (e.g. `origin/master`).
+    pub base_ref: String,
+    /// Short SHA of HEAD.
+    pub head: String,
+    /// Short SHA of the base ref tip.
+    pub base_head: String,
+    /// Number of commits HEAD is behind the base ref.
+    pub behind_by: u64,
+    /// Seconds since the last `git fetch` (from `.git/FETCH_HEAD` mtime).
+    /// `None` when FETCH_HEAD does not exist (never fetched or `--no-fetch`).
+    pub fetch_age_seconds: Option<u64>,
+    /// Whether the working tree has uncommitted changes.
+    pub worktree_dirty: bool,
+    /// `true` only when `behind_by == 0`.
+    pub safe_for_code_state_claims: bool,
+    /// The mode this invocation ran under.
+    pub mode: FreshnessMode,
+    /// Whether the historical-override escape hatch was used.
+    pub allow_historical: bool,
+    /// The caller-provided bypass reason, when `allow_historical` is `true`.
+    pub bypass_reason: Option<String>,
+}
+
+/// Run the freshness-check subcommand.
+///
+/// Returns `Ok(())` when the check passes or when in warn mode.
+/// Returns `Err` on fatal errors. Exits with code 1 when in block mode and
+/// the checkout is stale (unless `--allow-historical` was passed).
+pub fn run(config: FreshnessCheckConfig) -> Result<()> {
+    // Validate allow-historical usage.
+    if config.allow_historical && config.reason.is_none() {
+        bail!("--allow-historical requires --reason <text>");
+    }
+
+    // Resolve the effective base ref.
+    let base_ref = config.base.clone();
+
+    // Optionally fetch.
+    if !config.no_fetch {
+        fetch_base(&base_ref)?;
+    }
+
+    // Gather git data.
+    let head = git_short_sha("HEAD")?;
+    let base_head = git_short_sha(&base_ref)?;
+    let behind_by = compute_behind_by(&base_ref)?;
+    let fetch_age_seconds = read_fetch_age_seconds();
+    let worktree_dirty = is_worktree_dirty()?;
+    let safe_for_code_state_claims = behind_by == 0;
+
+    let receipt = FreshnessReceipt {
+        schema_version: 1,
+        base_ref: base_ref.clone(),
+        head,
+        base_head,
+        behind_by,
+        fetch_age_seconds,
+        worktree_dirty,
+        safe_for_code_state_claims,
+        mode: config.mode,
+        allow_historical: config.allow_historical,
+        bypass_reason: config.reason.clone(),
+    };
+
+    // Emit receipt.
+    let json = serde_json::to_string_pretty(&receipt)
+        .context("failed to serialize freshness receipt to JSON")?;
+
+    if let Some(ref path) = config.json_output {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory {}", parent.display()))?;
+        }
+        fs::write(path, &json)
+            .with_context(|| format!("failed to write receipt to {}", path.display()))?;
+        // Also print a human summary to stderr when writing to a file.
+        emit_human_summary(&receipt);
+    } else {
+        // Default: JSON to stdout.
+        println!("{json}");
+        emit_human_summary(&receipt);
+    }
+
+    // Decide exit code.
+    let stale = !safe_for_code_state_claims;
+    if config.mode == FreshnessMode::Block && stale && !config.allow_historical {
+        // Use std::process::exit so tests can observe the exit code.
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).stderr(Stdio::null()).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn git_short_sha(rev: &str) -> Result<String> {
+    git_output(&["rev-parse", "--short", rev])
+        .ok_or_else(|| color_eyre::eyre::eyre!("failed to resolve git rev: {rev}"))
+}
+
+fn fetch_base(base_ref: &str) -> Result<()> {
+    // Extract the remote and branch from e.g. "origin/master".
+    let (remote, branch) = if let Some(slash) = base_ref.find('/') {
+        (&base_ref[..slash], &base_ref[slash + 1..])
+    } else {
+        // If no slash, treat the whole thing as the remote and fetch all.
+        (base_ref, "")
+    };
+
+    let status = if branch.is_empty() {
+        Command::new("git")
+            .args(["fetch", remote])
+            .stderr(Stdio::null())
+            .stdout(Stdio::null())
+            .status()
+            .context("failed to run git fetch")?
+    } else {
+        Command::new("git")
+            .args(["fetch", remote, branch])
+            .stderr(Stdio::null())
+            .stdout(Stdio::null())
+            .status()
+            .context("failed to run git fetch")?
+    };
+
+    if !status.success() {
+        // Fetch errors are non-fatal — the user may be offline.
+        eprintln!(
+            "warning: git fetch {remote} {branch} failed (offline?); proceeding with cached data"
+        );
+    }
+    Ok(())
+}
+
+fn compute_behind_by(base_ref: &str) -> Result<u64> {
+    let count_str = git_output(&["rev-list", "--count", &format!("HEAD..{base_ref}")])
+        .unwrap_or_else(|| "0".to_string());
+    count_str
+        .trim()
+        .parse::<u64>()
+        .with_context(|| format!("failed to parse rev-list --count output: {count_str:?}"))
+}
+
+fn read_fetch_age_seconds() -> Option<u64> {
+    // Walk up from cwd to find .git/FETCH_HEAD.
+    let git_dir = git_output(&["rev-parse", "--git-dir"])?;
+    let fetch_head = std::path::Path::new(&git_dir).join("FETCH_HEAD");
+    let metadata = fs::metadata(&fetch_head).ok()?;
+    let modified = metadata.modified().ok()?;
+    let age = std::time::SystemTime::now().duration_since(modified).ok()?;
+    Some(age.as_secs())
+}
+
+fn is_worktree_dirty() -> Result<bool> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .context("failed to run git status")?;
+    Ok(!output.stdout.is_empty())
+}
+
+fn emit_human_summary(receipt: &FreshnessReceipt) {
+    if receipt.safe_for_code_state_claims {
+        eprintln!("freshness-check: HEAD is up-to-date with {} (behind_by=0)", receipt.base_ref);
+    } else {
+        eprintln!(
+            "freshness-check: HEAD is {} commit(s) behind {} — safe_for_code_state_claims=false",
+            receipt.behind_by, receipt.base_ref
+        );
+        if receipt.mode == FreshnessMode::Warn {
+            eprintln!("  (warn mode — exit 0; run `git pull --rebase` to update)");
+        } else if receipt.allow_historical {
+            eprintln!(
+                "  (block mode — historical override accepted: {:?})",
+                receipt.bypass_reason.as_deref().unwrap_or("")
+            );
+        } else {
+            eprintln!("  (block mode — exit 1; run `git pull --rebase` to update)");
+        }
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -49,6 +49,7 @@ pub mod fix_forward;
 pub mod fmt;
 pub mod forbid_fatal_constructs;
 pub mod forensics;
+pub mod freshness_check;
 pub mod gate_policy;
 pub mod gate_receipts;
 pub mod gates;

--- a/xtask/tests/freshness_check.rs
+++ b/xtask/tests/freshness_check.rs
@@ -1,0 +1,356 @@
+//! Integration tests for `cargo xtask freshness-check`.
+//!
+//! Each test creates an isolated git repository (or two-repo setup) using
+//! `tempfile` and `std::process::Command`, then invokes the xtask binary
+//! and asserts on exit codes and JSON output.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Stdio},
+};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Initialize a bare "remote" repo with one commit and a working clone of it.
+/// Returns `(remote_dir, work_dir)`.
+fn init_synced_repo() -> Result<(TempDir, TempDir)> {
+    let remote_dir = TempDir::new()?;
+    let work_dir = TempDir::new()?;
+
+    // Create the remote bare repo with an explicit initial branch named "master".
+    git_cmd(
+        &["init", "--bare", "--initial-branch=master", remote_dir.path().to_str().expect("path")],
+        None,
+    )
+    .or_else(|_| {
+        // Older git versions don't support --initial-branch; fall back and rename.
+        git_cmd(&["init", "--bare", remote_dir.path().to_str().expect("path")], None)?;
+        git_cmd(&["symbolic-ref", "HEAD", "refs/heads/master"], Some(remote_dir.path()))
+    })?;
+
+    // Create a temp source dir to make an initial commit.
+    let source_dir = TempDir::new()?;
+    git_cmd(&["init", "-b", "master", source_dir.path().to_str().expect("path")], None)
+        .or_else(|_| git_cmd(&["init", source_dir.path().to_str().expect("path")], None))?;
+    git_cmd(&["config", "user.email", "test@test.com"], Some(source_dir.path()))?;
+    git_cmd(&["config", "user.name", "Test"], Some(source_dir.path()))?;
+    // Ensure branch is named master (for older git).
+    let _ = git_cmd(&["checkout", "-b", "master"], Some(source_dir.path()));
+    fs::write(source_dir.path().join("README.md"), "init")?;
+    git_cmd(&["add", "."], Some(source_dir.path()))?;
+    git_cmd(&["commit", "-m", "init"], Some(source_dir.path()))?;
+    git_cmd(
+        &["remote", "add", "origin", remote_dir.path().to_str().expect("path")],
+        Some(source_dir.path()),
+    )?;
+    git_cmd(&["push", "origin", "HEAD:master"], Some(source_dir.path()))?;
+
+    // Clone into work_dir.
+    git_cmd(
+        &[
+            "clone",
+            remote_dir.path().to_str().expect("path"),
+            work_dir.path().to_str().expect("path"),
+        ],
+        None,
+    )?;
+    git_cmd(&["config", "user.email", "test@test.com"], Some(work_dir.path()))?;
+    git_cmd(&["config", "user.name", "Test"], Some(work_dir.path()))?;
+    // Ensure work_dir is on master.
+    let _ = git_cmd(&["checkout", "master"], Some(work_dir.path()));
+
+    Ok((remote_dir, work_dir))
+}
+
+/// Add a commit to `repo_dir`.
+fn add_commit(repo_dir: &Path, message: &str) -> Result<()> {
+    let file = repo_dir.join(format!("file_{}.txt", message.replace(' ', "_")));
+    fs::write(&file, message)?;
+    git_cmd(&["add", "."], Some(repo_dir))?;
+    git_cmd(&["commit", "-m", message], Some(repo_dir))?;
+    Ok(())
+}
+
+/// Push the `repo_dir` current branch to origin master.
+fn push_to_remote(repo_dir: &Path) -> Result<()> {
+    git_cmd(&["push", "origin", "HEAD:master"], Some(repo_dir))?;
+    Ok(())
+}
+
+/// Run a git command with optional working directory. Panics on failure.
+fn git_cmd(args: &[&str], cwd: Option<&Path>) -> Result<()> {
+    let mut cmd = Command::new("git");
+    cmd.args(args).stdout(Stdio::null()).stderr(Stdio::null());
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        anyhow::bail!("git {:?} failed with {:?}", args, status.code());
+    }
+    Ok(())
+}
+
+/// Parse the JSON emitted by freshness-check from stdout.
+fn parse_receipt(stdout: &[u8]) -> Result<Value> {
+    let text = std::str::from_utf8(stdout)?;
+    Ok(serde_json::from_str(text)?)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A freshly-cloned repo (HEAD == remote master) reports behind_by=0 and
+/// safe_for_code_state_claims=true, and exits 0.
+#[test]
+fn reports_zero_behind_when_synced() -> Result<()> {
+    let (_remote, work_dir) = init_synced_repo()?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let stdout = cmd
+        .current_dir(work_dir.path())
+        .args(["freshness-check", "--base", "origin/master", "--no-fetch"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let receipt = parse_receipt(&stdout)?;
+    assert_eq!(receipt["schema_version"], 1);
+    assert_eq!(receipt["behind_by"], 0);
+    assert_eq!(receipt["safe_for_code_state_claims"], true);
+    assert_eq!(receipt["mode"], "warn");
+
+    Ok(())
+}
+
+/// When the remote has commits HEAD hasn't fetched, behind_by > 0 and
+/// safe_for_code_state_claims=false.
+#[test]
+fn reports_nonzero_behind_when_stale() -> Result<()> {
+    let (remote_dir, work_dir) = init_synced_repo()?;
+
+    // Add a commit to remote (simulating another push we haven't pulled).
+    let source2 = TempDir::new()?;
+    git_cmd(
+        &[
+            "clone",
+            remote_dir.path().to_str().expect("path"),
+            source2.path().to_str().expect("path"),
+        ],
+        None,
+    )?;
+    git_cmd(&["config", "user.email", "test@test.com"], Some(source2.path()))?;
+    git_cmd(&["config", "user.name", "Test"], Some(source2.path()))?;
+    add_commit(source2.path(), "remote change")?;
+    push_to_remote(source2.path())?;
+
+    // Fetch into work_dir so origin/master is updated, but DON'T merge (HEAD stays behind).
+    git_cmd(&["fetch", "origin"], Some(work_dir.path()))?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let stdout = cmd
+        .current_dir(work_dir.path())
+        .args(["freshness-check", "--base", "origin/master", "--no-fetch"])
+        .assert()
+        .success() // warn mode always exits 0
+        .get_output()
+        .stdout
+        .clone();
+
+    let receipt = parse_receipt(&stdout)?;
+    let behind_by = receipt["behind_by"].as_u64().expect("behind_by is u64");
+    assert!(behind_by > 0, "expected behind_by > 0, got {behind_by}");
+    assert_eq!(receipt["safe_for_code_state_claims"], false);
+
+    Ok(())
+}
+
+/// `--mode warn` exits 0 even when stale.
+#[test]
+fn warn_mode_returns_zero_even_when_stale() -> Result<()> {
+    let (remote_dir, work_dir) = init_synced_repo()?;
+
+    let source2 = TempDir::new()?;
+    git_cmd(
+        &[
+            "clone",
+            remote_dir.path().to_str().expect("path"),
+            source2.path().to_str().expect("path"),
+        ],
+        None,
+    )?;
+    git_cmd(&["config", "user.email", "test@test.com"], Some(source2.path()))?;
+    git_cmd(&["config", "user.name", "Test"], Some(source2.path()))?;
+    add_commit(source2.path(), "another change")?;
+    push_to_remote(source2.path())?;
+    git_cmd(&["fetch", "origin"], Some(work_dir.path()))?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.current_dir(work_dir.path())
+        .args(["freshness-check", "--base", "origin/master", "--mode", "warn", "--no-fetch"])
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+/// `--mode block` exits 1 when stale.
+#[test]
+fn block_mode_returns_one_when_stale() -> Result<()> {
+    let (remote_dir, work_dir) = init_synced_repo()?;
+
+    let source2 = TempDir::new()?;
+    git_cmd(
+        &[
+            "clone",
+            remote_dir.path().to_str().expect("path"),
+            source2.path().to_str().expect("path"),
+        ],
+        None,
+    )?;
+    git_cmd(&["config", "user.email", "test@test.com"], Some(source2.path()))?;
+    git_cmd(&["config", "user.name", "Test"], Some(source2.path()))?;
+    add_commit(source2.path(), "blocking change")?;
+    push_to_remote(source2.path())?;
+    git_cmd(&["fetch", "origin"], Some(work_dir.path()))?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.current_dir(work_dir.path())
+        .args(["freshness-check", "--base", "origin/master", "--mode", "block", "--no-fetch"])
+        .assert()
+        .failure()
+        .code(1);
+
+    Ok(())
+}
+
+/// `--allow-historical --reason "bisect"` on a stale repo exits 0 in block mode.
+#[test]
+fn allow_historical_bypasses_block_with_reason() -> Result<()> {
+    let (remote_dir, work_dir) = init_synced_repo()?;
+
+    let source2 = TempDir::new()?;
+    git_cmd(
+        &[
+            "clone",
+            remote_dir.path().to_str().expect("path"),
+            source2.path().to_str().expect("path"),
+        ],
+        None,
+    )?;
+    git_cmd(&["config", "user.email", "test@test.com"], Some(source2.path()))?;
+    git_cmd(&["config", "user.name", "Test"], Some(source2.path()))?;
+    add_commit(source2.path(), "historical change")?;
+    push_to_remote(source2.path())?;
+    git_cmd(&["fetch", "origin"], Some(work_dir.path()))?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let stdout = cmd
+        .current_dir(work_dir.path())
+        .args([
+            "freshness-check",
+            "--base",
+            "origin/master",
+            "--mode",
+            "block",
+            "--no-fetch",
+            "--allow-historical",
+            "--reason",
+            "bisect",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let receipt = parse_receipt(&stdout)?;
+    assert_eq!(receipt["allow_historical"], true);
+    assert_eq!(receipt["bypass_reason"], "bisect");
+
+    Ok(())
+}
+
+/// `--allow-historical` without `--reason` must exit with a non-zero usage error.
+#[test]
+fn allow_historical_without_reason_errors() -> Result<()> {
+    let (_remote, work_dir) = init_synced_repo()?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    // clap enforces `requires = "reason"` so this should fail at arg parsing.
+    cmd.current_dir(work_dir.path())
+        .args(["freshness-check", "--base", "origin/master", "--allow-historical"])
+        .assert()
+        .failure();
+
+    Ok(())
+}
+
+/// `--json <path>` writes a valid schema-1 JSON receipt file.
+#[test]
+fn json_output_path_writes_receipt_file() -> Result<()> {
+    let (_remote, work_dir) = init_synced_repo()?;
+    let receipt_path = work_dir.path().join("target").join("devex").join("freshness.json");
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.current_dir(work_dir.path())
+        .args([
+            "freshness-check",
+            "--base",
+            "origin/master",
+            "--no-fetch",
+            "--json",
+            receipt_path.to_str().expect("path"),
+        ])
+        .assert()
+        .success();
+    assert!(receipt_path.exists(), "receipt file must be written");
+
+    let content = fs::read_to_string(&receipt_path)?;
+    let receipt: Value = serde_json::from_str(&content)?;
+    assert_eq!(receipt["schema_version"], 1);
+    assert!(receipt["head"].is_string());
+    assert!(receipt["base_head"].is_string());
+    assert!(receipt["behind_by"].is_number());
+    assert!(receipt["mode"].is_string());
+
+    Ok(())
+}
+
+/// `--no-fetch` does not invoke `git fetch` (we verify by checking that the
+/// command succeeds even when there is no network and the remote is unreachable).
+/// This test uses a path-based remote that exists, so the real test is that
+/// behind_by is computed correctly from cached data.
+#[test]
+fn no_fetch_skips_fetch_step() -> Result<()> {
+    let (_remote, work_dir) = init_synced_repo()?;
+
+    // The command should complete without error even with --no-fetch.
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .current_dir(work_dir.path())
+        .args(["freshness-check", "--base", "origin/master", "--no-fetch"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let receipt = parse_receipt(&output)?;
+    // `behind_by` must be a number (likely 0 for a fresh clone).
+    assert!(receipt["behind_by"].is_number());
+
+    Ok(())
+}


### PR DESCRIPTION
## Current truth

Implements `cargo xtask freshness-check` — a repo-native source-tree
staleness guard. Prevents code-state claims made from a checkout that is
behind `origin/master`.

### Command surface

```bash
cargo xtask freshness-check                                 # warn mode, base=origin/master
cargo xtask freshness-check --base origin/master
cargo xtask freshness-check --mode warn                     # exit 0 even when stale
cargo xtask freshness-check --mode block                    # exit 1 when stale
cargo xtask freshness-check --json target/devex/freshness.json
cargo xtask freshness-check --allow-historical --reason "bisect"
cargo xtask freshness-check --no-fetch
```

### JSON receipt (schema_version 1)

```json
{
  "schema_version": 1,
  "base_ref": "origin/master",
  "head": "abc1234",
  "base_head": "def5678",
  "behind_by": 5,
  "fetch_age_seconds": 3600,
  "worktree_dirty": false,
  "safe_for_code_state_claims": false,
  "mode": "warn",
  "allow_historical": false,
  "bypass_reason": null
}
```

### Exit codes

- `0` — always in warn mode (default)
- `0` — block mode AND `safe_for_code_state_claims == true`
- `1` — block mode AND stale (unless `--allow-historical` passed)

## Acceptance

```bash
cargo build -p xtask --locked
cargo test -p xtask --test freshness_check --locked
cargo xtask freshness-check --base origin/master
cargo xtask freshness-check --base origin/master --json target/devex/freshness.json
# validate JSON:
python -m json.tool target/devex/freshness.json
cargo clippy -p xtask -- -D warnings -A missing_docs
cargo xtask fmt --check
```

All 8 integration tests pass. Clippy clean. Fmt clean.

## Claim boundary

Source-tree freshness only. Binary freshness (`--binaries`) is a follow-up PR tracked under #8660 + #8665 doctrine. Not bundled here.

No production crate change. No CI workflow change.

## Files added

- `xtask/src/tasks/freshness_check.rs` — implementation
- `xtask/tests/freshness_check.rs` — 8 integration tests
- `scripts/githooks/warn-stale-checkout.sh` — opt-in warning hook

## Files modified

- `xtask/src/tasks/mod.rs` — register new module
- `xtask/src/main.rs` — wire `FreshnessCheck` subcommand

Closes #8619