### PR TITLE
test(parser): lock Unicode Collate unpack_U coderef map fixture (#8787)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -536,6 +536,15 @@ fn unicode_collate_pack_u_coderef_map_expr() {
 }
 
 #[test]
+fn unicode_collate_unpack_u_coderef_map_expr() {
+    // From Unicode::Collate: return may use map EXPR, LIST where the
+    // expression is a lexical coderef call and the list is an unpack call.
+    assert_clean_parse(
+        r#"return map $native_to_unicode->($_), unpack('U*', shift(@_).pack('U*'));"#,
+    );
+}
+
+#[test]
 fn unicode_collate_override_hangul_map_expr() {
     // From Unicode::Collate: map EXPR, LIST may assign the result of a helper
     // call over a coderef-produced source list.


### PR DESCRIPTION
Problem: `Unicode::Collate` remains in the system-Perl `unclosed_paren_identifier` bucket, including an `unpack_U` `return map EXPR, LIST` shape where the mapped expression is a lexical coderef call and the list is an `unpack(...)` call.

Fix: Add one parser-core regression fixture for the source-backed `Unicode::Collate` `unpack_U` coderef map shape.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked unicode_collate_unpack_u_coderef_map_expr -- --nocapture`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check`
- `cargo run --package xtask --profile agent --locked -- update-status --only parser --check`
- `cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy`
- `cargo run --package xtask --profile agent --locked -- fmt --check`
- `git diff --check`

Closes #8787.