### PR TITLE
fix(rename): respect byte offsets in string guard (#8464)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -76,16 +76,18 @@ impl LspServer {
     }
 
     fn offset_is_inside_quoted_string(content: &str, offset: usize) -> bool {
-        let chars = content.chars().collect::<Vec<_>>();
-        let limit = offset.min(chars.len());
         let mut in_single = false;
         let mut in_double = false;
         let mut escaped = false;
         let mut in_comment = false;
 
-        for ch in chars.iter().take(limit) {
+        for (byte_offset, ch) in content.char_indices() {
+            if byte_offset >= offset {
+                break;
+            }
+
             if in_comment {
-                if *ch == '\n' {
+                if ch == '\n' {
                     in_comment = false;
                 }
                 continue;
@@ -525,6 +527,18 @@ mod tests {
     fn rename_guard_detects_dynamic_typeglob_string_positions()
     -> Result<(), Box<dyn std::error::Error>> {
         let text = r#"*{"Mojolicious::Routes::Route::$name"} = sub { $cb->(@_) };"#;
+        let string_offset = text.find("Routes::Route").ok_or("missing dynamic package")? + 2;
+        let code_offset = text.find("$cb").ok_or("missing callback")? + 1;
+
+        assert!(LspServer::offset_is_inside_quoted_string(text, string_offset));
+        assert!(!LspServer::offset_is_inside_quoted_string(text, code_offset));
+        Ok(())
+    }
+
+    #[test]
+    fn rename_guard_uses_byte_offsets_with_unicode_prefix() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let text = "my $emoji = \"🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀\";\n*{\"Mojolicious::Routes::Route::$name\"} = sub { $cb->(@_) };";
         let string_offset = text.find("Routes::Route").ok_or("missing dynamic package")? + 2;
         let code_offset = text.find("$cb").ok_or("missing callback")? + 1;
 


### PR DESCRIPTION
Problem: The quoted-string rename guard from #8912 compared byte offsets to character indexes, so non-ASCII text before a string boundary could make the guard scan the wrong span.
Fix: Iterate with `char_indices()` and add a Unicode-prefix regression test for the dynamic typeglob string boundary.
Verification: `cargo test -p perl-lsp-rs --lib rename_guard --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo clippy -p perl-lsp-rs --lib --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo xtask fmt --check` passes; `git diff --check HEAD~1..HEAD` passes.