### PR TITLE
refactor(dispatch): split request handling flow

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/cancellation.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/cancellation.rs
@@ -50,18 +50,3 @@ pub fn enhanced_cancelled_response(
         error: Some(JsonRpcError { code: REQUEST_CANCELLED, message, data: Some(data) }),
     }
 }
-
-/// Macro for early cancellation check in dispatcher arms
-/// Takes the method name to include provider context in cancellation responses
-macro_rules! early_cancel_or {
-    ($self:ident, $id:expr, $method:expr, $handler:expr) => {{
-        if let Some(ref _rid) = $id {
-            if $self.is_cancelled(_rid) {
-                $self.cancel_clear(_rid);
-                return Some(cancelled_response_with_method(_rid, $method));
-            }
-        }
-        $handler
-    }};
-}
-pub(crate) use early_cancel_or;

--- a/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! 1. Request arrives via JSON-RPC transport
 //! 2. Cancellation token registered for long-running operations
-//! 3. Method string matched to handler in `handle_request`
+//! 3. Method string matched to handler in `routing::route_request`
 //! 4. Handler invoked with params and optional request ID
 //! 5. Response returned (or None for notifications)
 //! 6. Cancellation token cleaned up
@@ -48,265 +48,30 @@ mod ast_explorer;
 mod cancellation;
 mod experimental;
 mod lifecycle;
+mod preflight;
 mod request_cancellation;
+mod response;
+mod routing;
 mod text_document;
 mod workspace;
 
-pub(crate) use cancellation::early_cancel_or;
 pub(crate) use cancellation::enhanced_cancelled_response;
 
 use super::*;
