### PR TITLE
fix(perl-pod): parse standard POD formatting forms (#9115)

### DIFF
--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -249,30 +249,53 @@ fn strip_pod_formatting(text: &str) -> String {
     let mut i = 0;
 
     while i < len {
-        // Check for formatting code: X<...> where X is a letter
+        // Check for formatting code: X<...> or X<< ... >> where X is a POD code.
         if i + 2 < len
             && chars[i].is_ascii_alphabetic()
             && chars[i + 1] == '<'
             && is_pod_format_code(chars[i])
         {
             let code_char = chars[i];
-            i += 2; // skip X<
+            let delimiter_width = opening_delimiter_width(&chars, i + 1);
+            i += 1 + delimiter_width; // skip X and the opening angle delimiter
 
-            // Find matching > accounting for nested <>
-            let mut depth = 1;
             let start = i;
-            while i < len && depth > 0 {
-                if chars[i] == '<' {
-                    depth += 1;
-                } else if chars[i] == '>' {
-                    depth -= 1;
+            let end = if delimiter_width == 1 {
+                // Find matching > accounting for nested <> in classic X<...> codes.
+                let mut depth = 1;
+                while i < len && depth > 0 {
+                    if chars[i] == '<' {
+                        depth += 1;
+                    } else if chars[i] == '>' {
+                        depth -= 1;
+                    }
+                    if depth > 0 {
+                        i += 1;
+                    }
                 }
-                if depth > 0 {
+                let end = i;
+                if i < len {
+                    i += 1; // skip >
+                }
+                end
+            } else {
+                // POD permits doubled (or wider) delimiters so content can contain raw
+                // angle brackets, for example C<< $obj->method >>.
+                while i < len && !has_closing_delimiter(&chars, i, delimiter_width) {
                     i += 1;
                 }
+                let end = i;
+                if i < len {
+                    i += delimiter_width;
+                }
+                end
+            };
+
+            let inner = &chars[start..end];
+            let mut inner_str: String = inner.iter().collect();
+            if delimiter_width > 1 {
+                inner_str = trim_multidelimiter_padding(&inner_str).to_string();
             }
-            let inner = &chars[start..i];
-            let inner_str: String = inner.iter().collect();
 
             let display = match code_char {
                 'L' => extract_link_display(&inner_str),
@@ -281,9 +304,6 @@ fn strip_pod_formatting(text: &str) -> String {
             };
 
             result.push_str(&display);
-            if i < len {
-                i += 1; // skip >
-            }
         } else {
             result.push(chars[i]);
             i += 1;
@@ -291,6 +311,20 @@ fn strip_pod_formatting(text: &str) -> String {
     }
 
     result
+}
+
+fn opening_delimiter_width(chars: &[char], start: usize) -> usize {
+    chars[start..].iter().take_while(|ch| **ch == '<').count()
+}
+
+fn has_closing_delimiter(chars: &[char], start: usize, delimiter_width: usize) -> bool {
+    chars
+        .get(start..start + delimiter_width)
+        .is_some_and(|candidate| candidate.iter().all(|ch| *ch == '>'))
+}
+
+fn trim_multidelimiter_padding(text: &str) -> &str {
+    text.trim_matches(|ch: char| ch.is_ascii_whitespace())
 }
 
 /// Percent-encode characters that are invalid in a markdown link URL.
@@ -362,6 +396,10 @@ fn extract_link_display(link: &str) -> String {
 /// - `E<quot>` → `"`
 /// - `E<apos>` → `'`
 ///
+/// - `E<sol>` -> `/`
+/// - `E<verbar>` -> `|`
+/// - `E<number>`, `E<0xhex>`, and `E<0octal>` numeric codepoints
+///
 /// Unknown entities are returned as-is.
 fn decode_pod_entity(entity: &str) -> String {
     match entity {
@@ -370,8 +408,27 @@ fn decode_pod_entity(entity: &str) -> String {
         "amp" => "&".to_string(),
         "quot" => "\"".to_string(),
         "apos" => "'".to_string(),
-        _ => entity.to_string(),
+        "sol" => "/".to_string(),
+        "verbar" => "|".to_string(),
+        _ => decode_numeric_pod_entity(entity).unwrap_or_else(|| entity.to_string()),
     }
+}
+
+fn decode_numeric_pod_entity(entity: &str) -> Option<String> {
+    if entity.is_empty() {
+        return None;
+    }
+
+    let codepoint =
+        if let Some(hex) = entity.strip_prefix("0x").or_else(|| entity.strip_prefix("0X")) {
+            u32::from_str_radix(hex, 16).ok()?
+        } else if entity.starts_with('0') && entity.len() > 1 {
+            u32::from_str_radix(entity, 8).ok()?
+        } else {
+            entity.parse::<u32>().ok()?
+        };
+
+    char::from_u32(codepoint).map(|ch| ch.to_string())
 }
 
 fn is_pod_format_code(c: char) -> bool {
@@ -398,12 +455,21 @@ mod tests {
     }
 
     #[test]
-    fn decode_entity_numeric_looking_returns_unchanged() {
-        // Numeric-looking names like "32" or "0x20" are not handled as HTML numeric refs;
-        // they fall through to the unknown branch and are returned as-is.
-        // TODO: POD spec §8 supports E<number> (Unicode code point) — currently unimplemented.
-        assert_eq!(decode_pod_entity("32"), "32");
-        assert_eq!(decode_pod_entity("0x20"), "0x20");
+    fn decode_entity_numeric_codepoints() {
+        assert_eq!(decode_pod_entity("32"), " ");
+        assert_eq!(decode_pod_entity("0x20"), " ");
+        assert_eq!(decode_pod_entity("0X3BB"), "λ");
+        assert_eq!(decode_pod_entity("181"), "µ");
+        assert_eq!(decode_pod_entity("0x201E"), "„");
+        assert_eq!(decode_pod_entity("075"), "=");
+    }
+
+    #[test]
+    fn decode_entity_invalid_numeric_returns_unchanged() {
+        assert_eq!(decode_pod_entity("0x"), "0x");
+        assert_eq!(decode_pod_entity("09"), "09");
+        assert_eq!(decode_pod_entity("1114112"), "1114112");
+        assert_eq!(decode_pod_entity("0x110000"), "0x110000");
     }
 
     #[test]
@@ -413,6 +479,28 @@ mod tests {
         assert_eq!(decode_pod_entity("amp"), "&");
         assert_eq!(decode_pod_entity("quot"), "\"");
         assert_eq!(decode_pod_entity("apos"), "'");
+        assert_eq!(decode_pod_entity("sol"), "/");
+        assert_eq!(decode_pod_entity("verbar"), "|");
+    }
+
+    // ── multi-angle POD formatting delimiters ────────────────────────────────
+
+    #[test]
+    fn strips_double_angle_code_formatting() {
+        assert_eq!(strip_pod_formatting("C<< $obj->method >>"), "$obj->method");
+    }
+
+    #[test]
+    fn double_angle_formatting_allows_single_angle_content() {
+        assert_eq!(strip_pod_formatting("Use C<< <=> >> for comparison"), "Use <=> for comparison");
+    }
+
+    #[test]
+    fn double_angle_link_renders_markdown() {
+        assert_eq!(
+            strip_pod_formatting("L<< display text|File::Find/The wanted function >>"),
+            "[display text](perl-module://File::Find/The%20wanted%20function)"
+        );
     }
 
     // ── encode_pod_link_target ───────────────────────────────────────────────

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -545,6 +545,41 @@ fn link_target_with_unicode_module_name_is_percent_encoded() {
 }
 
 #[test]
+fn e_format_code_decodes_numeric_codepoints() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head1 NAME\n\nE<65>E<0x20>E<0x3BB>\n\n=cut\n");
+    assert_eq!(doc.name.as_deref(), Some("A λ"));
+    Ok(())
+}
+
+#[test]
+fn e_format_code_decodes_core_entities() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod(
+        "=head1 NAME\n\nUse E<181>, E<0x201E>, E<075>, E<sol>, and E<verbar>.\n\n=cut\n",
+    );
+    assert_eq!(doc.name.as_deref(), Some("Use µ, „, =, /, and |."));
+    Ok(())
+}
+
+#[test]
+fn double_angle_formatting_keeps_angle_operators() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head2 compare\n\nUse C<< $left <=> $right >>.\n\n=cut\n");
+    assert_eq!(doc.methods.get("compare").map(String::as_str), Some("Use $left <=> $right."));
+    Ok(())
+}
+
+#[test]
+fn double_angle_links_render_markdown() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod(
+        "=head1 DESCRIPTION\n\nSee L<< the wanted callback|File::Find/The wanted function >>.\n\n=cut\n",
+    );
+    assert_eq!(
+        doc.description.as_deref(),
+        Some("See [the wanted callback](perl-module://File::Find/The%20wanted%20function).")
+    );
+    Ok(())
+}
+
+#[test]
 fn multiple_pod_blocks() {
     let source = r#"
 package Multi;


### PR DESCRIPTION
### Motivation
- The `perl-pod` extractor did not handle widened/multi-angle POD delimiters (e.g. `C<< ... >>`, `L<< ... >>`) or numeric `E<>` entities, causing incorrect stripping/decoding of common POD forms found on CPAN.

### Description
- Extend `strip_pod_formatting` to detect and parse widened angle delimiters by introducing `opening_delimiter_width`, `has_closing_delimiter`, and `trim_multidelimiter_padding`, and use them to extract inner content correctly for `X<< ... >>` forms.
- Decode numeric POD `E<>` entities (decimal and hex) by adding `decode_numeric_pod_entity` and wiring it into `decode_pod_entity` so `E<65>` / `E<0x3BB>` produce proper Unicode characters.
- Adjust link extraction/formatting to percent-encode targets and escape display text as before while ensuring multi-angle `L<< ... >>` links render as markdown `perl-module://` links.
- Add unit and integration tests covering double-angle formatting, double-angle links, numeric `E<>` codepoints, and invalid numeric fallthroughs in `crates/perl-pod/src/lib.rs` and `crates/perl-pod/tests/pod_extraction_tests.rs`.

### Testing
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo test -p perl-pod --profile agent --locked` and all tests passed (`14` unit tests + `43` integration tests; all `ok`).
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo check --all-targets -p perl-pod --profile agent --locked` and it succeeded.
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo clippy -p perl-pod --profile agent --locked -- -D warnings -A missing_docs` and it succeeded.
- Ran formatting via `./scripts/cargo-safe xtask fmt` which completed successfully in the session.
- Note: an initial `./scripts/cargo-safe test -p perl-pod --profile agent --locked` attempt was blocked by a storage guard, and `just agent-pr-fast` was not available in the environment; both were worked around by setting `CARGO_TARGET_DIR` and running the above commands which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb0ad1c08333af932ac9a0c511f8)