### PR TITLE
fix(parser): parse reftype tied typeglob calls (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -994,15 +994,18 @@ impl<'a> Parser<'a> {
                             || third.kind == TokenKind::LeftParen;
                     }
                 }
-                // Builtin functions that take a single sigiled argument as argument:
-                // `max values %hash`, `func keys %h`, `func reverse @list`
-                // These are builtins whose first/only argument is a sigiled expression.
+                // Builtin functions that take a single sigiled/typeglob argument:
+                // `max values %hash`, `func keys %h`, `func reverse @list`,
+                // `reftype tied *STDOUT`.
+                // These are builtins whose first/only argument is a sigiled
+                // expression or explicit typeglob.
                 if Self::is_builtin_function(&next_text) {
                     if let Ok(third) = self.tokens.peek_second() {
                         let third_text: &str = &third.text;
                         return third_text.starts_with('$')
                             || third_text.starts_with('@')
                             || third_text.starts_with('%')
+                            || third.kind == TokenKind::Star
                             || third.kind == TokenKind::ScalarSigil
                             || third.kind == TokenKind::ArraySigil
                             || third.kind == TokenKind::HashSigil;

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -834,6 +834,13 @@ fn reftype_scalar_comparison() {
 }
 
 #[test]
+fn reftype_tied_typeglob_comparison() {
+    // From Capture::Tiny: an imported unary-style call may wrap a builtin call
+    // whose argument is a typeglob.
+    assert_clean_parse(r#"if (tied(*STDOUT) && (reftype tied *STDOUT eq 'GLOB')) { 1 }"#);
+}
+
+#[test]
 fn looks_like_number_sigil() {
     // looks_like_number $val — common in Type::Tiny and Params::Util
     assert_clean_parse(r#"return 0 unless looks_like_number $val;"#);


### PR DESCRIPTION
Problem: Capture::Tiny-style `reftype tied *STDOUT` was not recognized as a bare-call argument shape, leaving `unclosed_paren_identifier` recovery errors.
Fix: Let bare-call detection accept builtin calls whose first argument is an explicit typeglob, and lock the source-backed regression.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests reftype_tied_typeglob_comparison --profile agent --locked -- --nocapture` passes; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture` passes; `cargo test -p perl-parser-core --test complex_paren_args_tests --profile agent --locked -- --nocapture` passes; `cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked -- --nocapture` passes; `cargo xtask metrics parser-accuracy --check` passes; `cargo xtask update-status --only parser --check` passes; `cargo xtask metrics ratchet-check parser_accuracy` passes; `cargo xtask check-provider-confidence-matrix` passes; `cargo xtask fmt --check` passes; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs` passes; `git diff --check` passes.

Notes: Local Windows Strawberry sweep was used only for source-backed discovery and follow-up sanity (`unclosed_paren_identifier` 9 -> 7, clean files +2); this PR does not claim Linux raw-bucket movement. `./scripts/storage-doctor` timed out twice; a manual PowerShell check found pre-existing large repo-local target directories, so the storage invariant remains a pre-existing workspace issue outside this PR.