### PR TITLE
docs(parser): refresh unclosed_paren_identifier shape map (#8878)

### DIFF
--- a/docs/project/status/parser_unclosed_paren_identifier_shapes.md
+++ b/docs/project/status/parser_unclosed_paren_identifier_shapes.md
@@ -116,6 +116,7 @@ Shape:
 Representative locked tests:
 
 - `extutils_mm_unix_hash_slice_map_lc_keys_assignment`
+- `extutils_mm_unix_attrs_join_map_qq_hash_lookup`
 - `unicode_collate_hst_join_map_split_expr`
 - `unicode_collate_unpack_u_coderef_map_expr`
 - `extutils_mm_unix_grep_parens_over_map_arrayref_default`


### PR DESCRIPTION
Problem: The unclosed_paren_identifier shape map did not include the ExtUtils attrs map/qq fixture merged in #8876.
Fix: Add `extutils_mm_unix_attrs_join_map_qq_hash_lookup` to the existing source-list builtins group.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture` passes; `cargo xtask metrics parser-accuracy --check` passes; `cargo xtask update-status --only parser --check` passes; `cargo xtask metrics ratchet-check parser_accuracy` passes; `cargo xtask fmt --check` passes; `git diff --check` passes.

Claim boundary: docs-only; no parser runtime behavior, fixture, generated status, provider row, or raw bucket-count claim.

Fixes #8878.