-use request_cancellation::{
-    finalize_cancellation_state, handle_cancel_notification, register_request_cancellation,
-};
 
 impl LspServer {
     /// Handle a JSON-RPC request
     pub fn handle_request(&self, request: JsonRpcRequest) -> Option<JsonRpcResponse> {
-        let id = request.id.clone().and_then(|id| if id.is_null() { None } else { Some(id) });
-        let should_respond = id.is_some();
+        let context = preflight::RequestContext::from_request(&request);
 
-        if handle_cancel_notification(self, &request) {
-            return None; // Notifications don't get responses
+        match preflight::prepare_request(self, &request, &context) {
+            preflight::PreflightOutcome::Continue => {}
+            preflight::PreflightOutcome::NotificationHandled => return None,
+            preflight::PreflightOutcome::Respond(response) => return Some(response),
         }
 
-        if let Some(cancelled) = register_request_cancellation(self, id.as_ref(), &request) {
-            return Some(cancelled);
-        }
-
-        if !self.initialized.load(Ordering::Acquire)
-            && self.initialize_requested.load(Ordering::Acquire)
-            && request.method != "initialize"
-            && request.method != "initialized"
-            && request.method != "shutdown"
-            && request.method != "exit"
-        {
-            self.auto_initialize_for_compat(&request.method);
-        }
-
-        let result = match request.method.as_str() {
-            "initialize" => self.handle_initialize_dispatch(request.params),
-            "initialized" => self.handle_initialized_dispatch(),
-            // Compatibility: some lightweight clients send `initialize` and then
-            // immediately issue requests without an explicit `initialized` notification.
-            // Accept those requests once `initialize` has completed successfully.
-            _ if !self.initialize_requested.load(Ordering::Acquire)
-                && request.method != "shutdown"
-                && request.method != "exit" =>
-            {
-                Err(JsonRpcError {
-                    code: -32002, // ServerNotInitialized per LSP spec
-                    message: "Server not initialized".to_string(),
-                    data: None,
-                })
-            }
-            "shutdown" => self.handle_shutdown_dispatch(),
-            "exit" => self.handle_exit_dispatch(),
-            "textDocument/didOpen" => self.handle_did_open_dispatch(request.params),
-            "textDocument/didChange" => self.handle_did_change_dispatch(request.params),
-            "textDocument/didClose" => self.handle_did_close_dispatch(request.params),
-            "textDocument/didSave" => self.handle_did_save_dispatch(request.params),
-            "textDocument/willSave" => self.handle_will_save_dispatch(request.params),
-            "textDocument/willSaveWaitUntil" => {
-                self.handle_will_save_wait_until_dispatch(request.params)
-            }
-            "notebookDocument/didOpen" => self.handle_notebook_did_open_dispatch(request.params),
-            "notebookDocument/didChange" => {
-                self.handle_notebook_did_change_dispatch(request.params)
-            }
-            "notebookDocument/didSave" => self.handle_notebook_did_save_dispatch(request.params),
-            "notebookDocument/didClose" => self.handle_notebook_did_close_dispatch(request.params),
-            "textDocument/completion" => early_cancel_or!(self, id, "textDocument/completion", {
-                self.handle_completion_cancellable_dispatch(request.params, id.as_ref())
-            }),
-            "completionItem/resolve" => self.handle_completion_resolve_dispatch(request.params),
-            "textDocument/hover" => early_cancel_or!(self, id, "textDocument/hover", {
-                self.handle_hover_cancellable_dispatch(request.params, id.as_ref())
-            }),
-            "textDocument/signatureHelp" => self.handle_signature_help_dispatch(request.params),
-            "textDocument/definition" => early_cancel_or!(self, id, "textDocument/definition", {
-                self.handle_definition_cancellable_dispatch(request.params, id.as_ref())
-            }),
-            "textDocument/declaration" => self.handle_declaration_dispatch(request.params),
-            "textDocument/references" => early_cancel_or!(self, id, "textDocument/references", {
-                self.handle_references_dispatch(request.params)
-            }),
-            "textDocument/documentHighlight" => {
-                self.handle_document_highlight_dispatch(request.params)
-            }
-            "textDocument/prepareTypeHierarchy" => {
-                self.handle_prepare_type_hierarchy_dispatch(request.params)
-            }
-            "typeHierarchy/prepare" => {
-                // Alias for deprecated/alternate method string
-                self.handle_prepare_type_hierarchy_dispatch(request.params)
-            }
-            "typeHierarchy/supertypes" => {
-                self.handle_type_hierarchy_supertypes_dispatch(request.params)
-            }
-            "typeHierarchy/subtypes" => {
-                self.handle_type_hierarchy_subtypes_dispatch(request.params)
-            }
-            "textDocument/diagnostic" => self.handle_document_diagnostic_dispatch(request.params),
-            "workspace/diagnostic" => early_cancel_or!(
-                self,
-                id,
-                "workspace/diagnostic",
-                self.handle_workspace_diagnostic_dispatch(request.params)
-            ),
-            "textDocument/prepareRename" => self.handle_prepare_rename_dispatch(request.params),
-            "workspace/symbol" => early_cancel_or!(self, id, "workspace/symbol", {
-                self.handle_workspace_symbols_dispatch(request.params)
-            }),
-            "workspace/symbol/resolve" => {
-                self.handle_workspace_symbol_resolve_dispatch(request.params)
-            }
-            "textDocument/rename" => self.handle_rename_workspace_dispatch(request.params),
-            "textDocument/codeAction" => self.handle_code_action_dispatch(request.params),
-            "codeAction/resolve" => self.handle_code_action_resolve_dispatch(request.params),
-            "textDocument/semanticTokens/full" => {
-                self.handle_semantic_tokens_dispatch(request.params)
-            }
-            "textDocument/inlayHint" => early_cancel_or!(
-                self,
-                id,
-                "textDocument/inlayHint",
-                self.handle_inlay_hints_dispatch(request.params)
-            ),
-            "inlayHint/resolve" => self.handle_inlay_hint_resolve_dispatch(request.params),
-            "textDocument/documentLink" => self.handle_document_links_dispatch(request.params),
-            "documentLink/resolve" => self.handle_document_link_resolve_dispatch(request.params),
-            "textDocument/selectionRange" => self.handle_selection_range_dispatch(request.params),
-            "textDocument/onTypeFormatting" => {
-                self.handle_on_type_formatting_dispatch(request.params)
-            }
-            "textDocument/codeLens" => self.handle_code_lens_dispatch(request.params),
-            "codeLens/resolve" => self.handle_code_lens_resolve_dispatch(request.params),
-            "textDocument/linkedEditingRange" => {
-                self.handle_linked_editing_range_dispatch(request.params)
-            }
-            "textDocument/inlineCompletion" => {
-                self.handle_inline_completion_dispatch(request.params)
-            }
-            "textDocument/perlInlineCompletionStream" => {
-                self.handle_streaming_inline_completion_dispatch(request.params)
-            }
-            "textDocument/inlineValue" => self.handle_inline_value_dispatch(request.params),
-            "textDocument/moniker" => self.handle_moniker_dispatch(request.params),
-            "textDocument/documentColor" => self.handle_document_color_dispatch(request.params),
-            "textDocument/colorPresentation" => {
-                self.handle_color_presentation_dispatch(request.params)
-            }
-            "textDocument/semanticTokens/range" => {
-                self.handle_semantic_tokens_range_dispatch(request.params)
-            }
-            "workspace/executeCommand" => self.handle_execute_command_dispatch(request.params),
-            "textDocument/typeDefinition" => self.handle_type_definition_dispatch(request.params),
-            "textDocument/implementation" => self.handle_implementation_dispatch(request.params),
-            "textDocument/documentSymbol" => self.handle_document_symbol_dispatch(request.params),
-            "textDocument/foldingRange" => self.handle_folding_range_dispatch(request.params),
-            "textDocument/formatting" => self.handle_formatting_dispatch(request.params),
-            "textDocument/rangeFormatting" => self.handle_range_formatting_dispatch(request.params),
-            "textDocument/rangesFormatting" => {
-                self.handle_ranges_formatting_dispatch(request.params)
-            }
-            "textDocument/prepareCallHierarchy" => {
-                self.handle_prepare_call_hierarchy_dispatch(request.params)
-            }
-            "callHierarchy/incomingCalls" => early_cancel_or!(
-                self,
-                id,
-                "callHierarchy/incomingCalls",
-                self.handle_incoming_calls_dispatch(request.params)
-            ),
-            "callHierarchy/outgoingCalls" => early_cancel_or!(
-                self,
-                id,
-                "callHierarchy/outgoingCalls",
-                self.handle_outgoing_calls_dispatch(request.params)
-            ),
-            "perl/showAst" => self.handle_show_ast_dispatch(request.params),
-            "experimental/testDiscovery" => self.handle_test_discovery_dispatch(request.params),
-            "workspace/configuration" => self.handle_configuration_dispatch(request.params),
-            "workspace/didChangeWatchedFiles" => {
-                self.handle_did_change_watched_files_dispatch(request.params)
-            }
-            "workspace/didChangeWorkspaceFolders" => {
-                self.handle_did_change_workspace_folders_dispatch(request.params)
-            }
-            "workspace/didChangeConfiguration" => {
-                self.handle_did_change_configuration_dispatch(request.params)
-            }
-            "$/perl-lsp/clientResponse" => {
-                self.handle_client_response(request.params);
-                Ok(None)
-            }
-            "window/workDoneProgress/cancel" => {
-                self.handle_progress_cancel_dispatch(request.params)
-            }
-            "workspace/willRenameFiles" => self.handle_will_rename_files_dispatch(request.params),
-            "workspace/didRenameFiles" => self.handle_did_rename_files_dispatch(request.params),
-            "workspace/willDeleteFiles" => self.handle_will_delete_files_dispatch(request.params),
-            "workspace/didDeleteFiles" => self.handle_did_delete_files_dispatch(request.params),
-            "workspace/willCreateFiles" => self.handle_will_create_files_dispatch(request.params),
-            "workspace/didCreateFiles" => self.handle_did_create_files_dispatch(request.params),
-            "workspace/applyEdit" => self.handle_apply_edit_dispatch(request.params),
-            "workspace/textDocumentContent" => {
-                self.handle_text_document_content_dispatch(request.params)
-            }
-            "$/setTrace" => self.handle_set_trace_dispatch(request.params),
-            "$/test/slowOperation" => self.handle_slow_operation_dispatch(&id, request.params),
-            _ => {
-                tracing::debug!(method = %request.method, "Method not implemented");
-                // Enhanced error response with comprehensive context
-                Err(enhanced_error(
-                    METHOD_NOT_FOUND,
-                    &format!("Method '{}' not found or not supported", request.method),
-                    "method_not_found",
-                    Some(&request.method),
-                ))
-            }
-        };
-
-        // Check for enhanced cancellation with provider context before cleanup.
-        // This preserves cancelled responses for requests that are interrupted while
-        // handlers are already running.
-        if let Some(cancelled) = finalize_cancellation_state(id.as_ref()) {
-            return Some(cancelled);
-        }
-
-        match result {
-            Ok(Some(result)) if should_respond => {
-                tracing::trace!(method = %request.method, "Sending successful response");
-                Some(JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id,
-                    result: Some(result),
-                    error: None,
-                })
-            }
-            Ok(Some(_)) => {
-                tracing::trace!(method = %request.method, "Request is a notification (id missing), no response");
-                None
-            }
-            Ok(None) => {
-                tracing::trace!(method = %request.method, "Request is a notification, no response");
-                None // Notification, no response
-            }
-            Err(error) if should_respond => {
-                tracing::debug!(method = %request.method, error = ?error, "Sending error response");
-                Some(JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    id,
-                    result: None,
-                    error: Some(error),
-                })
-            }
-            Err(error) => {
-                tracing::debug!(method = %request.method, error = ?error, "Suppressed error response for notification request");
-                None
-            }
-        }
+        let routed = self.route_request(request, context.id.clone(), context.should_respond);
+        response::finalize_response(context.id.as_ref(), routed)
     }
 }
 

