### PR TITLE
fix(perl-pod): decode numeric POD entities (#0000)

### DIFF
--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -361,8 +361,11 @@ fn extract_link_display(link: &str) -> String {
 /// - `E<amp>` → `&`
 /// - `E<quot>` → `"`
 /// - `E<apos>` → `'`
+/// - `E<sol>` → `/`
+/// - `E<verbar>` → `|`
+/// - `E<number>` and `E<0xhex>` → Unicode scalar value
 ///
-/// Unknown entities are returned as-is.
+/// Unknown or invalid entities are returned as-is.
 fn decode_pod_entity(entity: &str) -> String {
     match entity {
         "lt" => "<".to_string(),
@@ -370,8 +373,21 @@ fn decode_pod_entity(entity: &str) -> String {
         "amp" => "&".to_string(),
         "quot" => "\"".to_string(),
         "apos" => "'".to_string(),
-        _ => entity.to_string(),
+        "sol" => "/".to_string(),
+        "verbar" => "|".to_string(),
+        _ => decode_numeric_pod_entity(entity).unwrap_or_else(|| entity.to_string()),
     }
+}
+
+fn decode_numeric_pod_entity(entity: &str) -> Option<String> {
+    let codepoint =
+        if let Some(hex) = entity.strip_prefix("0x").or_else(|| entity.strip_prefix("0X")) {
+            u32::from_str_radix(hex, 16).ok()?
+        } else {
+            entity.parse::<u32>().ok()?
+        };
+
+    char::from_u32(codepoint).map(|ch| ch.to_string())
 }
 
 fn is_pod_format_code(c: char) -> bool {
@@ -398,12 +414,16 @@ mod tests {
     }
 
     #[test]
-    fn decode_entity_numeric_looking_returns_unchanged() {
-        // Numeric-looking names like "32" or "0x20" are not handled as HTML numeric refs;
-        // they fall through to the unknown branch and are returned as-is.
-        // TODO: POD spec §8 supports E<number> (Unicode code point) — currently unimplemented.
-        assert_eq!(decode_pod_entity("32"), "32");
-        assert_eq!(decode_pod_entity("0x20"), "0x20");
+    fn decode_entity_numeric_entities() {
+        assert_eq!(decode_pod_entity("32"), " ");
+        assert_eq!(decode_pod_entity("0x20"), " ");
+        assert_eq!(decode_pod_entity("0X41"), "A");
+    }
+
+    #[test]
+    fn decode_entity_invalid_numeric_entities_return_unchanged() {
+        assert_eq!(decode_pod_entity("0x110000"), "0x110000");
+        assert_eq!(decode_pod_entity("0xZZ"), "0xZZ");
     }
 
     #[test]
@@ -413,6 +433,8 @@ mod tests {
         assert_eq!(decode_pod_entity("amp"), "&");
         assert_eq!(decode_pod_entity("quot"), "\"");
         assert_eq!(decode_pod_entity("apos"), "'");
+        assert_eq!(decode_pod_entity("sol"), "/");
+        assert_eq!(decode_pod_entity("verbar"), "|");
     }
 
     // ── encode_pod_link_target ───────────────────────────────────────────────

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -368,6 +368,27 @@ fn e_format_code_decodes_common_entities() {
     assert_eq!(doc.name.as_deref(), Some("< > & \" '"));
 }
 
+#[test]
+fn e_format_code_decodes_numeric_entities() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head1 NAME\n\nE<65>E<0x20>E<0x1F980>\n\n=cut\n");
+    assert_eq!(doc.name.as_deref(), Some("A 🦀"));
+    Ok(())
+}
+
+#[test]
+fn e_format_code_decodes_pod_named_separators() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head1 NAME\n\npathE<sol>to E<verbar> pipe\n\n=cut\n");
+    assert_eq!(doc.name.as_deref(), Some("path/to | pipe"));
+    Ok(())
+}
+
+#[test]
+fn invalid_numeric_entities_are_preserved() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head1 NAME\n\nE<0x110000> E<0xZZ>\n\n=cut\n");
+    assert_eq!(doc.name.as_deref(), Some("0x110000 0xZZ"));
+    Ok(())
+}
+
 // ── POD L<> link → markdown link tests (Option B) ───────────────────────
 
 /// `L<Module::Name>` should produce a markdown link with target `perl-module://Module::Name`.


### PR DESCRIPTION
### Motivation

- POD numeric and some named entities were left as raw text in extracted documentation, causing hover text to show `E<0x20>`-style tokens instead of the intended characters.
- Decoding common named separators and numeric entities enables more accurate hover previews and markdown links produced from POD.

### Description

- Extend `decode_pod_entity` to handle `E<sol>` and `E<verbar>` and to delegate numeric decoding to a new `decode_numeric_pod_entity` helper that supports decimal and `0x` hexadecimal code points via `u32::from_str_radix` and `char::from_u32`.
- Add `decode_numeric_pod_entity` which returns `Option<String>` and preserves invalid numeric entities unchanged by falling back to the original entity string when decoding fails.
- Update unit tests in `crates/perl-pod/src/lib.rs` and extraction-level tests in `crates/perl-pod/tests/pod_extraction_tests.rs` to cover decimal, hex, named separator entities, and invalid numeric entities.
- Keep existing POD extraction and link-encoding behavior unchanged aside from the improved entity decoding.

### Testing

- Ran `cargo test -p perl-pod --profile agent --locked` with `CARGO_TARGET_DIR=/tmp/perl-lsp-target` and all tests passed (`11` crate unit tests and `43` extraction tests reported as passing).
- Ran `cargo check --all-targets -p perl-pod --profile agent --locked` and it completed successfully.
- Ran `cargo clippy -p perl-pod --profile agent --locked -- -D warnings -A missing_docs` and it completed successfully.
- Ran `cargo fmt --check` and `./scripts/storage-doctor` during verification and they succeeded (a direct in-repo `cargo test` initially hit a storage guard, so tests were run using a tmp target directory to verify results).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb0ad1c08333af932ac9a0c511f8)