### PR TITLE
test(rename): add real-workspace package pilot receipt (#8197)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/refactor_runtime_blocker_receipts.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/refactor_runtime_blocker_receipts.rs
@@ -11,7 +11,9 @@ use crate::runtime::routing::{IndexAccessMode, route_index_access};
     not(target_arch = "wasm32"),
     any(test, feature = "expose_lsp_test_api")
 ))]
-use perl_lsp_rs_core::providers::navigation::rename_shadow::{RenameCutoverResult, rename_cutover};
+use perl_lsp_rs_core::providers::navigation::rename_shadow::{
+    RenameCutoverResult, RenamePackagePilotResult, rename_cutover, rename_package_pilot_proof,
+};
 #[cfg(all(feature = "workspace", not(target_arch = "wasm32")))]
 use perl_lsp_rs_core::providers::navigation::safe_delete_shadow::{
     SafeDeleteCutoverResult, safe_delete_cutover,
@@ -137,18 +139,22 @@ impl LspServer {
                                 byte_offset,
                                 &symbol,
                             )?;
-                            let outcome = rename_cutover(
+                            let outcome = rename_package_pilot_proof(
                                 live_provider_edit_count > 0,
                                 &queries,
                                 entity_id,
                                 new_name,
                             );
                             let (compiler_plan_edit_count, blockers) = match &outcome.result {
-                                RenameCutoverResult::Allowed { edits } => (edits.len(), Vec::new()),
-                                RenameCutoverResult::Blocked { blockers, edits } => {
-                                    (edits.len(), blockers.clone())
+                                RenamePackagePilotResult::Eligible { edits } => {
+                                    (edits.len(), Vec::new())
                                 }
+                                RenamePackagePilotResult::Ineligible {
+                                    edits, blockers, ..
+                                } => (edits.len(), blockers.clone()),
+                                _ => (0, Vec::new()),
                             };
+                            let package_pilot = rename_package_pilot_json(&outcome.result);
                             let mut receipt = outcome.receipt;
                             receipt.notes.push(format!(
                                 "rename runtime blocker UX: live_provider_edits={}; compiler_plan_edits={compiler_plan_edit_count}; blocker_count={}; blocker_reasons={}; blocker_ux={}; requires_confirmation={}; no live refactor behavior change",
@@ -158,17 +164,17 @@ impl LspServer {
                                 runtime_blocker_descriptions(&blockers),
                                 !blockers.is_empty()
                             ));
-                            Some((receipt, compiler_plan_edit_count, blockers))
+                            Some((receipt, compiler_plan_edit_count, blockers, package_pilot))
                         })
                         .flatten()
                 }
                 IndexAccessMode::Partial(_) | IndexAccessMode::None => None,
             };
