### PR TITLE
test(uri): cover dotfile extension boundaries (#6828)

### DIFF
--- a/crates/perl-uri/tests/classify_boundary_cases.rs
+++ b/crates/perl-uri/tests/classify_boundary_cases.rs
@@ -150,6 +150,23 @@ fn uri_extension_for_path_ending_in_slash() {
     assert_eq!(uri_extension("file:///path/"), None);
 }
 
+#[test]
+fn uri_extension_dotfile_with_extension_returns_trailing_segment() {
+    // Dotfile detection only skips the leading-dot-only case (`.bashrc`).
+    // Dotfiles with a later dot follow the same last-dot rule as other paths.
+    assert_eq!(uri_extension(".bashrc.bak"), Some("bak"));
+    assert_eq!(uri_extension(".config.json"), Some("json"));
+    assert_eq!(uri_extension("file:///home/user/.gitignore.bak"), Some("bak"));
+    assert_eq!(uri_extension(r"C:\Users\dev\.bashrc.bak"), Some("bak"));
+}
+
+#[test]
+fn uri_extension_returns_none_for_parent_dir_reference() {
+    // `..` has a dot, but the trailing extension segment is empty.
+    assert_eq!(uri_extension(".."), None);
+    assert_eq!(uri_extension("file:///path/.."), None);
+}
+
 // ---------------------------------------------------------------------------
 // uri_key: non-Windows path unchanged, drive letter normalization
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Problem: `perl-uri::classify::uri_extension` had no direct boundary coverage for dotfiles with later extensions or the `..` parent-dir reference.
Fix: Added tests proving dotfiles with a later dot use the trailing extension while leading-dot-only and empty-extension forms remain extensionless.
Verification: `$env:CARGO_TARGET_DIR='C:\Users\steven\.cache\devplane\perl-lsp\target'; cargo test -p perl-uri --test classify_boundary_cases --profile agent --locked -- --nocapture` passes; `cargo clippy -p perl-uri --tests --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo fmt -p perl-uri --check` passes; `git diff --check` passes.