### PR TITLE
fix(parser): parse anonymous sub comma lists (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -107,12 +107,15 @@ impl<'a> Parser<'a> {
     fn finish_subroutine_statement(&mut self, sub_node: Node) -> ParseResult<Node> {
         Ok(if let NodeKind::Subroutine { name, .. } = &sub_node.kind {
             if name.is_none() {
-                // Anonymous sub may be followed by arrow: sub { 42 }->()
-                let expr = if self.peek_kind() == Some(TokenKind::Arrow) {
+                // Anonymous sub may be followed by arrow or participate in a
+                // comma-list expression: sub { 1 }, sub { 2 }
+                let mut expr = if self.peek_kind() == Some(TokenKind::Arrow) {
                     self.parse_postfix_chain(sub_node)?
                 } else {
                     sub_node
                 };
+                expr = self.collect_comma_fat_arrow_continuation(expr)?;
+                expr = self.parse_word_or_expr(expr)?;
                 // Wrap anonymous subroutines in expression statements
                 let location = expr.location;
                 Node::new(

--- a/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
@@ -458,3 +458,17 @@ fn test_pdl_dbg_pattern() {
     let source = r#"$stab = $stab->{$_.'::'} for grep length, split /::/, $package;"#;
     assert_clean_parse(source);
 }
+
+#[test]
+fn test_app_cpan_generator_returns_anonymous_sub_list() {
+    // From App::Cpan::_generator: a block may return a bare list of anonymous
+    // subroutines without an explicit return statement.
+    let source = r#"sub _generator {
+    my @files = ();
+    sub {
+        push @files, File::Spec->canonpath($File::Find::name) if m/\A\w+\.pm\z/
+    },
+    sub { \@files },
+}"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
Problem: App::Cpan-style bare comma lists of anonymous subroutines emitted `unexpected_comma_expr` ERROR nodes when used as an implicit block return.
Fix: Let anonymous-sub statement starts reuse the existing comma/fat-arrow continuation collector before wrapping them as expression statements.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_comma_expr --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --all-targets --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `cargo xtask fmt --check`; `git diff --check`.

Local corpus evidence: Windows Strawberry sweep improved clean files 7497 -> 7501, dirty files 224 -> 220, ERROR-node files 179 -> 173, total ERROR nodes 850 -> 832, and `unexpected_comma_expr` 32 -> 26. Fixed or downgraded source shapes include App::Cpan, Types::Standard::Map, and Types::Standard::Tuple. Canonical parser denominator/failure packets are unchanged.