### PR TITLE
docs(parser): remove stale corpus refresh PR pointer (#8197)

### DIFF
--- a/docs/project/status/parser_unclosed_paren_identifier_shapes.md
+++ b/docs/project/status/parser_unclosed_paren_identifier_shapes.md
@@ -213,9 +213,9 @@ Valid starting evidence:
 - a focused, source-backed fixture reproduces a boundary failure against the
   current parser.
 
-Otherwise, the next bucket-count action is #8863. Fixture-only PRs should
-continue only when a new real-Perl source shape is not covered by the existing
-groups above.
+Otherwise, the next bucket-count action is a dedicated Linux corpus refresh.
+Fixture-only PRs should continue only when a new real-Perl source shape is not
+covered by the existing groups above.
 
 Recent closeouts:
 

--- a/plans/real-perl-editor-trust/implementation-plan.md
+++ b/plans/real-perl-editor-trust/implementation-plan.md
@@ -365,7 +365,8 @@ AST boundary receipts:
 
 Next parser runtime work should start only from current failing evidence: a
 fresh Linux receipt or a focused source-backed fixture that fails against the
-current parser. Otherwise #8863 owns bucket-count movement.
+current parser. Otherwise the deferred Linux corpus refresh owns bucket-count
+movement.
 
 Production delta
 
@@ -401,11 +402,12 @@ status, revert behavior first and leave fixture evidence for follow-up.
 
 ## Work item: linux-corpus-refresh
 
-Status: deferred on Windows; successor #8863
+Status: deferred on Windows; successor Linux corpus refresh
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked spec: [PLSP-SPEC-0004](../../docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md)
 Linked ADR: [PLSP-ADR-0001](../../docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
-Blocks: none for this closeout; successor #8863 owns future bucket-count claims
+Blocks: none for this closeout; successor Linux corpus refresh owns future
+bucket-count claims
 Blocked by: Linux system-Perl roots unavailable on this Windows host
 
 Goal
@@ -431,8 +433,9 @@ Deferral note
 
 The current Windows worktree does not have the Linux system roots named by the
 stale receipt (`/usr/share/perl`, `/usr/lib/x86_64-linux-gnu/perl`, and
-`/usr/share/perl5`). The refresh is deferred to successor issue #8863 and must
-run on a Linux host before any parser bucket-count movement is claimed.
+`/usr/share/perl5`). The refresh is deferred to a dedicated Linux corpus
+refresh lane and must run on a Linux host before any parser bucket-count
+movement is claimed.
 
 Proof commands
 
@@ -629,7 +632,8 @@ Completion audit
   the raw `unclosed_paren_identifier` bucket; fixture-only work remains active
   and must not claim bucket-count movement.
 - Linux corpus refresh: deferred on this Windows host because the Linux
-  system-Perl roots are unavailable; successor #8863 owns the fresh receipt.
+  system-Perl roots are unavailable; a dedicated Linux corpus refresh lane owns
+  the fresh receipt.
 - Provider confidence: `provider_confidence_matrix.md` maps provider source,
   confidence, freshness, fallback, runtime comparison, real-workspace links,
   live state, and next proof.


### PR DESCRIPTION
Problem: Parser planning docs still pointed to a specific stale corpus-refresh PR number even though the active goal requires standing worklists to avoid hard-coded old PR numbers.

Fix: Replace the old PR-number successor wording with a dedicated Linux corpus refresh lane and keep the unclosed_paren_identifier claim boundary tied to fresh receipt evidence.

Verification: `git diff --check` passes / `./scripts/cargo-safe xtask fmt --check` passes.

Accuracy-control deltas: denominator unchanged at 50 fixtures / 29 families / 139 scored lines / 117 scored symbols; failure packets unchanged at 0 active; provider rows unchanged; parser_accuracy ratchet floor unchanged.