### PR TITLE
fix(perl-module): parse escaped use lib delimiters (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -403,12 +403,36 @@ fn extract_one_quoted(s: &str) -> Option<(String, bool, &str)> {
     };
 
     let inner = &s[1..];
-    let end = inner.find(quote)?;
-    let content = &inner[..end];
-    let rest = &inner[end + 1..];
+    let mut content = String::new();
+    let mut escaped = false;
 
-    let (path, from_findbin) = resolve_findbin_in_string(content);
-    Some((path, from_findbin, rest))
+    for (end, ch) in inner.char_indices() {
+        if escaped {
+            if ch == quote {
+                content.push(ch);
+            } else {
+                content.push('\\');
+                content.push(ch);
+            }
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if ch == quote {
+            let rest = &inner[end + ch.len_utf8()..];
+            let (path, from_findbin) = resolve_findbin_in_string(&content);
+            return Some((path, from_findbin, rest));
+        }
+
+        content.push(ch);
+    }
+
+    None
 }
 
 fn resolve_findbin_in_string(s: &str) -> (String, bool) {

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -507,15 +507,18 @@ fn escaped_backslash_at_end_of_path() {
 #[test]
 fn double_quoted_path_with_escaped_double_quote() {
     // Edge case: double-quoted string containing an escaped quote.
-    // The statement splitter must handle the escaped quote so it doesn't
-    // terminate the string prematurely.
-    let source = r#"use lib "path/to/lib"; use lib 'also';"#;
+    // The extractor must not terminate the string at the escaped delimiter.
+    let source = r#"use lib "path/with\"quote;lib"; use lib 'also';"#;
 
     let paths = extract_use_lib_paths(source);
 
-    assert_eq!(paths.len(), 2);
-    assert!(paths.iter().any(|p| p.path.contains("lib")));
-    assert!(paths.iter().any(|p| p.path.contains("also")));
+    assert_eq!(
+        paths,
+        vec![
+            UseLibPath { path: "path/with\"quote;lib".to_string(), from_findbin: false },
+            UseLibPath { path: "also".to_string(), from_findbin: false },
+        ]
+    );
 }
 
 #[test]
@@ -526,8 +529,13 @@ fn single_quoted_path_with_escaped_single_quote() {
 
     let paths = extract_use_lib_paths(source);
 
-    // Should extract both paths without being confused by the \' in the first path.
-    assert!(paths.len() >= 2, "Expected at least 2 paths, got {}", paths.len());
+    assert_eq!(
+        paths,
+        vec![
+            UseLibPath { path: "it's; a path".to_string(), from_findbin: false },
+            UseLibPath { path: "also".to_string(), from_findbin: false },
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- `use lib` quoted-path extraction could stop at an escaped quote delimiter and thereby split or drop valid paths and following statements.

### Description

- Make `extract_one_quoted` in `crates/perl-module/src/resolution/use_lib.rs` scan quoted string contents with escape-awareness so escaped quote delimiters remain inside the extracted path and other backslash sequences are preserved, and return `None` for unterminated quoted strings.
- Update unit tests in `crates/perl-module/tests/use_lib_resolution_unit_tests.rs` to cover double-quoted paths with escaped double quotes and single-quoted paths with escaped single quotes and assert exact extraction results.
- Small refactor to preserve semantics of `resolve_findbin_in_string` and the surrounding extraction pipeline while fixing the quoted parsing edge cases.

### Testing

- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo test -p perl-module --profile agent --locked` and all tests in `perl-module` passed.
- Ran `./scripts/cargo-safe xtask fmt` and formatting completed successfully.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo check --all-targets -p perl-module --profile agent --locked` and `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo clippy -p perl-module --profile agent --locked -- -D warnings -A missing_docs` and both completed without errors.
- Note: `./scripts/cargo-safe test` and `./scripts/cargo-safe check`/`clippy` variants that use the devplane cache were blocked by the environment storage guard, so direct `cargo` invocations with an out-of-worktree `CARGO_TARGET_DIR` were used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb6008308333bc9104a1fcafb566)