### PR TITLE
docs: define perl-lsp source-of-truth model (#8801)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,7 +202,9 @@ agents/
 
 # Old review/planning artifacts
 review/
-plans/
+plans/*
+!plans/real-perl-editor-trust/
+!plans/real-perl-editor-trust/README.md
 scanner_comparison/
 issue_updates/
 

--- a/.perl-lsp/goals/README.md
+++ b/.perl-lsp/goals/README.md
@@ -1,0 +1,64 @@
+# Active Goals
+
+Active goals are machine-readable current-state manifests for `perl-lsp` lanes.
+They let agents identify the current objective, active work item, proof commands,
+and status pointers without scraping chat or hand-maintained narrative.
+
+| Layer | Owns | Must not do |
+|---|---|---|
+| Active goal | Machine-readable current work, status pointers, active work-item IDs, proof command list | Prose-only strategy, generated status content, durable design rationale |
+
+## Manifest Contract
+
+The active manifest should live at `.perl-lsp/goals/active.toml`. Future archived
+manifests should move under `.perl-lsp/goals/archive/`.
+
+An active manifest should include:
+
+- stable lane ID and title
+- active/inactive status
+- objective and end state
+- current work items
+- links to the relevant proposal, spec, ADR, plan, and status docs
+- proof commands that define the current checkable boundary
+
+## Status Pointers
+
+Goal manifests point at status docs; they do not copy generated state. Preferred
+current-state pointers for Real Perl Editor Trust are:
+
+- [parser accuracy next](../../docs/project/status/parser_accuracy_next.md)
+- [parser status](../../docs/project/status/parser.md)
+- [provider cutover](../../docs/project/status/provider_cutover.md)
+- [semantic scorecard](../../docs/project/status/semantic_scorecard.md)
+- [semantic shadow compare](../../docs/project/status/semantic_shadow_compare.md)
+- [UX capability dashboard](../../docs/project/status/ux_capability_dashboard.md)
+
+## Minimal Shape
+
+```toml
+id = "plsp-real-perl-editor-trust"
+title = "Real Perl editor trust"
+status = "active"
+owner = "codex-swarm"
+created = "YYYY-MM-DD"
+
+objective = """
+State the active lane objective.
+"""
+
+end_state = [
+  "State a checkable lane outcome.",
+]
+
+[[work_item]]
+id = "work-item-id"
+status = "active"
+spec = "docs/specs/PLSP-SPEC-####-short-name.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md"
+current_pointer = "docs/project/status/parser_accuracy_next.md"
+current_status = "docs/project/status/parser.md#raw-failure-buckets"
+commands = [
+  "cargo xtask update-status --only parser --check",
+]
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,6 +2,30 @@
 
 This directory contains Architecture Decision Records (ADRs) for significant design decisions in the Perl LSP project.
 
+## Source-of-Truth Layer
+
+ADRs describe durable decisions: the architecture, policy, or operating model
+that the repo should continue to follow after the current PR queue has moved
+on.
+
+| Layer | Owns | Must not do |
+|---|---|---|
+| ADR | Durable decision, context, considered options, consequences, follow-up obligations | Test queue, raw worklist, point-in-time metric claims, PR sequencing |
+
+Use ADRs for decisions that change how maintainers and agents interpret the
+repo. For lane execution, link ADRs to proposals, specs, plans, and current
+status surfaces instead of copying generated status content.
+
+Current generated and human-owned status sources include:
+
+- [parser accuracy next](../project/status/parser_accuracy_next.md)
+- [parser status](../project/status/parser.md)
+- [provider cutover](../project/status/provider_cutover.md)
+- [semantic scorecard](../project/status/semantic_scorecard.md)
+- [semantic shadow compare](../project/status/semantic_shadow_compare.md)
+- [semantic capability dashboard](../project/status/semantic_capability_dashboard.md)
+- [UX capability dashboard](../project/status/ux_capability_dashboard.md)
+
 ## ADR Index
 
 ### Legacy Series (0001–0002)
@@ -87,6 +111,6 @@ Architecture Decision Records (ADRs) capture important architectural decisions a
 
 ## Cross-References
 
-- [CLAUDE.md](../CLAUDE.md) - Project overview and capabilities
+- [CLAUDE.md](../../CLAUDE.md) - Project overview and capabilities
 - [CRATE_ARCHITECTURE_GUIDE.md](../reference/CRATE_ARCHITECTURE_GUIDE.md) - System architecture
 - [PARSER_COMPARISON.md](../reference/PARSER_COMPARISON.md) - Parser implementation details

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,61 @@
+# Proposals
+
+Proposals describe why a lane exists: the user pain, product motivation,
+alternatives considered, and success criteria that make the work worth doing.
+They are the PRD layer for `perl-lsp` planning.
+
+| Layer | Owns | Must not do |
+|---|---|---|
+| Proposal | User problem, affected surfaces, success criteria, alternatives, non-goals, claim boundary | PR sequencing, proof command ownership, generated metric state |
+
+## When to Add a Proposal
+
+Add a proposal when a lane changes product direction or combines multiple
+subsystems under one user-facing outcome. A proposal should make the lane useful
+to maintainers, reviewers, and future agents without encoding the implementation
+order.
+
+Proposal files should use the `PLSP-PROP-####-short-name.md` pattern for
+`perl-lsp` lanes. Link the proposal to specs, ADRs, implementation plans, and
+status docs when those artifacts exist.
+
+## Current Status Sources
+
+Generated status remains the source of current facts. Proposals may link to
+these files but should not copy generated tables or point-in-time counts:
+
+- [parser accuracy next](../project/status/parser_accuracy_next.md)
+- [parser status](../project/status/parser.md)
+- [provider cutover](../project/status/provider_cutover.md)
+- [semantic scorecard](../project/status/semantic_scorecard.md)
+- [semantic shadow compare](../project/status/semantic_shadow_compare.md)
+- [semantic capability dashboard](../project/status/semantic_capability_dashboard.md)
+- [UX capability dashboard](../project/status/ux_capability_dashboard.md)
+
+## Template
+
+```md
+# PLSP-PROP-####: Title
+
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Support/status impact:
+Policy impact:
+
+## Problem
+
+## Users and Surfaces
+
+## Success Criteria
+
+## Proposed Shape
+
+## Non-goals
+
+## Evidence Plan
+```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,65 @@
+# Specs
+
+Specs define what must be true for a behavior, status surface, or proof lane.
+They are contracts for acceptance, proof requirements, and claim boundaries.
+
+| Layer | Owns | Must not do |
+|---|---|---|
+| Spec | Behavior contract, acceptance criteria, proof requirements, status interpretation, claim limits | Product motivation, broad roadmap, PR sequence, active queue ownership |
+
+## When to Add a Spec
+
+Add a spec when future work needs a durable contract that reviewers and agents
+can apply across more than one PR. A spec should make it clear how to decide
+whether a change satisfies the lane without requiring chat history.
+
+Spec files for `perl-lsp` lane work should use the
+`PLSP-SPEC-####-short-name.md` pattern. Specs should link to generated status
+docs and human-owned dashboards, but they should not hand-edit or duplicate
+generated sections.
+
+## Acceptance and Proof
+
+Each spec should include:
+
+- the contract being enforced
+- valid and invalid PR shapes when useful
+- proof commands or status checks
+- explicit non-goals
+- claim boundaries for docs, releases, and user-facing behavior
+
+## Current Status Sources
+
+Generated status is current state, not spec text. Link to these files instead
+of copying generated values:
+
+- [parser accuracy next](../project/status/parser_accuracy_next.md)
+- [parser status](../project/status/parser.md)
+- [provider cutover](../project/status/provider_cutover.md)
+- [semantic scorecard](../project/status/semantic_scorecard.md)
+- [semantic shadow compare](../project/status/semantic_shadow_compare.md)
+- [semantic capability dashboard](../project/status/semantic_capability_dashboard.md)
+- [UX capability dashboard](../project/status/ux_capability_dashboard.md)
+
+## Template
+
+```md
+# PLSP-SPEC-####: Title
+
+Status:
+Owner:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Status impact:
+
+## Contract
+
+## Acceptance
+
+## Proof Commands
+
+## Non-goals
+
+## Claim Boundaries
+```

--- a/plans/real-perl-editor-trust/README.md
+++ b/plans/real-perl-editor-trust/README.md
@@ -1,0 +1,55 @@
+# Real Perl Editor Trust Plans
+
+This directory holds implementation plans for the Real Perl Editor Trust lane.
+Plans translate proposals, specs, ADRs, and current status receipts into a
+reviewable PR sequence.
+
+| Layer | Owns | Must not do |
+|---|---|---|
+| Plan | PR order, work-item decomposition, proof commands, rollback notes, issue/PR handoff state | Product claims, durable architecture decisions, generated metric content |
+
+## Lane Scope
+
+Real Perl Editor Trust covers three rails:
+
+- parser compatibility from generated parser status and raw bucket receipts
+- provider trust through confidence, freshness, fallback, and blocker receipts
+- control-plane execution through plans and active goals that future agents can
+  follow without chat history
+
+Plans should link to generated status and receipt files, then state the next
+reviewable unit of work. They should not replace generated status docs or
+rewrite subsystem dashboards.
+
+## Work Item Shape
+
+Each work item should include:
+
+```md
+## Work item: id
+
+Status:
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+Goal
+Production delta
+Non-goals
+Acceptance
+Proof commands
+Rollback
+```
+
+## Current Status Sources
+
+- [parser accuracy next](../../docs/project/status/parser_accuracy_next.md)
+- [parser status](../../docs/project/status/parser.md)
+- [parser failure worklist](../../docs/project/status/parser_accuracy_failure_worklist.md)
+- [provider cutover](../../docs/project/status/provider_cutover.md)
+- [semantic scorecard](../../docs/project/status/semantic_scorecard.md)
+- [semantic shadow compare](../../docs/project/status/semantic_shadow_compare.md)
+- [semantic capability dashboard](../../docs/project/status/semantic_capability_dashboard.md)
+- [UX capability dashboard](../../docs/project/status/ux_capability_dashboard.md)


### PR DESCRIPTION
Problem: The Real Perl Editor Trust lane needs repo-owned places for why, contracts, decisions, PR sequencing, and machine-readable active state so agents do not depend on chat history.\n\nFix: Add source-of-truth README scaffolding for proposals, specs, ADRs, Real Perl Editor Trust plans, and active goals, with status-doc links and layer ownership boundaries. Narrowly unignore the lane plan README while keeping old top-level plan artifacts ignored.\n\nClaim boundary: Docs-only scaffolding. This does not add behavior specs, active.toml, generated status changes, parser fixtures, provider cutover, or corpus-count claims.\n\nVerification:\n- rtk git diff --check\n- rtk python -c 'existence/trailing-whitespace check for the five source-of-truth README files'\n- rtk python -c 'local markdown link check for the five source-of-truth README files'