### PR TITLE
fix(parser): parse grep prefix increments in slices (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -84,7 +84,10 @@ impl<'a> Parser<'a> {
             }
 
             match self.peek_kind() {
-                Some(k) if Self::is_postfix_op(Some(k)) => {
+                Some(k)
+                    if Self::is_postfix_op(Some(k))
+                        && !self.should_parse_incdec_as_block_list_arg(&expr) =>
+                {
                     let op_token = self.consume_token()?;
                     let start = expr.location.start;
                     let end = op_token.end;
@@ -1194,6 +1197,20 @@ impl<'a> Parser<'a> {
         }
 
         Ok(expr)
+    }
+
+    fn should_parse_incdec_as_block_list_arg(&mut self, expr: &Node) -> bool {
+        let NodeKind::Identifier { name } = &expr.kind else {
+            return false;
+        };
+        let bare_name = Self::core_qualified_builtin_name(name).unwrap_or(name.as_str());
+        if !Self::is_block_list_func(bare_name) {
+            return false;
+        }
+        self.tokens.peek().ok().is_some_and(|token| {
+            matches!(token.kind, TokenKind::Increment | TokenKind::Decrement)
+                && token.start > expr.location.end
+        })
     }
 
     /// Check if we're at a statement boundary

--- a/crates/perl-parser-core/tests/unclosed_brace_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_brace_tests.rs
@@ -81,6 +81,17 @@ unless( eval {require warnings::register; warnings::register->import; 1} ) {
 }
 
 #[test]
+fn fields_phash_grep_prefix_increment_hash_slice() {
+    // From fields.pm: a dereferenced hash slice may use grep EXPR, LIST where
+    // the grep expression starts with a prefix increment.
+    let source = r#"
+my $i = 0;
+@$h{grep ++$i % 2, @_} = 1 .. @_ / 2;
+"#;
+    assert_clean_parse(source);
+}
+
+#[test]
 fn test_more_unless_diag_heredoc() {
     // From Test::More: heredoc terminators inside an unless block must close the
     // diagnostic call without leaving the block body waiting for another `}`.


### PR DESCRIPTION
Problem: `fields.pm` still left an `unclosed_brace` ERROR for a dereferenced hash-slice assignment whose `grep EXPR, LIST` selector starts with prefix increment.
Fix: Keep whitespace-separated `++`/`--` after block-list builtins as the first argument prefix instead of treating it as postfix increment on the builtin name.
Verification: `cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_unexpected_comma_expr --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --profile agent --locked builtin_block_list_tests -- --nocapture`; `cargo test -p perl-parser-core --test map_grep_sort_no_semicolon_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test word_operator_tests --profile agent --locked -- --nocapture`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; parser/status gates pass. `just agent-pr-fast` is blocked locally by the known Windows shell lookup issue; direct `cargo-safe xtask gates --tier pr-fast --receipt` exceeded the 5m local timeout.