### PR TITLE
feat(ux): expose explain-provider-decision command (#8197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the conservative `perl.explainProviderDecision` LSP execute-command
+  surface. It returns the structured provider decision explanation payload and
+  reports a low-confidence `missing_fact` / `no_result` fallback when no
+  provider-specific receipt is attached, avoiding false certainty while the
+  live provider receipt wiring lands.
+
 ### Planned
 
 - Documented the Rust 1.95 / 0.14.0 rollout sequence before implementation: compatibility spike first, then MSRV/toolchain, lint, no-panic, file-policy, CI routing, and release-prep lanes.

--- a/crates/perl-lsp-rs-core/src/protocol/capabilities.rs
+++ b/crates/perl-lsp-rs-core/src/protocol/capabilities.rs
@@ -100,6 +100,7 @@ pub fn get_supported_commands() -> Vec<String> {
         "perl.debugTest".to_string(),
         "perl.goToTest".to_string(),
         "perl.goToImplementation".to_string(),
+        "perl.explainProviderDecision".to_string(),
     ]
 }
 
@@ -209,6 +210,16 @@ mod tests {
         assert!(
             cmds.iter().any(|c| c == "perl.runSubtest"),
             "perl.runSubtest must be in get_supported_commands"
+        );
+    }
+
+    /// Verify that `perl.explainProviderDecision` is included in the supported commands list.
+    #[test]
+    fn explain_provider_decision_command_id_is_registered() {
+        let cmds = get_supported_commands();
+        assert!(
+            cmds.iter().any(|c| c == "perl.explainProviderDecision"),
+            "perl.explainProviderDecision must be in get_supported_commands"
         );
     }
 

--- a/crates/perl-lsp-rs/src/execute_command/provider.rs
+++ b/crates/perl-lsp-rs/src/execute_command/provider.rs
@@ -4,6 +4,12 @@ use crate::perl_critic::{BuiltInAnalyzer, CriticAnalyzer, CriticConfig};
 #[cfg(not(target_arch = "wasm32"))]
 use perl_lsp_rs_core::config::PerlOracleEnv;
 use perl_lsp_rs_core::config::WorkspaceConfig;
+use perl_lsp_rs_core::providers::{
+    ProviderDecisionConfidence, ProviderDecisionExplanation, ProviderDecisionFactSource,
+    ProviderDecisionFallback, ProviderDecisionFreshness, ProviderDecisionOutcome,
+    ProviderDecisionProvider, ProviderDecisionReason,
+};
+use serde::Deserialize;
 use serde_json::{Value, json};
 use std::borrow::Cow;
 #[cfg(windows)]
@@ -74,6 +80,15 @@ pub(crate) enum TestRunner {
     Yath,
     Prove,
     Perl,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExplainProviderDecisionRequest {
+    provider: ProviderDecisionProvider,
+    #[serde(default)]
+    receipt_id: Option<String>,
+    #[serde(default)]
+    scenario: Option<String>,
 }
 
 impl Default for ExecuteCommandProvider {
@@ -176,8 +191,38 @@ impl ExecuteCommandProvider {
                 let file_path = self.resolve_path_from_args(&arguments)?;
                 Ok(self.go_to_implementation(&file_path))
             }
+            "perl.explainProviderDecision" => self.explain_provider_decision(&arguments),
             _ => Err(format!("Unknown command: {}", command)),
         }
+    }
+
+    fn explain_provider_decision(&self, arguments: &[Value]) -> Result<Value, String> {
+        let request_value = arguments
+            .first()
+            .ok_or_else(|| "Missing explain-provider-decision argument".to_string())?;
+        let request: ExplainProviderDecisionRequest = serde_json::from_value(request_value.clone())
+            .map_err(|error| format!("Invalid explain-provider-decision argument: {error}"))?;
+
+        let mut explanation = ProviderDecisionExplanation::new(
+            request.provider,
+            ProviderDecisionOutcome::Fallback,
+            ProviderDecisionReason::MissingFact,
+            ProviderDecisionFactSource::Unknown,
+            ProviderDecisionConfidence::Low,
+            ProviderDecisionFreshness::Unknown,
+            false,
+            ProviderDecisionFallback::NoResult,
+        );
+
+        if let Some(receipt_id) = request.receipt_id {
+            explanation = explanation.with_receipt_id(receipt_id);
+        }
+        if let Some(scenario) = request.scenario {
+            explanation = explanation.with_scenario(scenario);
+        }
+
+        serde_json::to_value(explanation)
+            .map_err(|error| format!("Failed to serialize provider decision explanation: {error}"))
     }
 
     pub(crate) fn run_tests(&self, file_path: &Path) -> Result<Value, String> {
@@ -997,6 +1042,7 @@ pub fn get_supported_commands() -> Vec<String> {
         "perl.debugTest".to_string(),
         "perl.goToTest".to_string(),
         "perl.goToImplementation".to_string(),
+        "perl.explainProviderDecision".to_string(),
     ]
 }
 

