### PR TITLE
test(parser): lock Unicode Normalize typeglob ternary fixture (#8768)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -556,6 +556,17 @@ fn main_package_variable_in_paren_expr() {
 }
 
 #[test]
+fn unicode_normalize_typeglob_ternary_native_subs() {
+    // From Unicode::Normalize: a typeglob assignment may use a parenthesized
+    // main-package condition followed by ternary anonymous subs.
+    assert_clean_parse(
+        r#"*to_native = ($::IS_ASCII || $] < 5.008)
+             ? sub { return shift }
+             : sub { utf8::unicode_to_native(shift) };"#,
+    );
+}
+
+#[test]
 fn x_repetition_prefix_decrement_in_parens() {
     // From Pod::Simple::XHTML: repetition RHS may be a prefix decrement.
     assert_clean_parse(r#"push @out, ('  ' x --$indent) . '</li>';"#);


### PR DESCRIPTION
Problem: `unclosed_paren_identifier` remains the largest raw parser failure bucket, and `Unicode::Normalize` is one source file in that bucket.
Fix: add a focused parser-core clean-parse fixture for the Unicode::Normalize typeglob assignment with a parenthesized native-condition ternary of anonymous subs.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked unicode_normalize_typeglob_ternary_native_subs -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`.