### PR TITLE
policy(clippy): reconcile lint policy MSRV to Rust 1.95 (#8508)

### DIFF
--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,5 +1,5 @@
 schema = 1
-msrv = "1.93"
+msrv = "1.95"
 
 [policy]
 panic_free_tests = true


### PR DESCRIPTION
## Current truth

`workspace.package.rust-version = "1.95"` (set in #8509), but `policy/clippy-lints.toml:2 msrv = "1.93"` was stale. `cargo xtask check-lint-policy` failed with a mismatch.

This PR bumps the top-level `msrv` field to `"1.95"`. Per-lint `activate_when_msrv` thresholds (lines 713-779) are unchanged — those are forward-looking activation gates correctly set per each lint's stabilization version.

## Acceptance

```bash
cargo xtask check-lint-policy
# Output: lint policy ok: 100 lint entries, 12 planned flips, 2 debt entries
```

Also passes:
- `cargo check -p xtask --locked`
- `cargo xtask fmt --check`
- `git diff --check`

## Claim boundary

One-line config reconciliation. Does NOT promote any lint, does NOT remove allows, does NOT change CI behavior. The 12 lints at `activate_when_msrv <= 1.95` are now ELIGIBLE for promotion but remain at their current levels until separate follow-up PRs in the codex clippy-cleanup lane.

## Do not combine

Keep separate from:
- The 5 remaining workspace clippy allows (`collapsible_match`, `manual_range_contains`, `useless_vec`, `vec_init_then_push`, `assertions_on_constants`) — separate burndown PRs.
- The 12 planned-flip promotions — separate PRs once the cleanup lane picks them up.
- 0.14.0 release prep (#8576) — this is a prerequisite, not a release bump.

## Origin

Identified in the user's 2026-05-11 Final Release Sequence Step 3A. Self-merge eligible per the mechanical-CI-fix exception (single-line policy reconciliation, all checks green).