### PR TITLE
test(parser): lock Unicode Collate sort-map fixture (#8826)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -581,6 +581,15 @@ fn unicode_collate_gmatch_substr_return_map_expr() {
 }
 
 #[test]
+fn unicode_collate_sort_map_arrayref_pipeline() {
+    // From Unicode::Collate: a return may pipeline map BLOCK, sort BLOCK, and
+    // map EXPR arrayref construction without leaving the statement open.
+    assert_clean_parse(
+        r#"return map { $_->[1] } sort { $a->[0] cmp $b->[0] } map [ $obj->getSortKey($_), $_ ], @_;"#,
+    );
+}
+
+#[test]
 fn unicode_collate_hst_join_map_split_expr() {
     // From Unicode::Collate: join may take map EXPR, LIST where the source
     // list is a split expression after the mapped function call.


### PR DESCRIPTION
Problem: the active raw-bucket fixture lane still has source-backed Unicode::Collate unclosed_paren_identifier shapes that should be locked as focused parser coverage.

Fix: add one fixture for the Perl 5.38.2 Unicode::Collate return/map/sort/map arrayref pipeline.

Claim boundary: fixture-only. This does not change parser runtime behavior, edit generated status files, refresh the Linux corpus receipt, or claim raw bucket-count reduction.

Verification:
- tk cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture passed: 157 tests
- tk cargo xtask metrics parser-accuracy --check passed: 50 fixtures across 29 families
- tk cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt passed: 10/10 strict clean
- tk cargo xtask update-status --only parser --check passed
- tk cargo xtask metrics ratchet-check parser_accuracy passed
- tk cargo xtask fmt --check passed
- tk git diff --check passed