### PR TITLE
test(pragma): cover empty + before-first-pragma edges for cursor explicit-map API

### DIFF
--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -507,3 +507,47 @@ fn given_scoped_block_when_building_explicit_map_then_restore_point_is_zero_leng
     assert!(final_state.strict_subs);
     assert!(final_state.strict_refs);
 }
+
+/// Querying an empty `PragmaMap` via the explicit-map cursor API must return
+/// the default snapshot, matching `CompileTimePragmaEnvironment::snapshot_at`.
+/// This exercises the `entries.is_empty()` early-return branch in
+/// `PragmaQueryCursor::entry_for_offset` through the public `snapshot_at` /
+/// `state_at` methods (the existing empty-map test only covers the legacy
+/// tuple `state_for_offset` API).
+#[test]
+fn given_empty_explicit_pragma_map_when_using_cursor_then_default_snapshot_is_returned() {
+    let ast = program(vec![]);
+    let environment = CompileTimePragmaEnvironment::build(&ast);
+    let map = environment.map();
+    assert!(map.entries().is_empty(), "program without pragmas must produce empty map");
+
+    let mut cursor = map.cursor();
+    let snapshot = cursor.snapshot_at(map, 999);
+    let state = cursor.state_at(map, 999);
+
+    assert_eq!(snapshot, environment.snapshot_at(999));
+    assert_eq!(state, map.state_at(999));
+    assert_eq!(state, PragmaState::default());
+}
+
+/// Querying an offset that precedes the first pragma range via the explicit-map
+/// cursor API must return the default snapshot — same as the static
+/// `PragmaMap::snapshot_at`. This exercises the `entries[index].range.start >
+/// offset` branch in `entry_for_offset` where `partition_point` returns 0 and
+/// the index is not decremented (mirroring the legacy `state_for_offset`
+/// coverage for the same edge case).
+#[test]
+fn given_cursor_when_explicit_map_offset_is_before_first_pragma_then_default_snapshot_is_returned()
+{
+    let ast = program(vec![use_node("strict", &[], 10, 22)]);
+    let environment = CompileTimePragmaEnvironment::build(&ast);
+    let map = environment.map();
+
+    let mut cursor = map.cursor();
+    let snapshot = cursor.snapshot_at(map, 5);
+    let state = cursor.state_at(map, 5);
+
+    assert_eq!(snapshot, environment.snapshot_at(5));
+    assert_eq!(state, map.state_at(5));
+    assert!(!state.strict_vars, "no pragma has started at offset 5");
+}


### PR DESCRIPTION
## Summary

Test-only PR that closes a small parity gap in `perl-pragma`'s cursor coverage.

The legacy tuple `PragmaQueryCursor::state_for_offset` API has dedicated edge-case tests for:

- empty pragma maps (`given_empty_pragma_map_cursor_returns_default`, line 428)
- offsets that precede the first pragma range (`given_cursor_when_offset_is_before_first_pragma_then_default_state_is_returned`, line 447)

The newer explicit `PragmaMap` cursor API (`cursor.snapshot_at(&map, offset)` / `cursor.state_at(&map, offset)`) only has forward + a single backward query in `given_explicit_pragma_map_when_using_cursor_then_states_match_map_queries` — neither of those edges is exercised through the new API even though both flow through the same `PragmaQueryCursor::entry_for_offset` branches.

This PR adds two parity tests:

- `given_empty_explicit_pragma_map_when_using_cursor_then_default_snapshot_is_returned` — exercises the `entries.is_empty()` early-return through `snapshot_at` / `state_at` and asserts agreement with `CompileTimePragmaEnvironment::snapshot_at`.
- `given_cursor_when_explicit_map_offset_is_before_first_pragma_then_default_snapshot_is_returned` — exercises the `entries[self.index].range.start > offset` branch (where `partition_point` returns 0 and the index is not decremented) and asserts agreement with `PragmaMap::state_at` / `CompileTimePragmaEnvironment::snapshot_at`.

No production code changes. 44 added lines in `crates/perl-pragma/tests/behavior_spec_tests.rs`.

## Test plan

- [x] `cargo test -p perl-pragma --test behavior_spec_tests` — 31 passed (was 29)
- [x] `cargo test -p perl-pragma` — full crate green
- [x] `cargo fmt -p perl-pragma`
- [x] `cargo clippy -p perl-pragma --tests -- -D warnings`


---
_Generated by [Claude Code](https://claude.ai/code/session_01HJbAxMy2C71rwMTssVtPzC)_