### PR TITLE
docs(project): fix dead documentation references (#3227)

### DIFF
--- a/docs/project/ORIENTATION.md
+++ b/docs/project/ORIENTATION.md
@@ -1,6 +1,6 @@
 # Project Orientation
 
-> For the documentation hub, see [README.md](README.md). This page provides project orientation for active contributors.
+> For the documentation hub, see [README.md](../README.md). This page provides project orientation for active contributors.
 
 > **SNAPSHOT DISCLAIMER**: Orientation-only. For live status and metrics, see `docs/project/CURRENT_STATUS.md` and GitHub milestones/issues.
 

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -74,7 +74,7 @@ See [ROADMAP.md](../ROADMAP.md) for milestone details.
 4. Run `just ci-gate` to verify the repo-level receipt still passes
 5. Edit narrative sections (this file, `release.md`) only after the evidence is current
 
-**Historical archives**: see `docs/archive/status_snapshots/` for sprint logs and completion history.
+**Historical archives**: see [reference archive](../../reference/archive/) for retained historical docs and completion history.
 
 ---
 

--- a/docs/reference/VALIDATION-149-acceptance-criteria.md
+++ b/docs/reference/VALIDATION-149-acceptance-criteria.md
@@ -2,7 +2,10 @@
 
 ## Acceptance Criteria Validation Matrix
 
-This document validates that the architectural blueprint in `SPEC-149-missing-docs.manifest.yml` addresses all 12 acceptance criteria from `ISSUE-149.story.md`.
+This document validates that the retained documentation standards in
+[`book/src/developer/api-documentation-standards.md`](../../book/src/developer/api-documentation-standards.md)
+and [`schemas/documentation-standards.schema.yml`](../../schemas/documentation-standards.schema.yml)
+address all 12 missing-docs acceptance criteria tracked by Issue 149.
 
 ---
 
@@ -255,8 +258,8 @@ This document validates that the architectural blueprint in `SPEC-149-missing-do
 ## Deliverables Validation
 
 ### Required Artifacts
-- ✅ `SPEC-149-missing-docs.manifest.yml`: Comprehensive architectural blueprint
-- ✅ `schemas/documentation-standards.schema.yml`: Domain schema for patterns
+- ✅ [`book/src/developer/api-documentation-standards.md`](../../book/src/developer/api-documentation-standards.md): Comprehensive API documentation standards
+- ✅ [`schemas/documentation-standards.schema.yml`](../../schemas/documentation-standards.schema.yml): Domain schema for patterns
 - ✅ Implementation strategy with 6 phases and clear deliverables
 - ✅ Validation commands and success metrics
 


### PR DESCRIPTION
Summary
- Fixes three dead or stale documentation references from the docs staleness audit in EffortlessMetrics/perl-lsp-swarm#3023.
- Points the project orientation page at the existing docs hub.
- Replaces the missing status snapshot directory with the retained reference archive.
- Replaces removed Issue 149 story/spec artifact references with retained standards and schema documents.

Validation
- `git diff --check` passed.
- Verified the new link targets exist in the repository tree with `git cat-file -t`:
  - `docs/README.md`
  - `docs/reference/archive`
  - `book/src/developer/api-documentation-standards.md`
  - `schemas/documentation-standards.schema.yml`
- Searched the changed files for the removed stale references:
  - `docs/archive/status_snapshots`
  - `[README.md](README.md)`
  - `SPEC-149-missing-docs.manifest.yml`
  - `ISSUE-149.story.md`

Notes
- Related issue: EffortlessMetrics/perl-lsp-swarm#3023.
- Docs-only change; no runtime compatibility impact.
- Full docs drift cleanup remains broader follow-up work.
