### PR TITLE
test(parser): lock ExtUtils ignore map tuple fixture (#8857)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -669,6 +669,13 @@ fn extutils_mm_unix_to_inst_pm_wraplist_map_sort() {
 }
 
 #[test]
+fn extutils_mm_unix_ignore_map_tuple_qw() {
+    // From ExtUtils::MM_Unix: map BLOCK may return a parenthesized key/value
+    // tuple over a qw list while initializing ignore entries.
+    assert_clean_parse(r#"my %ignore = map {( $_ => 1 )} qw(Makefile.PL Build.PL test.pl t);"#);
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The active parser status routes capability work to the stale unclosed_paren_identifier raw bucket. Linux corpus roots are unavailable on this Windows host, so the lane calls for focused source-backed fixtures without bucket-count claims.

Fix: Add one ExtUtils::MM_Unix source-backed fixture for a map BLOCK returning a parenthesized key/value tuple over a qw list.

Claim boundary: Fixture-only. No parser runtime change, no generated status edit, and no bucket-count reduction claim.

Verification:
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture
- cargo xtask metrics parser-accuracy --check
- cargo xtask update-status --only parser --check
- cargo xtask metrics ratchet-check parser_accuracy
- cargo xtask fmt --check
- git diff --check