### PR TITLE
test(perl-lexer): cover Token, LexerMode, and LexerError accessors (#6754)

### DIFF
--- a/crates/perl-lexer/src/error.rs
+++ b/crates/perl-lexer/src/error.rs
@@ -56,3 +56,74 @@ impl LexerError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::LexerError;
+
+    // --- variants with positions ---
+
+    #[test]
+    fn lexer_error_unterminated_string_returns_position() {
+        let err = LexerError::UnterminatedString { position: 7 };
+        assert_eq!(err.position(), Some(7));
+    }
+
+    #[test]
+    fn lexer_error_unterminated_regex_returns_position() {
+        let err = LexerError::UnterminatedRegex { position: 42 };
+        assert_eq!(err.position(), Some(42));
+    }
+
+    #[test]
+    fn lexer_error_invalid_escape_returns_position() {
+        let err = LexerError::InvalidEscape { char: 'z', position: 15 };
+        assert_eq!(err.position(), Some(15));
+    }
+
+    #[test]
+    fn lexer_error_invalid_number_returns_position() {
+        let err = LexerError::InvalidNumber { position: 3, reason: "bad digit".into() };
+        assert_eq!(err.position(), Some(3));
+    }
+
+    #[test]
+    fn lexer_error_unexpected_char_returns_position() {
+        let err = LexerError::UnexpectedChar { char: '@', position: 99 };
+        assert_eq!(err.position(), Some(99));
+    }
+
+    #[test]
+    fn lexer_error_invalid_utf8_returns_position() {
+        let err = LexerError::InvalidUtf8 { position: 0 };
+        assert_eq!(err.position(), Some(0));
+    }
+
+    #[test]
+    fn lexer_error_heredoc_error_returns_position() {
+        let err = LexerError::HeredocError { position: 256, reason: "no terminator".into() };
+        assert_eq!(err.position(), Some(256));
+    }
+
+    // --- variant without a position ---
+
+    #[test]
+    fn lexer_error_other_returns_none() {
+        let err = LexerError::Other("something went wrong".into());
+        assert_eq!(err.position(), None);
+    }
+
+    // --- edge values ---
+
+    #[test]
+    fn lexer_error_position_zero_is_returned_correctly() {
+        let err = LexerError::UnterminatedString { position: 0 };
+        assert_eq!(err.position(), Some(0));
+    }
+
+    #[test]
+    fn lexer_error_position_usize_max_is_returned_correctly() {
+        let err = LexerError::UnterminatedString { position: usize::MAX };
+        assert_eq!(err.position(), Some(usize::MAX));
+    }
+}

--- a/crates/perl-lexer/src/mode.rs
+++ b/crates/perl-lexer/src/mode.rs
@@ -70,3 +70,89 @@ impl LexerMode {
         matches!(self, LexerMode::ExpectOperator)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::LexerMode;
+
+    // --- is_expect_term ---
+
+    #[test]
+    fn lexer_mode_expect_term_is_term() {
+        assert!(LexerMode::ExpectTerm.is_expect_term());
+    }
+
+    #[test]
+    fn lexer_mode_expect_operator_is_not_term() {
+        assert!(!LexerMode::ExpectOperator.is_expect_term());
+    }
+
+    #[test]
+    fn lexer_mode_expect_delimiter_is_not_term() {
+        assert!(!LexerMode::ExpectDelimiter.is_expect_term());
+    }
+
+    #[test]
+    fn lexer_mode_in_format_body_is_not_term() {
+        assert!(!LexerMode::InFormatBody.is_expect_term());
+    }
+
+    #[test]
+    fn lexer_mode_in_data_section_is_not_term() {
+        assert!(!LexerMode::InDataSection.is_expect_term());
+    }
+
+    // --- is_expect_operator ---
+
+    #[test]
+    fn lexer_mode_expect_operator_is_operator() {
+        assert!(LexerMode::ExpectOperator.is_expect_operator());
+    }
+
+    #[test]
+    fn lexer_mode_expect_term_is_not_operator() {
+        assert!(!LexerMode::ExpectTerm.is_expect_operator());
+    }
+
+    #[test]
+    fn lexer_mode_expect_delimiter_is_not_operator() {
+        assert!(!LexerMode::ExpectDelimiter.is_expect_operator());
+    }
+
+    #[test]
+    fn lexer_mode_in_format_body_is_not_operator() {
+        assert!(!LexerMode::InFormatBody.is_expect_operator());
+    }
+
+    #[test]
+    fn lexer_mode_in_data_section_is_not_operator() {
+        assert!(!LexerMode::InDataSection.is_expect_operator());
+    }
+
+    // --- mutual exclusion ---
+    // No mode is simultaneously term-expecting AND operator-expecting.
+
+    #[test]
+    fn lexer_mode_no_variant_is_both_term_and_operator() {
+        let modes = [
+            LexerMode::ExpectTerm,
+            LexerMode::ExpectOperator,
+            LexerMode::ExpectDelimiter,
+            LexerMode::InFormatBody,
+            LexerMode::InDataSection,
+        ];
+        for mode in modes {
+            assert!(
+                !(mode.is_expect_term() && mode.is_expect_operator()),
+                "{mode:?} should not be both term-expecting and operator-expecting",
+            );
+        }
+    }
+
+    // --- default ---
+
+    #[test]
+    fn lexer_mode_default_is_expect_term() {
+        assert_eq!(LexerMode::default(), LexerMode::ExpectTerm);
+    }
+}

