### PR TITLE
test(perl-pod): cover percent-encoding, link extraction, and malformed POD recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,6 +1804,9 @@ dependencies = [
 [[package]]
 name = "perl-pod"
 version = "0.14.0"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "perl-position-tracking"

--- a/crates/perl-pod/Cargo.toml
+++ b/crates/perl-pod/Cargo.toml
@@ -17,6 +17,7 @@ include = ["src/**", "tests/**", "Cargo.toml", "README.md", "LICENSE*"]
 [dependencies]
 
 [dev-dependencies]
+tempfile.workspace = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -609,7 +609,7 @@ fn for_directive_starts_pod_mode() {
 /// an extra newline when the body is still empty.
 #[test]
 fn item_as_first_line_in_section_no_leading_newline() {
-    let source = "=head2 options\n\n=over 4\n\n=item alpha\n\nFirst item.\n\n=back\n\n=cut\n";
+    let source = "=head2 options\n\n=item alpha\n\nFirst item.\n\n=cut\n";
     let doc = extract_pod(source);
     let method_doc = doc.methods.get("options").map(String::as_str).unwrap_or("");
     // The item should appear but must not start with a blank line
@@ -647,6 +647,10 @@ fn end_directive_inside_pod_is_skipped() {
     let doc = extract_pod(source);
     let name = doc.name.as_deref().unwrap_or("");
     assert!(name.contains("My::Module - real"), "name should be captured before =end; got: {name}");
+    assert!(
+        !name.contains("=end"),
+        "the =end directive line should not appear in name; got: {name}"
+    );
 }
 
 /// `=for` inside an active POD block hits the skip-directive branch (line 146).

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -699,13 +699,20 @@ fn unknown_e_entity_passes_through_as_text() {
     assert_eq!(name, "A nbsp B", "unknown E<> entity should pass through as text; got: {name}");
 }
 
-/// `first_paragraph` with a leading blank line before actual content.
-/// Exercises the `!result.is_empty()` False branch (line 229) — when we encounter
-/// a blank line but result is still empty, we must NOT break out of the loop.
+/// `extract_pod` with a DESCRIPTION section that has body content followed by a
+/// blank line — verifies that `first_paragraph` correctly truncates at the first
+/// blank line after actual content.
+///
+/// Note: the `!result.is_empty()` False branch inside `first_paragraph` (the
+/// "blank line before any content" path) is unreachable via `extract_pod` because
+/// `flush_section` calls `body.trim()` before passing the text to `first_paragraph`,
+/// which eliminates any leading blank lines.  That branch is implicitly dead code
+/// from the public API perspective.
 #[test]
-fn first_paragraph_skips_leading_blank_lines() {
-    // strip_pod_formatting is applied before first_paragraph, so feed the
-    // description via extract_pod with a blank line at the start of DESCRIPTION.
+fn first_paragraph_truncates_at_blank_line() {
+    // Two blank lines appear between the =head1 directive and the actual content.
+    // The body accumulation loop skips them (both body and line are empty), so
+    // first_paragraph receives "Actual first line.\nSecond line." after trim().
     let source = "=head1 DESCRIPTION\n\n\nActual first line.\nSecond line.\n\nNot in first paragraph.\n\n=cut\n";
     let doc = extract_pod(source);
     let desc = doc.description.as_deref().unwrap_or("");

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -1,4 +1,5 @@
 use perl_pod::{extract_pod, extract_pod_from_file};
+use std::io::Write as _;
 use std::path::Path;
 
 #[test]
@@ -569,4 +570,185 @@ sub run { }
     let doc = extract_pod(source);
     assert_eq!(doc.name.as_deref(), Some("Multi - Multiple POD blocks"));
     assert!(doc.methods.contains_key("run"));
+}
+
+// ── New coverage gap tests ────────────────────────────────────────────────
+
+/// `PodDoc::is_empty()` returns `false` when the doc has content.
+/// Exercises the `False` branches of the short-circuit `&&` chain (lines 31-33).
+#[test]
+fn is_empty_returns_false_when_doc_has_content() {
+    let doc = extract_pod("=head1 NAME\n\nFoo - something\n\n=cut\n");
+    assert!(!doc.is_empty(), "doc with a name should not be empty");
+}
+
+/// `=begin` as the very first directive triggers `in_pod` (line 74 True branch).
+/// Without this, POD mode never starts and the body would be skipped.
+#[test]
+fn begin_directive_starts_pod_mode() {
+    let source = "=begin pod\n\n=head1 NAME\n\nBegin::Module - started with =begin\n\n=cut\n";
+    let doc = extract_pod(source);
+    assert_eq!(
+        doc.name.as_deref(),
+        Some("Begin::Module - started with =begin"),
+        "=begin should initiate POD mode so subsequent sections are parsed"
+    );
+}
+
+/// `=for` as the very first directive triggers `in_pod` (line 75 True branch).
+#[test]
+fn for_directive_starts_pod_mode() {
+    let source =
+        "=for html <b>intro</b>\n\n=head1 NAME\n\nFor::Module - started with =for\n\n=cut\n";
+    let doc = extract_pod(source);
+    assert_eq!(doc.name.as_deref(), Some("For::Module - started with =for"));
+}
+
+/// `=item` appearing as the very first content line in a section (body is empty).
+/// Covers the `!body.is_empty()` False branch at line 109 — we should NOT push
+/// an extra newline when the body is still empty.
+#[test]
+fn item_as_first_line_in_section_no_leading_newline() {
+    let source = "=head2 options\n\n=over 4\n\n=item alpha\n\nFirst item.\n\n=back\n\n=cut\n";
+    let doc = extract_pod(source);
+    let method_doc = doc.methods.get("options").map(String::as_str).unwrap_or("");
+    // The item should appear but must not start with a blank line
+    assert!(method_doc.contains("- alpha"), "item text should be present; got: {method_doc}");
+    assert!(
+        !method_doc.starts_with('\n'),
+        "method doc must not start with a leading newline; got: {method_doc:?}"
+    );
+}
+
+/// `=begin` inside an active POD block hits the skip-directive branch (line 144).
+/// The directive line itself is skipped; subsequent content lines are still accumulated.
+#[test]
+fn begin_directive_line_inside_pod_is_skipped() {
+    // Only the "=begin html" line itself is skipped — the content of the block
+    // continues to accumulate. The directive line ("=begin html") must not
+    // appear verbatim in the output.
+    let source = "=head1 NAME\n\n=begin html\nMy::Module - real name\n=end html\n\n=cut\n";
+    let doc = extract_pod(source);
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(
+        !name.contains("=begin html"),
+        "the =begin directive line itself should not appear in name; got: {name}"
+    );
+    assert!(
+        name.contains("My::Module - real name"),
+        "content after the =begin line should still be captured; got: {name}"
+    );
+}
+
+/// `=end` inside an active POD block hits the skip-directive branch (line 145).
+#[test]
+fn end_directive_inside_pod_is_skipped() {
+    let source = "=head1 NAME\n\nMy::Module - real\n\n=end\n\n=cut\n";
+    let doc = extract_pod(source);
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(name.contains("My::Module - real"), "name should be captured before =end; got: {name}");
+}
+
+/// `=for` inside an active POD block hits the skip-directive branch (line 146).
+#[test]
+fn for_directive_inside_pod_is_skipped() {
+    let source =
+        "=head1 NAME\n\n=for comment this is a private note\n\nMy::ForModule - the name\n\n=cut\n";
+    let doc = extract_pod(source);
+    let name = doc.name.as_deref().unwrap_or("");
+    assert!(
+        name.contains("My::ForModule - the name"),
+        "text after =for directive should be captured; got: {name}"
+    );
+    assert!(!name.contains("private note"), "=for content should not appear in name; got: {name}");
+}
+
+/// `flush_section` called on a section whose body is empty (line 198-199 True branch).
+/// This happens when two section headers appear back-to-back with no content between them.
+#[test]
+fn flush_section_with_empty_body_is_silently_ignored() {
+    // =head1 NAME immediately followed by =head1 SYNOPSIS — the NAME section has no body
+    let source = "=head1 NAME\n\n=head1 SYNOPSIS\n\nuse Empty::Name;\n\n=cut\n";
+    let doc = extract_pod(source);
+    // NAME should be absent (empty body → flush is a no-op)
+    assert!(doc.name.is_none(), "empty NAME body should produce no name; got: {:?}", doc.name);
+    // SYNOPSIS should still be captured
+    assert!(
+        doc.synopsis.as_deref().is_some_and(|s| s.contains("use Empty::Name")),
+        "synopsis should be captured; got: {:?}",
+        doc.synopsis
+    );
+}
+
+/// `extract_pod_from_file` success path (line 45) — read a real temp file.
+#[test]
+fn extract_pod_from_file_success() -> Result<(), Box<dyn std::error::Error>> {
+    let mut tmp = tempfile::NamedTempFile::new()?;
+    write!(tmp, "=head1 NAME\n\nTempFile::Module - loaded from disk\n\n=cut\n")?;
+    let doc = extract_pod_from_file(tmp.path())?;
+    assert_eq!(doc.name.as_deref(), Some("TempFile::Module - loaded from disk"));
+    Ok(())
+}
+
+/// Unknown `E<>` entity passes through as the entity name (line 373).
+/// e.g. `E<nbsp>` is not in the known set and should return "nbsp".
+#[test]
+fn unknown_e_entity_passes_through_as_text() {
+    let doc = extract_pod("=head1 NAME\n\nA E<nbsp> B\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+    assert_eq!(name, "A nbsp B", "unknown E<> entity should pass through as text; got: {name}");
+}
+
+/// `first_paragraph` with a leading blank line before actual content.
+/// Exercises the `!result.is_empty()` False branch (line 229) — when we encounter
+/// a blank line but result is still empty, we must NOT break out of the loop.
+#[test]
+fn first_paragraph_skips_leading_blank_lines() {
+    // strip_pod_formatting is applied before first_paragraph, so feed the
+    // description via extract_pod with a blank line at the start of DESCRIPTION.
+    let source = "=head1 DESCRIPTION\n\n\nActual first line.\nSecond line.\n\nNot in first paragraph.\n\n=cut\n";
+    let doc = extract_pod(source);
+    let desc = doc.description.as_deref().unwrap_or("");
+    assert!(
+        desc.contains("Actual first line."),
+        "first paragraph text should be present; got: {desc}"
+    );
+    assert!(
+        !desc.contains("Not in first paragraph."),
+        "second paragraph should be excluded; got: {desc}"
+    );
+}
+
+/// `=over`/`=back` nesting: multiple overlapping list blocks within a single section.
+/// Verifies that `in_over` toggles correctly across nested/sequential lists.
+#[test]
+fn multiple_sequential_over_back_blocks() {
+    let source = r#"
+=head2 lists
+
+First list:
+
+=over 4
+
+=item one
+
+=item two
+
+=back
+
+Second list:
+
+=over 4
+
+=item three
+
+=back
+
+=cut
+"#;
+    let doc = extract_pod(source);
+    let method_doc = doc.methods.get("lists").map(String::as_str).unwrap_or("");
+    assert!(method_doc.contains("- one"), "first list item; got: {method_doc}");
+    assert!(method_doc.contains("- two"), "second list item; got: {method_doc}");
+    assert!(method_doc.contains("- three"), "third list item in second list; got: {method_doc}");
 }


### PR DESCRIPTION
Problem: `perl-pod` coverage tests included a false `=item` empty-body claim and a weak `=end` skip assertion.
Fix: Make the `=item` fixture truly first in the section body, and assert the `=end` directive text is absent from extracted POD output.
Verification: `cargo test -p perl-pod --test pod_extraction_tests --profile agent --locked` passes; `cargo test -p perl-pod --profile agent --locked` passes; direct `target-current\debug\xtask.exe fmt --check` passes after `cargo xtask fmt --check` exited without diagnostics; `git diff --check` passes.