### PR TITLE
docs(parser): record list-operator boundary handoff (#8883)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -60,9 +60,13 @@ adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
 plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-raw-bucket-fixture-lane"
 current_pointer = "docs/project/status/parser_accuracy_next.md"
 current_status = "docs/project/status/parser.md#raw-failure-buckets"
+shape_analysis = "docs/project/status/parser_unclosed_paren_identifier_shapes.md"
+boundary_receipt = "crates/perl-parser-core/tests/list_operator_boundary_receipts.rs"
 claim_boundary = "Fixture-only PRs lock source-backed shapes; bucket-count movement requires a refreshed corpus receipt."
+next_runtime_rule = "Start a parser runtime repair only from a fresh Linux receipt or a focused source-backed fixture that fails against the current parser."
 commands = [
   "cargo test -p perl-parser-core --test <bucket-test> --profile agent --locked -- --nocapture",
+  "cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture",
   "cargo xtask metrics parser-accuracy --check",
   "cargo xtask update-status --only parser --check",
   "cargo xtask metrics ratchet-check parser_accuracy",

--- a/docs/project/status/parser_unclosed_paren_identifier_shapes.md
+++ b/docs/project/status/parser_unclosed_paren_identifier_shapes.md
@@ -153,9 +153,27 @@ Keep these out of the first map/grep/sort grammar repair. They are adjacent
 but they do not share the same list-operator boundary as the repeated map/grep
 fixture train.
 
+## Boundary Receipts
+
+PR #8881 added AST-level boundary receipts in
+`crates/perl-parser-core/tests/list_operator_boundary_receipts.rs`. These tests
+prove that the current parser keeps representative source operands inside the
+intended call tree for:
+
+- DBI-style `map -> grep -> keys`
+- ExtUtils-style `join -> map -> sort -> keys`
+- Unicode::Collate-style `join -> map -> split`
+
+These receipts are stronger than clean-parse fixtures because they assert the
+shape of the parsed call tree, not only the absence of `Error` or `Missing*`
+nodes. They still do not prove current corpus movement or bucket-count
+reduction; that requires the Linux corpus refresh tracked by #8863.
+
 ## Recommended Next Parser PR
 
-Start with the list-operator boundary repair:
+Do not start a runtime repair from this stale bucket note alone. Start the
+list-operator boundary repair only when current evidence supplies a failing
+source-backed case:
 
 ```text
 fix(parser): repair repeated map/grep/sort expression boundary
@@ -165,11 +183,19 @@ Scope:
 
 - one parser behavior change
 - existing `unclosed_paren_identifier_tests` fixtures as the safety net
+- `list_operator_boundary_receipts` as the AST-shape safety net
 - no generated status hand edits
 - no bucket-count movement claim without the Linux corpus refresh
 
-Fixture-only PRs should continue only when a new real-Perl source shape is not
-covered by the existing groups above.
+Valid starting evidence:
+
+- a refreshed Linux receipt shows a current list-operator boundary failure; or
+- a focused, source-backed fixture reproduces a boundary failure against the
+  current parser.
+
+Otherwise, the next bucket-count action is #8863. Fixture-only PRs should
+continue only when a new real-Perl source shape is not covered by the existing
+groups above.
 
 ## Verification
 
@@ -177,6 +203,7 @@ For this analysis note:
 
 ```bash
 cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture
+cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture
 cargo xtask metrics parser-accuracy --check
 cargo xtask update-status --only parser --check
 cargo xtask metrics ratchet-check parser_accuracy

--- a/plans/real-perl-editor-trust/implementation-plan.md
+++ b/plans/real-perl-editor-trust/implementation-plan.md
@@ -360,6 +360,12 @@ Continue source-backed fixture or narrow parser-fix work from
 
 Current shape analysis:
 [unclosed_paren_identifier shape analysis](../../docs/project/status/parser_unclosed_paren_identifier_shapes.md).
+AST boundary receipts:
+`../../crates/perl-parser-core/tests/list_operator_boundary_receipts.rs`.
+
+Next parser runtime work should start only from current failing evidence: a
+fresh Linux receipt or a focused source-backed fixture that fails against the
+current parser. Otherwise #8863 owns bucket-count movement.
 
 Production delta
 
@@ -380,6 +386,7 @@ Proof commands
 
 ```bash
 cargo test -p perl-parser-core --test <bucket-test> --profile agent --locked -- --nocapture
+cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture
 cargo xtask metrics parser-accuracy --check
 cargo xtask update-status --only parser --check
 cargo xtask metrics ratchet-check parser_accuracy


### PR DESCRIPTION
Problem: After EffortlessMetrics/perl-lsp#8881, the unclosed_paren_identifier shape map and active goal did not record that AST-boundary receipts now exist, leaving the next runtime repair instruction too easy to read as speculative. Fix: Record list_operator_boundary_receipts as the AST-shape safety net and narrow parser runtime work to cases backed by a fresh Linux receipt or a focused source-backed failing fixture. Claim boundary: Docs and manifest handoff only. This does not change parser runtime behavior, add fixtures, edit generated parser status, refresh corpus receipts, or claim bucket-count reduction. Linux corpus movement remains EffortlessMetrics/perl-lsp-swarm#2693. Verification: toml parse passed; list_operator_boundary_receipts passed; parser-accuracy check passed; parser status check passed; parser_accuracy ratchet passed; fmt check passed; git diff check passed. Closes EffortlessMetrics/perl-lsp#8883.