### PR TITLE
chore(clippy): batched Rust 1.95 temporary allow burndown (#8508)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -368,15 +368,8 @@ panic = "deny"
 todo = "deny"
 unimplemented = "deny"
 dbg_macro = "deny"
-# Newly-stabilised in Rust 1.94/1.95. Each has a cluster of pre-existing
-# call sites; opt into them once the cleanup follow-ups land (see #8508).
-# `priority = 1` overrides `#![warn(clippy::all)]` (priority 0) that several
-# crate `lib.rs` files declare.
+# collapsible_match: ~20 lib sites across perl-lsp-rs-core; tracked in #8561; defer to post-0.14.0 cleanup.
 collapsible_match = { level = "allow", priority = 1 }
-manual_range_contains = { level = "allow", priority = 1 }
-useless_vec = { level = "allow", priority = 1 }
-vec_init_then_push = { level = "allow", priority = 1 }
-assertions_on_constants = { level = "allow", priority = 1 }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci)', 'cfg(feature, values("slow_tests"))'] }


### PR DESCRIPTION
## Current truth

Re-measured all 5 `[workspace.lints.clippy]` temporary allows against master post-#8707 (MSRV=1.95) using `cargo clippy --workspace --lib --locked -- -D warnings -A missing_docs` (the mandatory blocking CI gate):

| Lint | Lib sites | All-targets sites | Decision |
|------|-----------|-------------------|----------|
| `manual_range_contains` | 0 | 3 (perl-ci-hygiene tests/bin) | Removed |
| `useless_vec` | 0 | 1 (perl-diagnostics test) | Removed |
| `vec_init_then_push` | 0 | 2 (perl-diagnostics tests) | Removed |
| `assertions_on_constants` | 0 | 1 (perl-diagnostics test) | Removed |
| `collapsible_match` | ~20 | ~20 | Kept — EffortlessMetrics/perl-lsp-swarm#2723 |

The test/bin-only violations for the 4 removed lints are pre-existing on master (perl-ci-hygiene `main.rs` and perl-diagnostics test files). They are not caught by the mandatory `clippy-lib` gate (`blocking=true`, `--lib` only per `.ci/GATE_REGISTRY.toml`). The `clippy-all` gate is `blocking=false` (non-mandatory).

`collapsible_match` has ~20 lib violations concentrated in `perl-lsp-rs-core` (diagnostics, navigation, code-action providers) — above the 5-site bundling threshold. Debt tracked in EffortlessMetrics/perl-lsp-swarm#2723 for post-0.14.0 cleanup.

The old 4-line boilerplate comment (`# Newly-stabilised in Rust 1.94/1.95...`) is replaced with a specific per-allow debt reference.

## Acceptance

```bash
cargo build -p xtask --locked
cargo clippy --workspace --lib --locked -- -D warnings -A missing_docs
cargo xtask check-lint-policy
cargo xtask fmt --check
git diff --check
```

All pass. `check-lint-policy` output: `lint policy ok: 100 lint entries, 12 planned flips, 2 debt entries`.

## Claim boundary

Rust 1.95 cleanup wave — dead workspace allows removed. Does NOT:
- Touch `policy/clippy-debt.toml` (no new debt entries added there; EffortlessMetrics/perl-lsp-swarm#2723 tracks the collapsible_match cleanup)
- Promote any lints to deny (separate codex/strong-clippy lane per EffortlessMetrics/perl-lsp#8707 planned flips)
- Fix the pre-existing `expect_used` violations in `perl-ci-hygiene/src/main.rs` (pre-existing debt on master, outside scope)

## Do not combine

Do not bundle with the 12 planned-flip promotions from EffortlessMetrics/perl-lsp#8707. Those are codex-lane work requiring broader cleanup.

## Historical survey delta

The earlier survey predicted 3 `collapsible_match` lib sites (perl-regex, perl-pragma, perl-parser-pest) and 1 `manual_range_contains` site. The actual measurement on current master shows:
- `collapsible_match`: 20 lib sites (survey missed ~17 sites in perl-lsp-rs-core added between the survey and now)
- `manual_range_contains`, `useless_vec`, `vec_init_then_push`, `assertions_on_constants`: 0 lib sites each (cleanup already happened via other PRs)