### PR TITLE
test(parser): lock ExtUtils mpl_args map qq fixture (#8871)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -683,6 +683,13 @@ fn extutils_mm_unix_ldrun_join_map_qq_rpath() {
 }
 
 #[test]
+fn extutils_mm_unix_mpl_args_join_map_qq_brackets() {
+    // From ExtUtils::MM_Unix: join may take a bare map EXPR, LIST where the
+    // mapped expression is a qq[] literal over @ARGV.
+    assert_clean_parse(r#"my $mpl_args = join " ", map qq["$_"], @ARGV;"#);
+}
+
+#[test]
 fn extutils_mm_unix_split_command_map_quote_literal_pair() {
     // From ExtUtils::MM_Unix: function arguments may include map EXPR, LIST
     // where the expression is a unary-plus parenthesized key/value pair.


### PR DESCRIPTION
Problem: The active `unclosed_paren_identifier` raw bucket still contains source-backed ExtUtils map/quote-like shapes from a stale system-Perl receipt.

Fix: Add one fixture-only parser test for the `ExtUtils::MM_Unix` `mpl_args` shape `my $mpl_args = join " ", map qq["$_"], @ARGV;`.

Claim boundary: This locks a source-backed real-Perl shape only. It does not change parser runtime behavior, edit generated parser status, or claim raw bucket reduction. Linux corpus movement remains deferred to successor EffortlessMetrics/perl-lsp-swarm#2693.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `git diff --check`

Closes EffortlessMetrics/perl-lsp#8871.