### PR TITLE
fix(oracle): reject unresolved debugFile perl fallback (#8551)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -293,8 +293,9 @@ impl PerlOracleEnv {
     ///   processed).
     /// - `extra_env`: empty.
     ///
-    /// Returns `None` if the Perl binary cannot be resolved.  The caller should fall
-    /// back to `Command::new("perl")` or surface an actionable error to the user.
+    /// Returns `None` if the Perl binary cannot be resolved.  The caller should
+    /// surface an actionable error to the user instead of falling back to ambient
+    /// `perl` lookup.
     pub fn for_language_probe(config: &WorkspaceConfig, cwd: PathBuf) -> Option<Self> {
         use crate::platform::resolve_perl_path_with_toolchain;
 

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -19,6 +19,30 @@ use std::time::Instant;
 
 static INLINE_VALUE_REGEX: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
 
+fn unresolved_debug_perl_error(resolved: &std::path::Path) -> JsonRpcError {
+    JsonRpcError {
+        code: -32603,
+        message: format!(
+            "Cannot start Perl debugger for '{}': Perl binary could not be resolved from \
+             `perl.path` or PATH. Configure `perl.path` to an explicit Perl executable; \
+             refusing ambient fallback.",
+            resolved.display()
+        ),
+        data: Some(json!({"file": resolved.display().to_string()})),
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn debug_command_from_oracle(
+    oracle: Option<perl_lsp_rs_core::config::PerlOracleEnv>,
+    resolved: &std::path::Path,
+) -> Result<std::process::Command, JsonRpcError> {
+    oracle
+        .as_ref()
+        .map(perl_lsp_rs_core::config::PerlOracleEnv::into_command)
+        .ok_or_else(|| unresolved_debug_perl_error(resolved))
+}
+
 fn get_inline_value_regex() -> Option<&'static regex::Regex> {
     INLINE_VALUE_REGEX
         .get_or_init(|| regex::Regex::new(r"([$@%])([a-zA-Z_][a-zA-Z0-9_]*)"))
@@ -959,28 +983,24 @@ impl LspServer {
                     // PerlOracleEnv enforces a deny-all-ambient policy: PERL5OPT and
                     // local::lib are stripped; PERL5LIB passes through only when the
                     // user has explicitly opted in via `usePerl5lib` config.
-                    let debug_cwd =
-                        resolved.parent().map(std::path::Path::to_path_buf).unwrap_or_else(|| {
-                            std::env::current_dir()
-                                .unwrap_or_else(|_| std::path::PathBuf::from("."))
-                        });
                     #[cfg(not(target_arch = "wasm32"))]
                     let mut debug_cmd = {
                         use perl_lsp_rs_core::config::PerlOracleEnv;
+                        let debug_cwd = resolved
+                            .parent()
+                            .map(std::path::Path::to_path_buf)
+                            .unwrap_or_else(|| {
+                                std::env::current_dir()
+                                    .unwrap_or_else(|_| std::path::PathBuf::from("."))
+                            });
                         let debug_config = self.workspace_config.lock().clone();
-                        if let Some(oracle) =
-                            PerlOracleEnv::for_language_probe(&debug_config, debug_cwd)
-                        {
-                            oracle.into_command()
-                        } else {
-                            std::process::Command::new("perl")
-                        }
+                        debug_command_from_oracle(
+                            PerlOracleEnv::for_language_probe(&debug_config, debug_cwd),
+                            &resolved,
+                        )?
                     };
                     #[cfg(target_arch = "wasm32")]
-                    let mut debug_cmd = {
-                        let _ = debug_cwd;
-                        std::process::Command::new("perl")
-                    };
+                    return Err(unresolved_debug_perl_error(&resolved));
                     match debug_cmd
                         .arg("-d")
                         .arg("--")
@@ -1258,5 +1278,26 @@ mod tests {
             caps.inlay_hint_resolve_support.is_none(),
             "inlay_hint_resolve_support must remain None when client sends no resolveSupport"
         );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn debug_command_from_oracle_rejects_missing_oracle() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let resolved = std::path::PathBuf::from("script.pl");
+        let err = super::debug_command_from_oracle(None, &resolved).err().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "expected missing Perl oracle to reject debug launch",
+            )
+        })?;
+
+        assert_eq!(err.code, -32603);
+        assert!(
+            err.message.contains("refusing ambient fallback"),
+            "debugFile should fail closed instead of falling back to ambient perl: {}",
+            err.message
+        );
+        Ok(())
     }
 }

