### PR TITLE
test(parser): lock Test::More use_ok heredoc diag fixture (#8762)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_brace_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_brace_tests.rs
@@ -96,6 +96,24 @@ DIAGNOSTIC
     assert_clean_parse(source);
 }
 
+#[test]
+fn test_more_use_ok_regex_then_diag_heredoc() {
+    // From Test::More: a regex substitution before the heredoc diagnostic should
+    // not leave the enclosing unless block classified as an unclosed brace.
+    let source = r#"unless($ok) {
+    chomp $eval_error;
+    $@ =~ s{^BEGIN failed--compilation aborted at .*$}
+            {BEGIN failed--compilation aborted at $filename line $line.}m;
+    $tb->diag(<<DIAGNOSTIC);
+    Tried to use '$module'.
+    Error:  $eval_error
+DIAGNOSTIC
+
+}
+"#;
+    assert_clean_parse(source);
+}
+
 // --- Combined patterns from CPAN corpus ---
 
 #[test]


### PR DESCRIPTION
Problem: The unclosed_brace heredoc/delimiter bucket still includes Test::More, and use_ok has a distinct regex-substitution plus heredoc diagnostic path inside an unless block.
Fix: Add one parser-core clean-parse fixture for that Test::More use_ok heredoc diagnostic shape.
Verification: cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked test_more_use_ok_regex_then_diag_heredoc -- --nocapture; cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked -- --nocapture; cargo xtask metrics parser-accuracy --check; cargo xtask update-status --only parser --check; cargo xtask metrics ratchet-check parser_accuracy; cargo xtask fmt --check; git diff --check.