### PR TITLE
fix(parser): parse main-package qualified variables (#8702)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -584,7 +584,12 @@ impl<'a> Parser<'a> {
                 Some(TokenKind::DoubleColon) => {
                     // $:: — the main namespace stash
                     let dc_token = self.tokens.next()?; // consume ::
-                    ("::".to_string(), dc_token.end)
+                    if self.peek_kind() == Some(TokenKind::Identifier) {
+                        let name_token = self.tokens.next()?;
+                        (format!("::{}", name_token.text), name_token.end)
+                    } else {
+                        ("::".to_string(), dc_token.end)
+                    }
                 }
                 Some(TokenKind::Colon) => {
                     // $: — format line-break character variable

--- a/crates/perl-parser-core/tests/fix_main_stash_access.rs
+++ b/crates/perl-parser-core/tests/fix_main_stash_access.rs
@@ -55,6 +55,12 @@ fn double_colon_in_package_variable_unaffected() {
 }
 
 #[test]
+fn main_package_uppercase_variable() {
+    // $::IS_ASCII from Unicode::Normalize is a main-package variable.
+    assert_clean_parse(r#"my $x = $::IS_ASCII;"#);
+}
+
+#[test]
 fn main_stash_hash_sigil() {
     // %:: is the main symbol table as a hash — should parse without error
     assert_clean_parse(r#"my %stash = %::;"#);

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -519,6 +519,13 @@ fn unless_null_in_paren() {
     assert_clean_parse(r#"unless (null $root) { print "not null" }"#);
 }
 
+#[test]
+fn main_package_variable_in_paren_expr() {
+    // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
+    // variable, not as `$::` followed by a stray bare identifier.
+    assert_clean_parse(r#"my $x = ($::IS_ASCII || $] < 5.008);"#);
+}
+
 // === Sigil-peek heuristic: imported unary functions without parens (#1943) ===
 // These all fail with "expected ')', found identifier" before the fix because
 // `blessed`, `reftype`, etc. are not in the builtin table. The fix adds a


### PR DESCRIPTION
Problem: Main-package variables such as `$::IS_ASCII` were parsed as `$::` plus a stray identifier, producing `unclosed_paren_identifier` corpus errors.
Fix: Consume an identifier after the main-package `::` sigil form and cover both direct and parenthesized expression forms.
Verification: `cargo test -p perl-parser-core --test fix_main_stash_access --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`.

Local corpus receipt: Strawberry sweep clean files improved `1349 -> 1351`, ERROR-node files `67 -> 61`, total ERROR nodes `184 -> 158`, and `unclosed_paren_identifier` dropped `8 -> 2`. Full `perl-parser-core` integration suite still has the unrelated pre-existing `parser_panic_mode_recovery::parser_ac3_prevent_recursive_recovery` expectation failure.