### PR TITLE
test(parser): lock Carp DB args map eval fixture (#8837)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -720,6 +720,25 @@ fn local_carp_not_scalar_ternary_caller() {
     assert_clean_parse(r#"local @CARP_NOT = scalar( $cgc ? $cgc->() : caller() );"#);
 }
 
+#[test]
+fn carp_db_args_map_eval_or_do() {
+    // From Carp: map BLOCK over @DB::args may contain local assignment, eval,
+    // and an `or do` fallback without leaving the map source list unclosed.
+    assert_clean_parse(
+        r#"my @args = map {
+            my $arg;
+            local $@ = $@;
+            eval {
+                $arg = $_;
+                1;
+            } or do {
+                $arg = '** argument not available anymore **';
+            };
+            $arg;
+        } @DB::args;"#,
+    );
+}
+
 // === Sigil-peek heuristic: imported unary functions without parens (#1943) ===
 // These all fail with "expected ')', found identifier" before the fix because
 // `blessed`, `reftype`, etc. are not in the builtin table. The fix adds a


### PR DESCRIPTION
Problem: The Real Perl Editor Trust raw-bucket lane still points fixture-only capability work at the stale unclosed_paren_identifier bucket.\n\nFix: Add one source-backed Carp.pm fixture for map BLOCK over @DB::args with local assignment, eval, and or-do fallback.\n\nClaim boundary: This is fixture-only coverage from a stale corpus bucket; it does not claim raw bucket-count reduction without a refreshed Linux corpus receipt.\n\nVerification:\n- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture\n- cargo xtask metrics parser-accuracy --check\n- cargo xtask update-status --only parser --check\n- cargo xtask metrics ratchet-check parser_accuracy\n- cargo xtask fmt --check\n- git diff --check\n\nSource: https://raw.githubusercontent.com/Perl/perl5/v5.38.2/dist/Carp/lib/Carp.pm lines 342-352