### PR TITLE
refactor(ci-hygiene): split badge command module (#0000)

### DIFF
--- a/crates/perl-ci-hygiene/src/commands/badges.rs
+++ b/crates/perl-ci-hygiene/src/commands/badges.rs
@@ -1,0 +1,176 @@
+use color_eyre::eyre::{Context, Result};
+use regex::Regex;
+use std::fs;
+use std::path::Path;
+use std::sync::LazyLock;
+use toml::Value as TomlValue;
+
+const RED: &str = "\x1b[0;31m";
+const GREEN: &str = "\x1b[0;32m";
+const NC: &str = "\x1b[0m";
+
+static VS_MARKETPLACE_INSTALLS_BADGE_RE: LazyLock<Regex> =
+    LazyLock::new(|| match Regex::new(r"VS%20Marketplace-(\d+)%20installs") {
+        Ok(regex) => regex,
+        Err(error) => {
+            unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_RE is a known-good static pattern: {error}")
+        }
+    });
+
+static VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE: LazyLock<Regex> = LazyLock::new(
+    || match Regex::new(
+        r"(?s)<!-- perl-lsp:vs-marketplace-installs-badge:start -->.*?<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+    ) {
+        Ok(regex) => regex,
+        Err(error) => unreachable!(
+            "VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE is a known-good static pattern: {error}"
+        ),
+    },
+);
+
+pub(crate) fn generate_badges(repo_root: &Path, check_mode: bool) -> Result<i32> {
+    let facts_file = repo_root.join("docs/project/publication-facts.toml");
+    let facts_content = fs::read_to_string(&facts_file)
+        .with_context(|| format!("reading facts file {:?}", facts_file))?;
+    let facts: TomlValue = toml::from_str(&facts_content)
+        .with_context(|| format!("parsing facts file {:?}", facts_file))?;
+
+    let vscode_installs = vscode_installs_from_facts(&facts, &facts_file)?;
+    let badge_url = marketplace_badge_url(vscode_installs);
+    let root_readme = repo_root.join("README.md");
+    let ext_readme = repo_root.join("vscode-extension/README.md");
+
+    if check_mode {
+        return check_badges(
+            &[root_readme.as_path(), ext_readme.as_path()],
+            &badge_url,
+            vscode_installs,
+            &facts_file,
+        );
+    }
+
+    update_badges(&[root_readme.as_path(), ext_readme.as_path()], &badge_url)?;
+    println!(
+        "{}✓ Badges updated from value {} in publication-facts.toml{}",
+        GREEN, vscode_installs, NC
+    );
+    Ok(0)
+}
+
+fn vscode_installs_from_facts(facts: &TomlValue, facts_file: &Path) -> Result<u32> {
+    let vscode_installs_i64 = facts
+        .get("external")
+        .and_then(|e| e.get("vscode_marketplace_installs"))
+        .and_then(|v| v.get("value"))
+        .and_then(|v| v.as_integer())
+        .ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Could not read vscode_marketplace_installs.value from {}",
+                facts_file.display()
+            )
+        })?;
+
+    u32::try_from(vscode_installs_i64).with_context(|| {
+        format!("vscode_marketplace_installs value {vscode_installs_i64} is out of range for u32")
+    })
+}
+
+fn marketplace_badge_url(vscode_installs: u32) -> String {
+    format!("https://img.shields.io/badge/VS%20Marketplace-{vscode_installs}%20installs-0078D4")
+}
+
+fn check_badges(
+    readme_paths: &[&Path],
+    badge_url: &str,
+    vscode_installs: u32,
+    facts_file: &Path,
+) -> Result<i32> {
+    let mut has_drift = false;
+    for readme_path in readme_paths {
+        if !readme_path.exists() {
+            continue;
+        }
+
+        let content = fs::read_to_string(readme_path)?;
+        if content.contains(badge_url) {
+            continue;
+        }
+
+        report_badge_drift(readme_path, &content, vscode_installs, facts_file);
+        has_drift = true;
+    }
+
+    if has_drift {
+        eprintln!("Run: cargo xtask ci-hygiene generate-badges");
+        return Ok(1);
+    }
+
+    println!("{}✓ VS Marketplace badge check passed{}", GREEN, NC);
+    Ok(0)
+}
+
+fn report_badge_drift(readme_path: &Path, content: &str, vscode_installs: u32, facts_file: &Path) {
+    eprintln!("{}VS Marketplace badge drift in {}{}", RED, readme_path.display(), NC);
+    eprintln!("  expected installs: {} from {}", vscode_installs, facts_file.display());
+
+    if let Some(caps) = VS_MARKETPLACE_INSTALLS_BADGE_RE.captures(content)
+        && let Some(found) = caps.get(1)
+    {
+        eprintln!(
+            "  stale badge found: {} but expected {} in {}",
+            found.as_str(),
+            vscode_installs,
+            readme_path.display()
+        );
+    }
+}
+
+fn update_badges(readme_paths: &[&Path], badge_url: &str) -> Result<()> {
+    for readme_path in readme_paths {
+        if !readme_path.exists() {
+            continue;
+        }
+
+        let content = fs::read_to_string(readme_path)?;
+        let updated = update_badge_in_content(&content, badge_url);
+
+        if updated != content {
+            fs::write(readme_path, &updated)
+                .with_context(|| format!("writing updated badge to {:?}", readme_path))?;
+            println!("{}✓ Updated VS Marketplace badge in {}{}", GREEN, readme_path.display(), NC);
+        }
+    }
+
+    Ok(())
+}
+
+fn update_badge_in_content(content: &str, badge_url: &str) -> String {
+    if !VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.is_match(content) {
+        return content.to_string();
+    }
+
+    // Determine if we're dealing with HTML or Markdown format.
+    if content.contains("href=\"https://marketplace.visualstudio.com") {
+        return replace_badge_block(content, &html_badge_block(badge_url));
+    }
+
+    replace_badge_block(content, &markdown_badge_block(badge_url))
+}
+
+fn replace_badge_block(content: &str, replacement: &str) -> String {
+    VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.replace_all(content, replacement).into_owned()
+}
+
+fn html_badge_block(badge_url: &str) -> String {
+    format!(
+        "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n  <a href=\"https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs\"><img src=\"{}\" alt=\"VS Marketplace installs\" /></a>\n  <!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+        badge_url
+    )
+}
+
+fn markdown_badge_block(badge_url: &str) -> String {
+    format!(
+        "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n[![VS Marketplace Installs (manual)]({})](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)\n<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+        badge_url
+    )
+}

