### PR TITLE
fix(lexer): harden Unicode BOM and span boundaries (#6553)

### DIFF
--- a/crates/perl-lexer/src/lexer/helpers/file_normalization.rs
+++ b/crates/perl-lexer/src/lexer/helpers/file_normalization.rs
@@ -1,11 +1,13 @@
 use crate::PerlLexer;
 
+const UTF8_BOM: &[u8] = &[0xEF, 0xBB, 0xBF];
+
 impl PerlLexer<'_> {
     /// Normalize file start by skipping BOM if present
     pub(crate) fn normalize_file_start(&mut self) {
-        if self.position == 0 && self.matches_bytes(&[0xEF, 0xBB, 0xBF]) {
-            self.position = 3;
-            self.line_start_offset = 3;
+        if self.position == 0 && self.matches_bytes(UTF8_BOM) {
+            self.position = UTF8_BOM.len();
+            self.line_start_offset = UTF8_BOM.len();
         }
     }
 }

--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -191,6 +191,7 @@ impl<'a> PerlLexer<'a> {
         if self.position == 0 {
             self.normalize_file_start();
         }
+        self.normalize_char_boundary();
 
         // Loop to avoid recursion when processing heredocs
         loop {
@@ -602,10 +603,24 @@ impl<'a> PerlLexer<'a> {
         }
     }
 
+    /// Ensure the internal byte offset points at a UTF-8 char boundary.
+    ///
+    /// This is a defensive guard against malformed intermediate offsets from
+    /// complex lookahead/backtracking paths so downstream slicing never panics.
+    #[inline]
+    fn normalize_char_boundary(&mut self) {
+        while self.position < self.input.len() && !self.input.is_char_boundary(self.position) {
+            self.position += 1;
+        }
+    }
+
     #[allow(clippy::inline_always)] // Performance critical in lexer hot path
     #[inline(always)]
     fn current_char(&self) -> Option<char> {
         if self.position < self.input_bytes.len() {
+            if !self.input.is_char_boundary(self.position) {
+                return None;
+            }
             // For ASCII, direct access is safe
             let byte = Self::byte_at(self.input_bytes, self.position);
             if byte < 128 {
@@ -622,6 +637,9 @@ impl<'a> PerlLexer<'a> {
     #[inline(always)]
     fn peek_char(&self, offset: usize) -> Option<char> {
         if offset > self.config.max_lookahead {
+            return None;
+        }
+        if !self.input.is_char_boundary(self.position) {
             return None;
         }
 
@@ -644,6 +662,10 @@ impl<'a> PerlLexer<'a> {
     #[inline(always)]
     fn advance(&mut self) {
         if self.position < self.input_bytes.len() {
+            if !self.input.is_char_boundary(self.position) {
+                self.normalize_char_boundary();
+                return;
+            }
             let byte = Self::byte_at(self.input_bytes, self.position);
             if byte < 128 {
                 // ASCII fast path

--- a/crates/perl-lexer/src/unicode.rs
+++ b/crates/perl-lexer/src/unicode.rs
@@ -78,8 +78,12 @@ pub fn is_perl_identifier_continue(ch: char) -> bool {
             0x200C | 0x200D |
             // Standard variation selectors (e.g. U+FE0F) used to keep emoji presentation.
             0xFE00..=0xFE0F |
+            // Supplementary variation selectors.
+            0xE0100..=0xE01EF |
             // Fitzpatrick skin-tone modifiers.
-            0x1F3FB..=0x1F3FF
+            0x1F3FB..=0x1F3FF |
+            // Emoji tag sequence characters used by some flag-like emoji sequences.
+            0xE0020..=0xE007F
         )
 }
 
@@ -142,8 +146,10 @@ mod tests {
         assert!(is_perl_identifier_continue('\u{200C}'));
         assert!(is_perl_identifier_continue('\u{200D}'));
         assert!(is_perl_identifier_continue('\u{FE0F}'));
+        assert!(is_perl_identifier_continue('\u{E0100}'));
         assert!(is_perl_identifier_continue('\u{1F3FB}'));
         assert!(is_perl_identifier_continue('\u{1F3FD}'));
+        assert!(is_perl_identifier_continue('\u{E0067}'));
         assert!(!is_perl_identifier_continue(' '));
         assert!(!is_perl_identifier_continue('-'));
     }

--- a/crates/perl-lexer/tests/edge_case_tests.rs
+++ b/crates/perl-lexer/tests/edge_case_tests.rs
@@ -1147,6 +1147,41 @@ fn unicode_subroutine_name() -> R {
     Ok(())
 }
 
+#[test]
+fn unicode_emoji_identifier_with_joiners_is_single_token() -> R {
+    let input = "my $👩‍💻 = 1;";
+    assert_terminates(input);
+    let sig = significant(input);
+    let emoji_var = sig
+        .iter()
+        .find(|t| matches!(&t.token_type, TokenType::Identifier(id) if id.as_ref() == "$👩‍💻"))
+        .ok_or("expected emoji identifier token")?;
+
+    assert_eq!(emoji_var.text.as_ref(), "$👩‍💻");
+    assert_eq!(emoji_var.text.len(), emoji_var.end - emoji_var.start);
+    Ok(())
+}
+
+#[test]
+fn file_start_bom_is_skipped_and_does_not_shift_identifier_span() -> R {
+    let input = "\u{FEFF}my $name = 1;";
+    assert_terminates(input);
+    let sig = significant(input);
+    let my_kw = sig
+        .iter()
+        .find(|t| matches!(&t.token_type, TokenType::Keyword(k) if k.as_ref() == "my"))
+        .ok_or("expected my keyword token")?;
+    let id = sig
+        .iter()
+        .find(|t| matches!(&t.token_type, TokenType::Identifier(name) if name.as_ref() == "$name"))
+        .ok_or("expected $name identifier token")?;
+
+    assert_eq!(my_kw.start, 3, "keyword should begin after UTF-8 BOM bytes");
+    assert_eq!(id.text.as_ref(), "$name");
+    assert_eq!(id.text.len(), id.end - id.start);
+    Ok(())
+}
+
 // ===========================================================================
 // 6. Combined edge cases / integration-like tests
 // ===========================================================================

--- a/crates/perl-lexer/tests/unicode_fix_test.rs
+++ b/crates/perl-lexer/tests/unicode_fix_test.rs
@@ -1,44 +1,53 @@
-// Test to verify the Unicode fix works correctly
+use perl_lexer::{PerlLexer, TokenType};
 
-use perl_lexer::PerlLexer;
+type R = Result<(), Box<dyn std::error::Error>>;
 
-#[test]
-fn test_unicode_heredoc_fixes() {
-    let test_cases = vec![
-        "¡<<'",        // The specific failing case - should not panic
-        "<<'END'",     // Valid heredoc for comparison
-        "¡test",       // Unicode identifier
-        "¡ << 'test'", // Unicode with spacing
-    ];
+fn assert_spans_are_valid(input: &str) {
+    let mut lexer = PerlLexer::new(input);
+    let mut token_count = 0usize;
 
-    for input in test_cases {
-        println!("Testing input: {:?}", input);
-        let mut lexer = PerlLexer::new(input);
+    while let Some(token) = lexer.next_token() {
+        assert!(input.is_char_boundary(token.start), "token.start must be a char boundary");
+        assert!(input.is_char_boundary(token.end), "token.end must be a char boundary");
+        assert!(token.start <= token.end, "token start must not exceed end");
+        assert!(token.end <= input.len(), "token end must be within the input");
+        assert_eq!(
+            token.text.as_ref(),
+            &input[token.start..token.end],
+            "token text must match its byte span"
+        );
 
-        // This should not panic - the main test
-        let mut token_count = 0;
-        while let Some(token) = lexer.next_token() {
-            println!("  Token: {:?} '{}'", token.token_type, token.text);
-            token_count += 1;
+        token_count += 1;
+        assert!(token_count <= 64, "lexer should terminate for short regression cases");
 
-            // Safety valve to prevent infinite loops in testing
-            if token_count > 10 {
-                break;
-            }
+        if matches!(token.token_type, TokenType::EOF) {
+            break;
         }
-        println!("  Success! Processed {} tokens without panic", token_count);
     }
 }
 
 #[test]
-fn test_unicode_regression_case() {
-    // The specific failing case from the proptest regression
+fn unicode_and_bom_prefixes_do_not_panic_and_have_valid_spans() -> R {
+    let cases = [
+        "¡<<'",             // original regression shape
+        "\u{FEFF}my $x=1;", // UTF-8 BOM at file start
+        "👩‍💻<<'END'",        // ZWJ emoji prefix before heredoc-like bytes
+        "🏳️‍🌈q'abc'",         // variation selector + joiner before quote-like bytes
+        "🧑🏽‍💻\"x\"",          // skin tone modifier + ZWJ
+    ];
+
+    for case in cases {
+        assert_spans_are_valid(case);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn unicode_regression_case_no_panic() -> R {
     let input = "¡<<'";
-
     let mut lexer = PerlLexer::new(input);
-
-    // This should not panic anymore
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| lexer.next_token()));
-
-    assert!(result.is_ok(), "Lexer should not panic on Unicode input: {:?}", input);
+    assert!(result.is_ok(), "Lexer should not panic on Unicode input: {input:?}");
+    Ok(())
 }


### PR DESCRIPTION
Problem: Unicode-heavy prefixes, UTF-8 BOM handling, and intermediate non-char byte offsets could leave lexer span safety under-proven.\n\nFix: Add defensive char-boundary normalization, name the UTF-8 BOM bytes, broaden emoji continuation support, and replace noisy Unicode regression tests with span-validating fixtures.\n\nVerification: \cargo test -p perl-lexer --profile agent --locked\; \cargo check --all-targets -p perl-lexer --profile agent --locked\; \cargo clippy -p perl-lexer --profile agent --locked -- -D warnings -A missing_docs\; \cargo xtask fmt --check\; \cargo xtask metrics parser-accuracy --check\; \cargo xtask update-status --only parser --check\; \cargo xtask metrics ratchet-check parser_accuracy\; \git diff --check\.