### PR TITLE
docs(provider): publish Real Perl Editor Trust v1 dashboard (#8886)

### DIFF
--- a/docs/project/CURRENT_STATUS.md
+++ b/docs/project/CURRENT_STATUS.md
@@ -14,6 +14,7 @@
 | Parser corpus & coverage | [status/parser.md](status/parser.md) |
 | Quality metrics | [status/quality.md](status/quality.md) |
 | Semantic capability dashboard | [status/semantic_capability_dashboard.md](status/semantic_capability_dashboard.md) |
+| Real Perl Editor Trust v1 dashboard | [status/real_perl_editor_trust_v1.md](status/real_perl_editor_trust_v1.md) |
 | Editor UX planning scaffold | [status/editor_ux.json](status/editor_ux.json) |
 | Compiler-backed LSP roadmap | [COMPILER_BACKED_LSP_ROADMAP.md](COMPILER_BACKED_LSP_ROADMAP.md) |
 | Release readiness & blockers | [status/release.md](status/release.md) |

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -23,6 +23,7 @@
 | Parser corpus & coverage | [parser.md](parser.md) | Generator | Every parser-touching merge |
 | HIR lowering coverage | [hir_lowering.md](hir_lowering.md) | Generator | Every HIR lowering merge |
 | Compiler fact substrate | [compiler_facts.md](compiler_facts.md) | Human | Compiler-substrate lane changes |
+| Real Perl Editor Trust v1 dashboard | [real_perl_editor_trust_v1.md](real_perl_editor_trust_v1.md) | Human | Provider trust, support-claim, or real-workspace receipt changes |
 | Provider cutover matrix | [provider_cutover.md](provider_cutover.md) | Human | Provider shadow/live state changes |
 | Module resolution conformance | [module_resolution.md](module_resolution.md) | Human | Module-resolution behavior or tracking changes |
 | Quality metrics | [quality.md](quality.md) | Generator | Every merge |

--- a/docs/project/status/provider_confidence_matrix.md
+++ b/docs/project/status/provider_confidence_matrix.md
@@ -16,6 +16,8 @@ Provider cutover state remains in [provider cutover](provider_cutover.md).
 Real-workspace timing proof lives in the
 [2026-05-13 Mojolicious baseline](../../forensics/2026-05-13-real-workspace-baseline-mojolicious.md).
 User-facing support claims are mapped in [SUPPORT_TIERS.md](SUPPORT_TIERS.md).
+The Real Perl Editor Trust v1 routing dashboard is
+[real_perl_editor_trust_v1.md](real_perl_editor_trust_v1.md).
 
 ## Claim Boundary
 

--- a/docs/project/status/provider_cutover.md
+++ b/docs/project/status/provider_cutover.md
@@ -10,6 +10,9 @@ fallback behavior and rollback proof.
 For a row-per-provider receipt summary with fact source, confidence, freshness,
 fallback, runtime comparison, live state, and next proof, see
 [provider confidence matrix](provider_confidence_matrix.md).
+For the Real Perl Editor Trust v1 routing dashboard that ties provider state to
+support claims, real-workspace receipts, and next PRs, see
+[real_perl_editor_trust_v1.md](real_perl_editor_trust_v1.md).
 
 ## Recent Proof
 

--- a/docs/project/status/real_perl_editor_trust_v1.md
+++ b/docs/project/status/real_perl_editor_trust_v1.md
@@ -1,0 +1,90 @@
+# Real Perl Editor Trust v1 Dashboard
+
+> Human-owned. This dashboard routes the current Real Perl Editor Trust lane.
+> It does not generate metrics, broaden live provider behavior, or replace the
+> provider-specific proof surfaces.
+
+Last reviewed: 2026-05-13.
+
+This page answers:
+
+> Which editor surfaces have enough compiler-fact proof to be trusted live,
+> which surfaces are still shadowed, and what proof is required next?
+
+Use this page as the routing surface. Use the linked status docs as the source
+of current evidence.
+
+## Source Stack
+
+| Need | Source |
+| --- | --- |
+| User-facing support claims and known limitations | [SUPPORT_TIERS.md](SUPPORT_TIERS.md) |
+| Provider fact source, confidence, freshness, fallback, and next proof | [provider_confidence_matrix.md](provider_confidence_matrix.md) |
+| Provider live/shadow state and cutover rules | [provider_cutover.md](provider_cutover.md) |
+| Compiler-backed provider receipts | [semantic_shadow_compare.md](semantic_shadow_compare.md), [semantic_scorecard.md](semantic_scorecard.md) |
+| UX/provider capability context | [ux_capability_dashboard.md](ux_capability_dashboard.md) |
+| Real-workspace baseline anchor | [2026-05-13 Mojolicious baseline](../../forensics/2026-05-13-real-workspace-baseline-mojolicious.md) |
+| Lane plan and active work | [Real Perl Editor Trust plan](../../../plans/real-perl-editor-trust/implementation-plan.md), [active goal manifest](../../../.perl-lsp/goals/active.toml) |
+
+## Provider Trust Loop
+
+The v1 editor loop is:
+
+```text
+completion suggests it
+hover explains it
+definition jumps to it
+references finds its uses
+diagnostics trusts it
+rename / safe-delete know whether it is safe
+symbols and tokens expose project shape without noise
+```
+
+The loop is only trusted where each answer can identify its fact source,
+confidence, freshness, source-backed range, fallback state, and dynamic-boundary
+blocker when relevant.
+
+## Current Dashboard
+
+| Surface | Current state | Real-workspace receipt state | Fallback / blocker coverage | Next proof |
+| --- | --- | --- | --- | --- |
+| Completion | `partial live / shadowed` | Mojolicious baseline covers completion latency only; candidate quality receipt pending | Legacy fallback; generated and dynamic-boundary candidates remain shadowed or blocked | Mojolicious visible-symbol ranking receipt with candidate count, top-N churn, noise, generated labels, stale/dynamic blockers |
+| Hover | `partial live / provenance-backed` | Mojolicious baseline covers first-hover latency only; provenance quality receipt pending | Legacy fallback; imported, generated, dynamic-boundary, and fallback paths are labeled in receipts | Mojolicious hover provenance receipt for exact, imported, generated, dynamic, fallback, stale/missing fact cases |
+| Goto definition | `partial live exact/imported` | Navigation real-workspace quality candidates are in shadow compare; Mojolicious baseline covers goto latency only | Legacy fallback for generated/no-source, dynamic, stale, low-confidence, and ambiguous candidates | Navigation quality receipt proving current live exact/import/export behavior and fallback counts on the real-workspace fixture |
+| References | `partial live exact/imported` | References real-workspace quality candidates are in shadow compare; broader precision/recall receipt pending | Legacy fallback for generated/no-source, declaration-including, coderef, typeglob, dynamic, stale, low-confidence, and ambiguous cases | Navigation quality receipt for exact/import/export/literal-require hits, blockers, and fallback counts |
+| Diagnostics | `partial live` | Mojolicious baseline explicitly defers diagnostic correctness | Conservative diagnostics remain when semantic evidence is absent, ambiguous, stale, or dynamic | Broader false-positive / false-negative receipts plus real-workspace diagnostic correctness proof |
+| Document symbols | `shadowed` | No dedicated real-workspace document-symbol quality receipt yet | Existing provider remains live; compiler/source/freshness candidates stay shadowed | Real-workspace document-symbol quality receipt, then source-backed compiler document-symbol live slice |
+| Workspace symbols | `shadowed` | Shadow compare records quality candidates; noise/rank receipt pending | Existing workspace index remains live; stale/dynamic/generated candidates stay gated | Real-workspace workspace-symbol noise receipt before live high-confidence compiler symbols |
+| Semantic tokens | `shadowed` | No dedicated real-workspace semantic-token quality receipt yet | Existing parser/token provider remains live; stale/dynamic compiler classifications stay shadowed | Token/span invariant receipt, then narrow compiler-backed token classes |
+| Rename | `boundary-shadowed` | Real-workspace unsafe-edit proof pending | Stale, low-confidence, generated, and dynamic facts cannot authorize edits | Lexical rename live proof plus real-workspace unsafe-edit receipts |
+| Safe delete | `boundary-shadowed` | Real-workspace unsafe-delete proof pending | Stale, low-confidence, generated, imported/exported, and dynamic facts cannot authorize deletion | Exact-static safe-delete live proof plus explicit blocker UX receipts |
+
+## Near-Term PR Order
+
+This dashboard keeps the next provider lane separate from parser capability,
+framework facts, PIR, formatter, critic, release, and security work.
+
+1. `test(completion): add Mojolicious visible-symbol ranking receipt`
+2. `test(hover): add Mojolicious provenance quality receipt`
+3. `test(navigation): add Mojolicious live navigation receipt`
+4. `docs(provider): wire real-workspace receipts into provider confidence matrix`
+5. `feat(document-symbols): enable source-backed compiler document symbols`
+6. `test(workspace-symbols): add real-workspace compiler symbol noise receipt`
+7. `feat(rename): enable lexical rename from ScopeGraph`
+8. `feat(framework): add Class::Tiny generated-member facts`
+
+Parser raw-bucket work, Linux corpus refresh, security alert classification,
+Rust 1.95 rollout, native formatter, native critic, PIR, and determinism remain
+separate lanes with their own proof commands and claim boundaries.
+
+## Promotion Rules
+
+- Do not promote a provider because a fact exists.
+- Do not use real-workspace latency alone as correctness proof.
+- Do not use shadow receipts as live cutover claims.
+- Do not use stale corpus receipts for parser bucket-count movement or support
+  promotion.
+- Generated and dynamic facts must be labeled or blocked, not silently treated
+  as exact static facts.
+- Edit-producing providers require real-workspace unsafe-edit/delete receipts
+  before broader live behavior.


### PR DESCRIPTION
Problem: Real Perl Editor Trust routing is spread across provider cutover, provider confidence, support tiers, and real-workspace receipts.\nFix: Add a human-owned dashboard that links those proof surfaces, summarizes provider live/shadow trust state, and records the next scoped provider proofs without changing runtime behavior.\nVerification: \cargo xtask semantic-scorecard --check\; \cargo xtask semantic-shadow-compare --check\; \cargo xtask fmt --check\; \git diff --check\.