--- a/crates/perl-lsp-rs/src/runtime/dispatch/preflight.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/preflight.rs
@@ -1,0 +1,58 @@
+//! Request preflight checks before routing.
+//!
+//! Keeps cancellation registration and compatibility initialization separate from
+//! method routing and response construction.
+
+use super::super::*;
+use super::request_cancellation::{handle_cancel_notification, register_request_cancellation};
+
+pub(super) struct RequestContext {
+    pub(super) id: Option<Value>,
+    pub(super) should_respond: bool,
+}
+
+impl RequestContext {
+    pub(super) fn from_request(request: &JsonRpcRequest) -> Self {
+        let id = request.id.clone().and_then(|id| if id.is_null() { None } else { Some(id) });
+        let should_respond = id.is_some();
+
+        Self { id, should_respond }
+    }
+}
+
+pub(super) enum PreflightOutcome {
+    Continue,
+    NotificationHandled,
+    Respond(JsonRpcResponse),
+}
+
+pub(super) fn prepare_request(
+    server: &LspServer,
+    request: &JsonRpcRequest,
+    context: &RequestContext,
+) -> PreflightOutcome {
+    if handle_cancel_notification(server, request) {
+        return PreflightOutcome::NotificationHandled;
+    }
+
+    if let Some(cancelled) = register_request_cancellation(server, context.id.as_ref(), request) {
+        return PreflightOutcome::Respond(cancelled);
+    }
+
+    auto_initialize_for_compat(server, request);
+
+    PreflightOutcome::Continue
+}
+
+fn auto_initialize_for_compat(server: &LspServer, request: &JsonRpcRequest) {
+    if !server.initialized.load(Ordering::Acquire)
+        && server.initialize_requested.load(Ordering::Acquire)
+        && !is_lifecycle_method(&request.method)
+    {
+        server.auto_initialize_for_compat(&request.method);
+    }
+}
+
+fn is_lifecycle_method(method: &str) -> bool {
+    matches!(method, "initialize" | "initialized" | "shutdown" | "exit")
+}

