### PR TITLE
fix(parser): parse redundant comma separators (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -727,11 +727,14 @@ impl<'a> Parser<'a> {
 
                 match s.peek_kind() {
                     Some(TokenKind::Comma) | Some(TokenKind::FatArrow) => {
-                        s.tokens.next()?;
+                        let separator = s.consume_token()?;
+                        if separator.kind == TokenKind::Comma {
+                            s.consume_redundant_commas()?;
+                        }
                         // Handle `, =>` (comma then fat arrow) — consume the
                         // redundant separator.
                         if s.peek_kind() == Some(TokenKind::FatArrow) {
-                            s.tokens.next()?;
+                            s.consume_token()?;
                         }
                     }
                     _ => break,

--- a/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/hashes.rs
@@ -155,7 +155,8 @@ impl<'a> Parser<'a> {
                 pairs.push((first_expr, value));
             } else if self.peek_kind() == Some(TokenKind::Comma) {
                 // comma-separated pattern: key, value, key2, value2
-                self.tokens.next()?; // consume comma
+                self.consume_token()?; // consume comma
+                self.consume_redundant_commas()?;
 
                 if self.peek_kind() != Some(TokenKind::RightBrace) {
                     let second = self.parse_expression()?;
@@ -179,6 +180,7 @@ impl<'a> Parser<'a> {
             {
                 if self.peek_kind() == Some(TokenKind::Comma) {
                     self.consume_token()?; // consume comma
+                    self.consume_redundant_commas()?;
                 }
 
                 if self.peek_kind() == Some(TokenKind::RightBrace) {
@@ -194,6 +196,7 @@ impl<'a> Parser<'a> {
                     pairs.push((key, value));
                 } else if self.peek_kind() == Some(TokenKind::Comma) {
                     self.consume_token()?; // consume comma
+                    self.consume_redundant_commas()?;
 
                     if self.peek_kind() == Some(TokenKind::RightBrace) {
                         // Odd number of elements - last one becomes undef value

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -936,6 +936,7 @@ impl<'a> Parser<'a> {
                         let was_comma = self.peek_kind() == Some(TokenKind::Comma);
                         if was_comma {
                             self.consume_token()?; // consume comma
+                            self.consume_redundant_commas()?;
                         }
 
                         // Handle `, =>` (comma then fat arrow) and chained `=>`
@@ -1051,6 +1052,7 @@ impl<'a> Parser<'a> {
                     // picks up `c` as the value.
                     if self.peek_kind() == Some(TokenKind::Comma) {
                         self.consume_token()?; // consume ,
+                        self.consume_redundant_commas()?;
                     } else if self.peek_kind() == Some(TokenKind::FatArrow) {
                         // Chained fat arrow: the value we just pushed becomes
                         // the auto-quoted key for the next pair.  Autoquote the

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -436,6 +436,13 @@ impl<'a> Parser<'a> {
         Ok(token)
     }
 
+    fn consume_redundant_commas(&mut self) -> ParseResult<()> {
+        while self.peek_kind() == Some(TokenKind::Comma) {
+            self.consume_token()?;
+        }
+        Ok(())
+    }
+
     /// Get closing delimiter for a given opening delimiter
     #[inline]
     fn closing_delim_for(open_txt: &str) -> Option<String> {
@@ -517,6 +524,7 @@ impl<'a> Parser<'a> {
             let was_comma = self.peek_kind() == Some(TokenKind::Comma);
             if was_comma {
                 self.consume_token()?; // consume comma
+                self.consume_redundant_commas()?;
             }
 
             if self.peek_kind() == Some(TokenKind::FatArrow) {

--- a/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_comma_expr.rs
@@ -504,3 +504,50 @@ fn test_types_common_inlined_undef_three_item_return() {
 );"#;
     assert_clean_parse(source);
 }
+
+#[test]
+fn test_dancer2_method_args_redundant_leading_comma() {
+    // From Dancer2::Plugin::LogReport: style with a trailing comma on one
+    // line and a leading comma before the next named argument.
+    let source = r#"sub x {
+    $dsl->app->add_route
+      ( method => 'get'
+      , regexp => qr!^/foo$!,
+      , code   => sub { shift->app->template($forward_template) }
+      );
+}"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_throwable_moo_attribute_double_comma_after_call() {
+    // From Throwable::Error: a Moo attribute value can be followed by a
+    // redundant comma before the next named argument.
+    let source = r#"use Moo;
+has message => (
+  is       => 'ro',
+  isa      => Sub::Quote::quote_sub(q{
+      die "message must be a string"
+          unless defined($_[0]) && !ref($_[0]);
+  }),,
+  required => 1,
+);"#;
+    assert_clean_parse(source);
+}
+
+#[test]
+fn test_data_printer_hash_pair_double_comma() {
+    // From Data::Printer::Profile::Dumper: nested hash pairs may contain
+    // redundant comma separators.
+    let source = r#"sub profile {
+    return {
+        filters => [
+            {
+                'REF'     => \&_data_dumper_ref_filter,,
+                'Regexp'  => \&_data_dumper_regexp_filter,
+            },
+        ],
+    };
+}"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
Problem: Redundant comma separators in real CPAN-style list/hash argument shapes still produced parser ERROR nodes.
Fix: Skip redundant comma tokens after an accepted comma separator inside parser list, argument, hash, and array collection paths, with source-backed regressions from Dancer2, Throwable, and Data::Printer.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_comma_expr --profile agent --locked -- --nocapture` passes; `cargo test -p perl-parser-core --test fix_fat_arrow_expr --profile agent --locked -- --nocapture` passes; `cargo check -p perl-parser-core --all-targets --profile agent --locked` passes; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs` passes; parser/status/provider gates pass. Local Strawberry sweep improved clean files 7513 -> 7531, dirty files 208 -> 190, ERROR-node files 159 -> 141, total ERROR nodes 723 -> 665, and first `unexpected_comma_expr` buckets 18 -> 0. `cargo test -p perl-parser-core --profile agent --locked` still hits pre-existing `parser_panic_mode_recovery::parser_ac3_prevent_recursive_recovery` failure confirmed on origin/master. `cargo xtask gates --tier pr-fast --receipt` is blocked locally by Windows just/shebang shell resolution (`sh`/`cygpath` missing), with equivalent conflict-marker and README heading checks run manually.