### PR TITLE
fix(parser): allow alphanumeric substitution delimiters (#6745)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -129,9 +129,6 @@ pub fn extract_substitution_parts_strict(
         // for the replacement side (e.g. s{foo}/bar/ and s[foo]{bar}).
         let trimmed = skip_paired_substitution_replacement_gap(rest1);
         if let Some(rd) = trimmed.chars().next() {
-            if rd.is_ascii_alphanumeric() || rd.is_whitespace() {
-                return Err(SubstitutionError::MissingReplacement);
-            }
             let repl_closing = get_closing_delimiter(rd);
             extract_delimited_content_strict(trimmed, rd, repl_closing)
         } else {

--- a/crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs
+++ b/crates/perl-parser-core/tests/fix_subst_unusual_delimiters_2732.rs
@@ -250,6 +250,21 @@ fn test_subst_paired_pattern_missing_replacement_errors() {
     assert_has_error(r#"$x =~ s{foo};"#, "Missing");
 }
 
+/// Paired-pattern substitutions may use a closed alphanumeric replacement
+/// delimiter. Perl deparses this as `s/foo/y/`.
+#[test]
+fn test_subst_paired_pattern_alphanumeric_replacement_delimiter() {
+    assert_clean_parse(r#"$x =~ s{foo}xyx;"#);
+}
+
+/// Malformed paired substitution with an unclosed alphanumeric replacement
+/// delimiter should report the missing close, not pretend the replacement is
+/// absent.
+#[test]
+fn test_subst_paired_pattern_unclosed_alphanumeric_replacement_delimiter_errors() {
+    assert_has_error(r#"$x =~ s{foo}xyz;"#, "Missing closing delimiter");
+}
+
 /// Mixed delimiter transliteration: paired search + slash replacement.
 /// Perl accepts `tr{abc}/xyz/`.
 #[test]


### PR DESCRIPTION
Problem: Paired-pattern substitutions rejected alphanumeric replacement delimiters, even though Perl accepts closed forms like `s{foo}xyx`.
Fix: Allow the replacement parser to use the next character as the delimiter, so closed alphanumeric forms parse and unclosed forms report a missing closing delimiter instead of a missing replacement.
Verification: `cargo test -p perl-parser-core --test fix_subst_unusual_delimiters_2732 --profile agent --locked -- --nocapture`; `cargo check --all-targets -p perl-parser-core --profile agent --locked`; `cargo clippy --locked -p perl-parser-core --profile agent -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`
