### PR TITLE
fix(parser): stop list operators at ternary colon (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -499,7 +499,7 @@ impl<'a> Parser<'a> {
                                 if (if is_bare_func {
                                     self.should_continue_bare_call_after_block()
                                 } else {
-                                    !self.is_at_statement_end()
+                                    !self.is_implicit_arg_terminator()
                                 }) && !matches!(
                                     self.peek_kind(),
                                     Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
@@ -517,7 +517,7 @@ impl<'a> Parser<'a> {
                                         if !self.should_continue_bare_call_after_block() {
                                             break;
                                         }
-                                    } else if self.is_at_statement_end() {
+                                    } else if self.is_implicit_arg_terminator() {
                                         break;
                                     }
                                     args.push(self.parse_assignment_or_declaration()?);
@@ -534,14 +534,14 @@ impl<'a> Parser<'a> {
                                     "print" | "say" | "printf" | "exec" | "system" | "send"
                                 );
                                 if is_fh_builtin
-                                    && !self.is_at_statement_end()
+                                    && !self.is_implicit_arg_terminator()
                                     && !matches!(
                                         self.peek_kind(),
                                         Some(TokenKind::Comma | TokenKind::FatArrow)
                                     )
                                 {
                                     // No comma — treat the block as a filehandle and parse the list.
-                                    while !self.is_at_statement_end()
+                                    while !self.is_implicit_arg_terminator()
                                         && !matches!(
                                             self.peek_kind(),
                                             Some(
@@ -558,7 +558,7 @@ impl<'a> Parser<'a> {
                                         ) {
                                             self.consume_token()?;
                                         }
-                                        if self.is_at_statement_end() {
+                                        if self.is_implicit_arg_terminator() {
                                             break;
                                         }
                                         args.push(self.parse_ternary()?);
@@ -570,7 +570,7 @@ impl<'a> Parser<'a> {
                                         Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
                                     ) {
                                         self.consume_token()?; // consume comma or fat arrow
-                                        if self.is_at_statement_end() {
+                                        if self.is_implicit_arg_terminator() {
                                             break;
                                         }
                                         args.push(self.parse_comma()?);
@@ -843,7 +843,7 @@ impl<'a> Parser<'a> {
                                     )
                                 });
 
-                            if self.is_at_statement_end()
+                            if self.is_implicit_arg_terminator()
                                 || is_nullary_without_args
                                 || is_comma_terminated
                                 || is_str_op_terminated
@@ -866,10 +866,10 @@ impl<'a> Parser<'a> {
                                     args.push(self.parse_builtin_block()?);
 
                                     // Parse remaining arguments without requiring commas
-                                    // But respect statement boundaries including ] and )
+                                    // But respect statement and ternary branch boundaries.
                                     // Word operators terminate argument collection since
                                     // they bind less tightly than list operators.
-                                    while !self.is_at_statement_end()
+                                    while !self.is_implicit_arg_terminator()
                                         && !matches!(
                                             self.peek_kind(),
                                             Some(
@@ -888,7 +888,7 @@ impl<'a> Parser<'a> {
                                             self.consume_token()?;
                                         }
                                         // Check again after potential comma/fat arrow
-                                        if self.is_at_statement_end() {
+                                        if self.is_implicit_arg_terminator() {
                                             break;
                                         }
                                         args.push(self.parse_ternary()?);
@@ -925,7 +925,7 @@ impl<'a> Parser<'a> {
                                     // then collect the list to sort.
                                     args.push(self.parse_ternary()?);
 
-                                    while !self.is_at_statement_end()
+                                    while !self.is_implicit_arg_terminator()
                                         && !matches!(
                                             self.peek_kind(),
                                             Some(
@@ -942,7 +942,7 @@ impl<'a> Parser<'a> {
                                         ) {
                                             self.consume_token()?;
                                         }
-                                        if self.is_at_statement_end() {
+                                        if self.is_implicit_arg_terminator() {
                                             break;
                                         }
                                         args.push(self.parse_ternary()?);
@@ -959,7 +959,7 @@ impl<'a> Parser<'a> {
                                     // arg, then collect the list to sort (issue #2750 Pattern C).
                                     args.push(self.parse_ternary()?);
 
-                                    while !self.is_at_statement_end()
+                                    while !self.is_implicit_arg_terminator()
                                         && !matches!(
                                             self.peek_kind(),
                                             Some(
@@ -976,7 +976,7 @@ impl<'a> Parser<'a> {
                                         ) {
                                             self.consume_token()?;
                                         }
-                                        if self.is_at_statement_end() {
+                                        if self.is_implicit_arg_terminator() {
                                             break;
                                         }
                                         args.push(self.parse_ternary()?);
@@ -1047,6 +1047,10 @@ impl<'a> Parser<'a> {
                                         }
                                         args.push(self.parse_ternary()?);
                                     }
+                                } else if Self::is_optional_arg_builtin(bare_name)
+                                    && self.peek_kind() != Some(TokenKind::LeftParen)
+                                {
+                                    args.push(self.parse_shift()?);
                                 } else {
                                     // Parse the first argument
                                     args.push(self.parse_assignment_or_declaration()?);
@@ -1197,6 +1201,12 @@ impl<'a> Parser<'a> {
             None => true,
             _ => false,
         }
+    }
+
+    /// Stop implicit list-operator argument collection at ordinary statement
+    /// boundaries and at a ternary `:` separator owned by the enclosing branch.
+    fn is_implicit_arg_terminator(&mut self) -> bool {
+        self.is_at_statement_end() || self.peek_kind() == Some(TokenKind::Colon)
     }
 
     /// Check whether the current peek token is a quote-op name that should be

--- a/crates/perl-parser-core/tests/list_operator_boundary_receipts.rs
+++ b/crates/perl-parser-core/tests/list_operator_boundary_receipts.rs
@@ -85,6 +85,31 @@ fn map_quote_like_expression_keeps_sort_source_inside_map() -> Result<(), String
 }
 
 #[test]
+fn map_sort_source_stops_before_ternary_colon() -> Result<(), String> {
+    let source = r#"my @params = ref $data eq 'HASH' ? map { ($_ => $data->{$_}) } sort keys %$data : @$data;"#;
+    assert_clean_parse(source);
+
+    let statement = program_statement(source, "HTTP::Tiny map/sort ternary boundary")?;
+    let initializer = declaration_initializer(&statement, "HTTP::Tiny map/sort ternary boundary")?;
+
+    let NodeKind::Ternary { then_expr, .. } = &initializer.kind else {
+        return Err(format!(
+            "expected ternary initializer for HTTP::Tiny map/sort boundary, got {:?}",
+            initializer.kind
+        ));
+    };
+
+    let map_args = function_call(then_expr, "map", "HTTP::Tiny ternary then map boundary")?;
+    assert_eq!(map_args.len(), 2, "map should contain block and sort source");
+
+    let sort_args = function_call(arg(map_args, 1, "map source")?, "sort", "sort source boundary")?;
+    assert_eq!(sort_args.len(), 1, "sort should contain keys source before ternary colon");
+    function_call(arg(sort_args, 0, "sort source")?, "keys", "keys source boundary")?;
+
+    Ok(())
+}
+
+#[test]
 fn map_expression_keeps_split_source_inside_map() -> Result<(), String> {
     let source = r#"my $curHST = join '', map getHST($_, $vers), split /;/, $jcps;"#;
     assert_clean_parse(source);


### PR DESCRIPTION
Problem: HTTP::Tiny-style `map { ... } sort keys ...` ternary branches let implicit list-operator parsing consume the enclosing `:` and mis-shape the `ref $data eq ...` condition.
Fix: Stop implicit list-operator argument collection at ternary branch separators and parse optional-argument builtins as a single shift-level operand before outer comparisons/ternaries.
Verification: `cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test named_unary_precedence_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test named_unary_ternary_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_unexpected_eq_expr --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --all-targets --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `cargo xtask fmt --check`; `git diff --check`.

Local corpus evidence: Windows Strawberry sweep improved clean files 7488 -> 7497, dirty files 233 -> 224, ERROR-node files 190 -> 179, total ERROR nodes 884 -> 850, and `unexpected_token_in_expr` 35 -> 24. Canonical parser denominator/failure packets are unchanged.