### PR TITLE
test(parser): lock Unicode Collate gmatch substr map fixture (#8785)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -563,6 +563,15 @@ fn unicode_collate_varce_return_map_expr() {
 }
 
 #[test]
+fn unicode_collate_gmatch_substr_return_map_expr() {
+    // From Unicode::Collate: return may use map EXPR, LIST where the mapped
+    // expression is a builtin call and the source list is a method call.
+    assert_clean_parse(
+        r#"return map substr($str, $_->[0], $_->[1]), $self->index($str, $sub, 0, 'g');"#,
+    );
+}
+
+#[test]
 fn regexp_common_comment_combine_parenthesized_map_args() {
     // From Regexp::Common::comment: unary plus before a parenthesized map block
     // in a comma-separated argument list must not leave `combine` waiting for a `)`.


### PR DESCRIPTION
Problem: `Unicode::Collate` remains in the system-Perl `unclosed_paren_identifier` bucket, including a `return map EXPR, LIST` shape where the mapped expression is a `substr` call and the source list is a method call.

Fix: Add one parser-core regression fixture for the source-backed `gmatch` return-map substr shape.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked unicode_collate_gmatch_substr_return_map_expr -- --nocapture`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check`
- `cargo run --package xtask --profile agent --locked -- update-status --only parser --check`
- `cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy`
- `cargo run --package xtask --profile agent --locked -- fmt --check`
- `git diff --check`

Closes #8785.