### PR TITLE
goals: record real Perl editor trust closeout (#8866)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -140,11 +140,13 @@ commands = [
 
 [[work_item]]
 id = "lane-closeout"
-status = "ready"
+status = "completed"
 spec = "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md"
 adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
 plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
 current_pointer = "plans/real-perl-editor-trust/implementation-plan.md"
+receipt = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
+completed = "2026-05-13"
 claim_boundary = "Close only when deferred items have explicit successors and status/support claims point to proof."
 commands = [
   "cargo xtask update-status --only parser --check",

--- a/plans/real-perl-editor-trust/implementation-plan.md
+++ b/plans/real-perl-editor-trust/implementation-plan.md
@@ -395,8 +395,8 @@ Status: deferred on Windows; successor #8863
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked spec: [PLSP-SPEC-0004](../../docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md)
 Linked ADR: [PLSP-ADR-0001](../../docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
-Blocks: support-claim-refresh, lane-closeout
-Blocked by: raw-bucket-fixture-lane or explicit decision to refresh now
+Blocks: none for this closeout; successor #8863 owns future bucket-count claims
+Blocked by: Linux system-Perl roots unavailable on this Windows host
 
 Goal
 

--- a/plans/real-perl-editor-trust/implementation-plan.md
+++ b/plans/real-perl-editor-trust/implementation-plan.md
@@ -581,12 +581,12 @@ the limitation visible.
 
 ## Work item: lane-closeout
 
-Status: ready
+Status: completed; issue #8866
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked spec: all Real Perl Editor Trust specs
 Linked ADR: all Real Perl Editor Trust ADRs
 Blocks: none
-Blocked by: active goal manifest, support-claim-refresh, provider-confidence-closeout, linux-corpus-refresh or explicit deferral
+Blocked by: none
 
 Goal
 
@@ -608,6 +608,25 @@ Acceptance
 Active manifest points to this plan and current status docs; implementation plan
 has no missing required fields; status/support surfaces link claims to proof;
 deferred items name successor work.
+
+Completion audit
+
+- Source-of-truth stack: proposal, specs, ADRs, implementation plan, and active
+  goal manifest are present.
+- Parser control plane: `parser_accuracy_next.md` reports 0 active failure
+  packets and routes capability work to `parser.md#raw-failure-buckets`.
+- Parser claim boundary: `parser.md` records the stale system-Perl receipt and
+  the raw `unclosed_paren_identifier` bucket; fixture-only work remains active
+  and must not claim bucket-count movement.
+- Linux corpus refresh: deferred on this Windows host because the Linux
+  system-Perl roots are unavailable; successor #8863 owns the fresh receipt.
+- Provider confidence: `provider_confidence_matrix.md` maps provider source,
+  confidence, freshness, fallback, runtime comparison, real-workspace links,
+  live state, and next proof.
+- Real-workspace proof: the 2026-05-13 Mojolicious Windows receipt records the
+  covered editor-latency surfaces and explicit deferrals.
+- Support claims: `SUPPORT_TIERS.md` maps user-facing claims to proof commands,
+  status docs, known limitations, and next promotion proof.
 
 Proof commands
 


### PR DESCRIPTION
Problem: The Real Perl Editor Trust control plane had its prerequisites in place, but the lane-closeout work item still read as ready.

Fix: Record the closeout audit in the implementation plan and mark the lane-closeout work item completed in the active manifest. Raw-bucket fixture work remains active, and the Linux system-Perl corpus refresh stays deferred to successor EffortlessMetrics/perl-lsp-swarm#2693.

Claim boundary: This is a control-plane closeout only. It does not claim full CPAN support, parser bucket-count reduction, a fresh Linux corpus receipt, generated status changes, or broad live provider cutover.

Verification:
- `python -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('.perl-lsp/goals/active.toml').read_text()); print('active.toml ok')"`
- `cargo xtask update-status --only parser --check`
- `cargo xtask semantic-scorecard --check`
- `cargo xtask semantic-shadow-compare --check`
- `git diff --check`

Closes EffortlessMetrics/perl-lsp#8866.