### PR TITLE
fix(parser): parse return keyword labels (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -388,6 +388,17 @@ impl<'a> Parser<'a> {
             | TokenKind::Init
             | TokenKind::Unitcheck => self.parse_expression_statement(),
 
+            TokenKind::Return
+                if self
+                    .tokens
+                    .peek_second()
+                    .ok()
+                    .map(|t| t.kind == TokenKind::Colon)
+                    .unwrap_or(false) =>
+            {
+                self.parse_keyword_as_label()
+            }
+
             // Data sections
             TokenKind::DataMarker => self.parse_data_section(),
 
@@ -1203,8 +1214,7 @@ impl<'a> Parser<'a> {
         // Consume the colon
         self.expect(TokenKind::Colon)?;
 
-        // Parse the statement after the label
-        let statement = Box::new(self.parse_statement()?);
+        let statement = self.parse_label_statement_body()?;
 
         let end = self.previous_position();
         Ok(Node::new(
@@ -1264,14 +1274,25 @@ impl<'a> Parser<'a> {
         // Consume the `:`
         self.expect(TokenKind::Colon)?;
 
-        // Parse the statement that follows the label
-        let statement = Box::new(self.parse_statement()?);
+        let statement = self.parse_label_statement_body()?;
 
         let end = self.previous_position();
         Ok(Node::new(
             NodeKind::LabeledStatement { label, statement },
             SourceLocation { start, end },
         ))
+    }
+
+    fn parse_label_statement_body(&mut self) -> ParseResult<Box<Node>> {
+        if matches!(self.peek_kind(), Some(TokenKind::RightBrace) | Some(TokenKind::Eof)) {
+            let pos = self.current_position();
+            return Ok(Box::new(Node::new(
+                NodeKind::Block { statements: Vec::new() },
+                SourceLocation { start: pos, end: pos },
+            )));
+        }
+
+        Ok(Box::new(self.parse_statement()?))
     }
 
 }

--- a/crates/perl-parser-core/tests/fix_label_ternary_disambiguation.rs
+++ b/crates/perl-parser-core/tests/fix_label_ternary_disambiguation.rs
@@ -118,6 +118,31 @@ fn test_label_ternary_disambiguation_valid_return() {
     assert_clean_parse(r#"EXIT: return $result if defined $result;"#);
 }
 
+#[test]
+fn test_return_keyword_can_be_label_at_block_end() {
+    // From Hash::Merge: `return:` is a legal label, not a return statement
+    // followed by a stray colon. The label is the final statement in the block.
+    assert_clean_parse(
+        r#"
+sub get_behavior_spec {
+    exists $self->{behaviors}{$name} and return $self->{behaviors}{$name};
+  return:
+}
+"#,
+    );
+}
+
+#[test]
+fn test_return_keyword_can_be_label_before_statement() {
+    assert_clean_parse(
+        r#"
+sub get_behavior_spec {
+  return: print "after label";
+}
+"#,
+    );
+}
+
 /// Token after colon is `;` — labeled empty statement. Valid Perl.
 ///
 /// `LABEL: ;` is a legal labeled empty-statement in Perl.  Earlier versions of


### PR DESCRIPTION
Problem: Hash::Merge uses `return:` as a legal label, which the parser treated as a return statement followed by a stray colon.
Fix: Treat `return:` as a keyword label and allow label bodies to be empty at block end.
Verification: `cargo test -p perl-parser-core --test fix_label_ternary_disambiguation --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_phase_keyword_as_label_2389 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `git diff --check`.

Local corpus note: Windows Strawberry sweep improved clean files `7507 -> 7509`, dirty files `214 -> 212`, ERROR-node files `165 -> 163`, total ERROR nodes `755 -> 753`, and first `unexpected_token_in_expr` bucket `24 -> 22`. This is source-backed local evidence only; the PR does not claim Linux bucket-count movement.