### PR TITLE
fix(parser): parse DBI hash deref iterator (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -441,6 +441,21 @@ impl<'a> Parser<'a> {
             let mut name = name_token.text.to_string();
             let mut end = name_token.end;
 
+            // `%$$slice` may arrive as `%`, `$$`, `slice`; only join an
+            // adjacent tail so whitespace-delimited `$$ eq` keeps `eq` as op.
+            if name == "$$"
+                && self.peek_kind() == Some(TokenKind::Identifier)
+                && self
+                    .tokens
+                    .peek()
+                    .ok()
+                    .is_some_and(|next_token| next_token.start == end)
+            {
+                let next_token = self.tokens.next()?;
+                name.push_str(&next_token.text);
+                end = next_token.end;
+            }
+
             // Handle :: in package-qualified variables
             while self.peek_kind() == Some(TokenKind::DoubleColon) {
                 self.tokens.next()?; // consume ::

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -848,6 +848,15 @@ fn dbi_profile_dumper_apache_pid_ternary() {
 }
 
 #[test]
+fn dbi_each_hash_over_scalar_deref_slice() {
+    // From DBI: each may iterate over a hash dereference whose target is a
+    // scalar dereference, without leaving the parenthesized declaration open.
+    assert_clean_parse(
+        r#"while ( my ($idx, $name) = each %$$slice ) { $sth->bind_col($idx+1, \$row{$name}); }"#,
+    );
+}
+
+#[test]
 fn looks_like_number_sigil() {
     // looks_like_number $val — common in Type::Tiny and Params::Util
     assert_clean_parse(r#"return 0 unless looks_like_number $val;"#);


### PR DESCRIPTION
Problem: Local Windows Strawberry discovery still found DBI.pm in the stale `unclosed_paren_identifier` bucket at `while ( my ($idx, $name) = each %$$slice )`.

Fix: Add a source-backed DBI regression fixture and keep a precombined `$$` token joined with an adjacent identifier when it is used behind an outer dereference sigil, so `%$$slice` parses as one deref target instead of leaving `slice` as a stray identifier.

Claim boundary: Source-backed parser fix only. This uses local Windows Strawberry discovery for fixture selection and does not claim Linux corpus refresh or raw bucket-count movement.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests dbi_each_hash_over_scalar_deref_slice --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test cpan_misc_idioms dollar_dollar_scalar_deref --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test glob_deref_arrow_tests --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked -- --nocapture --test-threads=1`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`
- `git diff --check`