### PR TITLE
docs(parser): refresh list boundary receipts (#8197)

### DIFF
--- a/docs/project/status/parser_unclosed_paren_identifier_shapes.md
+++ b/docs/project/status/parser_unclosed_paren_identifier_shapes.md
@@ -172,12 +172,14 @@ Linux raw-bucket movement proof.
 ## AST Boundary Receipts
 
 `crates/perl-parser-core/tests/list_operator_boundary_receipts.rs` now asserts
-AST ownership for three representative list-operator shapes:
+AST ownership for four representative list-operator shapes:
 
 - DBI map/grep/keys: the outer `map` owns the `grep` source, and the nested
   `grep` owns the `keys` source.
 - ExtUtils attrs map/sort/keys: the outer `join` owns the `map` result, the
   `map` owns the `sort` source, and `sort` owns the `keys` source.
+- Capture::Tiny map/qw list declaration: the list declaration owns the `map`
+  initializer, and the `map` owns its block body plus the `qw` source list.
 - Unicode::Collate map/split: the outer `join` owns the `map` result, and the
   `map` owns the `split` source.
 


### PR DESCRIPTION
Problem: The unclosed_paren_identifier handoff still described three list-operator AST receipts after #9007 added the Capture::Tiny map/qw list-declaration receipt.\nFix: Update the handoff note to say four receipts and list the new Capture::Tiny ownership proof without claiming raw bucket-count movement.\nVerification: \cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture\; \cargo run -p xtask --profile agent --locked -- metrics parser-accuracy --check\; \cargo run -p xtask --profile agent --locked -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt\; \cargo run -p xtask --profile agent --locked -- update-status --only parser --check\; \cargo run -p xtask --profile agent --locked -- metrics ratchet-check parser_accuracy\; \cargo run -p xtask --profile agent --locked -- fmt --check\; \git diff --check\.