### PR TITLE
feat(perl-oracle): migrate execute-command Perl subprocesses to PerlOracleEnv (#8684)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -189,6 +189,46 @@ impl PerlOracleEnv {
             extra_env: BTreeMap::new(),
         })
     }
+
+    /// Constructor for user-triggered `executeCommand` invocations (`perl.runFile`,
+    /// `perl.runTestSub`).
+    ///
+    /// Unlike the startup `@INC` probe, these are user-explicit commands whose
+    /// scripts may legitimately rely on `PERL5OPT` and `local::lib`. The env
+    /// contract therefore differs:
+    ///
+    /// - `allow_perl5lib`: mirrors `config.use_perl5lib` (user's explicit choice).
+    /// - `allow_perl5opt`: always `true` — user scripts may use `-M` pragmas.
+    /// - `allow_local_lib`: always `true` — user's `local::lib` setup should be
+    ///   available when they run their own scripts.
+    /// - `timeout`: 30 seconds (matches the existing execute-command budget).
+    /// - `cwd`: falls back to the LSP process cwd; callers may pass a more
+    ///   specific directory (e.g., a workspace root).
+    /// - `extra_env`: empty.
+    ///
+    /// Returns `None` if the Perl binary cannot be resolved. The caller should
+    /// fall back to a plain `Command::new("perl")` or surface an error.
+    pub fn for_execute_command(config: &WorkspaceConfig, cwd: PathBuf) -> Option<Self> {
+        use crate::platform::resolve_perl_path_with_toolchain;
+
+        let perl_binary = match config.perl_path.as_deref().filter(|p| !p.is_empty()) {
+            Some(path) => PathBuf::from(path),
+            None => match resolve_perl_path_with_toolchain() {
+                Ok(path) => path,
+                Err(_) => return None,
+            },
+        };
+
+        Some(Self {
+            perl_binary,
+            cwd,
+            timeout: Duration::from_secs(30),
+            allow_perl5lib: config.use_perl5lib,
+            allow_perl5opt: true,
+            allow_local_lib: true,
+            extra_env: BTreeMap::new(),
+        })
+    }
 }
 
 // ── WASM stub ─────────────────────────────────────────────────────────────────
@@ -202,6 +242,14 @@ pub struct PerlOracleEnv;
 impl PerlOracleEnv {
     /// Returns `None` on WASM (no subprocess support).
     pub fn for_startup_inc_probe(_config: &WorkspaceConfig) -> Option<Self> {
+        None
+    }
+
+    /// Returns `None` on WASM (no subprocess support).
+    pub fn for_execute_command(
+        _config: &WorkspaceConfig,
+        _cwd: std::path::PathBuf,
+    ) -> Option<Self> {
         None
     }
 }
@@ -245,6 +293,32 @@ mod tests {
     }
 
     // ── struct-level flag tests (no subprocess needed) ────────────────────────
+
+    /// `for_execute_command` maps config flags correctly:
+    /// - `allow_perl5lib` = `config.use_perl5lib`
+    /// - `allow_perl5opt` = always `true`
+    /// - `allow_local_lib` = always `true`
+    #[test]
+    fn for_execute_command_respects_config_flags() {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        let mut config = WorkspaceConfig::default();
+        config.use_perl5lib = true;
+        let env = PerlOracleEnv::for_execute_command(&config, cwd.clone());
+        if let Some(e) = env {
+            assert!(e.allow_perl5lib, "allow_perl5lib must mirror config.use_perl5lib=true");
+            assert!(e.allow_perl5opt, "allow_perl5opt must always be true for execute-command");
+            assert!(e.allow_local_lib, "allow_local_lib must always be true for execute-command");
+        }
+
+        config.use_perl5lib = false;
+        let env = PerlOracleEnv::for_execute_command(&config, cwd);
+        if let Some(e) = env {
+            assert!(!e.allow_perl5lib, "allow_perl5lib must mirror config.use_perl5lib=false");
+            assert!(e.allow_perl5opt, "allow_perl5opt must always be true for execute-command");
+            assert!(e.allow_local_lib, "allow_local_lib must always be true for execute-command");
+        }
+    }
 
     /// `for_startup_inc_probe` maps `config.use_perl5lib` → `allow_perl5lib`.
     #[test]