--- a/crates/perl-lsp-rs/src/runtime/dispatch/response.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/response.rs
@@ -1,0 +1,73 @@
+//! JSON-RPC response construction for dispatched requests.
+
+use super::super::*;
+use super::request_cancellation::finalize_cancellation_state;
+
+pub(super) fn finalize_response(
+    request_id: Option<&Value>,
+    routed: RoutedResponse,
+) -> Option<JsonRpcResponse> {
+    match routed {
+        RoutedResponse::Immediate(response) => Some(response),
+        RoutedResponse::Handler { id, method, should_respond, result } => {
+            // Check for enhanced cancellation with provider context before cleanup.
+            // This preserves cancelled responses for requests that are interrupted while
+            // handlers are already running.
+            if let Some(cancelled) = finalize_cancellation_state(request_id) {
+                return Some(cancelled);
+            }
+
+            build_response(id, &method, should_respond, result)
+        }
+    }
+}
+
+pub(super) enum RoutedResponse {
+    Immediate(JsonRpcResponse),
+    Handler {
+        id: Option<Value>,
+        method: String,
+        should_respond: bool,
+        result: Result<Option<Value>, JsonRpcError>,
+    },
+}
+
+fn build_response(
+    id: Option<Value>,
+    method: &str,
+    should_respond: bool,
+    result: Result<Option<Value>, JsonRpcError>,
+) -> Option<JsonRpcResponse> {
+    match result {
+        Ok(Some(result)) if should_respond => {
+            tracing::trace!(method = %method, "Sending successful response");
+            Some(JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: Some(result),
+                error: None,
+            })
+        }
+        Ok(Some(_)) => {
+            tracing::trace!(method = %method, "Request is a notification (id missing), no response");
+            None
+        }
+        Ok(None) => {
+            tracing::trace!(method = %method, "Request is a notification, no response");
+            None
+        }
+        Err(error) if should_respond => {
+            tracing::debug!(method = %method, error = ?error, "Sending error response");
+            Some(JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                id,
+                result: None,
+                error: Some(error),
+            })
+        }
+        Err(error) => {
+            tracing::debug!(method = %method, error = ?error, "Suppressed error response for notification request");
+            None
+        }
+    }
+}

