### PR TITLE
goals: add active real Perl editor trust manifest (#8823)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -1,0 +1,147 @@
+id = "plsp-real-perl-editor-trust"
+title = "Real Perl editor trust"
+status = "active"
+owner = "codex-swarm"
+created = "2026-05-13"
+
+proposal = "docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md"
+status_pointer = "docs/project/status/parser_accuracy_next.md"
+
+specs = [
+  "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md",
+  "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md",
+  "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md",
+  "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md",
+]
+
+adrs = [
+  "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md",
+  "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md",
+]
+
+objective = """
+Turn parser compatibility, provider confidence, and real-workspace receipts
+into an executable control plane for improving perl-lsp user trust.
+"""
+
+end_state = [
+  "Parser measurement queue has no active packets or gaps.",
+  "Raw parser buckets route PR-sized parser capability lanes.",
+  "Corpus receipt freshness rules are encoded.",
+  "Provider confidence and freshness receipts exist before cutover.",
+  "Real-workspace baseline proves editor behavior on at least one real project.",
+  "Stable user claims link to proof commands and status docs.",
+]
+
+claim_boundaries = [
+  "Do not claim parser bucket reduction without a refreshed corpus receipt.",
+  "Do not broaden live provider behavior from receipt PRs alone.",
+  "Do not hand-edit generated status sections.",
+  "Do not claim all-CPAN support or full dynamic Perl inference.",
+]
+
+status_docs = [
+  "docs/project/status/parser_accuracy_next.md",
+  "docs/project/status/parser.md",
+  "docs/project/status/provider_cutover.md",
+  "docs/project/status/ux_capability_dashboard.md",
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[work_item]]
+id = "raw-bucket-fixture-lane"
+status = "active"
+spec = "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md"
+adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-raw-bucket-fixture-lane"
+current_pointer = "docs/project/status/parser_accuracy_next.md"
+current_status = "docs/project/status/parser.md#raw-failure-buckets"
+claim_boundary = "Fixture-only PRs lock source-backed shapes; bucket-count movement requires a refreshed corpus receipt."
+commands = [
+  "cargo test -p perl-parser-core --test <bucket-test> --profile agent --locked -- --nocapture",
+  "cargo xtask metrics parser-accuracy --check",
+  "cargo xtask update-status --only parser --check",
+  "cargo xtask metrics ratchet-check parser_accuracy",
+  "cargo xtask fmt --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "linux-corpus-refresh"
+status = "ready"
+spec = "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md"
+adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-linux-corpus-refresh"
+current_pointer = "docs/project/status/parser.md#raw-failure-buckets"
+claim_boundary = "May update parser bucket counts only from refreshed generated corpus status."
+commands = [
+  "cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt",
+  "cargo xtask update-status --only parser --write",
+  "cargo xtask update-status --only parser --check",
+  "cargo xtask metrics ratchet-check parser_accuracy",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "real-workspace-baseline-run"
+status = "ready"
+spec = "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md"
+adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-real-workspace-baseline-run"
+current_pointer = "docs/development/REAL_WORKSPACE_BASELINE_RAIL.md"
+claim_boundary = "A baseline proves the selected project and host receipt only; it is not all-CPAN proof or live provider cutover."
+commands = [
+  "just real-workspace-baseline mojolicious",
+  "cargo test -p perl-lsp-rs --test real_project_latency mojolicious -- --include-ignored --nocapture",
+  "cargo xtask semantic-scorecard --check",
+  "cargo xtask semantic-shadow-compare --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "provider-confidence-closeout"
+status = "ready"
+spec = "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md"
+adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-provider-confidence-closeout"
+current_pointer = "docs/project/status/provider_cutover.md"
+claim_boundary = "Provider receipt PRs may add proof and labels; broad live cutover requires cutover proof and rollback/fallback behavior."
+commands = [
+  "cargo test -p perl-lsp-rs-core --lib rename_shadow safe_delete_shadow -- --nocapture",
+  "cargo test -p perl-lsp-rs --lib refactor_runtime_blocker -- --nocapture",
+  "cargo xtask semantic-scorecard --check",
+  "cargo xtask semantic-shadow-compare --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "support-claim-refresh"
+status = "ready"
+spec = "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md"
+adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-support-claim-refresh"
+current_pointer = "docs/project/status/ux_capability_dashboard.md"
+claim_boundary = "Support claims must link to proof commands, status docs, known limitations, and next promotion proof."
+commands = [
+  "cargo xtask update-status --only parser --check",
+  "cargo xtask semantic-scorecard --check",
+  "cargo xtask semantic-shadow-compare --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "lane-closeout"
+status = "ready"
+spec = "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md"
+adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
+current_pointer = "plans/real-perl-editor-trust/implementation-plan.md"
+claim_boundary = "Close only when deferred items have explicit successors and status/support claims point to proof."
+commands = [
+  "cargo xtask update-status --only parser --check",
+  "cargo xtask semantic-scorecard --check",
+  "cargo xtask semantic-shadow-compare --check",
+  "git diff --check",
+]


### PR DESCRIPTION
Problem: The Real Perl Editor Trust lane has a plan and status docs, but no machine-readable current-state manifest for agents to start from.\nFix: Add .perl-lsp/goals/active.toml pointing to the proposal, specs, ADRs, implementation plan, generated status docs, active/ready work items, proof commands, and claim boundaries.\nVerification: tk git diff --check; TOML parse and referenced-file checks passed.\nClaim boundary: manifest-only; no implementation plan change, generated status edit, parser/provider behavior change, or support claim promotion.