### PR TITLE
test(perl-lexer): use result-returning coverage tests (#6754)

### DIFF
--- a/crates/perl-lexer/src/error.rs
+++ b/crates/perl-lexer/src/error.rs
@@ -64,66 +64,78 @@ mod tests {
     // --- variants with positions ---
 
     #[test]
-    fn lexer_error_unterminated_string_returns_position() {
+    fn lexer_error_unterminated_string_returns_position() -> Result<(), Box<dyn std::error::Error>>
+    {
         let err = LexerError::UnterminatedString { position: 7 };
         assert_eq!(err.position(), Some(7));
+        Ok(())
     }
 
     #[test]
-    fn lexer_error_unterminated_regex_returns_position() {
+    fn lexer_error_unterminated_regex_returns_position() -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::UnterminatedRegex { position: 42 };
         assert_eq!(err.position(), Some(42));
+        Ok(())
     }
 
     #[test]
-    fn lexer_error_invalid_escape_returns_position() {
+    fn lexer_error_invalid_escape_returns_position() -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::InvalidEscape { char: 'z', position: 15 };
         assert_eq!(err.position(), Some(15));
+        Ok(())
     }
 
     #[test]
-    fn lexer_error_invalid_number_returns_position() {
+    fn lexer_error_invalid_number_returns_position() -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::InvalidNumber { position: 3, reason: "bad digit".into() };
         assert_eq!(err.position(), Some(3));
+        Ok(())
     }
 
     #[test]
-    fn lexer_error_unexpected_char_returns_position() {
+    fn lexer_error_unexpected_char_returns_position() -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::UnexpectedChar { char: '@', position: 99 };
         assert_eq!(err.position(), Some(99));
+        Ok(())
     }
 
     #[test]
-    fn lexer_error_invalid_utf8_returns_position() {
+    fn lexer_error_invalid_utf8_returns_position() -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::InvalidUtf8 { position: 0 };
         assert_eq!(err.position(), Some(0));
+        Ok(())
     }
 
     #[test]
-    fn lexer_error_heredoc_error_returns_position() {
+    fn lexer_error_heredoc_error_returns_position() -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::HeredocError { position: 256, reason: "no terminator".into() };
         assert_eq!(err.position(), Some(256));
+        Ok(())
     }
 
     // --- variant without a position ---
 
     #[test]
-    fn lexer_error_other_returns_none() {
+    fn lexer_error_other_returns_none() -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::Other("something went wrong".into());
         assert_eq!(err.position(), None);
+        Ok(())
     }
 
     // --- edge values ---
 
     #[test]
-    fn lexer_error_position_zero_is_returned_correctly() {
+    fn lexer_error_position_zero_is_returned_correctly() -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::UnterminatedString { position: 0 };
         assert_eq!(err.position(), Some(0));
+        Ok(())
     }
 
     #[test]
-    fn lexer_error_position_usize_max_is_returned_correctly() {
+    fn lexer_error_position_usize_max_is_returned_correctly()
+    -> Result<(), Box<dyn std::error::Error>> {
         let err = LexerError::UnterminatedString { position: usize::MAX };
         assert_eq!(err.position(), Some(usize::MAX));
+        Ok(())
     }
 }

--- a/crates/perl-lexer/src/mode.rs
+++ b/crates/perl-lexer/src/mode.rs
@@ -78,62 +78,72 @@ mod tests {
     // --- is_expect_term ---
 
     #[test]
-    fn lexer_mode_expect_term_is_term() {
+    fn lexer_mode_expect_term_is_term() -> Result<(), Box<dyn std::error::Error>> {
         assert!(LexerMode::ExpectTerm.is_expect_term());
+        Ok(())
     }
 
     #[test]
-    fn lexer_mode_expect_operator_is_not_term() {
+    fn lexer_mode_expect_operator_is_not_term() -> Result<(), Box<dyn std::error::Error>> {
         assert!(!LexerMode::ExpectOperator.is_expect_term());
+        Ok(())
     }
 
     #[test]
-    fn lexer_mode_expect_delimiter_is_not_term() {
+    fn lexer_mode_expect_delimiter_is_not_term() -> Result<(), Box<dyn std::error::Error>> {
         assert!(!LexerMode::ExpectDelimiter.is_expect_term());
+        Ok(())
     }
 
     #[test]
-    fn lexer_mode_in_format_body_is_not_term() {
+    fn lexer_mode_in_format_body_is_not_term() -> Result<(), Box<dyn std::error::Error>> {
         assert!(!LexerMode::InFormatBody.is_expect_term());
+        Ok(())
     }
 
     #[test]
-    fn lexer_mode_in_data_section_is_not_term() {
+    fn lexer_mode_in_data_section_is_not_term() -> Result<(), Box<dyn std::error::Error>> {
         assert!(!LexerMode::InDataSection.is_expect_term());
+        Ok(())
     }
 
     // --- is_expect_operator ---
 
     #[test]
-    fn lexer_mode_expect_operator_is_operator() {
+    fn lexer_mode_expect_operator_is_operator() -> Result<(), Box<dyn std::error::Error>> {
         assert!(LexerMode::ExpectOperator.is_expect_operator());
+        Ok(())
     }
 
     #[test]
-    fn lexer_mode_expect_term_is_not_operator() {
+    fn lexer_mode_expect_term_is_not_operator() -> Result<(), Box<dyn std::error::Error>> {
         assert!(!LexerMode::ExpectTerm.is_expect_operator());
+        Ok(())
     }
 
     #[test]
-    fn lexer_mode_expect_delimiter_is_not_operator() {
+    fn lexer_mode_expect_delimiter_is_not_operator() -> Result<(), Box<dyn std::error::Error>> {
         assert!(!LexerMode::ExpectDelimiter.is_expect_operator());
+        Ok(())
     }
 
     #[test]
-    fn lexer_mode_in_format_body_is_not_operator() {
+    fn lexer_mode_in_format_body_is_not_operator() -> Result<(), Box<dyn std::error::Error>> {
         assert!(!LexerMode::InFormatBody.is_expect_operator());
+        Ok(())
     }
 
     #[test]
-    fn lexer_mode_in_data_section_is_not_operator() {
+    fn lexer_mode_in_data_section_is_not_operator() -> Result<(), Box<dyn std::error::Error>> {
         assert!(!LexerMode::InDataSection.is_expect_operator());
+        Ok(())
     }
 
     // --- mutual exclusion ---
     // No mode is simultaneously term-expecting AND operator-expecting.
 
     #[test]
-    fn lexer_mode_no_variant_is_both_term_and_operator() {
+    fn lexer_mode_no_variant_is_both_term_and_operator() -> Result<(), Box<dyn std::error::Error>> {
         let modes = [
             LexerMode::ExpectTerm,
             LexerMode::ExpectOperator,
@@ -147,12 +157,14 @@ mod tests {
                 "{mode:?} should not be both term-expecting and operator-expecting",
             );
         }
+        Ok(())
     }
 
     // --- default ---
 
     #[test]
-    fn lexer_mode_default_is_expect_term() {
+    fn lexer_mode_default_is_expect_term() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(LexerMode::default(), LexerMode::ExpectTerm);
+        Ok(())
     }
 }

--- a/crates/perl-lexer/src/token.rs
+++ b/crates/perl-lexer/src/token.rs
@@ -181,76 +181,89 @@ mod tests {
     use std::sync::Arc;
 
     #[test]
-    fn token_type_trivia_classifier_matches_expected_variants() {
+    fn token_type_trivia_classifier_matches_expected_variants()
+    -> Result<(), Box<dyn std::error::Error>> {
         assert!(TokenType::Whitespace.is_trivia());
         assert!(TokenType::Newline.is_trivia());
         assert!(TokenType::Comment(Arc::from("# note")).is_trivia());
         assert!(!TokenType::Identifier(Arc::from("foo")).is_trivia());
+        Ok(())
     }
 
     #[test]
-    fn token_type_recovery_classifier_matches_expected_variants() {
+    fn token_type_recovery_classifier_matches_expected_variants()
+    -> Result<(), Box<dyn std::error::Error>> {
         assert!(TokenType::UnknownRest.is_recovery_token());
         assert!(TokenType::Error(Arc::from("oops")).is_recovery_token());
         assert!(!TokenType::EOF.is_recovery_token());
+        Ok(())
     }
 
     // --- Token::new ---
 
     #[test]
-    fn token_new_stores_type_text_and_span() {
+    fn token_new_stores_type_text_and_span() -> Result<(), Box<dyn std::error::Error>> {
         let tok = Token::new(TokenType::Semicolon, ";", 3, 4);
         assert_eq!(tok.token_type, TokenType::Semicolon);
         assert_eq!(tok.text.as_ref(), ";");
         assert_eq!(tok.start, 3);
         assert_eq!(tok.end, 4);
+        Ok(())
     }
 
     #[test]
-    fn token_new_accepts_arc_str_directly() {
+    fn token_new_accepts_arc_str_directly() -> Result<(), Box<dyn std::error::Error>> {
         let text: Arc<str> = Arc::from("hello");
         let tok = Token::new(TokenType::Identifier(Arc::from("hello")), text, 0, 5);
         assert_eq!(tok.start, 0);
         assert_eq!(tok.end, 5);
+        Ok(())
     }
 
     // --- Token::len ---
 
     #[test]
-    fn token_len_returns_end_minus_start() {
+    fn token_len_returns_end_minus_start() -> Result<(), Box<dyn std::error::Error>> {
         let tok = Token::new(TokenType::Semicolon, ";", 10, 17);
         assert_eq!(tok.len(), 7);
+        Ok(())
     }
 
     #[test]
-    fn token_len_zero_when_span_is_empty() {
+    fn token_len_zero_when_span_is_empty() -> Result<(), Box<dyn std::error::Error>> {
         let tok = Token::new(TokenType::EOF, "", 5, 5);
         assert_eq!(tok.len(), 0);
+        Ok(())
     }
 
     #[test]
-    fn token_len_single_byte_span() {
+    fn token_len_single_byte_span() -> Result<(), Box<dyn std::error::Error>> {
         let tok = Token::new(TokenType::Comma, ",", 0, 1);
         assert_eq!(tok.len(), 1);
+        Ok(())
     }
 
     // --- Token::is_empty ---
 
     #[test]
-    fn token_is_empty_true_for_zero_length_span() {
+    fn token_is_empty_true_for_zero_length_span() -> Result<(), Box<dyn std::error::Error>> {
         let tok = Token::new(TokenType::EOF, "", 0, 0);
         assert!(tok.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn token_is_empty_true_for_non_zero_start_matching_end() {
+    fn token_is_empty_true_for_non_zero_start_matching_end()
+    -> Result<(), Box<dyn std::error::Error>> {
         let tok = Token::new(TokenType::EOF, "", 42, 42);
         assert!(tok.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn token_is_empty_false_for_non_zero_length_span() {
+    fn token_is_empty_false_for_non_zero_length_span() -> Result<(), Box<dyn std::error::Error>> {
         let tok = Token::new(TokenType::Semicolon, ";", 0, 1);
         assert!(!tok.is_empty());
+        Ok(())
     }
 }


### PR DESCRIPTION
Problem: The lexer coverage tests merged in #9060 used plain unit-test signatures, which does not match the repo AGENTS rule for tests.

Fix: Convert the new lexer coverage tests in `error`, `mode`, and `token` to `Result`-returning tests. Assertions and production code are unchanged.

Verification:
- `cargo test -p perl-lexer --lib --profile agent --locked`
- `cargo xtask fmt --check`
- `git diff --check`

Claim boundary: test-shape hygiene only; no lexer behavior, provider behavior, support-tier, parser-status, or parser bucket movement claim.