### PR TITLE
fix(perl-pod): decode additional POD entities (#0000)

### DIFF
--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -361,8 +361,11 @@ fn extract_link_display(link: &str) -> String {
 /// - `E<amp>` → `&`
 /// - `E<quot>` → `"`
 /// - `E<apos>` → `'`
+/// - `E<sol>` → `/`
+/// - `E<verbar>` → `|`
+/// - `E<123>` / `E<0x7B>` → the corresponding Unicode scalar value
 ///
-/// Unknown entities are returned as-is.
+/// Unknown or invalid entities are returned as-is.
 fn decode_pod_entity(entity: &str) -> String {
     match entity {
         "lt" => "<".to_string(),
@@ -370,8 +373,22 @@ fn decode_pod_entity(entity: &str) -> String {
         "amp" => "&".to_string(),
         "quot" => "\"".to_string(),
         "apos" => "'".to_string(),
-        _ => entity.to_string(),
+        "sol" => "/".to_string(),
+        "verbar" => "|".to_string(),
+        _ => decode_numeric_pod_entity(entity).unwrap_or_else(|| entity.to_string()),
     }
+}
+
+/// Decode a numeric POD entity as either decimal or `0x`-prefixed hexadecimal.
+fn decode_numeric_pod_entity(entity: &str) -> Option<String> {
+    let codepoint =
+        if let Some(hex) = entity.strip_prefix("0x").or_else(|| entity.strip_prefix("0X")) {
+            u32::from_str_radix(hex, 16).ok()?
+        } else {
+            entity.parse::<u32>().ok()?
+        };
+
+    char::from_u32(codepoint).map(|ch| ch.to_string())
 }
 
 fn is_pod_format_code(c: char) -> bool {
@@ -398,12 +415,18 @@ mod tests {
     }
 
     #[test]
-    fn decode_entity_numeric_looking_returns_unchanged() {
-        // Numeric-looking names like "32" or "0x20" are not handled as HTML numeric refs;
-        // they fall through to the unknown branch and are returned as-is.
-        // TODO: POD spec §8 supports E<number> (Unicode code point) — currently unimplemented.
-        assert_eq!(decode_pod_entity("32"), "32");
-        assert_eq!(decode_pod_entity("0x20"), "0x20");
+    fn decode_entity_numeric_values() {
+        assert_eq!(decode_pod_entity("32"), " ");
+        assert_eq!(decode_pod_entity("0x20"), " ");
+        assert_eq!(decode_pod_entity("0X7C"), "|");
+        assert_eq!(decode_pod_entity("9786"), "☺");
+    }
+
+    #[test]
+    fn decode_entity_invalid_numeric_values_return_unchanged() {
+        assert_eq!(decode_pod_entity("0x"), "0x");
+        assert_eq!(decode_pod_entity("0xZZ"), "0xZZ");
+        assert_eq!(decode_pod_entity("1114112"), "1114112");
     }
 
     #[test]
@@ -413,6 +436,8 @@ mod tests {
         assert_eq!(decode_pod_entity("amp"), "&");
         assert_eq!(decode_pod_entity("quot"), "\"");
         assert_eq!(decode_pod_entity("apos"), "'");
+        assert_eq!(decode_pod_entity("sol"), "/");
+        assert_eq!(decode_pod_entity("verbar"), "|");
     }
 
     // ── encode_pod_link_target ───────────────────────────────────────────────

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -570,3 +570,24 @@ sub run { }
     assert_eq!(doc.name.as_deref(), Some("Multi - Multiple POD blocks"));
     assert!(doc.methods.contains_key("run"));
 }
+
+#[test]
+fn e_format_code_decodes_numeric_entities() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head1 NAME\n\nE<65>E<0x42>E<0X43> E<9786>\n\n=cut\n");
+    assert_eq!(doc.name.as_deref(), Some("ABC ☺"));
+    Ok(())
+}
+
+#[test]
+fn e_format_code_decodes_sol_and_verbar_entities() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head1 NAME\n\npathE<sol>to E<verbar> fallback\n\n=cut\n");
+    assert_eq!(doc.name.as_deref(), Some("path/to | fallback"));
+    Ok(())
+}
+
+#[test]
+fn invalid_numeric_entities_remain_visible() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head1 NAME\n\nE<0xZZ> E<1114112>\n\n=cut\n");
+    assert_eq!(doc.name.as_deref(), Some("0xZZ 1114112"));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- POD `E<>` entities such as numeric code points and the `sol`/`verbar` names were being left verbatim in extracted documentation instead of being decoded to their intended characters.
- Downstream LSP hover rendering and markdown links rely on these entities being rendered correctly for readable documentation.

### Description

- Extend `decode_pod_entity` to decode `E<sol>` → `/` and `E<verbar>` → `|` and to fall back to numeric decoding for decimal and `0x`/`0X` hexadecimal forms via a new helper `decode_numeric_pod_entity`.
- Implement `decode_numeric_pod_entity` which parses decimal or hex code points and converts valid Unicode code points to characters, returning `None` for invalid values so the original text is preserved.
- Add unit and integration tests in `crates/perl-pod/src/lib.rs` and `crates/perl-pod/tests/pod_extraction_tests.rs` covering numeric entities, `sol`/`verbar`, and invalid numeric fallbacks, and update doc comments accordingly.

### Testing

- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/build cargo test -p perl-pod --profile agent --locked` and all tests passed (unit and extraction tests).
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/build cargo check --all-targets -p perl-pod --profile agent --locked` and `cargo clippy -p perl-pod --profile agent --locked -- -D warnings -A missing_docs`, both completed successfully.
- Ran formatting via `./scripts/cargo-safe xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb0ad1c08333af932ac9a0c511f8)