### PR TITLE
refactor(workspace-refactor): split rename_symbol into SRP submodule

### DIFF
--- a/crates/perl-refactoring/src/refactor/workspace_refactor.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_refactor.rs
@@ -50,6 +50,8 @@
 //! let optimized = refactor.optimize_imports()?;
 //! ```
 
+mod rename;
+
 use crate::import_optimizer::ImportOptimizer;
 use crate::refactor::refactor_plan::{
     RefactorConfidence, RefactorOperationKind, RefactorPlan, RefactorSafety, RefactorStats,
@@ -243,134 +245,23 @@ impl WorkspaceRefactor {
         _file_path: &Path,
         _position: (usize, usize),
     ) -> Result<RefactorResult, RefactorError> {
-        // Validate input parameters
-        if old_name.is_empty() {
-            return Err(RefactorError::InvalidInput("Symbol name cannot be empty".to_string()));
-        }
-        if new_name.is_empty() {
-            return Err(RefactorError::InvalidInput("New name cannot be empty".to_string()));
-        }
-        if old_name == new_name {
-            return Err(RefactorError::InvalidInput("Old and new names are identical".to_string()));
-        }
+        rename::validate_inputs(old_name, new_name)?;
 
-        // Infer symbol kind and bare name
-        let (sigil, bare) = normalize_var(old_name);
-        let kind = if sigil.is_some() { SymKind::Var } else { SymKind::Sub };
-
-        // For now assume package 'main'
-        let key = SymbolKey {
-            pkg: Arc::from("main".to_string()),
-            name: Arc::from(bare.to_string()),
-            sigil,
-            kind,
-        };
-
-        let mut edits: BTreeMap<PathBuf, Vec<TextEdit>> = BTreeMap::new();
-
-        // Find all references
-        let mut locations = self._index.find_refs(&key);
-
-        // Always try to include the definition explicitly
-        let def_loc = self._index.find_def(&key);
-        if let Some(def) = def_loc {
-            if !locations.iter().any(|loc| loc.uri == def.uri && loc.range == def.range) {
-                locations.push(def);
-            }
-        }
-
+        let target = rename::build_target(old_name);
         let store = self._index.document_store();
 
+        let mut locations = rename::collect_indexed_locations(&self._index, &target);
         if locations.is_empty() {
-            // Fallback naive search with performance optimizations
-            let _old_name_bytes = old_name.as_bytes();
-
-            for doc in store.all_documents() {
-                // Pre-check if the document even contains the target string to avoid unnecessary work
-                if !doc.text.contains(old_name) {
-                    continue;
-                }
-
-                let idx = doc.line_index.clone();
-                let mut pos = 0;
-                let _text_bytes = doc.text.as_bytes();
-
-                // Use faster byte-based searching with matches iterator
-                while let Some(found) = doc.text[pos..].find(old_name) {
-                    let start = pos + found;
-                    let end = start + old_name.len();
-
-                    // Early bounds checking to avoid invalid positions
-                    if start >= doc.text.len() || end > doc.text.len() {
-                        break;
-                    }
-
-                    let (start_line, start_col) = idx.offset_to_position(start);
-                    let (end_line, end_col) = idx.offset_to_position(end);
-                    let start_byte = idx.position_to_offset(start_line, start_col).unwrap_or(0);
-                    let end_byte = idx.position_to_offset(end_line, end_col).unwrap_or(0);
-                    locations.push(crate::workspace_index::Location {
-                        uri: doc.uri.clone(),
-                        range: crate::position::Range {
-                            start: crate::position::Position {
-                                byte: start_byte,
-                                line: start_line,
-                                column: start_col,
-                            },
-                            end: crate::position::Position {
-                                byte: end_byte,
-                                line: end_line,
-                                column: end_col,
-                            },
-                        },
-                    });
-                    pos = end;
-
-                    // Limit the number of matches to prevent runaway performance issues
-                    if locations.len() >= 1000 {
-                        break;
-                    }
-                }
-
-                // If we've found matches in this document and it's getting large, we can break early
-                // This is a heuristic to balance completeness with performance
-                if locations.len() >= 500 {
-                    break;
-                }
-            }
+            locations = rename::fallback_text_search(store, old_name);
         }
 
-        for loc in locations {
-            let path = uri_to_fs_path(&loc.uri).ok_or_else(|| {
-                RefactorError::UriConversion(format!("Failed to convert URI to path: {}", loc.uri))
-            })?;
-            if let Some(doc) = store.get(&loc.uri) {
-                let start_off =
-                    doc.line_index.position_to_offset(loc.range.start.line, loc.range.start.column);
-                let end_off =
-                    doc.line_index.position_to_offset(loc.range.end.line, loc.range.end.column);
-                if let (Some(start_off), Some(end_off)) = (start_off, end_off) {
-                    let replacement = match kind {
-                        SymKind::Var => {
-                            let sig = sigil.unwrap_or('$');
-                            format!("{}{}", sig, new_name.trim_start_matches(['$', '@', '%']))
-                        }
-                        _ => new_name.to_string(),
-                    };
-                    edits.entry(path).or_default().push(TextEdit {
-                        start: start_off,
-                        end: end_off,
-                        new_text: replacement,
-                    });
-                }
-            }
-        }
+        let file_edits = rename::build_file_edits(store, locations, &target, new_name)?;
 
-        let file_edits: Vec<FileEdit> =
-            edits.into_iter().map(|(file_path, edits)| FileEdit { file_path, edits }).collect();
-
-        let description = format!("Rename '{}' to '{}'", old_name, new_name);
-        Ok(RefactorResult { file_edits, description, warnings: vec![] })
+        Ok(RefactorResult {
+            file_edits,
+            description: format!("Rename '{}' to '{}'", old_name, new_name),
+            warnings: vec![],
+        })
     }
 
     /// Extract selected code into a new module

--- a/crates/perl-refactoring/src/refactor/workspace_refactor/rename.rs
+++ b/crates/perl-refactoring/src/refactor/workspace_refactor/rename.rs
@@ -1,0 +1,169 @@
+//! Single-responsibility helpers for [`super::WorkspaceRefactor::rename_symbol`].
+//!
+//! The public rename entry point delegates to focused functions in this module so
+//! each phase of the operation — input validation, symbol identification,
+//! location lookup, and edit construction — can evolve independently and be
+//! reasoned about on its own.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use super::{FileEdit, RefactorError, TextEdit};
+use crate::document_store::DocumentStore;
+use crate::workspace_index::{
+    Location, SymKind, SymbolKey, WorkspaceIndex, normalize_var, uri_to_fs_path,
+};
+
+/// Soft caps for the naive fallback search to keep workspace-wide scans bounded.
+const FALLBACK_MAX_TOTAL_MATCHES: usize = 1000;
+const FALLBACK_PER_DOC_EARLY_EXIT: usize = 500;
+
+/// Description of the symbol being renamed.
+pub(super) struct RenameTarget {
+    pub(super) sigil: Option<char>,
+    pub(super) kind: SymKind,
+    pub(super) key: SymbolKey,
+}
+
+/// Validate user-supplied rename inputs before doing any lookup work.
+pub(super) fn validate_inputs(old_name: &str, new_name: &str) -> Result<(), RefactorError> {
+    if old_name.is_empty() {
+        return Err(RefactorError::InvalidInput("Symbol name cannot be empty".to_string()));
+    }
+    if new_name.is_empty() {
+        return Err(RefactorError::InvalidInput("New name cannot be empty".to_string()));
+    }
+    if old_name == new_name {
+        return Err(RefactorError::InvalidInput("Old and new names are identical".to_string()));
+    }
+    Ok(())
+}
+
+/// Derive the symbol kind and lookup key from the user-supplied name.
+pub(super) fn build_target(old_name: &str) -> RenameTarget {
+    let (sigil, bare) = normalize_var(old_name);
+    let kind = if sigil.is_some() { SymKind::Var } else { SymKind::Sub };
+    let key = SymbolKey {
+        pkg: Arc::from("main".to_string()),
+        name: Arc::from(bare.to_string()),
+        sigil,
+        kind,
+    };
+    RenameTarget { sigil, kind, key }
+}
+
+/// Look up known references and definition for a symbol via the workspace index.
+///
+/// The definition is always appended when present so callers do not need to
+/// special-case it. Returns an empty vector when the index has no matches.
+pub(super) fn collect_indexed_locations(
+    index: &WorkspaceIndex,
+    target: &RenameTarget,
+) -> Vec<Location> {
+    let mut locations = index.find_refs(&target.key);
+    if let Some(def) = index.find_def(&target.key) {
+        if !locations.iter().any(|loc| loc.uri == def.uri && loc.range == def.range) {
+            locations.push(def);
+        }
+    }
+    locations
+}
+
+/// Heuristic byte-based text search used when the index returned no matches.
+///
+/// This is deliberately naive — it scans every open document for raw occurrences
+/// of `old_name` and is bounded by [`FALLBACK_MAX_TOTAL_MATCHES`] and
+/// [`FALLBACK_PER_DOC_EARLY_EXIT`] to keep workspace-wide scans tractable.
+pub(super) fn fallback_text_search(store: &DocumentStore, old_name: &str) -> Vec<Location> {
+    let mut locations = Vec::new();
+    for doc in store.all_documents() {
+        if !doc.text.contains(old_name) {
+            continue;
+        }
+
+        let idx = doc.line_index.clone();
+        let mut pos = 0;
+
+        while let Some(found) = doc.text[pos..].find(old_name) {
+            let start = pos + found;
+            let end = start + old_name.len();
+
+            if start >= doc.text.len() || end > doc.text.len() {
+                break;
+            }
+
+            let (start_line, start_col) = idx.offset_to_position(start);
+            let (end_line, end_col) = idx.offset_to_position(end);
+            let start_byte = idx.position_to_offset(start_line, start_col).unwrap_or(0);
+            let end_byte = idx.position_to_offset(end_line, end_col).unwrap_or(0);
+            locations.push(Location {
+                uri: doc.uri.clone(),
+                range: crate::position::Range {
+                    start: crate::position::Position {
+                        byte: start_byte,
+                        line: start_line,
+                        column: start_col,
+                    },
+                    end: crate::position::Position {
+                        byte: end_byte,
+                        line: end_line,
+                        column: end_col,
+                    },
+                },
+            });
+            pos = end;
+
+            if locations.len() >= FALLBACK_MAX_TOTAL_MATCHES {
+                break;
+            }
+        }
+
+        if locations.len() >= FALLBACK_PER_DOC_EARLY_EXIT {
+            break;
+        }
+    }
+    locations
+}
+
+/// Build the per-file text edits that perform the rename.
+pub(super) fn build_file_edits(
+    store: &DocumentStore,
+    locations: Vec<Location>,
+    target: &RenameTarget,
+    new_name: &str,
+) -> Result<Vec<FileEdit>, RefactorError> {
+    let mut edits: BTreeMap<PathBuf, Vec<TextEdit>> = BTreeMap::new();
+
+    for loc in locations {
+        let path = uri_to_fs_path(&loc.uri).ok_or_else(|| {
+            RefactorError::UriConversion(format!("Failed to convert URI to path: {}", loc.uri))
+        })?;
+        let Some(doc) = store.get(&loc.uri) else {
+            continue;
+        };
+        let start_off =
+            doc.line_index.position_to_offset(loc.range.start.line, loc.range.start.column);
+        let end_off = doc.line_index.position_to_offset(loc.range.end.line, loc.range.end.column);
+        if let (Some(start_off), Some(end_off)) = (start_off, end_off) {
+            edits.entry(path).or_default().push(TextEdit {
+                start: start_off,
+                end: end_off,
+                new_text: replacement_text(target, new_name),
+            });
+        }
+    }
+
+    Ok(edits.into_iter().map(|(file_path, edits)| FileEdit { file_path, edits }).collect())
+}
+
+/// Compute the replacement text for a single occurrence, preserving sigils for variables.
+fn replacement_text(target: &RenameTarget, new_name: &str) -> String {
+    match target.kind {
+        SymKind::Var => {
+            let sig = target.sigil.unwrap_or('$');
+            format!("{}{}", sig, new_name.trim_start_matches(['$', '@', '%']))
+        }
+        _ => new_name.to_string(),
+    }
+}


### PR DESCRIPTION
## Summary

Break the 135-line `WorkspaceRefactor::rename_symbol` body into a new `workspace_refactor/rename.rs` submodule with one helper per phase, leaving a thin (~20-line) orchestrator on the public API.

Pure refactor — behavior-preserving, no public API change, all existing tests in `perl-refactoring` continue to pass.

> Has `skip-title-check` label: this is an autonomous SRP refactor with no tracking issue.

## Why

`rename_symbol` was a single function juggling six distinct responsibilities:

1. Input validation
2. Symbol-key construction
3. Index-based reference + definition lookup
4. Fallback naive text search (with two magic-number caps inline)
5. Conversion of locations into per-file `TextEdit`s
6. Final `RefactorResult` assembly

Each phase had its own failure modes, soft caps, and edge cases, but they were tangled together in one ~135-line block. That made the rename logic hard to follow and hard to test/extend in isolation.

## What changed

New submodule `crates/perl-refactoring/src/refactor/workspace_refactor/rename.rs` with focused helpers:

| Helper | Responsibility |
|--------|----------------|
| `validate_inputs(old, new)` | Reject empty / identical names |
| `build_target(old_name)` | Derive sigil, `SymKind`, and `SymbolKey` |
| `collect_indexed_locations(index, target)` | `find_refs` + dedup-append `find_def` |
| `fallback_text_search(store, old_name)` | Bounded naive byte scan when index is empty |
| `build_file_edits(store, locs, target, new_name)` | URI→path + offset conversion → `BTreeMap<PathBuf, Vec<TextEdit>>` → `Vec<FileEdit>` |
| `replacement_text(target, new_name)` | Sigil-preserving replacement for variables |

The two fallback-search soft caps that were inline magic numbers (`1000` total, `500` per-doc early-exit) are now named constants `FALLBACK_MAX_TOTAL_MATCHES` and `FALLBACK_PER_DOC_EARLY_EXIT`.

`rename_symbol` now reads top-down as: validate → identify target → look up locations (index, then fallback) → build edits → assemble result.

## Behavior preservation

- No public types, signatures, or error variants changed.
- Same soft caps, same fallback search heuristic, same `BTreeMap` ordering for edits, same description string.
- All 27 `workspace_refactor` unit tests pass; all 371 tests in `perl-refactoring` pass.
- `cargo clippy -p perl-refactoring --lib --tests` is clean.
- `cargo fmt` is clean.
- `cargo build --workspace --lib` is clean.

## Test plan

- [x] `cargo build -p perl-refactoring`
- [x] `cargo test -p perl-refactoring` — all 371 tests pass
- [x] `cargo clippy -p perl-refactoring --lib --tests` — clean
- [x] `cargo fmt --package perl-refactoring -- --check` — clean
- [x] `cargo build --workspace --lib` — clean