### PR TITLE
test(parser): lock Capture Tiny stash map fixture (#8798)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -615,6 +615,13 @@ fn capture_tiny_return_if_grep_comparison() {
 }
 
 #[test]
+fn capture_tiny_stash_map_list_assignment() {
+    // From Capture::Tiny: lexical list assignment may consume a map BLOCK over
+    // a qw list without leaving the parenthesized declaration open.
+    assert_clean_parse(r#"my ($fh, $pos) = map { $stash->{$_}{$name} } qw/capture pos/;"#);
+}
+
+#[test]
 fn regexp_common_comment_combine_parenthesized_map_args() {
     // From Regexp::Common::comment: unary plus before a parenthesized map block
     // in a comma-separated argument list must not leave `combine` waiting for a `)`.


### PR DESCRIPTION
Problem: The parser capability handoff still points at the `unclosed_paren_identifier` bucket under heredoc/delimiter handling, and Capture::Tiny has a distinct source-backed map BLOCK assignment shape worth locking.

Fix: Add one parser-core regression fixture for Capture::Tiny's lexical list assignment from `map { ... } qw/.../`.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked capture_tiny_stash_map_list_assignment -- --nocapture`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo run --package xtask --profile agent --locked -- metrics parser-accuracy --check`
- `cargo run --package xtask --profile agent --locked -- update-status --only parser --check`
- `cargo run --package xtask --profile agent --locked -- metrics ratchet-check parser_accuracy`
- `cargo run --package xtask --profile agent --locked -- fmt --check`
- `git diff --check`