--- a/docs/architecture/perl-oracle-subprocess-contract.md
+++ b/docs/architecture/perl-oracle-subprocess-contract.md
@@ -87,18 +87,17 @@ when `config.use_system_inc` is `false`, so no subprocess is spawned in that cas
 | Field | Value |
 |---|---|
 | **Call site** | `perl-lsp-rs/src/runtime/language/misc.rs` (inline `perl -d` launch) |
-| **Spawn mechanism** | `PerlOracleEnv::for_language_probe(config, debug_cwd).into_command()` with fallback to bare `std::process::Command::new("perl")` on WASM and when `for_language_probe` returns `None` |
-| **Current env** | Via oracle: deny-all-ambient; `PERL5LIB` user-gated; `PERL5OPT` stripped; `local::lib` stripped. Fallback path: inherits ALL ambient env (wasm gate or `None` config). |
-| **Desired contract** | Remove bare fallback; surface actionable error if config is unavailable rather than silently inheriting ambient env. See #8551. |
+| **Spawn mechanism** | `PerlOracleEnv::for_language_probe(config, debug_cwd).into_command()`; unresolved Perl returns an actionable error instead of falling back to bare `Command::new("perl")` |
+| **Current env** | Via oracle: deny-all-ambient; `PERL5LIB` user-gated; `PERL5OPT` stripped; `local::lib` stripped. No ambient fallback. |
+| **Desired contract** | Already meets the post-#8551 permanent-subprocess contract. |
 | **Timeout** | 30 s (oracle default for `for_language_probe`) |
 | **Cache key** | None — on-demand per user action |
 | **Internalization path** | **Permanent** — launching the user's Perl debugger is inherently external |
 
 **Perl invocation:** `perl -d -- <file> <args>`
 
