### PR TITLE
fix(parser): parse bare cmp overload keys (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/declarations.rs
+++ b/crates/perl-parser-core/src/engine/parser/declarations.rs
@@ -793,7 +793,7 @@ impl<'a> Parser<'a> {
             }
         }
         // Handle bare arguments (no parentheses)
-        else if matches!(self.peek_kind(), Some(k) if matches!(k, TokenKind::String | TokenKind::Identifier | TokenKind::Minus | TokenKind::QuoteWords | TokenKind::QuoteSingle | TokenKind::QuoteDouble))
+        else if matches!(self.peek_kind(), Some(k) if matches!(k, TokenKind::String | TokenKind::Identifier | TokenKind::StringCompare | TokenKind::Minus | TokenKind::QuoteWords | TokenKind::QuoteSingle | TokenKind::QuoteDouble))
             && !Self::is_statement_terminator(self.peek_kind())
         {
             // Parse bare arguments like: use warnings 'void' or use constant FOO => 42
@@ -923,7 +923,7 @@ impl<'a> Parser<'a> {
                             args.push(minus.text.to_string());
                         }
                     }
-                    Some(TokenKind::Identifier) => {
+                    Some(TokenKind::Identifier | TokenKind::StringCompare) => {
                         // Check if this might be a constant declaration
                         let ident = self.consume_token()?;
                         let ident_text = ident.text.to_string();
@@ -1183,7 +1183,10 @@ impl<'a> Parser<'a> {
         let mut args = Vec::new();
 
         // Handle bare arguments (no parentheses)
-        if matches!(self.peek_kind(), Some(TokenKind::String) | Some(TokenKind::Identifier))
+        if matches!(
+            self.peek_kind(),
+            Some(TokenKind::String | TokenKind::Identifier | TokenKind::StringCompare)
+        )
             && !matches!(self.peek_kind(), Some(TokenKind::Semicolon) | Some(TokenKind::Eof) | None)
         {
             // Parse bare arguments like: no warnings 'void'
@@ -1247,7 +1250,7 @@ impl<'a> Parser<'a> {
                             }
                         }
                     }
-                    Some(TokenKind::Identifier) => {
+                    Some(TokenKind::Identifier | TokenKind::StringCompare) => {
                         args.push(self.consume_token()?.text.to_string());
 
                         // Handle comma or fat arrow after identifier

--- a/crates/perl-parser-core/tests/fix_parse_no_import_list_tests.rs
+++ b/crates/perl-parser-core/tests/fix_parse_no_import_list_tests.rs
@@ -26,6 +26,16 @@ fn test_no_overload_multiple_ops() {
 }
 
 #[test]
+fn test_no_overload_bare_cmp_key() {
+    let source = r#"
+no overload
+    '""' => 'type'
+  , cmp  => 'cmp';
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
 fn test_no_feature_nested_parens() {
     // Nested parens inside the arg list must be depth-tracked
     let source = r#"no feature ('say', 'state');"#;

--- a/crates/perl-parser-core/tests/use_import_pattern_tests.rs
+++ b/crates/perl-parser-core/tests/use_import_pattern_tests.rs
@@ -135,6 +135,17 @@ fn use_overload_coderef_in_parens() {
 }
 
 #[test]
+fn use_overload_bare_cmp_key() {
+    assert_clean_parse(
+        r#"
+use overload
+    '""' => 'type'
+  , cmp  => 'cmp';
+"#,
+    );
+}
+
+#[test]
 fn use_sub_block_in_import_parens() {
     assert_clean_parse(r#"use overload ('""' => sub { $_[0]->{name} });"#);
 }


### PR DESCRIPTION
Problem: MIME::Type uses `cmp => 'cmp'` in a `use overload` import list, and `cmp` is tokenized as `StringCompare`, so the parser stopped the import list and emitted an expression error.
Fix: Treat `StringCompare` like a bare import key in `use` and `no` declaration argument lists, with focused overload regressions for both forms.
Verification: `cargo test -p perl-parser-core --test use_import_pattern_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_parse_no_import_list_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --lib --profile agent --locked use_overload -- --nocapture`; `cargo test -p perl-parser-core --test cpan_module_patterns --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `git diff --check`.

Local corpus note: Windows Strawberry sweep improved clean files `7509 -> 7511`, dirty files `212 -> 210`, ERROR-node files `163 -> 161`, total ERROR nodes `753 -> 751`, and first `unexpected_token_in_expr` bucket `22 -> 20`. This is source-backed local evidence only; the PR does not claim Linux bucket-count movement.