### PR TITLE
test(parser): lock Unicode Collate decomposition map fixture (#8781)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -543,6 +543,19 @@ fn unicode_collate_override_hangul_map_expr() {
 }
 
 #[test]
+fn unicode_collate_decomposition_map_block() {
+    // From Unicode::Collate: parenthesized map BLOCK LIST may contain nested
+    // ternaries without leaving the caller waiting for a `)` before @decH.
+    assert_clean_parse(
+        r#"@ce = map({
+            exists $map->{$_} ? @{ $map->{$_} } :
+            $uXS && _exists_simple($_) ? _fetch_simple($_) :
+            $der->($_);
+        } @decH);"#,
+    );
+}
+
+#[test]
 fn regexp_common_comment_combine_parenthesized_map_args() {
     // From Regexp::Common::comment: unary plus before a parenthesized map block
     // in a comma-separated argument list must not leave `combine` waiting for a `)`.


### PR DESCRIPTION
Problem: `Unicode::Collate` remains in the system-Perl `unclosed_paren_identifier` bucket, including a parenthesized `map({ ... } LIST)` decomposition shape with nested ternaries.

Fix: Add one parser-core regression fixture for the source-backed decomposition map block shape.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked unicode_collate_decomposition_map_block -- --nocapture`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check`
- `cargo run --package xtask --profile agent --locked -- update-status --only parser --check`
- `cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy`
- `cargo run --package xtask --profile agent --locked -- fmt --check`
- `git diff --check`