### PR TITLE
refactor(completion): split import map extraction (#8846)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map.rs
@@ -1,7 +1,14 @@
 use super::ImportMap;
-use perl_module::import::resolve_known_export_tag;
 use perl_parser_core::ast::{Node, NodeKind};
 use std::collections::{HashMap, HashSet};
+
+mod runtime_imports;
+mod symbols;
+mod used_modules;
+
+use runtime_imports::collect_runtime_imports;
+use symbols::collect_import_symbols;
+use used_modules::is_importable_module;
 
 /// Walk the top-level AST and build an `ImportMap` from `use` statements.
 ///
@@ -9,312 +16,53 @@ use std::collections::{HashMap, HashSet};
 /// `strict`, `warnings`, `feature`, `constant`, `utf8`, `lib`, `parent`, `base`).
 pub(super) fn extract_import_map(ast: &Node) -> ImportMap {
     let mut map: ImportMap = HashMap::new();
-
-    fn collect_import_symbols(
-        module: &str,
-        arg: &str,
-        symbols: &mut HashSet<String>,
-    ) -> (bool, bool) {
-        let trimmed = arg.trim();
-        if trimmed.is_empty() {
-            return (false, false);
-        }
-        if matches!(trimmed, "=>" | "," | "(" | ")" | "[" | "]" | "{" | "}") {
-            return (false, false);
-        }
-
-        let mut content = trimmed;
-        if let Some(inner) = content.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
-            content = inner.trim();
-        }
-
-        if content.starts_with("qw") {
-            content = content
-                .trim_start_matches("qw")
-                .trim_start_matches(|c: char| "([{/<|!".contains(c))
-                .trim_end_matches(|c: char| ")]}/|!>".contains(c))
-                .trim();
-
-            let mut unresolved_tag = false;
-            for word in content.split_whitespace() {
-                if word.is_empty() {
-                    continue;
-                }
-                if word.starts_with(':') {
-                    if let Some(expanded) = resolve_known_export_tag(module, word) {
-                        symbols.extend(expanded.iter().map(|name| (*name).to_string()));
-                    } else {
-                        unresolved_tag = true;
-                    }
-                } else {
-                    symbols.insert(word.to_string());
-                }
-            }
-            return (!content.is_empty(), unresolved_tag);
-        }
-
-        let cleaned = content.trim_matches(|c: char| c == '\'' || c == '"');
-        if cleaned.is_empty() {
-            return (false, false);
-        }
-
-        let mut unresolved_tag = false;
-        for word in cleaned.split_whitespace() {
-            if word.is_empty() {
-                continue;
-            }
-            if word.starts_with(':') {
-                if let Some(expanded) = resolve_known_export_tag(module, word) {
-                    symbols.extend(expanded.iter().map(|name| (*name).to_string()));
-                } else {
-                    unresolved_tag = true;
-                }
-            } else {
-                symbols.insert(word.to_string());
-            }
-        }
-        (true, unresolved_tag)
-    }
-
-    fn collect_node_import_symbols(
-        module: &str,
-        arg: &Node,
-        symbols: &mut HashSet<String>,
-    ) -> (bool, bool) {
-        match &arg.kind {
-            NodeKind::String { value, .. } => {
-                collect_import_symbols(module, value.trim_matches('\'').trim_matches('"'), symbols)
-            }
-            NodeKind::Identifier { name } => collect_import_symbols(module, name, symbols),
-            NodeKind::ArrayLiteral { elements } => {
-                let mut has_symbols = false;
-                let mut has_unresolved_tag = false;
-                for element in elements {
-                    let (element_has_symbols, element_unresolved_tag) =
-                        collect_node_import_symbols(module, element, symbols);
-                    if element_has_symbols {
-                        has_symbols = true;
-                    }
-                    if element_unresolved_tag {
-                        has_unresolved_tag = true;
-                    }
-                }
-                (has_symbols, has_unresolved_tag)
-            }
-            _ => (false, false),
-        }
-    }
-
-    fn require_module_name(expr: &Node) -> Option<String> {
-        let NodeKind::FunctionCall { name, args } = &expr.kind else {
-            return None;
-        };
-        if name != "require" {
-            return None;
-        }
-        let first = args.first()?;
-        match &first.kind {
-            NodeKind::Identifier { name } => Some(name.clone()),
-            NodeKind::String { value, .. } => {
-                let cleaned = value.trim_matches('\'').trim_matches('"').trim();
-                Some(cleaned.trim_end_matches(".pm").replace('/', "::"))
-            }
-            _ => None,
-        }
-    }
-
-    fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
-        let (alias_name, call_node) = match &expr.kind {
-            NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
-                let NodeKind::Variable { name, .. } = &lhs.kind else {
-                    return None;
-                };
-                (name.as_str(), rhs.as_ref())
-            }
-            NodeKind::VariableDeclaration { variable, initializer: Some(rhs), .. } => {
-                let NodeKind::Variable { name, .. } = &variable.kind else {
-                    return None;
-                };
-                (name.as_str(), rhs.as_ref())
-            }
-            _ => return None,
-        };
-        let NodeKind::FunctionCall { name, args } = &call_node.kind else {
-            return None;
-        };
-        if !matches!(
-            name.as_str(),
-            "use_module"
-                | "require_module"
-                | "Module::Runtime::use_module"
-                | "Module::Runtime::require_module"
-        ) {
-            return None;
-        }
-        let first = args.first()?;
-        let NodeKind::String { value, .. } = &first.kind else {
-            return None;
-        };
-        let module = value.trim_matches('\'').trim_matches('"').trim();
-        if module.is_empty() {
-            return None;
-        }
-        Some((alias_name.to_string(), module.to_string()))
-    }
-
-    fn inner_expr(node: &Node) -> &Node {
-        if let NodeKind::ExpressionStatement { expression } = &node.kind {
-            expression.as_ref()
-        } else {
-            node
-        }
-    }
-
-    fn collect(node: &Node, map: &mut ImportMap) {
-        match &node.kind {
-            NodeKind::Use { module, args, .. } => {
-                let first_char: Option<char> = module.chars().next();
-                if !first_char.is_some_and(|c: char| c.is_ascii_uppercase()) {
-                    return;
-                }
-
-                if args.is_empty() {
-                    return;
-                }
-
-                let mut symbols: HashSet<String> = HashSet::new();
-                let mut has_symbol_args = false;
-                let mut has_unresolved_tag = false;
-
-                for arg in args {
-                    let first_byte = arg.as_bytes().first().copied().unwrap_or(0);
-                    if first_byte.is_ascii_digit() {
-                        continue;
-                    }
-                    if arg.starts_with('-') {
-                        continue;
-                    }
-                    let (has_symbols_in_arg, unresolved_tag) =
-                        collect_import_symbols(module, arg, &mut symbols);
-                    if has_symbols_in_arg {
-                        has_symbol_args = true;
-                    }
-                    if unresolved_tag {
-                        has_unresolved_tag = true;
-                    }
-                }
-
-                if has_unresolved_tag {
-                    return;
-                }
-
-                if has_symbol_args {
-                    map.entry(module.clone()).or_default().extend(symbols);
-                } else {
-                    map.entry(module.clone()).or_default();
-                }
-            }
-            NodeKind::Program { statements } | NodeKind::Block { statements } => {
-                let mut required_modules: Vec<String> = statements
-                    .iter()
-                    .filter_map(|stmt| require_module_name(inner_expr(stmt)))
-                    .collect();
-                let mut aliases: HashMap<String, String> = HashMap::new();
-                for stmt in statements {
-                    if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
-                        aliases.insert(alias, module.clone());
-                        if !required_modules.contains(&module) {
-                            required_modules.push(module);
-                        }
-                    }
-                }
-
-                for stmt in statements {
-                    let expr = inner_expr(stmt);
-                    let NodeKind::MethodCall { object, method, args } = &expr.kind else {
-                        continue;
-                    };
-                    if method != "import" {
-                        continue;
-                    }
-                    let object_name = match &object.kind {
-                        NodeKind::Identifier { name } => Some(name.as_str()),
-                        NodeKind::Variable { name, .. } => aliases.get(name).map(String::as_str),
-                        _ => None,
-                    };
-                    let Some(object_name) = object_name else {
-                        continue;
-                    };
-                    if !required_modules.iter().any(|module| module == object_name) {
-                        continue;
-                    }
-
-                    if args.is_empty() {
-                        continue;
-                    }
-
-                    let mut imported_symbols: HashSet<String> = HashSet::new();
-                    let mut has_symbols = false;
-                    let mut has_unresolved_tag = false;
-                    for arg in args {
-                        let (arg_has_symbols, arg_unresolved_tag) =
-                            collect_node_import_symbols(object_name, arg, &mut imported_symbols);
-                        if arg_has_symbols {
-                            has_symbols = true;
-                        }
-                        if arg_unresolved_tag {
-                            has_unresolved_tag = true;
-                        }
-                    }
-                    if has_unresolved_tag || !has_symbols {
-                        continue;
-                    }
-                    map.entry(object_name.to_string()).or_default().extend(imported_symbols);
-                }
-
-                for stmt in statements {
-                    collect(stmt, map);
-                }
-            }
-            _ => {}
-        }
-    }
-
     collect(ast, &mut map);
     map
 }
 
