### PR TITLE
docs: defer Linux corpus refresh to successor (#8862)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -72,11 +72,13 @@ commands = [
 
 [[work_item]]
 id = "linux-corpus-refresh"
-status = "ready"
+status = "deferred"
 spec = "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md"
 adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
 plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-linux-corpus-refresh"
 current_pointer = "docs/project/status/parser.md#raw-failure-buckets"
+successor_issue = "https://github.com/EffortlessMetrics/perl-lsp/issues/8863"
+deferred_reason = "Current Windows worktree lacks the Linux system Perl roots required for a system-profile corpus receipt."
 claim_boundary = "May update parser bucket counts only from refreshed generated corpus status."
 commands = [
   "cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt",

--- a/plans/real-perl-editor-trust/implementation-plan.md
+++ b/plans/real-perl-editor-trust/implementation-plan.md
@@ -391,7 +391,7 @@ status, revert behavior first and leave fixture evidence for follow-up.
 
 ## Work item: linux-corpus-refresh
 
-Status: ready
+Status: deferred on Windows; successor #8863
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked spec: [PLSP-SPEC-0004](../../docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md)
 Linked ADR: [PLSP-ADR-0001](../../docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
@@ -416,6 +416,13 @@ Acceptance
 
 Corpus sweep completes on Linux, generated parser status is updated through
 tooling, and the PR states bucket-count claims limited to that receipt.
+
+Deferral note
+
+The current Windows worktree does not have the Linux system roots named by the
+stale receipt (`/usr/share/perl`, `/usr/lib/x86_64-linux-gnu/perl`, and
+`/usr/share/perl5`). The refresh is deferred to successor issue #8863 and must
+run on a Linux host before any parser bucket-count movement is claimed.
 
 Proof commands
 


### PR DESCRIPTION
Problem: Real Perl Editor Trust still listed the Linux system-Perl corpus refresh as ready even though the current Windows worktree lacks the Linux roots required for that receipt.

Fix: Mark `linux-corpus-refresh` as deferred in the active manifest and implementation plan, record the Windows deferral reason, and link successor EffortlessMetrics/perl-lsp-swarm#2693 for the real Linux receipt refresh.

Claim boundary: This is a control-plane deferral only. It does not edit generated parser status, add parser fixtures, change parser/provider behavior, or claim parser bucket-count movement.

Verification:
- `Test-Path /usr/share/perl`, `/usr/lib/x86_64-linux-gnu/perl`, and `/usr/share/perl5` returned false; local `perl` is Strawberry Perl at `C:\Strawberry\perl\bin\perl.exe`.
- `python -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('.perl-lsp/goals/active.toml').read_text()); print('active.toml ok')"`
- `cargo xtask update-status --only parser --check`
- `git diff --check`

Closes EffortlessMetrics/perl-lsp#8862.