### PR TITLE
test(workspace): record Mojolicious editor baseline (#8848)

### DIFF
--- a/.ci/metrics/real_project_latency.json
+++ b/.ci/metrics/real_project_latency.json
@@ -1,40 +1,39 @@
 {
-  "schema_version": 1,
-  "measured_at": "2026-04-28T00:00:00Z",
-  "commit": "5c89a9371",
+  "commit": "733ad1aed",
+  "measured_at": "2026-05-13T11:17:08Z",
   "projects": {
-    "mojolicious": {
-      "file_count": 13,
+    "catalyst": {
+      "file_count": null,
       "metrics": {
         "cold_start_to_hover": {
-          "p50_ms": 463,
-          "p95_ms": 978,
-          "p99_ms": 978,
-          "samples": 10
+          "p50_ms": null,
+          "p95_ms": null,
+          "p99_ms": null,
+          "samples": null
         },
         "first_completion": {
-          "p50_ms": 0,
-          "p95_ms": 1,
-          "p99_ms": 1,
-          "samples": 10
+          "p50_ms": null,
+          "p95_ms": null,
+          "p99_ms": null,
+          "samples": null
         },
         "first_goto_definition": {
-          "p50_ms": 0,
-          "p95_ms": 3,
-          "p99_ms": 3,
-          "samples": 10
+          "p50_ms": null,
+          "p95_ms": null,
+          "p99_ms": null,
+          "samples": null
         },
         "incremental_reparse": {
-          "p50_ms": 1,
-          "p95_ms": 2,
-          "p99_ms": 2,
-          "samples": 10
+          "p50_ms": null,
+          "p95_ms": null,
+          "p99_ms": null,
+          "samples": null
         },
         "workspace_symbol_query": {
-          "p50_ms": 0,
-          "p95_ms": 0,
-          "p99_ms": 0,
-          "samples": 10
+          "p50_ms": null,
+          "p95_ms": null,
+          "p99_ms": null,
+          "samples": null
         }
       }
     },
@@ -73,41 +72,42 @@
         }
       }
     },
-    "catalyst": {
-      "file_count": null,
+    "mojolicious": {
+      "file_count": 13,
       "metrics": {
         "cold_start_to_hover": {
-          "p50_ms": null,
-          "p95_ms": null,
-          "p99_ms": null,
-          "samples": null
+          "p50_ms": 182,
+          "p95_ms": 863,
+          "p99_ms": 863,
+          "samples": 10
         },
         "first_completion": {
-          "p50_ms": null,
-          "p95_ms": null,
-          "p99_ms": null,
-          "samples": null
+          "p50_ms": 0,
+          "p95_ms": 0,
+          "p99_ms": 0,
+          "samples": 10
         },
         "first_goto_definition": {
-          "p50_ms": null,
-          "p95_ms": null,
-          "p99_ms": null,
-          "samples": null
+          "p50_ms": 0,
+          "p95_ms": 0,
+          "p99_ms": 0,
+          "samples": 10
         },
         "incremental_reparse": {
-          "p50_ms": null,
-          "p95_ms": null,
-          "p99_ms": null,
-          "samples": null
+          "p50_ms": 1,
+          "p95_ms": 2,
+          "p99_ms": 2,
+          "samples": 10
         },
         "workspace_symbol_query": {
-          "p50_ms": null,
-          "p95_ms": null,
-          "p99_ms": null,
-          "samples": null
+          "p50_ms": 0,
+          "p95_ms": 0,
+          "p99_ms": 0,
+          "samples": 10
         }
       }
     }
   },
+  "schema_version": 1,
   "tolerance_pct": 10
 }

--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -86,11 +86,12 @@ commands = [
 
 [[work_item]]
 id = "real-workspace-baseline-run"
-status = "ready"
+status = "completed"
 spec = "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md"
 adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
 plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-real-workspace-baseline-run"
 current_pointer = "docs/development/REAL_WORKSPACE_BASELINE_RAIL.md"
+receipt = "docs/forensics/2026-05-13-real-workspace-baseline-mojolicious.md"
 claim_boundary = "A baseline proves the selected project and host receipt only; it is not all-CPAN proof or live provider cutover."
 commands = [
   "just real-workspace-baseline mojolicious",

--- a/crates/perl-lsp-rs/tests/real_project_latency.rs
+++ b/crates/perl-lsp-rs/tests/real_project_latency.rs
@@ -487,6 +487,28 @@ fn summary_to_json(s: &LatencySummary) -> Value {
     })
 }
 
