### PR TITLE
docs(parser): record list-operator boundary receipts (#8882)

### DIFF
--- a/docs/project/status/parser_unclosed_paren_identifier_shapes.md
+++ b/docs/project/status/parser_unclosed_paren_identifier_shapes.md
@@ -153,9 +153,26 @@ Keep these out of the first map/grep/sort grammar repair. They are adjacent
 but they do not share the same list-operator boundary as the repeated map/grep
 fixture train.
 
+## AST Boundary Receipts
+
+`crates/perl-parser-core/tests/list_operator_boundary_receipts.rs` now asserts
+AST ownership for three representative list-operator shapes:
+
+- DBI map/grep/keys: the outer `map` owns the `grep` source, and the nested
+  `grep` owns the `keys` source.
+- ExtUtils attrs map/sort/keys: the outer `join` owns the `map` result, the
+  `map` owns the `sort` source, and `sort` owns the `keys` source.
+- Unicode Collate map/split: the outer `join` owns the `map` result, and the
+  `map` owns the `split` source.
+
+These receipt tests prove current AST shape for the representative cases above.
+They do not prove Linux corpus movement, and they do not remove the need for a
+fresh corpus receipt before any raw bucket-count claim.
+
 ## Recommended Next Parser PR
 
-Start with the list-operator boundary repair:
+If a runtime parser repair is still needed, start with the list-operator
+boundary lane:
 
 ```text
 fix(parser): repair repeated map/grep/sort expression boundary
@@ -164,7 +181,10 @@ fix(parser): repair repeated map/grep/sort expression boundary
 Scope:
 
 - one parser behavior change
-- existing `unclosed_paren_identifier_tests` fixtures as the safety net
+- existing `unclosed_paren_identifier_tests` and
+  `list_operator_boundary_receipts` fixtures as the safety net
+- a failing source-backed case or fresh Linux receipt evidence before changing
+  runtime parser behavior
 - no generated status hand edits
 - no bucket-count movement claim without the Linux corpus refresh
 


### PR DESCRIPTION
Problem: The unclosed_paren_identifier shape map did not record the AST-level list-operator boundary receipts landed by #8881.
Fix: Document the three receipt cases and require failing source-backed evidence or a fresh Linux receipt before any runtime list-operator repair.
Verification: `cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture` passes; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture` passes; `cargo xtask metrics parser-accuracy --check` passes; `cargo xtask update-status --only parser --check` passes; `cargo xtask metrics ratchet-check parser_accuracy` passes; `cargo xtask fmt --check` passes; `git diff --check` passes.

Claim boundary: docs-only; no parser runtime behavior, fixture, generated status, provider row, or raw bucket-count claim.

Fixes #8882.