### PR TITLE
test(parser): lock fields warnings fallback fixture (#8757)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_brace_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_brace_tests.rs
@@ -65,6 +65,21 @@ fn test_use_if_negation() {
     assert_clean_parse(source);
 }
 
+#[test]
+fn fields_warnings_register_fallback() {
+    // From fields.pm: an unless condition may contain an eval block, followed
+    // by a qualified typeglob assignment to an anonymous sub fallback.
+    let source = r#"
+unless( eval {require warnings::register; warnings::register->import; 1} ) {
+    *warnings::warnif = sub {
+        require Carp;
+        Carp::carp(@_);
+    }
+}
+"#;
+    assert_clean_parse(source);
+}
+
 // --- Combined patterns from CPAN corpus ---
 
 #[test]


### PR DESCRIPTION
Problem: The raw parser failure bucket lists fields.pm under unclosed_brace, and the startup warnings fallback shape was not locked by a focused fixture.
Fix: Add one parser-core fixture for the fields.pm pattern `unless( eval {require warnings::register; warnings::register->import; 1} ) { *warnings::warnif = sub { ... } }`.
Verification: `cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked fields_warnings_register_fallback -- --nocapture` passes; `cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked -- --nocapture` passes; `cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check` passes; `cargo run --package xtask --profile agent --locked -- update-status --only parser --check` passes; `cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy` passes; `cargo run --package xtask --profile agent --locked -- fmt --check` passes; `git diff --check` passes.