### PR TITLE
docs(status): refresh trust dashboard next provider work (#8197)

### DIFF
--- a/docs/project/status/real_perl_editor_trust_v1.md
+++ b/docs/project/status/real_perl_editor_trust_v1.md
@@ -65,8 +65,13 @@ blocker when relevant.
 This dashboard keeps the next provider lane separate from parser capability,
 framework facts, PIR, formatter, critic, release, and security work.
 
-1. `docs(status): review refactor support tiers before any symbol-level safe-delete cutover`
-2. `feat(provider): add provider decision explanation model`
+1. `test(safe-delete): add explicit live blocker UX and rollback receipt`
+2. `test(rename): add package/compiler-backed fallback/noise receipt`
+3. `feat(provider): attach request-local provider decision receipts`
+
+Provider decision explanations are already partial-live through
+`perl.explainProviderDecision`; the next explanation step is request-local
+receipt attachment, not re-adding the model.
 
 Parser raw-bucket work, Linux corpus refresh, security alert classification,
 Rust 1.95 rollout, native formatter, native critic, PIR, and determinism remain


### PR DESCRIPTION
Problem: The Real Perl Editor Trust v1 dashboard still routed future work toward adding the provider decision explanation model even though the support map already records perl.explainProviderDecision as partial-live.

Fix: Refresh the near-term provider order to point at the next actual proof slices: safe-delete live blocker UX and rollback receipt, rename package/compiler-backed fallback/noise receipt, and request-local provider decision receipt attachment.

Claim boundary: Docs/status routing only. No provider behavior changes, no support-tier promotion, no generated status edits, and no live safe-delete or rename cutover.

Verification: cargo xtask check-support-claims; cargo xtask check-provider-confidence-matrix; git diff --check.