### PR TITLE
test(parser): lock ExtUtils bootstrap join-map fixture (#8793)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -597,6 +597,17 @@ fn dbi_registry_map_block_over_grep_block() {
 }
 
 #[test]
+fn extutils_mm_unix_bootstrap_join_interpolated_map() {
+    // From ExtUtils::MM_Unix: a return join list may contain an interpolated
+    // map block in one string and a separate adjacent map block item.
+    assert_clean_parse(
+        r#"return join "\n",
+        "BOOTSTRAP = @{[map { qq{$_.bs} } @exts]}\n",
+        map { $self->_xs_make_bs($_) } @exts;"#,
+    );
+}
+
+#[test]
 fn regexp_common_comment_combine_parenthesized_map_args() {
     // From Regexp::Common::comment: unary plus before a parenthesized map block
     // in a comma-separated argument list must not leave `combine` waiting for a `)`.


### PR DESCRIPTION
Problem: The parser capability handoff still points at the unclosed_paren_identifier raw bucket, and ExtUtils::MM_Unix carries a source-backed return join list with both interpolated and adjacent map BLOCK expressions.
Fix: Add one parser-core regression fixture for the ExtUtils::MM_Unix bootstrap join/map shape.
Verification:
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked extutils_mm_unix_bootstrap_join_interpolated_map -- --nocapture
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture
- cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check
- cargo run --package xtask --profile agent --locked -- update-status --only parser --check
- cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy
- cargo run --package xtask --profile agent --locked -- fmt --check
- git diff --check

Closes #8793