### PR TITLE
fix(dead-code): don't flag for/foreach as dead branches (#9009)

### DIFF
--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -266,7 +266,7 @@ fn is_keyword_boundary(ch: Option<char>) -> bool {
 /// Returns `true` if `condition` is a trivially-false constant expression.
 ///
 /// Matches: `0`, `""`, `''`, `undef`, `(0)`, `( 0 )` — the standard Perl idioms
-/// used to write permanently-dead `if`/`while`/`for` blocks.
+/// used to write permanently-dead `if`/`while` blocks.
 fn is_always_false(condition: &str) -> bool {
     let c = condition.trim();
     matches!(c, "0" | "\"\"" | "''" | "undef")
@@ -321,7 +321,7 @@ fn detect_dead_branches(file_path: &Path, text: &str, out: &mut Vec<DeadCode>) {
         // Determine if this line opens a dead branch.
         // We look for: KEYWORD WHITESPACE? ( CONDITION ) WHITESPACE? {
         let dead_reason_and_keyword: Option<(String, &str)> = 'detect: {
-            for kw in &["if", "while", "elsif", "unless", "until", "for", "foreach"] {
+            for kw in &["if", "while", "elsif", "unless", "until"] {
                 let rest = match trimmed.strip_prefix(kw) {
                     Some(r)
                         if r.is_empty()
@@ -357,7 +357,7 @@ fn detect_dead_branches(file_path: &Path, text: &str, out: &mut Vec<DeadCode>) {
                         None
                     }
                 } else {
-                    // if/while/for/foreach: body is dead when condition is always-false
+                    // if/while/elsif: body is dead when condition is always-false
                     if is_always_false(inner) {
                         Some(format!(
                             "`{kw}` condition `{inner}` is always false — block is never executed"

--- a/crates/perl-parser/tests/dead_code_detector.rs
+++ b/crates/perl-parser/tests/dead_code_detector.rs
@@ -106,3 +106,90 @@ fn unconditional_return_still_flags_following_statement() -> TestResult {
     );
     Ok(())
 }
+
+#[test]
+fn for_loop_with_zero_is_not_dead_branch() -> TestResult {
+    // `for (0) {}` iterates once with $_ = 0 — NOT dead code.
+    // List iterators are not boolean conditions.
+    let index = WorkspaceIndex::new();
+    index_file_str(
+        &index,
+        "file:///script.pl",
+        "for (0) {\n    say 'runs once';\n}\n",
+    )?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead
+            .iter()
+            .any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "for (0) should not be flagged as a dead branch — it iterates once over the list (0)"
+    );
+    Ok(())
+}
+
+#[test]
+fn foreach_loop_with_zero_is_not_dead_branch() -> TestResult {
+    // `foreach (0) {}` iterates once with $_ = 0 — NOT dead code.
+    let index = WorkspaceIndex::new();
+    index_file_str(
+        &index,
+        "file:///script.pl",
+        "foreach (0) {\n    say 'runs once';\n}\n",
+    )?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead
+            .iter()
+            .any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "foreach (0) should not be flagged as a dead branch — it iterates once over the list (0)"
+    );
+    Ok(())
+}
+
+#[test]
+fn if_zero_is_still_a_dead_branch() -> TestResult {
+    // Regression guard: `if (0) {}` IS dead — boolean false, body never executes.
+    let index = WorkspaceIndex::new();
+    index_file_str(
+        &index,
+        "file:///script.pl",
+        "if (0) {\n    say 'dead';\n}\n",
+    )?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        dead.iter()
+            .any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "if (0) should still be flagged as a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn while_zero_is_still_a_dead_branch() -> TestResult {
+    // Regression guard: `while (0) {}` IS dead — boolean false, body never executes.
+    let index = WorkspaceIndex::new();
+    index_file_str(
+        &index,
+        "file:///script.pl",
+        "while (0) {\n    say 'dead';\n}\n",
+    )?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        dead.iter()
+            .any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "while (0) should still be flagged as a dead branch"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #9009 — `for (0) {}` and `foreach (0) {}` were incorrectly flagged as dead branches by `detect_dead_branches` in `perl-parser`.

## Root cause

`detect_dead_branches` applied the always-false heuristic to `for` and `foreach` using the same logic as `if` and `while`. But `for`/`foreach` are **list iterators**, not boolean-condition evaluators:

- `if (0) {}` — `0` is `false` in boolean context → body never executes ✓ correctly dead
- `while (0) {}` — `0` is `false` in boolean context → body never executes ✓ correctly dead
- `for (0) {}` — iterates once with `$_ = 0` ✗ false positive (body runs once)
- `foreach (0) {}` — iterates once with `$_ = 0` ✗ false positive (body runs once)

`(0)` in list context is a one-element list, so both loop bodies execute exactly once.

## Fix

Remove `"for"` and `"foreach"` from the keyword array in `detect_dead_branches` (line 324 of `dead_code/mod.rs`). Only boolean-context keywords (`if`, `while`, `elsif`, `unless`, `until`) belong there.

Also update two comments that incorrectly described `for`/`foreach` as valid dead-branch targets.

## Changes

- **`crates/perl-parser/src/dead_code/mod.rs`** — 3-line fix:
  - Remove `"for"` and `"foreach"` from the `kw` keyword list
  - Update `// if/while/for/foreach:` comment → `// if/while/elsif:`
  - Update `is_always_false` docstring to remove mention of `for` blocks

- **`crates/perl-parser/tests/dead_code_detector.rs`** — 4 new tests:
  - `for_loop_with_zero_is_not_dead_branch` — `for (0) {}` must not be flagged
  - `foreach_loop_with_zero_is_not_dead_branch` — `foreach (0) {}` must not be flagged
  - `if_zero_is_still_a_dead_branch` — regression guard: `if (0) {}` still flagged
  - `while_zero_is_still_a_dead_branch` — regression guard: `while (0) {}` still flagged

## Test plan

- [x] `cargo test -p perl-parser --test dead_code_detector` — 9/9 pass (5 pre-existing + 4 new)
- [x] `cargo clippy -p perl-parser --tests` — no new warnings
- [x] No changes to production code outside `dead_code/mod.rs`
- [x] No changes to other crates

## Verification

```
running 9 tests
test foreach_loop_with_zero_is_not_dead_branch ... ok
test if_zero_is_still_a_dead_branch ... ok
test for_loop_with_zero_is_not_dead_branch ... ok
test postfix_conditional_return_is_not_unconditional_terminator ... ok
test return_at_end_of_sub_does_not_flag_closing_brace ... ok
test detects_dead_code ... ok
test return_prefix_inside_identifier_is_not_a_terminator ... ok
test unconditional_return_still_flags_following_statement ... ok
test while_zero_is_still_a_dead_branch ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

https://claude.ai/code/session_01LdCzJjFL2rMRtzxLxYKjkK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdCzJjFL2rMRtzxLxYKjkK)_