### PR TITLE
fix(parser): parse cmp hash subscript keys (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1283,7 +1283,7 @@ impl<'a> Parser<'a> {
     /// This function builds a proper parse tree node for them, including support
     /// for hash slices like `@h{m, s}` which require a list node.
     fn parse_hash_subscript_key(&mut self) -> ParseResult<Node> {
-        // Try keyword-as-bareword first (not, and, or, xor, do, eval)
+        // Try keyword/operator-as-bareword first (not, and, or, xor, do, eval, cmp)
         if let Some(node) = self.try_parse_keyword_bareword_key()? {
             return Ok(node);
         }
@@ -1297,11 +1297,13 @@ impl<'a> Parser<'a> {
         self.parse_expression()
     }
 
-    /// Attempt to parse a keyword (`not`, `and`, `or`, `xor`, `do`, `eval`) as a
-    /// bareword hash key when it appears directly before `}`.
+    /// Attempt to parse a keyword or word operator (`not`, `and`, `or`, `xor`,
+    /// `do`, `eval`, `cmp`) as a bareword hash key when it appears directly
+    /// before `}`.
     ///
-    /// Returns `Some(Node)` if the current token is a keyword followed by `}`,
-    /// otherwise returns `None` to fall through to general expression parsing.
+    /// Returns `Some(Node)` if the current token is a keyword/operator followed
+    /// by `}`, otherwise returns `None` to fall through to general expression
+    /// parsing.
     fn try_parse_keyword_bareword_key(&mut self) -> ParseResult<Option<Node>> {
         let Some(kind) = self.peek_kind() else {
             return Ok(None);
@@ -1315,6 +1317,7 @@ impl<'a> Parser<'a> {
                 | TokenKind::WordXor
                 | TokenKind::Do
                 | TokenKind::Eval
+                | TokenKind::StringCompare
         );
 
         if !is_simple_keyword_key {

--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_hash_key.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_hash_key.rs
@@ -69,6 +69,16 @@ fn test_bare_hash_key_eval() {
     assert_clean_parse(r#"my $x = $h{eval};"#);
 }
 
+#[test]
+fn test_bare_hash_key_cmp() {
+    assert_clean_parse(r#"my %opt; $opt{cmp} ||= '=';"#);
+}
+
+#[test]
+fn test_arrow_hash_key_cmp() {
+    assert_clean_parse(r#"my $x = $opts->{cmp};"#);
+}
+
 // Chained deref with keyword key
 #[test]
 fn test_chained_hash_key_not() {


### PR DESCRIPTION
Problem: `cmp` is tokenized as `StringCompare`, so `$opt{cmp}` in SQL::Abstract-style hash subscripts fell into expression parsing and left `||=` stranded.
Fix: Treat `StringCompare` as a bare hash-subscript key only in the existing immediate-`}` keyword-key path, with direct and arrow regression coverage.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_rbrace_hash_key --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked cmp -- --nocapture`; `cargo run -p perl-parser --features cli --bin perl-parse --profile agent --locked -- C:\Strawberry\perl\vendor\lib\SQL\Abstract\Classic.pm`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `git diff --check`.