### PR TITLE
test(perl-token): cover unexecuted functions and tail branches in lib.rs

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -1871,4 +1871,134 @@ mod tests {
         assert_eq!(m.category, TokenCategory::Keyword);
         assert_eq!(m.display_name, "'sub'");
     }
+
+    // --- TokenKind role predicates ---
+
+    #[test]
+    fn is_assignment_operator_returns_true_for_assign_variants() {
+        assert!(TokenKind::Assign.is_assignment_operator());
+        assert!(TokenKind::PlusAssign.is_assignment_operator());
+        assert!(TokenKind::MinusAssign.is_assignment_operator());
+        assert!(TokenKind::StarAssign.is_assignment_operator());
+        assert!(TokenKind::SlashAssign.is_assignment_operator());
+        assert!(TokenKind::PercentAssign.is_assignment_operator());
+        assert!(TokenKind::DotAssign.is_assignment_operator());
+        assert!(TokenKind::AndAssign.is_assignment_operator());
+        assert!(TokenKind::OrAssign.is_assignment_operator());
+        assert!(TokenKind::XorAssign.is_assignment_operator());
+        assert!(TokenKind::PowerAssign.is_assignment_operator());
+        assert!(TokenKind::LeftShiftAssign.is_assignment_operator());
+        assert!(TokenKind::RightShiftAssign.is_assignment_operator());
+        assert!(TokenKind::LogicalAndAssign.is_assignment_operator());
+        assert!(TokenKind::LogicalOrAssign.is_assignment_operator());
+        assert!(TokenKind::DefinedOrAssign.is_assignment_operator());
+    }
+
+    #[test]
+    fn is_assignment_operator_returns_false_for_non_assign() {
+        assert!(!TokenKind::Plus.is_assignment_operator());
+        assert!(!TokenKind::Equal.is_assignment_operator());
+        assert!(!TokenKind::Identifier.is_assignment_operator());
+    }
+
+    #[test]
+    fn is_logical_operator_returns_true_for_logical_variants() {
+        assert!(TokenKind::And.is_logical_operator());
+        assert!(TokenKind::Or.is_logical_operator());
+        assert!(TokenKind::Not.is_logical_operator());
+        assert!(TokenKind::DefinedOr.is_logical_operator());
+        assert!(TokenKind::WordAnd.is_logical_operator());
+        assert!(TokenKind::WordOr.is_logical_operator());
+        assert!(TokenKind::WordNot.is_logical_operator());
+        assert!(TokenKind::WordXor.is_logical_operator());
+    }
+
+    #[test]
+    fn is_logical_operator_returns_false_for_non_logical() {
+        assert!(!TokenKind::Plus.is_logical_operator());
+        assert!(!TokenKind::Assign.is_logical_operator());
+        assert!(!TokenKind::Identifier.is_logical_operator());
+    }
+
+    #[test]
+    fn is_open_delimiter_returns_true_for_open_delimiters() {
+        assert!(TokenKind::LeftParen.is_open_delimiter());
+        assert!(TokenKind::LeftBrace.is_open_delimiter());
+        assert!(TokenKind::LeftBracket.is_open_delimiter());
+    }
+
+    #[test]
+    fn is_open_delimiter_returns_false_for_non_open() {
+        assert!(!TokenKind::RightParen.is_open_delimiter());
+        assert!(!TokenKind::Semicolon.is_open_delimiter());
+        assert!(!TokenKind::Plus.is_open_delimiter());
+    }
+
+    #[test]
+    fn is_quote_like_returns_true_for_quote_variants() {
+        assert!(TokenKind::Regex.is_quote_like());
+        assert!(TokenKind::Substitution.is_quote_like());
+        assert!(TokenKind::Transliteration.is_quote_like());
+        assert!(TokenKind::QuoteSingle.is_quote_like());
+        assert!(TokenKind::QuoteDouble.is_quote_like());
+        assert!(TokenKind::QuoteWords.is_quote_like());
+        assert!(TokenKind::QuoteCommand.is_quote_like());
+        assert!(TokenKind::HeredocStart.is_quote_like());
+    }
+
+    #[test]
+    fn is_quote_like_returns_false_for_non_quote() {
+        assert!(!TokenKind::String.is_quote_like());
+        assert!(!TokenKind::Identifier.is_quote_like());
+        assert!(!TokenKind::LeftParen.is_quote_like());
+    }
+
+    #[test]
+    fn is_recovery_boundary_returns_true_for_boundaries() {
+        assert!(TokenKind::Semicolon.is_recovery_boundary());
+        assert!(TokenKind::RightParen.is_recovery_boundary());
+        assert!(TokenKind::RightBrace.is_recovery_boundary());
+        assert!(TokenKind::RightBracket.is_recovery_boundary());
+        assert!(TokenKind::Eof.is_recovery_boundary());
+    }
+
+    #[test]
+    fn is_recovery_boundary_returns_false_for_non_boundary() {
+        assert!(!TokenKind::Plus.is_recovery_boundary());
+        assert!(!TokenKind::Identifier.is_recovery_boundary());
+        assert!(!TokenKind::LeftParen.is_recovery_boundary());
+    }
+
+    // --- TokenRef::new_checked branches ---
+
+    #[test]
+    fn token_ref_new_checked_rejects_end_before_start() {
+        let err = TokenRef::new_checked(TokenKind::Identifier, "x", 10, 3).unwrap_err();
+        assert_eq!(err, TokenSpanError::EndBeforeStart { start: 10, end: 3 });
+    }
+
+    #[test]
+    fn token_ref_new_checked_allows_empty_eof() {
+        let tok = TokenRef::new_checked(TokenKind::Eof, "", 7, 7).unwrap();
+        assert_eq!(tok.kind, TokenKind::Eof);
+        assert_eq!(tok.start, 7);
+        assert!(tok.is_empty());
+    }
+
+    #[test]
+    fn token_ref_new_checked_allows_empty_unknown() {
+        let tok = TokenRef::new_checked(TokenKind::Unknown, "", 3, 3).unwrap();
+        assert_eq!(tok.kind, TokenKind::Unknown);
+        assert_eq!(tok.start, 3);
+        assert!(tok.is_empty());
+    }
+
+    #[test]
+    fn token_ref_new_checked_rejects_empty_non_eof() {
+        let err = TokenRef::new_checked(TokenKind::Identifier, "", 5, 5).unwrap_err();
+        assert!(matches!(
+            err,
+            TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 5 }
+        ));
+    }
 }

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -1973,32 +1973,35 @@ mod tests {
 
     #[test]
     fn token_ref_new_checked_rejects_end_before_start() {
-        let err = TokenRef::new_checked(TokenKind::Identifier, "x", 10, 3).unwrap_err();
-        assert_eq!(err, TokenSpanError::EndBeforeStart { start: 10, end: 3 });
+        assert_eq!(
+            TokenRef::new_checked(TokenKind::Identifier, "x", 10, 3),
+            Err(TokenSpanError::EndBeforeStart { start: 10, end: 3 })
+        );
     }
 
     #[test]
-    fn token_ref_new_checked_allows_empty_eof() {
-        let tok = TokenRef::new_checked(TokenKind::Eof, "", 7, 7).unwrap();
+    fn token_ref_new_checked_allows_empty_eof() -> Result<(), Box<dyn std::error::Error>> {
+        let tok = TokenRef::new_checked(TokenKind::Eof, "", 7, 7)?;
         assert_eq!(tok.kind, TokenKind::Eof);
         assert_eq!(tok.start, 7);
         assert!(tok.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn token_ref_new_checked_allows_empty_unknown() {
-        let tok = TokenRef::new_checked(TokenKind::Unknown, "", 3, 3).unwrap();
+    fn token_ref_new_checked_allows_empty_unknown() -> Result<(), Box<dyn std::error::Error>> {
+        let tok = TokenRef::new_checked(TokenKind::Unknown, "", 3, 3)?;
         assert_eq!(tok.kind, TokenKind::Unknown);
         assert_eq!(tok.start, 3);
         assert!(tok.is_empty());
+        Ok(())
     }
 
     #[test]
     fn token_ref_new_checked_rejects_empty_non_eof() {
-        let err = TokenRef::new_checked(TokenKind::Identifier, "", 5, 5).unwrap_err();
-        assert!(matches!(
-            err,
-            TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 5 }
-        ));
+        assert_eq!(
+            TokenRef::new_checked(TokenKind::Identifier, "", 5, 5),
+            Err(TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 5 })
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add inline `mod tests` entries for the 5 functions that reported zero coverage in the lib-binary llvm-cov report: `is_assignment_operator`, `is_logical_operator`, `is_open_delimiter`, `is_quote_like`, `is_recovery_boundary`
- Add inline tests for the 2 missed branches in `TokenRef::new_checked`: the `?`-operator error path (end < start) and the empty-Eof / empty-Unknown accepted paths
- Test-only change — no production code modified

## Before / After

| Metric | Before | After | Δ |
|---|---|---|---|
| Regions covered | 97.72% (1112/1138) | 99.70% (1346/1350) | +1.98pp |
| Lines covered | 97.28% (679/698) | 99.87% (793/794) | +2.59pp |
| Branches covered | 80.00% (8/10) | 85.71% (12/14) | +5.71pp |
| Functions covered | 94.32% (83/88) | **100.00% (102/102)** | +5.68pp |

### Per-file delta

`crates/perl-token/src/lib.rs`: Functions 94.32% → 100.00%, Lines 97.28% → 99.87%, Regions 97.72% → 99.70%

## Coverage receipts (new tests → exact site covered)

| New test | Site exercised | lib.rs line |
|---|---|---|
| `is_assignment_operator_returns_true_for_assign_variants` | `TokenKind::is_assignment_operator` — all 16 true-arm variants | 971 |
| `is_assignment_operator_returns_false_for_non_assign` | `is_assignment_operator` — wildcard false arm | 971 |
| `is_logical_operator_returns_true_for_logical_variants` | `TokenKind::is_logical_operator` — all 8 variants | 1014 |
| `is_logical_operator_returns_false_for_non_logical` | `is_logical_operator` — wildcard false arm | 1014 |
| `is_open_delimiter_returns_true_for_open_delimiters` | `TokenKind::is_open_delimiter` — all 3 variants | 1052 |
| `is_open_delimiter_returns_false_for_non_open` | `is_open_delimiter` — wildcard false arm | 1052 |
| `is_quote_like_returns_true_for_quote_variants` | `TokenKind::is_quote_like` — all 8 variants | 1078 |
| `is_quote_like_returns_false_for_non_quote` | `is_quote_like` — wildcard false arm | 1078 |
| `is_recovery_boundary_returns_true_for_boundaries` | `TokenKind::is_recovery_boundary` — Semicolon, 3 close delimiters, Eof | 1094 |
| `is_recovery_boundary_returns_false_for_non_boundary` | `is_recovery_boundary` — non-boundary tokens | 1094 |
| `token_ref_new_checked_rejects_end_before_start` | `TokenRef::new_checked` — `?` error exit on `try_new` | 150 |
| `token_ref_new_checked_allows_empty_eof` | `TokenRef::new_checked` — empty Eof accepted path | 151 |
| `token_ref_new_checked_allows_empty_unknown` | `TokenRef::new_checked` — empty Unknown accepted path | 151 |
| `token_ref_new_checked_rejects_empty_non_eof` | `TokenRef::new_checked` — `EmptySpanNotAllowed` error arm | 152 |

## Why remaining gaps stay uncovered

**2 missed branches** (lib.rs lines 1633 and 1999): Both are the `^0` "else/panic" branch of `assert!(matches!(...))` test assertions. The LLVM branch instrumentor counts the `assert!` macro's internal panic path as a branch. These can never be hit in a passing test run — triggering them would mean the assertion failed, aborting the test binary. This is a structural instrument artifact in `assert!`, not a logic gap.

**1 missed region / line** (lib.rs line 1031): The `matches!(` token inside `is_word_operator` reports 0 in the lib-binary coverage but is exercised by the integration test binary (`token_role_tests.rs`). The "47 functions have mismatched data" warning from llvm-cov indicates this is a binary-merge artifact, not a real gap. The function itself shows 4 calls, which come from `token_roles_are_consistent` calling `is_low_precedence_word_operator` which delegates to `is_word_operator`.

## Test plan

- [x] `cargo test -p perl-token` — all tests pass (61 lib + 4 integration + 6 doctest)
- [x] `cargo clippy -p perl-token --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p perl-token -- --check` — clean
- [x] `cargo +nightly llvm-cov -p perl-token --tests --branch --locked --summary-only` — Functions 100.00%, Lines 99.87%

https://claude.ai/code/session_01X6d9sermWRfFwcAbTYpxa8

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6d9sermWRfFwcAbTYpxa8)_