### PR TITLE
feat(perl-oracle): declare DAP bridge env contract (#8687)

### DIFF
--- a/crates/perl-dap/src/bridge_adapter.rs
+++ b/crates/perl-dap/src/bridge_adapter.rs
@@ -31,6 +31,8 @@ use anyhow::{Context, Result};
 use nix::sys::signal::{self, Signal};
 #[cfg(unix)]
 use nix::unistd::Pid;
+use perl_lsp_rs_core::config::PerlOracleEnv;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
@@ -44,6 +46,23 @@ const PROXY_EXIT_POLL_MS: u64 = 25;
 /// Perl debugger flag to activate DAP protocol mode in Perl::LanguageServer
 const PLS_DAP_FLAG: &str = "-d:LanguageServer::DAP";
 
+/// Environment passthrough policy for the Perl::LanguageServer DAP bridge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct DapBridgeEnvConfig {
+    /// Pass parent `PERL5LIB` through to the bridged Perl process.
+    pub perl5lib_passthrough: bool,
+    /// Pass parent `PERL5OPT` through to the bridged Perl process.
+    pub perl5opt_passthrough: bool,
+}
+
+impl DapBridgeEnvConfig {
+    /// Create an explicit bridge environment policy.
+    pub const fn new(perl5lib_passthrough: bool, perl5opt_passthrough: bool) -> Self {
+        Self { perl5lib_passthrough, perl5opt_passthrough }
+    }
+}
+
 /// Bridge adapter that proxies DAP messages to Perl::LanguageServer
 ///
 /// This adapter spawns Perl::LanguageServer in DAP mode and forwards