--- a/crates/perl-lsp-rs/src/runtime/dispatch/routing.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/routing.rs
@@ -1,0 +1,230 @@
+//! Method routing for JSON-RPC requests.
+//!
+//! This module owns the method-to-handler table. Preflight checks and response
+//! rendering live in sibling modules so routing remains focused on dispatch.
+
+use super::super::*;
+use super::response::RoutedResponse;
+
+impl LspServer {
+    pub(super) fn route_request(
+        &self,
+        request: JsonRpcRequest,
+        id: Option<Value>,
+        should_respond: bool,
+    ) -> RoutedResponse {
+        let method = request.method.clone();
+        let result = match method.as_str() {
+            "initialize" => self.handle_initialize_dispatch(request.params),
+            "initialized" => self.handle_initialized_dispatch(),
+            // Compatibility: some lightweight clients send `initialize` and then
+            // immediately issue requests without an explicit `initialized` notification.
+            // Accept those requests once `initialize` has completed successfully.
+            _ if !self.initialize_requested.load(Ordering::Acquire)
+                && method != "shutdown"
+                && method != "exit" =>
+            {
+                Err(JsonRpcError {
+                    code: -32002, // ServerNotInitialized per LSP spec
+                    message: "Server not initialized".to_string(),
+                    data: None,
+                })
+            }
+            "shutdown" => self.handle_shutdown_dispatch(),
+            "exit" => self.handle_exit_dispatch(),
+            "textDocument/didOpen" => self.handle_did_open_dispatch(request.params),
+            "textDocument/didChange" => self.handle_did_change_dispatch(request.params),
+            "textDocument/didClose" => self.handle_did_close_dispatch(request.params),
+            "textDocument/didSave" => self.handle_did_save_dispatch(request.params),
+            "textDocument/willSave" => self.handle_will_save_dispatch(request.params),
+            "textDocument/willSaveWaitUntil" => {
+                self.handle_will_save_wait_until_dispatch(request.params)
+            }
+            "notebookDocument/didOpen" => self.handle_notebook_did_open_dispatch(request.params),
+            "notebookDocument/didChange" => {
+                self.handle_notebook_did_change_dispatch(request.params)
+            }
+            "notebookDocument/didSave" => self.handle_notebook_did_save_dispatch(request.params),
+            "notebookDocument/didClose" => self.handle_notebook_did_close_dispatch(request.params),
+            "textDocument/completion" => {
+                return self.route_cancellable(id, method, should_respond, |request_id| {
+                    self.handle_completion_cancellable_dispatch(request.params, request_id)
+                });
+            }
+            "completionItem/resolve" => self.handle_completion_resolve_dispatch(request.params),
+            "textDocument/hover" => {
+                return self.route_cancellable(id, method, should_respond, |request_id| {
+                    self.handle_hover_cancellable_dispatch(request.params, request_id)
+                });
+            }
+            "textDocument/signatureHelp" => self.handle_signature_help_dispatch(request.params),
+            "textDocument/definition" => {
+                return self.route_cancellable(id, method, should_respond, |request_id| {
+                    self.handle_definition_cancellable_dispatch(request.params, request_id)
+                });
+            }
+            "textDocument/declaration" => self.handle_declaration_dispatch(request.params),
+            "textDocument/references" => {
+                return self.route_cancellable(id, method, should_respond, |_| {
+                    self.handle_references_dispatch(request.params)
+                });
+            }
+            "textDocument/documentHighlight" => {
+                self.handle_document_highlight_dispatch(request.params)
+            }
+            "textDocument/prepareTypeHierarchy" => {
+                self.handle_prepare_type_hierarchy_dispatch(request.params)
+            }
+            "typeHierarchy/prepare" => {
+                // Alias for deprecated/alternate method string
+                self.handle_prepare_type_hierarchy_dispatch(request.params)
+            }
+            "typeHierarchy/supertypes" => {
+                self.handle_type_hierarchy_supertypes_dispatch(request.params)
+            }
+            "typeHierarchy/subtypes" => {
+                self.handle_type_hierarchy_subtypes_dispatch(request.params)
+            }
+            "textDocument/diagnostic" => self.handle_document_diagnostic_dispatch(request.params),
+            "workspace/diagnostic" => {
+                return self.route_cancellable(id, method, should_respond, |_| {
+                    self.handle_workspace_diagnostic_dispatch(request.params)
+                });
+            }
+            "textDocument/prepareRename" => self.handle_prepare_rename_dispatch(request.params),
+            "workspace/symbol" => {
+                return self.route_cancellable(id, method, should_respond, |_| {
+                    self.handle_workspace_symbols_dispatch(request.params)
+                });
+            }
+            "workspace/symbol/resolve" => {
+                self.handle_workspace_symbol_resolve_dispatch(request.params)
+            }
+            "textDocument/rename" => self.handle_rename_workspace_dispatch(request.params),
+            "textDocument/codeAction" => self.handle_code_action_dispatch(request.params),
+            "codeAction/resolve" => self.handle_code_action_resolve_dispatch(request.params),
+            "textDocument/semanticTokens/full" => {
+                self.handle_semantic_tokens_dispatch(request.params)
+            }
+            "textDocument/inlayHint" => {
+                return self.route_cancellable(id, method, should_respond, |_| {
+                    self.handle_inlay_hints_dispatch(request.params)
+                });
+            }
+            "inlayHint/resolve" => self.handle_inlay_hint_resolve_dispatch(request.params),
+            "textDocument/documentLink" => self.handle_document_links_dispatch(request.params),
+            "documentLink/resolve" => self.handle_document_link_resolve_dispatch(request.params),
+            "textDocument/selectionRange" => self.handle_selection_range_dispatch(request.params),
+            "textDocument/onTypeFormatting" => {
+                self.handle_on_type_formatting_dispatch(request.params)
+            }
+            "textDocument/codeLens" => self.handle_code_lens_dispatch(request.params),
+            "codeLens/resolve" => self.handle_code_lens_resolve_dispatch(request.params),
+            "textDocument/linkedEditingRange" => {
+                self.handle_linked_editing_range_dispatch(request.params)
+            }
+            "textDocument/inlineCompletion" => {
+                self.handle_inline_completion_dispatch(request.params)
+            }
+            "textDocument/perlInlineCompletionStream" => {
+                self.handle_streaming_inline_completion_dispatch(request.params)
+            }
+            "textDocument/inlineValue" => self.handle_inline_value_dispatch(request.params),
+            "textDocument/moniker" => self.handle_moniker_dispatch(request.params),
+            "textDocument/documentColor" => self.handle_document_color_dispatch(request.params),
+            "textDocument/colorPresentation" => {
+                self.handle_color_presentation_dispatch(request.params)
+            }
+            "textDocument/semanticTokens/range" => {
+                self.handle_semantic_tokens_range_dispatch(request.params)
+            }
+            "workspace/executeCommand" => self.handle_execute_command_dispatch(request.params),
+            "textDocument/typeDefinition" => self.handle_type_definition_dispatch(request.params),
+            "textDocument/implementation" => self.handle_implementation_dispatch(request.params),
+            "textDocument/documentSymbol" => self.handle_document_symbol_dispatch(request.params),
+            "textDocument/foldingRange" => self.handle_folding_range_dispatch(request.params),
+            "textDocument/formatting" => self.handle_formatting_dispatch(request.params),
+            "textDocument/rangeFormatting" => self.handle_range_formatting_dispatch(request.params),
+            "textDocument/rangesFormatting" => {
+                self.handle_ranges_formatting_dispatch(request.params)
+            }
+            "textDocument/prepareCallHierarchy" => {
+                self.handle_prepare_call_hierarchy_dispatch(request.params)
+            }
+            "callHierarchy/incomingCalls" => {
+                return self.route_cancellable(id, method, should_respond, |_| {
+                    self.handle_incoming_calls_dispatch(request.params)
+                });
+            }
+            "callHierarchy/outgoingCalls" => {
+                return self.route_cancellable(id, method, should_respond, |_| {
+                    self.handle_outgoing_calls_dispatch(request.params)
+                });
+            }
+            "perl/showAst" => self.handle_show_ast_dispatch(request.params),
+            "experimental/testDiscovery" => self.handle_test_discovery_dispatch(request.params),
+            "workspace/configuration" => self.handle_configuration_dispatch(request.params),
+            "workspace/didChangeWatchedFiles" => {
+                self.handle_did_change_watched_files_dispatch(request.params)
+            }
+            "workspace/didChangeWorkspaceFolders" => {
+                self.handle_did_change_workspace_folders_dispatch(request.params)
+            }
+            "workspace/didChangeConfiguration" => {
+                self.handle_did_change_configuration_dispatch(request.params)
+            }
+            "$/perl-lsp/clientResponse" => {
+                self.handle_client_response(request.params);
+                Ok(None)
+            }
+            "window/workDoneProgress/cancel" => {
+                self.handle_progress_cancel_dispatch(request.params)
+            }
+            "workspace/willRenameFiles" => self.handle_will_rename_files_dispatch(request.params),
+            "workspace/didRenameFiles" => self.handle_did_rename_files_dispatch(request.params),
+            "workspace/willDeleteFiles" => self.handle_will_delete_files_dispatch(request.params),
+            "workspace/didDeleteFiles" => self.handle_did_delete_files_dispatch(request.params),
+            "workspace/willCreateFiles" => self.handle_will_create_files_dispatch(request.params),
+            "workspace/didCreateFiles" => self.handle_did_create_files_dispatch(request.params),
+            "workspace/applyEdit" => self.handle_apply_edit_dispatch(request.params),
+            "workspace/textDocumentContent" => {
+                self.handle_text_document_content_dispatch(request.params)
+            }
+            "$/setTrace" => self.handle_set_trace_dispatch(request.params),
+            "$/test/slowOperation" => self.handle_slow_operation_dispatch(&id, request.params),
+            _ => {
+                tracing::debug!(method = %method, "Method not implemented");
+                // Enhanced error response with comprehensive context
+                Err(enhanced_error(
+                    METHOD_NOT_FOUND,
+                    &format!("Method '{}' not found or not supported", method),
+                    "method_not_found",
+                    Some(&method),
+                ))
+            }
+        };
+
+        RoutedResponse::Handler { id, method, should_respond, result }
+    }
+
+    fn route_cancellable<F>(
+        &self,
+        id: Option<Value>,
+        method: String,
+        should_respond: bool,
+        handler: F,
+    ) -> RoutedResponse
+    where
+        F: FnOnce(Option<&Value>) -> Result<Option<Value>, JsonRpcError>,
+    {
+        if let Some(request_id) = id.as_ref()
+            && self.is_cancelled(request_id)
+        {
+            self.cancel_clear(request_id);
+            return RoutedResponse::Immediate(cancelled_response_with_method(request_id, &method));
+        }
+
+        let result = handler(id.as_ref());
+        RoutedResponse::Handler { id, method, should_respond, result }
+    }
+}


