### PR TITLE
test(parser): lock ExtUtils nested grep-map shape (#8830)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -651,6 +651,15 @@ fn extutils_mm_unix_for_list_with_parenthesized_map() {
 }
 
 #[test]
+fn extutils_mm_unix_grep_parens_over_map_arrayref_default() {
+    // From ExtUtils::MM_Unix: grep() may take a map BLOCK source over an
+    // array dereference whose container falls back through word `or`.
+    assert_clean_parse(
+        r#"my @dirs = grep( -d $_, map { $self->catdir($_, 'auto') } @{$searchdirs || []} );"#,
+    );
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The parser capability handoff points at the unclosed_paren_identifier bucket, and the available ExtUtils probe includes a nested grep/map shape that should remain locked independently.\n\nFix: Add one parser-core clean-parse regression for grep(...) over a map BLOCK source with an array deref fallback expression.\n\nVerification: \cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture\; \cargo xtask metrics parser-accuracy --check\; \cargo xtask update-status --only parser --check\; \cargo xtask metrics ratchet-check parser_accuracy\; \cargo xtask fmt --check\; \git diff --check\.