### PR TITLE
refactor(import-optimizer): split analysis helpers (#8845)

### DIFF
--- a/crates/perl-refactoring/src/refactor/import_optimizer.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer.rs
@@ -43,9 +43,14 @@
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::LazyLock;
+
+mod duplicates;
+mod parsing;
+mod suggestions;
+mod usage;
 
 /// TextEdit for import optimization (local type for byte-offset ranges)
 ///
@@ -276,242 +281,13 @@ impl ImportOptimizer {
     /// # Ok::<(), String>(())
     /// ```
     pub fn analyze_content(&self, content: &str) -> Result<ImportAnalysis, String> {
-        let mut imports = Vec::new();
-        for (idx, line) in content.lines().enumerate() {
-            if let Some(caps) = USE_STATEMENT_RE.as_ref().map_err(|e| e.to_string())?.captures(line)
-            {
-                let module = caps[1].to_string();
-                let symbols_str = caps.get(2).map(|m| m.as_str()).unwrap_or("");
-                let symbols = if symbols_str.is_empty() {
-                    Vec::new()
-                } else {
-                    symbols_str
-                        .split_whitespace()
-                        .filter(|s| !s.is_empty())
-                        .map(|s| s.trim_matches(|c| c == ',' || c == ';' || c == '"'))
-                        .map(|s| s.to_string())
-                        .collect::<Vec<_>>()
-                };
-                imports.push(ImportEntry { module, symbols, line: idx + 1 });
-            }
-        }
-
-        // Build map for duplicate detection
-        let mut module_to_lines: BTreeMap<String, Vec<usize>> = BTreeMap::new();
-        for imp in &imports {
-            module_to_lines.entry(imp.module.clone()).or_default().push(imp.line);
-        }
-        let duplicate_imports = module_to_lines
-            .iter()
-            .filter(|(_, lines)| lines.len() > 1)
-            .map(|(module, lines)| DuplicateImport {
-                module: module.clone(),
-                lines: lines.clone(),
-                can_merge: true,
-            })
-            .collect::<Vec<_>>();
-
-        // Build content without `use` lines for symbol usage detection
-        let non_use_content = content
-            .lines()
-            .filter(
-                |line| {
-                    !line.trim_start().starts_with("use ") && !line.trim_start().starts_with("#")
-                }, // Exclude comment lines
-            )
-            .collect::<Vec<_>>()
-            .join(
-                "
-",
-            );
-
-        // Determine unused symbols for each import entry
-        let mut unused_imports = Vec::new();
-        for imp in &imports {
-            let mut unused_symbols = Vec::new();
-
-            // If there are explicit symbols (like qw()), check each one
-            if !imp.symbols.is_empty() {
-                for sym in &imp.symbols {
-                    let re = Regex::new(&format!(r"\b{}\b", regex::escape(sym)))
-                        .map_err(|e| e.to_string())?;
-
-                    // Check if symbol is used in non-use content
-                    if !re.is_match(&non_use_content) {
-                        unused_symbols.push(sym.clone());
-                    }
-                }
-            } else {
-                // Skip pragma modules like strict, warnings, etc.
-                let is_pragma = matches!(
-                    imp.module.as_str(),
-                    "strict"
-                        | "warnings"
-                        | "utf8"
-                        | "bytes"
-                        | "integer"
-                        | "locale"
-                        | "overload"
-                        | "sigtrap"
-                        | "subs"
-                        | "vars"
-                );
-
-                if !is_pragma {
-                    // For bare imports (without qw()), check if the module or any of its known exports are used
-                    let (is_known_module, known_exports) =
-                        match get_known_module_exports(&imp.module) {
-                            Some(exports) => (true, exports),
-                            None => (false, Vec::new()),
-                        };
-                    let mut is_used = false;
-
-                    // First check if the module is directly referenced (e.g., Module::function)
-                    let module_pattern = format!(r"\b{}\b", regex::escape(&imp.module));
-                    let module_re = Regex::new(&module_pattern).map_err(|e| e.to_string())?;
-                    if module_re.is_match(&non_use_content) {
-                        is_used = true;
-                    }
-
-                    // Also check for qualified function calls like Module::function
-                    if !is_used {
-                        let qualified_pattern = format!(r"{}::", regex::escape(&imp.module));
-                        let qualified_re =
-                            Regex::new(&qualified_pattern).map_err(|e| e.to_string())?;
-                        if qualified_re.is_match(&non_use_content) {
-                            is_used = true;
-                        }
-                    }
-
-                    // Special handling for Data::Dumper - check for Dumper function usage
-                    if !is_used && imp.module == "Data::Dumper" {
-                        if DUMPER_RE.as_ref().map_err(|e| e.to_string())?.is_match(&non_use_content)
-                        {
-                            is_used = true;
-                        }
-                    }
-
-                    // Then check if any known exports are used
-                    if !is_used && !known_exports.is_empty() {
-                        for export in &known_exports {
-                            let export_pattern = format!(r"\b{}\b", regex::escape(export));
-                            let export_re =
-                                Regex::new(&export_pattern).map_err(|e| e.to_string())?;
-                            if export_re.is_match(&non_use_content) {
-                                is_used = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    // Conservative approach: Don't flag bare imports as unused if they have exports
-                    // Modules with exports might have side effects or implicit behavior we can't detect
-                    // But modules with no exports (like LWP::UserAgent) can still be flagged if unused
-                    if !is_used && is_known_module && known_exports.is_empty() {
-                        unused_symbols.push("(bare import)".to_string());
-                    }
-                }
-            }
-
-            // Create unused import entry if there are unused symbols
-            if !unused_symbols.is_empty() {
-                unused_imports.push(UnusedImport {
-                    module: imp.module.clone(),
-                    symbols: unused_symbols,
-                    line: imp.line,
-                    reason: "Symbols not used in code".to_string(),
-                });
-            }
-        }
-
-        // Missing import detection
-        let imported_modules: BTreeSet<String> =
-            imports.iter().map(|imp| imp.module.clone()).collect();
-
-        // Strip strings and comments before scanning for Module::symbol patterns
-        let stripped =
-            STRING_RE.as_ref().map_err(|e| e.to_string())?.replace_all(content, " ").to_string();
-        let stripped = REGEX_LITERAL_RE
-            .as_ref()
-            .map_err(|e| e.to_string())?
-            .replace_all(&stripped, " ")
-            .to_string();
-        let stripped =
-            COMMENT_RE.as_ref().map_err(|e| e.to_string())?.replace_all(&stripped, " ").to_string();
-
-        let mut usage_map: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        for caps in QUALIFIED_USAGE_RE.as_ref().map_err(|e| e.to_string())?.captures_iter(&stripped)
-        {
-            // Only process if both capture groups matched
-            if let (Some(module_match), Some(symbol_match)) = (caps.get(1), caps.get(2)) {
-                let module = module_match.as_str().to_string();
-                let symbol = symbol_match.as_str().to_string();
-
-                if imported_modules.contains(&module) || is_pragma_module(&module) {
-                    continue;
-                }
-
-                usage_map.entry(module).or_default().push(symbol);
-            }
-        }
-        let last_import_line = imports.iter().map(|i| i.line).max().unwrap_or(0);
-        let missing_imports = usage_map
-            .into_iter()
-            .map(|(module, mut symbols)| {
-                symbols.sort();
-                symbols.dedup();
-                MissingImport {
-                    module,
-                    symbols,
-                    suggested_location: last_import_line + 1,
-                    confidence: 0.8,
-                }
-            })
-            .collect::<Vec<_>>();
-
-        // Generate organization suggestions
-        let mut organization_suggestions = Vec::new();
-
-        // Suggest sorting of import statements
-        let module_order: Vec<String> = imports.iter().map(|i| i.module.clone()).collect();
-        let mut sorted_order = module_order.clone();
-        sorted_order.sort();
-        if module_order != sorted_order {
-            organization_suggestions.push(OrganizationSuggestion {
-                description: "Sort import statements alphabetically".to_string(),
-                priority: SuggestionPriority::Low,
-            });
-        }
-
-        // Suggest removing duplicate imports
-        if !duplicate_imports.is_empty() {
-            let modules =
-                duplicate_imports.iter().map(|d| d.module.clone()).collect::<Vec<_>>().join(", ");
-            organization_suggestions.push(OrganizationSuggestion {
-                description: format!("Remove duplicate imports for modules: {}", modules),
-                priority: SuggestionPriority::Medium,
-            });
-        }
-
-        // Suggest sorting/deduplicating symbols within imports
-        let mut symbols_need_org = false;
-        for imp in &imports {
-            if imp.symbols.len() > 1 {
-                let mut sorted = imp.symbols.clone();
-                sorted.sort();
-                sorted.dedup();
-                if sorted != imp.symbols {
-                    symbols_need_org = true;
-                    break;
-                }
-            }
-        }
-        if symbols_need_org {
-            organization_suggestions.push(OrganizationSuggestion {
-                description: "Sort and deduplicate symbols within import statements".to_string(),
-                priority: SuggestionPriority::Low,
-            });
-        }
+        let imports = parsing::parse_imports(content)?;
+        let duplicate_imports = duplicates::find_duplicate_imports(&imports);
+        let non_use_content = parsing::non_use_content(content);
+        let unused_imports = usage::find_unused_imports(&imports, &non_use_content)?;
+        let missing_imports = usage::find_missing_imports(content, &imports)?;
+        let organization_suggestions =
+            suggestions::organization_suggestions(&imports, &duplicate_imports);
 
         Ok(ImportAnalysis {
             imports,

--- a/crates/perl-refactoring/src/refactor/import_optimizer/duplicates.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/duplicates.rs
@@ -1,0 +1,20 @@
+use std::collections::BTreeMap;
+
+use super::{DuplicateImport, ImportEntry};
+
+pub(super) fn find_duplicate_imports(imports: &[ImportEntry]) -> Vec<DuplicateImport> {
+    let mut module_to_lines: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for imp in imports {
+        module_to_lines.entry(imp.module.clone()).or_default().push(imp.line);
+    }
+
+    module_to_lines
+        .iter()
+        .filter(|(_, lines)| lines.len() > 1)
+        .map(|(module, lines)| DuplicateImport {
+            module: module.clone(),
+            lines: lines.clone(),
+            can_merge: true,
+        })
+        .collect()
+}

--- a/crates/perl-refactoring/src/refactor/import_optimizer/parsing.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/parsing.rs
@@ -1,0 +1,32 @@
+use super::{ImportEntry, USE_STATEMENT_RE};
+
+pub(super) fn parse_imports(content: &str) -> Result<Vec<ImportEntry>, String> {
+    let mut imports = Vec::new();
+    for (idx, line) in content.lines().enumerate() {
+        if let Some(caps) = USE_STATEMENT_RE.as_ref().map_err(|e| e.to_string())?.captures(line) {
+            let module = caps[1].to_string();
+            let symbols = caps.get(2).map_or_else(Vec::new, |m| parse_symbol_list(m.as_str()));
+            imports.push(ImportEntry { module, symbols, line: idx + 1 });
+        }
+    }
+    Ok(imports)
+}
+
+fn parse_symbol_list(symbols: &str) -> Vec<String> {
+    symbols
+        .split_whitespace()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.trim_matches(|c| c == ',' || c == ';' || c == '"'))
+        .map(str::to_string)
+        .collect()
+}
+
+pub(super) fn non_use_content(content: &str) -> String {
+    content
+        .lines()
+        .filter(|line| {
+            !line.trim_start().starts_with("use ") && !line.trim_start().starts_with('#')
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/perl-refactoring/src/refactor/import_optimizer/suggestions.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/suggestions.rs
@@ -1,0 +1,64 @@
+use super::{DuplicateImport, ImportEntry, OrganizationSuggestion, SuggestionPriority};
+
+pub(super) fn organization_suggestions(
+    imports: &[ImportEntry],
+    duplicate_imports: &[DuplicateImport],
+) -> Vec<OrganizationSuggestion> {
+    let mut suggestions = Vec::new();
+    add_sort_imports_suggestion(imports, &mut suggestions);
+    add_duplicate_imports_suggestion(duplicate_imports, &mut suggestions);
+    add_symbol_organization_suggestion(imports, &mut suggestions);
+    suggestions
+}
+
+fn add_sort_imports_suggestion(
+    imports: &[ImportEntry],
+    suggestions: &mut Vec<OrganizationSuggestion>,
+) {
+    let module_order: Vec<String> = imports.iter().map(|i| i.module.clone()).collect();
+    let mut sorted_order = module_order.clone();
+    sorted_order.sort();
+    if module_order != sorted_order {
+        suggestions.push(OrganizationSuggestion {
+            description: "Sort import statements alphabetically".to_string(),
+            priority: SuggestionPriority::Low,
+        });
+    }
+}
+
+fn add_duplicate_imports_suggestion(
+    duplicate_imports: &[DuplicateImport],
+    suggestions: &mut Vec<OrganizationSuggestion>,
+) {
+    if duplicate_imports.is_empty() {
+        return;
+    }
+
+    let modules = duplicate_imports.iter().map(|d| d.module.clone()).collect::<Vec<_>>().join(", ");
+    suggestions.push(OrganizationSuggestion {
+        description: format!("Remove duplicate imports for modules: {}", modules),
+        priority: SuggestionPriority::Medium,
+    });
+}
+
+fn add_symbol_organization_suggestion(
+    imports: &[ImportEntry],
+    suggestions: &mut Vec<OrganizationSuggestion>,
+) {
+    if imports.iter().any(symbols_need_organization) {
+        suggestions.push(OrganizationSuggestion {
+            description: "Sort and deduplicate symbols within import statements".to_string(),
+            priority: SuggestionPriority::Low,
+        });
+    }
+}
+
+fn symbols_need_organization(imp: &ImportEntry) -> bool {
+    if imp.symbols.len() <= 1 {
+        return false;
+    }
+    let mut sorted = imp.symbols.clone();
+    sorted.sort();
+    sorted.dedup();
+    sorted != imp.symbols
+}

--- a/crates/perl-refactoring/src/refactor/import_optimizer/usage.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/usage.rs
@@ -1,0 +1,128 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{
+    COMMENT_RE, DUMPER_RE, ImportEntry, MissingImport, QUALIFIED_USAGE_RE, REGEX_LITERAL_RE,
+    STRING_RE, UnusedImport, get_known_module_exports, is_pragma_module,
+};
+
+pub(super) fn find_unused_imports(
+    imports: &[ImportEntry],
+    non_use_content: &str,
+) -> Result<Vec<UnusedImport>, String> {
+    let mut unused_imports = Vec::new();
+
+    for imp in imports {
+        let unused_symbols = unused_symbols_for_import(imp, non_use_content)?;
+        if !unused_symbols.is_empty() {
+            unused_imports.push(UnusedImport {
+                module: imp.module.clone(),
+                symbols: unused_symbols,
+                line: imp.line,
+                reason: "Symbols not used in code".to_string(),
+            });
+        }
+    }
+
+    Ok(unused_imports)
+}
+
+fn unused_symbols_for_import(
+    imp: &ImportEntry,
+    non_use_content: &str,
+) -> Result<Vec<String>, String> {
+    if !imp.symbols.is_empty() {
+        return Ok(imp
+            .symbols
+            .iter()
+            .filter(|sym| !contains_word(non_use_content, sym))
+            .cloned()
+            .collect());
+    }
+
+    if is_pragma_module(&imp.module) || bare_import_is_used(imp, non_use_content)? {
+        return Ok(Vec::new());
+    }
+
+    Ok(vec!["(bare import)".to_string()])
+}
+
+fn bare_import_is_used(imp: &ImportEntry, non_use_content: &str) -> Result<bool, String> {
+    let Some(known_exports) = get_known_module_exports(&imp.module) else {
+        return Ok(true);
+    };
+
+    if !known_exports.is_empty() {
+        return Ok(true);
+    }
+
+    if contains_word(non_use_content, &imp.module)
+        || non_use_content.contains(&format!("{}::", imp.module))
+    {
+        return Ok(true);
+    }
+
+    if imp.module == "Data::Dumper"
+        && DUMPER_RE.as_ref().map_err(|e| e.to_string())?.is_match(non_use_content)
+    {
+        return Ok(true);
+    }
+
+    Ok(known_exports.iter().any(|export| contains_word(non_use_content, export)))
+}
+
+pub(super) fn find_missing_imports(
+    content: &str,
+    imports: &[ImportEntry],
+) -> Result<Vec<MissingImport>, String> {
+    let imported_modules: BTreeSet<String> = imports.iter().map(|imp| imp.module.clone()).collect();
+    let stripped = strip_non_code_for_usage_scan(content)?;
+    let mut usage_map: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for caps in QUALIFIED_USAGE_RE.as_ref().map_err(|e| e.to_string())?.captures_iter(&stripped) {
+        if let (Some(module_match), Some(symbol_match)) = (caps.get(1), caps.get(2)) {
+            let module = module_match.as_str().to_string();
+            if imported_modules.contains(&module) || is_pragma_module(&module) {
+                continue;
+            }
+            usage_map.entry(module).or_default().push(symbol_match.as_str().to_string());
+        }
+    }
+
+    let last_import_line = imports.iter().map(|i| i.line).max().unwrap_or(0);
+    Ok(usage_map
+        .into_iter()
+        .map(|(module, mut symbols)| {
+            symbols.sort();
+            symbols.dedup();
+            MissingImport {
+                module,
+                symbols,
+                suggested_location: last_import_line + 1,
+                confidence: 0.8,
+            }
+        })
+        .collect())
+}
+
+fn strip_non_code_for_usage_scan(content: &str) -> Result<String, String> {
+    let stripped =
+        STRING_RE.as_ref().map_err(|e| e.to_string())?.replace_all(content, " ").to_string();
+    let stripped = REGEX_LITERAL_RE
+        .as_ref()
+        .map_err(|e| e.to_string())?
+        .replace_all(&stripped, " ")
+        .to_string();
+    Ok(COMMENT_RE.as_ref().map_err(|e| e.to_string())?.replace_all(&stripped, " ").to_string())
+}
+
+fn contains_word(haystack: &str, needle: &str) -> bool {
+    haystack.match_indices(needle).any(|(idx, _)| {
+        let before = haystack[..idx].chars().next_back();
+        let after = haystack[idx + needle.len()..].chars().next();
+        !is_word_char(before) && !is_word_char(after)
+    })
+}
+
+fn is_word_char(ch: Option<char>) -> bool {
+    ch.is_some_and(|c| c.is_ascii_alphanumeric() || c == '_')
+}


### PR DESCRIPTION
### Motivation

- `ImportOptimizer::analyze_content` bundled parsing, duplicate detection, usage scanning, missing-import detection, and suggestion generation in one large function and needed decomposition for SRP and testability.

### Description

- Extracted parsing logic into `crates/perl-refactoring/src/refactor/import_optimizer/parsing.rs` with `parse_imports` and `non_use_content` helpers and symbol-list parsing. 
- Extracted duplicate-detection into `crates/perl-refactoring/src/refactor/import_optimizer/duplicates.rs` with `find_duplicate_imports`. 
- Extracted usage and missing-import analysis into `crates/perl-refactoring/src/refactor/import_optimizer/usage.rs` with `find_unused_imports`, `find_missing_imports`, and supporting helpers. 
- Extracted organization-suggestion logic into `crates/perl-refactoring/src/refactor/import_optimizer/suggestions.rs` with `organization_suggestions`. 
- Replaced the body of `analyze_content` in `crates/perl-refactoring/src/refactor/import_optimizer.rs` with a small orchestration that delegates to the new submodules and updated imports (`mod parsing; mod duplicates; mod usage; mod suggestions;`).

### Testing

- Ran formatter: `./scripts/cargo-safe xtask fmt` which completed successfully. 
- Ran the perl-refactoring test suite with environment-controlled cache/target: `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/build CARGO_HOME=/root/.cache/devplane/perl-lsp/cargo-home cargo test -p perl-refactoring --profile agent --locked` and all tests passed. 
- Ran type/check and lints: `cargo check --all-targets -p perl-refactoring --profile agent --locked` and `cargo clippy -p perl-refactoring --profile agent --locked -- -D warnings -A missing_docs` which completed successfully. 
- Performed repository checks: `./scripts/storage-doctor` and `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044621c1a08333811de5f7fd934b8e)