### PR TITLE
docs(readme): marketplace 313 installs + align extension README badges (#8730)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p align="center">
   <a href="https://crates.io/crates/perl-lsp-rs"><img src="https://img.shields.io/crates/d/perl-lsp-rs.svg?label=crates.io%20downloads" alt="crates.io downloads" /></a>
   <!-- perl-lsp:vs-marketplace-installs-badge:start -->
-  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/badge/VS%20Marketplace-287%20installs-0078D4" alt="VS Marketplace installs" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs"><img src="https://img.shields.io/badge/VS%20Marketplace-313%20installs-0078D4" alt="VS Marketplace installs" /></a>
   <!-- perl-lsp:vs-marketplace-installs-badge:end -->
   <a href="https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs"><img src="https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads" alt="Open VSX downloads" /></a>
 </p>

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,10 +1,16 @@
 # Perl Language Server
 
+[![CI](https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml/badge.svg)](https://github.com/EffortlessMetrics/perl-lsp/actions/workflows/ci.yml)
+[![GitHub release](https://img.shields.io/github/v/release/EffortlessMetrics/perl-lsp?display_name=tag)](https://github.com/EffortlessMetrics/perl-lsp/releases)
+[![docs.rs](https://docs.rs/perl-lsp-rs/badge.svg)](https://docs.rs/perl-lsp-rs)
+[![crates.io downloads](https://img.shields.io/crates/d/perl-lsp-rs.svg?label=crates.io%20downloads)](https://crates.io/crates/perl-lsp-rs)
 <!-- perl-lsp:vs-marketplace-installs-badge:start -->
-[![VS Marketplace Installs (manual)](https://img.shields.io/badge/VS%20Marketplace-287%20installs-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
+[![VS Marketplace installs](https://img.shields.io/badge/VS%20Marketplace-313%20installs-0078D4)](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)
 <!-- perl-lsp:vs-marketplace-installs-badge:end -->
-[![Open VSX Version](https://img.shields.io/open-vsx/v/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
-[![Open VSX Downloads](https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
+[![Open VSX downloads](https://img.shields.io/open-vsx/dt/EffortlessMetrics/perl-lsp-rs?label=Open%20VSX%20downloads)](https://open-vsx.org/extension/EffortlessMetrics/perl-lsp-rs)
+[![Codecov parser branch coverage](https://codecov.io/gh/EffortlessMetrics/perl-lsp/branch/master/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/perl-lsp)
+[![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://www.rust-lang.org/)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://github.com/EffortlessMetrics/perl-lsp/blob/master/LICENSE-MIT)
 
 A fast, native Perl 5 language server extension. Written in Rust for speed and reliability. No runtime dependencies -- just install and code.
 


### PR DESCRIPTION
## Current truth

Pre-publish hygiene for the 0.14.0 VSCode extension publish.

## Changes

- Main `README.md`: marketplace installs badge count `287` → `313`.
- `vscode-extension/README.md`: replace the bespoke 3-badge block (manual install + Open VSX Version + Open VSX Downloads) with the **9-badge set from the main README** (CI, GitHub release, docs.rs, crates.io downloads, VS Marketplace installs, Open VSX downloads, Codecov parser branch coverage, MSRV, License).
- Drops the Open VSX Version "live listing" badge per user direction.

## Acceptance

Docs-only PR. CI runs the standard markdown / fmt / link checks.

## Claim boundary

Readme cosmetics. Does NOT touch package.json version, manifest, or any publish-trigger surfaces.

## Origin

User direction 2026-05-12: prep README for 0.14.0 VSCode extension publish.