### PR TITLE
test(parser): assert list-operator boundary receipts (#8880)

### DIFF
--- a/crates/perl-parser-core/tests/list_operator_boundary_receipts.rs
+++ b/crates/perl-parser-core/tests/list_operator_boundary_receipts.rs
@@ -1,0 +1,107 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::{assert_clean_parse, parse};
+use perl_parser_core::{Node, NodeKind};
+
+fn program_statement(source: &str, context: &str) -> Result<Node, String> {
+    let ast = parse(source);
+    let NodeKind::Program { statements } = ast.kind else {
+        return Err(format!("expected Program node for {context}, got {:?}", ast.kind));
+    };
+    statements.into_iter().next().ok_or_else(|| format!("expected first statement for {context}"))
+}
+
+fn declaration_initializer<'a>(statement: &'a Node, context: &str) -> Result<&'a Node, String> {
+    let NodeKind::VariableDeclaration { initializer, .. } = &statement.kind else {
+        return Err(format!(
+            "expected VariableDeclaration for {context}, got {:?}",
+            statement.kind
+        ));
+    };
+    initializer.as_deref().ok_or_else(|| format!("expected initializer for {context}"))
+}
+
+fn function_call<'a>(
+    node: &'a Node,
+    expected_name: &str,
+    context: &str,
+) -> Result<&'a [Node], String> {
+    let NodeKind::FunctionCall { name, args } = &node.kind else {
+        return Err(format!(
+            "expected FunctionCall({expected_name}) for {context}, got {:?}",
+            node.kind
+        ));
+    };
+    if name != expected_name {
+        return Err(format!("expected FunctionCall({expected_name}) for {context}, got {name}"));
+    }
+    Ok(args)
+}
+
+fn arg<'a>(args: &'a [Node], index: usize, context: &str) -> Result<&'a Node, String> {
+    args.get(index).ok_or_else(|| format!("expected arg {index} for {context}"))
+}
+
+#[test]
+fn map_block_pipeline_keeps_grep_and_keys_inside_map() -> Result<(), String> {
+    let source = r#"my %dbd_class_registry = map { $dbd_prefix_registry->{$_}->{class} => { prefix => $_ } } grep { exists $dbd_prefix_registry->{$_}->{class} } keys %{$dbd_prefix_registry};"#;
+    assert_clean_parse(source);
+
+    let statement = program_statement(source, "DBI map/grep/keys boundary")?;
+    let initializer = declaration_initializer(&statement, "DBI map/grep/keys boundary")?;
+
+    let map_args = function_call(initializer, "map", "DBI map boundary")?;
+    assert_eq!(map_args.len(), 2, "map should contain block and grep source");
+    assert!(matches!(arg(map_args, 0, "map block")?.kind, NodeKind::Block { .. }));
+
+    let grep_args = function_call(arg(map_args, 1, "map source")?, "grep", "grep source boundary")?;
+    assert_eq!(grep_args.len(), 2, "grep should contain block and keys source");
+    assert!(matches!(arg(grep_args, 0, "grep block")?.kind, NodeKind::Block { .. }));
+    function_call(arg(grep_args, 1, "grep source")?, "keys", "keys source boundary")?;
+
+    Ok(())
+}
+
+#[test]
+fn map_quote_like_expression_keeps_sort_source_inside_map() -> Result<(), String> {
+    let source = r#"my $attrs = join " ", map { qq[$_="$attrs{$_}"] } sort keys %attrs;"#;
+    assert_clean_parse(source);
+
+    let statement = program_statement(source, "ExtUtils attrs map/sort boundary")?;
+    let initializer = declaration_initializer(&statement, "ExtUtils attrs map/sort boundary")?;
+
+    let join_args = function_call(initializer, "join", "join boundary")?;
+    assert_eq!(join_args.len(), 2, "join should contain separator and map result");
+
+    let map_args = function_call(arg(join_args, 1, "join map arg")?, "map", "map boundary")?;
+    assert_eq!(map_args.len(), 2, "map should contain qq block and sort source");
+    assert!(matches!(arg(map_args, 0, "map qq block")?.kind, NodeKind::Block { .. }));
+
+    let sort_args = function_call(arg(map_args, 1, "map source")?, "sort", "sort source boundary")?;
+    assert_eq!(sort_args.len(), 1, "sort should contain keys source");
+    function_call(arg(sort_args, 0, "sort source")?, "keys", "keys source boundary")?;
+
+    Ok(())
+}
+
+#[test]
+fn map_expression_keeps_split_source_inside_map() -> Result<(), String> {
+    let source = r#"my $curHST = join '', map getHST($_, $vers), split /;/, $jcps;"#;
+    assert_clean_parse(source);
+
+    let statement = program_statement(source, "Unicode Collate map/split boundary")?;
+    let initializer = declaration_initializer(&statement, "Unicode Collate map/split boundary")?;
+
+    let join_args = function_call(initializer, "join", "join boundary")?;
+    assert_eq!(join_args.len(), 2, "join should contain separator and map result");
+
+    let map_args = function_call(arg(join_args, 1, "join map arg")?, "map", "map boundary")?;
+    assert_eq!(map_args.len(), 2, "map should contain getHST expression and split source");
+    function_call(arg(map_args, 0, "map expression")?, "getHST", "map expression boundary")?;
+
+    let split_args =
+        function_call(arg(map_args, 1, "map source")?, "split", "split source boundary")?;
+    assert_eq!(split_args.len(), 2, "split should contain regex and source scalar");
+
+    Ok(())
+}


### PR DESCRIPTION
Problem: The unclosed_paren_identifier shape analysis recommends list-operator boundary repair work, but clean-parse fixtures alone do not prove that source operands stay inside the intended map/grep/sort calls.\n\nFix: Add AST-level receipt tests for three source-backed shapes: DBI map/grep/keys, ExtUtils map/sort/keys with qq interpolation, and Unicode Collate map/split.\n\nClaim boundary: Test/proof only. This does not change parser runtime behavior, edit generated parser status, refresh Linux corpus receipts, or claim raw bucket reduction. Linux corpus movement remains deferred to EffortlessMetrics/perl-lsp-swarm#2693.\n\nVerification:\n- cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture\n- cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture\n- cargo xtask metrics parser-accuracy --check\n- cargo xtask update-status --only parser --check\n- cargo xtask metrics ratchet-check parser_accuracy\n- cargo xtask fmt --check\n- git diff --check\n\nCloses EffortlessMetrics/perl-lsp#8880.