### PR TITLE
test(parser): lock ExtUtils map grep substitution fixture (#8870)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -701,6 +701,15 @@ fn extutils_mm_unix_hash_slice_map_lc_keys_assignment() {
 }
 
 #[test]
+fn extutils_mm_unix_map_over_grep_substitution() {
+    // From ExtUtils::MM_Unix: a hash assignment may merge a map BLOCK whose
+    // source list is a grep-like substitution expression over an array.
+    assert_clean_parse(
+        r#"%o = (%o, map { $_ => 1 } grep s/\.c(pp|xx|c)?\z/$self->{OBJ_EXT}/i, @o_files);"#,
+    );
+}
+
+#[test]
 fn main_package_variable_in_paren_expr() {
     // From Unicode::Normalize: `$::IS_ASCII` must parse as a main-package
     // variable, not as `$::` followed by a stray bare identifier.


### PR DESCRIPTION
Problem: The active `unclosed_paren_identifier` raw bucket still contains source-backed ExtUtils map/list ambiguity shapes from a stale system-Perl receipt.

Fix: Add one fixture-only parser test for the `ExtUtils::MM_Unix` hash assignment shape `%o = (%o, map { $_ => 1 } grep s/\.c(pp|xx|c)?\z/$self->{OBJ_EXT}/i, @o_files);`.

Claim boundary: This locks a source-backed real-Perl shape only. It does not change parser runtime behavior, edit generated parser status, or claim raw bucket reduction. Linux corpus movement remains deferred to successor EffortlessMetrics/perl-lsp-swarm#2693.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`

Closes EffortlessMetrics/perl-lsp#8870.