### PR TITLE
fix(parser): parse builtin call comparison tails (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -1003,10 +1003,11 @@ impl<'a> Parser<'a> {
                             }
 
                             let end = self.previous_position();
-                            Ok(Node::new(
+                            let call = Node::new(
                                 NodeKind::FunctionCall { name: func_name.to_string(), args },
                                 SourceLocation { start, end },
-                            ))
+                            );
+                            self.parse_named_unary_statement_tail(call)
                         }
                     }
                 }

--- a/crates/perl-parser-core/tests/fix_unexpected_token_in_expr_2731.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_token_in_expr_2731.rs
@@ -65,6 +65,18 @@ fn test_umask_before_or_in_bitwise_not() {
     assert_clean_parse(r#"my $perm = $fromstat[2] & ~(umask || 0);"#);
 }
 
+#[test]
+fn test_statement_start_builtin_paren_call_comparison_or_do() {
+    // From IPC::Cmd: statement-start builtin with explicit parens followed by
+    // an equality comparison and a low-precedence `or do` fallback.
+    assert_clean_parse(
+        r#"system( ref $cmd ? @$cmd : $cmd ) == 0 or do {
+    $self->error( $self->_pp_child_error( $cmd, $? ) );
+    $self->ok( 0 );
+};"#,
+    );
+}
+
 // === Sub-Pattern B: Special variable $: and friends ===
 // Perl punctuation variables $:, $;, $, that the parser did not handle.
 


### PR DESCRIPTION
Problem: statement-start generic builtin calls such as `system(...) == 0 or do { ... }` parsed the call but left comparison tails behind, producing recovery errors in source-backed IPC::Cmd-style code.
Fix: Resume the existing low-precedence statement tail parser after building generic statement-start builtin calls, and lock the IPC::Cmd shape with a regression test.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_token_in_expr_2731 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_word_op_and_after_open_2409 --profile agent --locked -- --nocapture`; `cargo run -p perl-parser --features cli --bin perl-parse --profile agent --locked -- -q -s C:\Strawberry\perl\lib\IPC\Cmd.pm`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; parser/provider gates pass. Corrected Windows Strawberry sweep delta vs current origin/master: clean 7545->7551, dirty 176->170, ERROR-node files 127->119, ERROR nodes 595->579, `unexpected_eq_expr` 12->4. Full `cargo test -p perl-parser-core --profile agent --locked` still hits pre-existing `parser_ac3_prevent_recursive_recovery` on clean origin/master.