--- a/crates/perl-lsp-rs/src/execute_command/tests.rs
+++ b/crates/perl-lsp-rs/src/execute_command/tests.rs
@@ -3,7 +3,7 @@
 use super::get_supported_commands;
 use super::provider::{ExecuteCommandProvider, TestRunner, select_test_runner};
 use super::test_support::mock_status;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::fs;
 use tempfile::tempdir;
 
@@ -171,6 +171,55 @@ fn test_supported_commands_includes_go_to_test() {
         commands.contains(&"perl.goToImplementation".to_string()),
         "perl.goToImplementation should be in supported commands list"
     );
+    assert!(
+        commands.contains(&"perl.explainProviderDecision".to_string()),
+        "perl.explainProviderDecision should be in supported commands list"
+    );
+}
+
+#[test]
+fn test_explain_provider_decision_returns_honest_no_receipt_fallback()
+-> Result<(), Box<dyn std::error::Error>> {
+    let provider = ExecuteCommandProvider::new();
+    let result = provider.execute_command(
+        "perl.explainProviderDecision",
+        vec![json!({
+            "provider": "safe_delete",
+            "receipt_id": "semantic-shadow-compare",
+            "scenario": "mojolicious-safe-delete"
+        })],
+    )?;
+
+    assert_eq!(result.get("provider").and_then(Value::as_str), Some("safe_delete"));
+    assert_eq!(result.get("decision").and_then(Value::as_str), Some("fallback"));
+    assert_eq!(result.get("reason").and_then(Value::as_str), Some("missing_fact"));
+    assert_eq!(result.get("fact_source").and_then(Value::as_str), Some("unknown"));
+    assert_eq!(result.get("confidence").and_then(Value::as_str), Some("low"));
+    assert_eq!(result.get("freshness").and_then(Value::as_str), Some("unknown"));
+    assert_eq!(result.get("fallback").and_then(Value::as_str), Some("no_result"));
+    assert_eq!(result.get("receipt_id").and_then(Value::as_str), Some("semantic-shadow-compare"));
+    assert_eq!(result.get("scenario").and_then(Value::as_str), Some("mojolicious-safe-delete"));
+    assert_eq!(result.get("dynamic_boundary").and_then(Value::as_bool), Some(false));
+    Ok(())
+}
+
+#[test]
+fn test_explain_provider_decision_rejects_missing_provider()
+-> Result<(), Box<dyn std::error::Error>> {
+    let provider = ExecuteCommandProvider::new();
+    let result = provider.execute_command("perl.explainProviderDecision", vec![json!({})]);
+
+    let error = match result {
+        Ok(value) => {
+            return Err(format!("missing provider should reject the request: {value}").into());
+        }
+        Err(error) => error,
+    };
+    assert!(
+        error.contains("Invalid explain-provider-decision argument"),
+        "error should identify invalid explain-provider payload, got: {error}"
+    );
+    Ok(())
 }
 
 #[test]

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -897,7 +897,8 @@ impl LspServer {
                 | "perl.runCritic"
                 | "perl.goToTest"
                 | "perl.goToImplementation"
-                | "perl.debugTests" => {
+                | "perl.debugTests"
+                | "perl.explainProviderDecision" => {
                     match provider.execute_command(command, arguments) {
                         Ok(result) => return Ok(Some(result)),
                         Err(e) => {

--- a/crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs
@@ -225,6 +225,50 @@ fn test_execute_command_capabilities() -> Result<(), Box<dyn std::error::Error>>
     assert!(command_strs.contains(&"perl.runFile"));
     assert!(command_strs.contains(&"perl.runTestSub"));
     assert!(command_strs.contains(&"perl.runCritic"));
+    assert!(command_strs.contains(&"perl.explainProviderDecision"));
+
+    Ok(())
+}
+
+#[test]
+fn test_execute_command_explain_provider_decision() -> Result<(), Box<dyn std::error::Error>> {
+    let server = setup_server(None);
+
+    let execute_request = JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        method: "workspace/executeCommand".to_string(),
+        params: Some(json!({
+            "command": "perl.explainProviderDecision",
+            "arguments": [{
+                "provider": "goto_definition",
+                "receipt_id": "semantic-shadow-compare",
+                "scenario": "mojolicious-navigation"
+            }]
+        })),
+        id: Some(json!(2)),
+    };
+
+    let response = server
+        .handle_request(execute_request)
+        .ok_or("No response from explain-provider-decision command")?;
+    let result = response.result.ok_or("No result in explain-provider-decision response")?;
+
+    assert_eq!(result.get("provider").and_then(|value| value.as_str()), Some("goto_definition"));
+    assert_eq!(result.get("decision").and_then(|value| value.as_str()), Some("fallback"));
+    assert_eq!(result.get("reason").and_then(|value| value.as_str()), Some("missing_fact"));
+    assert_eq!(result.get("fact_source").and_then(|value| value.as_str()), Some("unknown"));
+    assert_eq!(result.get("confidence").and_then(|value| value.as_str()), Some("low"));
+    assert_eq!(result.get("freshness").and_then(|value| value.as_str()), Some("unknown"));
+    assert_eq!(result.get("fallback").and_then(|value| value.as_str()), Some("no_result"));
+    assert_eq!(
+        result.get("receipt_id").and_then(|value| value.as_str()),
+        Some("semantic-shadow-compare")
+    );
+    assert_eq!(
+        result.get("scenario").and_then(|value| value.as_str()),
+        Some("mojolicious-navigation")
+    );
+    assert_eq!(result.get("dynamic_boundary").and_then(|value| value.as_bool()), Some(false));
 
     Ok(())
 }

--- a/crates/perl-lsp-rs/tests/snapshots/all_capabilities.json
+++ b/crates/perl-lsp-rs/tests/snapshots/all_capabilities.json
@@ -17,6 +17,9 @@
   },
   "colorProvider": true,
   "completionProvider": {
+    "completionItem": {
+      "labelDetailsSupport": true
+    },
     "resolveProvider": true,
     "triggerCharacters": [
       "$",
@@ -65,7 +68,8 @@
       "perl.debugFile",
       "perl.debugTest",
       "perl.goToTest",
-      "perl.goToImplementation"
+      "perl.goToImplementation",
+      "perl.explainProviderDecision"
     ]
   },
   "experimental": {
@@ -162,7 +166,8 @@
   },
   "textDocumentSync": {
     "change": 1,
-    "openClose": true
+    "openClose": true,
+    "save": true
   },
   "typeDefinitionProvider": true,
   "typeHierarchyProvider": {

--- a/crates/perl-lsp-rs/tests/snapshots/ga_lock_capabilities.json
+++ b/crates/perl-lsp-rs/tests/snapshots/ga_lock_capabilities.json
@@ -17,6 +17,9 @@
   },
   "colorProvider": true,
   "completionProvider": {
+    "completionItem": {
+      "labelDetailsSupport": true
+    },
     "resolveProvider": true,
     "triggerCharacters": [
       "$",
@@ -65,7 +68,8 @@
       "perl.debugFile",
       "perl.debugTest",
       "perl.goToTest",
-      "perl.goToImplementation"
+      "perl.goToImplementation",
+      "perl.explainProviderDecision"
     ]
   },
   "experimental": {
@@ -161,7 +165,8 @@
   },
   "textDocumentSync": {
     "change": 1,
-    "openClose": true
+    "openClose": true,
+    "save": true
   },
   "typeDefinitionProvider": true,
   "typeHierarchyProvider": {

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__code_action_kinds.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__code_action_kinds.snap
@@ -1,8 +1,12 @@
 ---
-source: crates/perl-lsp-rs/tests/lsp_capability_snapshot_test.rs
+source: crates/perl-lsp-rs/tests/lsp_cap_snap.rs
+assertion_line: 73
 expression: "&kinds"
 ---
 - quickfix
 - source.organizeImports
+- refactor
 - refactor.extract
+- refactor.inline
+- refactor.rewrite
 - source.fixAll

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__completion_trigger_characters.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__completion_trigger_characters.snap
@@ -1,11 +1,15 @@
 ---
-source: crates/perl-lsp-rs/tests/lsp_capability_snapshot_test.rs
+source: crates/perl-lsp-rs/tests/lsp_cap_snap.rs
 assertion_line: 93
 expression: "&triggers"
 ---
 - $
 - "@"
 - "%"
+- "-"
 - ">"
 - ":"
-- "-"
+- /
+- "\\"
+- "\""
+- "'"

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__execute_command_ids.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__execute_command_ids.snap
@@ -13,3 +13,4 @@ expression: "&commands"
 - perl.debugTest
 - perl.goToTest
 - perl.goToImplementation
+- perl.explainProviderDecision

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_full_client.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_full_client.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/perl-lsp-rs/tests/lsp_cap_snap.rs
+assertion_line: 52
 expression: caps
 ---
 callHierarchyProvider: true
@@ -7,7 +8,10 @@ codeActionProvider:
   codeActionKinds:
     - quickfix
     - source.organizeImports
+    - refactor
     - refactor.extract
+    - refactor.inline
+    - refactor.rewrite
     - source.fixAll
   resolveProvider: true
 codeLensProvider:
@@ -21,15 +25,20 @@ completionProvider:
     - $
     - "@"
     - "%"
+    - "-"
     - ">"
     - ":"
-    - "-"
+    - /
+    - "\\"
+    - "\""
+    - "'"
 declarationProvider: true
 definitionProvider: true
 diagnosticProvider:
   identifier: perl-lsp
   interFileDependencies: false
   workspaceDiagnostics: true
+documentFormattingProvider: true
 documentHighlightProvider: true
 documentLinkProvider:
   resolveProvider: true
@@ -38,6 +47,7 @@ documentOnTypeFormattingProvider:
   moreTriggerCharacter:
     - ;
     - "\n"
+documentRangeFormattingProvider: true
 documentSymbolProvider: true
 executeCommandProvider:
   commands:
@@ -52,6 +62,7 @@ executeCommandProvider:
     - perl.debugTest
     - perl.goToTest
     - perl.goToImplementation
+    - perl.explainProviderDecision
 experimental:
   perlInlineCompletionStream: true
 foldingRangeProvider: true

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_minimal_client.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_minimal_client.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/perl-lsp-rs/tests/lsp_cap_snap.rs
+assertion_line: 34
 expression: caps
 ---
 callHierarchyProvider: true
@@ -7,7 +8,10 @@ codeActionProvider:
   codeActionKinds:
     - quickfix
     - source.organizeImports
+    - refactor
     - refactor.extract
+    - refactor.inline
+    - refactor.rewrite
     - source.fixAll
   resolveProvider: true
 codeLensProvider:
@@ -21,15 +25,20 @@ completionProvider:
     - $
     - "@"
     - "%"
+    - "-"
     - ">"
     - ":"
-    - "-"
+    - /
+    - "\\"
+    - "\""
+    - "'"
 declarationProvider: true
 definitionProvider: true
 diagnosticProvider:
   identifier: perl-lsp
   interFileDependencies: false
   workspaceDiagnostics: true
+documentFormattingProvider: true
 documentHighlightProvider: true
 documentLinkProvider:
   resolveProvider: true
@@ -38,6 +47,7 @@ documentOnTypeFormattingProvider:
   moreTriggerCharacter:
     - ;
     - "\n"
+documentRangeFormattingProvider: true
 documentSymbolProvider: true
 executeCommandProvider:
   commands:
@@ -52,6 +62,7 @@ executeCommandProvider:
     - perl.debugTest
     - perl.goToTest
     - perl.goToImplementation
+    - perl.explainProviderDecision
 experimental:
   perlInlineCompletionStream: true
 foldingRangeProvider: true
@@ -201,7 +212,7 @@ workspace:
     schemes:
       - perldoc
   workspaceFolders:
-    changeNotifications: true
-    supported: true
+    changeNotifications: false
+    supported: false
 workspaceSymbolProvider:
   resolveProvider: true

--- a/crates/perl-lsp-rs/tests/snapshots/production_capabilities.json
+++ b/crates/perl-lsp-rs/tests/snapshots/production_capabilities.json
@@ -17,6 +17,9 @@
   },
   "colorProvider": true,
   "completionProvider": {
+    "completionItem": {
+      "labelDetailsSupport": true
+    },
     "resolveProvider": true,
     "triggerCharacters": [
       "$",
@@ -65,7 +68,8 @@
       "perl.debugFile",
       "perl.debugTest",
       "perl.goToTest",
-      "perl.goToImplementation"
+      "perl.goToImplementation",
+      "perl.explainProviderDecision"
     ]
   },
   "experimental": {
@@ -162,7 +166,8 @@
   },
   "textDocumentSync": {
     "change": 1,
-    "openClose": true
+    "openClose": true,
+    "save": true
   },
   "typeDefinitionProvider": true,
   "typeHierarchyProvider": {

--- a/docs/explanation/EXECUTE_COMMAND_CONFIGURATION_GUIDE.md
+++ b/docs/explanation/EXECUTE_COMMAND_CONFIGURATION_GUIDE.md
@@ -5,7 +5,8 @@
 ## Overview
 
 `workspace/executeCommand` exposes server-side commands such as `perl.runTests`,
-`perl.runFile`, `perl.runTestSub`, `perl.debugTests`, and `perl.runCritic`.
+`perl.runFile`, `perl.runTestSub`, `perl.debugTests`, `perl.runCritic`, and
+`perl.explainProviderDecision`.
 `perl.runCritic` now uses the native critic path by default. The native path
 shares perl-lsp parser, semantic, diagnostic, suppression, severity, code-action,
 and receipt surfaces with normal editor diagnostics.

--- a/docs/project/status/real_perl_editor_trust_v1.md
+++ b/docs/project/status/real_perl_editor_trust_v1.md
@@ -64,9 +64,9 @@ blocker when relevant.
 This dashboard keeps the next provider lane separate from parser capability,
 framework facts, PIR, formatter, critic, release, and security work.
 
-1. `feat(ux): expose explain-provider-decision command`
-2. `docs(user): explain measured Perl editor trust`
-3. `feat(diagnostics): label dynamic-boundary and low-confidence diagnostics`
+1. `docs(user): explain measured Perl editor trust`
+2. `feat(diagnostics): label dynamic-boundary and low-confidence diagnostics`
+3. `feat(provider): attach live provider receipts to explain-provider-decision`
 
 Parser raw-bucket work, Linux corpus refresh, security alert classification,
 Rust 1.95 rollout, native formatter, native critic, PIR, and determinism remain

--- a/docs/reference/COMMANDS_REFERENCE.md
+++ b/docs/reference/COMMANDS_REFERENCE.md
@@ -538,6 +538,7 @@ cargo test -p perl-lsp-rs --test lsp_behavioral_tests -- test_execute_command_de
 - ✅ `perl.runTestSub` - Execute specific test subroutine with isolation
 - ✅ `perl.debugTests` - Debug test execution with breakpoint support
 - ✅ `perl.runCritic` - Native critic analysis with explicit Perl::Critic compatibility
+- ✅ `perl.explainProviderDecision` - Return a structured provider decision explanation. The v1 command is conservative: when no provider-specific receipt is attached, it returns a low-confidence `missing_fact` / `no_result` fallback instead of inventing certainty.
 
 ### Advanced Code Actions Testing (*Diataxis: How-to Guide* - Code action workflows)
 

--- a/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
+++ b/docs/reference/LSP_IMPLEMENTATION_GUIDE.md
@@ -1686,6 +1686,7 @@ pub static SUPPORTED_COMMANDS: &[&str] = &[
     "perl.runTestSub",         // Execute specific test subroutine
     "perl.debugTests",         // Debug test execution
     "perl.runCritic",          // ⭐ NEW: Native critic analysis
+    "perl.explainProviderDecision", // Structured provider trust explanation
 ];
 ```
 
@@ -2001,6 +2002,7 @@ The Perl LSP server has achieved **100% user-visible coverage (53/53)** and **10
 | `perl.runTestSub` | ✅ Complete | Native | <2s | Subroutine isolation |
 | `perl.debugTests` | ✅ Complete | Native | <1s | Debug adapter preparation |
 | `perl.runCritic` | ✅ Complete | Native + compatibility | <2s | Native critic with explicit Perl::Critic compatibility |
+| `perl.explainProviderDecision` | ✅ Conservative v1 | Native | <50ms | Structured confidence/freshness explanation; no receipt means low-confidence fallback |
 
 ### Code Action Categories (*Diataxis: Reference* - Refactoring capabilities)
 | Category | Operations | Status | Performance | Cross-file Support |


### PR DESCRIPTION
Problem: The provider decision explanation model existed, but users and clients had no LSP command surface to request a structured explanation.

Fix: Register `perl.explainProviderDecision`, route it through `workspace/executeCommand`, and return a conservative v1 `ProviderDecisionExplanation` payload. When no provider-specific receipt is attached, the command reports a low-confidence `missing_fact` / `no_result` fallback instead of inventing certainty. Docs, changelog, and capability snapshots were updated; snapshot refresh also reconciles pre-existing capability drift surfaced by the command contract gate (`labelDetailsSupport`, `textDocumentSync.save`, code action kinds, completion triggers, and minimal-client workspace-folder support).

Claim boundary: This does not attach live provider receipts, broaden provider behavior, promote support tiers, change parser behavior, or claim corpus/bucket movement.

Verification:
- `cargo test -p perl-lsp-rs --lib explain_provider_decision --profile agent --locked -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_execute_command_tests explain_provider_decision --profile agent --locked -- --nocapture`
- `cargo test -p perl-lsp-rs-core --lib explain_provider_decision_command_id_is_registered --profile agent --locked -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_capabilities_snapshot --profile agent --locked -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_cap_snap --profile agent --locked -- --nocapture`
- `cargo clippy -p perl-lsp-rs --lib --profile agent --locked -- -D warnings -A missing_docs`
- `cargo clippy -p perl-lsp-rs-core --lib --profile agent --locked -- -D warnings -A missing_docs`
- `cargo xtask fmt --check`
- `cargo xtask check-provider-confidence-matrix`
- `cargo xtask check-support-claims`
- `cargo xtask semantic-shadow-compare --check`
- `git diff --check`

Note: H: had about 1.3 GB free and produced an initial local link failure, so Cargo validation was rerun with `CARGO_TARGET_DIR=C:\Users\steven\.cargo-targets\perl-lsp-source-of-truth-agent`.