### PR TITLE
fix(parser): parse keyword-named scalar derefs (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -380,7 +380,7 @@ impl<'a> Parser<'a> {
         if (full_name.is_empty()
             || (sigil == "$" && full_name == "$")
             || (matches!(sigil.as_str(), "@" | "%") && full_name == "$$"))
-            && self.peek_kind() == Some(TokenKind::Identifier)
+            && self.peek_kind().is_some_and(Self::is_variable_name_kind)
             && (full_name.is_empty()
                 || self
                     .tokens
@@ -444,11 +444,9 @@ impl<'a> Parser<'a> {
         // Check if next token is an identifier or a keyword that should be treated as identifier
         let next_kind = self.peek_kind();
 
-        let (name, end) = if next_kind == Some(TokenKind::Identifier) ||
-                             // Keywords can be used as variable names with any sigil
-                             // e.g., %try, $default, @for, &try are all valid Perl
-                             matches!(next_kind, Some(k) if Self::can_be_sub_name(k))
-        {
+        // Keywords can be used as variable names with any sigil
+        // e.g., %try, $default, @for, &try are all valid Perl.
+        let (name, end) = if next_kind.is_some_and(Self::is_variable_name_kind) {
             let name_token = self.tokens.next()?;
             let mut name = name_token.text.to_string();
             let mut end = name_token.end;
@@ -493,7 +491,9 @@ impl<'a> Parser<'a> {
                     // `$$` is the PID special variable, but `$$ident` is a scalar
                     // dereference target that must preserve the referenced name.
                     let token = self.tokens.next()?;
-                    if self.peek_kind() == Some(TokenKind::Identifier) {
+                    if self.tokens.peek().ok().is_some_and(|name_token| {
+                        Self::is_variable_name_kind(name_token.kind) && name_token.start == token.end
+                    }) {
                         let name_token = self.tokens.next()?;
                         let mut name = format!("${}", name_token.text);
                         let mut end = name_token.end;
@@ -1129,6 +1129,10 @@ impl<'a> Parser<'a> {
         }
 
         Ok(prototype)
+    }
+
+    fn is_variable_name_kind(kind: TokenKind) -> bool {
+        kind == TokenKind::Identifier || Self::can_be_sub_name(kind)
     }
 }
 

--- a/crates/perl-parser-core/tests/cpan_misc_idioms.rs
+++ b/crates/perl-parser-core/tests/cpan_misc_idioms.rs
@@ -337,6 +337,21 @@ mod dollar_dollar_scalar_deref {
     }
 
     #[test]
+    fn scalar_deref_keyword_named_variable_keeps_name() {
+        let source = "my $x = $$default;";
+        assert_clean_parse(source);
+        let sexp = sexp(source);
+        assert!(
+            sexp.contains("(variable $ $default)"),
+            "expected $$default to survive as a scalar-deref target token, got: {sexp}"
+        );
+        assert!(
+            !sexp.contains("(variable $ $))"),
+            "expected $$default not to collapse to the bare $$ PID variable, got: {sexp}"
+        );
+    }
+
+    #[test]
     fn bare_pid_special_variable_still_parses_as_pid() {
         let sexp = sexp("my $pid = $$;");
         assert!(

--- a/crates/perl-parser-core/tests/fix_expected_left_brace.rs
+++ b/crates/perl-parser-core/tests/fix_expected_left_brace.rs
@@ -251,3 +251,18 @@ catch Git::Error::Command { my $e = shift; warn $e; };
         "Expected 'with' before catch block",
     );
 }
+
+#[test]
+fn test_type_params_return_scalar_deref_named_variable() {
+    // From Type::Params::Parameter: scalar dereference of a named variable can
+    // appear as a return expression.
+    assert_no_diagnostics(
+        r#"
+sub _code_for_default {
+    if (is_ScalarRef $default) {
+        return $$default;
+    }
+}
+"#,
+    );
+}


### PR DESCRIPTION
Problem: Keyword-named scalar derefs such as `$$default` could collapse to bare `$$` when the dereferenced variable name tokenized as a keyword, producing `expected_left_brace` recovery in source-backed Type::Params shapes. Fix: Treat keyword-shaped variable-name tokens as adjacent double-sigil deref targets while preserving whitespace-delimited bare `$$` behavior, with Type::Params and cpan_misc_idioms regressions. Verification: `cargo test -p perl-parser-core --test fix_expected_left_brace --profile agent --locked test_type_params_return_scalar_deref_named_variable -- --nocapture`; `cargo test -p perl-parser-core --test cpan_misc_idioms --profile agent --locked dollar_dollar_scalar_deref -- --nocapture`; `cargo test -p perl-parser-core --test fix_expected_left_brace --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test cpan_misc_idioms --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test glob_deref_arrow_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_pos_lvalue --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`. Claim boundary: focused parser repair and source-backed regression coverage only; no Linux raw-bucket movement claim because EffortlessMetrics/perl-lsp-swarm#2693 still owns the fresh Linux corpus receipt.