-/// Collect the set of module names that the buffer's AST `use`s,
-/// regardless of whether each `use` has an explicit symbol list.
-///
-/// Unlike [`extract_import_map`] this does NOT track which symbols were
-/// imported; it only records *which packages* are referenced by `use`
-/// statements. Used by the bounded Unknown-receiver method-completion
-/// fallback (#7929) to know which workspace packages are visible from
-/// the current file.
-///
-/// `use Foo;`, `use Foo ();`, `use Foo qw(bar);`, and `use Foo BAR;`
-/// all add `Foo` to the returned set. Pragma-style lowercase modules
-/// (e.g. `use strict;`) are excluded.
-pub(super) fn collect_used_module_names(ast: &Node) -> HashSet<String> {
-    let mut modules: HashSet<String> = HashSet::new();
-
-    fn walk(node: &Node, modules: &mut HashSet<String>) {
-        match &node.kind {
-            NodeKind::Use { module, .. } => {
-                if module.chars().next().is_some_and(|c: char| c.is_ascii_uppercase()) {
-                    modules.insert(module.clone());
-                }
+fn collect(node: &Node, map: &mut ImportMap) {
+    match &node.kind {
+        NodeKind::Use { module, args, .. } => collect_use_import(module, args, map),
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            collect_runtime_imports(statements, map);
+            for stmt in statements {
+                collect(stmt, map);
             }
-            NodeKind::Program { statements } | NodeKind::Block { statements } => {
-                for stmt in statements {
-                    walk(stmt, modules);
-                }
-            }
-            _ => {}
         }
+        _ => {}
+    }
+}
+
+fn collect_use_import(module: &str, args: &[String], map: &mut ImportMap) {
+    if !is_importable_module(module) || args.is_empty() {
+        return;
     }
 
-    walk(ast, &mut modules);
-    modules
+    let mut symbols: HashSet<String> = HashSet::new();
+    let mut has_symbol_args = false;
+    let mut has_unresolved_tag = false;
+
+    for arg in args.iter().filter(|arg| is_symbol_arg_candidate(arg)) {
+        let (has_symbols_in_arg, unresolved_tag) =
+            collect_import_symbols(module, arg, &mut symbols);
+        has_symbol_args |= has_symbols_in_arg;
+        has_unresolved_tag |= unresolved_tag;
+    }
+
+    if has_unresolved_tag {
+        return;
+    }
+
+    if has_symbol_args {
+        map.entry(module.to_string()).or_default().extend(symbols);
+    } else {
+        map.entry(module.to_string()).or_default();
+    }
 }
+
+fn is_symbol_arg_candidate(arg: &str) -> bool {
+    let first_byte = arg.as_bytes().first().copied().unwrap_or(0);
+    !first_byte.is_ascii_digit() && !arg.starts_with('-')
+}
+
+pub(super) use used_modules::collect_used_module_names;

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map/runtime_imports.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map/runtime_imports.rs
@@ -1,0 +1,139 @@
+use super::ImportMap;
+use super::symbols::collect_node_import_symbols;
+use perl_parser_core::ast::{Node, NodeKind};
+use std::collections::{HashMap, HashSet};
+
+pub(super) fn collect_runtime_imports(statements: &[Node], map: &mut ImportMap) {
+    let mut required_modules = collect_required_modules(statements);
+    let aliases = collect_module_runtime_aliases(statements, &mut required_modules);
+
+    for stmt in statements {
+        let expr = inner_expr(stmt);
+        let NodeKind::MethodCall { object, method, args } = &expr.kind else {
+            continue;
+        };
+        if method != "import" || args.is_empty() {
+            continue;
+        }
+
+        let Some(object_name) = resolve_import_receiver(object, &aliases) else {
+            continue;
+        };
+        if !required_modules.iter().any(|module| module == object_name) {
+            continue;
+        }
+
+        collect_method_import_symbols(object_name, args, map);
+    }
+}
+
+pub(super) fn inner_expr(node: &Node) -> &Node {
+    if let NodeKind::ExpressionStatement { expression } = &node.kind {
+        expression.as_ref()
+    } else {
+        node
+    }
+}
+
+fn collect_required_modules(statements: &[Node]) -> Vec<String> {
+    statements.iter().filter_map(|stmt| require_module_name(inner_expr(stmt))).collect()
+}
+
+fn collect_module_runtime_aliases(
+    statements: &[Node],
+    required_modules: &mut Vec<String>,
+) -> HashMap<String, String> {
+    let mut aliases = HashMap::new();
+    for stmt in statements {
+        if let Some((alias, module)) = module_runtime_alias(inner_expr(stmt)) {
+            aliases.insert(alias, module.clone());
+            if !required_modules.contains(&module) {
+                required_modules.push(module);
+            }
+        }
+    }
+    aliases
+}
+
+fn collect_method_import_symbols(object_name: &str, args: &[Node], map: &mut ImportMap) {
+    let mut imported_symbols: HashSet<String> = HashSet::new();
+    let mut has_symbols = false;
+    let mut has_unresolved_tag = false;
+    for arg in args {
+        let (arg_has_symbols, arg_unresolved_tag) =
+            collect_node_import_symbols(object_name, arg, &mut imported_symbols);
+        has_symbols |= arg_has_symbols;
+        has_unresolved_tag |= arg_unresolved_tag;
+    }
+    if !has_unresolved_tag && has_symbols {
+        map.entry(object_name.to_string()).or_default().extend(imported_symbols);
+    }
+}
+
+fn resolve_import_receiver<'a>(
+    object: &'a Node,
+    aliases: &'a HashMap<String, String>,
+) -> Option<&'a str> {
+    match &object.kind {
+        NodeKind::Identifier { name } => Some(name.as_str()),
+        NodeKind::Variable { name, .. } => aliases.get(name).map(String::as_str),
+        _ => None,
+    }
+}
+
+fn require_module_name(expr: &Node) -> Option<String> {
+    let NodeKind::FunctionCall { name, args } = &expr.kind else {
+        return None;
+    };
+    if name != "require" {
+        return None;
+    }
+    let first = args.first()?;
+    match &first.kind {
+        NodeKind::Identifier { name } => Some(name.clone()),
+        NodeKind::String { value, .. } => {
+            let cleaned = value.trim_matches('\'').trim_matches('"').trim();
+            Some(cleaned.trim_end_matches(".pm").replace('/', "::"))
+        }
+        _ => None,
+    }
+}
+
+fn module_runtime_alias(expr: &Node) -> Option<(String, String)> {
+    let (alias_name, call_node) = match &expr.kind {
+        NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
+            let NodeKind::Variable { name, .. } = &lhs.kind else {
+                return None;
+            };
+            (name.as_str(), rhs.as_ref())
+        }
+        NodeKind::VariableDeclaration { variable, initializer: Some(rhs), .. } => {
+            let NodeKind::Variable { name, .. } = &variable.kind else {
+                return None;
+            };
+            (name.as_str(), rhs.as_ref())
+        }
+        _ => return None,
+    };
+    let NodeKind::FunctionCall { name, args } = &call_node.kind else {
+        return None;
+    };
+    if !matches!(
+        name.as_str(),
+        "use_module"
+            | "require_module"
+            | "Module::Runtime::use_module"
+            | "Module::Runtime::require_module"
+    ) {
+        return None;
+    }
+    let first = args.first()?;
+    let NodeKind::String { value, .. } = &first.kind else {
+        return None;
+    };
+    let module = value.trim_matches('\'').trim_matches('"').trim();
+    if module.is_empty() {
+        return None;
+    }
+    Some((alias_name.to_string(), module.to_string()))
+}

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map/symbols.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map/symbols.rs
@@ -1,0 +1,92 @@
+use perl_module::import::resolve_known_export_tag;
+use perl_parser_core::ast::{Node, NodeKind};
+use std::collections::HashSet;
+
+pub(super) fn collect_import_symbols(
+    module: &str,
+    arg: &str,
+    symbols: &mut HashSet<String>,
+) -> (bool, bool) {
+    let trimmed = arg.trim();
+    if trimmed.is_empty() {
+        return (false, false);
+    }
+    if matches!(trimmed, "=>" | "," | "(" | ")" | "[" | "]" | "{" | "}") {
+        return (false, false);
+    }
+
+    let mut content = trimmed;
+    if let Some(inner) = content.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        content = inner.trim();
+    }
+
+    if content.starts_with("qw") {
+        content = content
+            .trim_start_matches("qw")
+            .trim_start_matches(|c: char| "([{/<|!".contains(c))
+            .trim_end_matches(|c: char| ")]}/|!>".contains(c))
+            .trim();
+        return collect_words(module, content, symbols, !content.is_empty());
+    }
+
+    let cleaned = content.trim_matches(|c: char| c == '\'' || c == '"');
+    if cleaned.is_empty() {
+        return (false, false);
+    }
+
+    collect_words(module, cleaned, symbols, true)
+}
+
+pub(super) fn collect_node_import_symbols(
+    module: &str,
+    arg: &Node,
+    symbols: &mut HashSet<String>,
+) -> (bool, bool) {
+    match &arg.kind {
+        NodeKind::String { value, .. } => {
+            collect_import_symbols(module, value.trim_matches('\'').trim_matches('"'), symbols)
+        }
+        NodeKind::Identifier { name } => collect_import_symbols(module, name, symbols),
+        NodeKind::ArrayLiteral { elements } => {
+            collect_array_import_symbols(module, elements, symbols)
+        }
+        _ => (false, false),
+    }
+}
+
+fn collect_array_import_symbols(
+    module: &str,
+    elements: &[Node],
+    symbols: &mut HashSet<String>,
+) -> (bool, bool) {
+    let mut has_symbols = false;
+    let mut has_unresolved_tag = false;
+    for element in elements {
+        let (element_has_symbols, element_unresolved_tag) =
+            collect_node_import_symbols(module, element, symbols);
+        has_symbols |= element_has_symbols;
+        has_unresolved_tag |= element_unresolved_tag;
+    }
+    (has_symbols, has_unresolved_tag)
+}
+
+fn collect_words(
+    module: &str,
+    words: &str,
+    symbols: &mut HashSet<String>,
+    has_symbols_when_nonempty: bool,
+) -> (bool, bool) {
+    let mut unresolved_tag = false;
+    for word in words.split_whitespace().filter(|word| !word.is_empty()) {
+        if word.starts_with(':') {
+            if let Some(expanded) = resolve_known_export_tag(module, word) {
+                symbols.extend(expanded.iter().map(|name| (*name).to_string()));
+            } else {
+                unresolved_tag = true;
+            }
+        } else {
+            symbols.insert(word.to_string());
+        }
+    }
+    (has_symbols_when_nonempty, unresolved_tag)
+}

