### PR TITLE
fix(parser): parse imported bare-call comma args (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -358,11 +358,18 @@ impl<'a> Parser<'a> {
         let mut args = vec![];
 
         // In Perl, `=>` (fat arrow) is equivalent to `,` everywhere, including
-        // in indirect-call argument lists.  Consume any leading `=>` that
-        // separates the filehandle/object from the first argument:
+        // in indirect-call argument lists.  Consume a leading fat arrow, or the
+        // comma form for the double-sigil object shape that otherwise reaches
+        // this parser as an indirect call:
         //   print STDERR => "msg";  — STDERR is object, "msg" is first arg
-        if self.peek_kind() == Some(TokenKind::FatArrow) {
-            self.tokens.next()?; // consume =>
+        //   imported $$obj, $arg    — double-sigil object plus argument list
+        let comma_after_double_sigil_object = self.peek_kind() == Some(TokenKind::Comma)
+            && matches!(
+                &object.kind,
+                NodeKind::Variable { sigil, name } if sigil == "$" && name.starts_with('$')
+            );
+        if self.peek_kind() == Some(TokenKind::FatArrow) || comma_after_double_sigil_object {
+            self.tokens.next()?; // consume , or =>
         }
 
         // Continue parsing arguments until we hit a statement terminator

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -743,11 +743,24 @@ impl<'a> Parser<'a> {
                             // lower-precedence operators remain outside the call.
                             // Example: `is_ready $obj ? 1 : 0` must parse as
                             // `(is_ready $obj) ? 1 : 0`, not `is_ready($obj ? 1 : 0)`.
-                            let arg = self.parse_shift()?;
+                            let first_arg = self.parse_shift()?;
+                            let mut args = vec![first_arg];
+
+                            while matches!(
+                                self.peek_kind(),
+                                Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
+                            ) {
+                                self.consume_token()?;
+                                if self.is_at_statement_end() {
+                                    break;
+                                }
+                                args.push(self.parse_assignment_or_declaration()?);
+                            }
+
                             let start = expr.location.start;
-                            let end = arg.location.end;
+                            let end = args.last().map_or(expr.location.end, |arg| arg.location.end);
                             expr = Node::new(
-                                NodeKind::FunctionCall { name: name.clone(), args: vec![arg] },
+                                NodeKind::FunctionCall { name: name.clone(), args },
                                 SourceLocation { start, end },
                             );
                         } else if name.contains("::")

--- a/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
@@ -182,6 +182,20 @@ fn test_shift_with_bare_arg_then_comma() {
     assert_clean_parse(source);
 }
 
+#[test]
+fn test_mojo_file_map_block_imported_bare_call_comma_args() {
+    // From Mojo::File: imported bare calls inside map blocks may pass
+    // comma-separated args after a sigil-starting first arg.
+    let source = r#"@files = map { catfile $$self, $_ } @files;"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_imported_bare_call_comma_args_stays_before_ternary() {
+    let source = r#"my $value = is_ready $obj, $ctx ? 1 : 0;"#;
+    assert_clean_parse(source);
+}
+
 // === no warnings with multiple args ===
 
 #[test]


### PR DESCRIPTION
Problem: Imported bare calls with comma-separated args inside map blocks can leave an `unexpected_comma_expr` error, as in Mojo::File's `catfile $$self, $_` shape.
Fix: Collect explicit comma/fat-arrow args for sigil-starting imported bare calls and handle the double-sigil indirect-call subcase without broadening provider behavior.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_comma_expr --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `cargo xtask fmt --check`; `git diff --check`. Local Strawberry sweep: clean 7505->7507, dirty 216->214, ERROR-node files 169->165, first `unexpected_comma_expr` 22->18; total ERROR nodes 748->755 because already-dirty PkgConfig exposes later errors behind unchanged `unexpected_fat_arrow_expr`.