### PR TITLE
fix(xtask): wire up `queue project-labels` and write receipt in apply mode (#6989)

### DIFF
--- a/docs/ci/label-projection.md
+++ b/docs/ci/label-projection.md
@@ -18,7 +18,8 @@ cargo xtask queue project-labels \
 
 cargo xtask queue project-labels \
   --state target/receipts/queue-state.json \
-  --apply
+  --apply \
+  --receipt target/receipts/label-projection.json
 ```
 
 ## Input state shape
@@ -38,7 +39,7 @@ The projector does **not** infer canonical state from labels when a state receip
 
 ## Receipt fields
 
-Dry-run receipts include per-PR entries with:
+Receipts (written in both dry-run and `--apply` modes when `--receipt` is supplied) include per-PR entries with:
 
 - `current_labels`
 - `projected_apply`

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2389,6 +2389,29 @@ enum QueueCommand {
         #[arg(long)]
         fixture: Option<PathBuf>,
     },
+
+    /// Project UI labels from canonical PR state receipts.
+    ProjectLabels {
+        /// Path to canonical queue state JSON.
+        #[arg(long, default_value = "target/receipts/queue-state.json")]
+        state: PathBuf,
+
+        /// Plan label changes without applying them (default).
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Apply projected label changes against GitHub. Requires GH_TOKEN.
+        #[arg(long)]
+        apply: bool,
+
+        /// Optional output path for the label-projection receipt JSON.
+        #[arg(long)]
+        receipt: Option<PathBuf>,
+
+        /// Path to projection rules TOML.
+        #[arg(long, default_value = ".ci/state/label-projection.toml")]
+        config: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2478,6 +2501,15 @@ fn main() -> Result<()> {
             QueueCommand::Snapshot { out, fixture } => queue_snapshot::run_snapshot(out, fixture),
             QueueCommand::Health { receipt, fixture } => {
                 queue_health::run(queue_health::QueueHealthArgs { receipt, fixture })
+            }
+            QueueCommand::ProjectLabels { state, dry_run, apply, receipt, config } => {
+                label_projector::run_project_labels(label_projector::LabelProjectorArgs {
+                    state,
+                    dry_run,
+                    apply,
+                    receipt,
+                    config,
+                })
             }
         },
         Commands::Pr { command } => match command {

--- a/xtask/src/tasks/label_projector.rs
+++ b/xtask/src/tasks/label_projector.rs
@@ -132,18 +132,16 @@ pub fn run_project_labels(args: LabelProjectorArgs) -> Result<()> {
 
     let receipt = LabelProjectionReceipt { dry_run, verdict, projections };
 
-    if dry_run {
-        if let Some(path) = receipt_path {
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).with_context(|| {
-                    format!("failed to create receipt directory: {}", parent.display())
-                })?;
-            }
-            let serialized = serde_json::to_string_pretty(&receipt)
-                .context("failed to serialize label projection receipt")?;
-            fs::write(&path, serialized)
-                .with_context(|| format!("failed to write receipt: {}", path.display()))?;
+    if let Some(path) = receipt_path {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create receipt directory: {}", parent.display())
+            })?;
         }
+        let serialized = serde_json::to_string_pretty(&receipt)
+            .context("failed to serialize label projection receipt")?;
+        fs::write(&path, serialized)
+            .with_context(|| format!("failed to write receipt: {}", path.display()))?;
     }
 
     println!("label projection verdict: {}", receipt.verdict);

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -66,6 +66,7 @@ pub mod ignored_tests;
 pub mod inject_sha_assets;
 pub mod install_surface_check;
 pub mod intent_diff_gate;
+pub mod label_projector;
 pub mod layer_check;
 pub mod memory_trends;
 pub mod merge_ready;

--- a/xtask/tests/label_projector_tests.rs
+++ b/xtask/tests/label_projector_tests.rs
@@ -1,19 +1,23 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use assert_cmd::cargo::cargo_bin_cmd;
 use serde_json::Value;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 
-fn repo_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR")).parent().expect("xtask has workspace parent")
+fn repo_root() -> Result<PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    Ok(manifest_dir
+        .parent()
+        .ok_or_else(|| anyhow!("xtask manifest should have a workspace parent"))?
+        .to_path_buf())
 }
 
 #[test]
 fn dry_run_needs_builder_fix_projects_expected_add_remove() -> Result<()> {
     let tmp = tempdir()?;
     let receipt = tmp.path().join("label-projection.json");
-    let state = repo_root().join("xtask/tests/fixtures/label-projector/needs-builder-fix.json");
+    let state = repo_root()?.join("xtask/tests/fixtures/label-projector/needs-builder-fix.json");
 
     let mut cmd = cargo_bin_cmd!("xtask");
     let output = cmd
@@ -43,11 +47,46 @@ fn dry_run_needs_builder_fix_projects_expected_add_remove() -> Result<()> {
 }
 
 #[test]
+fn apply_writes_receipt_for_skipped_entries() -> Result<()> {
+    let tmp = tempdir()?;
+    let receipt = tmp.path().join("label-projection.json");
+    let state =
+        repo_root()?.join("xtask/tests/fixtures/label-projector/merge-ready-missing-receipt.json");
+
+    let mut cmd = cargo_bin_cmd!("xtask");
+    let output = cmd
+        .arg("queue")
+        .arg("project-labels")
+        .arg("--state")
+        .arg(&state)
+        .arg("--apply")
+        .arg("--receipt")
+        .arg(&receipt)
+        .env("GH_TOKEN", "dummy-token-not-used-for-skipped")
+        .output()
+        .context("running xtask queue project-labels for MERGE_READY in apply mode")?;
+
+    assert!(output.status.success(), "command failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    let value: Value = serde_json::from_str(&fs::read_to_string(&receipt)?)?;
+
+    assert_eq!(value["dry_run"], serde_json::json!(false));
+    assert_eq!(value["verdict"], serde_json::json!("skipped"));
+
+    let projection = &value["projections"][0];
+    assert_eq!(projection["skipped"], serde_json::json!(true));
+    assert_eq!(projection["dry_run"], serde_json::json!(false));
+    assert_eq!(projection["verdict"], serde_json::json!("skipped"));
+
+    Ok(())
+}
+
+#[test]
 fn dry_run_merge_ready_without_receipt_is_skipped() -> Result<()> {
     let tmp = tempdir()?;
     let receipt = tmp.path().join("label-projection.json");
     let state =
-        repo_root().join("xtask/tests/fixtures/label-projector/merge-ready-missing-receipt.json");
+        repo_root()?.join("xtask/tests/fixtures/label-projector/merge-ready-missing-receipt.json");
 
     let mut cmd = cargo_bin_cmd!("xtask");
     let output = cmd


### PR DESCRIPTION
## Summary

The `cargo xtask queue project-labels` subcommand was documented in
[`docs/ci/label-projection.md`](docs/ci/label-projection.md), registered as a
producer in `.ci/receipts/registry.toml`, and exercised by integration tests in
`xtask/tests/label_projector_tests.rs` — but the CLI variant and the
`pub mod label_projector` declaration were missing. Running the tests locally
showed:

```
error: unrecognized subcommand 'project-labels'
Usage: xtask queue <COMMAND>
```

These integration tests do not run under the standard CI workflow (`cargo test
--workspace --lib`) so the failure has been silent.

This PR also fixes #6989: the receipt-write block was guarded by `if dry_run`,
so `--apply --receipt path.json` silently dropped the receipt — contrary to the
schema in `.ci/receipts/schemas/label-projection.schema.json` (no dry-run
restriction on the `dry_run` field) and contrary to the issue's own verification
recipe.

## Changes

- `xtask/src/tasks/mod.rs` — declare `pub mod label_projector;`
- `xtask/src/main.rs` — add `QueueCommand::ProjectLabels` clap variant + dispatch
- `xtask/src/tasks/label_projector.rs` — write the receipt unconditionally (was guarded by `if dry_run`)
- `docs/ci/label-projection.md` — clarify receipts are written in both modes; add `--receipt` to apply example
- `xtask/tests/label_projector_tests.rs` — add `apply_writes_receipt_for_skipped_entries` test; refactor `repo_root()` to `Result<PathBuf>` for clippy `expect_used` compliance

## Test plan

- [x] `cargo test -p xtask --test label_projector_tests` — 3/3 pass (was 0/2)
- [x] `cargo clippy --test label_projector_tests -p xtask` — clean
- [x] `cargo clippy -p xtask --bin xtask` — clean
- [x] `cargo build -p xtask` — success
- [x] `cargo fmt -p xtask --check` — clean

Closes #6989.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1GyXC5BWba4tXQZNUdz8D)_