### PR TITLE
test(parser): lock Carp local caller fixture (#8755)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -561,6 +561,13 @@ fn x_repetition_prefix_decrement_in_parens() {
     assert_clean_parse(r#"push @out, ('  ' x --$indent) . '</li>';"#);
 }
 
+#[test]
+fn local_carp_not_scalar_ternary_caller() {
+    // From Carp: localized package arrays may be assigned from a scalar()
+    // parenthesized ternary without treating caller() as a missing `)`.
+    assert_clean_parse(r#"local @CARP_NOT = scalar( $cgc ? $cgc->() : caller() );"#);
+}
+
 // === Sigil-peek heuristic: imported unary functions without parens (#1943) ===
 // These all fail with "expected ')', found identifier" before the fix because
 // `blessed`, `reftype`, etc. are not in the builtin table. The fix adds a


### PR DESCRIPTION
Problem: The raw parser failure bucket still points at Carp.pm in the unclosed_paren_identifier set, and the local @CARP_NOT scalar ternary caller shape was not locked by a focused fixture.\nFix: Add one parser-core fixture for the Carp source pattern local @CARP_NOT = scalar(  ? ->() : caller() );.\nVerification: cargo test -p perl-parser-core --profile agent --locked local_carp_not_scalar_ternary_caller -- --nocapture passes; cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture passes; cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check passes; cargo run --package xtask --profile agent --locked -- update-status --only parser --check passes; cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy passes; cargo run --package xtask --profile agent --locked -- fmt --check passes; git diff --check passes.\n\nNote: direct Cargo with off-worktree CARGO_TARGET_DIR was used locally because the Bash scripts/cargo-safe wrapper left orphaned Cargo children under PowerShell during the full-file test.