### PR TITLE
policy(files): add non-Rust allowlist proposal generator (#8568)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1545,6 +1545,38 @@ enum NonRustCommand {
         #[arg(long, hide = true)]
         root: Option<PathBuf>,
     },
+
+    /// Generate draft allowlist proposals for unclassified non-Rust files.
+    ///
+    /// Writes:
+    ///   - `<output-dir>/non-rust-proposed-allowlist.toml` — draft entries ready for review.
+    ///   - `<output-dir>/non-rust-proposal.md` — human-readable summary.
+    ///
+    /// NEVER modifies `policy/non-rust-allowlist.toml`. The canonical ledger is
+    /// human-curated; this command only generates proposals for review.
+    Propose {
+        /// Output directory (default: `target/policy`).
+        #[arg(long, default_value = "target/policy")]
+        output_dir: PathBuf,
+
+        /// Grouping strategy: `directory` (default) groups by top-level dir;
+        /// `extension` groups by file extension.
+        #[arg(long, value_enum, default_value = "directory")]
+        group_by: ProposeGroupByArg,
+
+        /// Override the workspace root used for `git ls-files`. Test seam only.
+        #[arg(long, hide = true)]
+        root: Option<PathBuf>,
+    },
+}
+
+/// CLI-facing grouping argument (mirrors `file_policy::ProposeGroupBy`).
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum ProposeGroupByArg {
+    /// Group by top-level directory (default).
+    Directory,
+    /// Group by file extension.
+    Extension,
 }
 
 #[derive(Subcommand)]
@@ -3048,6 +3080,18 @@ fn main() -> Result<()> {
                         allowlist_path: allowlist,
                         root_override,
                     },
+                )
+            }
+            NonRustCommand::Propose { output_dir, group_by, root: root_override } => {
+                use tasks::file_policy::{ProposeConfig, ProposeGroupBy};
+                let root = utils::project_root()?;
+                let group_by = match group_by {
+                    ProposeGroupByArg::Directory => ProposeGroupBy::Directory,
+                    ProposeGroupByArg::Extension => ProposeGroupBy::Extension,
+                };
+                tasks::file_policy::non_rust_propose(
+                    &root,
+                    ProposeConfig { output_dir, group_by, root_override },
                 )
             }
         },

--- a/xtask/src/tasks/file_policy.rs
+++ b/xtask/src/tasks/file_policy.rs
@@ -761,6 +761,426 @@ pub fn check_file_policy(root: &std::path::Path, config: CheckFilePolicyConfig) 
 }
 
 // ---------------------------------------------------------------------------