--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map/used_modules.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/import_map/used_modules.rs
@@ -1,0 +1,41 @@
+use perl_parser_core::ast::{Node, NodeKind};
+use std::collections::HashSet;
+
+/// Collect the set of module names that the buffer's AST `use`s,
+/// regardless of whether each `use` has an explicit symbol list.
+///
+/// This does NOT track which symbols were imported; it only records *which
+/// packages* are referenced by `use` statements. Used by the bounded
+/// Unknown-receiver method-completion fallback (#7929) to know which workspace
+/// packages are visible from the current file.
+///
+/// `use Foo;`, `use Foo ();`, `use Foo qw(bar);`, and `use Foo BAR;` all add
+/// `Foo` to the returned set. Pragma-style lowercase modules (e.g. `use
+/// strict;`) are excluded.
+pub(in crate::providers::completion::completion) fn collect_used_module_names(
+    ast: &Node,
+) -> HashSet<String> {
+    let mut modules: HashSet<String> = HashSet::new();
+    walk(ast, &mut modules);
+    modules
+}
+
+fn walk(node: &Node, modules: &mut HashSet<String>) {
+    match &node.kind {
+        NodeKind::Use { module, .. } => {
+            if is_importable_module(module) {
+                modules.insert(module.clone());
+            }
+        }
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            for stmt in statements {
+                walk(stmt, modules);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub(super) fn is_importable_module(module: &str) -> bool {
+    module.chars().next().is_some_and(|c: char| c.is_ascii_uppercase())
+}


### PR DESCRIPTION
### Motivation

- The previous `import_map` implementation concentrated `use` parsing, runtime `->import` handling, symbol expansion, and used-module walking in one large function, making reasoning and testing harder.

### Description

- Split the large implementation into focused modules: `import_map.rs` (coordinator), `import_map/symbols.rs` (string/node symbol parsing and `qw`/tag expansion), `import_map/runtime_imports.rs` (require/Module::Runtime alias discovery and `->import(...)` handling), and `import_map/used_modules.rs` (used-module walker and module filtering predicate). 
- Kept the public entry point `extract_import_map(ast: &Node) -> ImportMap` unchanged while delegating responsibilities to the new helpers. 
- Reduced the coordinator to module-filtering, argument candidate filtering, and map insertion helpers and re-exported the used-module collector for local use. 
- Applied formatting and updated visibility for the used-module function to the minimal necessary scope (`pub(in crate::providers::completion::completion)`).

### Testing

- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo check --all-targets -p perl-lsp-rs-core --profile agent --locked` and it completed successfully. 
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo test -p perl-lsp-rs-core import_map --profile agent --locked` and the import_map tests passed. 
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs` which passed with no new warnings. 
- Ran `./scripts/cargo-safe xtask fmt` which completed successfully. 
- Note: an initial attempt to run `./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked` was blocked by an environment storage guard (`DENY: /root/.cache/devplane/perl-lsp`), so the full workspace test lane was not executed in that form.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a044621c1a08333811de5f7fd934b8e)