--- a/crates/perl-lsp-rs/src/execute_command/provider.rs
+++ b/crates/perl-lsp-rs/src/execute_command/provider.rs
@@ -1,6 +1,9 @@
 //! Backend command implementations for run/debug/test and analyzer actions.
 
 use crate::perl_critic::{BuiltInAnalyzer, CriticAnalyzer, CriticConfig};
+#[cfg(not(target_arch = "wasm32"))]
+use perl_lsp_rs_core::config::PerlOracleEnv;
+use perl_lsp_rs_core::config::WorkspaceConfig;
 use serde_json::{Value, json};
 use std::borrow::Cow;
 #[cfg(windows)]
@@ -63,6 +66,7 @@ pub(crate) fn normalize_path_for_external_command(path: &Path) -> PathBuf {
 /// Execute command provider implementing the LSP executeCommand method.
 pub struct ExecuteCommandProvider {
     workspace_roots: Vec<PathBuf>,
+    workspace_config: Option<WorkspaceConfig>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -78,15 +82,54 @@ impl Default for ExecuteCommandProvider {
     }
 }
 
+// Private helpers for PerlOracleEnv subprocess isolation.
+impl ExecuteCommandProvider {
+    /// Build a `Command` for a Perl subprocess using `PerlOracleEnv` when a
+    /// workspace config is available; falls back to `Command::new("perl")`
+    /// for backward compatibility when no config is attached.
+    ///
+    /// The `file_path` is used only to derive a `cwd` (its parent directory).
+    /// Callers must append the actual Perl arguments after this call.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn perl_command_for(&self, file_path: &Path) -> Command {
+        let cwd = file_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        if let Some(ref config) = self.workspace_config {
+            if let Some(oracle) = PerlOracleEnv::for_execute_command(config, cwd) {
+                return oracle.into_command();
+            }
+        }
+        Command::new("perl")
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn perl_command_for(&self, _file_path: &Path) -> Command {
+        Command::new("perl")
+    }
+}
+
 impl ExecuteCommandProvider {
     /// Create a new execute command provider.
     pub fn new() -> Self {
-        Self { workspace_roots: Vec::new() }
+        Self { workspace_roots: Vec::new(), workspace_config: None }
     }
 
     /// Create a provider with workspace root enforcement.
     pub fn with_workspace_roots(workspace_roots: Vec<PathBuf>) -> Self {
-        Self { workspace_roots }
+        Self { workspace_roots, workspace_config: None }
+    }
+
+    /// Attach a workspace configuration to enable PerlOracleEnv isolation for
+    /// Perl subprocess calls (`perl.runFile`, `perl.runTestSub`).
+    ///
+    /// When a config is present, `run_file` and `run_test_sub` use
+    /// `PerlOracleEnv::for_execute_command` instead of a bare
+    /// `Command::new("perl")`, applying the deny-all-ambient env policy.
+    pub fn with_workspace_config(mut self, config: WorkspaceConfig) -> Self {
+        self.workspace_config = Some(config);
+        self
     }
 
     /// Execute a supported command with validated JSON arguments.
@@ -237,7 +280,7 @@ impl ExecuteCommandProvider {
         "#;
         let ext_path = normalize_path_for_external_command(file_path);
 
-        let mut perl_cmd = Command::new("perl");
+        let mut perl_cmd = self.perl_command_for(file_path);
         perl_cmd.arg("-e").arg(perl_code).arg("--").arg(ext_path.as_os_str()).arg(sub_name);
         match crate::util::run_command_with_timeout(perl_cmd, 30) {
             Ok(result) => {
@@ -252,7 +295,7 @@ impl ExecuteCommandProvider {
 
     pub(crate) fn run_file(&self, file_path: &Path) -> Result<Value, String> {
         let ext_path = normalize_path_for_external_command(file_path);
-        let mut perl_cmd = Command::new("perl");
+        let mut perl_cmd = self.perl_command_for(file_path);
         perl_cmd.arg("--").arg(ext_path.as_os_str());
         match crate::util::run_command_with_timeout(perl_cmd, 30) {
             Ok(result) => Ok(self.format_command_result(result, None)),

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -861,7 +861,8 @@ impl LspServer {
                 }
             }
 
-            let provider = ExecuteCommandProvider::with_workspace_roots(workspace_roots);
+            let provider = ExecuteCommandProvider::with_workspace_roots(workspace_roots)
+                .with_workspace_config(self.workspace_config.lock().clone());
 
             match command {
                 // Keep existing test commands for backward compatibility

--- a/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
@@ -1,12 +1,15 @@
 //! Security regression tests for executeCommand.
 //!
 //! These tests verify that command injection vulnerabilities in run_test_sub,
-//! run_tests, and run_file have been properly mitigated.
+//! run_tests, and run_file have been properly mitigated, and that the
+//! PerlOracleEnv isolation applied via `with_workspace_config` prevents
+//! ambient env vars from leaking into the Perl subprocess.
 //!
 //! Note: With secure path resolution, malicious/non-existent paths are rejected
 //! early at the path validation stage (returning Err), preventing execution entirely.
 
 use perl_lsp::execute_command::ExecuteCommandProvider;
+use perl_lsp_rs_core::config::WorkspaceConfig;
 use serde_json::Value;
 use std::error::Error;
 use std::fs;
@@ -431,5 +434,161 @@ fn test_command_injection_pipe() -> Result<(), Box<dyn Error>> {
             assert_eq!(val["status"], "error", "Should report error status for pipe injection");
         }
     }
+    Ok(())
+}
+
+// ── PerlOracleEnv poisoned-env tests (#8684) ──────────────────────────────────
+//
+// Verify that `run_file` and `run_test_sub` do NOT propagate PERL5LIB or
+// PERL5OPT to the Perl subprocess unless the workspace config explicitly
+// allows them — regression guard for the #8493-class incident.
+//
+// These tests require a real Perl installation; they are skipped when no Perl
+// binary can be resolved.
+
+/// Serializes tests that mutate process-global env vars.
+///
+/// `std::env::set_var` / `remove_var` are process-global and unsafe in Rust
+/// 2024. This mutex ensures that concurrent test threads do not race over the
+/// same env vars when running with `RUST_TEST_THREADS > 1`.
+static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Helper: resolve the system Perl binary via the toolchain resolver.
+fn find_perl() -> Option<std::path::PathBuf> {
+    perl_lsp_rs_core::platform::resolve_perl_path_with_toolchain().ok()
+}
+
+/// Helper: build a minimal `WorkspaceConfig` with a resolved Perl binary and
+/// `use_perl5lib` set as requested.
+fn config_with_perl5lib(use_perl5lib: bool) -> Option<WorkspaceConfig> {
+    let perl = find_perl()?;
+    let mut config = WorkspaceConfig::default();
+    config.perl_path = Some(perl.to_string_lossy().into_owned());
+    config.use_perl5lib = use_perl5lib;
+    Some(config)
+}
+
+/// `run_file` with `use_perl5lib=false` must strip PERL5LIB from the subprocess.
+///
+/// Regression guard for the #8493-class incident: ambient PERL5LIB must not
+/// reach the subprocess when the workspace config opts out.
+#[test]
+#[allow(unsafe_code)] // set_var / remove_var are unsafe in Rust 2024
+fn run_file_strips_perl5lib_when_use_perl5lib_false() -> Result<(), Box<dyn Error>> {
+    let config = match config_with_perl5lib(false) {
+        Some(c) => c,
+        None => return Ok(()), // no Perl — skip
+    };
+
+    let temp_dir = TempDir::new()?;
+    // Script prints the PERL5LIB env var or "UNSET" if absent.
+    let script = temp_dir.path().join("check_env.pl");
+    std::fs::write(&script, "print $ENV{PERL5LIB} // 'UNSET';\n")?;
+
+    let poison_dir = TempDir::new()?;
+    let poison_path = poison_dir.path().to_string_lossy().into_owned();
+
+    let provider =
+        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()])
+            .with_workspace_config(config);
+
+    // Serialize env-var mutation across concurrent tests.
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+    // SAFETY: test-only; ENV_MUTEX serializes these mutations.
+    unsafe { std::env::set_var("PERL5LIB", &poison_path) };
+    let result = provider
+        .execute_command("perl.runFile", vec![Value::String(script.to_string_lossy().to_string())]);
+    unsafe { std::env::remove_var("PERL5LIB") };
+    drop(_guard);
+
+    let result = result?;
+    let output = result["output"].as_str().unwrap_or("");
+    assert!(
+        !output.contains(&poison_path),
+        "PERL5LIB poison path ({poison_path}) must NOT appear in subprocess output \
+         when use_perl5lib=false; got: {output:?}",
+    );
+    assert!(
+        output.contains("UNSET"),
+        "subprocess should see PERL5LIB as UNSET when use_perl5lib=false; got: {output:?}",
+    );
+    Ok(())
+}
+
+/// `run_file` with `use_perl5lib=true` must pass PERL5LIB through to the subprocess.
+#[test]
+#[allow(unsafe_code)]
+fn run_file_passes_perl5lib_when_use_perl5lib_true() -> Result<(), Box<dyn Error>> {
+    let config = match config_with_perl5lib(true) {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+
+    let temp_dir = TempDir::new()?;
+    let script = temp_dir.path().join("check_env.pl");
+    std::fs::write(&script, "print $ENV{PERL5LIB} // 'UNSET';\n")?;
+
+    let marker_dir = TempDir::new()?;
+    let marker_path = marker_dir.path().to_string_lossy().into_owned();
+
+    let provider =
+        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()])
+            .with_workspace_config(config);
+
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+    unsafe { std::env::set_var("PERL5LIB", &marker_path) };
+    let result = provider
+        .execute_command("perl.runFile", vec![Value::String(script.to_string_lossy().to_string())]);
+    unsafe { std::env::remove_var("PERL5LIB") };
+    drop(_guard);
+
+    let result = result?;
+    let output = result["output"].as_str().unwrap_or("");
+    assert!(
+        output.contains(&marker_path),
+        "PERL5LIB must be passed through when use_perl5lib=true; got: {output:?}",
+    );
+    Ok(())
+}
+
+/// `run_test_sub` with `use_perl5lib=false` must strip PERL5LIB from the subprocess.
+#[test]
+#[allow(unsafe_code)]
+fn run_test_sub_strips_perl5lib_when_use_perl5lib_false() -> Result<(), Box<dyn Error>> {
+    let config = match config_with_perl5lib(false) {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+
+    let temp_dir = TempDir::new()?;
+    // A Perl file with a sub that prints the env var.
+    let script = temp_dir.path().join("check_env_sub.pl");
+    std::fs::write(&script, "sub check_env { print $ENV{PERL5LIB} // 'UNSET'; }\n")?;
+
+    let poison_dir = TempDir::new()?;
+    let poison_path = poison_dir.path().to_string_lossy().into_owned();
+
+    let provider =
+        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()])
+            .with_workspace_config(config);
+
+    let _guard = ENV_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+    unsafe { std::env::set_var("PERL5LIB", &poison_path) };
+    let result = provider.execute_command(
+        "perl.runTestSub",
+        vec![
+            Value::String(script.to_string_lossy().to_string()),
+            Value::String("check_env".to_string()),
+        ],
+    );
+    unsafe { std::env::remove_var("PERL5LIB") };
+    drop(_guard);
+
+    let result = result?;
+    let output = result["output"].as_str().unwrap_or("");
+    assert!(
+        !output.contains(&poison_path),
+        "PERL5LIB poison path must NOT appear when use_perl5lib=false; got: {output:?}",
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Applies the deny-all-ambient subprocess env policy (introduced in #8675 for the startup `@INC` probe) to the two `execute_command/provider.rs` call sites identified in issue #8684:

- `run_test_sub` (was `Command::new("perl")` at line 240)
- `run_file` (was `Command::new("perl")` at line 255)

These are the only two explicit `perl` subprocess calls in the execute-command seam; `run_test_command` (which handles `perl`, `yath`, `prove` for `perl.runTests`) is a separate seam tracked in a follow-up issue.

---

## What changed

### `perl-lsp-rs-core`: `PerlOracleEnv::for_execute_command`

New named constructor for user-triggered `executeCommand` invocations. The env contract differs from the startup probe because user-explicit commands may legitimately rely on their Perl environment:

| Flag | Startup probe | Execute-command |
|------|--------------|-----------------|
| `allow_perl5lib` | `config.use_perl5lib` | `config.use_perl5lib` |
| `allow_perl5opt` | `false` | **`true`** — user scripts may use `-M` pragmas |
| `allow_local_lib` | `false` | **`true`** — user's `local::lib` should be available |
| `timeout` | 1 s | **30 s** — matches existing execute-command budget |

Returns `None` if the Perl binary can't be resolved; callers fall back to `Command::new("perl")`.

WASM stub added alongside the native implementation.

### `perl-lsp-rs`: `ExecuteCommandProvider::with_workspace_config`

New builder method that attaches a `WorkspaceConfig` to the provider. Internally, a private `perl_command_for(&self, file_path: &Path) -> Command` helper uses `PerlOracleEnv::for_execute_command` when a config is present, falling back to `Command::new("perl")` for backward-compat callers (existing `new()` / `with_workspace_roots()` call sites in tests are unchanged).

### `misc.rs` call site

`handle_execute_command` chains `.with_workspace_config(self.workspace_config.lock().clone())` so live LSP requests use oracle isolation from this PR forward.

---

## Tests

### New unit test (`perl_oracle_env.rs`)
- `for_execute_command_respects_config_flags` — struct-level invariants: `allow_perl5lib` mirrors `config.use_perl5lib`; `allow_perl5opt` and `allow_local_lib` are always `true`.

### New integration tests (`execute_command_security_tests.rs`)
Three poisoned-env regression guards for the #8493-class ambient-env incident:
- `run_file_strips_perl5lib_when_use_perl5lib_false` — PERL5LIB must NOT reach subprocess when user opted out
- `run_file_passes_perl5lib_when_use_perl5lib_true` — PERL5LIB passes through when user opted in
- `run_test_sub_strips_perl5lib_when_use_perl5lib_false` — same guarantee for the second seam

All three env-mutation tests are serialized via a static `ENV_MUTEX` to prevent TOCTOU races when `RUST_TEST_THREADS=2`.

All tests skip gracefully when no Perl binary is available.

---

## Verification

```bash
# All security tests (18 passed)
RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --test execute_command_security_tests -- --test-threads=2

# PerlOracleEnv unit tests (8 passed, including new for_execute_command test)
RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs-core --lib -- config::perl_oracle_env::tests

# Execute-command unit tests (all passing)
RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs --lib -- execute_command

# Clippy clean on lib code
cargo clippy -p perl-lsp-rs -p perl-lsp-rs-core --lib
```

---

## Scope

This PR covers **only** the two `execute_command/provider.rs` call sites per issue #8684's "Do not combine" constraint. The remaining seams (misc language runtime, lifecycle module-resolution, DAP) are tracked in #8685–#8688.

Closes #8684

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEJBcmYAqEenqpoJDtgRc4)_