### PR TITLE
fix(parser): parse undef comma-list returns (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -269,6 +269,7 @@ impl<'a> Parser<'a> {
                 | "sin"
                 | "log"
                 | "exp"
+                | "undef"
                 | "umask"
         )
     }

--- a/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
@@ -472,3 +472,21 @@ fn test_app_cpan_generator_returns_anonymous_sub_list() {
 }"#;
     assert_clean_parse(source);
 }
+
+#[test]
+fn test_types_common_inlined_undef_comma_return() {
+    // From Types::Common::{Numeric,String}: an anonymous subroutine can return
+    // a list whose first element is bare `undef`.
+    let source = r#"my $type = declare(
+    inlined => sub { undef, qq($_ > 0) },
+);"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_types_common_inlined_undef_three_item_return() {
+    let source = r#"my $type = declare(
+    inlined => sub { undef, qq($_ >= -9), qq($_ <= 9) },
+);"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
Problem: Bare `undef` at the start of an anonymous-sub return list was parsed as a generic builtin needing an argument, so `sub { undef, ... }` produced `unexpected_comma_expr` recovery.
Fix: Treat `undef` as an optional-argument builtin in statement position and add Types::Common-derived comma-list regression coverage.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_comma_expr --profile agent --locked -- --nocapture` passes; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked undef_ -- --nocapture` passes; `cargo check -p perl-parser-core --all-targets --profile agent --locked` passes; local Strawberry sweep improves clean files 7501->7505, dirty 220->216, ERROR-node files 173->169, total ERROR nodes 832->748, unexpected_comma_expr 26->22; `cargo xtask metrics parser-accuracy --check` passes; `cargo xtask update-status --only parser --check` passes; `cargo xtask metrics ratchet-check parser_accuracy` passes; `cargo xtask check-provider-confidence-matrix` passes; `cargo xtask fmt --check` passes; `git diff --check` passes. Broad `cargo test -p perl-parser-core --profile agent --locked` still fails `parser_ac3_prevent_recursive_recovery`, confirmed failing unchanged on `origin/master`.