-            let (compiler_receipt, compiler_plan_edit_count, compiler_blockers) =
+            let (compiler_receipt, compiler_plan_edit_count, compiler_blockers, package_pilot) =
                 compiler_receipt_parts.map_or(
-                    (None, None, None),
-                    |(receipt, edit_count, blockers)| {
-                        (Some(receipt), Some(edit_count), Some(blockers))
+                    (None, None, None, Value::Null),
+                    |(receipt, edit_count, blockers, package_pilot)| {
+                        (Some(receipt), Some(edit_count), Some(blockers), package_pilot)
                     },
                 );
 
@@ -180,6 +186,7 @@ impl LspServer {
                 "live_provider_error": live_provider_error,
                 "live_provider_edit_count": live_provider_edit_count,
                 "compiler_receipt": compiler_receipt,
+                "package_pilot": package_pilot,
                 "fallback_noise": rename_fallback_noise_json(
                     &symbol,
                     new_name,
@@ -752,6 +759,76 @@ fn enrich_safe_delete_decision_trace(
             "records safe-delete blocker proof only; no live symbol-level delete behavior changes"
         ),
     );
+}
+
+#[cfg(all(
+    feature = "workspace",
+    not(target_arch = "wasm32"),
+    any(test, feature = "expose_lsp_test_api")
+))]
+fn rename_package_pilot_json(result: &RenamePackagePilotResult) -> Value {
+    match result {
+        RenamePackagePilotResult::Eligible { edits } => json!({
+            "provider": "rename",
+            "eligible": true,
+            "reason": "none",
+            "edit_count": edits.len(),
+            "blocker_count": 0,
+            "edit_categories": edits
+                .iter()
+                .map(|edit| format!("{:?}", edit.category))
+                .collect::<Vec<_>>(),
+            "blocker_reasons": [],
+            "claim_boundary": "receipt-only package/compiler-backed pilot; no live package rename cutover",
+            "no_live_rename_cutover": true
+        }),
+        RenamePackagePilotResult::Ineligible { reason, edits, blockers } => json!({
+            "provider": "rename",
+            "eligible": false,
+            "reason": rename_package_pilot_ineligible_reason(*reason),
+            "edit_count": edits.len(),
+            "blocker_count": blockers.len(),
+            "edit_categories": edits
+                .iter()
+                .map(|edit| format!("{:?}", edit.category))
+                .collect::<Vec<_>>(),
+            "blocker_reasons": blockers
+                .iter()
+                .map(|blocker| format!("{:?}", blocker.reason))
+                .collect::<Vec<_>>(),
+            "claim_boundary": "receipt-only package/compiler-backed pilot; no live package rename cutover",
+            "no_live_rename_cutover": true
+        }),
+        _ => json!({
+            "provider": "rename",
+            "eligible": false,
+            "reason": "unknown",
+            "edit_count": 0,
+            "blocker_count": 0,
+            "edit_categories": [],
+            "blocker_reasons": [],
+            "claim_boundary": "receipt-only package/compiler-backed pilot; no live package rename cutover",
+            "no_live_rename_cutover": true
+        }),
+    }
+}
+
+#[cfg(all(
+    feature = "workspace",
+    not(target_arch = "wasm32"),
+    any(test, feature = "expose_lsp_test_api")
+))]
+fn rename_package_pilot_ineligible_reason(
+    reason: perl_lsp_rs_core::providers::navigation::rename_shadow::RenamePackagePilotIneligibleReason,
+) -> &'static str {
+    use perl_lsp_rs_core::providers::navigation::rename_shadow::RenamePackagePilotIneligibleReason;
+
+    match reason {
+        RenamePackagePilotIneligibleReason::EmptyPlan => "empty_plan",
+        RenamePackagePilotIneligibleReason::Blocked => "blocked",
+        RenamePackagePilotIneligibleReason::UnsupportedEditCategory => "unsupported_edit_category",
+        _ => "unknown",
+    }
 }
 
 #[cfg(all(

--- a/crates/perl-lsp-rs/src/runtime/language/refactor_runtime_blocker_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/refactor_runtime_blocker_tests.rs
@@ -556,6 +556,12 @@ fn refactor_runtime_blocker_ux_rename_receipt_records_package_fallback_noise()
     assert_eq!(receipt.get("symbol").and_then(Value::as_str), Some("helper"));
     assert_eq!(receipt.get("new_name").and_then(Value::as_str), Some("renamed_helper"));
     assert_eq!(receipt.get("no_live_behavior_change").and_then(Value::as_bool), Some(true));
+    let package_pilot = receipt.get("package_pilot").ok_or("missing package_pilot")?;
+    assert_eq!(package_pilot.get("provider").and_then(Value::as_str), Some("rename"));
+    assert_eq!(package_pilot.get("eligible").and_then(Value::as_bool), Some(false));
+    assert_eq!(package_pilot.get("reason").and_then(Value::as_str), Some("empty_plan"));
+    assert_eq!(package_pilot.get("edit_count").and_then(Value::as_u64), Some(0));
+    assert_eq!(package_pilot.get("no_live_rename_cutover").and_then(Value::as_bool), Some(true));
     assert_eq!(fallback_noise.get("provider").and_then(Value::as_str), Some("rename"));
     assert_eq!(fallback_noise.get("symbol").and_then(Value::as_str), Some("helper"));
     assert_eq!(fallback_noise.get("new_name").and_then(Value::as_str), Some("renamed_helper"));
