### PR TITLE
feat(perl-oracle): add for_language_probe() and migrate perl.debugFile seam (#8685)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -192,6 +192,52 @@ impl PerlOracleEnv {
         })
     }
 
+    /// Constructor for language-level Perl invocations that run on behalf of the user
+    /// but must not be affected by ambient runtime injection.
+    ///
+    /// Use this for LSP-triggered actions such as `perl.debugFile` that launch Perl
+    /// directly but are not system probes and not free-form user scripts.
+    ///
+    /// Semantics:
+    ///
+    /// - `allow_perl5lib`: mirrors `config.use_perl5lib` — the user's explicit opt-in
+    ///   to include `PERL5LIB` in the child environment.  This lets a user's libraries
+    ///   be found when they have configured the LSP to honour `PERL5LIB`, but prevents
+    ///   ambient contamination when they have not.
+    /// - `allow_perl5opt`: always `false` — `PERL5OPT` injects module flags into every
+    ///   Perl invocation and can cause language probes to misbehave or load untested
+    ///   code.  The user's Perl file must be runnable without ambient `-M` injections.
+    /// - `allow_local_lib`: always `false` — use the explicit `perl_path` config rather
+    ///   than ambient `local::lib` activation to locate the interpreter.
+    /// - `timeout`: 30 seconds (generous ceiling for interactive/user-facing actions).
+    /// - `cwd`: caller-supplied (typically the parent directory of the file being
+    ///   processed).
+    /// - `extra_env`: empty.
+    ///
+    /// Returns `None` if the Perl binary cannot be resolved.  The caller should fall
+    /// back to `Command::new("perl")` or surface an actionable error to the user.
+    pub fn for_language_probe(config: &WorkspaceConfig, cwd: PathBuf) -> Option<Self> {
+        use crate::platform::resolve_perl_path_with_toolchain;
+
+        let perl_binary = match config.perl_path.as_deref().filter(|p| !p.is_empty()) {
+            Some(path) => PathBuf::from(path),
+            None => match resolve_perl_path_with_toolchain() {
+                Ok(path) => path,
+                Err(_) => return None,
+            },
+        };
+
+        Some(Self {
+            perl_binary,
+            cwd,
+            timeout: Duration::from_secs(30),
+            allow_perl5lib: config.use_perl5lib,
+            allow_perl5opt: false,
+            allow_local_lib: false,
+            extra_env: BTreeMap::new(),
+        })
+    }
+
     /// Constructor for user-triggered `executeCommand` invocations (`perl.runFile`,
     /// `perl.runTestSub`).
     ///
