### PR TITLE
fix(parser): parse Sybase subname callback (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -753,7 +753,7 @@ impl<'a> Parser<'a> {
                         } else if name.contains("::")
                             && !self.is_at_statement_end()
                             && self.peek_kind() != Some(TokenKind::FatArrow)
-                            && matches!(
+                            && (matches!(
                                 self.peek_kind(),
                                 Some(
                                     TokenKind::String
@@ -761,10 +761,17 @@ impl<'a> Parser<'a> {
                                         | TokenKind::QuoteDouble
                                         | TokenKind::Number
                                 )
-                            )
+                            ) || (self.peek_kind() == Some(TokenKind::Identifier)
+                                && self
+                                    .tokens
+                                    .peek_second()
+                                    .ok()
+                                    .is_some_and(|t| t.kind == TokenKind::FatArrow)))
                         {
                             // Qualified call with string/number literal argument — issue #2750 Pattern B.
                             // e.g. `(Carp::croak "error")`, `(utf8::downgrade $$buf or Carp::croak "Wide char")`
+                            // Also handles `Sub::Name::subname bareword => sub { ... }`,
+                            // where the uppercase package prefix otherwise looks like a non-call.
                             // In paren-expression context, qualified names followed by a literal argument
                             // are treated as function calls (same as unqualified `croak "err"` via looks_like_bare_call).
                             // Guard: NOT followed by => (would be a hash-key) and NOT at statement end.

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -857,6 +857,18 @@ fn dbi_each_hash_over_scalar_deref_slice() {
 }
 
 #[test]
+fn dbic_sybase_subname_fat_arrow_coderef_arg() {
+    // From DBIx::Class::Storage::DBI::Sybase::ASE: a qualified imported
+    // list-style call may use a bare subname before `=> sub { ... }` while it
+    // is itself an argument to another function call.
+    assert_clean_parse(
+        r#"my $orig_cslib_cb = DBD::Sybase::set_cslib_cb(
+            Sub::Name::subname _insert_bulk_cslib_errhandler => sub { return 1; }
+        );"#,
+    );
+}
+
+#[test]
 fn looks_like_number_sigil() {
     // looks_like_number $val — common in Type::Tiny and Params::Util
     assert_clean_parse(r#"return 0 unless looks_like_number $val;"#);


### PR DESCRIPTION
Problem: Local Windows Strawberry discovery still found DBIx::Class::Storage::DBI::Sybase::ASE.pm in the stale `unclosed_paren_identifier` bucket at `Sub::Name::subname _insert_bulk_cslib_errhandler => sub { ... }` inside a `DBD::Sybase::set_cslib_cb(...)` call.

Fix: Add a source-backed Sybase regression fixture and extend the qualified bare-call path only for a bareword immediately followed by `=>`, so uppercase qualified imported calls can parse list-style callback naming without blocking existing `CORE::` qualified builtin handling.

Claim boundary: Source-backed parser fix only. This uses local Windows Strawberry discovery for fixture selection and does not claim Linux corpus refresh or raw bucket-count movement.

Verification:
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests dbic_sybase_subname_fat_arrow_coderef_arg --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test fix_unexpected_comma_expr --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test fat_arrow_args_tests --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture --test-threads=1`
- `cargo test -p perl-parser-core --test fix_fat_arrow_expr --profile agent --locked -- --nocapture --test-threads=1`
- `cargo xtask metrics parser-accuracy --check`
- `cargo xtask update-status --only parser --check`
- `cargo xtask metrics ratchet-check parser_accuracy`
- `cargo xtask fmt --check`
- `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`
- `git diff --check`