### PR TITLE
docs(release): centralize active release version sync via xtask (#8799)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These are behavioral and corpus-backed signals, not feature-inventory counts. Pr
 
 | Area | Current signal |
 |---|---:|
-| Release track | `v0.13.4` public-alpha patch |
+| Release track | `v0.14.0` public-alpha patch |
 | Published crate surface | 31 crates in `[workspace.metadata.publish.allow]` |
 | Ubuntu system Perl corpus | 94.5% clean (`2825/2990`) |
 | CPAN top 1000 corpus | 95.3% clean (`8931/9372`) |

--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -24,11 +24,11 @@
 
 | Metric | Value | Source |
 | --- | --- | --- |
-| **Workspace version line** | `v0.13.2` | [`Cargo.toml`](../../Cargo.toml) |
-| **Current release train** | `v0.13.2` public-alpha patch prep | [docs/releases/v0.13.2.md](../releases/v0.13.2.md) |
+| **Workspace version line** | `v0.14.0` | [`Cargo.toml`](../../Cargo.toml) |
+| **Current release train** | `v0.14.0` public-alpha patch prep | [docs/releases/v0.14.0.md](../releases/v0.14.0.md) |
 | **Published crate surface** | 31 crates | [`[workspace.metadata.publish.allow]`](../../Cargo.toml) |
 | **Release history** | [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) | Canonical cross-channel ledger |
-| **Active milestone** | `v0.13.2` release proof and channel prep | [status/index.md](status/index.md) |
+| **Active milestone** | `v0.14.0` release proof and channel prep | [status/index.md](status/index.md) |
 | **Merge gate** | `nix develop -c just ci-gate` | [protocols/verification.md](protocols/verification.md) |
 | **LSP Coverage** | See [status/lsp.md](status/lsp.md) | Generated per-merge |
 | **Test counts** | See [status/tests.md](status/tests.md) | Generated per-merge |

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -9,12 +9,12 @@
 ## Current Framing
 
 - Workspace version line: `v0.14.0`
-- Current release train: `v0.13.4` public-alpha patch prep, with release dispatch intentionally pending
+- Current release train: `v0.14.0` public-alpha patch prep, with release dispatch intentionally pending
 - Published crate surface target: 31 crates from `[workspace.metadata.publish.allow]`
 - Active work: finish release-prep verification, keep install-surface receipts wired into the runbook, and keep release language public-alpha rather than stable/GA
 - Canonical local receipt: `nix develop -c just ci-gate`
 
-Publication discipline: `v0.13.4` uses a normal SemVer package version for release channels while the human-facing product posture remains public alpha. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the cross-channel ledger, and do not dispatch the release until the prep checks pass.
+Publication discipline: `v0.14.0` uses a normal SemVer package version for release channels while the human-facing product posture remains public alpha. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the cross-channel ledger, and do not dispatch the release until the prep checks pass.
 
 ## How To Read This File
 
@@ -90,7 +90,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - End-to-end LSP feature development guide (#3027, PR #3115)
 - GIF recording guide and asset structure (#2336, PR #3130)
 
-## Active: Public-Alpha Release Prep (v0.13.2)
+## Active: Public-Alpha Release Prep (v0.14.0)
 
 - GitHub Release, crates.io, Docker, VS Code Marketplace, Open VSX, and Homebrew tap receipts are tracked separately
 - The owned Homebrew path is `brew install effortlessmetrics/tap/perllsp`
@@ -99,7 +99,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 
 ## Now / Next / Later
 
-### Now (v0.13.2 public-alpha patch prep)
+### Now (v0.14.0 public-alpha patch prep)
 
 - CI/control-plane Wave 2 substrate already landed and should not be re-implemented in parallel follow-up PRs:
   - Per-gate timeout regression coverage in gate receipts (#7525)
@@ -116,7 +116,7 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
   6. Merge-train planner/receipt protocol with stop conditions
   7. Tokmd advisory stabilization (explicitly non-required while calibrating signal)
 - Wave guardrails: no bulk stale-closure automation, no full merge bot scope, no global pre-push hooks, no broad CI architecture rewrite in this pass.
-- `v0.13.2` is staged as the next public-alpha patch release; run the release-prep checks before dispatching the train
+- `v0.14.0` is staged as the next public-alpha patch release; run the release-prep checks before dispatching the train
 - Pre-announcement license badge fix (PR #3193): canonical SPDX text in all 126 LICENSE files
 - Pre-announcement Docker arm64 timeout fix (#3188 → PR #3191, merged)
 - Per-release dependency triage: 7 dependabot PRs merged 2026-04-07 (#3178–#3184)
@@ -129,9 +129,9 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Semantic substrate migration status now tracks Wave 2/Wave 3 reality in [SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md](SEMANTIC_SUBSTRATE_FIRST_WAVE_PLAN.md): core semantic facts, HIR-backed `ImportSpec` / `ExportSet`, `visible_symbols_at`, and shadow receipts have fixture evidence; fact-source trace receipts are in place, and provider cutover now has narrow diagnostics and hover live-with-fallback behavior plus shadow/provenance receipts for completion, definition/reference, rename, safe-delete, workspace symbols, document symbols, and semantic tokens. The longer compiler-backed LSP direction is tracked in [COMPILER_BACKED_LSP_ROADMAP.md](COMPILER_BACKED_LSP_ROADMAP.md), with lane status in [COMPILER_CAPABILITY_STATUS.md](COMPILER_CAPABILITY_STATUS.md), fact-layer state in [compiler_facts.md](status/compiler_facts.md), and provider staging in [provider_cutover.md](status/provider_cutover.md). The import/export proof lane [#8264](https://github.com/EffortlessMetrics/perl-lsp/issues/8264), compile-environment state lane [#8280](https://github.com/EffortlessMetrics/perl-lsp/issues/8280), Exporter adapter registry lane [#8245](https://github.com/EffortlessMetrics/perl-lsp/issues/8245), first compile-effect log slice [#8291](https://github.com/EffortlessMetrics/perl-lsp/pull/8291), symbolic-ref boundary slice [#8297](https://github.com/EffortlessMetrics/perl-lsp/pull/8297), differential oracle proof [#8300](https://github.com/EffortlessMetrics/perl-lsp/pull/8300), provider fact-source trace receipts [#8305](https://github.com/EffortlessMetrics/perl-lsp/pull/8305), diagnostics proof/cutover [#8319](https://github.com/EffortlessMetrics/perl-lsp/issues/8319) / [#8327](https://github.com/EffortlessMetrics/perl-lsp/issues/8327), completion proof [#8342](https://github.com/EffortlessMetrics/perl-lsp/pull/8342), hover proof [#8344](https://github.com/EffortlessMetrics/perl-lsp/pull/8344), hover live provenance slice [#8369](https://github.com/EffortlessMetrics/perl-lsp/issues/8369), definition/reference proof [#8349](https://github.com/EffortlessMetrics/perl-lsp/pull/8349), rename/safe-delete proof [#8351](https://github.com/EffortlessMetrics/perl-lsp/pull/8351), workspace-symbol source/freshness proof [#8353](https://github.com/EffortlessMetrics/perl-lsp/issues/8353), document-symbol source/freshness proof [#8359](https://github.com/EffortlessMetrics/perl-lsp/issues/8359), and semantic-token source/freshness proof [#8360](https://github.com/EffortlessMetrics/perl-lsp/issues/8360) are complete; broader real-Perl conformance expansion remains tracked under [#8199](https://github.com/EffortlessMetrics/perl-lsp/issues/8199).
 - CI/control-plane next-wave execution sequencing is tracked in [CI_WAVE_EXECUTION_PLAN.md](CI_WAVE_EXECUTION_PLAN.md), with #7404 (`update-status --write` streaming) as the top urgency lane.
 
-### Next (post v0.13.2)
+### Next (post v0.14.0)
 
-- The 0.12.x line has built confidence across parser, diagnostics, refactoring, and distribution
+- The 0.13.x line has built confidence across parser, diagnostics, refactoring, and distribution
 - Resume parser, corpus, semantic, and DAP hardening after the release-channel receipts close
 - Run the editor-trust wave through [EDITOR_TRUST_WAVE.md](EDITOR_TRUST_WAVE.md): one lane, one canonical PR, one acceptance checklist, one verification receipt
 - Keep the install story verified across all distribution channels
@@ -178,7 +178,13 @@ Initial public alpha announcement. The 0.12.x line built confidence
 across parser corpus, diagnostics, refactoring, and distribution.
 0.13.0 is the announcement version.
 
-### Beyond v0.13.0
+### v0.14.0
+
+Public-alpha minor release train in progress for the Rust 1.95 MSRV line.
+RP-1 (readiness queue) is complete and RP-2 (dry-run publish readiness)
+is open on `master` readiness tracking.
+
+### Beyond v0.14.0
 
 - Stability contract for APIs and advertised wire behavior
 - Performance hardening for larger workspaces
@@ -213,4 +219,4 @@ For live capability posture, run `just status-check` or read [CURRENT_STATUS.md]
 | Evidence-backed metrics | [CURRENT_STATUS.md](CURRENT_STATUS.md) |
 | Top-level summary docs | [../../ROADMAP.md](../../ROADMAP.md), [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) |
 
-<!-- Last Updated: 2026-05-01 -->
+<!-- Last Updated: 2026-05-12 -->

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -5,7 +5,7 @@
 
 ## What's True Right Now
 
-- **Release posture**: `v0.13.2` is staged as the next public-alpha patch train. The workspace version line is `v0.13.2`, the published crate surface is 31 crates, and release dispatch is intentionally pending until the prep checks pass.
+- **Release posture**: `v0.14.0` is staged as the next public-alpha patch train. The workspace version line is `v0.14.0`, the published crate surface is 31 crates, and release dispatch is intentionally pending until the prep checks pass.
 - **Status discipline**: this file is for narrative, subsystem files are for evidence, and `just status-update` plus `just status-check` are the anti-drift workflow
 - **LSP server**: `features.toml` is the canonical capability catalog; 58 user-visible features at 100% coverage (116/116 including plumbing protocol methods and DAP handlers — corrected in PR #4107 after the DAP catalog undercount audit) — computed coverage is generated from it
 - **Test infrastructure**: `nix develop -c just ci-gate` is the canonical merge receipt and `cargo xtask ignored-tests` is the tracked-test-debt source
@@ -37,14 +37,14 @@
 
 ## What's Next
 
-**Now (active milestone: v0.13.2 public-alpha release prep)**
-- Run the `v0.13.2` release-prep checks before dispatching release orchestration
+**Now (active milestone: v0.14.0 public-alpha release prep)**
+- Run the `v0.14.0` release-prep checks before dispatching release orchestration
 - Keep public-alpha wording consistent: package versions use normal SemVer, but the product posture is not stable/GA
 - Keep the three parser verification lanes explicit and green: `just corpus-sweep-check`, `just cpan-corpus-check`, and `just parser-audit`, with `just common-corpus-check` covering the pinned strict-clean subset
-- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line, the `perl-lsp-rs` extension package, and the 32-crate published surface
+- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line, the `perl-lsp-rs` extension package, and the 31-crate published surface
 - Keep Homebrew, GitHub release assets, VS Code Marketplace, and Open VSX install receipts explicit in the release closeout
 
-**Next (post v0.13.2 public alpha)**
+**Next (post v0.14.0 public alpha)**
 - Keep all three parser corpus lanes current: Ubuntu system Perl, the cached CPAN top 1000 install, and the repo-owned corpus audit
 - Fold internal torture and edge-case suites into routine verification receipts
 - Resume parser, corpus, semantic, and DAP hardening after the release-channel receipts are closed
@@ -77,5 +77,5 @@ See [ROADMAP.md](../ROADMAP.md) for milestone details.
 
 ---
 
-*Last Updated: 2026-05-01 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
+*Last Updated: 2026-05-12 (narrative sections only; run `just status-update` to refresh subsystem metrics)*
 *Canonical docs: [ROADMAP.md](../ROADMAP.md), [../../features.toml](../../features.toml)*

--- a/docs/project/status/release.md
+++ b/docs/project/status/release.md
@@ -5,8 +5,8 @@
 
 ## Current Release Call
 
-**Current release train**: `v0.13.2` public-alpha patch prep
-**Workspace version line**: `v0.13.2`
+**Current release train**: `v0.14.0` public-alpha patch prep
+**Workspace version line**: `v0.14.0`
 **Published crate surface**: 31 crates
 **Release target**: channel verification across GitHub Releases, crates.io, Docker, VS Code Marketplace, Open VSX, and the owned Homebrew tap
 **Ship readiness**: release dispatch is intentionally pending. Run the release-prep checks, then use release orchestration only after the prep PR is merged.
@@ -14,7 +14,14 @@
 ## Active Blockers
 
 - No known install-surface blocker after the Homebrew, GNU/musl, installer, and VS Code managed-binary guards landed
-- Remaining work is operational: finish `v0.13.2` prep verification, then publish and record final channel receipts
+- Remaining work is operational: finish `v0.14.0` prep verification, then publish and record final channel receipts
+
+## 0.14.0 Prep Receipts (2026-05-12)
+
+- Release notes file: `docs/releases/0.14.0.md`
+- Changelog entry: `CHANGELOG.md` `[0.14.0]`
+- Version surfaces: workspace crates, feature catalog metadata, and VS Code extension package staged at `0.14.0`
+- Required pre-dispatch checks: version sync, release-history gating, release surface verification, release artifact checks, and install/receipts coverage (see [0.14.0 readiness queue](../../releases/0.14.0-readiness.md))
 
 ## 0.13.2 Prep Receipts (2026-05-02)
 
@@ -85,4 +92,4 @@ Native + Bridge preview. Harden preview flows is active work.
 
 ---
 
-*Last Updated: 2026-05-10*
+*Last Updated: 2026-05-12*

--- a/justfile
+++ b/justfile
@@ -2402,6 +2402,11 @@ release-build:
 version-check:
     @cargo xtask check-version-sync
 
+# Sync active release narrative docs (version + published crate surface count)
+# from `Cargo.toml` and `[workspace.metadata.publish.allow]`.
+sync-release-docs:
+    @cargo xtask sync-release-docs --write
+
 # Bump the workspace version across every tracked site.
 #
 # Usage: just bump-version 0.13.0

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -496,6 +496,13 @@ enum Commands {
     /// Run version-sync checks from `perl-ci-hygiene`.
     CheckVersionSync,
 
+    /// Sync active release narrative docs from workspace version and publish count.
+    SyncReleaseDocs {
+        /// Write synced files (omit to run a dry check).
+        #[arg(long)]
+        write: bool,
+    },
+
     /// Check for disallowed direct `ExitStatus::from_raw()` usage.
     CheckFromRaw,
 
@@ -2560,6 +2567,7 @@ fn main() -> Result<()> {
             workflow_trigger_lint::run(policy, receipt, fixture, format)
         }
         Commands::CheckVersionSync => check_version_sync::run(),
+        Commands::SyncReleaseDocs { write } => sync_release_docs::run(write),
         Commands::CheckFromRaw => ci_policy::check_from_raw(),
         Commands::CheckMemoryLifecyclePolicy => ci_policy::check_memory_lifecycle(),
         Commands::CheckMemoryRetainedOwnerDrift { base, report_only } => {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -98,6 +98,7 @@ pub mod semantic_scorecard;
 pub mod semantic_shadow_compare;
 pub mod srp_microcrates;
 pub mod swarm_summary;
+pub mod sync_release_docs;
 pub mod targeted_checks;
 pub mod test;
 pub mod test_lsp;

--- a/xtask/src/tasks/sync_release_docs.rs
+++ b/xtask/src/tasks/sync_release_docs.rs
@@ -1,0 +1,406 @@
+//! Keep release narrative docs synchronized from one source of truth.
+//!
+//! The workspace version is read from `Cargo.toml` and the published crate
+//! surface count is derived from `[workspace.metadata.publish.allow]`.
+//! This keeps active narrative docs aligned with the true release surface without
+//! hand-editing version/count literals.
+
+use crate::utils::project_root;
+use color_eyre::eyre::{Context, Result, bail};
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml::Value;
+
+/// Values used to hydrate release narrative files.
+#[derive(Debug)]
+struct ReleaseSurface {
+    version: String,
+    published_crate_count: usize,
+}
+
+/// Synchronize active release docs from workspace-derived values.
+pub fn run(write: bool) -> Result<()> {
+    let root = project_root()?;
+    let surface = collect_release_surface(&root)?;
+
+    let mut changed_files: Vec<(PathBuf, String)> = Vec::new();
+
+    apply_sync(
+        &root.join("README.md"),
+        |content| sync_readme(content, &surface),
+        &mut changed_files,
+    )?;
+    apply_sync(
+        &root.join("docs/project/CURRENT_STATUS.md"),
+        |content| sync_current_status(content, &surface),
+        &mut changed_files,
+    )?;
+    apply_sync(
+        &root.join("docs/project/ROADMAP.md"),
+        |content| sync_roadmap(content, &surface),
+        &mut changed_files,
+    )?;
+    apply_sync(
+        &root.join("docs/project/status/index.md"),
+        |content| sync_status_index(content, &surface),
+        &mut changed_files,
+    )?;
+    apply_sync(
+        &root.join("docs/project/status/release.md"),
+        |content| sync_release_notes(content, &surface),
+        &mut changed_files,
+    )?;
+
+    if changed_files.is_empty() {
+        println!("Release docs are in sync.");
+        return Ok(());
+    }
+
+    if write {
+        for (path, content) in &changed_files {
+            fs::write(path, content)
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            println!("Updated {}", path.display());
+        }
+        println!("Synced {} file(s) from workspace metadata.", changed_files.len());
+        return Ok(());
+    }
+
+    for (path, _) in &changed_files {
+        eprintln!("{} is out of date", path.display());
+    }
+    bail!("{} release doc file(s) out of date; rerun with --write", changed_files.len());
+}
+
+fn apply_sync<F>(path: &Path, mut sync: F, changed_files: &mut Vec<(PathBuf, String)>) -> Result<()>
+where
+    F: FnMut(&str) -> Result<String>,
+{
+    let current =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let updated = sync(&current)?;
+    if updated != current {
+        changed_files.push((path.to_path_buf(), updated));
+    }
+    Ok(())
+}
+
+fn collect_release_surface(root: &Path) -> Result<ReleaseSurface> {
+    let cargo_toml = root.join("Cargo.toml");
+    let raw = fs::read_to_string(&cargo_toml)
+        .with_context(|| format!("reading {}", cargo_toml.display()))?;
+    let parsed: Value = toml::from_str(&raw).context("parsing Cargo.toml")?;
+
+    let version = parsed
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|pkg| pkg.get("version"))
+        .and_then(toml::Value::as_str)
+        .map(|v| v.to_string())
+        .ok_or_else(|| {
+            color_eyre::eyre::eyre!("Cargo.toml is missing [workspace.package].version")
+        })?;
+
+    let publish_allow = parsed
+        .get("workspace")
+        .and_then(|workspace| workspace.get("metadata"))
+        .and_then(|metadata| metadata.get("publish"))
+        .and_then(|publish| publish.get("allow"))
+        .and_then(toml::Value::as_array)
+        .ok_or_else(|| {
+            color_eyre::eyre::eyre!("Cargo.toml is missing [workspace.metadata.publish.allow]")
+        })?;
+
+    let published_crate_count = publish_allow.len();
+    if published_crate_count == 0 {
+        bail!("publish allowlist is empty");
+    }
+
+    Ok(ReleaseSurface { version, published_crate_count })
+}
+
+fn sync_readme(content: &str, surface: &ReleaseSurface) -> Result<String> {
+    let mut release_track_seen = false;
+    let mut published_surface_seen = false;
+
+    let mut lines: Vec<String> = Vec::new();
+    for line in content.lines() {
+        if line.starts_with("| Release track | `") {
+            lines.push(format!("| Release track | `v{}` public-alpha patch |", surface.version));
+            release_track_seen = true;
+        } else if line.starts_with("| Published crate surface | ") {
+            lines.push(format!(
+                "| Published crate surface | {} crates in `[workspace.metadata.publish.allow]` |",
+                surface.published_crate_count
+            ));
+            published_surface_seen = true;
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+
+    if !release_track_seen {
+        bail!("README.md: release track line not found");
+    }
+    if !published_surface_seen {
+        bail!("README.md: published crate surface line not found");
+    }
+    Ok(restore_trailing_newline(content, &lines))
+}
+
+fn sync_current_status(content: &str, surface: &ReleaseSurface) -> Result<String> {
+    let mut version_seen = false;
+    let mut train_seen = false;
+    let mut count_seen = false;
+    let mut milestone_seen = false;
+
+    let mut lines: Vec<String> = Vec::new();
+    for line in content.lines() {
+        if line.starts_with("| **Workspace version line** | ") {
+            lines.push(format!(
+                "| **Workspace version line** | `v{}` | [`Cargo.toml`](../../Cargo.toml) |",
+                surface.version
+            ));
+            version_seen = true;
+        } else if line.starts_with("| **Current release train** | ") {
+            lines.push(format!(
+                "| **Current release train** | `v{}` public-alpha patch prep | [docs/releases/v{}.md](../releases/v{}.md) |",
+                surface.version, surface.version, surface.version
+            ));
+            train_seen = true;
+        } else if line.starts_with("| **Published crate surface** | ") {
+            lines.push(format!(
+                "| **Published crate surface** | {} crates | [`[workspace.metadata.publish.allow]`](../../Cargo.toml) |",
+                surface.published_crate_count
+            ));
+            count_seen = true;
+        } else if line.starts_with("| **Active milestone** | `") {
+            lines.push(format!(
+                "| **Active milestone** | `v{}` release proof and channel prep | [status/index.md](status/index.md) |",
+                surface.version
+            ));
+            milestone_seen = true;
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+
+    if !version_seen {
+        bail!("CURRENT_STATUS.md: workspace version row not found");
+    }
+    if !train_seen {
+        bail!("CURRENT_STATUS.md: current release train row not found");
+    }
+    if !count_seen {
+        bail!("CURRENT_STATUS.md: published crate surface row not found");
+    }
+    if !milestone_seen {
+        bail!("CURRENT_STATUS.md: active milestone row not found");
+    }
+    Ok(restore_trailing_newline(content, &lines))
+}
+
+fn sync_roadmap(content: &str, surface: &ReleaseSurface) -> Result<String> {
+    let mut workspace_version_seen = false;
+    let mut current_release_seen = false;
+    let mut published_surface_seen = false;
+    let mut publication_discipline_seen = false;
+    let mut active_section_seen = false;
+    let mut now_section_seen = false;
+    let mut now_gate_seen = false;
+    let mut next_header_seen = false;
+
+    let mut lines: Vec<String> = Vec::new();
+    for line in content.lines() {
+        if line.starts_with("- Workspace version line: `v") {
+            lines.push(format!("- Workspace version line: `v{}`", surface.version));
+            workspace_version_seen = true;
+        } else if line.starts_with("- Current release train: `v") {
+            lines.push(format!(
+                "- Current release train: `v{}` public-alpha patch prep, with release dispatch intentionally pending",
+                surface.version
+            ));
+            current_release_seen = true;
+        } else if line.starts_with("- Published crate surface target: ") {
+            lines.push(format!(
+                "- Published crate surface target: {} crates from `[workspace.metadata.publish.allow]`",
+                surface.published_crate_count
+            ));
+            published_surface_seen = true;
+        } else if line.starts_with("Publication discipline: `v") {
+            lines.push(format!(
+                "Publication discipline: `v{}` uses a normal SemVer package version for release channels while the human-facing product posture remains public alpha. See [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md) for the cross-channel ledger, and do not dispatch the release until the prep checks pass.",
+                surface.version
+            ));
+            publication_discipline_seen = true;
+        } else if line.starts_with("## Active: Public-Alpha Release Prep (v") {
+            lines.push(format!(
+                "## Active: Public-Alpha Release Prep (v{})",
+                surface.version
+            ));
+            active_section_seen = true;
+        } else if line.starts_with("### Now (v") && line.contains("public-alpha patch prep)") {
+            lines.push(format!("### Now (v{} public-alpha patch prep)", surface.version));
+            now_section_seen = true;
+        } else if line.starts_with("- `v") && line.contains("is staged as the next public-alpha patch release; run the release-prep checks before dispatching the train") {
+            lines.push(format!(
+                "- `v{}` is staged as the next public-alpha patch release; run the release-prep checks before dispatching the train",
+                surface.version
+            ));
+            now_gate_seen = true;
+        } else if line.starts_with("### Next (post v") {
+            lines.push(format!("### Next (post v{})", surface.version));
+            next_header_seen = true;
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+
+    if !workspace_version_seen {
+        bail!("ROADMAP.md: workspace version line not found");
+    }
+    if !current_release_seen {
+        bail!("ROADMAP.md: current release train line not found");
+    }
+    if !published_surface_seen {
+        bail!("ROADMAP.md: published crate surface target line not found");
+    }
+    if !publication_discipline_seen {
+        bail!("ROADMAP.md: publication discipline line not found");
+    }
+    if !active_section_seen {
+        bail!("ROADMAP.md: Active: Public-Alpha Release Prep heading not found");
+    }
+    if !now_section_seen {
+        bail!("ROADMAP.md: current-release Now section not found");
+    }
+    if !now_gate_seen {
+        bail!("ROADMAP.md: release-prep check gate line not found");
+    }
+    if !next_header_seen {
+        bail!("ROADMAP.md: Next (post ...) heading not found");
+    }
+    Ok(restore_trailing_newline(content, &lines))
+}
+
+fn sync_status_index(content: &str, surface: &ReleaseSurface) -> Result<String> {
+    let mut release_posture_seen = false;
+    let mut now_section_seen = false;
+    let mut now_gate_seen = false;
+    let mut published_surface_bullet_seen = false;
+    let mut next_section_seen = false;
+
+    let mut lines: Vec<String> = Vec::new();
+    for line in content.lines() {
+        if line.starts_with("- **Release posture**: `v") {
+            lines.push(format!(
+                "- **Release posture**: `v{}` is staged as the next public-alpha patch train. The workspace version line is `v{}`, the published crate surface is {} crates, and release dispatch is intentionally pending until the prep checks pass.",
+                surface.version, surface.version, surface.published_crate_count
+            ));
+            release_posture_seen = true;
+        } else if line.starts_with("**Now (active milestone: v") {
+            lines.push(format!(
+                "**Now (active milestone: v{} public-alpha release prep)**",
+                surface.version
+            ));
+            now_section_seen = true;
+        } else if line.starts_with("- Run the `v")
+            && line.contains(" release-prep checks before dispatching release orchestration")
+        {
+            lines.push(format!(
+                "- Run the `v{}` release-prep checks before dispatching release orchestration",
+                surface.version
+            ));
+            now_gate_seen = true;
+        } else if line.contains("published surface")
+            && line.starts_with("- Keep the top-level README")
+        {
+            lines.push(format!(
+                "- Keep the top-level README, status docs, and release runbooks aligned with the actual `perllsp` asset line, the `perl-lsp-rs` extension package, and the {}-crate published surface",
+                surface.published_crate_count
+            ));
+            published_surface_bullet_seen = true;
+        } else if line.starts_with("**Next (post v") {
+            lines.push(format!("**Next (post v{} public alpha)**", surface.version));
+            next_section_seen = true;
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+
+    if !release_posture_seen {
+        bail!("status/index.md: release posture line not found");
+    }
+    if !now_section_seen {
+        bail!("status/index.md: now section heading not found");
+    }
+    if !now_gate_seen {
+        bail!("status/index.md: now release-prep checks line not found");
+    }
+    if !published_surface_bullet_seen {
+        bail!("status/index.md: published-surface alignment line not found");
+    }
+    if !next_section_seen {
+        bail!("status/index.md: next section heading not found");
+    }
+    Ok(restore_trailing_newline(content, &lines))
+}
+
+fn sync_release_notes(content: &str, surface: &ReleaseSurface) -> Result<String> {
+    let mut train_seen = false;
+    let mut workspace_seen = false;
+    let mut surface_seen = false;
+    let mut remaining_seen = false;
+
+    let mut lines: Vec<String> = Vec::new();
+    for line in content.lines() {
+        if line.starts_with("**Current release train**: `v") {
+            lines.push(format!(
+                "**Current release train**: `v{}` public-alpha patch prep",
+                surface.version
+            ));
+            train_seen = true;
+        } else if line.starts_with("**Workspace version line**: `v") {
+            lines.push(format!("**Workspace version line**: `v{}`", surface.version));
+            workspace_seen = true;
+        } else if line.starts_with("**Published crate surface**: ") {
+            lines.push(format!(
+                "**Published crate surface**: {} crates",
+                surface.published_crate_count
+            ));
+            surface_seen = true;
+        } else if line.starts_with("- Remaining work is operational: finish `v")
+            && line.contains(" prep verification, then publish and record final channel receipts")
+        {
+            lines.push(format!(
+                "- Remaining work is operational: finish `v{}` prep verification, then publish and record final channel receipts",
+                surface.version
+            ));
+            remaining_seen = true;
+        } else {
+            lines.push(line.to_string());
+        }
+    }
+
+    if !train_seen {
+        bail!("status/release.md: current release train line not found");
+    }
+    if !workspace_seen {
+        bail!("status/release.md: workspace version line not found");
+    }
+    if !surface_seen {
+        bail!("status/release.md: published crate surface line not found");
+    }
+    if !remaining_seen {
+        bail!("status/release.md: remaining blockers prep verification line not found");
+    }
+    Ok(restore_trailing_newline(content, &lines))
+}
+
+fn restore_trailing_newline(original: &str, lines: &[String]) -> String {
+    let mut updated = lines.join("\n");
+    if original.ends_with('\n') {
+        updated.push('\n');
+    }
+    updated
+}


### PR DESCRIPTION
Problem: Release-tracking docs had hand-maintained version numbers and crate counts that were already out of sync with workspace state.
Fix: Add `cargo xtask sync-release-docs` to compute workspace version and publish-surface count from `Cargo.toml`, then sync active release narratives from that control plane.
Verification: `cargo xtask sync-release-docs --write` is clean; `cargo xtask check-version-sync` reports 42/42 hard sites in agreement on `0.14.0`.