### PR TITLE
docs(parser): expose raw failure buckets in status (#8743)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -66,6 +66,30 @@ Failures in the system-Perl baseline grouped by cluster. Counts come from `first
 | other | 46 |
 <!-- END: PARSER_FAILURE_WORKLIST -->
 
+### Raw Failure Buckets
+
+Raw first-error buckets from the same system-Perl receipt, grouped by cluster so the generated worklist can be split into one parser-fix lane at a time.
+
+| Cluster | Bucket | Files |
+| --- | --- | --- |
+<!-- BEGIN: PARSER_FAILURE_BUCKETS -->
+| heredoc / delimiter handling | `unclosed_paren_identifier` | 22 |
+| heredoc / delimiter handling | `unclosed_brace` | 10 |
+| heredoc / delimiter handling | `unexpected_rparen_expr` | 8 |
+| heredoc / delimiter handling | `expected_left_brace` | 6 |
+| heredoc / delimiter handling | `unexpected_rbrace_expr` | 6 |
+| heredoc / delimiter handling | `unclosed_bracket` | 2 |
+| heredoc / delimiter handling | `unclosed_paren` | 2 |
+| recovery-only failures | `unexpected_token_in_expr` | 38 |
+| other | `unexpected_assign_expr` | 12 |
+| other | `unexpected_comma_expr` | 10 |
+| other | `unexpected_eq_expr` | 10 |
+| other | `expected_colon` | 4 |
+| other | `expected_comma` | 4 |
+| other | `unexpected_word_op_or` | 4 |
+| other | `substitution_misparse` | 2 |
+<!-- END: PARSER_FAILURE_BUCKETS -->
+
 <!-- BEGIN: PARSER_METRICS_BULLETS -->
 - **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.
 - **Strict promise lists**: `just common-corpus-check` and the CPAN known-clean manifest inside `just cpan-corpus-check` pin subsets that must remain clean on top of the broader baseline receipts.

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -20,7 +20,7 @@ mod failure;
 use accuracy::{
     ParserAccuracyArtifactSummary, parser_accuracy_rows, read_parser_accuracy_artifact,
 };
-use failure::build_failure_worklist;
+use failure::{build_failure_bucket_details, build_failure_worklist};
 
 fn parser_marker_bounds(marker_name: &str) -> (String, String) {
     (format!("<!-- BEGIN: {marker_name} -->"), format!("<!-- END: {marker_name} -->"))
@@ -409,6 +409,13 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |receipt| build_failure_worklist(receipt),
     );
+    let failure_bucket_details = metrics.system_receipt.as_ref().map_or_else(
+        || {
+            "| insufficient_data (no receipt — run `just corpus-sweep-check` to generate) | insufficient_data | insufficient_data |"
+                .to_string()
+        },
+        |receipt| build_failure_bucket_details(receipt),
+    );
 
     let parser_coverage_bullets = format!(
         "- **Three-baseline model**: compatibility is tracked with `just corpus-sweep-check` against Ubuntu system Perl, ecosystem breadth with `just cpan-corpus-check` against the cached CPAN top-1000 install, and deterministic regression coverage with `just parser-audit` against the repo-owned corpus.\n\
@@ -431,6 +438,7 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
     text = replace_parser_status_block(&text, "PARSER_STRICT_CLEAN_ROW", &strict_clean_row)?;
     text = replace_parser_status_block(&text, "PARSER_ACCURACY_SUMMARY", &parser_accuracy_summary)?;
     text = replace_parser_status_block(&text, "PARSER_FAILURE_WORKLIST", &failure_worklist)?;
+    text = replace_parser_status_block(&text, "PARSER_FAILURE_BUCKETS", &failure_bucket_details)?;
     Ok(text)
 }
 

--- a/xtask/src/tasks/update_status/parser/failure.rs
+++ b/xtask/src/tasks/update_status/parser/failure.rs
@@ -26,6 +26,17 @@ impl FailureCluster {
     }
 }
 
+fn ordered_clusters() -> [FailureCluster; 6] {
+    [
+        FailureCluster::TransliterationQuote,
+        FailureCluster::DeclarationPackage,
+        FailureCluster::HeredocDelimiter,
+        FailureCluster::RecoveryOnly,
+        FailureCluster::EncodingMultibyte,
+        FailureCluster::Other,
+    ]
+}
+
 /// Classify a single error bucket name into a [`FailureCluster`].
 ///
 /// Priority order (highest first):
@@ -99,20 +110,42 @@ pub(crate) fn build_failure_worklist(
         *counts.entry(cluster).or_insert(0) += count;
     }
 
-    let clusters = [
-        FailureCluster::TransliterationQuote,
-        FailureCluster::DeclarationPackage,
-        FailureCluster::HeredocDelimiter,
-        FailureCluster::RecoveryOnly,
-        FailureCluster::EncodingMultibyte,
-        FailureCluster::Other,
-    ];
-
-    clusters
+    ordered_clusters()
         .iter()
         .map(|cluster| {
             let count = counts.get(cluster).copied().unwrap_or(0);
             format!("| {} | {} |", cluster.display_name(), count)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Build a markdown table that preserves the raw first-error buckets inside
+/// each generated parser failure cluster.
+///
+/// The rows are ordered by cluster, then by descending count and bucket name.
+pub(crate) fn build_failure_bucket_details(
+    report: &super::super::super::parser_corpus_sweep::SweepReport,
+) -> String {
+    if report.first_error_buckets.is_empty() {
+        return "| none | n/a | 0 |".to_string();
+    }
+
+    let mut rows: Vec<_> = report
+        .first_error_buckets
+        .iter()
+        .map(|(bucket_name, &count)| (classify_failure_bucket(bucket_name), bucket_name, count))
+        .collect();
+    rows.sort_by(|(cluster_a, bucket_a, count_a), (cluster_b, bucket_b, count_b)| {
+        cluster_a
+            .cmp(cluster_b)
+            .then_with(|| count_b.cmp(count_a))
+            .then_with(|| bucket_a.cmp(bucket_b))
+    });
+
+    rows.iter()
+        .map(|(cluster, bucket, count)| {
+            format!("| {} | `{}` | {} |", cluster.display_name(), bucket, count)
         })
         .collect::<Vec<_>>()
         .join("\n")

--- a/xtask/src/tasks/update_status/parser/tests.rs
+++ b/xtask/src/tasks/update_status/parser/tests.rs
@@ -3,11 +3,13 @@ use super::accuracy::{
     ParserAccuracyArtifactSummary, ParserAccuracyDenominator, ParserAccuracyFamilySummary,
     ParserAccuracyMetricSummary,
 };
-use super::failure::{FailureCluster, build_failure_worklist, classify_failure_bucket};
+use super::failure::{
+    FailureCluster, build_failure_bucket_details, build_failure_worklist, classify_failure_bucket,
+};
 use super::*;
 use color_eyre::eyre::Result;
 
-const PARSER_STATUS_MARKER_NAMES: [&str; 9] = [
+const PARSER_STATUS_MARKER_NAMES: [&str; 10] = [
     "PARSER_TRACKING_TABLE",
     "PARSER_PERFORMANCE_TABLE",
     "PARSER_METRICS_BULLETS",
@@ -17,6 +19,7 @@ const PARSER_STATUS_MARKER_NAMES: [&str; 9] = [
     "PARSER_STRICT_CLEAN_ROW",
     "PARSER_ACCURACY_SUMMARY",
     "PARSER_FAILURE_WORKLIST",
+    "PARSER_FAILURE_BUCKETS",
 ];
 
 fn parser_status_template() -> &'static str {
@@ -28,7 +31,8 @@ fn parser_status_template() -> &'static str {
          <!-- BEGIN: PARSER_PERFORMANCE_TABLE -->\nold\n<!-- END: PARSER_PERFORMANCE_TABLE -->\n\
          <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n\
          <!-- BEGIN: TOKEN_HEALTH_TABLE -->\nold\n<!-- END: TOKEN_HEALTH_TABLE -->\n\
-         <!-- BEGIN: PARSER_FAILURE_WORKLIST -->\nold\n<!-- END: PARSER_FAILURE_WORKLIST -->\n"
+         <!-- BEGIN: PARSER_FAILURE_WORKLIST -->\nold\n<!-- END: PARSER_FAILURE_WORKLIST -->\n\
+         <!-- BEGIN: PARSER_FAILURE_BUCKETS -->\nold\n<!-- END: PARSER_FAILURE_BUCKETS -->\n"
 }
 
 #[test]
@@ -530,7 +534,8 @@ fn test_classify_failure_bucket_routing() {
 }
 
 #[test]
-fn test_build_failure_worklist_with_populated_receipt() -> Result<()> {
+fn parser_failure_worklist_builds_cluster_and_bucket_details_with_populated_receipt() -> Result<()>
+{
     use std::collections::BTreeMap;
 
     let mut buckets = BTreeMap::new();
@@ -606,11 +611,86 @@ fn test_build_failure_worklist_with_populated_receipt() -> Result<()> {
     let worklist2 = build_failure_worklist(&report);
     assert_eq!(worklist, worklist2, "cluster worklist must be deterministic");
 
+    let bucket_details = build_failure_bucket_details(&report);
+    assert!(bucket_details.contains("| declaration / package parsing | `expected_variable` | 6 |"));
+    assert!(
+        bucket_details.contains("| heredoc / delimiter handling | `expected_left_brace` | 10 |")
+    );
+    assert!(bucket_details.contains("| recovery-only failures | `unexpected_token_in_expr` | 3 |"));
+    assert!(bucket_details.contains("| other | `expected_colon` | 5 |"));
+    assert!(matches!(
+        (
+            bucket_details.find("expected_variable"),
+            bucket_details.find("expected_left_brace"),
+            bucket_details.find("unexpected_token_in_expr"),
+            bucket_details.find("expected_colon")
+        ),
+        (Some(declaration), Some(heredoc), Some(recovery), Some(other))
+            if declaration < heredoc && heredoc < recovery && recovery < other
+    ));
+
     Ok(())
 }
 
 #[test]
-fn test_build_failure_worklist_empty_buckets() {
+fn parser_failure_worklist_replaces_cluster_and_bucket_status_markers() -> Result<()> {
+    use std::collections::BTreeMap;
+
+    let report = super::super::super::parser_corpus_sweep::SweepReport {
+        schema_version: "1".to_string(),
+        commit: "abc".to_string(),
+        timestamp: "2026-04-09T00:00:00Z".to_string(),
+        corpus_profile: "system".to_string(),
+        corpus_roots: vec![],
+        resolved_roots_count: 0,
+        perl_version: "5.038".to_string(),
+        total_files: 20,
+        files_unreadable: 0,
+        clean_files: 18,
+        files_with_errors: 2,
+        total_dirty_files: 2,
+        files_with_structured_recovery_only: 0,
+        files_with_error_nodes: 2,
+        files_with_catastrophic_parse_failure: 0,
+        total_error_nodes: 2,
+        recovered_node_count: 0,
+        first_unrecovered_error_node_buckets: BTreeMap::new(),
+        first_error_buckets: BTreeMap::from([
+            ("unclosed_paren_identifier".to_string(), 2usize),
+            ("unexpected_token_in_expr".to_string(), 1usize),
+        ]),
+        files_by_bucket: BTreeMap::new(),
+        file_results: vec![],
+        elapsed_secs: 1.0,
+        phase_timings: None,
+        median_error_density_per_1k_loc: None,
+        recovery_salvage_rate: None,
+        slowest_files: vec![],
+    };
+    let metrics = ParserMetrics {
+        syntax_sections: 611,
+        system_receipt: Some(ParserSweepReceipt::with_recovery_shape(report)),
+        cpan_receipt: None,
+        project_corpus: None,
+        common_corpus_receipt: None,
+        common_corpus_pinned: 10,
+        performance_scorecard: None,
+        parser_accuracy: None,
+        token_metrics: token::token_metrics_fixture(),
+    };
+
+    let result = generate_parser_status(&metrics, parser_status_template())?;
+
+    assert!(result.contains("| heredoc / delimiter handling | 2 |"));
+    assert!(result.contains("| recovery-only failures | 1 |"));
+    assert!(result.contains("| heredoc / delimiter handling | `unclosed_paren_identifier` | 2 |"));
+    assert!(result.contains("| recovery-only failures | `unexpected_token_in_expr` | 1 |"));
+    assert!(!result.contains("\nold\n"), "all parser status markers should be replaced");
+    Ok(())
+}
+
+#[test]
+fn parser_failure_worklist_handles_empty_buckets() {
     use super::super::super::parser_corpus_sweep::SweepReport;
     use std::collections::BTreeMap;
 
@@ -644,6 +724,7 @@ fn test_build_failure_worklist_empty_buckets() {
     };
 
     let worklist = build_failure_worklist(&report);
+    let bucket_details = build_failure_bucket_details(&report);
     // All six clusters should appear with 0 counts
     assert!(
         worklist.contains("transliteration / quote parsing"),
@@ -657,6 +738,10 @@ fn test_build_failure_worklist_empty_buckets() {
     // Output should have 6 rows
     let row_count = worklist.lines().count();
     assert_eq!(row_count, 6, "empty worklist must have exactly 6 rows, got {row_count}");
+    assert_eq!(
+        bucket_details, "| none | n/a | 0 |",
+        "raw bucket detail should be explicit when no buckets are present"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Problem: `parser_accuracy_next.md` now hands off empty measurement queues to the parser capability worklist, but the largest row is still a coarse cluster.

Fix: Add a generated raw failure-bucket table under `Parser Failure Worklist`, sourced from `SweepReport::first_error_buckets`, so the heredoc/delimiter lane can be split by concrete bucket.

Deltas:
- Denominator: unchanged at 50 fixtures / 29 families; 139 scored lines; 117 scored symbols.
- Failure packets: unchanged at 0 active.
- Provider rows: unchanged; no provider/runtime behavior touched.
- Ratchet: no floor changes; `parser_accuracy` ratchet passes all floors.

Verification:
- `cargo xtask fmt`
- `cargo test -p xtask --profile agent --locked parser_failure_worklist -- --nocapture`
- `cargo xtask update-status --only parser --write`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs`
- `git diff --check`

Closes #8743.