### PR TITLE
fix(perl-module): support alternate qw import delimiters (#0000)

### DIFF
--- a/crates/perl-module/src/import/mod.rs
+++ b/crates/perl-module/src/import/mod.rs
@@ -320,7 +320,7 @@ pub struct RequireImportEntry {
 /// # Recognised patterns
 ///
 /// - `require Module::Path;` followed (anywhere later) by
-///   `Module::Path->import(qw(a b c));`
+///   `Module::Path->import(qw(a b c));` or another Perl `qw` delimiter
 /// - `require Module::Path;` followed by
 ///   `Module::Path->import('a', 'b');`
 /// - `require Module::Path;` followed by
@@ -447,6 +447,31 @@ fn parse_literal_import_call(line: &str, expected_module: &str) -> Option<Vec<St
     Some(symbols)
 }
 
+fn parse_qw_arg_list(trimmed: &str) -> Option<Vec<String>> {
+    let after_operator = trimmed.strip_prefix("qw")?;
+    let delimiter = after_operator.chars().next()?;
+    if delimiter.is_ascii_alphanumeric() || delimiter == '_' || delimiter.is_whitespace() {
+        return None;
+    }
+
+    let closing = match delimiter {
+        '(' => ')',
+        '[' => ']',
+        '{' => '}',
+        '<' => '>',
+        other => other,
+    };
+
+    let inner_start = "qw".len() + delimiter.len_utf8();
+    let inner_end = trimmed.len().checked_sub(closing.len_utf8())?;
+    if inner_start > inner_end || !trimmed.ends_with(closing) {
+        return None;
+    }
+
+    let inner = &trimmed[inner_start..inner_end];
+    Some(inner.split_whitespace().filter(|word| !word.is_empty()).map(str::to_string).collect())
+}
+
 /// Parse the interior of an `import(...)` argument list that contains only
 /// literal strings and/or a `qw(...)` list.
 ///
@@ -458,10 +483,7 @@ fn parse_literal_arg_list(args: &str) -> Option<Vec<String>> {
         return Some(Vec::new());
     }
 
-    // qw(...) form.
-    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
-        let words: Vec<String> =
-            inner.split_whitespace().filter(|w| !w.is_empty()).map(|w| w.to_string()).collect();
+    if let Some(words) = parse_qw_arg_list(trimmed) {
         return Some(words);
     }
 

--- a/crates/perl-module/tests/require_import_extractor.rs
+++ b/crates/perl-module/tests/require_import_extractor.rs
@@ -29,6 +29,28 @@ fn qw_list_produces_entries() -> Result<(), String> {
 }
 
 #[test]
+fn qw_list_with_non_paren_delimiter_produces_entries() -> Result<(), String> {
+    let cases = [
+        ("Foo->import(qw[alpha beta]);", ["alpha", "beta"]),
+        ("Foo->import(qw{gamma delta});", ["gamma", "delta"]),
+        ("Foo->import(qw<epsilon zeta>);", ["epsilon", "zeta"]),
+        ("Foo->import(qw!eta theta!);", ["eta", "theta"]),
+    ];
+
+    for (import_line, expected_names) in cases {
+        let source = format!("require Foo;\n{import_line}\n");
+        let entries = extract_require_import_symbols(&source);
+        let names: Vec<&str> = entries.iter().map(|entry| entry.symbol.as_str()).collect();
+
+        if names != expected_names {
+            return Err(format!("expected {expected_names:?} for {import_line:?}, got {names:?}"));
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
 fn single_quoted_args_produce_entries() -> Result<(), String> {
     let source = "require Foo;\nFoo->import('foo', 'bar');\n";
     let entries = extract_require_import_symbols(source);
@@ -83,6 +105,16 @@ fn nested_module_name_is_preserved() -> Result<(), String> {
 }
 
 // ── Non-goals: must not produce entries ─────────────────────────────────────
+
+#[test]
+fn malformed_qw_list_is_rejected() -> Result<(), String> {
+    let source = "require Foo;\nFoo->import(qw[alpha beta));\n";
+    let entries = extract_require_import_symbols(source);
+    if !entries.is_empty() {
+        return Err(format!("expected no entries for malformed qw list, got {entries:?}"));
+    }
+    Ok(())
+}
 
 #[test]
 fn dynamic_module_name_is_rejected() -> Result<(), String> {


### PR DESCRIPTION
### Motivation
- The literal `require`/`import` symbol extractor only recognised `qw(...)` with parentheses and missed other valid Perl `qw` delimiter forms. 
- Adding delimiter-aware `qw` parsing improves real-world coverage and prevents missed symbol extraction in non-parenthesis `qw` usages.

### Description
- Add a new helper `parse_qw_arg_list` that accepts `qw` with paired delimiters `()`, `[]`, `{}`, `<>` and repeated single-character delimiters (for example `!`), returning split symbol words. 
- Integrate the helper into `parse_literal_arg_list` so `parse_literal_import_call` now recognises alternate `qw` delimiters. 
- Update documentation comment to note support for alternate `qw` delimiters and add regression tests in `crates/perl-module/tests/require_import_extractor.rs` to cover valid non-paren delimiters and a malformed `qw` case. 

### Testing
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-module --profile agent --locked` and all `perl-module` tests passed. 
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-module --profile agent --locked` and the crate checks succeeded. 
- Ran `./scripts/cargo-safe fmt --all --check` and code formatting passed. 
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-module --profile agent --locked -- -D warnings -A missing_docs` and lints passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb6008308333bc9104a1fcafb566)