--- a/crates/perl-lexer/src/token.rs
+++ b/crates/perl-lexer/src/token.rs
@@ -177,7 +177,7 @@ impl Token {
 
 #[cfg(test)]
 mod tests {
-    use super::TokenType;
+    use super::{Token, TokenType};
     use std::sync::Arc;
 
     #[test]
@@ -193,5 +193,64 @@ mod tests {
         assert!(TokenType::UnknownRest.is_recovery_token());
         assert!(TokenType::Error(Arc::from("oops")).is_recovery_token());
         assert!(!TokenType::EOF.is_recovery_token());
+    }
+
+    // --- Token::new ---
+
+    #[test]
+    fn token_new_stores_type_text_and_span() {
+        let tok = Token::new(TokenType::Semicolon, ";", 3, 4);
+        assert_eq!(tok.token_type, TokenType::Semicolon);
+        assert_eq!(tok.text.as_ref(), ";");
+        assert_eq!(tok.start, 3);
+        assert_eq!(tok.end, 4);
+    }
+
+    #[test]
+    fn token_new_accepts_arc_str_directly() {
+        let text: Arc<str> = Arc::from("hello");
+        let tok = Token::new(TokenType::Identifier(Arc::from("hello")), text, 0, 5);
+        assert_eq!(tok.start, 0);
+        assert_eq!(tok.end, 5);
+    }
+
+    // --- Token::len ---
+
+    #[test]
+    fn token_len_returns_end_minus_start() {
+        let tok = Token::new(TokenType::Semicolon, ";", 10, 17);
+        assert_eq!(tok.len(), 7);
+    }
+
+    #[test]
+    fn token_len_zero_when_span_is_empty() {
+        let tok = Token::new(TokenType::EOF, "", 5, 5);
+        assert_eq!(tok.len(), 0);
+    }
+
+    #[test]
+    fn token_len_single_byte_span() {
+        let tok = Token::new(TokenType::Comma, ",", 0, 1);
+        assert_eq!(tok.len(), 1);
+    }
+
+    // --- Token::is_empty ---
+
+    #[test]
+    fn token_is_empty_true_for_zero_length_span() {
+        let tok = Token::new(TokenType::EOF, "", 0, 0);
+        assert!(tok.is_empty());
+    }
+
+    #[test]
+    fn token_is_empty_true_for_non_zero_start_matching_end() {
+        let tok = Token::new(TokenType::EOF, "", 42, 42);
+        assert!(tok.is_empty());
+    }
+
+    #[test]
+    fn token_is_empty_false_for_non_zero_length_span() {
+        let tok = Token::new(TokenType::Semicolon, ";", 0, 1);
+        assert!(!tok.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds inline unit tests for three under-covered APIs in `crates/perl-lexer/`:

- **Target 1 — `token.rs`**: `Token::new` (fields stored correctly, accepts `Arc<str>`), `Token::len` (end−start arithmetic, zero-length, single-byte), `Token::is_empty` (zero span at 0 and at arbitrary offset, non-zero span).
- **Target 2 — `mode.rs`**: `LexerMode::is_expect_term` and `is_expect_operator` for all five variants (`ExpectTerm`, `ExpectOperator`, `ExpectDelimiter`, `InFormatBody`, `InDataSection`); mutual-exclusion invariant (no variant is both term- and operator-expecting); `Default` is `ExpectTerm`.
- **Target 3 — `error.rs`**: `LexerError::position` returns `Some(pos)` for all seven positioned variants and `None` for `Other(_)`; edge values `0` and `usize::MAX` both round-trip correctly.

## Test plan

- [ ] `cargo test -p perl-lexer --lib` — 123 tests, 0 failures
- [ ] `cargo fmt -p perl-lexer` — no changes
- [ ] `cargo clippy -p perl-lexer --lib --tests -- -D warnings` — clean

https://claude.ai/code/session_01WF2dSufytJt2818PE5rhG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WF2dSufytJt2818PE5rhG2)_