### PR TITLE
test(parser): lock Pod::Simple XHTML entity map fixture (#8764)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -562,6 +562,15 @@ fn x_repetition_prefix_decrement_in_parens() {
 }
 
 #[test]
+fn pod_simple_xhtml_entity_regex_map_assignment() {
+    // From Pod::Simple::XHTML: a parenthesized lexical assignment may use
+    // map EXPR, LIST followed by a join expression with another map chain.
+    assert_clean_parse(
+        r#"my ($entity_re) = map qr{$_}, join '|', map quotemeta, sort keys %entity_to_char;"#,
+    );
+}
+
+#[test]
 fn local_carp_not_scalar_ternary_caller() {
     // From Carp: localized package arrays may be assigned from a scalar()
     // parenthesized ternary without treating caller() as a missing `)`.


### PR DESCRIPTION
Problem: The parser capability handoff points at the heredoc/delimiter cluster, with `unclosed_paren_identifier` as the largest raw bucket, and Pod::Simple::XHTML is one of the bucket files.
Fix: Add one parser-core clean-parse fixture for the Pod::Simple::XHTML parenthesized lexical assignment using map/join/map.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked pod_simple_xhtml_entity_regex_map_assignment -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`.