### PR TITLE
test(parser): lock Unicode Normalize printable map fixture (#8777)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -588,6 +588,13 @@ fn unicode_normalize_unpack_u_map_block() {
 }
 
 #[test]
+fn unicode_normalize_printable_map_sprintf_split() {
+    // From Unicode::Normalize: join may take a map block whose expression calls
+    // sprintf, followed by a split expression as the map source list.
+    assert_clean_parse(r#"return join " ", map { sprintf "\\x%02x", ord $_ } split "", $s;"#);
+}
+
+#[test]
 fn x_repetition_prefix_decrement_in_parens() {
     // From Pod::Simple::XHTML: repetition RHS may be a prefix decrement.
     assert_clean_parse(r#"push @out, ('  ' x --$indent) . '</li>';"#);


### PR DESCRIPTION
Problem: `unclosed_paren_identifier` remains the largest raw parser failure bucket, and `Unicode::Normalize` is one source file in that bucket.
Fix: add a focused parser-core clean-parse fixture for the Unicode::Normalize printable-string helper shape: `join " ", map { sprintf "\\x%02x", ord $_ } split "", $s`.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked unicode_normalize_printable_map_sprintf_split -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`.