### PR TITLE
test(parser): lock Test::More heredoc diag fixture (#8760)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_brace_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_brace_tests.rs
@@ -80,6 +80,22 @@ unless( eval {require warnings::register; warnings::register->import; 1} ) {
     assert_clean_parse(source);
 }
 
+#[test]
+fn test_more_unless_diag_heredoc() {
+    // From Test::More: heredoc terminators inside an unless block must close the
+    // diagnostic call without leaving the block body waiting for another `}`.
+    let source = r#"unless($ok) {
+    chomp $eval_error;
+    $tb->diag(<<DIAGNOSTIC);
+    Tried to require '$module'.
+    Error:  $eval_error
+DIAGNOSTIC
+
+}
+"#;
+    assert_clean_parse(source);
+}
+
 // --- Combined patterns from CPAN corpus ---
 
 #[test]


### PR DESCRIPTION
Problem: The raw parser failure bucket lists Test/More.pm under unclosed_brace, and the heredoc diagnostic inside an unless block was not locked by a focused fixture.
Fix: Add one parser-core fixture for the Test::More `unless($ok) { $tb->diag(<<DIAGNOSTIC); ... }` heredoc shape.
Verification: `cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked test_more_unless_diag_heredoc -- --nocapture` passes; `cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked -- --nocapture` passes; `cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check` passes; `cargo run --package xtask --profile agent --locked -- update-status --only parser --check` passes; `cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy` passes; `cargo run --package xtask --profile agent --locked -- fmt --check` passes; `git diff --check` passes.