### PR TITLE
test(workspace): refresh Mojolicious baseline receipt (#8848)

### DIFF
--- a/.ci/metrics/real_project_latency.json
+++ b/.ci/metrics/real_project_latency.json
@@ -1,6 +1,6 @@
 {
-  "commit": "733ad1aed",
-  "measured_at": "2026-05-13T11:17:08Z",
+  "commit": "7ee5cec98",
+  "measured_at": "2026-05-13T12:21:10Z",
   "projects": {
     "catalyst": {
       "file_count": null,
@@ -76,15 +76,15 @@
       "file_count": 13,
       "metrics": {
         "cold_start_to_hover": {
-          "p50_ms": 182,
-          "p95_ms": 863,
-          "p99_ms": 863,
+          "p50_ms": 192,
+          "p95_ms": 1029,
+          "p99_ms": 1029,
           "samples": 10
         },
         "first_completion": {
           "p50_ms": 0,
-          "p95_ms": 0,
-          "p99_ms": 0,
+          "p95_ms": 1,
+          "p99_ms": 1,
           "samples": 10
         },
         "first_goto_definition": {
@@ -95,8 +95,8 @@
         },
         "incremental_reparse": {
           "p50_ms": 1,
-          "p95_ms": 2,
-          "p99_ms": 2,
+          "p95_ms": 3,
+          "p99_ms": 3,
           "samples": 10
         },
         "workspace_symbol_query": {

--- a/docs/forensics/2026-05-13-real-workspace-baseline-mojolicious.md
+++ b/docs/forensics/2026-05-13-real-workspace-baseline-mojolicious.md
@@ -1,7 +1,7 @@
 # Real-Workspace Baseline: mojolicious (windows)
 
 **Date**: 2026-05-13
-**Commit**: 733ad1aed
+**Commit**: 7ee5cec98
 **System**: windows
 **Project**: mojolicious
 
@@ -20,13 +20,13 @@
 
 | p50 | p95 | p99 | Samples |
 |-----|-----|-----|---------|
-| 182 | 863 | 863 | 10 |
+| 192 | 1029 | 1029 | 10 |
 
 ### First Completion (ms)
 
 | p50 | p95 | p99 | Samples |
 |-----|-----|-----|---------|
-| 0 | 0 | 0 | 10 |
+| 0 | 1 | 1 | 10 |
 
 ### Goto-Definition (ms)
 
@@ -38,7 +38,7 @@
 
 | p50 | p95 | p99 | Samples |
 |-----|-----|-----|---------|
-| 1 | 2 | 2 | 10 |
+| 1 | 3 | 3 | 10 |
 
 ### Workspace Symbol Query (ms)
 
@@ -81,7 +81,7 @@ provider cutover by itself.
 
 ## Outliers
 
-- **cold_start_to_hover** p95=863ms exceeds 500ms threshold
+- **cold_start_to_hover** p95=1029ms exceeds 500ms threshold
 
 Outliers are recorded threshold misses for the named metric. They do not block
 the receipt, but they do block promotion of a no-outlier latency claim for that

--- a/scripts/real-workspace-baseline.sh
+++ b/scripts/real-workspace-baseline.sh
@@ -147,6 +147,7 @@ do
         OUTLIERS="${OUTLIERS}- **${MNAME}** p95=${MVAL}ms exceeds 500ms threshold"$'\n'
     fi
 done
+OUTLIERS="${OUTLIERS%$'\n'}"
 if [ -z "$OUTLIERS" ]; then
     OUTLIERS="None - all p95 values within 500ms threshold."
 fi


### PR DESCRIPTION
Problem: #8850 landed the Mojolicious real-workspace baseline with a receipt tied to an older parser-fixture commit and the report generator could leave an extra blank line after outlier rows.
Fix: Refresh the Mojolicious receipt from current master and trim the generated outlier list before writing the forensic report.
Verification: `scripts/real-workspace-baseline.sh mojolicious windows`; `cargo test -p perl-lsp-rs --test real_project_latency test_real_project_latency_baseline_schema --profile agent --locked -- --nocapture`; `cargo xtask semantic-scorecard --check`; `cargo xtask semantic-shadow-compare --check`; `cargo xtask fmt --check`; `git diff --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`.