### PR TITLE
tooling(pr): validate issue-number title locally (#8614)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -74,6 +74,12 @@ enum Commands {
         command: QueueCommand,
     },
 
+    /// PR-related local tooling (title check, etc.)
+    Pr {
+        #[command(subcommand)]
+        command: PrSubcommand,
+    },
+
     /// Build project with various configurations
     Build {
         /// Build in release mode
@@ -2100,6 +2106,31 @@ enum CiSubcommand {
 }
 
 #[derive(Subcommand)]
+enum PrSubcommand {
+    /// Validate a PR title matches the required format and references an open issue.
+    ///
+    /// Mirrors the `validate-title` GitHub Actions check for local pre-push use.
+    /// Pass a title string directly or omit to read from `git log -1 --pretty=%s`.
+    #[command(name = "title-check")]
+    TitleCheck {
+        /// PR title to validate. If omitted, reads the HEAD commit subject.
+        title: Option<String>,
+
+        /// Emit a JSON receipt instead of human-readable output.
+        #[arg(long)]
+        json: bool,
+
+        /// Exit 1 on warnings (e.g. closed issue) in addition to hard failures.
+        #[arg(long)]
+        strict: bool,
+
+        /// Skip the GitHub issue-existence API call.
+        #[arg(long)]
+        no_gh: bool,
+    },
+}
+
+#[derive(Subcommand)]
 enum DevexCommand {
     /// Plan the cheapest correct local proof commands for the current diff.
     Plan {
@@ -2252,6 +2283,16 @@ fn main() -> Result<()> {
             QueueCommand::Snapshot { out, fixture } => queue_snapshot::run_snapshot(out, fixture),
             QueueCommand::Health { receipt, fixture } => {
                 queue_health::run(queue_health::QueueHealthArgs { receipt, fixture })
+            }
+        },
+        Commands::Pr { command } => match command {
+            PrSubcommand::TitleCheck { title, json, strict, no_gh } => {
+                tasks::pr::title_check::run(tasks::pr::title_check::TitleCheckConfig {
+                    title,
+                    json,
+                    strict,
+                    no_gh,
+                })
             }
         },
         Commands::Build { release, features, c_scanner, rust_scanner } => {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -78,6 +78,7 @@ pub mod parser_corpus_sweep;
 pub mod parser_matrix;
 pub mod parser_ratchet;
 pub mod populate_book;
+pub mod pr;
 pub mod prep_crates_io_launch;
 pub mod publication_facts;
 pub mod publish;

--- a/xtask/src/tasks/pr/mod.rs
+++ b/xtask/src/tasks/pr/mod.rs
@@ -1,0 +1,6 @@
+//! PR-related xtask subcommands.
+//!
+//! Container namespace for local PR tooling. Add new PR-related subcommands
+//! here (e.g., `cargo xtask pr summary`, `cargo xtask pr lint`).
+
+pub mod title_check;

--- a/xtask/src/tasks/pr/title_check.rs
+++ b/xtask/src/tasks/pr/title_check.rs
@@ -1,0 +1,460 @@
+//! `cargo xtask pr title-check` — local PR title validator.
+//!
+//! Mirrors the `validate-title` GitHub Actions check so developers can
+//! validate before pushing.  Does NOT replace the CI check; it is a
+//! local pre-push convenience.
+//!
+//! # Exit codes
+//! - `0` — all checks pass (or only warnings in default mode).
+//! - `1` — a required check failed, or `--strict` and at least one warning.
+//!
+//! # JSON receipt (schema_version 1)
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "title": "fix(scope): thing (#1234)",
+//!   "issue_ref": 1234,
+//!   "issue_exists": true,
+//!   "issue_open": true,
+//!   "type": "fix",
+//!   "scope": "scope",
+//!   "subject": "thing",
+//!   "overall": "ok",
+//!   "checks": [
+//!     {"name": "issue-ref-present", "status": "ok"},
+//!     {"name": "issue-exists",      "status": "ok"},
+//!     {"name": "conventional-format","status": "ok"},
+//!     {"name": "subject-length",     "status": "ok"},
+//!     {"name": "issue-open",         "status": "ok"}
+//!   ]
+//! }
+//! ```
+
+use color_eyre::eyre::{Context, Result, bail};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+// ---------------------------------------------------------------------------
+// Public config
+// ---------------------------------------------------------------------------
+
+/// Configuration for the `pr title-check` subcommand.
+pub struct TitleCheckConfig {
+    /// Optional title to check. When `None`, read from `git log -1 --pretty=%s`.
+    pub title: Option<String>,
+    /// Emit JSON receipt to stdout instead of human-readable output.
+    pub json: bool,
+    /// Exit 1 on warnings (not just hard failures).
+    pub strict: bool,
+    /// Skip the GitHub issue-existence check entirely.
+    pub no_gh: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/// Overall validation status.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OverallStatus {
+    /// All checks passed.
+    Ok,
+    /// At least one warning (no hard failure).
+    Warn,
+    /// At least one hard failure.
+    Fail,
+}
+
+impl std::fmt::Display for OverallStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OverallStatus::Ok => write!(f, "ok"),
+            OverallStatus::Warn => write!(f, "warn"),
+            OverallStatus::Fail => write!(f, "fail"),
+        }
+    }
+}
+
+/// Individual check result status.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckStatus {
+    Ok,
+    Warn,
+    Fail,
+    Skipped,
+}
+
+impl std::fmt::Display for CheckStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CheckStatus::Ok => write!(f, "ok"),
+            CheckStatus::Warn => write!(f, "warn"),
+            CheckStatus::Fail => write!(f, "fail"),
+            CheckStatus::Skipped => write!(f, "skipped"),
+        }
+    }
+}
+
+/// A single named check.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CheckResult {
+    pub name: String,
+    pub status: CheckStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// Full JSON receipt schema (schema_version 1).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TitleCheckReceipt {
+    pub schema_version: u32,
+    pub title: String,
+    pub issue_ref: Option<u64>,
+    pub issue_exists: Option<bool>,
+    pub issue_open: Option<bool>,
+    #[serde(rename = "type")]
+    pub commit_type: Option<String>,
+    pub scope: Option<String>,
+    pub subject: Option<String>,
+    pub overall: OverallStatus,
+    pub checks: Vec<CheckResult>,
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Run the `pr title-check` subcommand.
+pub fn run(cfg: TitleCheckConfig) -> Result<()> {
+    let title = match cfg.title {
+        Some(t) => t,
+        None => read_head_commit_subject()?,
+    };
+
+    let receipt = validate_title(&title, cfg.no_gh)?;
+
+    if cfg.json {
+        let json =
+            serde_json::to_string_pretty(&receipt).context("failed to serialize JSON receipt")?;
+        println!("{json}");
+    } else {
+        print_human(&receipt);
+    }
+
+    // Decide exit code.
+    let fail = match receipt.overall {
+        OverallStatus::Fail => true,
+        OverallStatus::Warn => cfg.strict,
+        OverallStatus::Ok => false,
+    };
+
+    if fail {
+        bail!("pr title-check failed (overall: {})", receipt.overall);
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Validation logic
+// ---------------------------------------------------------------------------
+
+/// Perform all checks and return a receipt.
+///
+/// `no_gh` suppresses the GitHub API call (useful in offline / CI contexts
+/// where `GH_TOKEN` is absent or `--no-gh` was passed explicitly).
+fn validate_title(title: &str, no_gh: bool) -> Result<TitleCheckReceipt> {
+    let mut checks: Vec<CheckResult> = Vec::new();
+
+    // ------------------------------------------------------------------
+    // 1. Issue reference present: regex mirrors the GitHub Actions workflow
+    //    `.github/workflows/pr-title-check.yml` which uses /\B#(\d+)\b/g
+    // ------------------------------------------------------------------
+    let issue_re = Regex::new(r"\B#(\d+)\b").ok();
+    let issue_ref: Option<u64> = issue_re.as_ref().and_then(|re| {
+        re.captures(title).and_then(|cap| cap.get(1)).and_then(|m| m.as_str().parse().ok())
+    });
+
+    // Reject #0 (Codex placeholder), per the workflow.
+    let issue_ref = issue_ref.filter(|&n| n != 0);
+
+    if issue_ref.is_some() {
+        checks.push(CheckResult {
+            name: "issue-ref-present".into(),
+            status: CheckStatus::Ok,
+            message: None,
+        });
+    } else {
+        checks.push(CheckResult {
+            name: "issue-ref-present".into(),
+            status: CheckStatus::Fail,
+            message: Some(
+                "Title must contain an issue reference like (#1234). \
+                 Pattern: \\B#\\d+\\b"
+                    .into(),
+            ),
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Conventional-commit format: type(scope)?: subject
+    //    Types: fix, feat, test, docs, chore, perf, refactor, ci, build,
+    //           revert, style, security, tooling, status
+    // ------------------------------------------------------------------
+    let conv_re = Regex::new(
+        r"(?x)
+        ^
+        (?P<type>feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert|security|tooling|status)
+        (?:\((?P<scope>[^)]+)\))?
+        !?
+        :\s
+        (?P<subject>.+)
+        $",
+    )
+    .ok();
+
+    let (commit_type, scope, subject) = match &conv_re {
+        Some(re) => match re.captures(title) {
+            Some(caps) => {
+                let t = caps.name("type").map(|m| m.as_str().to_string());
+                let s = caps.name("scope").map(|m| m.as_str().to_string());
+                // Subject is everything before the optional trailing issue ref.
+                let raw_subject =
+                    caps.name("subject").map(|m| m.as_str().to_string()).unwrap_or_default();
+                // Strip trailing " (#NNNN)" for subject length check.
+                let subject_stripped = strip_issue_ref(&raw_subject);
+                checks.push(CheckResult {
+                    name: "conventional-format".into(),
+                    status: CheckStatus::Ok,
+                    message: None,
+                });
+                (t, s, Some(subject_stripped))
+            }
+            None => {
+                checks.push(CheckResult {
+                    name: "conventional-format".into(),
+                    status: CheckStatus::Fail,
+                    message: Some(
+                        "Title must match `type(scope)?: subject`. \
+                         Valid types: feat, fix, docs, style, refactor, perf, test, \
+                         chore, ci, build, revert, security, tooling, status"
+                            .into(),
+                    ),
+                });
+                (None, None, None)
+            }
+        },
+        None => {
+            checks.push(CheckResult {
+                name: "conventional-format".into(),
+                status: CheckStatus::Skipped,
+                message: Some("regex compilation failed".into()),
+            });
+            (None, None, None)
+        }
+    };
+
+    // ------------------------------------------------------------------
+    // 3. Subject length (warn at > 72 chars before the issue ref)
+    // ------------------------------------------------------------------
+    let subject_for_len = subject.clone().unwrap_or_else(|| strip_issue_ref(title));
+    let subject_len = subject_for_len.chars().count();
+    if subject_len > 72 {
+        checks.push(CheckResult {
+            name: "subject-length".into(),
+            status: CheckStatus::Warn,
+            message: Some(format!("Subject is {subject_len} chars (max 72 before issue ref)")),
+        });
+    } else {
+        checks.push(CheckResult {
+            name: "subject-length".into(),
+            status: CheckStatus::Ok,
+            message: None,
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Issue exists on GitHub (optional — skipped when no_gh or no token)
+    // ------------------------------------------------------------------
+    let gh_available = !no_gh && gh_token_present();
+    let (issue_exists, issue_open) = if let Some(num) = issue_ref {
+        if gh_available {
+            match query_issue(num) {
+                Ok((exists, open)) => (Some(exists), Some(open)),
+                Err(_) => (None, None),
+            }
+        } else {
+            (None, None)
+        }
+    } else {
+        (None, None)
+    };
+
+    // Emit issue-exists check.
+    if issue_ref.is_some() {
+        match issue_exists {
+            Some(true) => {
+                checks.push(CheckResult {
+                    name: "issue-exists".into(),
+                    status: CheckStatus::Ok,
+                    message: None,
+                });
+            }
+            Some(false) => {
+                checks.push(CheckResult {
+                    name: "issue-exists".into(),
+                    status: CheckStatus::Warn,
+                    message: issue_ref.map(|n| format!("Issue #{n} not found — verify the number")),
+                });
+            }
+            None => {
+                checks.push(CheckResult {
+                    name: "issue-exists".into(),
+                    status: CheckStatus::Skipped,
+                    message: Some("GitHub check skipped (--no-gh or GH_TOKEN not set)".into()),
+                });
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 5. Issue open (warn when closed, unless type is docs/status or
+    //    subject contains "supersede")
+    // ------------------------------------------------------------------
+    let closed_exempt =
+        commit_type.as_deref().map(|t| matches!(t, "docs" | "status")).unwrap_or(false)
+            || subject.as_deref().map(|s| s.contains("supersede")).unwrap_or(false);
+
+    if let (Some(num), Some(true), Some(open)) = (issue_ref, issue_exists, issue_open) {
+        if !open && !closed_exempt {
+            checks.push(CheckResult {
+                name: "issue-open".into(),
+                status: CheckStatus::Warn,
+                message: Some(format!(
+                    "Issue #{num} is closed. Use --strict to fail on this warning, \
+                     or use `docs:`/`status:` type to suppress."
+                )),
+            });
+        } else {
+            checks.push(CheckResult {
+                name: "issue-open".into(),
+                status: CheckStatus::Ok,
+                message: None,
+            });
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Compute overall status.
+    // ------------------------------------------------------------------
+    let overall = compute_overall(&checks);
+
+    Ok(TitleCheckReceipt {
+        schema_version: 1,
+        title: title.to_string(),
+        issue_ref,
+        issue_exists,
+        issue_open,
+        commit_type,
+        scope,
+        subject,
+        overall,
+        checks,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Strip a trailing ` (#NNNN)` or `(#NNNN)` suffix from a subject string.
+fn strip_issue_ref(s: &str) -> String {
+    Regex::new(r"\s*\(#\d+\)\s*$")
+        .ok()
+        .and_then(|re| {
+            let s2 = re.replace(s, "");
+            if s2 != s { Some(s2.into_owned()) } else { None }
+        })
+        .unwrap_or_else(|| s.to_string())
+}
+
+/// Compute overall status from a list of check results.
+fn compute_overall(checks: &[CheckResult]) -> OverallStatus {
+    let mut overall = OverallStatus::Ok;
+    for c in checks {
+        match c.status {
+            CheckStatus::Fail => return OverallStatus::Fail,
+            CheckStatus::Warn => overall = OverallStatus::Warn,
+            CheckStatus::Ok | CheckStatus::Skipped => {}
+        }
+    }
+    overall
+}
+
+/// Read the subject line of HEAD.
+fn read_head_commit_subject() -> Result<String> {
+    let out = Command::new("git")
+        .args(["log", "-1", "--pretty=%s"])
+        .output()
+        .context("failed to run `git log -1 --pretty=%s`")?;
+    if !out.status.success() {
+        bail!(
+            "git log exited with status {:?}: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let subject = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    Ok(subject)
+}
+
+/// Return `true` when a GH_TOKEN or GITHUB_TOKEN environment variable is set.
+fn gh_token_present() -> bool {
+    std::env::var("GH_TOKEN").is_ok() || std::env::var("GITHUB_TOKEN").is_ok()
+}
+
+/// Query GitHub REST API to check if an issue exists and whether it is open.
+/// Returns `(exists, open)`.
+fn query_issue(issue_number: u64) -> Result<(bool, bool)> {
+    let url =
+        format!("https://api.github.com/repos/EffortlessMetrics/perl-lsp/issues/{issue_number}");
+    let out = Command::new("gh").args(["api", &url]).output().context("failed to run `gh api`")?;
+
+    if !out.status.success() {
+        // 404 → issue doesn't exist.
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if stderr.contains("404") || out.status.code() == Some(1) {
+            return Ok((false, false));
+        }
+        bail!("gh api exited with status {:?}: {}", out.status.code(), stderr);
+    }
+
+    let body: serde_json::Value =
+        serde_json::from_slice(&out.stdout).context("failed to parse gh api response")?;
+    let state = body["state"].as_str().unwrap_or("unknown");
+    Ok((true, state == "open"))
+}
+
+/// Print a human-readable summary.
+fn print_human(receipt: &TitleCheckReceipt) {
+    println!("Title: {}", receipt.title);
+    println!();
+    for c in &receipt.checks {
+        let symbol = match c.status {
+            CheckStatus::Ok => "ok  ",
+            CheckStatus::Warn => "WARN",
+            CheckStatus::Fail => "FAIL",
+            CheckStatus::Skipped => "skip",
+        };
+        if let Some(msg) = &c.message {
+            println!("  [{symbol}] {} — {msg}", c.name);
+        } else {
+            println!("  [{symbol}] {}", c.name);
+        }
+    }
+    println!();
+    println!("Overall: {}", receipt.overall);
+}

--- a/xtask/tests/pr_title_check.rs
+++ b/xtask/tests/pr_title_check.rs
@@ -1,0 +1,247 @@
+//! Integration tests for `cargo xtask pr title-check`.
+//!
+//! Each test invokes the xtask binary and asserts on exit codes and output.
+//! Tests that require a git repo use `tempfile` + a minimal init sequence.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use anyhow::Result;
+use assert_cmd::cargo::cargo_bin_cmd;
+use serde_json::Value;
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Stdio},
+};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Initialize a minimal git repo with one commit in a temp directory.
+fn init_git_repo() -> Result<TempDir> {
+    let dir = TempDir::new()?;
+    git_cmd(&["init", "-b", "master"], dir.path()).or_else(|_| git_cmd(&["init"], dir.path()))?;
+    git_cmd(&["config", "user.email", "test@test.com"], dir.path())?;
+    git_cmd(&["config", "user.name", "Test"], dir.path())?;
+    fs::write(dir.path().join("README.md"), "init")?;
+    git_cmd(&["add", "."], dir.path())?;
+    git_cmd(&["commit", "-m", "fix(scope): initial commit (#1234)"], dir.path())?;
+    Ok(dir)
+}
+
+fn git_cmd(args: &[&str], cwd: &Path) -> Result<()> {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+    if !status.success() {
+        anyhow::bail!("git {:?} failed with {:?}", args, status.code());
+    }
+    Ok(())
+}
+
+/// Parse JSON from stdout bytes.
+fn parse_json(stdout: &[u8]) -> Result<Value> {
+    let text = std::str::from_utf8(stdout)?;
+    Ok(serde_json::from_str(text)?)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A well-formed conventional-commit title with an issue ref passes.
+#[test]
+fn valid_title_passes() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["pr", "title-check", "--no-gh", "fix(scope): subject (#1234)"]).assert().success();
+    Ok(())
+}
+
+/// A title with no issue reference fails (hard failure).
+#[test]
+fn missing_issue_ref_fails() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["pr", "title-check", "--no-gh", "fix(scope): subject"]).assert().failure().code(1);
+    Ok(())
+}
+
+/// A title with a zero-valued issue reference (#0) fails (Codex placeholder).
+#[test]
+fn zero_issue_ref_fails() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["pr", "title-check", "--no-gh", "fix(scope): subject (#0)"])
+        .assert()
+        .failure()
+        .code(1);
+    Ok(())
+}
+
+/// A title that doesn't follow conventional-commit format fails.
+#[test]
+fn malformed_type_fails() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["pr", "title-check", "--no-gh", "Bad title format (#1234)"])
+        .assert()
+        .failure()
+        .code(1);
+    Ok(())
+}
+
+/// A subject longer than 72 chars (before the issue ref) warns in default mode but exits 0.
+#[test]
+fn subject_too_long_warns_exits_zero() -> Result<()> {
+    // Construct a subject that is exactly 73 chars long.
+    let long_subject = "a".repeat(73);
+    let title = format!("fix(scope): {long_subject} (#1234)");
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["pr", "title-check", "--no-gh", &title]).assert().success(); // warn mode: exits 0
+    Ok(())
+}
+
+/// In `--strict` mode, a too-long subject causes exit 1.
+#[test]
+fn strict_mode_fails_on_length_warn() -> Result<()> {
+    let long_subject = "a".repeat(73);
+    let title = format!("fix(scope): {long_subject} (#1234)");
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.args(["pr", "title-check", "--no-gh", "--strict", &title]).assert().failure().code(1);
+    Ok(())
+}
+
+/// `--json` emits a JSON receipt with schema_version=1 and required fields.
+#[test]
+fn json_output_schema_v1() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let stdout = cmd
+        .args(["pr", "title-check", "--no-gh", "--json", "fix(scope): subject (#1234)"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v = parse_json(&stdout)?;
+    assert_eq!(v["schema_version"], 1, "schema_version must be 1");
+    assert!(v["title"].is_string(), "title must be a string");
+    assert!(v["overall"].is_string(), "overall must be a string");
+    assert!(v["checks"].is_array(), "checks must be an array");
+    assert_eq!(v["issue_ref"], 1234, "issue_ref must be 1234");
+    assert_eq!(v["type"], "fix", "type must be fix");
+    assert_eq!(v["scope"], "scope", "scope must be scope");
+    Ok(())
+}
+
+/// JSON receipt includes all check names.
+#[test]
+fn json_checks_include_required_names() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let stdout = cmd
+        .args(["pr", "title-check", "--no-gh", "--json", "fix(scope): subject (#1234)"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v = parse_json(&stdout)?;
+    let checks = v["checks"].as_array().expect("checks array");
+    let names: Vec<&str> = checks.iter().filter_map(|c| c["name"].as_str()).collect();
+
+    assert!(names.contains(&"issue-ref-present"), "missing issue-ref-present check");
+    assert!(names.contains(&"conventional-format"), "missing conventional-format check");
+    assert!(names.contains(&"subject-length"), "missing subject-length check");
+    Ok(())
+}
+
+/// `--no-gh` skips the issue-exists check (status should be `skipped`).
+#[test]
+fn no_gh_skips_issue_check() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let stdout = cmd
+        .args(["pr", "title-check", "--no-gh", "--json", "fix(scope): subject (#1234)"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v = parse_json(&stdout)?;
+    let checks = v["checks"].as_array().expect("checks array");
+    let issue_exists = checks.iter().find(|c| c["name"] == "issue-exists");
+
+    if let Some(check) = issue_exists {
+        assert_eq!(
+            check["status"], "skipped",
+            "issue-exists check must be skipped when --no-gh is passed"
+        );
+    }
+    // If issue-exists is not emitted at all when skipped, that's also acceptable.
+    Ok(())
+}
+
+/// When no title arg is provided, the command reads from `git log -1 --pretty=%s`.
+/// The HEAD commit has a valid title, so the command should exit 0.
+#[test]
+fn reads_head_commit_when_no_title_arg() -> Result<()> {
+    let repo = init_git_repo()?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.current_dir(repo.path()).args(["pr", "title-check", "--no-gh"]).assert().success();
+    Ok(())
+}
+
+/// When no title arg is provided and HEAD commit lacks an issue ref, it exits 1.
+#[test]
+fn reads_head_commit_fails_when_missing_issue_ref() -> Result<()> {
+    let dir = TempDir::new()?;
+    git_cmd(&["init", "-b", "master"], dir.path()).or_else(|_| git_cmd(&["init"], dir.path()))?;
+    git_cmd(&["config", "user.email", "test@test.com"], dir.path())?;
+    git_cmd(&["config", "user.name", "Test"], dir.path())?;
+    fs::write(dir.path().join("README.md"), "init")?;
+    git_cmd(&["add", "."], dir.path())?;
+    // Commit with no issue ref.
+    git_cmd(&["commit", "-m", "fix(scope): no issue number here"], dir.path())?;
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    cmd.current_dir(dir.path()).args(["pr", "title-check", "--no-gh"]).assert().failure().code(1);
+    Ok(())
+}
+
+/// JSON overall field is `"ok"` for a valid title.
+#[test]
+fn json_overall_ok_for_valid_title() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let stdout = cmd
+        .args(["pr", "title-check", "--no-gh", "--json", "feat(parser): add cool thing (#9999)"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v = parse_json(&stdout)?;
+    assert_eq!(v["overall"], "ok");
+    Ok(())
+}
+
+/// JSON overall field is `"fail"` for a title missing the issue ref.
+#[test]
+fn json_overall_fail_for_missing_ref() -> Result<()> {
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let stdout = cmd
+        .args(["pr", "title-check", "--no-gh", "--json", "feat(parser): add cool thing"])
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v = parse_json(&stdout)?;
+    assert_eq!(v["overall"], "fail");
+    Ok(())
+}


### PR DESCRIPTION
## Current truth

Adds `cargo xtask pr title-check` as the first command in a new `pr` subcommand namespace within xtask.

**Files added/changed:**
- `xtask/src/tasks/pr/mod.rs` — namespace container; extensible for future `pr summary`, `pr lint`, etc.
- `xtask/src/tasks/pr/title_check.rs` — all validation logic
- `xtask/src/tasks/mod.rs` — `pub mod pr;` declaration
- `xtask/src/main.rs` — `Pr { command: PrSubcommand }` entry + `PrSubcommand::TitleCheck` dispatch
- `xtask/tests/pr_title_check.rs` — 13 integration tests

## Acceptance

```bash
cargo build -p xtask --locked
cargo test -p xtask --test pr_title_check --locked
cargo clippy -p xtask -- -D warnings -A missing_docs
cargo fmt -p xtask -- --check
```

### Sample runs

Valid title (exit 0):
```
$ cargo xtask pr title-check "fix(scope): test (#1234)"
Title: fix(scope): test (#1234)

  [ok  ] issue-ref-present
  [ok  ] conventional-format
  [ok  ] subject-length
  [skip] issue-exists — GitHub check skipped (--no-gh or GH_TOKEN not set)

Overall: ok
```

Invalid title (exit 1):
```
$ cargo xtask pr title-check "no issue ref here"
Title: no issue ref here

  [FAIL] issue-ref-present — Title must contain an issue reference like (#1234). Pattern: \B#\d+\b
  [FAIL] conventional-format — …
  [ok  ] subject-length

Overall: fail
```

JSON receipt (exit 0):
```json
{
  "schema_version": 1,
  "title": "fix(scope): test (#1234)",
  "issue_ref": 1234,
  "type": "fix",
  "scope": "scope",
  "subject": "test",
  "overall": "ok",
  "checks": [...]
}
```

## Claim boundary

- **Local validation only.** Does NOT replace the `validate-title` GitHub Actions workflow (`pr-title-check.yml`), which still runs at PR-open time.
- Does NOT auto-fix titles.
- Regex `\B#(\d+)\b` is copied verbatim from `.github/workflows/pr-title-check.yml` line 41.
- `#0` is rejected (Codex placeholder), matching the workflow's zero-issue guard.
- GitHub issue-existence check requires `GH_TOKEN`/`GITHUB_TOKEN` to be set; skipped otherwise (or with `--no-gh`).

Closes #8614