### PR TITLE
fix(parser): parse indirect constructor word-op tails (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -786,6 +786,10 @@ impl<'a> Parser<'a> {
                                             | TokenKind::RightBrace
                                             | TokenKind::Comma
                                             | TokenKind::FatArrow
+                                            | TokenKind::WordOr
+                                            | TokenKind::WordAnd
+                                            | TokenKind::WordXor
+                                            | TokenKind::WordNot
                                     )
                                 )
                             {

--- a/crates/perl-parser-core/tests/fix_new_as_function_call.rs
+++ b/crates/perl-parser-core/tests/fix_new_as_function_call.rs
@@ -51,6 +51,13 @@ fn test_new_qualified_class_still_works() {
     assert_clean_parse(r#"my $fh = new IO::Handle();"#);
 }
 
+#[test]
+fn test_new_indirect_class_or_tail() {
+    assert_clean_parse(
+        r#"my $handle = new IO::File ">$got->{ErrFile}" or croak "Cannot open file: $!";"#,
+    );
+}
+
 /// new() result used in method chain: new($x)->method() must chain correctly.
 /// The FunctionCall node must surface to parse_postfix for chaining.
 #[test]


### PR DESCRIPTION
Problem: Strawberry BerkeleyDB.pm left unexpected_word_op_or ERROR nodes for indirect `new IO::File ...` declaration initializers followed by `or`.
Fix: Stop the special `new` constructor argument loop at low-precedence word operators and add a focused regression.
Verification: `cargo test -p perl-parser-core --test fix_new_as_function_call --profile agent --locked test_new_indirect_class_or_tail -- --nocapture`; `cargo test -p perl-parser-core --test fix_new_as_function_call --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_word_op_after_return_control_2396 --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test cpan_misc_idioms --profile agent --locked -- --nocapture`; `cargo xtask parser-corpus-sweep --roots C:\Strawberry\perl\vendor\lib\BerkeleyDB.pm`; `cargo xtask parser-corpus-sweep --roots C:\Strawberry\perl\lib,C:\Strawberry\perl\vendor\lib`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `git diff --check` pass. `just agent-pr-fast` is blocked locally because just cannot find the configured shell on this Windows host.