### PR TITLE
fix(parser): parse braced scalar ternaries (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -330,6 +330,11 @@ impl<'a> Parser<'a> {
 
             // Parse postfix chain (handles function call parens, method calls, etc.)
             inner = self.parse_postfix_chain(inner)?;
+            if self.peek_kind() == Some(TokenKind::Question) {
+                // `${ref($x) ? $x : fallback($x)}` may enter this partial-deref
+                // path when the lexer greedily captures `${ref` as one token.
+                inner = self.parse_ternary_with(inner)?;
+            }
 
             self.consume_deref_body_terminators()?;
             self.expect(TokenKind::RightBrace)?;

--- a/crates/perl-parser-core/tests/unclosed_brace_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_brace_tests.rs
@@ -92,6 +92,14 @@ my $i = 0;
 }
 
 #[test]
+fn alien_build_basic_braced_scalar_ternary() {
+    // From Alien::Build::Version::Basic: a braced scalar dereference may choose
+    // the referenced scalar through a ternary expression.
+    let source = r#"my @y = split /\./, ${ref($_[1]) ? $_[1] : version($_[1])};"#;
+    assert_clean_parse(source);
+}
+
+#[test]
 fn test_more_unless_diag_heredoc() {
     // From Test::More: heredoc terminators inside an unless block must close the
     // diagnostic call without leaving the block body waiting for another `}`.


### PR DESCRIPTION
Problem: Alien::Build::Version::Basic still left an unclosed_brace ERROR for a braced scalar dereference whose body is a ternary function-call expression. Fix: Let the partial braced-scalar dereference path continue into an in-brace ternary before requiring the closing brace, and lock the source-backed shape in unclosed_brace_tests. Verification: cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test complex_paren_args_tests --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test fix_ternary_stmt_start --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test fix_proto_dollar_dollar --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test glob_deref_arrow_tests --profile agent --locked -- --nocapture; cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture; cargo check -p perl-parser-core --all-targets --profile agent --locked; cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs; cargo xtask metrics parser-accuracy --check; cargo xtask update-status --only parser --check; cargo xtask metrics ratchet-check parser_accuracy; cargo xtask fmt --check; cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt; git diff --check. Local Windows Strawberry discovery: post-#8952 sweep was 7554 clean / 167 dirty / 116 files with ERROR nodes / 573 total ERROR nodes. This branch sweep was 7556 clean / 165 dirty / 114 files with ERROR nodes / 565 total ERROR nodes. Claim boundary: this is source-backed Windows corpus progress for one parser shape. It does not claim Linux corpus bucket movement or full CPAN cleanliness; EffortlessMetrics/perl-lsp-swarm#2693 remains the required Linux receipt path.