### PR TITLE
fix(vscode-extension): bump engines.vscode to ^1.118.0 to match @types/vscode (#8731)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -7,7 +7,7 @@
   "preview": true,
   "markdown": "github",
   "engines": {
-    "vscode": "^1.116.0"
+    "vscode": "^1.118.0"
   },
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
## Current truth

0.14.0 VSCode extension publish (run 25721140145) failed at `Build release VSIX`:

```
##[error]@types/vscode ^1.118.0 greater than engines.vscode ^1.116.0. Either upgrade engines.vscode or use an older @types/vscode version
```

## Required change

One-line: `engines.vscode: ^1.116.0` → `^1.118.0` in `vscode-extension/package.json`.

## Acceptance

- `Build release VSIX` step succeeds on re-dispatched publish workflow.
- VSIX package built + uploaded.

## Claim boundary

One-line config alignment. No code or behavior changes.

## Origin

User direction 2026-05-12 — unblock 0.14.0 VSCode marketplace + Open VSX publish.

Closes #8731.