### PR TITLE
fix(parser): parse nested lexical list bindings (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -520,20 +520,7 @@ impl<'a> Parser<'a> {
             let mut variables = Vec::new();
 
             while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
-                // `undef` is valid as a throw-away placeholder in list
-                // destructuring: my ($a, undef, $b) = func();
-                // This also covers the nested form:
-                //   (my ($a, $b, undef), $c) = func();
-                let var = if self.peek_kind() == Some(TokenKind::Undef) {
-                    let undef_token = self.consume_token()?;
-                    Node::new(
-                        NodeKind::Undef,
-                        SourceLocation { start: undef_token.start, end: undef_token.end },
-                    )
-                } else {
-                    self.parse_variable()?
-                };
-                variables.push(var);
+                variables.push(self.parse_declaration_list_entry(false)?);
 
                 if self.peek_kind() == Some(TokenKind::Comma) {
                     self.consume_token()?; // consume comma

--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -13,42 +13,7 @@ impl<'a> Parser<'a> {
 
             // Parse comma-separated list of variables with their individual attributes
             while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
-                // `undef` is valid as a placeholder in list destructuring:
-                //   my ($self, undef, $src) = @_;
-                let var = if self.peek_kind() == Some(TokenKind::Undef) {
-                    let undef_token = self.consume_token()?;
-                    Node::new(
-                        NodeKind::Undef,
-                        SourceLocation { start: undef_token.start, end: undef_token.end },
-                    )
-                } else {
-                    self.parse_variable()?
-                };
-
-                // Parse optional attributes for this specific variable
-                let mut var_attributes = Vec::new();
-                while self.peek_kind() == Some(TokenKind::Colon) {
-                    self.tokens.next()?; // consume colon
-                    let attr_token = self.expect(TokenKind::Identifier)?;
-                    var_attributes.push(attr_token.text.to_string());
-                }
-
-                // Create a node that includes both the variable and its attributes
-                let var_with_attrs = if var_attributes.is_empty() {
-                    var
-                } else {
-                    let start = var.location.start;
-                    let end = self.previous_position();
-                    Node::new(
-                        NodeKind::VariableWithAttributes {
-                            variable: Box::new(var),
-                            attributes: var_attributes,
-                        },
-                        SourceLocation { start, end },
-                    )
-                };
-
-                variables.push(var_with_attrs);
+                variables.push(self.parse_declaration_list_entry(true)?);
 
                 if self.peek_kind() == Some(TokenKind::Comma) {
                     self.consume_token()?; // consume comma
@@ -205,6 +170,68 @@ impl<'a> Parser<'a> {
         }
 
         Ok(())
+    }
+
+    fn parse_declaration_list_entry(&mut self, allow_attributes: bool) -> ParseResult<Node> {
+        let var = match self.peek_kind() {
+            Some(TokenKind::Undef) => {
+                let undef_token = self.consume_token()?;
+                Node::new(
+                    NodeKind::Undef,
+                    SourceLocation { start: undef_token.start, end: undef_token.end },
+                )
+            }
+            Some(TokenKind::LeftParen) => self.parse_declaration_list_group(allow_attributes)?,
+            _ => self.parse_variable()?,
+        };
+
+        if !allow_attributes {
+            return Ok(var);
+        }
+
+        let mut var_attributes = Vec::new();
+        while self.peek_kind() == Some(TokenKind::Colon) {
+            self.tokens.next()?; // consume colon
+            let attr_token = self.expect(TokenKind::Identifier)?;
+            var_attributes.push(attr_token.text.to_string());
+        }
+
+        if var_attributes.is_empty() {
+            Ok(var)
+        } else {
+            let start = var.location.start;
+            let end = self.previous_position();
+            Ok(Node::new(
+                NodeKind::VariableWithAttributes {
+                    variable: Box::new(var),
+                    attributes: var_attributes,
+                },
+                SourceLocation { start, end },
+            ))
+        }
+    }
+
+    fn parse_declaration_list_group(&mut self, allow_attributes: bool) -> ParseResult<Node> {
+        let open = self.consume_token()?; // consume (
+        let start = open.start;
+        let mut elements = Vec::new();
+
+        while self.peek_kind() != Some(TokenKind::RightParen) && !self.tokens.is_eof() {
+            elements.push(self.parse_declaration_list_entry(allow_attributes)?);
+
+            if self.peek_kind() == Some(TokenKind::Comma) {
+                self.consume_token()?; // consume comma
+            } else if self.peek_kind() != Some(TokenKind::RightParen) {
+                return Err(ParseError::syntax(
+                    "Expected comma or closing parenthesis in variable list",
+                    self.current_position(),
+                ));
+            }
+        }
+
+        self.expect_closing_delimiter(TokenKind::RightParen)?;
+        let end = self.previous_position();
+        Ok(Node::new(NodeKind::ArrayLiteral { elements }, SourceLocation { start, end }))
     }
 
     /// Parse local statement (can localize any lvalue, not just simple variables)

--- a/crates/perl-parser-core/src/hir/lower.rs
+++ b/crates/perl-parser-core/src/hir/lower.rs
@@ -563,7 +563,10 @@ impl Lowerer {
                 attributes,
                 initializer,
             } => {
-                let bindings = variables.iter().filter_map(variable_binding).collect::<Vec<_>>();
+                let bindings = variables
+                    .iter()
+                    .flat_map(|variable| variable_decl_bindings(variable).0)
+                    .collect::<Vec<_>>();
                 let item_id = self.push_item(
                     node,
                     None,
@@ -1604,9 +1607,17 @@ impl Lowerer {
         confidence: RecoveryConfidence,
     ) {
         for variable in variables {
-            if !is_declaration_binding_node(variable) {
-                self.visit(variable, confidence);
+            self.visit_declaration_list_entry(variable, confidence);
+        }
+    }
+
+    fn visit_declaration_list_entry(&mut self, variable: &Node, confidence: RecoveryConfidence) {
+        if let NodeKind::ArrayLiteral { elements } = &variable.kind {
+            for element in elements {
+                self.visit_declaration_list_entry(element, confidence);
             }
+        } else if !is_declaration_binding_node(variable) {
+            self.visit(variable, confidence);
         }
     }
 }
@@ -2008,6 +2019,18 @@ fn variable_decl_bindings(node: &Node) -> (Vec<VariableBinding>, bool) {
     match &node.kind {
         NodeKind::Assignment { lhs, .. } => (variable_binding(lhs).into_iter().collect(), true),
         NodeKind::VariableWithAttributes { variable, .. } => variable_decl_bindings(variable),
+        NodeKind::ArrayLiteral { elements } => {
+            let mut bindings = Vec::new();
+            let mut has_embedded_initializer = false;
+            for element in elements {
+                let (mut element_bindings, element_has_initializer) =
+                    variable_decl_bindings(element);
+                bindings.append(&mut element_bindings);
+                has_embedded_initializer |= element_has_initializer;
+            }
+            (bindings, has_embedded_initializer)
+        }
+        NodeKind::Undef => (Vec::new(), false),
         _ => (variable_binding(node).into_iter().collect(), false),
     }
 }
@@ -2040,6 +2063,7 @@ fn is_declaration_binding_node(node: &Node) -> bool {
     match &node.kind {
         NodeKind::Variable { .. } | NodeKind::Typeglob { .. } => true,
         NodeKind::VariableWithAttributes { variable, .. } => is_declaration_binding_node(variable),
+        NodeKind::ArrayLiteral { elements } => elements.iter().all(is_declaration_binding_node),
         _ => false,
     }
 }

--- a/crates/perl-parser-core/tests/fix_nested_lexical_list_tests.rs
+++ b/crates/perl-parser-core/tests/fix_nested_lexical_list_tests.rs
@@ -1,0 +1,46 @@
+mod cpan_test_helpers;
+
+use cpan_test_helpers::*;
+use perl_parser_core::hir::{HirKind, lower_ast};
+
+#[test]
+fn perltidy_nested_optional_arg_list_clean_parse() {
+    let source = r#"
+sub write_blank_code_line {
+    my ( $self, ($forced) ) = @_;
+}
+"#;
+
+    assert_clean_parse(source);
+}
+
+#[test]
+fn nested_list_entries_lower_as_decl_bindings() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = parse(
+        r#"
+sub write_blank_code_line {
+    my ( $self, ($forced) ) = @_;
+}
+"#,
+    );
+    let hir = lower_ast(&ast);
+
+    let Some(variables) = hir.items.iter().find_map(|item| match &item.kind {
+        HirKind::VariableDecl(decl) if decl.is_list => Some(&decl.variables),
+        _ => None,
+    }) else {
+        return Err("expected list variable declaration in HIR".into());
+    };
+
+    let names = variables
+        .iter()
+        .map(|binding| format!("{}{}", binding.sigil, binding.name))
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["$self", "$forced"]);
+
+    let nested_refs =
+        hir.scope_graph.references.iter().filter(|reference| reference.name == "forced").count();
+    assert_eq!(nested_refs, 0, "nested declaration binding should not be recorded as a reference");
+
+    Ok(())
+}


### PR DESCRIPTION
Problem: Strawberry Perl::Tidy files left expected_variable ERROR nodes for nested lexical list bindings such as `my ( $self, ($forced) ) = @_`.
Fix: Parse nested declaration-list groups, reuse that path for declaration arguments, and flatten nested groups into HIR declaration bindings without recording them as references.
Verification: `cargo test -p perl-parser-core --test fix_nested_lexical_list_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test fix_my_list_undef_placeholder --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test hir_tests --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core --test cpan_variable_declarations --profile agent --locked -- --nocapture`; `cargo test -p perl-parser-core declaration_in_args --profile agent --locked -- --nocapture`; `cargo xtask parser-corpus-sweep --roots C:\Strawberry\perl\vendor\lib\Perl\Tidy\FileWriter.pm`; `cargo xtask parser-corpus-sweep --roots C:\Strawberry\perl\lib,C:\Strawberry\perl\vendor\lib`; `cargo check -p perl-parser-core --all-targets --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics ratchet-check parser_accuracy`; `cargo xtask check-provider-confidence-matrix`; `git diff --check` pass. `just agent-pr-fast` is blocked locally because just cannot find the configured shell on this Windows host.