### PR TITLE
test(parser): lock ExtUtils attrs map qq fixture (#8875)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -690,6 +690,13 @@ fn extutils_mm_unix_mpl_args_join_map_qq_brackets() {
 }
 
 #[test]
+fn extutils_mm_unix_attrs_join_map_qq_hash_lookup() {
+    // From ExtUtils::MM_Unix: join may take a map BLOCK source over sorted
+    // attribute keys while the mapped qq[] expression interpolates a hash lookup.
+    assert_clean_parse(r#"my $attrs = join " ", map { qq[$_="$attrs{$_}"] } sort keys %attrs;"#);
+}
+
+#[test]
 fn extutils_mm_unix_split_command_map_quote_literal_pair() {
     // From ExtUtils::MM_Unix: function arguments may include map EXPR, LIST
     // where the expression is a unary-plus parenthesized key/value pair.


### PR DESCRIPTION
Problem: The active unclosed_paren_identifier raw bucket still routes fixture-only source-backed parser coverage while the Linux corpus receipt is stale. Fix: Add one ExtUtils::MM_Unix fixture for a join call whose list is map BLOCK over sorted attribute keys, locking a real map/quote-like shape without parser runtime changes. Claim boundary: Fixture-only source-backed shape. This does not change parser runtime behavior, edit generated parser status, or claim raw bucket reduction. Linux corpus movement remains deferred to EffortlessMetrics/perl-lsp-swarm#2693. Verification: cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture; cargo xtask metrics parser-accuracy --check; cargo xtask update-status --only parser --check; cargo xtask metrics ratchet-check parser_accuracy; cargo xtask fmt --check; git diff --check. Closes EffortlessMetrics/perl-lsp#8875.