### PR TITLE
test(parser): lock ExtUtils TO_INST_PM map-sort fixture (#8843)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -660,6 +660,15 @@ fn extutils_mm_unix_grep_parens_over_map_arrayref_default() {
 }
 
 #[test]
+fn extutils_mm_unix_to_inst_pm_wraplist_map_sort() {
+    // From ExtUtils::MM_Unix: wraplist() arguments may include map EXPR over
+    // a sorted keys expression while building the TO_INST_PM make macro.
+    assert_clean_parse(
+        r#"push @m, "\n\nTO_INST_PM = ".$self->wraplist(map $self->quote_dep($_), sort keys %{$self->{PM}})."\n";"#,
+    );
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The Real Perl Editor Trust raw-bucket fixture lane still points at the stale unclosed_paren_identifier bucket. Fix: Add one source-backed ExtUtils::MM_Unix TO_INST_PM wraplist map-sort clean-parse fixture; no parser runtime behavior or generated status docs changed. Claim boundary: This locks a source-backed shape only and does not claim bucket-count reduction without a refreshed Linux corpus receipt. Verification: cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture passed; cargo xtask metrics parser-accuracy --check passed; cargo xtask update-status --only parser --check passed; cargo xtask metrics ratchet-check parser_accuracy passed; cargo xtask fmt --check passed; git diff --check passed.