### PR TITLE
test(parser): lock Regexp::Common map fixture (#8751)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -529,6 +529,17 @@ fn unicode_collate_map_expr_in_for_list() {
 }
 
 #[test]
+fn regexp_common_comment_combine_parenthesized_map_args() {
+    // From Regexp::Common::comment: unary plus before a parenthesized map block
+    // in a comma-separated argument list must not leave `combine` waiting for a `)`.
+    assert_clean_parse(
+        r#"my $pattern = combine +(map {to_eol $_} @{$group -> {to_eol}}),
+                       (map {from_to @$_} @{$group -> {from_to}}),
+                       (map {id       $_} @{$group -> {id}});"#,
+    );
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The current parser capability handoff points at the `unclosed_paren_identifier` raw bucket, and `Regexp::Common::comment` lacked a focused regression for its `combine +(map {...}), (map {...})` argument-list shape.
Fix: Add a clean-parse parser-core regression covering the Regexp::Common `combine` call with parenthesized map block arguments.
Verification:
- `cargo test -p perl-parser-core --profile agent --locked --test unclosed_paren_identifier_tests regexp_common_comment_combine_parenthesized_map_args -- --nocapture`
- `cargo test -p perl-parser-core --profile agent --locked --test unclosed_paren_identifier_tests -- --nocapture`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`

Parser-status deltas:
- denominator unchanged: 50 fixtures / 29 families
- scored lines/symbols unchanged: 139 lines / 117 symbols
- failure packets unchanged: 0 active
- provider/runtime rows unchanged
- parser_accuracy ratchet unchanged and passing

Closes #8751