### PR TITLE
fix(parser): parse commented substitution replacement (#8713)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -2889,9 +2889,7 @@ impl<'a> PerlLexer<'a> {
 
         let pattern_is_paired = quote_handler::paired_close(delimiter).is_some();
         if pattern_is_paired {
-            while self.current_char().is_some_and(char::is_whitespace) {
-                self.advance();
-            }
+            self.skip_paired_substitution_replacement_gap();
 
             if let Some(repl_delim) = self.current_char()
                 && Self::is_quote_delim(repl_delim)
@@ -2929,6 +2927,31 @@ impl<'a> PerlLexer<'a> {
         };
 
         Some(Token { token_type, text: Arc::from(text), start, end: self.position })
+    }
+
+    fn skip_paired_substitution_replacement_gap(&mut self) {
+        let mut comment_eligible = false;
+        loop {
+            let mut saw_whitespace = false;
+            while self.current_char().is_some_and(char::is_whitespace) {
+                self.advance();
+                saw_whitespace = true;
+            }
+            comment_eligible |= saw_whitespace;
+
+            if comment_eligible && self.current_char() == Some('#') {
+                while let Some(ch) = self.current_char() {
+                    self.advance();
+                    if matches!(ch, '\n' | '\r') {
+                        break;
+                    }
+                }
+                comment_eligible = true;
+                continue;
+            }
+
+            break;
+        }
     }
 
     fn read_substitution_replacement_body(&mut self, delim: char) -> (String, bool) {

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -364,6 +364,35 @@ fn substitution_mixed_paired_delimiters() -> R {
 }
 
 #[test]
+fn substitution_paired_replacement_after_comment() -> R {
+    let input =
+        "s[^~([^/]+)?(?=/|$)]   # tilde with optional username\n    [$1 ? $home : glob(\"~\")]ex";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution for paired delimiter replacement after comment, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), input);
+    Ok(())
+}
+
+#[test]
+fn substitution_paired_replacement_after_consecutive_comments() -> R {
+    let input = "s{foo} # first comment\n# second comment\n{bar}x";
+    let sig = significant(input);
+    let first = sig.first().ok_or("no tokens")?;
+    assert!(
+        matches!(first.token_type, TokenType::Substitution),
+        "Expected Substitution for paired delimiter replacement after consecutive comments, got {:?}",
+        first.token_type
+    );
+    assert_eq!(first.text.as_ref(), input);
+    Ok(())
+}
+
+#[test]
 fn substitution_with_modifiers_ge() -> R {
     let input = "s/foo/bar/ge";
     let sig = significant(input);

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -127,7 +127,7 @@ pub fn extract_substitution_parts_strict(
     } else {
         // Paired pattern delimiters still allow either paired or non-paired delimiters
         // for the replacement side (e.g. s{foo}/bar/ and s[foo]{bar}).
-        let trimmed = rest1.trim_start();
+        let trimmed = skip_paired_substitution_replacement_gap(rest1);
         if let Some(rd) = trimmed.chars().next() {
             if rd.is_ascii_alphanumeric() || rd.is_whitespace() {
                 return Err(SubstitutionError::MissingReplacement);
@@ -155,6 +155,33 @@ pub fn extract_substitution_parts_strict(
         .map_err(SubstitutionError::InvalidModifier)?;
 
     Ok((pattern, replacement, modifiers))
+}
+
+fn skip_paired_substitution_replacement_gap(mut text: &str) -> &str {
+    let mut comment_eligible = false;
+    loop {
+        let trimmed = text.trim_start_matches(char::is_whitespace);
+        let saw_whitespace = trimmed.len() != text.len();
+        text = trimmed;
+        comment_eligible |= saw_whitespace;
+
+        if comment_eligible && text.starts_with('#') {
+            text = after_line_comment(text);
+            comment_eligible = true;
+            continue;
+        }
+
+        return text;
+    }
+}
+
+fn after_line_comment(text: &str) -> &str {
+    for (idx, ch) in text.char_indices() {
+        if matches!(ch, '\n' | '\r') {
+            return &text[idx + ch.len_utf8()..];
+        }
+    }
+    ""
 }
 
 /// Extract content between delimiters with strict tracking of whether closing was found.

--- a/crates/perl-parser-core/tests/cpan_regex_patterns.rs
+++ b/crates/perl-parser-core/tests/cpan_regex_patterns.rs
@@ -41,6 +41,25 @@ fn global_substitution_with_eval() {
 }
 
 #[test]
+fn substitution_replacement_after_comment() {
+    let code = r#"
+$value =~ s[^~([^/]+)?(?=/|$)]   # tilde with optional username
+    [$1 ? (eval { (getpwnam $1)[7] } || "~$1") : ($ENV{HOME} || glob("~"))]ex;
+"#;
+    assert_clean_parse(code);
+}
+
+#[test]
+fn substitution_replacement_after_consecutive_comments() {
+    let code = r#"
+$value =~ s{foo} # first comment
+# second comment
+{bar}x;
+"#;
+    assert_clean_parse(code);
+}
+
+#[test]
 fn transliteration() {
     let code = "($count = $str) =~ tr/aeiou//;";
     assert_clean_parse(code);


### PR DESCRIPTION
Problem: Paired-delimiter substitutions such as Module::Build::Platform::Unix's `s[...] # comment\n[...]ex` parsed as an unclosed substitution because lexer/parser-core did not skip comment gaps before the replacement delimiter.
Fix: Skip whitespace plus line comments between paired substitution pattern delimiters and replacement delimiters in both lexer tokenization and strict substitution extraction, while preserving immediate `#` as a valid replacement delimiter.
Verification:
- `cargo test -p perl-lexer --test edge_case_tests --profile agent --locked -- --nocapture`
- `cargo test -p perl-parser-core --test cpan_regex_patterns --profile agent --locked -- --nocapture`
- `cargo check -p perl-lexer -p perl-parser-core --all-targets --profile agent --locked`
- `cargo clippy -p perl-lexer -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask parser-corpus-sweep --roots C:\Strawberry\perl\lib,C:\Strawberry\perl\vendor\lib --output target/receipts/strawberry-corpus-sweep-after-substitution-comment.json --verbose` (+2 clean / -2 dirty / -2 ERROR-node files / -2 total ERROR nodes; `unclosed_substitution_delimiter` removed)
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask semantic-scorecard --check`
- `cargo xtask semantic-shadow-compare --check`
- `cargo xtask fmt --check`
- `git diff --check`

Non-goals: no parser status baseline refresh, no parser-accuracy fixture relabeling, no provider behavior changes.
