### PR TITLE
docs(spec): define parser compatibility bucket closeout (#8805)

### DIFF
--- a/docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md
+++ b/docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md
@@ -1,0 +1,144 @@
+# PLSP-SPEC-0001: Parser compatibility bucket closeout
+
+Status: proposed
+Owner: perl-lsp maintainers
+Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked ADRs: planned `PLSP-ADR-0001`
+Linked plan: planned `plans/real-perl-editor-trust/implementation-plan.md`
+Status impact: parser accuracy next, parser status, parser receipts
+
+## Contract
+
+Generated parser status routes parser work.
+
+When [parser accuracy next](../project/status/parser_accuracy_next.md) has active
+failure packets, agents must address those measurement failures before starting
+capability work.
+
+When [parser accuracy next](../project/status/parser_accuracy_next.md) has no
+active failure packets and no measurement gaps, agents must follow
+[parser raw failure buckets](../project/status/parser.md#raw-failure-buckets)
+for capability work. The next parser capability lane is the largest raw bucket
+inside the largest nonzero parser failure cluster unless the implementation
+plan explicitly parks it with a reason.
+
+Generated sections are not hand-edited. Status changes must come from xtask
+generators and be covered by the relevant parser status checks.
+
+## Freshness Rule
+
+Raw bucket counts are point-in-time compatibility data. They can drive
+discovery, but they do not prove current bucket movement unless refreshed.
+
+| Receipt state | Allowed use | Claim boundary |
+|---|---|---|
+| Fresh corpus receipt | Route parser-fix lanes and update bucket counts | May claim bucket count movement when generated status updates prove it |
+| Stale corpus receipt | Discover source-backed fixture shapes | Must not claim bucket count movement |
+| Fixture-only PR | Lock one source-backed real-Perl shape | Must not claim corpus improvement or bucket reduction |
+| Parser-fix PR | Change parser behavior for one narrow failure shape | May claim behavior fix only for covered fixtures until corpus receipt refresh |
+
+Before starting a bucket-count closeout claim, refresh the Linux corpus receipt
+with the corpus sweep command when the required roots are available. When the
+roots are not available, continue with fixture extraction only and state that
+fresh corpus movement is deferred.
+
+## Bucket Lane Shape
+
+Each raw bucket lane must stay PR-sized.
+
+1. Verify current status pointers in `parser_accuracy_next.md` and `parser.md`.
+2. Check receipt freshness in `parser.md#raw-failure-buckets`.
+3. Refresh the Linux corpus receipt when available.
+4. If the receipt cannot be refreshed, extract one focused source-backed fixture.
+5. Add no parser runtime change unless the new fixture fails.
+6. Keep fixture-only PRs separate from parser runtime fixes.
+7. Run focused parser tests and parser status checks.
+8. Regenerate generated status only through xtask commands.
+9. State the claim boundary in the PR body.
+
+## Current Example
+
+The current example bucket is owned by
+[parser raw failure buckets](../project/status/parser.md#raw-failure-buckets).
+At spec creation time, the largest listed raw bucket is
+`unclosed_paren_identifier` under the `heredoc / delimiter handling` cluster.
+This example is illustrative; agents must re-read generated status before
+starting work.
+
+Valid PR shapes:
+
+- `test(parser): lock Unicode::Collate map fixture`
+- `test(parser): lock Regexp::Common map fixture`
+- `test(parser): lock ExtUtils map-list fixture`
+- `test(parser): lock Carp local caller fixture`
+
+Invalid PR shapes:
+
+- broad parser rewrite because a bucket exists
+- bucket-count reduction claim without a fresh generated corpus receipt
+- fixture-only coverage mixed with parser runtime behavior change
+- hand-editing generated parser status
+- combining measurement wiring, corpus refresh, and parser behavior change in
+  one PR
+
+## Acceptance
+
+A parser bucket PR satisfies this spec when:
+
+- the PR names the source status pointer it follows
+- the PR states whether the corpus receipt is fresh or stale
+- fixture-only PRs add one focused source-backed fixture and no parser runtime
+  behavior change
+- parser-fix PRs include a failing fixture or receipt-backed failure shape
+  before changing parser behavior
+- generated status updates, when present, come from xtask output
+- the PR body states what can and cannot be claimed after the change
+- proof commands pass or any unavailable receipt is explicitly deferred
+
+## Proof Commands
+
+Focused fixture or parser-fix proof:
+
+```bash
+cargo test -p perl-parser-core --test <bucket-test> --profile agent --locked -- --nocapture
+```
+
+Parser status proof:
+
+```bash
+cargo xtask metrics parser-accuracy --check
+cargo xtask update-status --only parser --check
+cargo xtask metrics ratchet-check parser_accuracy
+cargo xtask fmt --check
+git diff --check
+```
+
+Fresh corpus receipt proof when Linux roots are available:
+
+```bash
+cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt
+cargo xtask update-status --only parser --check
+```
+
+## Non-goals
+
+- no full CPAN-clean claim
+- no broad parser rewrite
+- no provider confidence or cutover behavior
+- no real-workspace baseline requirements
+- no generated status hand edits
+- no claim that stale raw buckets prove current failures
+
+## Claim Boundaries
+
+Fixture-only PRs may claim that `perl-lsp` locks a source-backed real-Perl
+shape. They may not claim that corpus compatibility improved or that the raw
+bucket shrank.
+
+Parser-fix PRs may claim the fixed behavior covered by their fixtures and
+targeted tests. They may not claim broader corpus movement until generated
+status from a fresh receipt proves it.
+
+Corpus-refresh PRs may update generated status and bucket counts. They should
+avoid unrelated parser runtime changes so reviewers can separate measurement
+movement from behavior changes.


### PR DESCRIPTION
Problem: Parser capability work needs a durable contract for routing from generated status to raw buckets without stale receipt overclaims.\n\nFix: Add PLSP-SPEC-0001 defining parser_accuracy_next.md vs parser.md routing, receipt freshness rules, bucket lane shape, valid/invalid PR shapes, acceptance, proof commands, non-goals, and claim boundaries.\n\nClaim boundary: Docs-only spec. This does not add parser fixtures, parser runtime changes, provider behavior changes, generated status edits, or corpus-count claims.\n\nVerification:\n- rtk git diff --check\n- rtk python -c 'spec section and local markdown link check'