### PR TITLE
test(parser): lock ExtUtils hash-slice map fixture (#8868)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -694,6 +694,13 @@ fn extutils_mm_unix_split_command_map_quote_literal_pair() {
 }
 
 #[test]
+fn extutils_mm_unix_hash_slice_map_lc_keys_assignment() {
+    // From ExtUtils::MM_Unix: a hash-slice assignment may use map EXPR, LIST
+    // over keys() as the slice index list before a postfix condition.
+    assert_clean_parse(r#"@ignore{map lc, keys %ignore} = values %ignore if $Is{VMS};"#);
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The active `unclosed_paren_identifier` raw bucket still contains source-backed ExtUtils shapes from a stale system-Perl receipt.

Fix: Add one fixture-only parser test for the `ExtUtils::MM_Unix` hash-slice assignment shape `@ignore{map lc, keys %ignore} = values %ignore if $Is{VMS};`.

Claim boundary: This locks a source-backed real-Perl shape only. It does not change parser runtime behavior, edit generated parser status, or claim raw bucket reduction. Linux corpus movement remains deferred to successor EffortlessMetrics/perl-lsp-swarm#2693.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`

Closes EffortlessMetrics/perl-lsp#8868.