### PR TITLE
test(parser): lock DBI map-grep registry fixture (#8791)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -588,6 +588,15 @@ fn unicode_collate_hst_join_map_split_expr() {
 }
 
 #[test]
+fn dbi_registry_map_block_over_grep_block() {
+    // From DBI: map BLOCK LIST may take a grep BLOCK expression as the source
+    // list before a keys expression without leaving the parent assignment open.
+    assert_clean_parse(
+        r#"my %dbd_class_registry = map { $dbd_prefix_registry->{$_}->{class} => { prefix => $_ } } grep { exists $dbd_prefix_registry->{$_}->{class} } keys %{$dbd_prefix_registry};"#,
+    );
+}
+
+#[test]
 fn regexp_common_comment_combine_parenthesized_map_args() {
     // From Regexp::Common::comment: unary plus before a parenthesized map block
     // in a comma-separated argument list must not leave `combine` waiting for a `)`.


### PR DESCRIPTION
Problem: The parser capability handoff still points at the unclosed_paren_identifier raw bucket, and DBI.pm carries a source-backed map BLOCK over grep BLOCK shape not covered by the recent Unicode fixtures.
Fix: Add one parser-core regression fixture for DBI.pm's dbd_class_registry map/grep/keys expression.
Verification:
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked dbi_registry_map_block_over_grep_block -- --nocapture
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture
- cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check
- cargo run --package xtask --profile agent --locked -- update-status --only parser --check
- cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy
- cargo run --package xtask --profile agent --locked -- fmt --check
- git diff --check

Closes #8791