### PR TITLE
test(parser): lock Unicode Normalize unpack_U map fixture (#8775)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -581,6 +581,13 @@ fn unicode_normalize_pack_u_map_block() {
 }
 
 #[test]
+fn unicode_normalize_unpack_u_map_block() {
+    // From Unicode::Normalize: map may take an unpack call whose list contains
+    // a shifted argument concatenated with a pack call.
+    assert_clean_parse(r#"return map { from_native($_) } unpack('U*', shift(@_).pack('U*'));"#);
+}
+
+#[test]
 fn x_repetition_prefix_decrement_in_parens() {
     // From Pod::Simple::XHTML: repetition RHS may be a prefix decrement.
     assert_clean_parse(r#"push @out, ('  ' x --$indent) . '</li>';"#);


### PR DESCRIPTION
Problem: `unclosed_paren_identifier` remains the largest raw parser failure bucket, and `Unicode::Normalize` is one source file in that bucket.
Fix: add a focused parser-core clean-parse fixture for the Unicode::Normalize `dot_t_unpack_U` helper shape: `map { from_native($_) } unpack('U*', shift(@_).pack('U*'))`.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked unicode_normalize_unpack_u_map_block -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`.