### PR TITLE
test(perl-oracle): hermetic DAP test subprocess env contracts (#8690)

### DIFF
--- a/crates/perl-dap/benches/dap_benchmarks.rs
+++ b/crates/perl-dap/benches/dap_benchmarks.rs
@@ -27,6 +27,7 @@ use perl_dap::debug_adapter::{DapMessage, DebugAdapter};
 use perl_dap::platform::{
     format_command_args, normalize_path, resolve_perl_path, setup_environment,
 };
+use perl_lsp_rs_core::config::PerlOracleEnv;
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::hint::black_box;
@@ -312,7 +313,7 @@ fn benchmark_dap_dispatch(c: &mut Criterion) {
 // ========== Phase 3: Live Session Benchmarks ==========
 
 fn perl_available() -> bool {
-    std::process::Command::new("perl").arg("--version").output().is_ok()
+    PerlOracleEnv::for_dap_test_fixture().is_some()
 }
 
 fn write_script(path: &Path, line_count: usize) -> std::io::Result<()> {

--- a/crates/perl-dap/tests/common/mod.rs
+++ b/crates/perl-dap/tests/common/mod.rs
@@ -5,6 +5,7 @@
 //! required to drive a real `perl -d` debug session in tests.
 
 use perl_dap::{DapMessage, DebugAdapter};
+use perl_lsp_rs_core::config::PerlOracleEnv;
 use serde_json::{Value, json};
 use std::sync::mpsc::{Receiver, channel};
 use std::time::{Duration, Instant};
@@ -357,5 +358,5 @@ pub fn workflow_timeout() -> Duration {
 
 /// Returns `true` when `perl` is on `PATH`.
 pub fn perl_available() -> bool {
-    std::process::Command::new("perl").arg("--version").output().is_ok()
+    PerlOracleEnv::for_dap_test_fixture().is_some()
 }

--- a/crates/perl-dap/tests/dap_comprehensive_test.rs
+++ b/crates/perl-dap/tests/dap_comprehensive_test.rs
@@ -1,4 +1,5 @@
 use perl_dap::{DapMessage, DebugAdapter};
+use perl_lsp_rs_core::config::PerlOracleEnv;
 use perl_tdd_support::{must, must_some};
 use serde_json::json;
 use std::fs::write;
@@ -556,7 +557,7 @@ fn test_sequence_number_increment() {
 #[test]
 fn test_dap_full_session_lifecycle() -> TestResult {
     // Skip if perl is not available
-    if std::process::Command::new("perl").arg("--version").output().is_err() {
+    if PerlOracleEnv::for_dap_test_fixture().is_none() {
         eprintln!("Skipping DAP lifecycle test - perl not available");
         return Ok(());
     }

--- a/crates/perl-dap/tests/dap_dependency_tests.rs
+++ b/crates/perl-dap/tests/dap_dependency_tests.rs
@@ -7,9 +7,9 @@
 #[cfg(feature = "dap-phase3")]
 mod dap_dependencies {
     use anyhow::Result;
+    use perl_lsp_rs_core::config::PerlOracleEnv;
     use serde_json::Value;
     use std::path::PathBuf;
-    use std::process::Command;
 
     fn repo_root() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
@@ -81,10 +81,14 @@ mod dap_dependencies {
     #[test]
     // AC:18
     fn test_perl_version_compatibility() -> Result<()> {
-        let perl_version = Command::new("perl").arg("-e").arg("print $];").output();
+        let perl_version = PerlOracleEnv::for_dap_test_fixture().and_then(|oracle| {
+            let mut cmd = oracle.into_command();
+            cmd.arg("-e").arg("print $];");
+            cmd.output().ok()
+        });
 
         match perl_version {
-            Ok(output) if output.status.success() => {
+            Some(output) if output.status.success() => {
                 let version_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
                 let version_num: f64 = version_str.parse().map_err(|e| {
                     anyhow::anyhow!("failed to parse perl version '{version_str}': {e}")

--- a/crates/perl-dap/tests/dap_integration_test.rs
+++ b/crates/perl-dap/tests/dap_integration_test.rs
@@ -1,4 +1,5 @@
 use perl_dap::{DapMessage, DebugAdapter};
+use perl_lsp_rs_core::config::PerlOracleEnv;
 use serde_json::json;
 use std::fs::write;
 use std::sync::mpsc::channel;
@@ -10,7 +11,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 #[test]
 fn test_dap_basic_flow() -> TestResult {
     // Skip if perl is not available
-    if std::process::Command::new("perl").arg("--version").output().is_err() {
+    if PerlOracleEnv::for_dap_test_fixture().is_none() {
         eprintln!("Skipping DAP basic flow test - perl not available");
         return Ok(());
     }

--- a/crates/perl-dap/tests/dap_module_resolution_smoke.rs
+++ b/crates/perl-dap/tests/dap_module_resolution_smoke.rs
@@ -10,6 +10,7 @@
 //! Related issue: #8621
 
 use perl_dap::{DapMessage, DebugAdapter};
+use perl_lsp_rs_core::config::PerlOracleEnv;
 use serde_json::{Value, json};
 use std::fs;
 use std::path::PathBuf;
@@ -30,7 +31,7 @@ type TestResult = Result<(), Box<dyn std::error::Error>>;
 const MODULE_BREAKPOINT_LINE: u64 = 14; // my $x = 1 — first executable line in sub run
 
 fn perl_available() -> bool {
-    std::process::Command::new("perl").arg("--version").output().is_ok()
+    PerlOracleEnv::for_dap_test_fixture().is_some()
 }
 
 fn smoke_timeout() -> Duration {

--- a/crates/perl-dap/tests/dap_smoke_e2e.rs
+++ b/crates/perl-dap/tests/dap_smoke_e2e.rs
@@ -1,6 +1,7 @@
 //! End-to-end DAP smoke test using the native debug adapter and real `perl -d`.
 
 use perl_dap::{DapMessage, DebugAdapter};
+use perl_lsp_rs_core::config::PerlOracleEnv;
 use serde_json::{Value, json};
 use std::fs::write;
 use std::sync::mpsc::{Receiver, channel};
@@ -10,7 +11,7 @@ use tempfile::tempdir;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 fn perl_available() -> bool {
-    std::process::Command::new("perl").arg("--version").output().is_ok()
+    PerlOracleEnv::for_dap_test_fixture().is_some()
 }
 
 fn smoke_timeout() -> Duration {

--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -379,6 +379,48 @@ impl PerlOracleEnv {
             extra_env: BTreeMap::new(),
         }
     }
+
+    /// Constructor for DAP test fixture Perl probes.
+    ///
+    /// Checks whether `perl` is available on `PATH` and, if so, returns a
+    /// `PerlOracleEnv` with the DAP test fixture env contract:
+    ///
+    /// - `allow_perl5lib`: `false` — DAP tests must be hermetic; ambient
+    ///   `PERL5LIB` must not change which tests pass or skip.
+    /// - `allow_perl5opt`: `false` — runtime injection flags must not affect
+    ///   test results.
+    /// - `allow_local_lib`: `false` — `local::lib` activation is not part of
+    ///   the test fixture contract.
+    /// - `timeout`: 5 seconds (sufficient for unit/integration test probes).
+    /// - `cwd`: current working directory of the test process.
+    /// - `extra_env`: empty.
+    ///
+    /// Returns `None` when `perl` is not on `PATH`, enabling skip-when-missing
+    /// semantics: `if oracle.is_none() { return; }`.
+    ///
+    /// The existence check itself runs with an inherited environment so that
+    /// PATH resolution works in all CI configurations; the deny-all-ambient
+    /// policy applies to every subsequent invocation via [`into_command`].
+    ///
+    /// [`into_command`]: PerlOracleEnv::into_command
+    pub fn for_dap_test_fixture() -> Option<Self> {
+        let available = std::process::Command::new("perl").arg("--version").output().is_ok();
+        if !available {
+            return None;
+        }
+
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        Some(Self {
+            perl_binary: PathBuf::from("perl"),
+            cwd,
+            timeout: Duration::from_secs(5),
+            allow_perl5lib: false,
+            allow_perl5opt: false,
+            allow_local_lib: false,
+            extra_env: BTreeMap::new(),
+        })
+    }
 }
 
 // ── WASM stub ─────────────────────────────────────────────────────────────────

--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -398,13 +398,21 @@ impl PerlOracleEnv {
     /// Returns `None` when `perl` is not on `PATH`, enabling skip-when-missing
     /// semantics: `if oracle.is_none() { return; }`.
     ///
-    /// The existence check itself runs with an inherited environment so that
-    /// PATH resolution works in all CI configurations; the deny-all-ambient
-    /// policy applies to every subsequent invocation via [`into_command`].
+    /// The existence check itself preserves PATH resolution but strips Perl
+    /// ambient variables that could change skip/pass behavior; the
+    /// deny-all-ambient policy applies to every subsequent invocation via
+    /// [`into_command`].
     ///
     /// [`into_command`]: PerlOracleEnv::into_command
     pub fn for_dap_test_fixture() -> Option<Self> {
-        let available = std::process::Command::new("perl").arg("--version").output().is_ok();
+        let available = Command::new("perl")
+            .arg("--version")
+            .env_remove("PERL5LIB")
+            .env_remove("PERL5OPT")
+            .env_remove("PERL_LOCAL_LIB_ROOT")
+            .env_remove("PERL_LOCAL_LIB_PREFIX")
+            .output()
+            .is_ok();
         if !available {
             return None;
         }
@@ -468,6 +476,11 @@ impl PerlOracleEnv {
         _allow_perl5opt: bool,
     ) -> Self {
         PerlOracleEnv
+    }
+
+    /// Returns `None` on WASM (no subprocess support).
+    pub fn for_dap_test_fixture() -> Option<Self> {
+        None
     }
 }
 
@@ -840,6 +853,63 @@ mod tests {
             "DAP bridge must pass PERL5OPT through when opted in; got: {allowed_stdout:?}",
         );
 
+        Ok(())
+    }
+
+    /// `for_dap_test_fixture` uses the deny-all-ambient fixture contract.
+    #[test]
+    fn for_dap_test_fixture_denies_ambient_perl_env() -> TestResult {
+        let _env_guard = env_lock()?;
+        let Some(oracle) = PerlOracleEnv::for_dap_test_fixture() else {
+            return Ok(());
+        };
+
+        assert_eq!(oracle.perl_binary, PathBuf::from("perl"));
+        assert!(!oracle.allow_perl5lib, "DAP test fixtures must strip PERL5LIB");
+        assert!(!oracle.allow_perl5opt, "DAP test fixtures must strip PERL5OPT");
+        assert!(!oracle.allow_local_lib, "DAP test fixtures must strip local::lib env");
+        assert!(oracle.extra_env.is_empty(), "DAP test fixture extra_env starts empty");
+        Ok(())
+    }
+
+    /// `for_dap_test_fixture` strips parent-process Perl env from actual Perl
+    /// fixture invocations.
+    #[test]
+    fn for_dap_test_fixture_strips_poisoned_env_from_invocation() -> TestResult {
+        let _env_guard = env_lock()?;
+        let Some(oracle) = PerlOracleEnv::for_dap_test_fixture() else {
+            return Ok(());
+        };
+
+        let poison_dir = tempfile::tempdir()?;
+        let poison_path = poison_dir.path().to_string_lossy().into_owned();
+
+        unsafe { std::env::set_var("PERL5LIB", &poison_path) };
+        unsafe { std::env::set_var("PERL5OPT", "-Mstrict") };
+        unsafe { std::env::set_var("PERL_LOCAL_LIB_ROOT", &poison_path) };
+
+        let result = (|| -> TestResult<String> {
+            let mut cmd = oracle.into_command();
+            cmd.args([
+                "-e",
+                "print join('|', $ENV{PERL5LIB}//'UNSET', $ENV{PERL5OPT}//'UNSET', $ENV{PERL_LOCAL_LIB_ROOT}//'UNSET')",
+            ]);
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+            let out = cmd.output()?;
+            Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+        })();
+
+        unsafe { std::env::remove_var("PERL5LIB") };
+        unsafe { std::env::remove_var("PERL5OPT") };
+        unsafe { std::env::remove_var("PERL_LOCAL_LIB_ROOT") };
+
+        let stdout = result?;
+        assert_eq!(
+            stdout.trim(),
+            "UNSET|UNSET|UNSET",
+            "DAP test fixture Perl invocations must strip ambient Perl env; got: {stdout:?}",
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes EffortlessMetrics/perl-lsp#8690. Adds PerlOracleEnv::for_dap_test_fixture() and migrates the scoped DAP test and bench Perl subprocess probes to the canonical deny-all-ambient fixture contract.

## Problem

DAP test availability and version probes were using raw perl subprocesses and could inherit ambient Perl environment such as PERL5LIB, PERL5OPT, or local::lib activation. That can make test skip/pass behavior depend on the operator machine instead of the fixture contract.

## Fix

- Add PerlOracleEnv::for_dap_test_fixture() for hermetic DAP test fixture probes.
- Strip Perl ambient variables from the availability probe before deciding skip/pass.
- Return a deny-all fixture oracle for actual invocations: no PERL5LIB, no PERL5OPT, no local::lib; PATH-based perl resolution remains available for tests.
- Add the WASM stub for API symmetry.
- Migrate the seven scoped DAP test and bench call sites.
- Add direct unit coverage for the DAP fixture env contract and poisoned-env invocation behavior.

## Claim boundary

This PR only covers DAP test and bench fixture probes from EffortlessMetrics/perl-lsp#8690. It does not change runtime DAP bridge/debuggee environment semantics, bridge_adapter.rs, debug_adapter/process.rs, TDD support, LSP providers, or xtask seams.

## Verification

Passed:

    cargo test -p perl-lsp-rs-core --lib for_dap_test_fixture --profile agent --locked -- --nocapture --test-threads=1
    cargo test -p perl-lsp-rs-core --lib perl_oracle_env --profile agent --locked -- --nocapture --test-threads=1
    cargo test -p perl-dap --test dap_dependency_tests --profile agent --locked -- --nocapture
    cargo test -p perl-dap --test dap_smoke_e2e --profile agent --locked -- --nocapture
    cargo test -p perl-dap --test dap_module_resolution_smoke --profile agent --locked -- --nocapture
    cargo test -p perl-dap --test dap_integration_test --profile agent --locked -- --nocapture
    cargo test -p perl-dap --test dap_comprehensive_test --profile agent --locked -- --nocapture
    cargo check -p perl-lsp-rs-core --lib --profile agent --locked
    cargo check -p perl-dap --all-targets --profile agent --locked
    cargo clippy -p perl-lsp-rs-core --lib --profile agent --locked -- -D warnings -A missing_docs
    cargo clippy -p perl-dap --lib --profile agent --locked -- -D warnings -A missing_docs
    cargo xtask fmt --check
    git diff --check

Known validation gaps observed locally:

- cargo test -p perl-dap --profile agent --locked fails in dap_e2e_workflow_tests::test_e2e_single_breakpoint_hit_inspect_continue because the Windows Strawberry Perl stack frame points at C:/Strawberry/perl/vendor/lib/Term/ReadLine/Perl.pm, outside this PR scope.
- cargo clippy -p perl-dap --tests --profile agent --locked and --all-targets -D warnings hit existing unrelated DAP test clippy debt: panic, unwrap, and manual loop-counter issues in other tests. perl-dap --lib clippy is clean.