### PR TITLE
fix(parser): parse caller prefix level (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -83,6 +83,30 @@ impl<'a> Parser<'a> {
                 }
             }
 
+            if let NodeKind::Identifier { name } = &expr.kind {
+                // `caller ++$i` passes a pre-incremented stack level to caller;
+                // do not read it as post-incrementing the `caller` bareword.
+                let next_is_prefix_inc_arg = matches!(
+                    self.peek_kind(),
+                    Some(TokenKind::Increment | TokenKind::Decrement)
+                ) && self.tokens.peek_second().ok().is_some_and(|token| {
+                    token.text.starts_with('$')
+                        || token.text.starts_with('@')
+                        || token.text.starts_with('%')
+                });
+                if name == "caller" && next_is_prefix_inc_arg {
+                    let start = expr.location.start;
+                    let func_name = name.clone();
+                    let arg = self.parse_unary()?;
+                    let end = arg.location.end;
+                    expr = Node::new(
+                        NodeKind::FunctionCall { name: func_name, args: vec![arg] },
+                        SourceLocation { start, end },
+                    );
+                    continue;
+                }
+            }
+
             match self.peek_kind() {
                 Some(k) if Self::is_postfix_op(Some(k)) => {
                     let op_token = self.consume_token()?;

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -913,6 +913,18 @@ fn caller_in_condition() {
     assert_clean_parse(r#"if (caller ne 'main') { run_tests() }"#);
 }
 
+#[test]
+fn net_telnet_caller_prefix_increment_level() {
+    // From Net::Telnet: caller may take a prefix-increment stack-level
+    // expression while assigning the returned package/file/line tuple.
+    assert_clean_parse(
+        r#"while (($pkg, $file, $line) = caller ++$i) {
+    next if $isa{$pkg};
+    return ($pkg, $file, $line);
+}"#,
+    );
+}
+
 // === ref + string comparison operators (is_str_op_terminated) ===
 
 #[test]


### PR DESCRIPTION
﻿Problem: Net::Telnet uses caller ++ while assigning caller package/file/line tuple data; the parser treated ++ as a postfix increment on the caller bareword and left the stack-level expression outside the call.
Fix: Add a focused Net::Telnet regression and parse only caller followed by prefix increment/decrement of a sigil variable as a caller stack-level argument before generic postfix ++/-- handling.
Verification: cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test named_unary_precedence_tests --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test statement_start_nullary_builtin_tests --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test fix_unexpected_token_in_expr_2731 --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked -- --nocapture; cargo check -p perl-parser-core --all-targets --profile agent --locked; cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs; cargo xtask metrics parser-accuracy --check; cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt; cargo xtask update-status --only parser --check; cargo xtask metrics ratchet-check parser_accuracy; cargo xtask fmt --check; git diff --check.

Claim boundary: This is a focused source-backed parser repair from the stale raw bucket lane. The Windows Strawberry discovery sweep improved from 7551 clean / 170 dirty / 119 files with ERROR nodes / 579 total ERROR nodes with unclosed_paren_identifier present, to 7553 clean / 168 dirty / 117 files with ERROR nodes / 575 total ERROR nodes with unclosed_paren_identifier absent from first unrecovered ERROR-node buckets. This is local Windows discovery evidence only; it does not claim Linux corpus bucket movement or full CPAN cleanliness. Linux bucket-count claims still require EffortlessMetrics/perl-lsp-swarm#2693.