-**Gap (needs #8551 fix):** The bare `Command::new("perl")` fallback at
-`misc.rs:982` inherits ambient env. When `PerlOracleEnv::for_language_probe` returns
-`None` (binary not resolved), callers should surface an error, not fall through.
+**Failure mode:** If no Perl binary can be resolved from config or `PATH`, the handler
+returns an LSP error and refuses ambient fallback.
 
 ---
 
@@ -374,15 +373,14 @@ Quick-reference. Sorted by internalization path priority (gaps first).
 
 | # | Call site | Mechanism | PERL5LIB | PERL5OPT | local::lib | Timeout | Internalization |
 |---|---|---|---|---|---|---|---|
-| 1.3 | `misc.rs` (fallback path) | Bare `Command::new("perl")` | ⚠ ambient | ⚠ ambient | ⚠ ambient | 30 s | Permanent — **GAP** |
 | 1.4 | `provider.rs` (fallback path) | Bare `Command::new("perl")` | ⚠ ambient | ⚠ ambient | ⚠ ambient | 30 s | Permanent — **GAP** |
+| 1.3 | `misc.rs:perl.debugFile` | `PerlOracleEnv::for_language_probe` | user-gated | ✓ denied | ✓ denied | 30 s | Permanent |
 | 1.5 | `virtual_content.rs:fetch_perldoc` | `PerlOracleEnv::for_perldoc` | user-gated | ✓ denied | ✓ denied | 10 s | Bridge |
 | 1.1 | `mod.rs:fetch_perl_inc` | `PerlOracleEnv::for_module_resolution` | user-gated | ✓ denied | ✓ denied | 1 000 ms | Bridge |
 | 1.2 | `perl_oracle_env.rs:for_module_resolution` | `PerlOracleEnv` alias of §1.1 | user-gated | ✓ denied | ✓ denied | 1 000 ms | Bridge |
 | 1.6 | `process.rs:check_syntax` | `PerlOracleEnv::for_version_probe` | ✓ denied | ✓ denied | ✓ denied | 5 s | Bridge |
 | 1.7 | `process.rs:launch_perl` | `PerlOracleEnv::for_version_probe` | ✓ denied | ✓ denied | ✓ denied | 30 s | Permanent |
 | 1.8 | `bridge_adapter.rs:build_pls_dap_command` | `PerlOracleEnv::for_dap_bridge` | configurable | configurable | ✓ denied | 30 s | Permanent |
-| 1.3 | `misc.rs` (oracle path) | `PerlOracleEnv::for_language_probe` | user-gated | ✓ denied | ✓ denied | 30 s | Permanent |
 | 1.4 | `provider.rs` (oracle path) | `PerlOracleEnv::for_execute_command` | user-gated | ✓ allowed | ✓ allowed | 30 s | Permanent |
 | 1.9 | `perl_oracle_env.rs:for_dap_test_fixture` | `Command::new("perl")` (partial strip) | ✓ removed | ✓ removed | ✓ removed | 5 s (subsequent) | Oracle |
 | 2.1 | `test_runner.rs:hermetic_perl_command` | `Command::new` + `env_clear()` | ✓ denied | ✓ denied | ✓ denied | per-test | Oracle |
@@ -401,23 +399,13 @@ Legend: ✓ denied/removed = no leak · user-gated = follows `usePerl5lib` confi
 
 ## Section 5 — Open gaps (action items for Phase 2 / #8551)
 
-The `perldoc` hover seam (§1.5) is wrapped by `PerlOracleEnv::for_perldoc`. The
-remaining editor-runtime gaps are the silent `perl` fallback paths below.
+The `perldoc` hover seam (§1.5) is wrapped by `PerlOracleEnv::for_perldoc`, and
+`perl.debugFile` (§1.3) now refuses unresolved Perl instead of falling back to ambient
+`perl`. The remaining editor-runtime gap is the silent execute-command fallback below.
 
-### Gap B: `misc.rs` fallback (§1.3) — medium priority
+### Gap A: `provider.rs` fallback (§1.4) — medium priority
 
-The bare `Command::new("perl")` fallback in the `perl.debugFile` handler fires when
-`PerlOracleEnv::for_language_probe` returns `None` (binary unresolved). The fallback
-silently inherits ambient env — the exact behaviour the oracle contract is designed to
-prevent.
-
-**Proposed fix:** Remove the silent fallback. When `for_language_probe` returns `None`,
-surface an actionable LSP error notification: `"Perl binary not found. Set
-`perl-lsp.perlPath` in workspace settings."` Do not fall through to `Command::new("perl")`.
-
-### Gap C: `provider.rs` fallback (§1.4) — medium priority
-
-Same pattern as Gap B: `perl_command_for` falls back to bare `Command::new("perl")` when
+`ExecuteCommandProvider::perl_command_for` falls back to bare `Command::new("perl")` when
 no config is available. Remove fallback; surface error.
 
 ---


### PR DESCRIPTION
Problem: `perl.debugFile` still had a bare `perl` fallback when the oracle could not resolve a Perl binary.
Fix: Return an actionable LSP error instead of falling back to ambient `perl`, and update the subprocess contract to mark the debugFile seam closed.
Verification: `cargo test -p perl-lsp-rs debug_command_from_oracle_rejects_missing_oracle --profile agent --locked -- --nocapture`; `cargo xtask fmt --check`; `cargo clippy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs`; `git diff --check`.