### PR TITLE
fix(dead-code): exclude for/foreach from dead-branch detection in perl-dead-code (#9009)

### DIFF
--- a/crates/perl-dead-code/src/dead_branches.rs
+++ b/crates/perl-dead-code/src/dead_branches.rs
@@ -10,7 +10,11 @@ pub(crate) fn detect_dead_branches(file_path: &Path, text: &str, out: &mut Vec<D
         let trimmed = lines[i].trim();
 
         let dead_reason_and_keyword: Option<(String, &str)> = 'detect: {
-            for kw in &["if", "while", "elsif", "unless", "until", "for", "foreach"] {
+            // NOTE: `for` and `foreach` are list iterators, not boolean condition checkers.
+            // `for (0)` iterates once with $_ = 0 — it is NOT dead code even though 0 is
+            // always-false in a boolean context.  Only if/while/elsif/unless/until use the
+            // condition as a boolean gate where is_always_false / is_always_true applies.
+            for kw in &["if", "while", "elsif", "unless", "until"] {
                 let rest = match trimmed.strip_prefix(kw) {
                     Some(r)
                         if r.is_empty()

--- a/crates/perl-dead-code/tests/dead_code_behavior_tests.rs
+++ b/crates/perl-dead-code/tests/dead_code_behavior_tests.rs
@@ -128,3 +128,192 @@ fn scenario_workspace_analysis_aggregates_unreachable_and_dead_branch() -> Resul
     assert!(analysis.dead_code.iter().any(|item| item.code_type == DeadCodeType::DeadBranch));
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// for / foreach — list iterator false-positive regression suite (#9009)
+//
+// `for` and `foreach` are list iterators, not boolean condition checkers.
+// `for (0)` runs the body once with $_ = 0.  It is NEVER dead code, even
+// though `0` is falsy in boolean context.  The dead-branch detector must
+// not conflate list-iterator semantics with boolean condition semantics.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scenario_for_loop_with_constant_zero_is_not_dead_branch() -> Result<(), String> {
+    // Given: `for (0)` iterates once with $_ = 0 — this is live code
+    let detector = detector_with_single_file(
+        "file:///for_zero.pl",
+        "for (0) {\n    say 'runs once, $_ is 0';\n}\n",
+    )?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/for_zero.pl")?;
+
+    // Then no dead-branch diagnostic is emitted
+    assert!(
+        !dead.iter().any(|item| item.code_type == DeadCodeType::DeadBranch),
+        "for (0) iterates once — must not be reported as a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn scenario_foreach_loop_with_constant_zero_is_not_dead_branch() -> Result<(), String> {
+    // Given: `foreach (0)` iterates once with $_ = 0 — this is live code
+    let detector = detector_with_single_file(
+        "file:///foreach_zero.pl",
+        "foreach (0) {\n    say 'runs once, $_ is 0';\n}\n",
+    )?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/foreach_zero.pl")?;
+
+    // Then no dead-branch diagnostic is emitted
+    assert!(
+        !dead.iter().any(|item| item.code_type == DeadCodeType::DeadBranch),
+        "foreach (0) iterates once — must not be reported as a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn scenario_for_loop_with_empty_string_is_not_dead_branch() -> Result<(), String> {
+    // Given: `for ("")` iterates once with $_ = "" — still live code
+    let detector = detector_with_single_file(
+        "file:///for_empty_str.pl",
+        "for (\"\") {\n    say \"runs once, \\$_ is empty string\";\n}\n",
+    )?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/for_empty_str.pl")?;
+
+    // Then no dead-branch diagnostic is emitted
+    assert!(
+        !dead.iter().any(|item| item.code_type == DeadCodeType::DeadBranch),
+        "for (\"\") iterates once — must not be reported as a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn scenario_for_loop_with_undef_is_not_dead_branch() -> Result<(), String> {
+    // Given: `for (undef)` iterates once with $_ = undef — still live code
+    let detector = detector_with_single_file(
+        "file:///for_undef.pl",
+        "for (undef) {\n    say 'runs once, $_ is undef';\n}\n",
+    )?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/for_undef.pl")?;
+
+    // Then no dead-branch diagnostic is emitted
+    assert!(
+        !dead.iter().any(|item| item.code_type == DeadCodeType::DeadBranch),
+        "for (undef) iterates once with $_ = undef — must not be a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn scenario_for_loop_with_multi_element_list_is_not_dead_branch() -> Result<(), String> {
+    // Given: `for (1, 2, 3)` iterates three times — definitely live
+    let detector =
+        detector_with_single_file("file:///for_list.pl", "for (1, 2, 3) {\n    say $_ ;\n}\n")?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/for_list.pl")?;
+
+    // Then no dead-branch diagnostic is emitted
+    assert!(
+        !dead.iter().any(|item| item.code_type == DeadCodeType::DeadBranch),
+        "for (1, 2, 3) iterates — must not be a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn scenario_for_loop_mixed_with_dead_if_in_same_file() -> Result<(), String> {
+    // Given: a file with a live `for (0)` loop AND a genuinely dead `if (0)` branch
+    let detector = detector_with_single_file(
+        "file:///mixed.pl",
+        "for (0) {\n    say 'live';\n}\nif (0) {\n    say 'dead';\n}\n",
+    )?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/mixed.pl")?;
+
+    // Then exactly one dead-branch is reported (the `if (0)`, not the `for (0)`)
+    let dead_branches: Vec<_> =
+        dead.iter().filter(|item| item.code_type == DeadCodeType::DeadBranch).collect();
+    assert_eq!(
+        dead_branches.len(),
+        1,
+        "only the `if (0)` block should be flagged; got {dead_branches:?}"
+    );
+    assert!(
+        dead_branches[0].reason.contains("if"),
+        "the dead branch should be the `if` block, not the `for` loop"
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Regression guards — existing detections must still fire after the fix
+// ---------------------------------------------------------------------------
+
+#[test]
+fn regression_while_zero_loop_is_still_dead() -> Result<(), String> {
+    // Given: `while (0)` — loop body is never executed (0 is always false)
+    let detector =
+        detector_with_single_file("file:///while_zero.pl", "while (0) {\n    say 'never';\n}\n")?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/while_zero.pl")?;
+
+    // Then the loop is flagged as a dead branch
+    assert!(
+        dead.iter().any(|item| item.code_type == DeadCodeType::DeadBranch
+            && item.reason.contains("always false")),
+        "while (0) must still be flagged as a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn regression_if_zero_branch_is_still_dead() -> Result<(), String> {
+    // Given: `if (0)` — body never executes
+    let detector = detector_with_single_file(
+        "file:///if_zero_regression.pl",
+        "if (0) {\n    say 'never';\n}\n",
+    )?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/if_zero_regression.pl")?;
+
+    // Then the if-block is flagged
+    assert!(
+        dead.iter().any(|item| item.code_type == DeadCodeType::DeadBranch),
+        "if (0) must still be flagged as a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn regression_unless_one_branch_is_still_dead() -> Result<(), String> {
+    // Given: `unless (1)` — body never executes
+    let detector = detector_with_single_file(
+        "file:///unless_one_regression.pl",
+        "unless (1) {\n    say 'never';\n}\n",
+    )?;
+
+    // When dead-code analysis runs
+    let dead = detect_for_path(&detector, "/unless_one_regression.pl")?;
+
+    // Then the block is flagged as dead
+    assert!(
+        dead.iter().any(|item| item.code_type == DeadCodeType::DeadBranch
+            && item.reason.contains("always true")),
+        "unless (1) must still be flagged as a dead branch"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9009 in `perl-dead-code` — the same false-positive bug that was fixed in `perl-parser/src/dead_code/mod.rs` (commit `1094f65`) was still present in the sibling `perl-dead-code` crate.

## Root cause

`perl-dead-code/src/dead_branches.rs` had `"for"` and `"foreach"` in its dead-branch keyword list alongside `"if"` and `"while"`. This caused:

```perl
for (0) { say 'runs once'; }     # incorrectly flagged as DeadBranch
foreach (0) { say 'runs once'; } # incorrectly flagged as DeadBranch
```

`for` and `foreach` are **list iterators**, not boolean condition checkers. `for (0)` executes the body once with `$_ = 0`. Even though `0` is falsy in boolean context, it is a valid single-element list. The body is reached — it is not dead code.

By contrast, `if (0)` and `while (0)` treat the condition as a boolean gate: the body is genuinely unreachable. Only `if`, `while`, `elsif`, `unless`, and `until` apply boolean semantics to their condition expressions.

## Changes

### `crates/perl-dead-code/src/dead_branches.rs`

One-line fix: remove `"for"` and `"foreach"` from the detection keyword slice, matching the fix already applied to `perl-parser/src/dead_code/mod.rs`.

```diff
-for kw in &["if", "while", "elsif", "unless", "until", "for", "foreach"] {
+// NOTE: for/foreach are list iterators, not boolean condition checkers.
+// for (0) iterates once with $_ = 0 — NOT dead even though 0 is falsy.
+for kw in &["if", "while", "elsif", "unless", "until"] {
```

### `crates/perl-dead-code/tests/dead_code_behavior_tests.rs`

9 new BDD scenarios (Given/When/Then structure) in two groups:

**False-positive guards (6 scenarios)** — assert that list-iterator forms are never flagged:
- `for (0)` is NOT a dead branch
- `foreach (0)` is NOT a dead branch
- `for ("")` is NOT a dead branch (another would-have-been false positive)
- `for (undef)` is NOT a dead branch
- `for (1, 2, 3)` is NOT a dead branch
- Mixed file: `for (0)` + `if (0)` in the same file — exactly one `DeadBranch` emitted (the `if`, not the `for`)

**Regression guards (3 scenarios)** — assert that correct detections still fire:
- `while (0)` IS still flagged as dead
- `if (0)` IS still flagged as dead
- `unless (1)` IS still flagged as dead

## Verification

```
test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Formatting: `cargo fmt -p perl-dead-code -- --check` clean.
Clippy: `cargo clippy -p perl-dead-code --tests` — no errors.
Workspace lib tests: `cargo test --workspace --lib` — all pass.

## Scope

- 2 files changed: `src/dead_branches.rs` (fix) + `tests/dead_code_behavior_tests.rs` (9 new tests)
- No production API changes — `DeadCodeDetector`, `DeadCodeType`, `DeadCode`, `generate_report` are unchanged
- No other crates touched

https://claude.ai/code/session_01ErEcvx7ocYr4NMXGFFqYxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErEcvx7ocYr4NMXGFFqYxQ)_