### PR TITLE
fix(oracle): make perldoc hover subprocess hermetic (#8551)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -31,7 +31,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use std::collections::BTreeMap;
 #[cfg(not(target_arch = "wasm32"))]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(not(target_arch = "wasm32"))]
 use std::process::Command;
 #[cfg(not(target_arch = "wasm32"))]
@@ -40,6 +40,52 @@ use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use super::SYSTEM_INC_PROBE_TIMEOUT;
 use super::WorkspaceConfig;
+
+#[cfg(all(not(target_arch = "wasm32"), windows))]
+const PERLDOC_EXECUTABLE_CANDIDATES: &[&str] =
+    &["perldoc.bat", "perldoc.cmd", "perldoc.exe", "perldoc"];
+
+#[cfg(all(not(target_arch = "wasm32"), not(windows)))]
+const PERLDOC_EXECUTABLE_CANDIDATES: &[&str] = &["perldoc"];
+
+#[cfg(not(target_arch = "wasm32"))]
+fn perldoc_binary_near_perl(perl_binary: &Path) -> Option<PathBuf> {
+    let dir = perl_binary.parent()?;
+    if dir.as_os_str().is_empty() {
+        return None;
+    }
+
+    for candidate_name in PERLDOC_EXECUTABLE_CANDIDATES {
+        let candidate = dir.join(candidate_name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn default_perldoc_binary() -> PathBuf {
+    PathBuf::from("perldoc")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn resolve_perldoc_binary(config: &WorkspaceConfig) -> PathBuf {
+    if let Some(configured_perl) = config.perl_path.as_deref().filter(|path| !path.is_empty())
+        && let Some(perldoc) = perldoc_binary_near_perl(Path::new(configured_perl))
+    {
+        return perldoc;
+    }
+
+    if let Ok(perl_binary) = crate::platform::resolve_perl_path_with_toolchain()
+        && let Some(perldoc) = perldoc_binary_near_perl(&perl_binary)
+    {
+        return perldoc;
+    }
+
+    default_perldoc_binary()
+}
 
 /// Controlled subprocess environment for a single Perl oracle seam.
 ///
@@ -311,6 +357,35 @@ impl PerlOracleEnv {
         })
     }
 
+    /// Constructor for `perldoc` hover documentation lookups.
+    ///
+    /// `perldoc` is not the editor's semantic source of truth; it is a bridge for
+    /// user-requested documentation. It still runs inside the editor session, so
+    /// ambient Perl state must be explicit:
+    ///
+    /// - `allow_perl5lib`: mirrors `config.use_perl5lib` so project-local docs
+    ///   are visible only when the user opted into `PERL5LIB`.
+    /// - `allow_perl5opt`: always `false` because `PERL5OPT` injects runtime
+    ///   flags into every Perl-family subprocess.
+    /// - `allow_local_lib`: always `false`; the perldoc binary is resolved from
+    ///   the configured Perl toolchain when possible.
+    /// - `LC_ALL`: forced to `C` for deterministic plain-text output.
+    /// - `timeout`: 10 seconds, matching the existing hover budget.
+    pub fn for_perldoc(config: &WorkspaceConfig, cwd: PathBuf) -> Self {
+        let mut extra_env = BTreeMap::new();
+        extra_env.insert("LC_ALL".to_string(), "C".to_string());
+
+        Self {
+            perl_binary: resolve_perldoc_binary(config),
+            cwd,
+            timeout: Duration::from_secs(10),
+            allow_perl5lib: config.use_perl5lib,
+            allow_perl5opt: false,
+            allow_local_lib: false,
+            extra_env,
+        }
+    }
+
     /// Constructor for the Perl::LanguageServer DAP bridge process.
     ///
     /// The DAP bridge launches a long-running Perl::LanguageServer process on
@@ -464,6 +539,11 @@ impl PerlOracleEnv {
     }
 
     /// Returns a no-op stub on WASM (no subprocess support).
+    pub fn for_perldoc(_config: &WorkspaceConfig, _cwd: std::path::PathBuf) -> Self {
+        PerlOracleEnv
+    }
+
+    /// Returns a no-op stub on WASM (no subprocess support).
     pub fn for_version_probe(_perl_binary: std::path::PathBuf, _cwd: std::path::PathBuf) -> Self {
         PerlOracleEnv
     }
@@ -557,6 +637,163 @@ mod tests {
             assert!(e.allow_perl5opt, "allow_perl5opt must always be true for execute-command");
             assert!(e.allow_local_lib, "allow_local_lib must always be true for execute-command");
         }
+    }
+
+    // ── for_perldoc tests ─────────────────────────────────────────────────────
+
+    /// `for_perldoc` mirrors `config.use_perl5lib` while denying `PERL5OPT`
+    /// and `local::lib`, and pins locale for stable plain-text docs.
+    #[test]
+    fn for_perldoc_respects_config_flags() {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        let mut config = WorkspaceConfig::default();
+        config.use_perl5lib = true;
+        let env = PerlOracleEnv::for_perldoc(&config, cwd.clone());
+        assert!(env.allow_perl5lib, "perldoc should honor explicit use_perl5lib=true");
+        assert!(!env.allow_perl5opt, "perldoc must strip PERL5OPT");
+        assert!(!env.allow_local_lib, "perldoc must strip local::lib activation vars");
+        assert_eq!(env.extra_env.get("LC_ALL").map(String::as_str), Some("C"));
+
+        config.use_perl5lib = false;
+        let env = PerlOracleEnv::for_perldoc(&config, cwd);
+        assert!(!env.allow_perl5lib, "perldoc should honor explicit use_perl5lib=false");
+        assert!(!env.allow_perl5opt, "perldoc must strip PERL5OPT");
+        assert!(!env.allow_local_lib, "perldoc must strip local::lib activation vars");
+        assert_eq!(env.extra_env.get("LC_ALL").map(String::as_str), Some("C"));
+    }
+
+    #[test]
+    fn for_perldoc_prefers_configured_perl_sibling() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let perl_name = if cfg!(windows) { "perl.exe" } else { "perl" };
+        let perldoc_name =
+            PERLDOC_EXECUTABLE_CANDIDATES.first().ok_or("missing perldoc executable candidate")?;
+        let perl_path = temp.path().join(perl_name);
+        let perldoc_path = temp.path().join(perldoc_name);
+        std::fs::write(&perl_path, "")?;
+        std::fs::write(&perldoc_path, "")?;
+
+        let config = WorkspaceConfig {
+            perl_path: Some(perl_path.to_string_lossy().into_owned()),
+            ..WorkspaceConfig::default()
+        };
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let env = PerlOracleEnv::for_perldoc(&config, cwd);
+
+        assert_eq!(
+            env.perl_binary, perldoc_path,
+            "perldoc should resolve from the configured Perl toolchain directory"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn for_perldoc_does_not_use_missing_configured_sibling() -> TestResult {
+        let temp = tempfile::tempdir()?;
+        let perl_name = if cfg!(windows) { "perl.exe" } else { "perl" };
+        let perl_path = temp.path().join(perl_name);
+        let missing_perldoc_path = temp.path().join(
+            PERLDOC_EXECUTABLE_CANDIDATES.first().ok_or("missing perldoc executable candidate")?,
+        );
+        std::fs::write(&perl_path, "")?;
+
+        let config = WorkspaceConfig {
+            perl_path: Some(perl_path.to_string_lossy().into_owned()),
+            ..WorkspaceConfig::default()
+        };
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let env = PerlOracleEnv::for_perldoc(&config, cwd);
+
+        assert_ne!(
+            env.perl_binary, missing_perldoc_path,
+            "missing configured-toolchain perldoc must not be used as an explicit binary"
+        );
+        Ok(())
+    }
+
+    /// The perldoc oracle strips poisoned ambient env by default, while still
+    /// allowing `PERL5LIB` only when the user explicitly enabled it.
+    #[test]
+    fn for_perldoc_strips_poisoned_env_and_gates_perl5lib() -> TestResult {
+        let _env_guard = env_lock()?;
+        let perl = match perl_path() {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+        let poison_dir = tempfile::tempdir()?;
+        let poison_path = poison_dir.path().to_string_lossy().into_owned();
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+        unsafe { std::env::set_var("PERL5LIB", &poison_path) };
+        unsafe { std::env::set_var("PERL5OPT", "-Mstrict") };
+        unsafe { std::env::set_var("PERL_LOCAL_LIB_ROOT", &poison_path) };
+        unsafe { std::env::set_var("PERL_LOCAL_LIB_PREFIX", &poison_path) };
+
+        let result = (|| -> TestResult<(String, String)> {
+            let denied_config = WorkspaceConfig {
+                perl_path: Some(perl.to_string_lossy().into_owned()),
+                use_perl5lib: false,
+                ..WorkspaceConfig::default()
+            };
+            let denied = PerlOracleEnv::for_perldoc(&denied_config, cwd.clone());
+            let mut cmd = std::process::Command::new(&perl);
+            denied.configure_command(&mut cmd);
+            cmd.args([
+                "-e",
+                "print join('|', $ENV{PERL5LIB}//'UNSET', $ENV{PERL5OPT}//'UNSET', \
+                 $ENV{PERL_LOCAL_LIB_ROOT}//'UNSET', $ENV{PERL_LOCAL_LIB_PREFIX}//'UNSET', \
+                 $ENV{LC_ALL}//'UNSET')",
+            ]);
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+            let denied_out = cmd.output()?;
+
+            let allowed_config = WorkspaceConfig {
+                perl_path: Some(perl.to_string_lossy().into_owned()),
+                use_perl5lib: true,
+                ..WorkspaceConfig::default()
+            };
+            let allowed = PerlOracleEnv::for_perldoc(&allowed_config, cwd);
+            let mut cmd = std::process::Command::new(&perl);
+            allowed.configure_command(&mut cmd);
+            cmd.args([
+                "-e",
+                "print join('|', $ENV{PERL5LIB}//'UNSET', $ENV{PERL5OPT}//'UNSET', \
+                 $ENV{PERL_LOCAL_LIB_ROOT}//'UNSET', $ENV{PERL_LOCAL_LIB_PREFIX}//'UNSET', \
+                 $ENV{LC_ALL}//'UNSET')",
+            ]);
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+            let allowed_out = cmd.output()?;
+
+            Ok((
+                String::from_utf8_lossy(&denied_out.stdout).into_owned(),
+                String::from_utf8_lossy(&allowed_out.stdout).into_owned(),
+            ))
+        })();
+
+        unsafe { std::env::remove_var("PERL5LIB") };
+        unsafe { std::env::remove_var("PERL5OPT") };
+        unsafe { std::env::remove_var("PERL_LOCAL_LIB_ROOT") };
+        unsafe { std::env::remove_var("PERL_LOCAL_LIB_PREFIX") };
+
+        let (denied_stdout, allowed_stdout) = result?;
+        assert_eq!(
+            denied_stdout.trim(),
+            "UNSET|UNSET|UNSET|UNSET|C",
+            "perldoc must strip poisoned env when PERL5LIB is disabled; got: {denied_stdout:?}",
+        );
+        assert!(
+            allowed_stdout.starts_with(&poison_path),
+            "perldoc should pass PERL5LIB through only when opted in; got: {allowed_stdout:?}",
+        );
+        assert!(
+            allowed_stdout.ends_with("|UNSET|UNSET|UNSET|C"),
+            "perldoc must still strip PERL5OPT/local::lib and set LC_ALL; got: {allowed_stdout:?}",
+        );
+
+        Ok(())
     }
 
     // ── for_language_probe tests ──────────────────────────────────────────────

--- a/crates/perl-lsp-rs/src/runtime/language/virtual_content.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/virtual_content.rs
@@ -4,6 +4,9 @@
 //! like perldoc:// URIs for Perl documentation.
 
 use super::super::*;
+#[cfg(not(target_arch = "wasm32"))]
+use perl_lsp_rs_core::config::PerlOracleEnv;
+use perl_lsp_rs_core::config::WorkspaceConfig;
 
 impl LspServer {
     /// Handle workspace/textDocumentContent request
@@ -23,8 +26,8 @@ impl LspServer {
             data: None,
         })?;
 
-        // Parse URI to determine scheme
-        if let Some(content) = fetch_virtual_content(uri) {
+        let workspace_config = self.workspace_config.lock().clone();
+        if let Some(content) = fetch_virtual_content(uri, &workspace_config) {
             Ok(Some(json!({ "text": content })))
         } else {
             Err(JsonRpcError {
@@ -42,21 +45,26 @@ impl LspServer {
 }
 
 /// Fetch content for a virtual URI
-fn fetch_virtual_content(uri: &str) -> Option<String> {
+fn fetch_virtual_content(uri: &str, config: &WorkspaceConfig) -> Option<String> {
     if let Some(module_name) = uri.strip_prefix("perldoc://") {
-        fetch_perldoc(module_name)
+        fetch_perldoc(module_name, config)
     } else {
         None
     }
 }
 
 /// Fetch Perl documentation using perldoc
-fn fetch_perldoc(module: &str) -> Option<String> {
+#[cfg(not(target_arch = "wasm32"))]
+fn fetch_perldoc(module: &str, config: &WorkspaceConfig) -> Option<String> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let oracle = PerlOracleEnv::for_perldoc(config, cwd);
+    let timeout_secs = oracle.timeout.as_secs();
+
     // Run perldoc -T Module::Name to get plain text documentation
     // Use -- to prevent argument injection if module starts with -
-    let mut cmd = std::process::Command::new("perldoc");
+    let mut cmd = oracle.into_command();
     cmd.arg("-T").arg("--").arg(module);
-    let output = match crate::util::run_command_with_timeout(cmd, 10) {
+    let output = match crate::util::run_command_with_timeout(cmd, timeout_secs) {
         Ok(output) => output,
         Err(e) => {
             tracing::warn!(module, error = %e, "Failed to run perldoc");
@@ -73,6 +81,12 @@ fn fetch_perldoc(module: &str) -> Option<String> {
     }
 }
 
+/// Fetch Perl documentation using perldoc.
+#[cfg(target_arch = "wasm32")]
+fn fetch_perldoc(_module: &str, _config: &WorkspaceConfig) -> Option<String> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,7 +95,8 @@ mod tests {
     fn parser_fetch_perldoc_strict() {
         // Try to fetch documentation for the 'strict' module
         // This test will be skipped if perldoc is not available
-        if let Some(content) = fetch_perldoc("strict") {
+        let config = WorkspaceConfig::default();
+        if let Some(content) = fetch_perldoc("strict", &config) {
             assert!(content.contains("strict") || content.contains("STRICT"));
             assert!(content.len() > 100); // Should have some substantial content
         } else {
@@ -92,14 +107,16 @@ mod tests {
     #[test]
     fn parser_fetch_perldoc_invalid() {
         // Try to fetch documentation for a non-existent module
-        let result = fetch_perldoc("ThisModuleDefinitelyDoesNotExist12345");
+        let config = WorkspaceConfig::default();
+        let result = fetch_perldoc("ThisModuleDefinitelyDoesNotExist12345", &config);
         assert!(result.is_none());
     }
 
     #[test]
     fn parser_virtual_content_perldoc_uri() {
         let uri = "perldoc://strict";
-        let content = fetch_virtual_content(uri);
+        let config = WorkspaceConfig::default();
+        let content = fetch_virtual_content(uri, &config);
         // May be None if perldoc is not available
         if let Some(content) = content {
             assert!(!content.is_empty());
@@ -109,7 +126,8 @@ mod tests {
     #[test]
     fn parser_virtual_content_invalid_scheme() {
         let uri = "invalid://some/path";
-        let content = fetch_virtual_content(uri);
+        let config = WorkspaceConfig::default();
+        let content = fetch_virtual_content(uri, &config);
         assert!(content.is_none());
     }
 
@@ -118,7 +136,8 @@ mod tests {
         // Try to fetch documentation with a flag-like string
         // This should not crash or execute unexpected commands
         // perldoc -T -- -f should look for module named "-f" which likely doesn't exist
-        let result = fetch_perldoc("-f");
+        let config = WorkspaceConfig::default();
+        let result = fetch_perldoc("-f", &config);
         assert!(result.is_none());
     }
 }

--- a/docs/architecture/perl-oracle-subprocess-contract.md
+++ b/docs/architecture/perl-oracle-subprocess-contract.md
@@ -125,16 +125,15 @@ contract for the execute-command seam.
 | Field | Value |
 |---|---|
 | **Call site** | `perl-lsp-rs/src/runtime/language/virtual_content.rs:fetch_perldoc` |
-| **Spawn mechanism** | Bare `std::process::Command::new("perldoc")` — **not yet migrated to `PerlOracleEnv`** |
-| **Current env** | Inherits ALL ambient env from the LSP process (PERL5LIB, PERL5OPT, HOME, PATH, perlbrew shims, etc.) |
-| **Desired contract** | Use an explicit binary path for `perldoc` (resolved from same toolchain as `perl_path`). Strip `PERL5OPT`. Allow `PERL5LIB` user-gated (so documentation from project libraries is available). Bound timeout. |
+| **Spawn mechanism** | `PerlOracleEnv::for_perldoc(config, cwd).into_command()` |
+| **Current env** | Deny-all-ambient base. `PERL5LIB` passes through only when `config.use_perl5lib=true`. `PERL5OPT` and `local::lib` variables are stripped. `PATH` is preserved for binary/helper resolution. `LC_ALL=C` is forced for stable text output. |
+| **Desired contract** | Already meets the post-#8551 bridge contract. `perldoc` resolves from the configured Perl toolchain directory when possible, then falls back to `perldoc` on `PATH`. Long-term: replace with an in-process POD reader. |
 | **Timeout** | 10 s (via `run_command_with_timeout` at call site) |
 | **Cache key** | None currently — per-request; caching by module name would reduce subprocess churn |
 | **Internalization path** | **Bridge** — replace with embedded documentation tables or bundled POD extractor that does not need a subprocess |
 
-**Gap (needs #8551 fix):** This is the one editor-runtime call site that remains as a
-bare `Command::new("perldoc")` after the #8525/#8537 migration wave. It should either be
-wrapped in an oracle or migrated to an in-process POD reader.
+**Perl invocation:** `perldoc -T -- <module>` with the perldoc binary resolved from the
+configured Perl toolchain when possible.
 
 ---
 
@@ -375,9 +374,9 @@ Quick-reference. Sorted by internalization path priority (gaps first).
 
 | # | Call site | Mechanism | PERL5LIB | PERL5OPT | local::lib | Timeout | Internalization |
 |---|---|---|---|---|---|---|---|
-| 1.5 | `virtual_content.rs:fetch_perldoc` | Bare `Command::new("perldoc")` | ⚠ ambient | ⚠ ambient | ⚠ ambient | 10 s | Bridge — **GAP** |
 | 1.3 | `misc.rs` (fallback path) | Bare `Command::new("perl")` | ⚠ ambient | ⚠ ambient | ⚠ ambient | 30 s | Permanent — **GAP** |
 | 1.4 | `provider.rs` (fallback path) | Bare `Command::new("perl")` | ⚠ ambient | ⚠ ambient | ⚠ ambient | 30 s | Permanent — **GAP** |
+| 1.5 | `virtual_content.rs:fetch_perldoc` | `PerlOracleEnv::for_perldoc` | user-gated | ✓ denied | ✓ denied | 10 s | Bridge |
 | 1.1 | `mod.rs:fetch_perl_inc` | `PerlOracleEnv::for_module_resolution` | user-gated | ✓ denied | ✓ denied | 1 000 ms | Bridge |
 | 1.2 | `perl_oracle_env.rs:for_module_resolution` | `PerlOracleEnv` alias of §1.1 | user-gated | ✓ denied | ✓ denied | 1 000 ms | Bridge |
 | 1.6 | `process.rs:check_syntax` | `PerlOracleEnv::for_version_probe` | ✓ denied | ✓ denied | ✓ denied | 5 s | Bridge |
@@ -402,18 +401,8 @@ Legend: ✓ denied/removed = no leak · user-gated = follows `usePerl5lib` confi
 
 ## Section 5 — Open gaps (action items for Phase 2 / #8551)
 
-### Gap A: `perldoc` (§1.5) — highest priority
-
-`fetch_perldoc` in `virtual_content.rs` uses a bare `Command::new("perldoc")` that
-inherits all ambient env. This is an editor-runtime seam that runs on hover requests.
-
-**Proposed fix:**
-1. Resolve `perldoc` binary from the same toolchain as `perl_path` (prefer explicit
-   path over `PATH` lookup).
-2. Wrap in `PerlOracleEnv` or an equivalent strip: strip `PERL5OPT`, user-gate
-   `PERL5LIB`, set explicit `LC_ALL=C`.
-3. Cache the result by module name to avoid repeated subprocesses on hover.
-4. Long-term: replace with an in-process POD reader.
+The `perldoc` hover seam (§1.5) is wrapped by `PerlOracleEnv::for_perldoc`. The
+remaining editor-runtime gaps are the silent `perl` fallback paths below.
 
 ### Gap B: `misc.rs` fallback (§1.3) — medium priority
 


### PR DESCRIPTION
Problem: `perldoc://` hover content still spawned a bare `perldoc` process with ambient Perl environment.
Fix: Route perldoc through `PerlOracleEnv::for_perldoc`, strip PERL5OPT/local::lib state, user-gate PERL5LIB, and update the subprocess contract.
Verification: `cargo test -p perl-lsp-rs-core for_perldoc --profile agent --locked -- --nocapture`; `cargo test -p perl-lsp-rs virtual_content --profile agent --locked -- --nocapture`; `cargo xtask fmt --check`; `cargo clippy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs`; `git diff --check`.