### PR TITLE
fix(parser): parse symbolic call tails (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -556,8 +556,15 @@ impl<'a> Parser<'a> {
         // First, try to parse the initial part as a simple statement
         let mut expr = self.parse_simple_statement()?;
 
-        // Check for word operators (or, and, xor) which have very low precedence
-        expr = self.parse_word_or_expr(expr)?;
+        // Some statement-start calls parse their argument list before returning
+        // here, but symbolic logical operators still belong to the surrounding
+        // expression: `print(...) || die`, `system(...) && die`.
+        if self.peek_kind() == Some(TokenKind::And) || Self::is_logical_or(self.peek_kind()) {
+            expr = self.parse_named_unary_statement_tail(expr)?;
+        } else {
+            // Check for word operators (or, and, xor) which have very low precedence.
+            expr = self.parse_word_or_expr(expr)?;
+        }
 
         // Statement modifiers are handled at the statement level in parse_statement()
 

--- a/crates/perl-parser-core/tests/word_operator_tests.rs
+++ b/crates/perl-parser-core/tests/word_operator_tests.rs
@@ -91,6 +91,18 @@ fn test_system_and_die() {
 }
 
 #[test]
+fn test_print_parens_symbolic_or_die() {
+    // From Test::Script: parenthesized print call followed by symbolic OR.
+    assert_clean_parse(r#"print($fh 'unshift @INC, ') || die "unable to write $filename: $!";"#);
+}
+
+#[test]
+fn test_system_parens_symbolic_and_die() {
+    // From Win32::GuiTest::Cmd: parenthesized system call followed by symbolic AND.
+    assert_clean_parse(r#"system("regsvr32 $server") && die "regsvr32 failed";"#);
+}
+
+#[test]
 fn test_eval_or_die() {
     assert_clean_parse(r#"eval { require Foo } or die "Cannot load Foo";"#);
 }


### PR DESCRIPTION
Problem: Parenthesized statement-start calls such as `print(...) || die` and `system(...) && die` parsed the call but left the symbolic logical tail as a separate `unexpected_token_in_expr` recovery node. Fix: Continue the statement expression through the symbolic logical tail when `&&`, `||`, or defined-or follows the parsed simple statement, with source-backed Test::Script and Win32::GuiTest regressions. Verification: `cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked symbolic -- --nocapture`; `cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test block_list_in_args_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_expected_left_brace --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test named_unary_precedence_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test statement_start_nullary_builtin_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_defined_ref_word_operators_2622 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_word_op_after_return_control_2396 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_word_op_and_after_open_2409 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_unexpected_token_in_expr_2731 --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask fmt --check`; `git diff --check`. Local Windows Strawberry discovery: clean files 7541 -> 7545, dirty files 180 -> 176, total ERROR nodes 599 -> 595, and `unexpected_token_in_expr` first-error bucket 16 -> 12; Test::Script.pm and Win32::GuiTest::Cmd.pm dropped from that bucket. Claim boundary: focused Windows source-backed parser evidence only; this does not claim Linux raw-bucket movement, and EffortlessMetrics/perl-lsp-swarm#2693 still owns the fresh Linux corpus receipt.