### PR TITLE
fix(corpus): match precedence comment to operator order (#6821)

### DIFF
--- a/crates/perl-lsp-rs/tests/fixtures/corpus/property_based_testing_fixtures.rs
+++ b/crates/perl-lsp-rs/tests/fixtures/corpus/property_based_testing_fixtures.rs
@@ -338,7 +338,7 @@ fn generate_operator_precedence_test_cases() -> Vec<PropertyTestCase> {
         ("$a + $b * $c", "Multiplication before addition"),
         ("($a + $b) * $c", "Parentheses override precedence"),
         ("$a ** $b ** $c", "Right-associative exponentiation"),
-        ("$a / $b * $c", "Left-associative multiplication/division"),
+        ("$a / $b * $c", "Left-associative division/multiplication"),
         ("$a % $b + $c", "Modulo before addition"),
         ("-$a ** $b", "Unary minus and exponentiation"),
         ("++$a * $b", "Pre-increment and multiplication"),


### PR DESCRIPTION
## Summary

Fix inaccurate associativity comment in the property-based test corpus
(issue #6821).

The expression `$a / $b * $c` has division first, then multiplication,
so the comment labelling it "Left-associative multiplication/division"
mis-orders the operators relative to what the expression actually
contains. Both operators share the same precedence and left-associativity
in Perl, so the only thing the comment had wrong was the order — swap
to "division/multiplication" so it matches the expression.

## Test plan

- [x] `cargo check -p perl-lsp-rs --tests` clean
- [x] Diff is a single-character-style change inside a string literal — no
      behaviour or test logic touched

Closes #6821

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFp44BcuDXM8LUSVosc3xm)_