### PR TITLE
fix(parser): parse dynamic typeglob condition derefs (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
@@ -271,6 +271,11 @@ impl<'a> Parser<'a> {
                     if op_token.kind == TokenKind::Star {
                         if let Some(next_kind) = self.peek_kind() {
                             let next_text = self.tokens.peek()?.text.to_string();
+                            let next_is_sigil_identifier = next_kind == TokenKind::Identifier
+                                && next_text
+                                    .chars()
+                                    .next()
+                                    .is_some_and(|c| matches!(c, '$' | '@' | '%' | '&' | '*'));
                             let terminator_kind =
                                 self.tokens.peek_second().ok().map(|t| t.kind);
                             if let Some(name) = typeglob_punctuation_name(
@@ -286,7 +291,9 @@ impl<'a> Parser<'a> {
                             }
 
                             match next_kind {
-                                kind if Self::can_be_sub_name(kind) => {
+                                kind if Self::can_be_sub_name(kind)
+                                    && !next_is_sigil_identifier =>
+                                {
                                     let id_token = self.tokens.next()?;
                                     let end = id_token.end;
                                     let node = Node::new(

--- a/crates/perl-parser-core/tests/glob_deref_arrow_tests.rs
+++ b/crates/perl-parser-core/tests/glob_deref_arrow_tests.rs
@@ -78,6 +78,15 @@ fn glob_hash_slot_assign() {
     assert_clean_parse(r#"*alias = *$oldglob{$slot};"#);
 }
 
+#[test]
+fn dynamic_glob_double_scalar_in_condition_decl() {
+    // Data::Printer::Filter::GLOB: ref tied *$$glob inside an if condition
+    // must consume the full dynamic glob operand before the closing paren.
+    assert_clean_parse(
+        r#"if ($ddp->show_tied and my $tie = ref tied *$$glob) { $string .= " (tied)" }"#,
+    );
+}
+
 // Full context patterns from real files
 
 #[test]


### PR DESCRIPTION
Problem: Dynamic typeglob derefs like `*$$glob` in condition declarations could be treated as static typeglob names, leaving the trailing identifier to surface as `unclosed_paren_identifier`.
Fix: Treat sigil-prefixed identifier tokens after `*` as dynamic glob operands and lock the Data::Printer::Filter::GLOB condition shape.
Verification: `cargo test -p perl-parser-core --test glob_deref_arrow_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask check-provider-confidence-matrix`; `git diff --check`; `./scripts/storage-doctor`.
Note: Local Strawberry corpus sweep was discovery-only; no Linux raw-bucket movement is claimed. Full local `cargo test -p perl-parser-core --profile agent --locked -- --nocapture` still hits the pre-existing `parser_panic_mode_recovery::parser_ac3_prevent_recursive_recovery` assertion outside this parser path.