### PR TITLE
test(parser): lock ExtUtils map quote-literal pair fixture (#8861)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -683,6 +683,17 @@ fn extutils_mm_unix_ldrun_join_map_qq_rpath() {
 }
 
 #[test]
+fn extutils_mm_unix_split_command_map_quote_literal_pair() {
+    // From ExtUtils::MM_Unix: function arguments may include map EXPR, LIST
+    // where the expression is a unary-plus parenthesized key/value pair.
+    assert_clean_parse(
+        r#"my @cmds = $self->split_command($pm_to_blib,
+            map +($self->quote_literal($_) => $self->quote_literal($self->{PM}{$_})),
+            sort keys %{$self->{PM}});"#,
+    );
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The parser capability handoff still routes fixture-only work to the stale `unclosed_paren_identifier` raw bucket without bucket-count claims.
Fix: Add one ExtUtils::MM_Unix source-backed regression for the `split_command(..., map +(... => ...), sort keys ...)` quote-literal pair idiom.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`.