### PR TITLE
fix(rename): keep rollback receipt helper feature-neutral (#8197)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/refactor_runtime_blocker_receipts.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/refactor_runtime_blocker_receipts.rs
@@ -870,7 +870,6 @@ fn rename_package_pilot_json(result: &RenamePackagePilotResult) -> Value {
     }
 }
 
-#[cfg(all(feature = "workspace", not(target_arch = "wasm32")))]
 fn package_rename_rollback_receipt_json(
     planned_live_provider_edit_count: usize,
     returned_workspace_edit_count: usize,


### PR DESCRIPTION
Problem: `perl.previewPackageRename` is feature-neutral code, but its rollback receipt JSON helper was gated behind the workspace feature after #9035.
Fix: Remove the unnecessary cfg from the helper so the preview path does not add another non-workspace compile seam.
Verification: `cargo test -p perl-lsp-rs --lib --profile agent --locked refactor_runtime_blocker_ux_package_rename_preview -- --nocapture --test-threads=1` passes; `cargo check -p perl-lsp-rs --lib --all-features --profile agent --locked` passes; `cargo xtask fmt --check` passes; `git diff --check` passes.