### PR TITLE
fix(lexer): keep quote-like sub names bare (#8197)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1898,7 +1898,11 @@ impl<'a> PerlLexer<'a> {
             // Check for substitution/transliteration operators
             // Skip if after '->'  -- these are method names, not operators.
             #[allow(clippy::collapsible_if)]
-            if !self.after_arrow && self.hash_brace_depth == 0 && matches!(text, "s" | "tr" | "y") {
+            if !self.after_sub
+                && !self.after_arrow
+                && self.hash_brace_depth == 0
+                && matches!(text, "s" | "tr" | "y")
+            {
                 let immediate = self.current_char();
                 let (candidate, char_after_next, has_whitespace) =
                     if immediate.is_some_and(|c| c.is_whitespace()) {
@@ -1967,7 +1971,8 @@ impl<'a> PerlLexer<'a> {
                     // Inside hash subscript braces, regex-like operators stay bareword
                     // keys (`@h{m, s}`), but q-family operators can still introduce real
                     // quote expressions in slices (`@h{qw/a b/}`).
-                    op if !self.after_arrow
+                    op if !self.after_sub
+                        && !self.after_arrow
                         && quote_handler::is_quote_operator(op)
                         && (self.hash_brace_depth == 0
                             || matches!(op, "q" | "qq" | "qw" | "qr" | "qx")) =>

--- a/crates/perl-lexer/tests/focused_regression_contracts.rs
+++ b/crates/perl-lexer/tests/focused_regression_contracts.rs
@@ -67,6 +67,38 @@ fn quote_like_qr_bracket_is_quote_regex() -> TestResult {
 }
 
 #[test]
+fn quote_like_words_after_sub_are_identifiers() -> TestResult {
+    let cases = [
+        ("sub m { # source comment keeps the block open\n}\n", "m"),
+        ("sub s { 1 }\n", "s"),
+        ("sub tr { 1 }\n", "tr"),
+        ("sub q { 1 }\n", "q"),
+    ];
+
+    for (input, expected_name) in cases {
+        let mut lexer = PerlLexer::new(input);
+
+        let sub = next_non_trivia(&mut lexer).ok_or("missing sub token")?;
+        assert!(
+            matches!(&sub.token_type, TokenType::Keyword(keyword) if keyword.as_ref() == "sub")
+        );
+
+        let name = next_non_trivia(&mut lexer).ok_or("missing sub name token")?;
+        assert!(matches!(
+            &name.token_type,
+            TokenType::Identifier(identifier) | TokenType::Keyword(identifier)
+                if identifier.as_ref() == expected_name
+        ));
+        assert_eq!(name.text.as_ref(), expected_name);
+
+        let brace = next_non_trivia(&mut lexer).ok_or("missing sub block brace")?;
+        assert_eq!(brace.token_type, TokenType::LeftBrace);
+    }
+
+    Ok(())
+}
+
+#[test]
 fn transliteration_tr_with_modifiers_is_single_token() -> TestResult {
     let input = "tr/a-z/A-Z/cdr";
     let mut lexer = PerlLexer::new(input);

--- a/crates/perl-parser-core/tests/fix_expected_left_brace.rs
+++ b/crates/perl-parser-core/tests/fix_expected_left_brace.rs
@@ -118,6 +118,16 @@ fn test_sub_named_cmp() {
 }
 
 #[test]
+fn test_sub_named_m_with_comment_after_block_open() {
+    // CPAN/Shell.pm: `m` is a subroutine name here, not an m{...} regex.
+    assert_no_diagnostics(
+        r#"sub m { # emacs confused here }; sub mimimimimi { # emacs in sync here
+    my $self = shift;
+}"#,
+    );
+}
+
+#[test]
 fn test_sub_named_for() {
     assert_no_diagnostics(r#"sub for { 1 }"#);
 }


### PR DESCRIPTION
Problem: CPAN::Shell defines `sub m { ... }`, but the lexer treated quote-like words after `sub` as regex/substitution operators and left an `expected_left_brace` parser ERROR.
Fix: Keep quote-like words bare while the lexer is in the `after_sub` window, with lexer and parser regressions for `m`, `s`, `tr`, and `q` sub names.
Verification: `cargo test -p perl-lexer --test focused_regression_contracts --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_expected_left_brace --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_expected_left_brace_2399 --profile agent --locked -- --nocapture`; `cargo test -p perl-lexer --test tokenizer_edge_case_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-lexer --test regex_arbitrary_delimiters_issue_444 --profile agent --locked -- --nocapture`; `cargo test -p perl-lexer --test quote_like_recovery_tests --profile agent --locked -- --nocapture`; `cargo check -p perl-lexer --all-targets --profile agent --locked`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-lexer --profile agent --locked -- -D warnings -A missing_docs`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `git diff --check`.

Focused CPAN sweep on local Strawberry Perl: `CPAN::Shell.pm` no longer appears as an `expected_left_brace` ERROR source. Full local Strawberry sweep: clean files 7533 -> 7537, dirty files 188 -> 184, ERROR-node files 139 -> 135, total ERROR nodes 653 -> 649, and `expected_left_brace` first-error bucket 16 -> 12. This is current Windows source-backed evidence only; it does not claim movement in the stale Linux raw-bucket receipt.

Local caveat: `just agent-pr-fast` is blocked on this Windows host by `just could not find the shell: program not found`; direct cargo/xtask gates above passed.