### PR TITLE
feat(vscode): expose provider explanation commands (#8197)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -774,6 +774,24 @@
         "icon": "$(gear)"
       },
       {
+        "command": "perl-lsp.explainProviderDecision",
+        "title": "Explain Provider Decision",
+        "category": "Perl LSP",
+        "icon": "$(debug)"
+      },
+      {
+        "command": "perl-lsp.previewSafeDelete",
+        "title": "Preview Safe Delete",
+        "category": "Perl LSP",
+        "icon": "$(shield)"
+      },
+      {
+        "command": "perl-lsp.copyProviderDecisionReceipt",
+        "title": "Copy Provider Decision Receipt",
+        "category": "Perl LSP",
+        "icon": "$(copy)"
+      },
+      {
         "command": "perl-lsp.reportIssue",
         "title": "Report Issue",
         "category": "Perl",
@@ -873,6 +891,18 @@
         },
         {
           "command": "perl-lsp.openConfigurationGuide"
+        },
+        {
+          "command": "perl-lsp.explainProviderDecision",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.previewSafeDelete",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.copyProviderDecisionReceipt",
+          "when": "editorLangId == perl"
         },
         {
           "command": "perl-lsp.reportIssue"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -308,6 +308,194 @@ export async function setPerlCriticSeverity(
     vscode.window.showInformationMessage(`PerlCritic severity set to ${severity}.`);
 }
 
+type LspExecuteCommandClient = {
+    sendRequest<T>(method: string, params: unknown): Promise<T>;
+};
+
+type ProviderDecisionQuickPickItem = vscode.QuickPickItem & {
+    provider: string;
+};
+
+const PROVIDER_DECISION_OPTIONS: ProviderDecisionQuickPickItem[] = [
+    { label: 'Completion', provider: 'completion' },
+    { label: 'Goto definition', provider: 'goto_definition' },
+    { label: 'References', provider: 'references' },
+    { label: 'Hover', provider: 'hover' },
+    { label: 'Diagnostics', provider: 'diagnostics' },
+    { label: 'Rename', provider: 'rename' },
+    { label: 'Safe delete', provider: 'safe_delete' },
+    { label: 'Workspace symbols', provider: 'workspace_symbols' },
+    { label: 'Document symbols', provider: 'document_symbols' },
+    { label: 'Semantic tokens', provider: 'semantic_tokens' },
+    { label: 'Module resolution', provider: 'module_resolution' },
+    { label: 'DAP module paths', provider: 'dap_module_paths' },
+    { label: 'Perl subprocess', provider: 'perl_subprocess' },
+];
+
+function activeRequestPosition(): Record<string, unknown> | undefined {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        return undefined;
+    }
+
+    return {
+        uri_scheme: editor.document.uri.toString().split(':', 1)[0] || 'file',
+        line: editor.selection.active.line,
+        character: editor.selection.active.character,
+    };
+}
+
+function providerDecisionArgument(provider: string): Record<string, unknown> {
+    const argument: Record<string, unknown> = { provider };
+    const requestPosition = activeRequestPosition();
+    if (requestPosition) {
+        argument.request_position = requestPosition;
+    }
+    return argument;
+}
+
+function activeSafeDeletePreviewArgument(): Record<string, unknown> | undefined {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'perl') {
+        return undefined;
+    }
+
+    return {
+        textDocument: { uri: editor.document.uri.toString() },
+        position: {
+            line: editor.selection.active.line,
+            character: editor.selection.active.character,
+        },
+    };
+}
+
+function trustOutputChannel(): vscode.OutputChannel {
+    return outputChannel ?? vscode.window.createOutputChannel('Perl LSP Trust');
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : undefined;
+}
+
+function stringField(value: Record<string, unknown> | undefined, field: string): string | undefined {
+    const fieldValue = value?.[field];
+    return typeof fieldValue === 'string' ? fieldValue : undefined;
+}
+
+function providerDecisionJson(value: unknown): string {
+    return JSON.stringify(value, null, 2);
+}
+
+async function executeLspCommand(
+    activeClient: LspExecuteCommandClient | undefined,
+    command: string,
+    argument: Record<string, unknown>
+): Promise<unknown | undefined> {
+    if (!activeClient) {
+        vscode.window.showWarningMessage(serverNotRunningMessage());
+        return undefined;
+    }
+
+    try {
+        return await activeClient.sendRequest('workspace/executeCommand', {
+            command,
+            arguments: [argument],
+        });
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`Perl LSP command failed: ${message}`);
+        return undefined;
+    }
+}
+
+async function chooseProvider(providerOverride?: string): Promise<string | undefined> {
+    if (providerOverride) {
+        return providerOverride;
+    }
+
+    const selection = await vscode.window.showQuickPick(PROVIDER_DECISION_OPTIONS, {
+        placeHolder: 'Choose a provider decision to explain',
+    });
+    return selection?.provider;
+}
+
+async function showProviderDecisionResult(title: string, result: unknown): Promise<void> {
+    const resultObject = asObject(result);
+    const message = stringField(resultObject, 'user_message') ?? `${title} completed.`;
+    const channel = trustOutputChannel();
+    channel.appendLine('');
+    channel.appendLine(`[${title}]`);
+    channel.appendLine(providerDecisionJson(result));
+
+    const action = stringField(resultObject, 'decision') === 'blocked'
+        ? await vscode.window.showWarningMessage(message, 'Show Output')
+        : await vscode.window.showInformationMessage(message, 'Show Output');
+
+    if (action === 'Show Output') {
+        channel.show();
+    }
+}
+
+export async function explainProviderDecisionCommand(
+    activeClient: LspExecuteCommandClient | undefined = client,
+    providerOverride?: string
+): Promise<void> {
+    const provider = await chooseProvider(providerOverride);
+    if (!provider) {
+        return;
+    }
+
+    const result = await executeLspCommand(
+        activeClient,
+        'perl.explainProviderDecision',
+        providerDecisionArgument(provider)
+    );
+    if (result !== undefined) {
+        await showProviderDecisionResult('Provider decision explanation', result);
+    }
+}
+
+export async function previewSafeDeleteCommand(
+    activeClient: LspExecuteCommandClient | undefined = client
+): Promise<void> {
+    const argument = activeSafeDeletePreviewArgument();
+    if (!argument) {
+        vscode.window.showErrorMessage('Preview Safe Delete requires an active Perl file.');
+        return;
+    }
+
+    const result = await executeLspCommand(activeClient, 'perl.previewSafeDelete', argument);
+    if (result !== undefined) {
+        await showProviderDecisionResult('Safe-delete preview', result);
+    }
+}
+
+export async function copyProviderDecisionReceiptCommand(
+    activeClient: LspExecuteCommandClient | undefined = client,
+    providerOverride?: string
+): Promise<void> {
+    const provider = await chooseProvider(providerOverride);
+    if (!provider) {
+        return;
+    }
+
+    const result = await executeLspCommand(
+        activeClient,
+        'perl.explainProviderDecision',
+        providerDecisionArgument(provider)
+    );
+    const resultObject = asObject(result);
+    if (!resultObject) {
+        return;
+    }
+
+    const payload = resultObject.copyable_payload ?? resultObject;
+    await vscode.env.clipboard.writeText(providerDecisionJson(payload));
+    vscode.window.showInformationMessage('Provider decision receipt copied.');
+}
+
 export async function activate(context: vscode.ExtensionContext) {
     outputChannel = vscode.window.createOutputChannel('Perl Language Server');
     const mcpDisposable = registerMcpSupport(outputChannel);
@@ -602,6 +790,27 @@ export async function activate(context: vscode.ExtensionContext) {
     const showParserAstCommand = vscode.commands.registerCommand('perl-lsp.showParserAst', async () => {
         await showParserAst();
     });
+
+    const explainProviderDecisionCommandDisposable = vscode.commands.registerCommand(
+        'perl-lsp.explainProviderDecision',
+        async (provider?: unknown) => {
+            await explainProviderDecisionCommand(client, typeof provider === 'string' ? provider : undefined);
+        }
+    );
+
+    const previewSafeDeleteCommandDisposable = vscode.commands.registerCommand(
+        'perl-lsp.previewSafeDelete',
+        async () => {
+            await previewSafeDeleteCommand(client);
+        }
+    );
+
+    const copyProviderDecisionReceiptCommandDisposable = vscode.commands.registerCommand(
+        'perl-lsp.copyProviderDecisionReceipt',
+        async (provider?: unknown) => {
+            await copyProviderDecisionReceiptCommand(client, typeof provider === 'string' ? provider : undefined);
+        }
+    );
 
     const whatsNewManager = new WhatsNewManager(context, outputChannel);
     const showWhatsNewCommand = vscode.commands.registerCommand('perl-lsp.showWhatsNew', async () => {
@@ -908,6 +1117,9 @@ export async function activate(context: vscode.ExtensionContext) {
         showIncPathsCommand,
         openModuleCommand,
         showParserAstCommand,
+        explainProviderDecisionCommandDisposable,
+        previewSafeDeleteCommandDisposable,
+        copyProviderDecisionReceiptCommandDisposable,
         showVersionCommand,
         statusMenuCommand,
         reinstallCommand,

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -354,6 +354,43 @@ describe('perl-lsp.createDebugConfig command', () => {
 });
 
 // ---------------------------------------------------------------------------
+// trust explanation commands
+// ---------------------------------------------------------------------------
+describe('perl-lsp trust explanation commands', () => {
+  let pkg: any;
+  let commandIds: string[];
+  let paletteEntries: any[];
+
+  beforeAll(() => {
+    pkg = readPackageJson();
+    commandIds = pkg.contributes.commands.map((c: any) => c.command);
+    paletteEntries = pkg.contributes.menus.commandPalette;
+  });
+
+  test.each([
+    ['perl-lsp.explainProviderDecision', 'Explain Provider Decision'],
+    ['perl-lsp.previewSafeDelete', 'Preview Safe Delete'],
+    ['perl-lsp.copyProviderDecisionReceipt', 'Copy Provider Decision Receipt'],
+  ])('%s is declared as a Perl LSP command', (id, title) => {
+    const cmd = pkg.contributes.commands.find((c: any) => c.command === id);
+    expect(commandIds).toContain(id);
+    expect(cmd).toBeDefined();
+    expect(cmd.title).toBe(title);
+    expect(cmd.category).toBe('Perl LSP');
+  });
+
+  test.each([
+    'perl-lsp.explainProviderDecision',
+    'perl-lsp.previewSafeDelete',
+    'perl-lsp.copyProviderDecisionReceipt',
+  ])('%s is available from the Perl command palette', (id) => {
+    const entry = paletteEntries.find((e: any) => e.command === id);
+    expect(entry).toBeDefined();
+    expect(entry.when).toContain('editorLangId == perl');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // No duplicate activation events
 // ---------------------------------------------------------------------------
 describe('package.json activationEvents', () => {

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -18,6 +18,9 @@ jest.mock('vscode-languageclient/node', () => ({
   },
 }));
 import {
+  copyProviderDecisionReceiptCommand,
+  explainProviderDecisionCommand,
+  previewSafeDeleteCommand,
   validateIncludePaths,
   runPerlCriticOnActiveFile,
   setPerlCriticSeverity,
@@ -44,6 +47,7 @@ function makeContext(version = '0.12.3'): any {
 describe('extension UX warnings', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    (vscode.window as any).activeTextEditor = undefined;
     (vscode.workspace as any).workspaceFolders = undefined;
     (vscode.extensions as any).all = [];
     (vscode.workspace.getConfiguration as jest.Mock).mockImplementation(
@@ -497,5 +501,116 @@ describe('extension UX warnings', () => {
       })
     );
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('PerlCritic severity set to 4.');
+  });
+
+  test('explains a provider decision through the LSP execute command', async () => {
+    const sendRequest = jest.fn(async () => ({
+      provider: 'goto_definition',
+      decision: 'fallback',
+      user_message: 'Goto definition used fallback.',
+    }));
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        languageId: 'perl',
+        uri: vscode.Uri.file('/workspace/lib/Foo.pm'),
+      },
+      selection: {
+        active: { line: 12, character: 4 },
+      },
+    };
+
+    await explainProviderDecisionCommand({ sendRequest } as any, 'goto_definition');
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'workspace/executeCommand',
+      {
+        command: 'perl.explainProviderDecision',
+        arguments: [
+          {
+            provider: 'goto_definition',
+            request_position: {
+              uri_scheme: 'file',
+              line: 12,
+              character: 4,
+            },
+          },
+        ],
+      }
+    );
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Goto definition used fallback.',
+      'Show Output'
+    );
+  });
+
+  test('previews safe-delete through the no-edit LSP command', async () => {
+    const sendRequest = jest.fn(async () => ({
+      provider: 'safe_delete',
+      decision: 'blocked',
+      user_message: 'Safe delete refused. No edits were applied.',
+    }));
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        languageId: 'perl',
+        uri: vscode.Uri.file('/workspace/lib/Foo.pm'),
+      },
+      selection: {
+        active: { line: 8, character: 2 },
+      },
+    };
+
+    await previewSafeDeleteCommand({ sendRequest } as any);
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'workspace/executeCommand',
+      {
+        command: 'perl.previewSafeDelete',
+        arguments: [
+          {
+            textDocument: { uri: 'file:///workspace/lib/Foo.pm' },
+            position: { line: 8, character: 2 },
+          },
+        ],
+      }
+    );
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      'Safe delete refused. No edits were applied.',
+      'Show Output'
+    );
+  });
+
+  test('copies the provider decision bug-report payload', async () => {
+    const sendRequest = jest.fn(async () => ({
+      provider: 'safe_delete',
+      decision: 'blocked',
+      copyable_payload: {
+        schema_version: 'provider_decision_bug_report.v1',
+        provider: 'safe_delete',
+        decision: 'blocked',
+      },
+    }));
+
+    await copyProviderDecisionReceiptCommand({ sendRequest } as any, 'safe_delete');
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'workspace/executeCommand',
+      expect.objectContaining({
+        command: 'perl.explainProviderDecision',
+        arguments: [
+          expect.objectContaining({
+            provider: 'safe_delete',
+          }),
+        ],
+      })
+    );
+    const clipboardText = (vscode.env.clipboard.writeText as jest.Mock).mock.calls[0][0] as string;
+    expect(JSON.parse(clipboardText)).toEqual({
+      schema_version: 'provider_decision_bug_report.v1',
+      provider: 'safe_delete',
+      decision: 'blocked',
+    });
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Provider decision receipt copied.'
+    );
   });
 });


### PR DESCRIPTION
Problem: Provider decision explanations and safe-delete previews exist in the server, but VS Code users cannot invoke them from the command palette.

Fix: Add three VS Code commands for explaining provider decisions, previewing safe delete, and copying provider decision receipts. The commands call the existing LSP execute-command surfaces and show/copy existing user-readable receipt data.

Claim boundary: Command exposure only. No provider promotion, no live safe-delete symbol deletion, no parser/status edits, and no support-tier promotion.

Verification:
- 
pm --prefix vscode-extension run compile
- 
pm --prefix vscode-extension test -- --runTestsByPath src/test/commands.test.ts src/test/extensionUx.test.ts
- 
pm --prefix vscode-extension run lint
- git diff --check

Known gap: Full 
pm --prefix vscode-extension test still has pre-existing unrelated failures in Gherkin step-definition/provider tests and activation-event expectations.