+// Proposal generator — `cargo xtask non-rust propose`
+// ---------------------------------------------------------------------------
+
+/// Grouping strategy for `cargo xtask non-rust propose`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProposeGroupBy {
+    /// Group by top-level directory (default).
+    Directory,
+    /// Group by file extension.
+    Extension,
+}
+
+/// Configuration for `cargo xtask non-rust propose`.
+pub struct ProposeConfig {
+    /// Output directory (defaults to `target/policy`).
+    pub output_dir: std::path::PathBuf,
+    /// How to group unclassified files.
+    pub group_by: ProposeGroupBy,
+    /// Override the workspace root used for `git ls-files` (test seam).
+    pub root_override: Option<std::path::PathBuf>,
+}
+
+/// Return today's date as `YYYY-MM-DD` using Unix timestamp arithmetic.
+pub fn today_ymd() -> (u32, u32, u32) {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+    let days = secs / 86400;
+    days_to_ymd(days)
+}
+
+/// Add `n` days to a `(year, month, day)` tuple using the Julian Day Number
+/// method. Accurate for years 1970-2200.
+pub fn add_days(ymd: (u32, u32, u32), n: u32) -> (u32, u32, u32) {
+    // Convert (y, m, d) → JDN using the standard proleptic Gregorian formula.
+    // All arithmetic is signed to avoid underflow.
+    let (year, month, day) = (ymd.0 as i64, ymd.1 as i64, ymd.2 as i64);
+    let a = (14 - month) / 12;
+    let y = year + 4800 - a;
+    let m = month + 12 * a - 3;
+    let jdn = day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
+    // JDN for Unix epoch (1970-01-01) = 2440588.
+    let unix_days = (jdn - 2_440_588 + n as i64) as u64;
+    days_to_ymd(unix_days)
+}
+
+/// Format a `(year, month, day)` tuple as `YYYY-MM-DD`.
+pub fn fmt_ymd(ymd: (u32, u32, u32)) -> String {
+    format!("{:04}-{:02}-{:02}", ymd.0, ymd.1, ymd.2)
+}
+
+/// Heuristic: infer classification from a top-level directory name.
+fn classify_dir(dir: &str) -> &'static str {
+    match dir {
+        "docs" | "doc" | "book" | "guide" | "guides" | "wiki" | "website" | "pages" => "docs",
+        "test" | "tests" | "t" | "spec" | "specs" | "fixtures" | "test_corpus" | "test-corpus" => {
+            "test"
+        }
+        "vendor" | "third_party" | "third-party" | "extern" | "external" => "vendor",
+        "scripts" | "bin" | "tools" | "tool" | "ci" | ".ci" | ".github" | "xtask" => "build",
+        "data" | "assets" | "static" | "public" | "resources" | "corpus" | "samples" => "data",
+        "vscode-extension" | "vscode" | "editor" | "editors" => "data",
+        _ => "tbd",
+    }
+}
+
+/// Heuristic: infer classification from a file extension.
+fn classify_ext(ext: &str) -> &'static str {
+    match ext {
+        "md" | "rst" | "txt" | "adoc" | "asciidoc" => "docs",
+        "toml" | "yaml" | "yml" | "json" | "ron" | "json5" => "build",
+        "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" | "cmd" => "build",
+        "py" | "js" | "ts" | "rb" | "pl" | "pm" | "lua" | "tcl" => "build",
+        "png" | "jpg" | "jpeg" | "gif" | "svg" | "ico" | "webp" => "data",
+        "woff" | "woff2" | "ttf" | "eot" | "otf" => "data",
+        "pdf" | "docx" | "xlsx" | "pptx" => "docs",
+        "nix" | "lock" | "makefile" | "mk" | "cmake" => "build",
+        "html" | "css" | "scss" | "less" => "data",
+        "proto" | "thrift" | "avsc" => "data",
+        "csv" | "tsv" | "parquet" => "data",
+        "" => "tbd",
+        _ => "tbd",
+    }
+}
+
+/// Entry point for `cargo xtask non-rust propose`.
+///
+/// Reads the current inventory, groups unclassified files by the chosen
+/// strategy, and writes two output files:
+///
+/// - `<output_dir>/non-rust-proposed-allowlist.toml` — draft allowlist entries.
+/// - `<output_dir>/non-rust-proposal.md` — human-readable summary.
+///
+/// The canonical `policy/non-rust-allowlist.toml` is NEVER modified.
+pub fn non_rust_propose(root: &Path, config: ProposeConfig) -> Result<()> {
+    let effective_root: std::path::PathBuf =
+        if let Some(ref r) = config.root_override { r.clone() } else { root.to_path_buf() };
+    let root = effective_root.as_path();
+
+    println!("Building inventory for proposal generation...");
+
+    let allowlist = load_allowlist(root)?;
+    let tracked = list_tracked_files(root)?;
+    let prepared = prepare_allow_entries(&allowlist.allow);
+
+    // Collect unclassified non-Rust files.
+    let unclassified: Vec<String> = tracked
+        .iter()
+        .filter_map(|p| {
+            let record = classify_file_with_prepared(p, &prepared);
+            if record.category == "unclassified" { Some(p.clone()) } else { None }
+        })
+        .collect();
+
+    println!("  {} unclassified files to group", unclassified.len());
+
+    // Group files.
+    let groups: BTreeMap<String, Vec<String>> = match config.group_by {
+        ProposeGroupBy::Directory => group_by_directory(&unclassified),
+        ProposeGroupBy::Extension => group_by_extension(&unclassified),
+    };
+
+    let today = today_ymd();
+    let review_after = add_days(today, 30);
+    let today_str = fmt_ymd(today);
+    let review_after_str = fmt_ymd(review_after);
+
+    // Build proposed AllowEntry list.
+    let mut entries: Vec<AllowEntry> = Vec::new();
+    for (group_key, files) in &groups {
+        let (glob_pattern, entry_id) = match config.group_by {
+            ProposeGroupBy::Directory => {
+                // "(root)" is a virtual key for files that have no parent directory.
+                // Their glob is simply "*" (all root-level files).
+                let glob = if group_key == "(root)" {
+                    "*".to_string()
+                } else {
+                    format!("{group_key}/**/*")
+                };
+                let sanitized = group_key
+                    .chars()
+                    .map(|c| if c == '/' || c == '.' || c == '(' || c == ')' { '-' } else { c })
+                    .collect::<String>()
+                    .to_lowercase();
+                let id = format!("proposed-dir-{sanitized}");
+                (glob, id)
+            }
+            ProposeGroupBy::Extension => {
+                let glob = if group_key.is_empty() {
+                    // Files with no extension — list individually or use a tbd glob.
+                    "**/*".to_string()
+                } else {
+                    format!("**/*.{group_key}")
+                };
+                let id = if group_key.is_empty() {
+                    "proposed-ext-no-extension".to_string()
+                } else {
+                    format!("proposed-ext-{}", group_key.to_lowercase())
+                };
+                (glob, id)
+            }
+        };
+
+        let classification = match config.group_by {
+            ProposeGroupBy::Directory => {
+                let top = group_key.split('/').next().unwrap_or(group_key.as_str());
+                classify_dir(top)
+            }
+            ProposeGroupBy::Extension => classify_ext(group_key.as_str()),
+        };
+
+        let reason = match config.group_by {
+            ProposeGroupBy::Directory => {
+                format!("auto-proposed: {} files in {}/", files.len(), group_key)
+            }
+            ProposeGroupBy::Extension => {
+                let ext_label = if group_key.is_empty() {
+                    "(no extension)".to_string()
+                } else {
+                    format!(".{group_key}")
+                };
+                format!("auto-proposed: {} {} files", files.len(), ext_label)
+            }
+        };
+
+        let broad_glob_reason = Some(
+            "auto-proposed bulk classification — refine per-directory before promotion".to_string(),
+        );
+
+        entries.push(AllowEntry {
+            id: entry_id,
+            glob: Some(glob_pattern.clone()),
+            path: None,
+            kind: "non-rust".to_string(),
+            language: "mixed".to_string(),
+            surface: "unclassified".to_string(),
+            classification: classification.to_string(),
+            owner: "TBD".to_string(),
+            reason,
+            covered_by: vec![glob_pattern],
+            created: today_str.clone(),
+            review_after: review_after_str.clone(),
+            expires: None,
+            broad_glob_reason,
+            retired: false,
+        });
+    }
+
+    // Write output files.
+    fs::create_dir_all(&config.output_dir)
+        .with_context(|| format!("creating {}", config.output_dir.display()))?;
+
+    let toml_path = config.output_dir.join("non-rust-proposed-allowlist.toml");
+    let md_path = config.output_dir.join("non-rust-proposal.md");
+
+    let toml_content = render_proposed_toml(&entries, config.group_by, today_str.as_str())?;
+    fs::write(&toml_path, &toml_content)
+        .with_context(|| format!("writing {}", toml_path.display()))?;
+    println!("  wrote {}", toml_path.display());
+
+    let md_content = render_proposal_markdown(&groups, &entries, config.group_by, &unclassified);
+    fs::write(&md_path, &md_content).with_context(|| format!("writing {}", md_path.display()))?;
+    println!("  wrote {}", md_path.display());
+
+    println!(
+        "\nProposal complete: {} unclassified files → {} groups\n\
+         Review {} and {} before promoting to policy/non-rust-allowlist.toml",
+        unclassified.len(),
+        groups.len(),
+        toml_path.display(),
+        md_path.display()
+    );
+
+    Ok(())
+}
+
+/// Group files by their top-level directory component.
+fn group_by_directory(files: &[String]) -> BTreeMap<String, Vec<String>> {
+    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for file in files {
+        let top_dir = file.split('/').next().unwrap_or(file.as_str());
+        // If a file has no directory component, group under "(root)".
+        let key = if file.contains('/') { top_dir.to_string() } else { "(root)".to_string() };
+        groups.entry(key).or_default().push(file.clone());
+    }
+    groups
+}
+
+/// Group files by their file extension (without leading dot).
+fn group_by_extension(files: &[String]) -> BTreeMap<String, Vec<String>> {
+    let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for file in files {
+        let basename = file.rsplit('/').next().unwrap_or(file.as_str());
+        let ext = basename
+            .rsplit_once('.')
+            .filter(|(stem, ext)| !stem.is_empty() && !ext.is_empty())
+            .map(|(_, e)| e)
+            .unwrap_or("")
+            .to_lowercase();
+        groups.entry(ext).or_default().push(file.clone());
+    }
+    groups
+}
+
+/// Render the proposed allowlist as TOML.
+fn render_proposed_toml(
+    entries: &[AllowEntry],
+    group_by: ProposeGroupBy,
+    today: &str,
+) -> Result<String> {
+    let group_label = match group_by {
+        ProposeGroupBy::Directory => "directory",
+        ProposeGroupBy::Extension => "extension",
+    };
+
+    let mut out = String::new();
+    out.push_str("# Non-Rust Proposed Allowlist\n");
+    out.push_str("#\n");
+    out.push_str("# AUTO-GENERATED by `cargo xtask non-rust propose`.\n");
+    out.push_str("# DO NOT edit directly. Review each entry and promote to\n");
+    out.push_str("# policy/non-rust-allowlist.toml after setting owner/surface/classification.\n");
+    out.push_str("#\n");
+    out.push_str(&format!("# Generated: {today}\n"));
+    out.push_str(&format!("# Grouped by: {group_label}\n"));
+    out.push_str("#\n");
+    out.push_str("# Fields marked TBD MUST be set by a human reviewer\n");
+    out.push_str("# before promoting any entry into the canonical ledger.\n\n");
+
+    out.push_str("schema_version = 1\n");
+    out.push_str("policy = \"non-rust-allowlist\"\n");
+    out.push_str("owner = \"TBD\"\n");
+    out.push_str("status = \"proposed\"\n");
+    out.push_str(&format!("updated = \"{today}\"\n\n"));
+
+    out.push_str("[defaults]\n");
+    out.push_str("rust_is_default = true\n");
+    out.push_str("xtask_is_default_for_repo_automation = true\n");
+    out.push_str("new_non_rust_requires_review = true\n");
+    out.push_str("broad_globs_require_reason = true\n");
+    out.push_str("coverage_required_for_production_surfaces = true\n\n");
+
+    for entry in entries {
+        out.push_str("[[allow]]\n");
+        out.push_str(&format!("id = {:?}\n", entry.id));
+        if let Some(ref g) = entry.glob {
+            out.push_str(&format!("glob = {:?}\n", g));
+        }
+        if let Some(ref p) = entry.path {
+            out.push_str(&format!("path = {:?}\n", p));
+        }
+        out.push_str(&format!("kind = {:?}\n", entry.kind));
+        out.push_str(&format!("language = {:?}\n", entry.language));
+        out.push_str(&format!("surface = {:?}\n", entry.surface));
+        out.push_str(&format!("classification = {:?}\n", entry.classification));
+        out.push_str(&format!("owner = {:?}\n", entry.owner));
+        out.push_str(&format!("reason = {:?}\n", entry.reason));
+        // covered_by array
+        out.push_str("covered_by = [");
+        for (i, c) in entry.covered_by.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            out.push_str(&format!("{c:?}"));
+        }
+        out.push_str("]\n");
+        out.push_str(&format!("created = {:?}\n", entry.created));
+        out.push_str(&format!("review_after = {:?}\n", entry.review_after));
+        if let Some(ref bgr) = entry.broad_glob_reason {
+            out.push_str(&format!("broad_glob_reason = {:?}\n", bgr));
+        }
+        out.push('\n');
+    }
+
+    Ok(out)
+}
+
+/// Render a human-readable markdown summary of the proposal.
+fn render_proposal_markdown(
+    groups: &BTreeMap<String, Vec<String>>,
+    entries: &[AllowEntry],
+    group_by: ProposeGroupBy,
+    all_unclassified: &[String],
+) -> String {
+    let group_label = match group_by {
+        ProposeGroupBy::Directory => "directory",
+        ProposeGroupBy::Extension => "extension",
+    };
+
+    // Extension breakdown for summary.
+    let mut ext_counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for file in all_unclassified {
+        let basename = file.rsplit('/').next().unwrap_or(file.as_str());
+        let ext = basename.rsplit_once('.').map(|(_, e)| e).unwrap_or("");
+        *ext_counts.entry(ext).or_insert(0) += 1;
+    }
+
+    let mut out = String::new();
+    out.push_str("# Non-Rust Allowlist Proposal\n\n");
+    out.push_str("> AUTO-GENERATED by `cargo xtask non-rust propose`. Do not edit by hand.\n");
+    out.push_str("> Review each group, set `owner`/`surface`/`classification`, then promote\n");
+    out.push_str("> to `policy/non-rust-allowlist.toml`.\n\n");
+
+    out.push_str("## Summary\n\n");
+    out.push_str(&format!(
+        "| Metric | Value |\n|---|---|\n\
+         | Unclassified files | {} |\n\
+         | Groups ({group_label}) | {} |\n\
+         | Proposed entries | {} |\n\n",
+        all_unclassified.len(),
+        groups.len(),
+        entries.len(),
+    ));
+
+    out.push_str("## Top extensions\n\n");
+    out.push_str("| Extension | Count |\n|---|---|\n");
+    let mut ext_vec: Vec<(&&str, &usize)> = ext_counts.iter().collect();
+    ext_vec.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+    for (ext, count) in ext_vec.iter().take(20) {
+        let label = if ext.is_empty() { "(no ext)" } else { ext };
+        out.push_str(&format!("| `.{label}` | {count} |\n"));
+    }
+    out.push('\n');
+
+    out.push_str(&format!("## Groups by {group_label}\n\n"));
+    for (group_key, files) in groups {
+        let entry_id = entries
+            .iter()
+            .find(|e| {
+                e.reason.contains(&format!("{}/", group_key))
+                    || e.reason.contains(group_key.as_str())
+            })
+            .map(|e| e.id.as_str())
+            .unwrap_or("—");
+        out.push_str(&format!("### `{group_key}` ({} files)\n\n", files.len()));
+        out.push_str(&format!("- Proposed entry: `{entry_id}`\n"));
+        out.push_str("- `owner`: TBD — must be set before promotion\n");
+        out.push_str("- `surface`: unclassified — must be refined\n");
+        // Show first 10 files as examples.
+        if !files.is_empty() {
+            out.push_str("- Sample files:\n");
+            for f in files.iter().take(10) {
+                out.push_str(&format!("  - `{f}`\n"));
+            }
+            if files.len() > 10 {
+                out.push_str(&format!("  - … and {} more\n", files.len() - 10));
+            }
+        }
+        out.push('\n');
+    }
+
+    out.push_str("## Next steps\n\n");
+    out.push_str("1. Review `target/policy/non-rust-proposed-allowlist.toml`.\n");
+    out.push_str("2. For each entry: set `owner`, `surface`, refine `classification`.\n");
+    out.push_str("3. Copy approved entries into `policy/non-rust-allowlist.toml`.\n");
+    out.push_str("4. Run `cargo xtask check-file-policy --mode advisory` to verify.\n");
+    out.push_str("5. Do NOT promote entries with `owner = \"TBD\"`.\n");
+
+    out
+}
+
+// ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
 

