### PR TITLE
feat(rename): enable lexical scoped fallback (#8197)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -57,7 +57,9 @@ impl LspServer {
         if !result.is_valid || result.edits.is_empty() {
             return None;
         }
-        if !result.edits.iter().any(|edit| self.is_lexical_declaration_edit(doc, edit)) {
+        let lexical_declaration_edit_count =
+            result.edits.iter().filter(|edit| self.is_lexical_declaration_edit(doc, edit)).count();
+        if lexical_declaration_edit_count != 1 {
             return None;
         }
 

--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -13,13 +13,113 @@ use super::super::*;
 use crate::protocol::{req_position, req_uri};
 #[cfg(feature = "workspace")]
 use crate::runtime::routing::{IndexAccessMode, route_index_access};
+use perl_lsp_rs_core::providers::rename::{RenameOptions, RenameProvider, TextEdit as RenameEdit};
 
 /// Returns true if `c` is a Perl variable sigil (`$`, `@`, or `%`).
 fn is_perl_sigil(c: char) -> bool {
     matches!(c, '$' | '@' | '%')
 }
 
+fn strip_perl_sigil(name: &str) -> &str {
+    match name.chars().next() {
+        Some(c) if is_perl_sigil(c) => &name[c.len_utf8()..],
+        _ => name,
+    }
+}
+
+fn lexical_declaration_keyword_before(source: &str, symbol_start: usize) -> bool {
+    let line_start =
+        if symbol_start == 0 { 0 } else { source[..symbol_start].rfind('\n').map_or(0, |p| p + 1) };
+    let prefix = source[line_start..symbol_start].trim_end();
+    let previous_word =
+        prefix.split(|c: char| !c.is_alphanumeric() && c != '_').rfind(|word| !word.is_empty());
+    matches!(previous_word, Some("my" | "state"))
+}
+
 impl LspServer {
+    fn scoped_lexical_rename_edits(
+        &self,
+        doc: &crate::state::DocumentState,
+        ast: &perl_parser_core::Node,
+        offset: usize,
+        normalized_name: &str,
+    ) -> Option<Vec<Value>> {
+        if normalized_name.chars().next().is_none_or(|c| !is_perl_sigil(c)) {
+            return None;
+        }
+
+        let provider = RenameProvider::new(ast, doc.text.clone());
+        let result = provider.scoped_rename(
+            offset,
+            strip_perl_sigil(normalized_name),
+            &RenameOptions::default(),
+        );
+        if !result.is_valid || result.edits.is_empty() {
+            return None;
+        }
+        if !result.edits.iter().any(|edit| self.is_lexical_declaration_edit(doc, edit)) {
+            return None;
+        }
+
+        Some(
+            result
+                .edits
+                .iter()
+                .map(|edit| self.rename_edit_to_lsp_text_edit(doc, edit, normalized_name))
+                .collect(),
+        )
+    }
+
+    fn is_lexical_declaration_edit(
+        &self,
+        doc: &crate::state::DocumentState,
+        edit: &RenameEdit,
+    ) -> bool {
+        if edit.location.start == 0 || edit.location.start > doc.text.len() {
+            return false;
+        }
+        let Some(prefix) = doc.text.get(..edit.location.start) else {
+            return false;
+        };
+        let Some(previous) = prefix.chars().next_back() else {
+            return false;
+        };
+        if !is_perl_sigil(previous) {
+            return false;
+        }
+        lexical_declaration_keyword_before(&doc.text, edit.location.start - previous.len_utf8())
+    }
+
+    fn rename_edit_to_lsp_text_edit(
+        &self,
+        doc: &crate::state::DocumentState,
+        edit: &RenameEdit,
+        normalized_name: &str,
+    ) -> Value {
+        let mut start = edit.location.start;
+        let mut new_text = edit.new_text.clone();
+
+        if start > 0
+            && let Some(prefix) = doc.text.get(..start)
+            && let Some(previous) = prefix.chars().next_back()
+            && is_perl_sigil(previous)
+        {
+            start = start.saturating_sub(previous.len_utf8());
+            new_text = normalized_name.to_string();
+        }
+
+        let (start_line, start_char) = self.offset_to_pos16(doc, start);
+        let (end_line, end_char) = self.offset_to_pos16(doc, edit.location.end);
+
+        json!({
+            "range": {
+                "start": { "line": start_line, "character": start_char },
+                "end": { "line": end_line, "character": end_char }
+            },
+            "newText": new_text
+        })
+    }
+
     fn token_span_at(content: &str, offset: usize) -> Option<(usize, usize)> {
         let chars: Vec<char> = content.chars().collect();
         if chars.is_empty() {
@@ -308,10 +408,7 @@ impl LspServer {
                         self.normalize_rename_target(current_symbol.as_deref(), new_name)?;
                     // build_rename_edit re-applies the sigil from key.sigil, so pass the
                     // bare identifier to avoid double-sigil output like "$$total".
-                    let normalized_bare: &str = match normalized_name.chars().next() {
-                        Some(c) if is_perl_sigil(c) => &normalized_name[c.len_utf8()..],
-                        _ => normalized_name.as_str(),
-                    };
+                    let normalized_bare = strip_perl_sigil(&normalized_name);
                     let workspace_symbol_key =
                         symbol_key.as_ref().map(super::to_workspace_symbol_key);
 
@@ -397,6 +494,16 @@ impl LspServer {
                         let current_symbol = self.get_token_at_position(&doc.text, offset);
                         let normalized_name =
                             self.normalize_rename_target(Some(current_symbol.as_str()), new_name)?;
+
+                        if let Some(edits) =
+                            self.scoped_lexical_rename_edits(doc, ast, offset, &normalized_name)
+                        {
+                            return Ok(Some(json!({
+                                "changes": {
+                                    uri: edits
+                                }
+                            })));
+                        }
 
                         // Create semantic analyzer for same-file rename
                         let analyzer = crate::semantic::SemanticAnalyzer::analyze(ast);

--- a/crates/perl-lsp-rs/tests/navigation_regression_tests.rs
+++ b/crates/perl-lsp-rs/tests/navigation_regression_tests.rs
@@ -901,32 +901,33 @@ fn test_rename_scope_isolation_nested_same_name() -> TestResult {
         )
         .unwrap_or(json!(null));
 
-    if !response.is_null() {
-        // Gather all affected line numbers.
-        let mut affected_lines: Vec<u64> = Vec::new();
-        if let Some(changes) = response.get("changes").and_then(|c| c.as_object()) {
-            for edits in changes.values() {
-                if let Some(edits_arr) = edits.as_array() {
-                    for edit in edits_arr {
-                        if let Some(line) =
-                            edit.pointer("/range/start/line").and_then(|l| l.as_u64())
-                        {
-                            affected_lines.push(line);
-                        }
-                    }
-                }
-            }
-        }
+    assert!(response.is_object(), "rename should return a WorkspaceEdit, got {response:?}");
 
-        // If scope isolation is implemented, lines 2 and 3 (inner block) must NOT be touched.
-        for &line in &affected_lines {
-            assert!(
-                line != 2 && line != 3,
-                "rename of outer `$x` must not touch inner-scope `$x` on lines 2-3, \
-                 but got an edit at line {line}"
-            );
+    let mut affected_lines: Vec<u64> = Vec::new();
+    let changes = response
+        .get("changes")
+        .and_then(|c| c.as_object())
+        .ok_or("rename response should include changes")?;
+    for edits in changes.values() {
+        let edits_arr = edits.as_array().ok_or("rename changes should contain edit arrays")?;
+        for edit in edits_arr {
+            let line = edit
+                .pointer("/range/start/line")
+                .and_then(|l| l.as_u64())
+                .ok_or("rename edit should include start line")?;
+            let new_text =
+                edit.get("newText").and_then(|text| text.as_str()).ok_or("missing newText")?;
+            assert_eq!(new_text, "$outer_x", "lexical rename should preserve the scalar sigil");
+            affected_lines.push(line);
         }
     }
+    affected_lines.sort_unstable();
+
+    assert_eq!(
+        affected_lines,
+        vec![0, 5],
+        "rename of outer `$x` must only touch the outer declaration and reference"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #8197. Routes sigiled same-file lexical rename through the core scoped rename provider when it can prove exactly one my/state lexical declaration edit, preserving legacy fallback for other rename classes.

## Problem

Same-file rename could fall back to broad parser-shaped edits for lexical variables with shadowed names. That made rename less trustworthy in ordinary nested lexical scopes.

## Fix

- Add a narrow scoped lexical rename path inside the same-file fallback.
- Normalize sigiled variable rename targets so bare client input still preserves the original Perl sigil.
- Convert core scoped rename edits into LSP text edits that replace the full sigiled variable token.
- Keep the existing workspace rename path and non-lexical fallback behavior unchanged.
- Strengthen the nested same-name regression so it now requires only the outer declaration and outer reference to be edited.
- Fix the rename quote guard to use byte offsets when scanning text with Unicode before dynamic typeglob strings.

## Claim boundary

This PR only narrows live same-file rename behavior for source-backed sigiled lexical variables where the current document AST can prove exactly one my/state declaration edit. It does not enable workspace-wide lexical rename cutover, compiler-fact rename cutover, generated/dynamic/stale/low-confidence rename edits, rename support-tier promotion, or cross-file refactor claims.

## Verification

Passed locally:

    cargo test -p perl-lsp-rs --test navigation_regression_tests test_rename_scope_isolation_nested_same_name --profile agent --locked -- --nocapture --test-threads=1
    cargo test -p perl-lsp-rs --test lsp_rename_tests --profile agent --locked -- --nocapture --test-threads=1
    cargo test -p perl-lsp-rs-core --lib scoped_rename --profile agent --locked -- --nocapture --test-threads=1
    cargo clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs
    cargo xtask fmt --check
    git diff --check origin/master..HEAD
