### PR TITLE
fix(parser): parse nullary umask before or (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -239,11 +239,12 @@ impl<'a> Parser<'a> {
         )
     }
 
-    /// Check if an identifier is an optional-argument builtin that can operate
-    /// on `$_` when called without an explicit argument.  When followed by a
-    /// binary operator in expression context (e.g., `defined && ...`,
-    /// `length > 0`, `ord >= 32`), these builtins should be treated as having
-    /// no argument rather than trying to parse the operator as their operand.
+    /// Check if an identifier is an optional-argument builtin that can be called
+    /// without an explicit argument. Some use implicit `$_`; others, such as
+    /// `umask`, have a true nullary form. When followed by a binary operator in
+    /// expression context (e.g., `defined && ...`, `length > 0`, `ord >= 32`,
+    /// `umask || 0`), these builtins should be treated as having no argument
+    /// rather than trying to parse the operator as their operand.
     pub(crate) fn is_optional_arg_builtin(name: &str) -> bool {
         matches!(
             name,
@@ -268,6 +269,7 @@ impl<'a> Parser<'a> {
                 | "sin"
                 | "log"
                 | "exp"
+                | "umask"
         )
     }
 

--- a/crates/perl-parser-core/tests/fix_unexpected_token_in_expr_2731.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_token_in_expr_2731.rs
@@ -59,6 +59,12 @@ fn test_defined_or_die() {
     assert_clean_parse("defined || die;");
 }
 
+#[test]
+fn test_umask_before_or_in_bitwise_not() {
+    // From File::Copy: nullary umask may appear before `||` inside a unary bitwise not.
+    assert_clean_parse(r#"my $perm = $fromstat[2] & ~(umask || 0);"#);
+}
+
 // === Sub-Pattern B: Special variable $: and friends ===
 // Perl punctuation variables $:, $;, $, that the parser did not handle.
 


### PR DESCRIPTION
Problem: Current corpus evidence showed File::Copy failing on nullary `umask || 0` inside `~(...)`.
Fix: Treat `umask` as an optional-argument builtin so it can terminate before binary operators, and lock the File::Copy-derived regression.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_token_in_expr_2731 --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --all-targets --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; parser/status ratchets passed; local Strawberry sweep made File::Copy clean and reduced `unexpected_token_in_expr` 37 -> 35.