@@ -51,6 +70,8 @@ const PLS_DAP_FLAG: &str = "-d:LanguageServer::DAP";
 pub struct BridgeAdapter {
     /// The spawned Perl::LanguageServer process
     child_process: Option<Child>,
+    /// Env passthrough policy for the bridge subprocess.
+    env_config: DapBridgeEnvConfig,
 }
 
 impl BridgeAdapter {
@@ -64,7 +85,12 @@ impl BridgeAdapter {
     /// let adapter = BridgeAdapter::new();
     /// ```
     pub fn new() -> Self {
-        Self { child_process: None }
+        Self::with_env_config(DapBridgeEnvConfig::default())
+    }
+
+    /// Create a bridge adapter with an explicit subprocess environment policy.
+    pub fn with_env_config(env_config: DapBridgeEnvConfig) -> Self {
+        Self { child_process: None, env_config }
     }
 
     /// Spawn Perl::LanguageServer in DAP mode
@@ -102,7 +128,8 @@ impl BridgeAdapter {
             crate::platform::resolve_perl_path().context("Failed to find perl binary on PATH")?;
 
         // Spawn Perl::LanguageServer in DAP mode
-        let child = Command::new(perl_path)
+        let child = self
+            .build_pls_dap_command(perl_path)
             .arg(PLS_DAP_FLAG)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -121,6 +148,19 @@ impl BridgeAdapter {
 
         self.child_process = Some(child);
         Ok(())
+    }
+
+    fn build_pls_dap_command(&self, perl_path: PathBuf) -> Command {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let oracle = PerlOracleEnv::for_dap_bridge(
+            perl_path,
+            cwd,
+            self.env_config.perl5lib_passthrough,
+            self.env_config.perl5opt_passthrough,
+        );
+        let mut command = Command::new(&oracle.perl_binary);
+        oracle.configure_command(command.as_std_mut());
+        command
     }
 
     /// Proxy messages between VS Code and Perl::LanguageServer
@@ -337,8 +377,9 @@ impl Drop for BridgeAdapter {
 
 #[cfg(test)]
 mod tests {
-    use super::BridgeAdapter;
+    use super::{BridgeAdapter, DapBridgeEnvConfig};
     use anyhow::Result;
+    use std::path::PathBuf;
     use std::process::Stdio;
     use std::time::Duration;
     use tokio::process::Command;
@@ -391,6 +432,41 @@ mod tests {
         }
     }
 
+    #[test]
+    fn bridge_env_config_defaults_to_deny_ambient_perl_env() {
+        let adapter = BridgeAdapter::new();
+        let command = adapter.build_pls_dap_command(PathBuf::from("perl"));
+        let envs: Vec<_> = command.as_std().get_envs().collect();
+
+        assert!(
+            envs.iter().all(|(key, _)| *key != "PERL5LIB"),
+            "default bridge config must not pass PERL5LIB"
+        );
+        assert!(
+            envs.iter().all(|(key, _)| *key != "PERL5OPT"),
+            "default bridge config must not pass PERL5OPT"
+        );
+        assert!(
+            command.as_std().get_current_dir().is_some(),
+            "bridge command should set cwd explicitly"
+        );
+    }
+
+    #[test]
+    fn bridge_env_config_allows_debug_passthrough_when_opted_in() {
+        let adapter = BridgeAdapter::with_env_config(DapBridgeEnvConfig::new(true, true));
+        let oracle = perl_lsp_rs_core::config::PerlOracleEnv::for_dap_bridge(
+            PathBuf::from("perl"),
+            PathBuf::from("."),
+            adapter.env_config.perl5lib_passthrough,
+            adapter.env_config.perl5opt_passthrough,
+        );
+
+        assert!(oracle.allow_perl5lib, "opt-in bridge config should allow PERL5LIB");
+        assert!(oracle.allow_perl5opt, "opt-in bridge config should allow PERL5OPT");
+        assert!(!oracle.allow_local_lib, "bridge config should not widen local::lib");
+    }
+
     async fn process_is_running(pid: u32) -> Result<bool> {
         #[cfg(unix)]
         {
@@ -406,13 +482,15 @@ mod tests {
 
         #[cfg(windows)]
         {
-            let output = Command::new("cmd")
-                .arg("/C")
-                .arg(format!("tasklist /FI \"PID eq {pid}\" /NH"))
+            let output = Command::new("tasklist")
+                .arg("/FI")
+                .arg(format!("PID eq {pid}"))
+                .arg("/NH")
                 .output()
                 .await?;
             if !output.status.success() {
-                anyhow::bail!("tasklist failed while checking child process {pid}");
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!("tasklist failed while checking child process {pid}: {stderr}");
             }
             Ok(String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
         }

--- a/crates/perl-dap/src/lib.rs
+++ b/crates/perl-dap/src/lib.rs
@@ -398,7 +398,7 @@ pub mod tcp_attach;
 // See #455: Implement safe evaluation (AC10)
 
 // Re-export Phase 1 public types
-pub use bridge_adapter::BridgeAdapter;
+pub use bridge_adapter::{BridgeAdapter, DapBridgeEnvConfig};
 pub use configuration::{
     AttachConfiguration, LaunchConfiguration, create_attach_json_snippet,
     create_launch_json_snippet,

--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -90,7 +90,7 @@ pub struct PerlOracleEnv {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl PerlOracleEnv {
-    /// Build a [`Command`] with ALL non-allowlisted env vars stripped.
+    /// Apply this oracle's environment contract to an existing [`Command`].
     ///
     /// The sequence is:
     /// 1. `Command::env_clear()` — drop the entire parent environment.
@@ -102,9 +102,13 @@ impl PerlOracleEnv {
     ///
     /// The working directory is set to `self.cwd` explicitly so the subprocess
     /// never inherits the LSP process's cwd.
-    pub fn into_command(&self) -> Command {
-        let mut cmd = Command::new(&self.perl_binary);
-
+    ///
+    /// Prefer [`into_command`] for ordinary `std::process::Command` callers.
+    /// This lower-level helper exists for call sites that wrap a standard
+    /// command builder, such as `tokio::process::Command::as_std_mut`.
+    ///
+    /// [`into_command`]: PerlOracleEnv::into_command
+    pub fn configure_command(&self, cmd: &mut Command) {
         // 1. Clear entire parent environment — deny-all-ambient policy.
         cmd.env_clear();
 
@@ -142,6 +146,12 @@ impl PerlOracleEnv {
 
         // Explicit cwd — never inherit.
         cmd.current_dir(&self.cwd);
+    }
+
+    /// Build a [`Command`] with ALL non-allowlisted env vars stripped.
+    pub fn into_command(&self) -> Command {
+        let mut cmd = Command::new(&self.perl_binary);
+        self.configure_command(&mut cmd);
 
         cmd
     }
@@ -301,6 +311,46 @@ impl PerlOracleEnv {
         })
     }
 
+    /// Constructor for the Perl::LanguageServer DAP bridge process.
+    ///
+    /// The DAP bridge launches a long-running Perl::LanguageServer process on
+    /// behalf of a debug session. Unlike LSP analysis probes, debug sessions may
+    /// legitimately opt into ambient Perl runtime variables, so this constructor
+    /// accepts the debug configuration's passthrough decisions explicitly.
+    ///
+    /// Env contract:
+    ///
+    /// - `allow_perl5lib`: caller-supplied debug passthrough choice.
+    /// - `allow_perl5opt`: caller-supplied debug passthrough choice.
+    /// - `allow_local_lib`: always `false`; bridge passthrough is limited to
+    ///   the two debug-approved Perl variables until a separate config contract
+    ///   declares more.
+    /// - `PATH`: preserved by [`into_command`] / [`configure_command`] so the
+    ///   bridge process and debuggee can resolve helper commands.
+    /// - `timeout`: 30 seconds as a startup budget marker; the bridge process
+    ///   itself is managed by the adapter lifecycle after spawn.
+    /// - `cwd`: caller-supplied and explicit.
+    /// - `extra_env`: empty.
+    ///
+    /// [`configure_command`]: PerlOracleEnv::configure_command
+    /// [`into_command`]: PerlOracleEnv::into_command
+    pub fn for_dap_bridge(
+        perl_binary: PathBuf,
+        cwd: PathBuf,
+        allow_perl5lib: bool,
+        allow_perl5opt: bool,
+    ) -> Self {
+        Self {
+            perl_binary,
+            cwd,
+            timeout: Duration::from_secs(30),
+            allow_perl5lib,
+            allow_perl5opt,
+            allow_local_lib: false,
+            extra_env: BTreeMap::new(),
+        }
+    }
+
     /// Constructor for Perl version probes.
     ///
     /// Used when an already-resolved Perl binary needs to be interrogated for its
@@ -365,6 +415,16 @@ impl PerlOracleEnv {
 
     /// Returns a no-op stub on WASM (no subprocess support).
     pub fn for_version_probe(_perl_binary: std::path::PathBuf, _cwd: std::path::PathBuf) -> Self {
+        PerlOracleEnv
+    }
+
+    /// Returns a no-op stub on WASM (no subprocess support).
+    pub fn for_dap_bridge(
+        _perl_binary: std::path::PathBuf,
+        _cwd: std::path::PathBuf,
+        _allow_perl5lib: bool,
+        _allow_perl5opt: bool,
+    ) -> Self {
         PerlOracleEnv
     }
 }
@@ -659,6 +719,83 @@ mod tests {
             stdout.trim(),
             "UNSET",
             "PERL5LIB must be stripped when use_perl5lib=false; got: {stdout:?}",
+        );
+
+        Ok(())
+    }
+
+    /// `for_dap_bridge` mirrors the debug configuration passthrough flags.
+    #[test]
+    fn for_dap_bridge_respects_passthrough_flags() {
+        let perl_binary = PathBuf::from("perl");
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        let denied = PerlOracleEnv::for_dap_bridge(perl_binary.clone(), cwd.clone(), false, false);
+        assert!(!denied.allow_perl5lib, "DAP bridge must deny PERL5LIB when disabled");
+        assert!(!denied.allow_perl5opt, "DAP bridge must deny PERL5OPT when disabled");
+        assert!(!denied.allow_local_lib, "DAP bridge must not allow local::lib by default");
+        assert!(denied.extra_env.is_empty(), "DAP bridge extra_env starts empty");
+
+        let allowed = PerlOracleEnv::for_dap_bridge(perl_binary, cwd, true, true);
+        assert!(allowed.allow_perl5lib, "DAP bridge must allow PERL5LIB when opted in");
+        assert!(allowed.allow_perl5opt, "DAP bridge must allow PERL5OPT when opted in");
+        assert!(!allowed.allow_local_lib, "DAP bridge local::lib remains denied");
+    }
+
+    /// `for_dap_bridge` blocks poisoned ambient Perl env unless debug config opts in.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn for_dap_bridge_gates_perl5lib_and_perl5opt() -> TestResult {
+        let _env_guard = env_lock()?;
+        let perl = match perl_path() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        let poison_dir = tempfile::tempdir()?;
+        let poison_path = poison_dir.path().to_string_lossy().into_owned();
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        unsafe { std::env::set_var("PERL5LIB", &poison_path) };
+        unsafe { std::env::set_var("PERL5OPT", "-Mstrict") };
+
+        let result = (|| -> TestResult<(String, String)> {
+            let denied = PerlOracleEnv::for_dap_bridge(perl.clone(), cwd.clone(), false, false);
+            let mut cmd = denied.into_command();
+            cmd.args(["-e", "print join('|', $ENV{PERL5LIB}//'UNSET', $ENV{PERL5OPT}//'UNSET')"]);
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+            let denied_out = cmd.output()?;
+
+            let allowed = PerlOracleEnv::for_dap_bridge(perl, cwd, true, true);
+            let mut cmd = allowed.into_command();
+            cmd.args(["-e", "print join('|', $ENV{PERL5LIB}//'UNSET', $ENV{PERL5OPT}//'UNSET')"]);
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+            let allowed_out = cmd.output()?;
+
+            Ok((
+                String::from_utf8_lossy(&denied_out.stdout).into_owned(),
+                String::from_utf8_lossy(&allowed_out.stdout).into_owned(),
+            ))
+        })();
+
+        unsafe { std::env::remove_var("PERL5LIB") };
+        unsafe { std::env::remove_var("PERL5OPT") };
+
+        let (denied_stdout, allowed_stdout) = result?;
+        assert_eq!(
+            denied_stdout.trim(),
+            "UNSET|UNSET",
+            "DAP bridge must strip poisoned env when passthrough is disabled; got: {denied_stdout:?}",
+        );
+        assert!(
+            allowed_stdout.contains(&poison_path),
+            "DAP bridge must pass PERL5LIB through when opted in; got: {allowed_stdout:?}",
+        );
+        assert!(
+            allowed_stdout.contains("-Mstrict"),
+            "DAP bridge must pass PERL5OPT through when opted in; got: {allowed_stdout:?}",
         );
 
         Ok(())


### PR DESCRIPTION
Problem: The DAP bridge spawned Perl::LanguageServer with raw ambient process env, so PERL5LIB/PERL5OPT could leak into the bridge process without an explicit seam contract.
Fix: Add PerlOracleEnv::for_dap_bridge, apply the OracleEnv contract to the bridge spawn via tokio command wrapping, and expose a deny-by-default bridge env config for future debug passthrough plumbing.
Claim boundary: This only migrates the bridge_adapter.rs Perl::LanguageServer spawn. It does not add launch.json passthrough settings, migrate DAP test subprocesses, or touch other PerlOracle seams. The current bridge mode defaults to stripping PERL5LIB/PERL5OPT because no debug passthrough config field exists yet.
Verification: cargo test -p perl-lsp-rs-core --profile agent --locked for_dap_bridge -- --nocapture; cargo test -p perl-dap --profile agent --locked bridge_env_config -- --nocapture; cargo test -p perl-dap --test bridge_adapter_unit_tests --profile agent --locked -- --nocapture; cargo test -p perl-dap --test bridge_integration_tests --profile agent --locked -- --nocapture; cargo test -p perl-lsp-rs-core --profile agent --locked perl_oracle_env -- --nocapture; cargo test -p perl-dap --lib --profile agent --locked bridge_adapter::tests -- --nocapture; cargo xtask fmt --check; git diff --check.
Validation gaps: cargo clippy -p perl-dap --all-targets --profile agent --locked -- -D warnings -A missing_docs still fails on existing perl-dap warnings outside this change (request_seq explicit counter loop and legacy test unwrap/expect/panic sites). cargo test -p perl-dap --profile agent --locked -- --nocapture passes the lib and bridge/integration coverage reached here but still fails on the existing Windows-incompatible dap_packaging::test_binary_permissions_unix assertion.

Closes #8687