### PR TITLE
fix(parser): parse PID special-variable ternary (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -375,6 +375,13 @@ impl<'a> Parser<'a> {
         // name instead of leaving the tail as a stray identifier node.
         if (full_name.is_empty() || (sigil == "$" && full_name == "$"))
             && self.peek_kind() == Some(TokenKind::Identifier)
+            && (sigil != "$"
+                || full_name != "$"
+                || self
+                    .tokens
+                    .peek()
+                    .ok()
+                    .is_some_and(|name_token| name_token.start == end))
         {
             let name_token = self.tokens.next()?;
             full_name.push_str(&name_token.text);

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -841,6 +841,13 @@ fn reftype_tied_typeglob_comparison() {
 }
 
 #[test]
+fn dbi_profile_dumper_apache_pid_ternary() {
+    // From DBI::ProfileDumper::Apache: the PID special variable may appear on
+    // both sides of a parenthesized string comparison before a ternary.
+    assert_clean_parse(r#"my $group_pid = ($$ eq $initial_pid) ? $$ : getppid();"#);
+}
+
+#[test]
 fn looks_like_number_sigil() {
     // looks_like_number $val — common in Type::Tiny and Params::Util
     assert_clean_parse(r#"return 0 unless looks_like_number $val;"#);


### PR DESCRIPTION
Problem: Windows Strawberry discovery found DBI::ProfileDumper::Apache still hitting the stale `unclosed_paren_identifier` bucket on `($$ eq $initial_pid) ? $$ : getppid()`.

Fix: Add a source-backed regression fixture and keep precombined `$$` joined to a following identifier only when the identifier is adjacent, preserving `$$sv` scalar-deref parsing while allowing whitespace-delimited PID comparisons.

Claim boundary: Source-backed parser fix only. The discovery source was local Windows Strawberry Perl, not the deferred Linux corpus refresh, so this PR does not claim raw bucket-count movement.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests dbi_profile_dumper_apache_pid_ternary --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test cpan_misc_idioms dollar_dollar_scalar_deref --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test cpan_misc_idioms --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked -- --nocapture --test-threads=1`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`
- `git diff --check`