### PR TITLE
test(parser): lock Unicode::Collate map fixture (#8749)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -520,6 +520,15 @@ fn unless_null_in_paren() {
 }
 
 #[test]
+fn unicode_collate_map_expr_in_for_list() {
+    // From Unicode::Collate: map EXPR, LIST inside a for-list must not leave
+    // the parenthesized list waiting for a `)` before the identifier body.
+    assert_clean_parse(
+        r#"for my $vwt (map $self->getWt($_), @$subE) { my($var, @wt) = unpack(VCE_TEMPLATE, $vwt); }"#,
+    );
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The raw parser failure buckets point agents at Unicode::Collate under unclosed_paren_identifier, but the bucket did not have a focused named regression for that map-expression-in-for-list shape.
Fix: Add a clean-parse parser-core regression covering the Unicode::Collate map EXPR, LIST form inside a for-list.
Verification:
- `cargo test -p perl-parser-core --profile agent --locked --test unclosed_paren_identifier_tests unicode_collate -- --nocapture`
- `cargo test -p perl-parser-core --profile agent --locked --test unclosed_paren_identifier_tests -- --nocapture`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`

Parser-status deltas:
- denominator unchanged: 50 fixtures / 29 families
- scored lines/symbols unchanged: 139 lines / 117 symbols
- failure packets unchanged: 0 active
- provider/runtime rows unchanged
- parser_accuracy ratchet unchanged and passing

Closes #8749