### PR TITLE
test(parser): lock Capture Tiny grep comparison fixture (#8795)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -608,6 +608,13 @@ fn extutils_mm_unix_bootstrap_join_interpolated_map() {
 }
 
 #[test]
+fn capture_tiny_return_if_grep_comparison() {
+    // From Capture::Tiny: a postfix-if return condition may compare @_ with a
+    // grep BLOCK expression without treating the block as an unclosed list.
+    assert_clean_parse(r#"return 1 if @_ == grep { -f } @_;"#);
+}
+
+#[test]
 fn regexp_common_comment_combine_parenthesized_map_args() {
     // From Regexp::Common::comment: unary plus before a parenthesized map block
     // in a comma-separated argument list must not leave `combine` waiting for a `)`.


### PR DESCRIPTION
Problem: The parser capability handoff still points at the unclosed_paren_identifier raw bucket, and Capture::Tiny carries a source-backed postfix-if return whose condition compares @_ with a grep BLOCK expression.
Fix: Add one parser-core regression fixture for the Capture::Tiny grep comparison shape.
Verification:
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked capture_tiny_return_if_grep_comparison -- --nocapture
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture
- cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check
- cargo run --package xtask --profile agent --locked -- update-status --only parser --check
- cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy
- cargo run --package xtask --profile agent --locked -- fmt --check
- git diff --check

Closes #8795