### PR TITLE
fix(docker): bump Dockerfile base images to rust:1.95 to match workspace MSRV (#8734)

### DIFF
--- a/.docker/perl-lsp/Dockerfile
+++ b/.docker/perl-lsp/Dockerfile
@@ -12,7 +12,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Stage 1: builder
 # ─────────────────────────────────────────────────────────────────────────────
-FROM rust:1.92-slim-bookworm AS builder
+FROM rust:1.95-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/.docker/rust/Dockerfile
+++ b/.docker/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-slim-bookworm
+FROM rust:1.95-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Current truth

0.14.0 Docker publish failed at the runtime image build for both `linux/amd64` and `linux/arm64`. Root cause: `.docker/rust/Dockerfile` and `.docker/perl-lsp/Dockerfile` are still pinned to `rust:1.92-slim-bookworm` while workspace MSRV is Rust 1.95.

## Required change

Two-line config alignment:
- `.docker/rust/Dockerfile:1` — `rust:1.92-slim-bookworm` → `rust:1.95-slim-bookworm`
- `.docker/perl-lsp/Dockerfile:15` — `FROM rust:1.92-slim-bookworm AS builder` → `FROM rust:1.95-slim-bookworm AS builder`

## Acceptance

```bash
docker build -f .docker/rust/Dockerfile -t perl-lsp-builder:local .
docker build -f .docker/perl-lsp/Dockerfile -t perl-lsp-runtime:local .
docker run --rm perl-lsp-runtime:local --help
```

Then the `Publish Docker Images` workflow re-dispatch with `version=0.14.0` should succeed at runtime image build steps.

## Claim boundary

Two-line config alignment. No code or behavior changes. Doesn't normalize IMAGE_NAME to lowercase (separate concern, file follow-up if needed).

## Origin

User diagnosis 2026-05-12. Same pattern as #8719 (Rust 1.95 pin alignment in CI/Nix/docs). Closes #8734.