### PR TITLE
test(dead-code): lock in for/foreach list-context semantics (#9009)

### DIFF
--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -320,6 +320,10 @@ fn detect_dead_branches(file_path: &Path, text: &str, out: &mut Vec<DeadCode>) {
 
         // Determine if this line opens a dead branch.
         // We look for: KEYWORD WHITESPACE? ( CONDITION ) WHITESPACE? {
+        //
+        // `for` and `foreach` are intentionally excluded: they are list
+        // iterators in Perl, not boolean guards. `for (0) {}` executes once
+        // with $_ = 0; it is not dead code.
         let dead_reason_and_keyword: Option<(String, &str)> = 'detect: {
             for kw in &["if", "while", "elsif", "unless", "until"] {
                 let rest = match trimmed.strip_prefix(kw) {
@@ -357,7 +361,7 @@ fn detect_dead_branches(file_path: &Path, text: &str, out: &mut Vec<DeadCode>) {
                         None
                     }
                 } else {
-                    // if/while/for/foreach: body is dead when condition is always-false
+                    // if/while/elsif: body is dead when condition is always-false
                     if is_always_false(inner) {
                         Some(format!(
                             "`{kw}` condition `{inner}` is always false — block is never executed"

--- a/crates/perl-parser/tests/dead_code_detector.rs
+++ b/crates/perl-parser/tests/dead_code_detector.rs
@@ -151,3 +151,66 @@ fn if_zero_condition_still_flagged_as_dead_branch() -> TestResult {
     );
     Ok(())
 }
+
+#[test]
+fn while_zero_condition_still_flagged_as_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "while (0) {\n    say 'never runs';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "while (0) body is never executed — should be flagged as a dead branch"
+    );
+    Ok(())
+}
+
+// The following tests cover values that are always false in boolean context
+// but valid list elements that execute a `for` loop body once.
+
+#[test]
+fn for_loop_with_empty_string_is_not_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "for (\"\") {\n    say 'runs once';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "for (\"\") iterates once with $_ = '' — it is not dead code"
+    );
+    Ok(())
+}
+
+#[test]
+fn for_loop_with_single_quoted_empty_string_is_not_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "for ('') {\n    say 'runs once';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "for ('') iterates once with $_ = '' — it is not dead code"
+    );
+    Ok(())
+}
+
+#[test]
+fn for_loop_with_undef_is_not_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "for (undef) {\n    say 'runs once';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "for (undef) iterates once with $_ = undef — it is not dead code"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Problem: for/foreach list-context regressions were only partially locked after the dead-branch fix.
Fix: add focused parser tests for boolean-false values in for-list context and clarify why for/foreach are excluded from boolean dead-branch detection.
Verification: `./scripts/cargo-safe test -p perl-parser --test dead_code_detector --profile agent --locked -- --nocapture` passes; `cargo fmt -p perl-parser --check` passes; `git diff --check` passes.