### PR TITLE
ci: add local ci-doctor parity check (#4826)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1465,6 +1465,24 @@ enum Commands {
         #[arg(long)]
         reason: Option<String>,
     },
+
+    /// Check local CI parity: toolchain, fmt, clippy, git cleanliness, Perl, perl-lsp binary.
+    ///
+    /// Emits a human-readable summary by default.
+    /// Use --json for a machine-readable JSON receipt (schema_version 1).
+    /// Use --strict to exit 1 on any warn or fail.
+    ///
+    /// Example: `cargo xtask ci-doctor --strict`
+    #[command(name = "ci-doctor")]
+    CiDoctor {
+        /// Emit a JSON receipt instead of human-readable output.
+        #[arg(long)]
+        json: bool,
+
+        /// Exit 1 if any check is warn or fail (default: warn-only, exit 0).
+        #[arg(long)]
+        strict: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2929,6 +2947,9 @@ fn main() -> Result<()> {
                 allow_historical,
                 reason,
             })
+        }
+        Commands::CiDoctor { json, strict } => {
+            tasks::ci_doctor::run(tasks::ci_doctor::CiDoctorConfig { json, strict })
         }
     }
 }

--- a/xtask/src/tasks/ci_doctor.rs
+++ b/xtask/src/tasks/ci_doctor.rs
@@ -1,0 +1,461 @@
+//! `cargo xtask ci-doctor` — local CI parity diagnostics.
+//!
+//! Checks that the local environment matches what CI expects:
+//! Rust toolchain, fmt/clippy availability, git cleanliness, fmt drift,
+//! Perl interpreter, perl-lsp binary, and platform/env sanity.
+//!
+//! # Exit codes
+//! - `0` in default (warn) mode — always.
+//! - `0` in strict mode when all checks are `ok`.
+//! - `1` in strict mode when any check is `warn` or `fail`.
+//!
+//! # JSON receipt (schema_version 1)
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "overall": "ok",
+//!   "checks": [
+//!     {
+//!       "name": "rustc-toolchain-match",
+//!       "status": "ok",
+//!       "expected": "1.95.0",
+//!       "actual": "1.95.0",
+//!       "note": "match"
+//!     }
+//!   ]
+//! }
+//! ```
+
+use color_eyre::eyre::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::process::{Command, Stdio};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Status of an individual check.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    /// Check passed — environment matches expectation.
+    Ok,
+    /// Discrepancy detected but not fatal (warn mode: exit 0; strict: exit 1).
+    Warn,
+    /// Hard failure — something is broken.
+    Fail,
+}
+
+impl CheckStatus {
+    fn severity(&self) -> u8 {
+        match self {
+            CheckStatus::Ok => 0,
+            CheckStatus::Warn => 1,
+            CheckStatus::Fail => 2,
+        }
+    }
+
+    fn symbol(&self) -> &'static str {
+        match self {
+            CheckStatus::Ok => "ok  ",
+            CheckStatus::Warn => "warn",
+            CheckStatus::Fail => "FAIL",
+        }
+    }
+}
+
+/// Result of a single diagnostic check.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Check {
+    /// Stable identifier for this check (kebab-case).
+    pub name: String,
+    /// Pass / warn / fail.
+    pub status: CheckStatus,
+    /// What was expected (empty string when not applicable).
+    pub expected: String,
+    /// What was actually found (empty string when not applicable).
+    pub actual: String,
+    /// Human-readable note explaining the outcome.
+    pub note: String,
+}
+
+impl Check {
+    fn ok(name: &str, value: &str, note: &str) -> Self {
+        Check {
+            name: name.to_string(),
+            status: CheckStatus::Ok,
+            expected: value.to_string(),
+            actual: value.to_string(),
+            note: note.to_string(),
+        }
+    }
+
+    fn warn(name: &str, expected: &str, actual: &str, note: &str) -> Self {
+        Check {
+            name: name.to_string(),
+            status: CheckStatus::Warn,
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+            note: note.to_string(),
+        }
+    }
+
+    fn fail(name: &str, expected: &str, actual: &str, note: &str) -> Self {
+        Check {
+            name: name.to_string(),
+            status: CheckStatus::Fail,
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+            note: note.to_string(),
+        }
+    }
+}
+
+/// The JSON receipt schema emitted by ci-doctor.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CiDoctorReceipt {
+    /// Always 1 for this schema generation.
+    pub schema_version: u32,
+    /// Worst status across all checks.
+    pub overall: CheckStatus,
+    /// All checks in order.
+    pub checks: Vec<Check>,
+}
+
+/// Configuration for the ci-doctor subcommand.
+pub struct CiDoctorConfig {
+    /// Emit JSON receipt to stdout instead of human-readable output.
+    pub json: bool,
+    /// Exit 1 when any check is warn or fail.
+    pub strict: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Run all ci-doctor checks and emit the result.
+pub fn run(config: CiDoctorConfig) -> Result<()> {
+    let checks = collect_checks();
+    let overall = compute_overall(&checks);
+
+    let receipt = CiDoctorReceipt { schema_version: 1, overall: overall.clone(), checks };
+
+    if config.json {
+        let json = serde_json::to_string_pretty(&receipt)
+            .context("failed to serialize ci-doctor receipt to JSON")?;
+        println!("{json}");
+    } else {
+        emit_human_summary(&receipt);
+    }
+
+    if config.strict && overall != CheckStatus::Ok {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate helpers
+// ---------------------------------------------------------------------------
+
+fn compute_overall(checks: &[Check]) -> CheckStatus {
+    let max_severity = checks.iter().map(|c| c.status.severity()).max().unwrap_or(0);
+    match max_severity {
+        0 => CheckStatus::Ok,
+        1 => CheckStatus::Warn,
+        _ => CheckStatus::Fail,
+    }
+}
+
+fn collect_checks() -> Vec<Check> {
+    vec![
+        check_rustc_toolchain_match(),
+        check_rustfmt_installed(),
+        check_clippy_installed(),
+        check_git_clean(),
+        check_fmt_drift(),
+        check_perl_interpreter(),
+        check_perl_lsp_binary(),
+        check_platform_sanity(),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+/// Check 1: rustc version matches rust-toolchain.toml channel.
+fn check_rustc_toolchain_match() -> Check {
+    let name = "rustc-toolchain-match";
+
+    let pinned = match read_pinned_channel() {
+        Some(v) => v,
+        None => {
+            return Check::warn(
+                name,
+                "rust-toolchain.toml",
+                "not found",
+                "rust-toolchain.toml not found or unreadable",
+            );
+        }
+    };
+
+    let actual = match run_version_cmd("rustc", &["--version"]) {
+        Some(v) => v,
+        None => {
+            return Check::fail(
+                name,
+                &pinned,
+                "not found",
+                "rustc not found on PATH; install via rustup",
+            );
+        }
+    };
+
+    // Extract the version token (second word in "rustc X.Y.Z (hash date)").
+    let actual_ver = actual.split_whitespace().nth(1).unwrap_or(&actual).to_string();
+
+    if actual_ver == pinned {
+        Check::ok(name, &pinned, "match")
+    } else {
+        Check::warn(
+            name,
+            &pinned,
+            &actual_ver,
+            &format!(
+                "rustc {actual_ver} differs from pinned {pinned}; run `rustup override set {pinned}`"
+            ),
+        )
+    }
+}
+
+/// Check 2: rustfmt is installed and callable.
+fn check_rustfmt_installed() -> Check {
+    let name = "rustfmt-installed";
+    match run_version_cmd("cargo", &["fmt", "--version"]) {
+        Some(v) => Check::ok(name, &v, "installed"),
+        None => Check::fail(
+            name,
+            "installed",
+            "not found",
+            "cargo fmt not available; run `rustup component add rustfmt`",
+        ),
+    }
+}
+
+/// Check 3: clippy is installed and callable.
+fn check_clippy_installed() -> Check {
+    let name = "clippy-installed";
+    match run_version_cmd("cargo", &["clippy", "--version"]) {
+        Some(v) => Check::ok(name, &v, "installed"),
+        None => Check::fail(
+            name,
+            "installed",
+            "not found",
+            "cargo clippy not available; run `rustup component add clippy`",
+        ),
+    }
+}
+
+/// Check 4: git working tree is clean.
+fn check_git_clean() -> Check {
+    let name = "git-clean";
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output();
+
+    match output {
+        Err(_) => Check::warn(name, "clean", "unknown", "git not found; cannot check working tree"),
+        Ok(out) => {
+            if out.stdout.is_empty() {
+                Check::ok(name, "clean", "working tree is clean")
+            } else {
+                let count = out.stdout.split(|&b| b == b'\n').filter(|l| !l.is_empty()).count();
+                Check::warn(
+                    name,
+                    "clean",
+                    &format!("{count} modified file(s)"),
+                    "working tree has uncommitted changes (WIP is fine; mention if unexpected)",
+                )
+            }
+        }
+    }
+}
+
+/// Check 5: cargo xtask fmt --check exits 0 (no fmt drift).
+fn check_fmt_drift() -> Check {
+    let name = "fmt-drift";
+    // We run `cargo fmt --check` rather than `cargo xtask fmt --check`
+    // to avoid a recursive xtask invocation and reduce cost.
+    let result = Command::new("cargo")
+        .args(["fmt", "--check"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    match result {
+        Err(_) => {
+            Check::warn(name, "formatted", "unknown", "cargo fmt not found; cannot check drift")
+        }
+        Ok(status) => {
+            if status.success() {
+                Check::ok(name, "formatted", "no fmt drift detected")
+            } else {
+                Check::warn(
+                    name,
+                    "formatted",
+                    "drift detected",
+                    "run `cargo xtask fmt` to fix formatting",
+                )
+            }
+        }
+    }
+}
+
+/// Check 6: Perl interpreter is available.
+fn check_perl_interpreter() -> Check {
+    let name = "perl-interpreter";
+    match run_version_cmd("perl", &["-e", "print $^V"]) {
+        Some(v) => Check::ok(name, &v, "perl found on PATH"),
+        None => {
+            // Perl absence is a warn — perl-lsp can be used without a local Perl installation
+            // (e.g. editing Perl code on a machine without a runtime).
+            Check::warn(
+                name,
+                "available",
+                "not found",
+                "perl not found on PATH; debugging Perl code requires a local interpreter",
+            )
+        }
+    }
+}
+
+/// Check 7: perl-lsp binary is available (post-install parity check).
+fn check_perl_lsp_binary() -> Check {
+    let name = "perl-lsp-binary";
+    let found = which_binary("perl-lsp");
+    if found {
+        Check::ok(name, "found", "perl-lsp found on PATH")
+    } else {
+        // Absence is a warn, not a fail — the user may not have installed the binary yet.
+        Check::warn(
+            name,
+            "found",
+            "not found",
+            "perl-lsp not found on PATH; run `cargo install --path crates/perl-lsp-rs` or add target/debug to PATH",
+        )
+    }
+}
+
+/// Check 8: platform/env sanity (CARGO_TARGET_DIR, PERL5LIB).
+fn check_platform_sanity() -> Check {
+    let name = "platform-env-sanity";
+    let mut issues: Vec<String> = Vec::new();
+
+    // Check CARGO_TARGET_DIR if set.
+    if let Ok(val) = std::env::var("CARGO_TARGET_DIR") {
+        let path = std::path::Path::new(&val);
+        if !path.is_absolute() {
+            issues.push(format!("CARGO_TARGET_DIR={val:?} is not an absolute path"));
+        }
+        // On Windows, flag paths with drive letters but mixed separators.
+        #[cfg(target_os = "windows")]
+        if val.contains('/') && val.contains('\\') {
+            issues.push(format!(
+                "CARGO_TARGET_DIR={val:?} mixes forward and back slashes; prefer one style"
+            ));
+        }
+    }
+
+    // Check PERL5LIB if set.
+    if let Ok(val) = std::env::var("PERL5LIB") {
+        if val.trim().is_empty() {
+            issues.push("PERL5LIB is set but empty".to_string());
+        }
+    }
+
+    if issues.is_empty() {
+        Check::ok(name, "sane", "no environment anomalies detected")
+    } else {
+        Check::warn(name, "sane", "anomalies detected", &issues.join("; "))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn read_pinned_channel() -> Option<String> {
+    let root = crate::utils::project_root().ok()?;
+    let path = root.join("rust-toolchain.toml");
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let table: toml::Value = toml::from_str(&raw).ok()?;
+    let channel = table.get("toolchain")?.get("channel")?.as_str()?;
+    Some(channel.trim().to_string())
+}
+
+/// Run a command and return its stdout as a trimmed string.
+/// Returns `None` if the command is not found or exits non-zero.
+fn run_version_cmd(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+/// Return `true` if the named binary exists somewhere on PATH.
+fn which_binary(name: &str) -> bool {
+    // Try `which` on Unix, `where` on Windows.
+    #[cfg(target_os = "windows")]
+    let checker = ("where", [name, ""]);
+    #[cfg(not(target_os = "windows"))]
+    let checker = ("which", [name, ""]);
+
+    Command::new(checker.0)
+        .arg(checker.1[0])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable output
+// ---------------------------------------------------------------------------
+
+fn emit_human_summary(receipt: &CiDoctorReceipt) {
+    let overall_label = match &receipt.overall {
+        CheckStatus::Ok => "ok",
+        CheckStatus::Warn => "warn",
+        CheckStatus::Fail => "FAIL",
+    };
+    println!("ci-doctor  overall: {overall_label}");
+    println!();
+    for check in &receipt.checks {
+        let sym = check.status.symbol();
+        if check.expected == check.actual || check.expected.is_empty() {
+            println!("  [{sym}] {}: {}", check.name, check.note);
+        } else {
+            println!(
+                "  [{sym}] {}: {} (expected: {}, got: {})",
+                check.name, check.note, check.expected, check.actual
+            );
+        }
+    }
+    println!();
+    if receipt.overall != CheckStatus::Ok {
+        println!("  run with --strict to fail CI on the above warnings/failures");
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -17,6 +17,7 @@ pub mod check_toolchain;
 pub mod check_version_sync;
 pub mod ci;
 pub mod ci_audit_workflows;
+pub mod ci_doctor;
 pub mod ci_hygiene;
 pub mod ci_measure;
 pub mod ci_metrics;

--- a/xtask/tests/ci_doctor.rs
+++ b/xtask/tests/ci_doctor.rs
@@ -1,0 +1,210 @@
+//! Integration tests for `cargo xtask ci-doctor`.
+//!
+//! Each test invokes the xtask binary and asserts on exit code and output
+//! shape. The tests do not depend on whether specific tools (Perl, perl-lsp)
+//! are installed — they verify output structure, not specific check outcomes.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse JSON from stdout bytes.
+fn parse_json(bytes: &[u8]) -> Result<Value> {
+    let text = std::str::from_utf8(bytes)?;
+    Ok(serde_json::from_str(text)?)
+}
+
+/// Names of the 8 checks defined in v1.
+const CHECK_NAMES: &[&str] = &[
+    "rustc-toolchain-match",
+    "rustfmt-installed",
+    "clippy-installed",
+    "git-clean",
+    "fmt-drift",
+    "perl-interpreter",
+    "perl-lsp-binary",
+    "platform-env-sanity",
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Default mode (no flags) must exit 0 regardless of individual check outcomes.
+#[test]
+fn default_mode_exits_zero() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["ci-doctor"]).assert().success();
+    Ok(())
+}
+
+/// Default human output must contain all 8 check section names.
+#[test]
+fn human_output_shape() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let out = cmd.args(["ci-doctor"]).assert().success().get_output().stdout.clone();
+    let text = String::from_utf8(out)?;
+
+    for name in CHECK_NAMES {
+        assert!(text.contains(name), "human output missing check name {name:?}; got:\n{text}");
+    }
+    // Must contain the overall status line.
+    assert!(text.contains("ci-doctor"), "human output missing 'ci-doctor' header; got:\n{text}");
+    assert!(text.contains("overall:"), "human output missing 'overall:' label; got:\n{text}");
+    Ok(())
+}
+
+/// `--json` emits a valid schema-v1 receipt with all required fields.
+#[test]
+fn json_output_schema_v1() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let out = cmd.args(["ci-doctor", "--json"]).assert().success().get_output().stdout.clone();
+    let receipt = parse_json(&out)?;
+
+    // Top-level required fields.
+    assert_eq!(receipt["schema_version"], 1, "schema_version must be 1");
+    assert!(
+        receipt["overall"].is_string(),
+        "overall must be a string; got: {:?}",
+        receipt["overall"]
+    );
+    assert!(
+        ["ok", "warn", "fail"].contains(&receipt["overall"].as_str().unwrap()),
+        "overall must be ok|warn|fail; got: {:?}",
+        receipt["overall"]
+    );
+
+    // Checks array.
+    let checks = receipt["checks"].as_array().expect("checks must be an array");
+    assert_eq!(
+        checks.len(),
+        CHECK_NAMES.len(),
+        "expected {} checks, got {}",
+        CHECK_NAMES.len(),
+        checks.len()
+    );
+
+    // Verify each check has the required fields and matches the expected name.
+    for (i, check) in checks.iter().enumerate() {
+        let name = CHECK_NAMES[i];
+        assert_eq!(
+            check["name"].as_str(),
+            Some(name),
+            "check[{i}].name mismatch: expected {name:?}, got {:?}",
+            check["name"]
+        );
+        assert!(
+            ["ok", "warn", "fail"].contains(&check["status"].as_str().unwrap_or("")),
+            "check[{i}].status must be ok|warn|fail; got: {:?}",
+            check["status"]
+        );
+        assert!(check["expected"].is_string(), "check[{i}].expected must be a string");
+        assert!(check["actual"].is_string(), "check[{i}].actual must be a string");
+        assert!(check["note"].is_string(), "check[{i}].note must be a string");
+    }
+
+    Ok(())
+}
+
+/// `--strict` exits 1 if any check is warn or fail.
+/// We verify this by parsing the JSON first and only asserting failure when
+/// the receipt actually contains at least one non-ok check.
+#[test]
+fn strict_mode_fails_on_warn() -> Result<()> {
+    // First get the JSON receipt without strict to know what overall is.
+    let mut probe = cargo_bin_cmd!("xtask");
+    let probe_out =
+        probe.args(["ci-doctor", "--json"]).assert().success().get_output().stdout.clone();
+    let receipt = parse_json(&probe_out)?;
+    let overall = receipt["overall"].as_str().unwrap_or("ok");
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let assertion = cmd.args(["ci-doctor", "--strict"]);
+
+    if overall == "ok" {
+        // All checks pass — strict mode should also exit 0.
+        assertion.assert().success();
+    } else {
+        // At least one check is warn or fail — strict mode must exit 1.
+        assertion.assert().failure().code(1);
+    }
+
+    Ok(())
+}
+
+/// Default mode (warn-only) exits 0 even when checks are warn/fail.
+/// We verify this by checking that the default exit code is always 0.
+#[test]
+fn default_mode_passes_with_warn() -> Result<()> {
+    // Default mode must always exit 0 (it never enforces strict).
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["ci-doctor"]).assert().success();
+    Ok(())
+}
+
+/// Perl interpreter absence must produce a `warn` status, not `fail`.
+///
+/// This test exercises the `perl-interpreter` check by parsing the JSON
+/// receipt and verifying that if perl is absent the status is `warn`.
+#[test]
+fn missing_perl_interpreter_warns_not_fails() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let out = cmd.args(["ci-doctor", "--json"]).assert().success().get_output().stdout.clone();
+    let receipt = parse_json(&out)?;
+
+    let checks = receipt["checks"].as_array().expect("checks must be an array");
+    let perl_check = checks
+        .iter()
+        .find(|c| c["name"].as_str() == Some("perl-interpreter"))
+        .expect("perl-interpreter check must be present");
+
+    let status = perl_check["status"].as_str().unwrap_or("unknown");
+    assert_ne!(
+        status, "fail",
+        "perl-interpreter status must not be 'fail'; got {status:?} (Perl absence is a warn)"
+    );
+    // Status must be either "ok" (perl found) or "warn" (not found).
+    assert!(
+        status == "ok" || status == "warn",
+        "perl-interpreter status must be ok or warn; got {status:?}"
+    );
+
+    Ok(())
+}
+
+/// `--json` and `--strict` flags are composable: JSON is emitted, then exit 1 on warn/fail.
+#[test]
+fn json_and_strict_are_composable() -> Result<()> {
+    // Get JSON receipt to know the expected exit code.
+    let mut probe = cargo_bin_cmd!("xtask");
+    let probe_out =
+        probe.args(["ci-doctor", "--json"]).assert().success().get_output().stdout.clone();
+    let receipt = parse_json(&probe_out)?;
+    let overall = receipt["overall"].as_str().unwrap_or("ok");
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let out = cmd
+        .args(["ci-doctor", "--json", "--strict"])
+        .output()
+        .expect("xtask ci-doctor --json --strict must run");
+
+    // JSON output must be valid schema-v1.
+    let json = parse_json(&out.stdout)?;
+    assert_eq!(json["schema_version"], 1);
+
+    // Exit code must match the overall status.
+    let exit_code = out.status.code().unwrap_or(-1);
+    if overall == "ok" {
+        assert_eq!(exit_code, 0, "strict mode with ok overall must exit 0");
+    } else {
+        assert_eq!(exit_code, 1, "strict mode with warn/fail overall must exit 1");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Current truth

Adds `cargo xtask ci-doctor` — a local CI parity diagnostic command.

8 checks are run in order:

| # | Check | Behavior on absence |
|---|-------|---------------------|
| 1 | `rustc-toolchain-match` | warn if version differs from `rust-toolchain.toml` |
| 2 | `rustfmt-installed` | fail if `cargo fmt --version` exits non-zero |
| 3 | `clippy-installed` | fail if `cargo clippy --version` exits non-zero |
| 4 | `git-clean` | warn if working tree has uncommitted changes |
| 5 | `fmt-drift` | warn if `cargo fmt --check` exits non-zero |
| 6 | `perl-interpreter` | **warn** (not fail) if `perl` not on PATH |
| 7 | `perl-lsp-binary` | warn if `perl-lsp` not on PATH |
| 8 | `platform-env-sanity` | warn on CARGO_TARGET_DIR/PERL5LIB anomalies |

`overall` is the worst status across all checks.

## Acceptance

```bash
cargo build -p xtask --locked
cargo test -p xtask --test ci_doctor --locked   # 7 tests, all pass
cargo xtask ci-doctor
cargo xtask ci-doctor --json
cargo clippy -p xtask -- -D warnings -A missing_docs
cargo xtask fmt --check
```

### Sample human output

```
ci-doctor  overall: warn

  [ok  ] rustc-toolchain-match: match
  [ok  ] rustfmt-installed: installed
  [ok  ] clippy-installed: installed
  [warn] git-clean: working tree has uncommitted changes (WIP is fine; mention if unexpected) (expected: clean, got: 4 modified file(s))
  [warn] fmt-drift: run `cargo xtask fmt` to fix formatting (expected: formatted, got: drift detected)
  [ok  ] perl-interpreter: perl found on PATH
  [warn] perl-lsp-binary: perl-lsp not found on PATH; run `cargo install --path crates/perl-lsp-rs` or add target/debug to PATH (expected: found, got: not found)
  [ok  ] platform-env-sanity: no environment anomalies detected

  run with --strict to fail CI on the above warnings/failures
```

### Sample JSON output (`--json`)

```json
{
  "schema_version": 1,
  "overall": "warn",
  "checks": [
    { "name": "rustc-toolchain-match", "status": "ok", "expected": "1.95.0", "actual": "1.95.0", "note": "match" },
    { "name": "rustfmt-installed", "status": "ok", "expected": "rustfmt 1.9.0-stable (...)", "actual": "rustfmt 1.9.0-stable (...)", "note": "installed" },
    { "name": "clippy-installed", "status": "ok", "expected": "clippy 0.1.95 (...)", "actual": "clippy 0.1.95 (...)", "note": "installed" },
    { "name": "git-clean", "status": "warn", "expected": "clean", "actual": "4 modified file(s)", "note": "working tree has uncommitted changes" },
    { "name": "fmt-drift", "status": "warn", "expected": "formatted", "actual": "drift detected", "note": "run `cargo xtask fmt` to fix formatting" },
    { "name": "perl-interpreter", "status": "ok", "expected": "v5.42.2", "actual": "v5.42.2", "note": "perl found on PATH" },
    { "name": "perl-lsp-binary", "status": "warn", "expected": "found", "actual": "not found", "note": "perl-lsp not found on PATH; ..." },
    { "name": "platform-env-sanity", "status": "ok", "expected": "sane", "actual": "sane", "note": "no environment anomalies detected" }
  ]
}
```

## Claim boundary

- Local parity diagnostics only. Does **not** modify CI workflows or post anywhere.
- `--strict` is the only mode that exits non-zero; default is always exit 0 (developer-friendly).
- `perl-interpreter` is intentionally `warn` (not `fail`) — perl-lsp can be used on machines without a local Perl runtime.

## Files changed

- `xtask/src/tasks/ci_doctor.rs` — new task implementation (461 lines)
- `xtask/tests/ci_doctor.rs` — integration tests (210 lines, 7 tests)
- `xtask/src/tasks/mod.rs` — +1 `pub mod ci_doctor`
- `xtask/src/main.rs` — +21 lines wiring `CiDoctor` variant into `Commands` enum

Closes #4826