@@ -606,6 +612,66 @@ fn refactor_runtime_blocker_ux_rename_receipt_records_package_fallback_noise()
             "rename runtime blocker UX",
             "compiler_plan_edits=",
             "blocker_count=0",
+            "requires_confirmation=false",
+            "no live refactor behavior change",
+        ],
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn refactor_runtime_blocker_ux_rename_receipt_records_real_workspace_package_pilot_boundary()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    let files = open_semantic_real_workspace(&server)?;
+    let base = files.get("lib/RealBaseline/Base.pm").ok_or("missing RealBaseline Base fixture")?;
+
+    let (shared_line, shared_character) = position_of(base, "shared {")?;
+    let shared_params = json!({
+        "textDocument": {"uri": REAL_BASELINE_BASE_URI},
+        "position": {"line": shared_line, "character": shared_character},
+        "newName": "renamed_shared"
+    });
+    let receipt = server
+        .test_rename_runtime_blocker_ux_receipt(Some(shared_params))?
+        .ok_or("missing real-workspace package pilot rename receipt")?;
+    let compiler = compiler_receipt(&receipt)?;
+    let package_pilot = receipt.get("package_pilot").ok_or("missing package_pilot")?;
+    let fallback_noise = receipt.get("fallback_noise").ok_or("missing fallback_noise")?;
+
+    assert_eq!(receipt.get("provider").and_then(Value::as_str), Some("rename"));
+    assert_eq!(receipt.get("symbol").and_then(Value::as_str), Some("shared"));
+    assert_eq!(receipt.get("new_name").and_then(Value::as_str), Some("renamed_shared"));
+    assert_eq!(receipt.get("no_live_behavior_change").and_then(Value::as_bool), Some(true));
+    assert_eq!(package_pilot.get("provider").and_then(Value::as_str), Some("rename"));
+    assert_eq!(
+        package_pilot.get("eligible").and_then(Value::as_bool),
+        Some(false),
+        "unexpected package pilot classification: {package_pilot}"
+    );
+    assert_eq!(package_pilot.get("reason").and_then(Value::as_str), Some("empty_plan"));
+    assert_eq!(package_pilot.get("edit_count").and_then(Value::as_u64), Some(0));
+    assert_eq!(package_pilot.get("blocker_count").and_then(Value::as_u64), Some(0));
+    assert_eq!(package_pilot.get("no_live_rename_cutover").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        fallback_noise.get("fallback_state").and_then(Value::as_str),
+        Some("compiler_empty")
+    );
+    assert_eq!(
+        fallback_noise.get("compiler_requires_confirmation").and_then(Value::as_bool),
+        Some(false)
+    );
+    assert_trace_contains(compiler, "Fallback", "Low", "NotApplicable")?;
+    assert_note_contains(
+        compiler,
+        &[
+            "rename package pilot proof",
+            "eligible=false",
+            "reason=empty_plan",
+            "claim_boundary=receipt-only package/compiler-backed pilot",
+            "no_live_rename_cutover=true",
+            "rename runtime blocker UX",
             "requires_confirmation=false",
             "no live refactor behavior change",
         ],


### PR DESCRIPTION
Problem: Package/compiler-backed rename pilot traces did not expose the scoped pilot classification in runtime receipts for real-workspace requests.
Fix: Route runtime rename blocker receipts through the package pilot proof, add a `package_pilot` receipt section, and cover the real-workspace empty-plan boundary without enabling package rename edits.
Verification: `cargo test -p perl-lsp-rs --lib refactor_runtime_blocker --profile agent --locked -- --nocapture --test-threads=1`; `cargo run -p xtask --profile agent --locked -- fmt --check`; `cargo clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs`; `git diff --check`; `./scripts/storage-doctor`