### PR TITLE
test(parser): lock Unicode Collate HST join map fixture (#8789)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -581,6 +581,13 @@ fn unicode_collate_gmatch_substr_return_map_expr() {
 }
 
 #[test]
+fn unicode_collate_hst_join_map_split_expr() {
+    // From Unicode::Collate: join may take map EXPR, LIST where the source
+    // list is a split expression after the mapped function call.
+    assert_clean_parse(r#"my $curHST = join '', map getHST($_, $vers), split /;/, $jcps;"#);
+}
+
+#[test]
 fn regexp_common_comment_combine_parenthesized_map_args() {
     // From Regexp::Common::comment: unary plus before a parenthesized map block
     // in a comma-separated argument list must not leave `combine` waiting for a `)`.


### PR DESCRIPTION
Problem: `Unicode::Collate` remains in the system-Perl `unclosed_paren_identifier` bucket, including an HST `join` call whose argument list contains `map EXPR, LIST` followed by a `split` source list.

Fix: Add one parser-core regression fixture for the source-backed `Unicode::Collate` HST join/map/split shape.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked unicode_collate_hst_join_map_split_expr -- --nocapture`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check`
- `cargo run --package xtask --profile agent --locked -- update-status --only parser --check`
- `cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy`
- `cargo run --package xtask --profile agent --locked -- fmt --check`
- `git diff --check`

Closes #8789.