### PR TITLE
test(parser): lock Unicode Collate override map fixture (#8779)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -536,6 +536,13 @@ fn unicode_collate_pack_u_coderef_map_expr() {
 }
 
 #[test]
+fn unicode_collate_override_hangul_map_expr() {
+    // From Unicode::Collate: map EXPR, LIST may assign the result of a helper
+    // call over a coderef-produced source list.
+    assert_clean_parse(r#"@ce = map _pack_override($_, $u, $der), $hang->($u);"#);
+}
+
+#[test]
 fn regexp_common_comment_combine_parenthesized_map_args() {
     // From Regexp::Common::comment: unary plus before a parenthesized map block
     // in a comma-separated argument list must not leave `combine` waiting for a `)`.


### PR DESCRIPTION
Problem: `unclosed_paren_identifier` remains the largest raw parser failure bucket, and `Unicode::Collate` is one source file in that bucket.
Fix: add a focused parser-core clean-parse fixture for the Unicode::Collate override-Hangul map shape: `map _pack_override($_, $u, $der), $hang->($u)`.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked unicode_collate_override_hangul_map_expr -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`.