### PR TITLE
test(parser): lock Path Tiny braced map fixture (#8831)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -1066,6 +1066,15 @@ fn print_parens_block_filehandle_typeglob_deref() {
 }
 
 #[test]
+fn path_tiny_print_braced_filehandle_map_block() {
+    // From Path::Tiny: print with explicit parens may combine a braced
+    // filehandle and a map BLOCK source list.
+    assert_clean_parse(
+        r#"print( {$fh} map { ref eq 'ARRAY' ? @$_ : $_ } @data ) or $self->_throw('print');"#,
+    );
+}
+
+#[test]
 fn undef_in_return_expr() {
     // return undef — undef at statement boundary, no sigil follows
     assert_clean_parse(r#"sub f { return undef; }"#);


### PR DESCRIPTION
Problem: The Real Perl Editor Trust parser lane is still using stale unclosed_paren_identifier corpus buckets for fixture discovery, and Path::Tiny appears in the CPAN top-1000 receipt with a braced-filehandle map shape not locked directly.

Fix: Add one source-backed parser fixture for print( {filehandle} map BLOCK LIST ) in unclosed_paren_identifier_tests.

Claim boundary: fixture-only coverage. This PR does not change parser runtime behavior and does not claim any raw bucket-count reduction without a refreshed corpus receipt.

Verification:
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture
- cargo xtask metrics parser-accuracy --check
- cargo xtask update-status --only parser --check
- cargo xtask metrics ratchet-check parser_accuracy
- cargo xtask fmt --check
- git diff --check