--- a/xtask/tests/non_rust_propose.rs
+++ b/xtask/tests/non_rust_propose.rs
@@ -1,0 +1,383 @@
+//! Integration tests for `cargo xtask non-rust propose` (issue #8568).
+//!
+//! Each test creates an isolated temp directory simulating a minimal git repo,
+//! then invokes the xtask binary and asserts on output files and exit codes.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use anyhow::Result;
+use assert_cmd::Command;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command as StdCommand, Stdio},
+};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers (shared with check_file_policy.rs pattern)
+// ---------------------------------------------------------------------------
+
+/// Initialize a minimal git repo in `dir` with one initial commit.
+fn init_git_repo(dir: &Path) -> Result<()> {
+    git_cmd(&["init", "-b", "master"], Some(dir)).or_else(|_| git_cmd(&["init"], Some(dir)))?;
+    git_cmd(&["config", "user.email", "test@test.com"], Some(dir))?;
+    git_cmd(&["config", "user.name", "Test"], Some(dir))?;
+    let _ = git_cmd(&["checkout", "-b", "master"], Some(dir));
+    Ok(())
+}
+
+fn git_cmd(args: &[&str], cwd: Option<&Path>) -> Result<()> {
+    let mut cmd = StdCommand::new("git");
+    cmd.args(args).stdout(Stdio::null()).stderr(Stdio::null());
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        anyhow::bail!("git {:?} failed with {:?}", args, status.code());
+    }
+    Ok(())
+}
+
+fn add_and_commit(repo: &Path, files: &[(&str, &str)], message: &str) -> Result<()> {
+    for (name, content) in files {
+        let path = repo.join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, content)?;
+    }
+    git_cmd(&["add", "."], Some(repo))?;
+    git_cmd(&["commit", "-m", message], Some(repo))?;
+    Ok(())
+}
+
+/// Build the standard allowlist header with no entries (empty ledger).
+fn empty_allowlist() -> String {
+    r#"schema_version = 1
+policy = "non-rust-allowlist"
+owner = "test"
+status = "advisory"
+updated = "2026-01-01"
+
+[defaults]
+rust_is_default = true
+xtask_is_default_for_repo_automation = true
+new_non_rust_requires_review = true
+broad_globs_require_reason = true
+coverage_required_for_production_surfaces = true
+"#
+    .to_string()
+}
+
+/// Create a minimal test repo and return (TempDir, root path).
+fn setup_repo(extra_files: &[(&str, &str)]) -> Result<(TempDir, PathBuf)> {
+    let tmp = TempDir::new()?;
+    let root = tmp.path().to_path_buf();
+
+    init_git_repo(&root)?;
+
+    let mut files: Vec<(&str, &str)> = vec![("src/lib.rs", "// Rust sentinel")];
+    files.extend_from_slice(extra_files);
+    add_and_commit(&root, &files, "initial")?;
+
+    // Write allowlist (not committed — path passed via --allowlist).
+    let policy_dir = root.join("policy");
+    fs::create_dir_all(&policy_dir)?;
+    fs::write(policy_dir.join("non-rust-allowlist.toml"), empty_allowlist())?;
+
+    Ok((tmp, root))
+}
+
+/// Run `cargo xtask non-rust propose` with the given extra args.
+fn run_propose(root: &Path, extra_args: &[&str]) -> Result<std::process::Output> {
+    let allowlist_path = root.join("policy/non-rust-allowlist.toml");
+    let root_str = root.to_str().expect("root is UTF-8");
+    let mut cmd = Command::cargo_bin("xtask")?;
+    cmd.current_dir(root);
+    cmd.args(["non-rust", "propose"]);
+    // Pass the root seam so git ls-files runs in temp repo.
+    cmd.args(["--root", root_str]);
+    // Use a temp output dir inside the repo.
+    cmd.args(["--output-dir", root.join("target/policy").to_str().expect("UTF-8")]);
+    // Pass allowlist override (even though it won't be mutated — just ensures
+    // the command can load it without needing the real workspace).
+    let _ = allowlist_path; // used via --root; allowlist is found relative to root
+    cmd.args(extra_args);
+    let output = cmd.output()?;
+    Ok(output)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The canonical `policy/non-rust-allowlist.toml` must NOT be modified after
+/// running `propose`.
+#[test]
+fn propose_writes_only_target_dir() -> Result<()> {
+    let (_tmp, root) =
+        setup_repo(&[("book/ch01.md", "# Chapter 1"), ("docs/guide.md", "# Guide")])?;
+
+    let allowlist_before = fs::read_to_string(root.join("policy/non-rust-allowlist.toml"))?;
+
+    let output = run_propose(&root, &[])?;
+    assert!(
+        output.status.success(),
+        "propose must exit 0; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let allowlist_after = fs::read_to_string(root.join("policy/non-rust-allowlist.toml"))?;
+    assert_eq!(
+        allowlist_before, allowlist_after,
+        "propose must NOT modify policy/non-rust-allowlist.toml"
+    );
+
+    // Proposed outputs must be inside target/policy/.
+    assert!(
+        root.join("target/policy/non-rust-proposed-allowlist.toml").exists(),
+        "proposed TOML must exist in target/policy/"
+    );
+    assert!(
+        root.join("target/policy/non-rust-proposal.md").exists(),
+        "proposal markdown must exist in target/policy/"
+    );
+
+    Ok(())
+}
+
+/// Default grouping is `directory`: files in `book/` and `docs/` produce 2
+/// directory-glob entries, not one entry per file.
+#[test]
+fn propose_groups_by_directory_by_default() -> Result<()> {
+    // Create many files across two directories.
+    let files: Vec<(&str, &str)> = vec![
+        ("book/ch01.md", "# ch1"),
+        ("book/ch02.md", "# ch2"),
+        ("book/ch03.md", "# ch3"),
+        ("docs/api.md", "# api"),
+        ("docs/guide.md", "# guide"),
+    ];
+    let (_tmp, root) = setup_repo(&files)?;
+
+    let output = run_propose(&root, &["--group-by", "directory"])?;
+    assert!(
+        output.status.success(),
+        "propose must exit 0; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let toml_content =
+        fs::read_to_string(root.join("target/policy/non-rust-proposed-allowlist.toml"))?;
+
+    // Must have exactly 2 `[[allow]]` sections (book + docs).
+    let allow_count = toml_content.matches("[[allow]]").count();
+    assert_eq!(
+        allow_count, 2,
+        "directory grouping must produce 2 entries (book + docs), got {allow_count}:\n{toml_content}"
+    );
+
+    // Glob patterns must be directory-style, not per-file paths.
+    assert!(
+        toml_content.contains("book/**/*") || toml_content.contains("\"book/**/*\""),
+        "must have a book/**/* glob entry"
+    );
+    assert!(
+        toml_content.contains("docs/**/*") || toml_content.contains("\"docs/**/*\""),
+        "must have a docs/**/* glob entry"
+    );
+
+    Ok(())
+}
+
+/// `--group-by extension` produces extension-glob entries instead of directory entries.
+#[test]
+fn propose_groups_by_extension_with_flag() -> Result<()> {
+    let files: Vec<(&str, &str)> = vec![
+        ("book/ch01.md", "# ch1"),
+        ("docs/api.md", "# api"),
+        ("scripts/build.sh", "#!/bin/bash"),
+        ("scripts/deploy.sh", "#!/bin/bash"),
+    ];
+    let (_tmp, root) = setup_repo(&files)?;
+
+    let output = run_propose(&root, &["--group-by", "extension"])?;
+    assert!(
+        output.status.success(),
+        "propose must exit 0; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let toml_content =
+        fs::read_to_string(root.join("target/policy/non-rust-proposed-allowlist.toml"))?;
+
+    // Must have entries for .md and .sh (2 extensions).
+    let allow_count = toml_content.matches("[[allow]]").count();
+    assert_eq!(
+        allow_count, 2,
+        "extension grouping must produce 2 entries (.md + .sh), got {allow_count}:\n{toml_content}"
+    );
+
+    // Extension globs must use **/*.ext pattern.
+    assert!(
+        toml_content.contains("**/*.md") || toml_content.contains("\"**/*.md\""),
+        "must have a **/*.md glob"
+    );
+    assert!(
+        toml_content.contains("**/*.sh") || toml_content.contains("\"**/*.sh\""),
+        "must have a **/*.sh glob"
+    );
+
+    Ok(())
+}
+
+/// Generated entries must have `review_after` approximately 30 days from today.
+#[test]
+fn propose_emits_review_after_30_days() -> Result<()> {
+    let (_tmp, root) = setup_repo(&[("docs/readme.md", "# Readme")])?;
+
+    let output = run_propose(&root, &[])?;
+    assert!(output.status.success(), "propose must exit 0");
+
+    let toml_content =
+        fs::read_to_string(root.join("target/policy/non-rust-proposed-allowlist.toml"))?;
+
+    // The review_after field must appear in the TOML.
+    assert!(toml_content.contains("review_after"), "proposed TOML must contain review_after field");
+
+    // The review_after date must be in the future (not today or past).
+    // We verify it is at least today + 29 days (allowing for clock skew in fast CI).
+    // Parse the date from the TOML.
+    let review_line = toml_content
+        .lines()
+        .find(|l| l.trim_start().starts_with("review_after"))
+        .expect("review_after line must exist");
+
+    // Extract YYYY-MM-DD from `review_after = "2026-06-10"`.
+    let date_str =
+        review_line.split('"').nth(1).expect("review_after must have a quoted date value");
+
+    let parts: Vec<u32> = date_str.split('-').map(|s| s.parse().unwrap()).collect();
+    assert_eq!(parts.len(), 3, "review_after date must be YYYY-MM-DD");
+
+    // Simple sanity: year must be >= 2026.
+    assert!(parts[0] >= 2026, "review_after year must be >= 2026, got {}", parts[0]);
+
+    Ok(())
+}
+
+/// Generated entries must have `owner = "TBD"` — never a real owner.
+#[test]
+fn propose_emits_owner_tbd_placeholder() -> Result<()> {
+    let (_tmp, root) = setup_repo(&[("book/ch01.md", "# ch1")])?;
+
+    let output = run_propose(&root, &[])?;
+    assert!(output.status.success(), "propose must exit 0");
+
+    let toml_content =
+        fs::read_to_string(root.join("target/policy/non-rust-proposed-allowlist.toml"))?;
+
+    // Every `owner` field in the [[allow]] sections must be "TBD".
+    let owner_lines: Vec<&str> = toml_content
+        .lines()
+        .filter(|l| l.trim_start().starts_with("owner =") && !l.contains("owner = \"TBD\""))
+        .filter(|l| !l.trim().starts_with('#'))
+        .collect();
+
+    // There should be no owner lines that are NOT "TBD" (excluding the top-level
+    // `owner = "TBD"` line, which is the allowlist-level owner).
+    let non_tbd: Vec<&str> =
+        owner_lines.iter().copied().filter(|l| !l.contains("\"TBD\"")).collect();
+    assert!(
+        non_tbd.is_empty(),
+        "all owner fields in proposed entries must be \"TBD\", found non-TBD: {non_tbd:?}"
+    );
+
+    // At least one owner = "TBD" line must exist.
+    assert!(
+        toml_content.contains("owner = \"TBD\""),
+        "proposed TOML must have owner = \"TBD\" placeholder"
+    );
+
+    Ok(())
+}
+
+/// `propose` emits a human-readable markdown summary with group sections.
+#[test]
+fn propose_emits_human_markdown() -> Result<()> {
+    let (_tmp, root) = setup_repo(&[("book/ch01.md", "# ch1"), ("docs/guide.md", "# guide")])?;
+
+    let output = run_propose(&root, &[])?;
+    assert!(output.status.success(), "propose must exit 0");
+
+    let md_content = fs::read_to_string(root.join("target/policy/non-rust-proposal.md"))?;
+
+    // Must have the main heading.
+    assert!(
+        md_content.contains("# Non-Rust Allowlist Proposal"),
+        "markdown must have a main heading"
+    );
+    // Must have a Summary section.
+    assert!(md_content.contains("## Summary"), "markdown must have a Summary section");
+    // Must have count information.
+    assert!(
+        md_content.contains("Unclassified files"),
+        "markdown must mention unclassified file count"
+    );
+    // Must have group sections.
+    assert!(
+        md_content.contains("## Groups by")
+            || md_content.contains("### `book`")
+            || md_content.contains("### `docs`"),
+        "markdown must have per-group sections"
+    );
+
+    Ok(())
+}
+
+/// After `propose`, running advisory check against the proposed allowlist should
+/// exit 0 — the proposed allowlist actually covers the files it claims to.
+#[test]
+fn propose_round_trips_via_advisory_checker() -> Result<()> {
+    let files: Vec<(&str, &str)> =
+        vec![("book/ch01.md", "# ch1"), ("book/ch02.md", "# ch2"), ("docs/guide.md", "# guide")];
+    let (_tmp, root) = setup_repo(&files)?;
+
+    // Run propose first.
+    let propose_out = run_propose(&root, &[])?;
+    assert!(
+        propose_out.status.success(),
+        "propose must exit 0; stderr={}",
+        String::from_utf8_lossy(&propose_out.stderr)
+    );
+
+    let proposed_allowlist = root.join("target/policy/non-rust-proposed-allowlist.toml");
+    assert!(proposed_allowlist.exists(), "proposed allowlist must be written");
+
+    // Now run advisory check using the proposed allowlist.
+    let root_str = root.to_str().expect("root is UTF-8");
+    let allowlist_str = proposed_allowlist.to_str().expect("UTF-8");
+    let mut cmd = Command::cargo_bin("xtask")?;
+    cmd.current_dir(&root);
+    cmd.args([
+        "non-rust",
+        "check",
+        "--mode",
+        "advisory",
+        "--allowlist",
+        allowlist_str,
+        "--root",
+        root_str,
+    ]);
+    let check_out = cmd.output()?;
+
+    assert!(
+        check_out.status.success(),
+        "advisory check against proposed allowlist must exit 0; stderr={}",
+        String::from_utf8_lossy(&check_out.stderr)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Current truth

Adds `cargo xtask non-rust propose` — the proposal generator that turns
the 2,117 unclassified non-Rust files into reviewable draft allowlist
entries. PR 4 (`check-file-policy`, #8566/#8708) landed first as required.

## What landed

- **`xtask/src/tasks/file_policy.rs`**: `non_rust_propose()` entry point,
  `group_by_directory()` / `group_by_extension()` groupers, `add_days()` /
  `today_ymd()` / `fmt_ymd()` date helpers (JDN arithmetic, DRY with existing
  `days_to_ymd()`), `render_proposed_toml()` / `render_proposal_markdown()`.
- **`xtask/src/main.rs`**: `NonRustCommand::Propose` subcommand with
  `--output-dir`, `--group-by`, and hidden `--root` test seam.
- **`xtask/tests/non_rust_propose.rs`**: 7 integration tests.

## Acceptance

```bash
cargo build -p xtask --locked
cargo test -p xtask --test non_rust_propose --locked
cargo xtask non-rust propose
# Proposal complete: 2117 unclassified files → 22 groups
ls target/policy/non-rust-proposed-allowlist.toml target/policy/non-rust-proposal.md
diff policy/non-rust-allowlist.toml policy/non-rust-allowlist.toml  # unchanged
cargo xtask non-rust check --mode advisory --allowlist target/policy/non-rust-proposed-allowlist.toml
# result: OK — no violations (unclassified: 0)
cargo clippy -p xtask -- -D warnings -A missing_docs
cargo xtask fmt --check
```

Sample top 5 entries from generated TOML:

```toml
[[allow]]
id = "proposed-dir-(root)"
glob = "*"
kind = "non-rust"
surface = "unclassified"
classification = "tbd"
owner = "TBD"
review_after = "2026-06-11"
broad_glob_reason = "auto-proposed bulk classification — refine per-directory before promotion"

[[allow]]
id = "proposed-dir--kiro"
glob = ".kiro/**/*"
classification = "tbd"
owner = "TBD"
review_after = "2026-06-11"

[[allow]]
id = "proposed-dir-archive"
glob = "archive/**/*"
classification = "tbd"
owner = "TBD"

[[allow]]
id = "proposed-dir-benchmarks"
glob = "benchmarks/**/*"
classification = "tbd"
owner = "TBD"

[[allow]]
id = "proposed-dir-book"
glob = "book/**/*"
classification = "docs"
owner = "TBD"
```

Sample markdown summary header:

```
# Non-Rust Allowlist Proposal

| Metric       | Value |
|---|---|
| Unclassified files | 2117 |
| Groups (directory) | 22   |
| Proposed entries   | 22   |

## Top extensions
| `.json` | 163 |
| `.txt`  | 59  |
| `.toml` | 30  |
| `.sh`   | 25  |
```

## Claim boundary

Generates PROPOSALS only. Every `owner` is `"TBD"`. Human must review
`owner`, `surface`, and `classification` before promoting any entry into
`policy/non-rust-allowlist.toml`. Does NOT auto-promote. Canonical ledger
is byte-identical before and after `propose`.

Closes #8568