### PR TITLE
fix(parser-core): guard empty-source error classification (#8197)

### DIFF
--- a/crates/perl-parser-core/src/syntax/error/classifier.rs
+++ b/crates/perl-parser-core/src/syntax/error/classifier.rs
@@ -196,8 +196,8 @@ impl ErrorClassifier {
             }
         }
 
-        // Check if we're at EOF
-        if error_node.location.start >= source.len() - 1 {
+        // Check if we're at EOF; use saturating_sub to avoid underflow on empty source
+        if source.is_empty() || error_node.location.start >= source.len().saturating_sub(1) {
             return ParseErrorKind::UnexpectedEof;
         }
 

--- a/crates/perl-parser-core/tests/error_classifier_tests.rs
+++ b/crates/perl-parser-core/tests/error_classifier_tests.rs
@@ -128,3 +128,22 @@ fn explanation_some_for_common_kinds() -> Result<(), Box<dyn std::error::Error>>
     assert!(c.get_explanation(&ParseErrorKind::InvalidSyntax).is_none());
     Ok(())
 }
+
+#[test]
+fn classify_empty_source_does_not_panic() -> Result<(), Box<dyn std::error::Error>> {
+    // Regression: source.len() - 1 underflows when source is empty (usize wraps in release,
+    // panics in debug). Should return UnexpectedEof, not crash.
+    let classifier = ErrorClassifier::new();
+    let node = V1Node::new(
+        V1NodeKind::Error {
+            message: "err".to_string(),
+            expected: vec![],
+            found: None,
+            partial: None,
+        },
+        SourceLocation::new(0, 0),
+    );
+    let kind = classifier.classify(&node, "");
+    assert_eq!(kind, ParseErrorKind::UnexpectedEof);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **Bug**: `ErrorClassifier::classify` computes `source.len() - 1` without guarding against an empty `source` string. On an empty input, `usize` subtraction wraps to `usize::MAX` in release builds (returning `InvalidSyntax` silently instead of `UnexpectedEof`) and panics in debug builds.
- **Fix**: Replace `source.len() - 1` with `source.len().saturating_sub(1)` and add an explicit `source.is_empty()` short-circuit at the same guard for clarity.
- **Test**: Added `classify_empty_source_does_not_panic` to `tests/error_classifier_tests.rs` — this test previously panicked in debug mode.

## Files changed

- `crates/perl-parser-core/src/syntax/error/classifier.rs` — one-line fix at line 200
- `crates/perl-parser-core/tests/error_classifier_tests.rs` — regression test

## Test plan

- [x] `cargo test -p perl-parser-core --test error_classifier_tests` — all 8 tests pass (including new regression)
- [x] `cargo fmt -p perl-parser-core` — no changes
- [x] `cargo clippy -p perl-parser-core --tests -- -D warnings` — clean

https://claude.ai/code/session_01HNnGfzahZEFoTZoB2ahija

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNnGfzahZEFoTZoB2ahija)_