### PR TITLE
docs(parser-accuracy): point handoff at raw buckets (#8745)

### DIFF
--- a/docs/project/status/parser_accuracy_next.md
+++ b/docs/project/status/parser_accuracy_next.md
@@ -18,4 +18,4 @@ Use the measurement gap table only when there are no active failure packets. Kee
 
 ## Capability Handoff
 
-Measurement wiring is clear. Follow [`parser.md`](parser.md#parser-failure-worklist-clustered) for capability work; take the largest nonzero parser failure cluster as the next parser lane and keep it separate from measurement-only work.
+Measurement wiring is clear. Follow [`parser.md`](parser.md#raw-failure-buckets) for capability work; take the largest raw bucket inside the largest nonzero parser failure cluster as the next parser lane and keep it separate from measurement-only work.

--- a/xtask/src/tasks/metrics/parser_accuracy.rs
+++ b/xtask/src/tasks/metrics/parser_accuracy.rs
@@ -6335,7 +6335,7 @@ fn render_next_pointer_status_receipt(artifact: &ParserAccuracyArtifact) -> Stri
         if has_no_gaps {
             output.push_str("\n## Capability Handoff\n\n");
             output.push_str(
-                "Measurement wiring is clear. Follow [`parser.md`](parser.md#parser-failure-worklist-clustered) for capability work; take the largest nonzero parser failure cluster as the next parser lane and keep it separate from measurement-only work.\n",
+                "Measurement wiring is clear. Follow [`parser.md`](parser.md#raw-failure-buckets) for capability work; take the largest raw bucket inside the largest nonzero parser failure cluster as the next parser lane and keep it separate from measurement-only work.\n",
             );
         }
     }
@@ -8543,8 +8543,11 @@ sub dynamic_boundary_case {
         assert!(pointer.contains("Pointer: no active failure packets."));
         assert!(pointer.contains("| none | n/a | n/a |"));
         assert!(pointer.contains("## Capability Handoff"));
-        assert!(pointer.contains("parser.md#parser-failure-worklist-clustered"));
-        assert!(pointer.contains("largest nonzero parser failure cluster"));
+        assert!(pointer.contains("parser.md#raw-failure-buckets"));
+        assert!(
+            pointer
+                .contains("largest raw bucket inside the largest nonzero parser failure cluster")
+        );
         assert!(matches!(
             (
                 pointer.find("Use the measurement gap table only"),


### PR DESCRIPTION
Problem: `parser_accuracy_next.md` points clear measurement queues to parser capability work, but the text still targeted the coarse cluster after raw buckets were added.

Fix: Point the generated capability handoff at `parser.md#raw-failure-buckets` and tell agents to take the largest raw bucket inside the largest nonzero cluster.

Deltas:
- Denominator: unchanged at 50 fixtures / 29 families; 139 scored lines; 117 scored symbols.
- Failure packets: unchanged at 0 active.
- Provider rows: unchanged; no provider/runtime behavior touched.
- Ratchet: no floor changes; `parser_accuracy` ratchet passes all floors.

Verification:
- `cargo xtask fmt`
- `cargo test -p xtask --profile agent --locked next_pointer -- --nocapture`
- `cargo xtask metrics parser-accuracy --export-status-receipts`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs`
- `git diff --check`

Closes #8745.