### PR TITLE
test(parser): lock ExtUtils map-list fixture (#8753)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -540,6 +540,15 @@ fn regexp_common_comment_combine_parenthesized_map_args() {
 }
 
 #[test]
+fn extutils_mm_unix_for_list_with_parenthesized_map() {
+    // From ExtUtils::MM_Unix: a for-list may mix qw groups and a parenthesized
+    // map block without treating the next identifier as a missing `)`.
+    assert_clean_parse(
+        r#"for my $macro (qw(PERL_LIB PERL_ARCHLIB), (map { ("INSTALL".$_, "DESTINSTALL".$_) } $self->installvars), qw(PERL_SRC)) { $self->{$macro} ||= ""; }"#,
+    );
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The current parser capability handoff points at the `unclosed_paren_identifier` raw bucket, and `ExtUtils/MM_Unix.pm` lacked a focused regression for its for-list with mixed `qw(...)` groups and a parenthesized `map` block.
Fix: Add a clean-parse parser-core regression covering the ExtUtils::MM_Unix map-list shape.
Verification:
- `cargo test -p perl-parser-core --profile agent --locked --test unclosed_paren_identifier_tests extutils_mm_unix_for_list_with_parenthesized_map -- --nocapture`
- `cargo test -p perl-parser-core --profile agent --locked --test unclosed_paren_identifier_tests -- --nocapture`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`

Parser-status deltas:
- denominator unchanged: 50 fixtures / 29 families
- scored lines/symbols unchanged: 139 lines / 117 symbols
- failure packets unchanged: 0 active
- provider/runtime rows unchanged
- parser_accuracy ratchet unchanged and passing

Closes #8753