### PR TITLE
fix(release): repair Rust 1.95 prep receipts (#8576)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -275,7 +275,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
           components: rustfmt, clippy
 
       - name: Install just
@@ -235,7 +235,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
           components: rustfmt, clippy
 
       - name: Install just
@@ -488,7 +488,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
 
       - name: Install just
         uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8  # v2.77.5
@@ -613,7 +613,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
 
       - name: Install just
         uses: taiki-e/install-action@fa0dd4cd0a40696e6f9766370614a5ce482e6aa8  # v2.77.5
@@ -646,7 +646,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
@@ -830,7 +830,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
@@ -930,7 +930,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (master)
         with:
-          toolchain: 1.93.1
+          toolchain: 1.95.0
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Toolchain (rust-toolchain.toml pins 1.93.1)
+      - name: Toolchain (rust-toolchain.toml pins 1.95.0)
         run: rustc --version
 
       - name: Cache cargo dependencies

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -14,7 +14,7 @@ Tag commit timestamps may differ from release dates.
 
 | Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
 |---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
-| [0.14.0] | `v0.14.0` | [yes][gh-0.14.0] | 2026-05-12 | `pending` | [v0.13.4...v0.14.0] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.14.0 (31 crates) | [perl-lsp-rs][vsce] | [v0.14.0][n-0.14.0] |
+| [0.14.0] | `v0.14.0` | pending | pending | `pending` | [v0.13.4...v0.14.0] | pending | pending | pending | [v0.14.0][n-0.14.0] |
 | [0.13.4] | `v0.13.4` | pending | pending | `pending` | [v0.13.3...v0.13.4] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | pending | pending | [v0.13.4][n-0.13.4] |
 | [0.13.3] | `v0.13.3` | [yes][gh-0.13.3] | 2026-05-03 | `06fc1443` | [v0.13.2...v0.13.3] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.3 (31 crates) | [perl-lsp-rs][vsce] | [v0.13.3][n-0.13.3] |
 | [0.13.2] | `v0.13.2` | [yes][gh-0.13.2] | 2026-05-02 | `0e9c5d78` | [v0.13.1...v0.13.2] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.13.2 (31 crates) | [perl-lsp-rs][vsce] | [v0.13.2][n-0.13.2] |

--- a/crates/perl-dap/tests/common/mod.rs
+++ b/crates/perl-dap/tests/common/mod.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 
 /// Information extracted from a `stopped` event.
 #[derive(Debug, Clone)]
+// Shared workflow-test fixture fields are intentionally read by selected
+// scenario helpers only; keep the full event shape available for new DAP flows.
 #[allow(dead_code)]
 pub struct StoppedInfo {
     /// Stopped reason, e.g. `"breakpoint"`, `"step"`, `"entry"`.
@@ -33,6 +35,7 @@ pub struct DapWorkflowSession {
     seq: i64,
 }
 
+// Shared workflow-test helpers are consumed incrementally by DAP scenarios.
 #[allow(dead_code)]
 impl DapWorkflowSession {
     /// Create a new session and send `initialize`.

--- a/crates/perl-lsp-rs/tests/common/test_utils.rs
+++ b/crates/perl-lsp-rs/tests/common/test_utils.rs
@@ -15,6 +15,7 @@
 
 // Import from the parent's common module (test files must declare `mod common;` before `mod test_utils;`)
 use super::LspServer;
+use perl_tdd_support::must;
 use serde_json::{Value, json};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::{Duration, Instant};
@@ -43,16 +44,24 @@ fn send_request_with_timeout(
     super::send_request_no_wait(server, request);
 
     match &id {
-        Value::Number(n) if n.as_i64().is_some() => {
-            // Safety: guard ensures as_i64() is Some
-            let id_num = n.as_i64().unwrap_or(0);
-            super::read_response_matching_i64(server, id_num, timeout).unwrap_or_else(|| {
-                super::protocol_io::error_response_for_request(
-                    Some(id.clone()),
-                    super::protocol_io::ERR_TEST_TIMEOUT,
-                    "test harness timeout",
-                )
-            })
+        Value::Number(n) => {
+            if let Some(id_num) = n.as_i64() {
+                super::read_response_matching_i64(server, id_num, timeout).unwrap_or_else(|| {
+                    super::protocol_io::error_response_for_request(
+                        Some(id.clone()),
+                        super::protocol_io::ERR_TEST_TIMEOUT,
+                        "test harness timeout",
+                    )
+                })
+            } else {
+                super::read_response_matching(server, &id, timeout).unwrap_or_else(|| {
+                    super::protocol_io::error_response_for_request(
+                        Some(id.clone()),
+                        super::protocol_io::ERR_TEST_TIMEOUT,
+                        "test harness timeout",
+                    )
+                })
+            }
         }
         value => super::read_response_matching(server, value, timeout).unwrap_or_else(|| {
             super::protocol_io::error_response_for_request(
@@ -102,6 +111,10 @@ impl TestServerBuilder {
     }
 
     pub fn build(self) -> TestServer {
+        must(self.try_build())
+    }
+
+    pub fn try_build(self) -> Result<TestServer, String> {
         // Build initialization params
         let mut init_params = self.initialization_params.unwrap_or_else(|| {
             json!({
@@ -164,7 +177,7 @@ impl TestServerBuilder {
                     );
                 }
 
-                return TestServer { server, timeout };
+                return Ok(TestServer { server, timeout });
             }
 
             if attempt == 0 {
@@ -172,19 +185,13 @@ impl TestServerBuilder {
                     "TestServerBuilder: Initialize failed on attempt 1, retrying with a fresh server: {init_response:#}"
                 );
             } else {
-                // Initialize failed after retry — this is a hard failure.
-                // We use assert_eq! to produce a descriptive failure without panic!.
-                assert_eq!(
-                    init_response.get("error"),
-                    None,
+                return Err(format!(
                     "TestServerBuilder: Initialize failed after retry: {init_response:#}"
-                );
+                ));
             }
         }
 
-        // Unreachable: loop always returns (success) or fails the assert above.
-        // Return a dummy to satisfy type inference — never actually executed.
-        TestServer { server: super::start_lsp_server(), timeout }
+        Err("TestServerBuilder initialization loop exhausted".to_string())
     }
 }
 

--- a/crates/perl-lsp-rs/tests/editor_intelligence_scorecard.rs
+++ b/crates/perl-lsp-rs/tests/editor_intelligence_scorecard.rs
@@ -32,6 +32,8 @@ use perl_corpus::{DocumentSymbolAssertionKind, DocumentSymbolGoldFixture};
 use serde_json::Value;
 use std::path::PathBuf;
 
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -122,18 +124,15 @@ fn document_symbol_names(resp: &Value) -> Vec<String> {
 /// Run all hover gold fixtures and assert every assertion passes.
 /// Reports a pass-rate summary to stdout under --nocapture.
 #[test]
-fn test_hover_gold_corpus() {
+fn test_hover_gold_corpus() -> TestResult {
     let root = gold_corpus_root();
     let fixtures: Vec<HoverGoldFixture> = match load_hover_gold_fixtures(&root) {
         Ok(f) if !f.is_empty() => f,
         Ok(_) => {
             eprintln!("SKIP: no hover gold fixtures found in {}", root.display());
-            return;
+            return Ok(());
         }
-        Err(e) => {
-            assert!(false, "Failed to load hover gold fixtures: {e}");
-            return;
-        }
+        Err(e) => return Err(e),
     };
 
     let server = TestServerBuilder::new().build();
@@ -143,14 +142,7 @@ fn test_hover_gold_corpus() {
     let mut failures: Vec<String> = Vec::new();
 
     for fixture in &fixtures {
-        let code_result = std::fs::read_to_string(&fixture.fixture_path);
-        assert!(
-            code_result.is_ok(),
-            "Cannot read fixture {}: {:?}",
-            fixture.fixture_path.display(),
-            code_result.as_ref().err()
-        );
-        let code = code_result.unwrap_or_default();
+        let code = std::fs::read_to_string(&fixture.fixture_path)?;
 
         let uri = format!("file:///gold/{}.pl", fixture.name);
         server.open_document(&uri, &code);
@@ -199,6 +191,8 @@ fn test_hover_gold_corpus() {
         total,
         failures.join("\n")
     );
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -207,18 +201,15 @@ fn test_hover_gold_corpus() {
 
 /// Run all goto-definition gold fixtures and assert every assertion passes.
 #[test]
-fn test_goto_gold_corpus() {
+fn test_goto_gold_corpus() -> TestResult {
     let root = gold_corpus_root();
     let fixtures: Vec<GotoGoldFixture> = match load_goto_gold_fixtures(&root) {
         Ok(f) if !f.is_empty() => f,
         Ok(_) => {
             eprintln!("SKIP: no goto gold fixtures found in {}", root.display());
-            return;
+            return Ok(());
         }
-        Err(e) => {
-            assert!(false, "Failed to load goto gold fixtures: {e}");
-            return;
-        }
+        Err(e) => return Err(e),
     };
 
     let server = TestServerBuilder::new().build();
@@ -228,14 +219,7 @@ fn test_goto_gold_corpus() {
     let mut failures: Vec<String> = Vec::new();
 
     for fixture in &fixtures {
-        let code_result = std::fs::read_to_string(&fixture.fixture_path);
-        assert!(
-            code_result.is_ok(),
-            "Cannot read fixture {}: {:?}",
-            fixture.fixture_path.display(),
-            code_result.as_ref().err()
-        );
-        let code = code_result.unwrap_or_default();
+        let code = std::fs::read_to_string(&fixture.fixture_path)?;
 
         let uri = format!("file:///gold/{}.pl", fixture.name);
         server.open_document(&uri, &code);
@@ -279,6 +263,8 @@ fn test_goto_gold_corpus() {
         total,
         failures.join("\n")
     );
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -288,18 +274,15 @@ fn test_goto_gold_corpus() {
 /// Run all completion gold fixtures and assert every assertion passes.
 /// Reports top-1 accuracy, top-5 accuracy, non-empty rate, and noise-free rate.
 #[test]
-fn test_completion_gold_corpus() {
+fn test_completion_gold_corpus() -> TestResult {
     let root = gold_corpus_root();
     let fixtures: Vec<CompletionGoldFixture> = match load_completion_gold_fixtures(&root) {
         Ok(f) if !f.is_empty() => f,
         Ok(_) => {
             eprintln!("SKIP: no completion gold fixtures found in {}", root.display());
-            return;
+            return Ok(());
         }
-        Err(e) => {
-            assert!(false, "Failed to load completion gold fixtures: {e}");
-            return;
-        }
+        Err(e) => return Err(e),
     };
 
     let server = TestServerBuilder::new().build();
@@ -309,14 +292,7 @@ fn test_completion_gold_corpus() {
     let mut failures: Vec<String> = Vec::new();
 
     for fixture in &fixtures {
-        let code_result = std::fs::read_to_string(&fixture.fixture_path);
-        assert!(
-            code_result.is_ok(),
-            "Cannot read fixture {}: {:?}",
-            fixture.fixture_path.display(),
-            code_result.as_ref().err()
-        );
-        let code = code_result.unwrap_or_default();
+        let code = std::fs::read_to_string(&fixture.fixture_path)?;
 
         let uri = format!("file:///gold/{}.pl", fixture.name);
         server.open_document(&uri, &code);
@@ -374,6 +350,8 @@ fn test_completion_gold_corpus() {
         total,
         failures.join("\n")
     );
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -382,18 +360,15 @@ fn test_completion_gold_corpus() {
 
 /// Run all diagnostics gold fixtures (`expected.json`) and assert every assertion passes.
 #[test]
-fn test_diagnostics_gold_corpus() {
+fn test_diagnostics_gold_corpus() -> TestResult {
     let root = gold_corpus_root();
     let fixtures: Vec<GoldFixture> = match load_gold_fixtures(&root) {
         Ok(f) if !f.is_empty() => f,
         Ok(_) => {
             eprintln!("SKIP: no diagnostics gold fixtures found in {}", root.display());
-            return;
+            return Ok(());
         }
-        Err(e) => {
-            assert!(false, "Failed to load diagnostics gold fixtures: {e}");
-            return;
-        }
+        Err(e) => return Err(e),
     };
 
     let server = TestServerBuilder::new().build();
@@ -403,14 +378,7 @@ fn test_diagnostics_gold_corpus() {
     let mut failures: Vec<String> = Vec::new();
 
     for fixture in &fixtures {
-        let code_result = std::fs::read_to_string(&fixture.fixture_path);
-        assert!(
-            code_result.is_ok(),
-            "Cannot read fixture {}: {:?}",
-            fixture.fixture_path.display(),
-            code_result.as_ref().err()
-        );
-        let code = code_result.unwrap_or_default();
+        let code = std::fs::read_to_string(&fixture.fixture_path)?;
 
         let uri = format!("file:///gold/{}.pl", fixture.name);
         server.open_document(&uri, &code);
@@ -482,6 +450,8 @@ fn test_diagnostics_gold_corpus() {
         total,
         failures.join("\n")
     );
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -490,18 +460,15 @@ fn test_diagnostics_gold_corpus() {
 
 /// Run all document-symbol gold fixtures and assert every assertion passes.
 #[test]
-fn test_document_symbols_gold_corpus() {
+fn test_document_symbols_gold_corpus() -> TestResult {
     let root = gold_corpus_root();
     let fixtures: Vec<DocumentSymbolGoldFixture> = match load_document_symbol_gold_fixtures(&root) {
         Ok(f) if !f.is_empty() => f,
         Ok(_) => {
             eprintln!("SKIP: no document-symbol gold fixtures found in {}", root.display());
-            return;
+            return Ok(());
         }
-        Err(e) => {
-            assert!(false, "Failed to load document-symbol gold fixtures: {e}");
-            return;
-        }
+        Err(e) => return Err(e),
     };
 
     let server = TestServerBuilder::new().build();
@@ -511,14 +478,7 @@ fn test_document_symbols_gold_corpus() {
     let mut failures: Vec<String> = Vec::new();
 
     for fixture in &fixtures {
-        let code_result = std::fs::read_to_string(&fixture.fixture_path);
-        assert!(
-            code_result.is_ok(),
-            "Cannot read fixture {}: {:?}",
-            fixture.fixture_path.display(),
-            code_result.as_ref().err()
-        );
-        let code = code_result.unwrap_or_default();
+        let code = std::fs::read_to_string(&fixture.fixture_path)?;
 
         let uri = format!("file:///gold/{}.pl", fixture.name);
         server.open_document(&uri, &code);
@@ -559,4 +519,6 @@ fn test_document_symbols_gold_corpus() {
         total,
         failures.join("\n")
     );
+
+    Ok(())
 }

--- a/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
+++ b/crates/perl-lsp-rs/tests/execute_command_security_tests.rs
@@ -13,6 +13,7 @@ use perl_lsp_rs_core::config::WorkspaceConfig;
 use serde_json::Value;
 use std::error::Error;
 use std::fs;
+#[cfg(unix)]
 use std::path::Path;
 use tempfile::TempDir;
 

--- a/crates/perl-lsp-rs/tests/support/bdd_diagnostics.rs
+++ b/crates/perl-lsp-rs/tests/support/bdd_diagnostics.rs
@@ -2,6 +2,8 @@ use serde_json::{Value, json};
 
 use super::lsp_harness::LspHarness;
 
+// BDD diagnostic helpers are test-support fixtures retained for scenario-style
+// regression tests even when individual helpers are not used by the current set.
 #[allow(dead_code)]
 pub struct BddScenario {
     name: &'static str,
@@ -27,12 +29,15 @@ impl BddScenario {
     }
 }
 
+// Scenario-style diagnostic flow helpers are intentionally reusable across
+// future LSP diagnostic tests.
 #[allow(dead_code)]
 pub struct DocumentDiagnosticFlow<'a> {
     harness: &'a mut LspHarness,
     uri: String,
 }
 
+// Diagnostic flow helpers are fixture API for BDD-style integration tests.
 #[allow(dead_code)]
 impl<'a> DocumentDiagnosticFlow<'a> {
     pub fn new(harness: &'a mut LspHarness, uri: impl Into<String>) -> Self {

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -102,10 +102,8 @@ ripr is **never** used as proof; it is used as a **prompt**.
 
 ## Toolchain
 
-`rust-toolchain.toml` pins `1.93.1`. While the repository is on that toolchain,
-the workflow installs `ripr` `0.4.0`, the latest compatible advisory version for
-the Rust 1.93 line. The Rust 1.95 rollout can unpin or bump this after the repo
-toolchain moves.
+`rust-toolchain.toml` pins `1.95.0`. The workflow installs `ripr` `0.4.0` as
+the current advisory version for this lane.
 
 ---
 

--- a/docs/contributing/FIRST_PR.md
+++ b/docs/contributing/FIRST_PR.md
@@ -44,7 +44,7 @@ cargo install just
 just doctor
 ```
 
-Rust toolchain is pinned in `rust-toolchain.toml` (MSRV 1.93, channel `1.93.1`). `rustup` picks it up automatically.
+Rust toolchain is pinned in `rust-toolchain.toml` (MSRV 1.95, channel `1.95.0`). `rustup` picks it up automatically.
 
 **Windows users:** Enable long path support before building (one-time, requires admin terminal):
 

--- a/docs/project/CI_LOCAL_VALIDATION.md
+++ b/docs/project/CI_LOCAL_VALIDATION.md
@@ -276,7 +276,7 @@ just ci-parser-features-check
 
 ### MSRV Validation
 
-Validate against Minimum Supported Rust Version (1.93.1):
+Validate against Minimum Supported Rust Version (1.95.0):
 
 ```bash
 # Fast merge gate on MSRV
@@ -286,7 +286,7 @@ just ci-gate-msrv
 just ci-full-msrv
 
 # Or manually
-RUSTUP_TOOLCHAIN=1.93.1 just ci-gate
+RUSTUP_TOOLCHAIN=1.95.0 just ci-gate
 ```
 
 ### Cost Estimation
@@ -426,7 +426,7 @@ flake.nix
 ### Reproducibility Guarantees
 
 1. **Rust Version Pinning**
-   - MSRV 1.93.1 is specified in `flake.nix`
+   - MSRV 1.95.0 is specified in `flake.nix`
    - Also enforced via `rust-toolchain.toml`
    - CI workflows use the same version
 
@@ -533,7 +533,7 @@ nix --experimental-features 'nix-command flakes' develop
 # Wrong (uses system Rust):
 just ci-gate
 
-# Correct (uses Nix Rust 1.93.1):
+# Correct (uses Nix Rust 1.95.0):
 nix develop -c just ci-gate
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,9 @@
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
 
-        # MSRV: Rust 1.93.1 - pinned for OpenAI Codex compatibility
+        # MSRV: Rust 1.95.0 - pinned for OpenAI Codex compatibility
         # This matches rust-toolchain.toml and CI workflows
-        rustVersion = "1.93.1";
+        rustVersion = "1.95.0";
         rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
           extensions = [ "rust-src" "clippy" "rustfmt" ];
           targets = [ "wasm32-unknown-unknown" ];  # For WASM determinism checks

--- a/justfile
+++ b/justfile
@@ -875,8 +875,8 @@ _check-tools-nextest:
 # CI Validation Commands (Issue #211)
 # ============================================================================
 
-# MSRV: Rust 1.93 (for OpenAI Codex compatibility)
-# The rust-toolchain.toml pins to 1.93.1, so standard commands use MSRV by default.
+# MSRV: Rust 1.95 (for OpenAI Codex compatibility)
+# The rust-toolchain.toml pins to 1.95.0, so standard commands use MSRV by default.
 # Use these recipes to explicitly verify MSRV compliance:
 
 # Phase 0: publish receipts to review/receipts/YYYY-MM-DD/
@@ -899,10 +899,10 @@ ci-measure:
 # UX Regression Tests (first-5-minutes user experience)
 # ============================================================================
 
-# Fast merge gate on MSRV (~2-5 min) - proves 1.93 compatibility
+# Fast merge gate on MSRV (~2-5 min) - proves 1.95 compatibility
 ci-gate-msrv:
-    @echo "🚪 Running fast merge gate on MSRV (Rust 1.93)..."
-    @RUSTUP_TOOLCHAIN=1.93.1 just ci-gate
+    @echo "🚪 Running fast merge gate on MSRV (Rust 1.95)..."
+    @RUSTUP_TOOLCHAIN=1.95.0 just ci-gate
 
 # Low-memory merge gate - for constrained environments (WSL, CI runners, low-RAM)
 # Forces single-threaded builds/tests to prevent OOM crashes
@@ -927,10 +927,10 @@ ci-gate-low-mem:
         just ci-features-invariants'
     @echo "✅ Low-memory merge gate passed!"
 
-# Full CI on MSRV (~10-20 min) - proves 1.93 compatibility for releases
+# Full CI on MSRV (~10-20 min) - proves 1.95 compatibility for releases
 ci-full-msrv:
-    @echo "🚀 Running full CI on MSRV (Rust 1.93)..."
-    @RUSTUP_TOOLCHAIN=1.93.1 just ci-full
+    @echo "🚀 Running full CI on MSRV (Rust 1.95)..."
+    @RUSTUP_TOOLCHAIN=1.95.0 just ci-full
 
 # Check for nested Cargo.lock files (footgun prevention)
 ci-check-no-nested-lock:


### PR DESCRIPTION
Problem: #8717 merged before its review/CI follow-up commits attached to the PR head, leaving release-history channels overclaimed and active CI/Nix/doc pins on Rust 1.93.1.\nFix: Carry forward the missing release-prep repairs on top of master: mark 0.14.0 release channels pending, align active Rust pins/docs/just recipes to 1.95.0, add allow justifications, tighten reviewed test helper error paths, and keep the execute-command Path import Unix-scoped for Windows checks.\nVerification: \\cargo check --locked --tests -p perl-lsp-rs --profile agent\\; \\cargo xtask check-version-sync\\; \\C:\\Program Files\\Git\\bin\\bash.exe scripts/check_release_history.sh\\; \\cargo xtask metrics parser-accuracy --check\\; \\cargo xtask update-status --only parser --check\\; \\cargo xtask metrics ratchet-check parser_accuracy\\; \\cargo xtask semantic-scorecard --check\\; \\cargo xtask semantic-shadow-compare --check\\; \\cargo xtask fmt --check\\; \\git diff --check\\.
