### PR TITLE
fix(parser): parse x repetition prefix incdec rhs (#8705)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/precedence.rs
@@ -957,6 +957,8 @@ impl<'a> Parser<'a> {
                             | TokenKind::Not
                             | TokenKind::Minus
                             | TokenKind::Plus
+                            | TokenKind::Increment
+                            | TokenKind::Decrement
                             | TokenKind::Backslash
                             | TokenKind::BitwiseNot => true,
                             TokenKind::Identifier => {

--- a/crates/perl-parser-core/src/engine/parser/x_repetition_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/x_repetition_tests.rs
@@ -96,3 +96,22 @@ fn test_x_with_variable_rhs() {
     let sexp = ast.to_sexp();
     assert!(sexp.contains("binary_x"), "Expected binary_x in: {sexp}");
 }
+
+#[test]
+fn test_x_with_prefix_decrement_rhs() {
+    // Pod::Simple::XHTML uses `('  ' x --$indent)` while constructing lists.
+    let mut parser = Parser::new(r#"my $s = " " x --$indent;"#);
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "Unexpected ERROR in: {sexp}");
+    assert!(sexp.contains("binary_x"), "Expected binary_x in: {sexp}");
+}
+
+#[test]
+fn test_x_with_prefix_increment_rhs() {
+    let mut parser = Parser::new(r#"my $s = " " x ++$indent;"#);
+    let ast = must(parser.parse());
+    let sexp = ast.to_sexp();
+    assert!(!sexp.contains("ERROR"), "Unexpected ERROR in: {sexp}");
+    assert!(sexp.contains("binary_x"), "Expected binary_x in: {sexp}");
+}

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -526,6 +526,12 @@ fn main_package_variable_in_paren_expr() {
     assert_clean_parse(r#"my $x = ($::IS_ASCII || $] < 5.008);"#);
 }
 
+#[test]
+fn x_repetition_prefix_decrement_in_parens() {
+    // From Pod::Simple::XHTML: repetition RHS may be a prefix decrement.
+    assert_clean_parse(r#"push @out, ('  ' x --$indent) . '</li>';"#);
+}
+
 // === Sigil-peek heuristic: imported unary functions without parens (#1943) ===
 // These all fail with "expected ')', found identifier" before the fix because
 // `blessed`, `reftype`, etc. are not in the builtin table. The fix adds a


### PR DESCRIPTION
Problem: `Pod::Simple::XHTML` uses x-repetition with prefix inc/dec on the RHS, which recovered as `unclosed_paren_identifier` in the Strawberry corpus.
Fix: Admit `++` / `--` as x-repetition RHS operand starts and add focused parser-core regressions for the corpus shape.
Verification:
- `cargo test -p perl-parser-core --profile agent --locked x_repetition -- --nocapture`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask parser-corpus-sweep --roots C:\Strawberry\perl\lib --output target\receipts\strawberry-corpus-sweep-after-x-prefix-incdec.json --verbose` (1353/1425 clean, dirty 68, ERROR-node files 59, ERROR nodes 128)
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask semantic-scorecard --check`
- `cargo xtask semantic-shadow-compare --check`
- `cargo xtask fmt --check`
- `git diff --check`