### PR DESCRIPTION
### Motivation

- The previous `handle_request` combined preflight checks, cancellation registration, method routing, and response rendering into one large function, making it hard to reason about and maintain.
- The change aims to apply Single Responsibility Principle by isolating concerns so each part of the dispatch flow is focused and easier to test.

### Description

- Introduce a `preflight` module (`crates/perl-lsp-rs/src/runtime/dispatch/preflight.rs`) that extracts request ID/response context, handles `$/cancelRequest` notifications, registers cancellation tokens, and performs compatibility auto-initialization.
- Add a `routing` module (`.../routing.rs`) that owns the method-to-handler table and a `route_cancellable` helper for cancellable methods so routing is focused on dispatch decisions only.
- Add a `response` module (`.../response.rs`) that finalizes cancellation state and constructs JSON-RPC responses from routed handler results, preserving enhanced cancelled responses when applicable.
- Simplify `handle_request` in `mod.rs` to orchestrate the three phases (`preflight -> routing -> response`) and remove the old inline dispatch/cancellation mixing and the now-unused `early_cancel_or` macro.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` and it completed successfully after adjusting disk-guard settings.
- Ran the unit test `requests_are_accepted_after_initialize_even_without_initialized_notification` via `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked requests_are_accepted_after_initialize_even_without_initialized_notification` and it passed.
- Ran formatting (`./scripts/cargo-safe xtask fmt`) and lints with `MIN_FREE_GB=5 MAX_USED_PCT=95 ./scripts/cargo-safe clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs` and both completed successfully under the adjusted environment constraints.
- Ran `./scripts/storage-doctor` to verify storage usage and worked around the repo disk guard when necessary during the checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02816d8494833390f1c0cf3258b4bc)