+fn empty_metric_json() -> Value {
+    json!({
+        "p50_ms": Value::Null,
+        "p95_ms": Value::Null,
+        "p99_ms": Value::Null,
+        "samples": Value::Null
+    })
+}
+
+fn placeholder_project_json() -> Value {
+    json!({
+        "file_count": Value::Null,
+        "metrics": {
+            "cold_start_to_hover": empty_metric_json(),
+            "first_completion": empty_metric_json(),
+            "first_goto_definition": empty_metric_json(),
+            "incremental_reparse": empty_metric_json(),
+            "workspace_symbol_query": empty_metric_json()
+        }
+    })
+}
+
 /// Write the baseline JSON file (creates parent directories if needed).
 fn write_baseline(projects: &[ProjectMetrics]) {
     let root = workspace_root();
@@ -506,7 +528,16 @@ fn write_baseline(projects: &[ProjectMetrics]) {
         .trim()
         .to_string();
 
-    let mut projects_map = serde_json::Map::new();
+    let mut projects_map = fs::read_to_string(&output_path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+        .and_then(|v| v.get("projects").and_then(Value::as_object).cloned())
+        .unwrap_or_default();
+
+    for name in ["mojolicious", "dancer2", "catalyst"] {
+        projects_map.entry(name.to_string()).or_insert_with(placeholder_project_json);
+    }
+
     for p in projects {
         let metrics = json!({
             "cold_start_to_hover": summary_to_json(&p.cold_start_to_hover),

--- a/docs/development/REAL_WORKSPACE_BASELINE_RAIL.md
+++ b/docs/development/REAL_WORKSPACE_BASELINE_RAIL.md
@@ -8,15 +8,18 @@
 
 | Phase | Issue | Builder-ready? | PR | Receipt |
 |---|---|---|---|---|
-| 1. Real-workspace baseline suite | [#7949](https://github.com/EffortlessMetrics/perl-lsp/issues/7949) | not yet (`needs-assignee`) | _pending_ | `cargo test -p perl-lsp-rs --lib real_workspace` |
+| 1. Real-workspace baseline suite | [#8848](https://github.com/EffortlessMetrics/perl-lsp/issues/8848) | yes | current Real Perl Editor Trust baseline PR | [2026-05-13 Mojolicious Windows receipt](../forensics/2026-05-13-real-workspace-baseline-mojolicious.md) and `.ci/metrics/real_project_latency.json` |
 | 2. Editor-trust roadmap rollup | [#7952](https://github.com/EffortlessMetrics/perl-lsp/issues/7952) | not yet (`needs-spec`, `v0.14.0`, `umbrella`) | _pending_ | `cargo xtask semantic-shadow-compare --check` |
 
 ## Exit criteria
 
 - [ ] All phases land or are explicitly deferred with a successor.
-- [ ] Receipt commands in this doc reproduce the closeout proof.
+- [x] Phase 1 has a current Mojolicious receipt with explicit covered/deferred
+  provider surfaces.
+- [x] Receipt commands in this doc reproduce the closeout proof, with a Git Bash
+  fallback documented for Windows agents whose `just` shell is unavailable.
 - [ ] Status doc updated (`docs/project/status/semantic_capability_dashboard.md` and `docs/project/status/semantic_scorecard.md` regenerated post-merge).
-- [ ] Claim boundary recorded.
+- [x] Claim boundary recorded in the current receipt.
 
 ## Claim boundary
 
@@ -61,4 +64,8 @@ Do **not** roll this rail's PRs into:
 
 ## Lane assignment
 
-**Builder (sonnet)** — phase 1 implementation contract lives in #7949. Phase 2 (#7952) is an umbrella; it will spawn child rails (this one among them) and is not directly built. Until #7949 carries `builder-ready`, this rail's PRs cannot land beyond the docs PR for this rollout file.
+The older #7949 phase-1 tracker is historical. The current Real Perl Editor
+Trust baseline receipt is tracked by #8848 and records the first covered
+Mojolicious fixture/host proof. Phase 2 (#7952) remains an umbrella for broader
+editor-trust rollout work and should spawn focused child rails instead of being
+built directly.

--- a/docs/forensics/2026-05-13-real-workspace-baseline-mojolicious.md
+++ b/docs/forensics/2026-05-13-real-workspace-baseline-mojolicious.md
@@ -1,18 +1,18 @@
-# Real-Workspace Baseline: {PROJECT} ({SYSTEM})
+# Real-Workspace Baseline: mojolicious (windows)
 
-**Date**: {DATE}
-**Commit**: {COMMIT}
-**System**: {SYSTEM}
-**Project**: {PROJECT}
+**Date**: 2026-05-13
+**Commit**: 733ad1aed
+**System**: windows
+**Project**: mojolicious
 
 ## Substrate Versions
 
 | Component | Version |
 |-----------|---------|
-| perl-lsp  | {PERLLSP_VERSION} |
-| Rust      | {RUST_VERSION} |
-| Perl      | {PERL_VERSION} |
-| OS        | {OS_VERSION} |
+| perl-lsp  | 0.14.0 |
+| Rust      | rustc 1.95.0 (59807616e 2026-04-14) |
+| Perl      | v5.42.2 |
+| OS        | MINGW64_NT-10.0-26200 3.6.7-fb42d713.x86_64 x86_64 |
 
 ## Metrics
 
@@ -20,36 +20,36 @@
 
 | p50 | p95 | p99 | Samples |
 |-----|-----|-----|---------|
-| {COLD_START_P50} | {COLD_START_P95} | {COLD_START_P99} | {COLD_START_N} |
+| 182 | 863 | 863 | 10 |
 
 ### First Completion (ms)
 
 | p50 | p95 | p99 | Samples |
 |-----|-----|-----|---------|
-| {COMPLETION_P50} | {COMPLETION_P95} | {COMPLETION_P99} | {COMPLETION_N} |
+| 0 | 0 | 0 | 10 |
 
 ### Goto-Definition (ms)
 
 | p50 | p95 | p99 | Samples |
 |-----|-----|-----|---------|
-| {GOTO_DEF_P50} | {GOTO_DEF_P95} | {GOTO_DEF_P99} | {GOTO_DEF_N} |
+| 0 | 0 | 0 | 10 |
 
 ### Incremental Reparse (ms)
 
 | p50 | p95 | p99 | Samples |
 |-----|-----|-----|---------|
-| {REPARSE_P50} | {REPARSE_P95} | {REPARSE_P99} | {REPARSE_N} |
+| 1 | 2 | 2 | 10 |
 
 ### Workspace Symbol Query (ms)
 
 | p50 | p95 | p99 | Samples |
 |-----|-----|-----|---------|
-| {WSSYM_P50} | {WSSYM_P95} | {WSSYM_P99} | {WSSYM_N} |
+| 0 | 0 | 0 | 10 |
 
 ## Project Stats
 
-- **Perl files**: {FILE_COUNT} (.pm / .pl / .t)
-- **Fixture source**: {FIXTURE_DIR}
+- **Perl files**: 13 (.pm / .pl / .t)
+- **Fixture source**: test_corpus/real_projects/mojolicious_skeleton/
 
 ## Provider Coverage
 
@@ -81,7 +81,7 @@ provider cutover by itself.
 
 ## Outliers
 
-{OUTLIERS}
+- **cold_start_to_hover** p95=863ms exceeds 500ms threshold
 
 Outliers are recorded threshold misses for the named metric. They do not block
 the receipt, but they do block promotion of a no-outlier latency claim for that
@@ -91,17 +91,17 @@ metric until a follow-up run or fix clears the threshold.
 
 ```bash
 # Reproduce this measurement
-just real-workspace-baseline {PROJECT} {SYSTEM}
+just real-workspace-baseline mojolicious windows
 
 # Windows fallback when just cannot locate its shell
-"C:/Program Files/Git/bin/bash.exe" scripts/real-workspace-baseline.sh {PROJECT} {SYSTEM}
+"C:/Program Files/Git/bin/bash.exe" scripts/real-workspace-baseline.sh mojolicious windows
 ```
 
 - Binary built with: `cargo build -p perl-lsp-rs --release`
-- Test invoked via: `cargo test -p perl-lsp-rs --test real_project_latency {PROJECT} -- --include-ignored --nocapture`
+- Test invoked via: `cargo test -p perl-lsp-rs --test real_project_latency mojolicious -- --include-ignored --nocapture`
 - Samples per metric: 10 (p50/p95/p99)
-- Fixture path: `test_corpus/real_projects/{FIXTURE_DIR}/`
+- Fixture path: `test_corpus/real_projects/mojolicious_skeleton/`
 
 ## Notes
 
-{NOTES}
+Current baseline run for mojolicious on windows. Establishes a Real Perl Editor Trust measurement anchor for the selected fixture and host.

--- a/plans/real-perl-editor-trust/implementation-plan.md
+++ b/plans/real-perl-editor-trust/implementation-plan.md
@@ -430,7 +430,7 @@ with an explicit deferral note and keep fixture-only work in scope.
 
 ## Work item: real-workspace-baseline-run
 
-Status: ready
+Status: completed; receipt [2026-05-13 Mojolicious Windows baseline](../../docs/forensics/2026-05-13-real-workspace-baseline-mojolicious.md)
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked spec: [PLSP-SPEC-0003](../../docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md)
 Linked ADR: [PLSP-ADR-0002](../../docs/adr/PLSP-ADR-0002-confidence-before-cutover.md)
@@ -444,7 +444,10 @@ module resolution, provider behavior, and confidence boundaries.
 
 Production delta
 
-Adds a receipt or forensic/status link for the selected CPAN-style project.
+Recorded a current Mojolicious Windows editor-latency receipt, refreshed the
+raw latency JSON for that fixture, and updated the report generator/template to
+state provider coverage, explicit deferrals, confidence/status links, outlier
+interpretation, and claim boundaries.
 
 Non-goals
 

--- a/scripts/real-workspace-baseline.sh
+++ b/scripts/real-workspace-baseline.sh
@@ -148,7 +148,7 @@ do
     fi
 done
 if [ -z "$OUTLIERS" ]; then
-    OUTLIERS="None — all p95 values within 500ms threshold."
+    OUTLIERS="None - all p95 values within 500ms threshold."
 fi
 
 # ── Write markdown report ─────────────────────────────────────────────────────
@@ -212,15 +212,50 @@ content = """\
 - **Perl files**: ${FILE_COUNT} (.pm / .pl / .t)
 - **Fixture source**: test_corpus/real_projects/${FIXTURE_DIR}/
 
+## Provider Coverage
+
+| Surface | Status | Receipt |
+|---------|--------|---------|
+| Cold start / first hover | covered | \`cold_start_to_hover\` |
+| Completion latency | covered | \`first_completion\` |
+| Goto definition latency | covered | \`first_goto_definition\` |
+| Incremental reparse | covered | \`incremental_reparse\` |
+| Workspace symbols | covered | \`workspace_symbol_query\` |
+| Workspace indexing | indirect | initialization, document open, and provider requests exercise the fixture workspace; dedicated index-shape receipts remain in provider/status docs |
+| Module resolution | indirect | fixture package layout is exercised through hover, completion, goto, and workspace-symbol requests; dedicated module-resolution receipts remain separate |
+| Diagnostics | deferred | latency harness does not wait for publishDiagnostics; use diagnostics/provider receipts for diagnostic correctness claims |
+| Memory profile | deferred | this harness records wall-clock latency, not heap or RSS |
+
+## Provider Confidence Links
+
+- [Provider cutover](../project/status/provider_cutover.md)
+- [UX capability dashboard](../project/status/ux_capability_dashboard.md)
+- [Semantic scorecard](../project/status/semantic_scorecard.md)
+- [Semantic shadow compare](../project/status/semantic_shadow_compare.md)
+
+## Claim Boundary
+
+This receipt supports a measured editor-latency claim for the selected fixture
+and host system only. It does not claim full CPAN compatibility, broader
+framework coverage, memory/resource ceilings, diagnostic correctness, or live
+provider cutover by itself.
+
 ## Outliers
 
 ${OUTLIERS}
+
+Outliers are recorded threshold misses for the named metric. They do not block
+the receipt, but they do block promotion of a no-outlier latency claim for that
+metric until a follow-up run or fix clears the threshold.
 
 ## Reproducibility Notes
 
 \`\`\`bash
 # Reproduce this measurement
 just real-workspace-baseline ${PROJECT} ${SYSTEM}
+
+# Windows fallback when just cannot locate its shell
+"C:/Program Files/Git/bin/bash.exe" scripts/real-workspace-baseline.sh ${PROJECT} ${SYSTEM}
 \`\`\`
 
 - Binary built with: \`cargo build -p perl-lsp-rs --release\`
@@ -230,7 +265,7 @@ just real-workspace-baseline ${PROJECT} ${SYSTEM}
 
 ## Notes
 
-First baseline run for ${PROJECT} on ${SYSTEM}. Establishes measurement anchor for v0.13.0 release gate.
+Current baseline run for ${PROJECT} on ${SYSTEM}. Establishes a Real Perl Editor Trust measurement anchor for the selected fixture and host.
 """
 with open(path, 'w') as f:
     f.write(content)


### PR DESCRIPTION
Problem: Real Perl Editor Trust needed a current real-workspace receipt linked to provider confidence/status artifacts instead of only older baseline notes. Fix: Record a current Mojolicious Windows editor-latency receipt, preserve the aggregate latency JSON schema for single-project runs, and update the active goal/plan/rail docs so the baseline run is no longer routed as ready work. Claim boundary: This proves only the Mojolicious skeleton fixture on this Windows host. It does not claim all-CPAN support, diagnostic correctness, memory ceilings, broader framework coverage, or live provider cutover. Verification: just real-workspace-baseline mojolicious windows attempted but failed because just could not find its shell in this Windows session; direct Git Bash fallback C:/Program Files/Git/bin/bash.exe scripts/real-workspace-baseline.sh mojolicious windows passed; cargo test -p perl-lsp-rs --test real_project_latency mojolicious --profile agent --locked -- --include-ignored --nocapture passed; cargo test -p perl-lsp-rs --test real_project_latency test_real_project_latency_baseline_schema --profile agent --locked -- --nocapture passed; cargo xtask semantic-scorecard --check passed; cargo xtask semantic-shadow-compare --check passed; cargo xtask fmt --check passed; git diff --check passed.