### PR TITLE
fix(parser): parse old-style dynamic array derefs (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -370,13 +370,15 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // The lexer may hand us a sigil-only token (`&`) or a precombined `$$`
-        // token followed by the referenced identifier. Preserve the full target
-        // name instead of leaving the tail as a stray identifier node.
-        if (full_name.is_empty() || (sigil == "$" && full_name == "$"))
+        // The lexer may hand us a sigil-only token (`&`), a precombined `$$`
+        // token, or an old-style deref prefix such as `@$$` followed by the
+        // referenced identifier. Preserve the full target name instead of
+        // leaving the tail as a stray identifier node.
+        if (full_name.is_empty()
+            || (sigil == "$" && full_name == "$")
+            || (matches!(sigil.as_str(), "@" | "%") && full_name == "$$"))
             && self.peek_kind() == Some(TokenKind::Identifier)
-            && (sigil != "$"
-                || full_name != "$"
+            && (full_name.is_empty()
                 || self
                     .tokens
                     .peek()

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -514,6 +514,13 @@ fn max_values_postfix_deref() {
 }
 
 #[test]
+fn dbix_class_shift_dynamic_array_deref_join() {
+    // From DBIx::Class::SQLMaker::ClassicExtensions: a join argument may shift
+    // from an old-style dynamic array dereference.
+    assert_clean_parse(r#"\[ join( ' IN ', shift @$$lhs, shift @$$rhs ), @$$lhs, @$$rhs ];"#);
+}
+
+#[test]
 fn unless_null_in_paren() {
     // unless (null $root)
     assert_clean_parse(r#"unless (null $root) { print "not null" }"#);


### PR DESCRIPTION
Problem: DBIx::Class-style `shift @$$lhs` old-style dynamic array dereferences left the deref target tail as a stray identifier, producing `unclosed_paren_identifier`.
Fix: Preserve adjacent `@$$ident` / `%$$ident` combined-token deref prefixes in variable parsing and lock the DBIx::Class regression.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests dbix_class_shift_dynamic_array_deref_join --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests dbi_each_hash_over_scalar_deref_slice --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests dbi_profile_dumper_apache_pid_ternary --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `cargo xtask fmt --check`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `git diff --check`. Local Windows Strawberry sweep after the branch: 7456/7769 clean, `unclosed_paren_identifier` 2; discovery-only, no Linux raw-bucket movement claimed.