@@ -244,6 +290,11 @@ pub struct PerlOracleEnv;
 impl PerlOracleEnv {
     /// Returns `None` on WASM (no subprocess support).
     pub fn for_startup_inc_probe(_config: &WorkspaceConfig) -> Option<Self> {
+        None
+    }
+
+    /// Returns `None` on WASM (no subprocess support).
+    pub fn for_language_probe(_config: &WorkspaceConfig, _cwd: std::path::PathBuf) -> Option<Self> {
         None
     }
 
@@ -320,6 +371,104 @@ mod tests {
             assert!(e.allow_perl5opt, "allow_perl5opt must always be true for execute-command");
             assert!(e.allow_local_lib, "allow_local_lib must always be true for execute-command");
         }
+    }
+
+    // ── for_language_probe tests ──────────────────────────────────────────────
+
+    /// `for_language_probe` mirrors `config.use_perl5lib` → `allow_perl5lib`
+    /// and always denies `PERL5OPT` and `local::lib`.
+    #[test]
+    fn for_language_probe_respects_config_flags() {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        let mut config = WorkspaceConfig::default();
+        config.use_perl5lib = true;
+        let env = PerlOracleEnv::for_language_probe(&config, cwd.clone());
+        if let Some(e) = env {
+            assert!(e.allow_perl5lib, "allow_perl5lib must mirror config.use_perl5lib=true");
+            assert!(!e.allow_perl5opt, "allow_perl5opt must always be false for language probe");
+            assert!(!e.allow_local_lib, "allow_local_lib must always be false for language probe");
+        }
+
+        config.use_perl5lib = false;
+        let env = PerlOracleEnv::for_language_probe(&config, cwd);
+        if let Some(e) = env {
+            assert!(!e.allow_perl5lib, "allow_perl5lib must mirror config.use_perl5lib=false");
+            assert!(!e.allow_perl5opt, "allow_perl5opt must always be false for language probe");
+            assert!(!e.allow_local_lib, "allow_local_lib must always be false for language probe");
+        }
+    }
+
+    /// `for_language_probe` strips `PERL5OPT` even when set in the parent env —
+    /// poisoned-env regression guard for the #8685 seam.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn for_language_probe_strips_perl5opt() -> TestResult {
+        let perl = match perl_path() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let mut config = WorkspaceConfig::default();
+        config.perl_path = Some(perl.to_string_lossy().into_owned());
+
+        let oracle = PerlOracleEnv::for_language_probe(&config, cwd)
+            .ok_or("for_language_probe returned None unexpectedly")?;
+
+        unsafe { std::env::set_var("PERL5OPT", "-Mstrict") };
+        let mut cmd = oracle.into_command();
+        cmd.args(["-e", "print $ENV{PERL5OPT} // 'UNSET'"]);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        let out = cmd.output()?;
+        unsafe { std::env::remove_var("PERL5OPT") };
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert_eq!(
+            stdout.trim(),
+            "UNSET",
+            "PERL5OPT must be stripped by for_language_probe; got: {stdout:?}",
+        );
+        Ok(())
+    }
+
+    /// `for_language_probe` strips `PERL5LIB` when `use_perl5lib=false` —
+    /// poisoned-env regression guard for the #8685 seam.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn for_language_probe_strips_perl5lib_when_disabled() -> TestResult {
+        let perl = match perl_path() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let mut config = WorkspaceConfig::default();
+        config.use_perl5lib = false;
+        config.perl_path = Some(perl.to_string_lossy().into_owned());
+
+        let oracle = PerlOracleEnv::for_language_probe(&config, cwd)
+            .ok_or("for_language_probe returned None unexpectedly")?;
+
+        let poison_dir = tempfile::tempdir()?;
+        let poison_path = poison_dir.path().to_string_lossy().into_owned();
+
+        unsafe { std::env::set_var("PERL5LIB", &poison_path) };
+        let mut cmd = oracle.into_command();
+        cmd.args(["-e", "print $ENV{PERL5LIB} // 'UNSET'"]);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        let out = cmd.output()?;
+        unsafe { std::env::remove_var("PERL5LIB") };
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert_eq!(
+            stdout.trim(),
+            "UNSET",
+            "PERL5LIB must be stripped when use_perl5lib=false; got: {stdout:?}",
+        );
+        Ok(())
     }
 
     /// `for_startup_inc_probe` maps `config.use_perl5lib` → `allow_perl5lib`.

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -955,8 +955,33 @@ impl LspServer {
                     let ext_resolved =
                         crate::execute_command::normalize_path_for_external_command(&resolved);
 
-                    // Launch perl -d as a detached child process
-                    match std::process::Command::new("perl")
+                    // Launch perl -d as a detached child process.
+                    // PerlOracleEnv enforces a deny-all-ambient policy: PERL5OPT and
+                    // local::lib are stripped; PERL5LIB passes through only when the
+                    // user has explicitly opted in via `usePerl5lib` config.
+                    let debug_cwd =
+                        resolved.parent().map(std::path::Path::to_path_buf).unwrap_or_else(|| {
+                            std::env::current_dir()
+                                .unwrap_or_else(|_| std::path::PathBuf::from("."))
+                        });
+                    #[cfg(not(target_arch = "wasm32"))]
+                    let mut debug_cmd = {
+                        use perl_lsp_rs_core::config::PerlOracleEnv;
+                        let debug_config = self.workspace_config.lock().clone();
+                        if let Some(oracle) =
+                            PerlOracleEnv::for_language_probe(&debug_config, debug_cwd)
+                        {
+                            oracle.into_command()
+                        } else {
+                            std::process::Command::new("perl")
+                        }
+                    };
+                    #[cfg(target_arch = "wasm32")]
+                    let mut debug_cmd = {
+                        let _ = debug_cwd;
+                        std::process::Command::new("perl")
+                    };
+                    match debug_cmd
                         .arg("-d")
                         .arg("--")
                         .arg(&ext_resolved)


### PR DESCRIPTION
## Summary

Closes #8685.

Adds `PerlOracleEnv::for_language_probe()` — the missing named constructor for LSP-triggered Perl invocations that are user-facing but must not be contaminated by ambient runtime injection — and uses it to replace the bare `Command::new("perl")` in the `perl.debugFile` handler.

### Problem

The `perl.debugFile` LSP command (`misc.rs:959`) launched `perl -d <file>` using a raw `std::process::Command::new("perl")`. This inherited the entire LSP process environment, meaning:

- `PERL5OPT=-Mevil` in the parent environment would be injected into every `perl -d` invocation.
- `PERL5LIB` would leak regardless of whether the user had set `usePerl5lib = false` in their workspace config.
- `PERL_LOCAL_LIB_ROOT` from an ambient `local::lib` activation would silently affect the debugger.

This is the same failure mode documented in the #8493 incident for the startup `@INC` probe.

### Solution

**New constructor: `PerlOracleEnv::for_language_probe(config, cwd)`**

```
allow_perl5lib   = config.use_perl5lib   // user's explicit opt-in
allow_perl5opt   = false                  // always stripped — deterministic
allow_local_lib  = false                  // always stripped — use config not ambient
timeout          = 30s
```

The constructor reuses the same binary-resolution logic as `for_startup_inc_probe` and `for_execute_command` (config `perl_path` → toolchain resolver → `None`). It falls back to `Command::new("perl")` only when the Perl binary cannot be resolved, preserving the existing user-facing error path.

**Call site migration: `misc.rs` `perl.debugFile` arm**

The `perl -d` launch now:
1. Clones the workspace config (already locked in the outer `handle_execute_command` scope).
2. Derives `cwd` from the resolved file's parent directory.
3. Constructs the `Command` via `PerlOracleEnv::for_language_probe` (falls back to `Command::new("perl")` when resolver returns `None`).
4. Appends `-d -- <file>` and sets stdio to null exactly as before.

**WASM stub**: `for_language_probe` returns `None` on `wasm32`, consistent with all other oracle constructors.

## Files changed

| File | Change |
|------|--------|
| `crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs` | Add `for_language_probe()` constructor + WASM stub + 3 tests |
| `crates/perl-lsp-rs/src/runtime/language/misc.rs` | Migrate `perl.debugFile` from `Command::new("perl")` to `PerlOracleEnv::for_language_probe` |

## Tests added (`perl_oracle_env.rs`)

| Test | What it proves |
|------|---------------|
| `for_language_probe_respects_config_flags` | Struct-level: `allow_perl5lib` mirrors `config.use_perl5lib`; `allow_perl5opt` and `allow_local_lib` are always `false` |
| `for_language_probe_strips_perl5opt` | Subprocess-level: ambient `PERL5OPT=-Mstrict` does NOT leak to the child when `use_perl5lib=false` |
| `for_language_probe_strips_perl5lib_when_disabled` | Subprocess-level: ambient `PERL5LIB=/poison` does NOT leak when `config.use_perl5lib = false` |

All 3 tests skip gracefully when Perl is not installed on the CI host (same pattern as existing oracle tests).

## Verification

```
cargo clippy -p perl-lsp-rs-core -p perl-lsp-rs --lib -- -D warnings   # clean
cargo xtask fmt                                                          # clean
cargo test -p perl-lsp-rs-core --lib -- config::perl_oracle_env         # 11/11 pass
```

## Claim boundary

This PR covers exactly the `misc.rs:959` call site (issue #8685 scope). It does NOT touch:

- `module_resolution.rs` (issue #8686 — production seam already migrated in a prior cycle; the remaining `Command::new` at line 1419 is inside a `#[test]` fn and is a skip-guard, not a seam)
- `bridge_adapter.rs` (issue #8687)
- `debug_adapter/process.rs` (issue #8688)
- TDD support or xtask seams

https://claude.ai/code/session_014HKyfDKeuo6uPMyy92zdKu

---
_Generated by [Claude Code](https://claude.ai/code/session_014HKyfDKeuo6uPMyy92zdKu)_