--- a/crates/perl-ci-hygiene/src/commands/mod.rs
+++ b/crates/perl-ci-hygiene/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod badges;
 pub(crate) mod doc_paths;

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -14,7 +14,6 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::LazyLock;
 use toml::Value as TomlValue;
 use walkdir::{DirEntry, WalkDir};
 
@@ -30,21 +29,6 @@ const GREEN: &str = "\x1b[0;32m";
 const YELLOW: &str = "\x1b[0;33m";
 const BLUE: &str = "\x1b[0;34m";
 const NC: &str = "\x1b[0m";
-
-static VS_MARKETPLACE_INSTALLS_BADGE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"VS%20Marketplace-(\d+)%20installs").unwrap_or_else(|error| {
-        unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_RE is a known-good static pattern: {error}")
-    })
-});
-
-static VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?s)<!-- perl-lsp:vs-marketplace-installs-badge:start -->.*?<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
-    )
-    .unwrap_or_else(|error| {
-        unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE is a known-good static pattern: {error}")
-    })
-});
 
 fn main() -> std::process::ExitCode {
     if let Err(err) = color_eyre::install() {
@@ -1504,124 +1488,8 @@ fn find_cancel_test_binary(repo_root: &Path) -> Option<PathBuf> {
 }
 
 fn cmd_generate_badges(repo_root: &Path, check_mode: bool) -> Result<i32> {
-    let facts_file = repo_root.join("docs/project/publication-facts.toml");
-    let facts_content = fs::read_to_string(&facts_file)
-        .with_context(|| format!("reading facts file {:?}", facts_file))?;
-    let facts: TomlValue = toml::from_str(&facts_content)
-        .with_context(|| format!("parsing facts file {:?}", facts_file))?;
-
-    let vscode_installs_i64 = facts
-        .get("external")
-        .and_then(|e| e.get("vscode_marketplace_installs"))
-        .and_then(|v| v.get("value"))
-        .and_then(|v| v.as_integer())
-        .ok_or_else(|| {
-            color_eyre::eyre::eyre!(
-                "Could not read vscode_marketplace_installs.value from {}",
-                facts_file.display()
-            )
-        })?;
-
-    let vscode_installs = u32::try_from(vscode_installs_i64).with_context(|| {
-        format!("vscode_marketplace_installs value {} is out of range for u32", vscode_installs_i64)
-    })?;
-
-    let badge_url = format!(
-        "https://img.shields.io/badge/VS%20Marketplace-{}%20installs-0078D4",
-        vscode_installs
-    );
-
-    let root_readme = repo_root.join("README.md");
-    let ext_readme = repo_root.join("vscode-extension/README.md");
-
-    if check_mode {
-        let mut has_drift = false;
-        for readme_path in [&root_readme, &ext_readme] {
-            if readme_path.exists() {
-                let content = fs::read_to_string(readme_path)?;
-                if !content.contains(&badge_url) {
-                    eprintln!(
-                        "{}VS Marketplace badge drift in {}{}",
-                        RED,
-                        readme_path.display(),
-                        NC
-                    );
-                    eprintln!(
-                        "  expected installs: {} from {}",
-                        vscode_installs,
-                        facts_file.display()
-                    );
-
-                    if let Some(caps) = VS_MARKETPLACE_INSTALLS_BADGE_RE.captures(&content)
-                        && let Some(found) = caps.get(1)
-                    {
-                        eprintln!(
-                            "  stale badge found: {} but expected {} in {}",
-                            found.as_str(),
-                            vscode_installs,
-                            readme_path.display()
-                        );
-                    }
-                    has_drift = true;
-                }
-            }
-        }
-        if has_drift {
-            eprintln!("Run: cargo xtask ci-hygiene generate-badges");
-            return Ok(1);
-        }
-        println!("{}✓ VS Marketplace badge check passed{}", GREEN, NC);
-        return Ok(0);
-    }
-
-    // Generate mode: update badges
-    for readme_path in [&root_readme, &ext_readme] {
-        if !readme_path.exists() {
-            continue;
-        }
-
-        let content = fs::read_to_string(readme_path)?;
-        let updated = update_badge_in_content(&content, &badge_url)?;
-
-        if updated != content {
-            fs::write(readme_path, &updated)
-                .with_context(|| format!("writing updated badge to {:?}", readme_path))?;
-            println!("{}✓ Updated VS Marketplace badge in {}{}", GREEN, readme_path.display(), NC);
-        }
-    }
-
-    println!(
-        "{}✓ Badges updated from value {} in publication-facts.toml{}",
-        GREEN, vscode_installs, NC
-    );
-    Ok(0)
+    commands::badges::generate_badges(repo_root, check_mode)
 }
-
-fn update_badge_in_content(content: &str, badge_url: &str) -> Result<String> {
-    if !VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.is_match(content) {
-        return Ok(content.to_string());
-    }
-
-    // Determine if we're dealing with HTML or Markdown format
-    if content.contains("href=\"https://marketplace.visualstudio.com") {
-        // HTML format
-        let replacement = format!(
-            "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n  <a href=\"https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs\"><img src=\"{}\" alt=\"VS Marketplace installs\" /></a>\n  <!-- perl-lsp:vs-marketplace-installs-badge:end -->",
-            badge_url
-        );
-        return Ok(VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE
-            .replace_all(content, replacement)
-            .into_owned());
-    }
-
-    // Markdown format
-    let replacement = format!(
-        "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n[![VS Marketplace Installs (manual)]({})](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)\n<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
-        badge_url
-    );
-    Ok(VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.replace_all(content, replacement).into_owned())
-}
-
 fn pre_push_hook_script() -> &'static str {
     r#"#!/usr/bin/env bash
 # ============================================================================


### PR DESCRIPTION
### Motivation
- The VS Marketplace badge parsing, checking, and rewriting logic lived inline inside a large `main.rs`, increasing cognitive load and violating SRP for the ci-hygiene binary.
- Extracting the badge workflow into a focused module improves readability and enables clearer unitization of parsing, checking, and rendering responsibilities.

### Description
- Add `crates/perl-ci-hygiene/src/commands/badges.rs` implementing `generate_badges` and SRP helpers for fact parsing, badge URL construction, drift reporting, update rewriting, and HTML/Markdown block rendering.
- Wire the new module into the command surface by adding `pub(crate) mod badges;` to `crates/perl-ci-hygiene/src/commands/mod.rs`.
- Remove the inlined badge statics and helpers from `crates/perl-ci-hygiene/src/main.rs` and replace `cmd_generate_badges` with a thin wrapper that calls `commands::badges::generate_badges(repo_root, check_mode)`.

### Testing
- Ran `cargo fmt --manifest-path crates/perl-ci-hygiene/Cargo.toml` with no issues.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check --all-targets -p perl-ci-hygiene --profile agent --locked` which succeeded.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-ci-hygiene --profile agent --locked` and all tests passed.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-ci-hygiene --profile agent --locked -- -D warnings -A missing_docs` which completed successfully; the repo-level `./scripts/cargo-safe check` was blocked by a storage guard so the direct `CARGO_TARGET_DIR` checks listed above were used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bcf42ecc83338b83c958c61494cf)