### PR TITLE
fix(ux-tests): register scenario 20 in fixture matrix lockstep (fix-forward for #8682)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -799,6 +799,35 @@
         "first_five_minutes_harness",
         "manual_editor_smoke"
       ]
+    },
+    {
+      "id": "real_workspace_providers",
+      "scenario_file": "ux_scenario_20_real_workspace_providers.rs",
+      "subsystem_owner": "editor_intelligence",
+      "ci_tier": "pr",
+      "component": "goto_definition",
+      "instrumentation": {
+        "run_receipt": true,
+        "first_useful_result": true,
+        "protocol_goldens": false
+      },
+      "user_journey": "run completion, goto-definition, hover, and diagnostics over a real four-file CPAN-style workspace fixture",
+      "measures": [
+        "workflow_pass_rate",
+        "workflow_stability_rate",
+        "cross_file_definition_success_rate",
+        "module_resolution_workflow_success_rate"
+      ],
+      "expected_outcomes": [
+        "completion, goto-definition, hover, and diagnostics all respond without crash",
+        "cross-file definition requests resolve or return clean empty results",
+        "real-workspace fixture exercises provider parity across module boundaries"
+      ],
+      "confidence_signals": [
+        "first_five_minutes_harness",
+        "manual_editor_smoke",
+        "issue_burndown_regression_guard"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Current truth

Master is red: PR #8637 merged `ux_scenario_20_real_workspace_providers.rs` without adding the corresponding entry to `editor_ux_fixture_matrix.json`. The `editor_ux_fixture_matrix_covers_all_scenarios` lockstep test panics because the file exists on disk but is not registered in the matrix.

## Required change

Added one workflow entry to `crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json` for `ux_scenario_20_real_workspace_providers.rs` with component `goto_definition`, measures including `cross_file_definition_success_rate` and `module_resolution_workflow_success_rate`.

## Acceptance

- `editor_ux_fixture_matrix_covers_all_scenarios` passes (was panicking)
- `ux_scenario_20_real_workspace_providers` all 18 tests pass (no regression)
- `cargo clippy -p perl-lsp-ux-tests --tests -- -D warnings -A missing_docs` — no issues
- `cargo xtask fmt --check` — exit 0

## Claim boundary

Registration only. No test logic changes. No additional scenarios added.

Refs #8637