### PR TITLE
fix(oracle): reject unresolved execute-command perl fallback (#8551)

### DIFF
--- a/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
+++ b/crates/perl-lsp-rs-core/src/config/perl_oracle_env.rs
@@ -334,8 +334,9 @@ impl PerlOracleEnv {
     ///   specific directory (e.g., a workspace root).
     /// - `extra_env`: empty.
     ///
-    /// Returns `None` if the Perl binary cannot be resolved. The caller should
-    /// fall back to a plain `Command::new("perl")` or surface an error.
+    /// Returns `None` if the Perl binary cannot be resolved. Editor-runtime
+    /// callers should surface an actionable error instead of falling back to
+    /// ambient `perl` lookup.
     pub fn for_execute_command(config: &WorkspaceConfig, cwd: PathBuf) -> Option<Self> {
         use crate::platform::resolve_perl_path_with_toolchain;
 

--- a/crates/perl-lsp-rs/src/execute_command/provider.rs
+++ b/crates/perl-lsp-rs/src/execute_command/provider.rs
@@ -84,29 +84,35 @@ impl Default for ExecuteCommandProvider {
 
 // Private helpers for PerlOracleEnv subprocess isolation.
 impl ExecuteCommandProvider {
-    /// Build a `Command` for a Perl subprocess using `PerlOracleEnv` when a
-    /// workspace config is available; falls back to `Command::new("perl")`
-    /// for backward compatibility when no config is attached.
+    /// Build a `Command` for a Perl subprocess using `PerlOracleEnv`.
     ///
     /// The `file_path` is used only to derive a `cwd` (its parent directory).
     /// Callers must append the actual Perl arguments after this call.
     #[cfg(not(target_arch = "wasm32"))]
-    fn perl_command_for(&self, file_path: &Path) -> Command {
+    fn perl_command_for(&self, file_path: &Path) -> Result<Command, String> {
         let cwd = file_path
             .parent()
             .map(Path::to_path_buf)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-        if let Some(ref config) = self.workspace_config {
-            if let Some(oracle) = PerlOracleEnv::for_execute_command(config, cwd) {
-                return oracle.into_command();
-            }
-        }
-        Command::new("perl")
+        let Some(config) = self.workspace_config.as_ref() else {
+            return Err(Self::unresolved_execute_command_perl_error(file_path));
+        };
+        let Some(oracle) = PerlOracleEnv::for_execute_command(config, cwd) else {
+            return Err(Self::unresolved_execute_command_perl_error(file_path));
+        };
+        Ok(oracle.into_command())
     }
 
     #[cfg(target_arch = "wasm32")]
-    fn perl_command_for(&self, _file_path: &Path) -> Command {
-        Command::new("perl")
+    fn perl_command_for(&self, file_path: &Path) -> Result<Command, String> {
+        Err(Self::unresolved_execute_command_perl_error(file_path))
+    }
+
+    fn unresolved_execute_command_perl_error(file_path: &Path) -> String {
+        format!(
+            "Cannot run Perl command for '{}': Perl binary could not be resolved from `perl.path` or PATH. Configure `perl.path` to an explicit Perl executable; refusing ambient fallback.",
+            file_path.display()
+        )
     }
 }
 
@@ -124,9 +130,9 @@ impl ExecuteCommandProvider {
     /// Attach a workspace configuration to enable PerlOracleEnv isolation for
     /// Perl subprocess calls (`perl.runFile`, `perl.runTestSub`).
     ///
-    /// When a config is present, `run_file` and `run_test_sub` use
-    /// `PerlOracleEnv::for_execute_command` instead of a bare
-    /// `Command::new("perl")`, applying the deny-all-ambient env policy.
+    /// `run_file` and `run_test_sub` use `PerlOracleEnv::for_execute_command`
+    /// instead of a bare `Command::new("perl")`, applying the
+    /// deny-all-ambient env policy.
     pub fn with_workspace_config(mut self, config: WorkspaceConfig) -> Self {
         self.workspace_config = Some(config);
         self
@@ -280,7 +286,7 @@ impl ExecuteCommandProvider {
         "#;
         let ext_path = normalize_path_for_external_command(file_path);
 
-        let mut perl_cmd = self.perl_command_for(file_path);
+        let mut perl_cmd = self.perl_command_for(file_path)?;
         perl_cmd.arg("-e").arg(perl_code).arg("--").arg(ext_path.as_os_str()).arg(sub_name);
         match crate::util::run_command_with_timeout(perl_cmd, 30) {
             Ok(result) => {
@@ -295,7 +301,7 @@ impl ExecuteCommandProvider {
 
     pub(crate) fn run_file(&self, file_path: &Path) -> Result<Value, String> {
         let ext_path = normalize_path_for_external_command(file_path);
-        let mut perl_cmd = self.perl_command_for(file_path);
+        let mut perl_cmd = self.perl_command_for(file_path)?;
         perl_cmd.arg("--").arg(ext_path.as_os_str());
         match crate::util::run_command_with_timeout(perl_cmd, 30) {
             Ok(result) => Ok(self.format_command_result(result, None)),

--- a/crates/perl-lsp-rs/src/execute_command/tests.rs
+++ b/crates/perl-lsp-rs/src/execute_command/tests.rs
@@ -3,11 +3,19 @@
 use super::get_supported_commands;
 use super::provider::{ExecuteCommandProvider, TestRunner, select_test_runner};
 use super::test_support::mock_status;
+use perl_lsp_rs_core::config::WorkspaceConfig;
 use serde_json::Value;
 use std::fs;
+use std::path::PathBuf;
 use tempfile::tempdir;
 
 // ============= GO-TO-TEST / GO-TO-IMPLEMENTATION TESTS =============
+
+fn provider_with_execute_perl(workspace_roots: Vec<PathBuf>) -> ExecuteCommandProvider {
+    let mut config = WorkspaceConfig::default();
+    config.perl_path = Some("perl".to_string());
+    ExecuteCommandProvider::with_workspace_roots(workspace_roots).with_workspace_config(config)
+}
 
 #[test]
 fn test_go_to_test_basic_mapping() -> Result<(), Box<dyn std::error::Error>> {
@@ -496,8 +504,7 @@ fn test_command_routing_perl_run_file() -> Result<(), Box<dyn std::error::Error>
     let test_content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\nprint 'hello world';\n";
     fs::write(&temp_file, test_content)?;
 
-    let provider =
-        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()]);
+    let provider = provider_with_execute_perl(vec![temp_dir.path().to_path_buf()]);
     let result = provider
         .execute_command("perl.runFile", vec![Value::String(temp_file.display().to_string())]);
 
@@ -520,8 +527,7 @@ fn test_command_routing_perl_run_test_sub() -> Result<(), Box<dyn std::error::Er
         "#!/usr/bin/perl\nuse strict;\nuse warnings;\nsub test_sub { print 'test executed'; }\n";
     fs::write(&temp_file, test_content)?;
 
-    let provider =
-        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()]);
+    let provider = provider_with_execute_perl(vec![temp_dir.path().to_path_buf()]);
     let result = provider.execute_command(
         "perl.runTestSub",
         vec![Value::String(temp_file.display().to_string()), Value::String("test_sub".to_string())],
@@ -533,6 +539,48 @@ fn test_command_routing_perl_run_test_sub() -> Result<(), Box<dyn std::error::Er
     assert!(result_value.is_object(), "Should return a structured result");
     assert!(result_value["success"].is_boolean(), "Should have success field");
     assert!(result_value["subroutine"].is_string(), "Should have subroutine field");
+    Ok(())
+}
+
+#[test]
+fn test_run_file_rejects_unresolved_perl_fallback() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    let temp_file = temp_dir.path().join("test_no_ambient_run_file.pl");
+    fs::write(&temp_file, "print 'hello';\n")?;
+
+    let provider =
+        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()]);
+    let result = provider
+        .execute_command("perl.runFile", vec![Value::String(temp_file.display().to_string())]);
+
+    assert!(result.is_err(), "perl.runFile must reject missing oracle config");
+    let error = result.err().ok_or("expected error")?;
+    assert!(
+        error.contains("refusing ambient fallback"),
+        "error should explain ambient fallback refusal: {error}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_run_test_sub_rejects_unresolved_perl_fallback() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempdir()?;
+    let temp_file = temp_dir.path().join("test_no_ambient_run_test_sub.pl");
+    fs::write(&temp_file, "sub test_sub { print 'hello'; }\n")?;
+
+    let provider =
+        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()]);
+    let result = provider.execute_command(
+        "perl.runTestSub",
+        vec![Value::String(temp_file.display().to_string()), Value::String("test_sub".to_string())],
+    );
+
+    assert!(result.is_err(), "perl.runTestSub must reject missing oracle config");
+    let error = result.err().ok_or("expected error")?;
+    assert!(
+        error.contains("refusing ambient fallback"),
+        "error should explain ambient fallback refusal: {error}"
+    );
     Ok(())
 }
 
@@ -1134,7 +1182,7 @@ fn test_run_critic_file_existence_logic() -> Result<(), Box<dyn std::error::Erro
 
 #[test]
 fn test_method_return_values_not_defaults() -> Result<(), Box<dyn std::error::Error>> {
-    let provider = ExecuteCommandProvider::new();
+    let provider = provider_with_execute_perl(Vec::new());
 
     // Create real test files using a portable temp directory
     let tmp = tempdir()?;
@@ -1215,10 +1263,7 @@ fn test_execute_command_multi_root_security() -> Result<(), Box<dyn std::error::
     fs::write(&file2, "print 'file2';")?;
     fs::write(&outside_file, "print 'outside';")?;
 
-    let provider = ExecuteCommandProvider::with_workspace_roots(vec![
-        workspace_dir1.clone(),
-        workspace_dir2.clone(),
-    ]);
+    let provider = provider_with_execute_perl(vec![workspace_dir1.clone(), workspace_dir2.clone()]);
 
     // 1. Should succeed for file in workspace 1
     let result1 = provider
@@ -1343,8 +1388,7 @@ fn test_command_routing_perl_run_subtest() -> Result<(), Box<dyn std::error::Err
         "use Test::More;\nsub my_subtest { ok(1); }\nmy_subtest();\ndone_testing;\n",
     )?;
 
-    let provider =
-        ExecuteCommandProvider::with_workspace_roots(vec![temp_dir.path().to_path_buf()]);
+    let provider = provider_with_execute_perl(vec![temp_dir.path().to_path_buf()]);
     let result = provider.execute_command(
         "perl.runSubtest",
         vec![

--- a/docs/architecture/perl-oracle-subprocess-contract.md
+++ b/docs/architecture/perl-oracle-subprocess-contract.md
@@ -106,9 +106,9 @@ returns an LSP error and refuses ambient fallback.
 | Field | Value |
 |---|---|
 | **Call site** | `perl-lsp-rs/src/execute_command/provider.rs:perl_command_for` |
-| **Spawn mechanism** | `PerlOracleEnv::for_execute_command(config, cwd).into_command()` with fallback to bare `Command::new("perl")` when config is absent or binary resolution fails |
-| **Current env** | Via oracle: deny-all-ambient base; `PERL5LIB` user-gated; `PERL5OPT` **allowed** (user scripts may use `-M` pragmas); `local::lib` **allowed** (user scripts may depend on it). Fallback path: inherits ALL ambient. |
-| **Desired contract** | Same oracle path is correct. Fallback bare `Command::new("perl")` at `provider.rs:104,109` should surface a user-visible error instead of silently inheriting ambient. |
+| **Spawn mechanism** | `PerlOracleEnv::for_execute_command(config, cwd).into_command()`; unresolved Perl or missing workspace config returns a user-visible error instead of falling back to bare `Command::new("perl")` |
+| **Current env** | Deny-all-ambient base; `PERL5LIB` user-gated; `PERL5OPT` **allowed** (user scripts may use `-M` pragmas); `local::lib` **allowed** (user scripts may depend on it). |
+| **Desired contract** | Already meets the post-#8551 execute-command contract. Missing oracle config or unresolved Perl fails closed with an actionable error. |
 | **Timeout** | 30 s |
 | **Cache key** | None — on-demand per user command invocation |
 | **Internalization path** | **Permanent** — user-initiated script execution requires the user's Perl |
@@ -373,7 +373,6 @@ Quick-reference. Sorted by internalization path priority (gaps first).
 
 | # | Call site | Mechanism | PERL5LIB | PERL5OPT | local::lib | Timeout | Internalization |
 |---|---|---|---|---|---|---|---|
-| 1.4 | `provider.rs` (fallback path) | Bare `Command::new("perl")` | ⚠ ambient | ⚠ ambient | ⚠ ambient | 30 s | Permanent — **GAP** |
 | 1.3 | `misc.rs:perl.debugFile` | `PerlOracleEnv::for_language_probe` | user-gated | ✓ denied | ✓ denied | 30 s | Permanent |
 | 1.5 | `virtual_content.rs:fetch_perldoc` | `PerlOracleEnv::for_perldoc` | user-gated | ✓ denied | ✓ denied | 10 s | Bridge |
 | 1.1 | `mod.rs:fetch_perl_inc` | `PerlOracleEnv::for_module_resolution` | user-gated | ✓ denied | ✓ denied | 1 000 ms | Bridge |
@@ -397,16 +396,12 @@ Legend: ✓ denied/removed = no leak · user-gated = follows `usePerl5lib` confi
 
 ---
 
-## Section 5 — Open gaps (action items for Phase 2 / #8551)
+## Section 5 — Gap status for Phase 2 / #8551
 
-The `perldoc` hover seam (§1.5) is wrapped by `PerlOracleEnv::for_perldoc`, and
-`perl.debugFile` (§1.3) now refuses unresolved Perl instead of falling back to ambient
-`perl`. The remaining editor-runtime gap is the silent execute-command fallback below.
-
-### Gap A: `provider.rs` fallback (§1.4) — medium priority
-
-`ExecuteCommandProvider::perl_command_for` falls back to bare `Command::new("perl")` when
-no config is available. Remove fallback; surface error.
+The editor-runtime subprocess seams in this inventory are now routed through
+`PerlOracleEnv` or fail closed with a user-visible error instead of silently
+falling back to ambient `perl`. Remaining bare `Command::new("perl")` rows are
+oracle, fixture, or xtask/CI tooling seams, not editor-runtime truth paths.
 
 ---
 


### PR DESCRIPTION
Problem: `perl.runFile` and `perl.runTestSub` still had a silent bare `perl` fallback when the execute-command oracle was unavailable.
Fix: Make the execute-command Perl helper fail closed with an actionable error, update routing tests to use explicit configured Perl where execution is intended, and mark the editor-runtime subprocess gap closed in the contract.
Verification: `cargo test -p perl-lsp-rs unresolved_perl_fallback --profile agent --locked -- --nocapture`; `cargo test -p perl-lsp-rs execute_command::tests --profile agent --locked -- --nocapture`; `cargo xtask fmt --check`; `cargo clippy -p perl-lsp-rs-core -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs`; `git diff --check`.