### PR TITLE
test(parser): lock ExtUtils map-list fixture (#8197)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -722,6 +722,16 @@ fn extutils_mm_unix_hash_slice_map_lc_keys_assignment() {
 }
 
 #[test]
+fn extutils_mm_unix_perl_candidates_map_parenthesized_list() {
+    // From ExtUtils::MM_Unix: push may take a map BLOCK whose source list is
+    // a parenthesized literal list on the following line.
+    assert_clean_parse(
+        r#"push @perls, map { "$_$Config{exe_ext}" }
+                     ("perl$Config{version}", 'perl5', 'perl');"#,
+    );
+}
+
+#[test]
 fn extutils_mm_unix_map_over_grep_substitution() {
     // From ExtUtils::MM_Unix: a hash assignment may merge a map BLOCK whose
     // source list is a grep-like substitution expression over an array.


### PR DESCRIPTION
Problem: The stale parser raw-bucket route still points at `unclosed_paren_identifier` list-operator shapes, but this machine cannot refresh the Linux corpus receipt.
Fix: Add a focused source-backed ExtUtils::MM_Unix fixture for `push @perls, map BLOCK` where the map source is a parenthesized literal list on the following line.
Verification: `cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked -- --nocapture` passes; `cargo xtask metrics parser-accuracy --check` passes; `cargo xtask update-status --only parser --check` passes after generating the local common-corpus receipt; `cargo xtask metrics ratchet-check parser_accuracy` passes; `cargo xtask fmt --check` passes; `git diff --check` passes.

Claim boundary: fixture-only parser coverage. No parser runtime behavior change, no generated parser-status update, no corpus bucket-count movement claim.