### PR TITLE
fix(xtask): format ci doctor test (#8699)

### DIFF
--- a/xtask/tests/ci_doctor_cli.rs
+++ b/xtask/tests/ci_doctor_cli.rs
@@ -14,32 +14,17 @@ fn ci_doctor_exits_zero_in_normal_env() {
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     // The header must always appear
-    assert!(
-        stdout.contains("cargo xtask ci doctor"),
-        "expected header in output:\n{stdout}"
-    );
+    assert!(stdout.contains("cargo xtask ci doctor"), "expected header in output:\n{stdout}");
 
     // Toolchain and component sections must appear
-    assert!(
-        stdout.contains("── Toolchain ──"),
-        "expected toolchain section:\n{stdout}"
-    );
-    assert!(
-        stdout.contains("── Rust components ──"),
-        "expected components section:\n{stdout}"
-    );
+    assert!(stdout.contains("── Toolchain ──"), "expected toolchain section:\n{stdout}");
+    assert!(stdout.contains("── Rust components ──"), "expected components section:\n{stdout}");
 
     // Platform section must appear
-    assert!(
-        stdout.contains("── Platform ──"),
-        "expected platform section:\n{stdout}"
-    );
+    assert!(stdout.contains("── Platform ──"), "expected platform section:\n{stdout}");
 
     // The summary line must appear
-    assert!(
-        stdout.contains("ci doctor:"),
-        "expected summary line:\n{stdout}"
-    );
+    assert!(stdout.contains("ci doctor:"), "expected summary line:\n{stdout}");
 }
 
 /// Verify `cargo xtask ci` (without sub-command) still runs the CI suite.


### PR DESCRIPTION
Problem: The CI doctor merge left xtask test formatting drift, causing `cargo xtask fmt --check` to fail in PR-fast on unrelated PRs.
Fix: Apply rustfmt to `xtask/tests/ci_doctor_cli.rs`.
Verification: `cargo xtask fmt --check` passes; `git diff --check` passes.