### PR TITLE
test(parser): lock ExtUtils ldrun map qq fixture (#8859)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -676,6 +676,13 @@ fn extutils_mm_unix_ignore_map_tuple_qw() {
 }
 
 #[test]
+fn extutils_mm_unix_ldrun_join_map_qq_rpath() {
+    // From ExtUtils::MM_Unix: join may take map(qq{...}, LIST) where the
+    // mapped expression interpolates $_ inside a quote-like operator.
+    assert_clean_parse(r#"$ldrun = join " ", map(qq{-Wl,-rpath,"$_"}, @dirs);"#);
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The active parser status routes capability work to the stale unclosed_paren_identifier raw bucket. Linux corpus roots are unavailable on this Windows host, so the lane calls for focused source-backed fixtures without bucket-count claims.

Fix: Add one ExtUtils::MM_Unix source-backed fixture for join over map(qq{...}, LIST), covering the ldrun rpath construction idiom.

Claim boundary: Fixture-only. No parser runtime change, no generated status edit, and no bucket-count reduction claim.

Verification:
- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture
- cargo xtask metrics parser-accuracy --check
- cargo xtask update-status --only parser --check
- cargo xtask metrics ratchet-check parser_accuracy
- cargo xtask fmt --check
- git diff --check