### PR TITLE
docs(parser): surface raw bucket receipt freshness (#8747)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -70,6 +70,10 @@ Failures in the system-Perl baseline grouped by cluster. Counts come from `first
 
 Raw first-error buckets from the same system-Perl receipt, grouped by cluster so the generated worklist can be split into one parser-fix lane at a time.
 
+<!-- BEGIN: PARSER_FAILURE_RECEIPT_NOTE -->
+Receipt snapshot: profile `system`, commit `3c287d7db`, generated `2026-04-28`, Perl `5.038002`, `86` resolved roots. Raw bucket counts are point-in-time compatibility data; before starting a parser-fix lane from a bucket, rerun `cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` on Linux or add a focused fixture when system roots are unavailable.
+<!-- END: PARSER_FAILURE_RECEIPT_NOTE -->
+
 | Cluster | Bucket | Files |
 | --- | --- | --- |
 <!-- BEGIN: PARSER_FAILURE_BUCKETS -->

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -189,6 +189,17 @@ fn short_day(timestamp: &str) -> &str {
     timestamp.get(..10).unwrap_or(timestamp)
 }
 
+fn format_failure_receipt_note(receipt: &ParserSweepReceipt) -> String {
+    format!(
+        "Receipt snapshot: profile `{}`, commit `{}`, generated `{}`, Perl `{}`, `{}` resolved roots. Raw bucket counts are point-in-time compatibility data; before starting a parser-fix lane from a bucket, rerun `cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` on Linux or add a focused fixture when system roots are unavailable.",
+        receipt.corpus_profile,
+        receipt.commit,
+        short_day(&receipt.timestamp),
+        receipt.perl_version,
+        receipt.resolved_roots_count,
+    )
+}
+
 fn ns_to_ms(ns: u128) -> f64 {
     ns as f64 / 1_000_000.0
 }
@@ -409,6 +420,13 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
         },
         |receipt| build_failure_worklist(receipt),
     );
+    let failure_receipt_note = metrics.system_receipt.as_ref().map_or_else(
+        || {
+            "Receipt snapshot unavailable. Raw bucket counts are `insufficient_data` until `just corpus-sweep-check` refreshes `.ci/parser-corpus-baseline.json`."
+                .to_string()
+        },
+        format_failure_receipt_note,
+    );
     let failure_bucket_details = metrics.system_receipt.as_ref().map_or_else(
         || {
             "| insufficient_data (no receipt — run `just corpus-sweep-check` to generate) | insufficient_data | insufficient_data |"
@@ -438,6 +456,8 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
     text = replace_parser_status_block(&text, "PARSER_STRICT_CLEAN_ROW", &strict_clean_row)?;
     text = replace_parser_status_block(&text, "PARSER_ACCURACY_SUMMARY", &parser_accuracy_summary)?;
     text = replace_parser_status_block(&text, "PARSER_FAILURE_WORKLIST", &failure_worklist)?;
+    text =
+        replace_parser_status_block(&text, "PARSER_FAILURE_RECEIPT_NOTE", &failure_receipt_note)?;
     text = replace_parser_status_block(&text, "PARSER_FAILURE_BUCKETS", &failure_bucket_details)?;
     Ok(text)
 }

--- a/xtask/src/tasks/update_status/parser/tests.rs
+++ b/xtask/src/tasks/update_status/parser/tests.rs
@@ -9,7 +9,7 @@ use super::failure::{
 use super::*;
 use color_eyre::eyre::Result;
 
-const PARSER_STATUS_MARKER_NAMES: [&str; 10] = [
+const PARSER_STATUS_MARKER_NAMES: [&str; 11] = [
     "PARSER_TRACKING_TABLE",
     "PARSER_PERFORMANCE_TABLE",
     "PARSER_METRICS_BULLETS",
@@ -19,6 +19,7 @@ const PARSER_STATUS_MARKER_NAMES: [&str; 10] = [
     "PARSER_STRICT_CLEAN_ROW",
     "PARSER_ACCURACY_SUMMARY",
     "PARSER_FAILURE_WORKLIST",
+    "PARSER_FAILURE_RECEIPT_NOTE",
     "PARSER_FAILURE_BUCKETS",
 ];
 
@@ -32,6 +33,7 @@ fn parser_status_template() -> &'static str {
          <!-- BEGIN: PARSER_METRICS_BULLETS -->\nold\n<!-- END: PARSER_METRICS_BULLETS -->\n\
          <!-- BEGIN: TOKEN_HEALTH_TABLE -->\nold\n<!-- END: TOKEN_HEALTH_TABLE -->\n\
          <!-- BEGIN: PARSER_FAILURE_WORKLIST -->\nold\n<!-- END: PARSER_FAILURE_WORKLIST -->\n\
+         <!-- BEGIN: PARSER_FAILURE_RECEIPT_NOTE -->\nold\n<!-- END: PARSER_FAILURE_RECEIPT_NOTE -->\n\
          <!-- BEGIN: PARSER_FAILURE_BUCKETS -->\nold\n<!-- END: PARSER_FAILURE_BUCKETS -->\n"
 }
 
@@ -683,6 +685,9 @@ fn parser_failure_worklist_replaces_cluster_and_bucket_status_markers() -> Resul
 
     assert!(result.contains("| heredoc / delimiter handling | 2 |"));
     assert!(result.contains("| recovery-only failures | 1 |"));
+    assert!(result.contains("Receipt snapshot: profile `system`, commit `abc`"));
+    assert!(result.contains("generated `2026-04-09`"));
+    assert!(result.contains("before starting a parser-fix lane from a bucket"));
     assert!(result.contains("| heredoc / delimiter handling | `unclosed_paren_identifier` | 2 |"));
     assert!(result.contains("| recovery-only failures | `unexpected_token_in_expr` | 1 |"));
     assert!(!result.contains("\nold\n"), "all parser status markers should be replaced");


### PR DESCRIPTION
Problem: parser.md raw failure buckets are point-in-time system-corpus receipt data, but the leading bucket can be stale relative to current focused parser regressions.\nFix: Add a generated receipt freshness note above the raw bucket table and assert the marker/content in xtask status tests.\nVerification: \cargo test -p xtask --profile agent --locked parser_failure -- --nocapture\; \cargo xtask update-status --only parser --check\; \cargo xtask metrics parser-accuracy --check\; \cargo xtask metrics ratchet-check parser_accuracy\; \cargo xtask fmt --check\; \cargo clippy --locked -p xtask --profile agent -- -D warnings -A missing_docs\; \git diff --check\.\n\nDeltas: parser accuracy denominator unchanged at 50 fixtures / 29 families, 139 scored lines, 117 scored symbols; active failure packets unchanged at 0; provider/runtime rows unchanged; ratchet floors unchanged and passing.\n\nCloses #8747