### PR TITLE
fix(docs): resolve broken intra-doc links in perl-parser

### DIFF
--- a/crates/perl-parser/src/heredoc_anti_patterns/mod.rs
+++ b/crates/perl-parser/src/heredoc_anti_patterns/mod.rs
@@ -3,10 +3,10 @@
 //! This module provides detection and analysis of problematic Perl patterns
 //! that make static parsing difficult or impossible, particularly around heredocs.
 //!
-//! The [`AntiPatternDetector`] scans Perl source for seven categories of
-//! heredoc-related anti-patterns and produces [`Diagnostic`]s describing each
-//! finding, with severity, explanation, suggested fix, and documentation
-//! references.
+//! The [`crate::heredoc_anti_patterns::AntiPatternDetector`] scans Perl source
+//! for seven categories of heredoc-related anti-patterns and produces
+//! [`crate::heredoc_anti_patterns::Diagnostic`]s describing each finding, with
+//! severity, explanation, suggested fix, and documentation references.
 
 mod detectors;
 mod model;

--- a/crates/perl-parser/src/refactor/inline.rs
+++ b/crates/perl-parser/src/refactor/inline.rs
@@ -161,8 +161,8 @@ pub fn analyze_sub_for_inlining(
 
 /// Text-based Perl subroutine inliner.
 ///
-/// Create one instance per source file and call [`inline_call`] (or its
-/// variants) to produce the inlined expression text.
+/// Create one instance per source file and call [`SubInliner::inline_call`]
+/// (or its variants) to produce the inlined expression text.
 pub struct SubInliner {
     source: String,
 }
@@ -184,7 +184,7 @@ impl SubInliner {
         Ok(inlined)
     }
 
-    /// Like [`inline_call`] but also returns any warnings (e.g. side effects).
+    /// Like [`Self::inline_call`] but also returns any warnings (e.g. side effects).
     pub fn inline_call_with_warnings(
         &self,
         sub_name: &str,
@@ -193,7 +193,7 @@ impl SubInliner {
         self.inline_call_inner(sub_name, call_expr, &[])
     }
 
-    /// Like [`inline_call`] but accepts a list of variable names that already
+    /// Like [`Self::inline_call`] but accepts a list of variable names that already
     /// exist in the outer scope, so collisions can be detected and renamed.
     pub fn inline_call_with_outer_vars(
         &self,


### PR DESCRIPTION
## Summary

Fixes the docs build by resolving 5 rustdoc broken intra-doc link warnings in `perl-parser`. These are warnings today but errors under `RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links'`, which is the configured strict mode in `.github/ci-config.yml`.

## What broke and why

**`crates/perl-parser/src/heredoc_anti_patterns/mod.rs`** — module-level docs referenced `` [`AntiPatternDetector`] `` and `` [`Diagnostic`] ``. Those names are brought in via `pub use detectors::…;` / `pub use model::…;`, but rustdoc doesn't resolve `pub use`-imported items in the module-doc resolution scope. The submodules themselves (`detectors`, `model`) are private, so the disambiguated `detectors::AntiPatternDetector` form also fails to resolve. Fix: use the canonical public path `crate::heredoc_anti_patterns::AntiPatternDetector` (and same for `Diagnostic`), which matches what consumers of the API actually write.

**`crates/perl-parser/src/refactor/inline.rs`** — three references to `` [`inline_call`] `` were unresolvable because `inline_call` is a method on `SubInliner`, not a free function. Fix: `SubInliner::inline_call` on the struct doc, `Self::inline_call` on the sibling methods inside `impl SubInliner`.

## Verification

```
$ cargo doc -p perl-parser -p perl-lsp-rs --no-deps --locked
… Finished `dev` profile … (no warnings)

$ RUSTDOCFLAGS='-D rustdoc::broken_intra_doc_links -D rustdoc::bare_urls' \
    cargo doc -p perl-parser -p perl-lsp-rs --no-deps --locked
… Finished `dev` profile … (was: 5 errors → build failed)
```

Before this PR: 5 broken-intra-doc-link warnings (errors under strict flags).
After: clean.

## Test plan
- [x] `cargo doc -p perl-parser -p perl-lsp-rs --no-deps --locked` — clean
- [x] `cargo doc` under strict RUSTDOCFLAGS — clean
- [x] `cargo fmt --check -p perl-parser` — clean
- [x] Diff is doc-comments only; no code behavior changes


---
_Generated by [Claude Code](https://claude.ai/code/session_011AqdYzAMQnpoCuXkWyN2co)_