### PR TITLE
fix(parser): parse semicolon-terminated deref bodies (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -278,6 +278,7 @@ impl<'a> Parser<'a> {
             // Parse the expression inside the braces
             let expr = self.parse_expression()?;
 
+            self.consume_deref_body_terminators()?;
             self.expect(TokenKind::RightBrace)?;
             let end = self.previous_position();
 
@@ -330,6 +331,7 @@ impl<'a> Parser<'a> {
             // Parse postfix chain (handles function call parens, method calls, etc.)
             inner = self.parse_postfix_chain(inner)?;
 
+            self.consume_deref_body_terminators()?;
             self.expect(TokenKind::RightBrace)?;
             let end = self.previous_position();
 
@@ -361,6 +363,7 @@ impl<'a> Parser<'a> {
                 // $#{expr} — last index via block dereference
                 self.tokens.next()?; // consume {
                 let inner = self.parse_expression()?;
+                self.consume_deref_body_terminators()?;
                 self.expect(TokenKind::RightBrace)?;
                 let brace_end = self.previous_position();
                 return Ok(Node::new(
@@ -420,6 +423,13 @@ impl<'a> Parser<'a> {
                 SourceLocation { start: token.start, end },
             ))
         }
+    }
+
+    fn consume_deref_body_terminators(&mut self) -> ParseResult<()> {
+        while self.peek_kind() == Some(TokenKind::Semicolon) {
+            self.consume_token()?;
+        }
+        Ok(())
     }
 
     /// Parse a variable when we have a sigil token first
@@ -638,6 +648,7 @@ impl<'a> Parser<'a> {
             // Parse the expression inside the braces
             let expr = self.parse_expression()?;
 
+            self.consume_deref_body_terminators()?;
             self.expect(TokenKind::RightBrace)?;
             let end = self.previous_position();
 
@@ -696,6 +707,7 @@ impl<'a> Parser<'a> {
     /// `start` is the position of the `&` sigil.
     fn parse_code_dereference(&mut self, start: usize) -> ParseResult<Node> {
         let inner_expr = self.parse_expression()?;
+        self.consume_deref_body_terminators()?;
         self.expect(TokenKind::RightBrace)?;
         let deref_end = self.previous_position();
         let deref_node = Node::new(

--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs
@@ -65,3 +65,21 @@ fn test_do_empty_block_condition() {
 fn test_do_empty_block_with_space() {
     assert_clean_parse("do { };");
 }
+
+#[test]
+fn test_dbix_hash_splice_with_semicolon_terminated_deref_body() {
+    // From DBIx::Class::Storage::DBIHacks: a hash constructor may splice a
+    // hash dereference whose braced expression is terminated with `;`.
+    assert_clean_parse(
+        r#"sub x {
+    my $return = {
+        %{
+            $colinfos->{$source_alias}->{$colname}
+              ||
+            $self->throw_exception("No such column");
+        },
+        -result_source => $rsrc,
+    };
+}"#,
+    );
+}


### PR DESCRIPTION
Problem: DBIx::Class hash constructors can splice `%{ ...; }` deref bodies, and the parser left an ERROR node on the closing `}`.
Fix: Consume semicolon terminators before closing scalar/array/hash/code deref bodies, with a source-backed DBIx regression fixture.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_rbrace_expr_2404 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test postfix_deref_regression_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test complex_paren_args_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_expected_colon --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_unclosed_brace_semicolon_remaining --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_unclosed_bracket_2398 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test test_edge_cases_deep --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `git diff --check`.

Focused DBIx::Class Storage sweep on local Strawberry Perl: total ERROR nodes 42 -> 41, DBIHacks.pm 31 -> 30, and the `unexpected_rbrace_expr` first-error bucket 1 -> 0. This does not claim movement in the stale Linux raw-bucket receipt.

Local caveat: `just agent-pr-fast` is blocked on this Windows host by `just could not find the shell: program not found`; direct cargo/xtask gates above passed.