### PR TITLE
fix(perl-pod): decode numeric POD escapes (#0000)

### DIFF
--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -358,20 +358,52 @@ fn extract_link_display(link: &str) -> String {
 /// Handles standard POD escape sequences:
 /// - `E<lt>` → `<`
 /// - `E<gt>` → `>`
+/// - `E<sol>` → `/`
+/// - `E<verbar>` → `|`
 /// - `E<amp>` → `&`
 /// - `E<quot>` → `"`
 /// - `E<apos>` → `'`
+/// - `E<181>` → `µ`
+/// - `E<0x201E>` → `„`
+/// - `E<075>` → `=`
 ///
-/// Unknown entities are returned as-is.
+/// Unknown or invalid entities are returned as-is.
 fn decode_pod_entity(entity: &str) -> String {
     match entity {
         "lt" => "<".to_string(),
         "gt" => ">".to_string(),
+        "sol" => "/".to_string(),
+        "verbar" => "|".to_string(),
         "amp" => "&".to_string(),
         "quot" => "\"".to_string(),
         "apos" => "'".to_string(),
-        _ => entity.to_string(),
+        _ => decode_numeric_pod_entity(entity).unwrap_or_else(|| entity.to_string()),
     }
+}
+
+fn decode_numeric_pod_entity(entity: &str) -> Option<String> {
+    if entity.is_empty() {
+        return None;
+    }
+
+    let (digits, radix) =
+        if let Some(hex) = entity.strip_prefix("0x").or_else(|| entity.strip_prefix("0X")) {
+            (hex, 16)
+        } else if entity.len() > 1 {
+            match entity.strip_prefix('0') {
+                Some(octal) => (octal, 8),
+                None => (entity, 10),
+            }
+        } else {
+            (entity, 10)
+        };
+
+    if digits.is_empty() {
+        return None;
+    }
+
+    let codepoint = u32::from_str_radix(digits, radix).ok()?;
+    char::from_u32(codepoint).map(|ch| ch.to_string())
 }
 
 fn is_pod_format_code(c: char) -> bool {
@@ -398,18 +430,26 @@ mod tests {
     }
 
     #[test]
-    fn decode_entity_numeric_looking_returns_unchanged() {
-        // Numeric-looking names like "32" or "0x20" are not handled as HTML numeric refs;
-        // they fall through to the unknown branch and are returned as-is.
-        // TODO: POD spec §8 supports E<number> (Unicode code point) — currently unimplemented.
-        assert_eq!(decode_pod_entity("32"), "32");
-        assert_eq!(decode_pod_entity("0x20"), "0x20");
+    fn decode_entity_numeric_decimal_hex_and_octal() {
+        assert_eq!(decode_pod_entity("32"), " ");
+        assert_eq!(decode_pod_entity("181"), "µ");
+        assert_eq!(decode_pod_entity("0x201E"), "„");
+        assert_eq!(decode_pod_entity("075"), "=");
+    }
+
+    #[test]
+    fn decode_entity_invalid_numeric_returns_name_unchanged() {
+        assert_eq!(decode_pod_entity("0x"), "0x");
+        assert_eq!(decode_pod_entity("0x110000"), "0x110000");
+        assert_eq!(decode_pod_entity("09"), "09");
     }
 
     #[test]
     fn decode_entity_known_entities() {
         assert_eq!(decode_pod_entity("lt"), "<");
         assert_eq!(decode_pod_entity("gt"), ">");
+        assert_eq!(decode_pod_entity("sol"), "/");
+        assert_eq!(decode_pod_entity("verbar"), "|");
         assert_eq!(decode_pod_entity("amp"), "&");
         assert_eq!(decode_pod_entity("quot"), "\"");
         assert_eq!(decode_pod_entity("apos"), "'");

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -156,6 +156,14 @@ fn mixed_formatting() {
 }
 
 #[test]
+fn decodes_pod_numeric_and_core_named_entities() {
+    let doc = extract_pod(
+        "=head1 NAME\n\nUse E<181>, E<0x201E>, E<075>, E<sol>, and E<verbar>.\n\n=cut\n",
+    );
+    assert_eq!(doc.name.as_deref(), Some("Use µ, „, =, /, and |."));
+}
+
+#[test]
 fn handles_cut_properly() {
     let source = r#"
 =head1 NAME


### PR DESCRIPTION
### Motivation
- POD extraction previously left numeric `E<>` escapes and some core named entities (e.g. `sol`, `verbar`) undecoded, which produced less-friendly extracted documentation for hover/tooling surfaces.
- The intent is to surface readable characters in extracted docs (including decimal, hex and octal numeric escapes) while preserving unknown/invalid entities unchanged.

### Description
- Enhance `decode_pod_entity` to handle core named entities `sol` and `verbar` and to delegate unknown names to a numeric decoder. 
- Add `decode_numeric_pod_entity` which decodes decimal, hexadecimal (`0x`/`0X`) and octal (leading `0`) numeric POD entities to Unicode codepoints and returns `None` for invalid inputs.
- Update POD extraction tests by adding `decodes_pod_numeric_and_core_named_entities` and extend unit tests for numeric and invalid entity handling (`decode_entity_numeric_decimal_hex_and_octal`, `decode_entity_invalid_numeric_returns_name_unchanged`).
- Preserve prior behavior for unknown non-numeric entities by leaving them unchanged.

### Testing
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo test -p perl-pod --profile agent --locked` and all unit and extraction tests passed.
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo check --all-targets -p perl-pod --profile agent --locked` and it completed successfully.
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo clippy -p perl-pod --profile agent --locked -- -D warnings -A missing_docs` and `./scripts/cargo-safe xtask fmt` with no issues; `just agent-pr-fast` was not run because `just` is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb0ad1c08333af932ac9a0c511f8)