### PR TITLE
fix(safe-delete): allow preview command validation (#8197)

### DIFF
--- a/crates/perl-lsp-rs-core/src/runtime/input_validation/constants.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/input_validation/constants.rs
@@ -29,6 +29,7 @@ pub(crate) const ALLOWED_COMMANDS: &[&str] = &[
     "perl.extractVariable",
     "perl.extractSubroutine",
     "perl.optimizeImports",
+    "perl.previewSafeDelete",
 ];
 
 /// Suspicious patterns rejected in generic payloads.

--- a/crates/perl-lsp-rs-core/src/runtime/input_validation/mod.rs
+++ b/crates/perl-lsp-rs-core/src/runtime/input_validation/mod.rs
@@ -222,6 +222,21 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_execute_command_allows_preview_safe_delete() {
+        let method = "workspace/executeCommand";
+        let params = serde_json::json!({
+            "command": "perl.previewSafeDelete",
+            "arguments": [{
+                "textDocument": {"uri": "file:///workspace/lib/My.pm"},
+                "position": {"line": 0, "character": 0}
+            }]
+        });
+
+        let result = validate_lsp_request(method, &params);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_validate_execute_command_blocked() {
         let method = "workspace/executeCommand";
         let params = serde_json::json!({

--- a/crates/perl-lsp-rs-core/tests/runtime_validation_boundary.rs
+++ b/crates/perl-lsp-rs-core/tests/runtime_validation_boundary.rs
@@ -231,6 +231,7 @@ fn validate_lsp_request_execute_command_all_allowed_commands_pass() -> anyhow::R
         "perl.extractVariable",
         "perl.extractSubroutine",
         "perl.optimizeImports",
+        "perl.previewSafeDelete",
     ];
 
     for command in allowed {


### PR DESCRIPTION
Problem: `perl.previewSafeDelete` is advertised after #9002, but the core execute-command validation allowlist still rejects it.
Fix: Add `perl.previewSafeDelete` to the validation allowlist and cover the boundary in inline and integration validation tests.
Verification: `cargo test -p perl-lsp-rs-core test_validate_execute_command_allows_preview_safe_delete --profile agent --locked -- --nocapture`; `cargo test -p perl-lsp-rs-core --test runtime_validation_boundary validate_lsp_request_execute_command_all_allowed_commands_pass --profile agent --locked -- --nocapture`; `cargo run -p xtask --profile agent --locked -- fmt --check`; `git diff --check origin/master..HEAD`; `./scripts/storage-doctor`.