### PR TITLE
fix(perl-module): widen require import extraction (#0000)

### DIFF
--- a/crates/perl-module/src/import/mod.rs
+++ b/crates/perl-module/src/import/mod.rs
@@ -326,6 +326,10 @@ pub struct RequireImportEntry {
 /// - `require Module::Path;` followed by
 ///   `Module::Path->import("a", "b");`
 ///
+/// Whitespace around `->`, `import`, and the call parentheses is tolerated
+/// for literal receiver calls. Common `qw` delimiters (`()`, `[]`, `{}`, `<>`,
+/// and `/.../`) are recognised.
+///
 /// # Non-goals (not matched)
 ///
 /// - `require $var;` (dynamic module name — variable)
@@ -417,11 +421,19 @@ fn parse_literal_require_line(line: &str) -> Option<&str> {
     if !module.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
         return None;
     }
-    // Must consist only of identifier chars and `::` separators.
-    if !module.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':') {
+    if !is_literal_module_name(module) {
         return None;
     }
     Some(module)
+}
+
+fn is_literal_module_name(module: &str) -> bool {
+    let mut segments = module.split("::");
+    segments.all(|segment| {
+        !segment.is_empty()
+            && segment.chars().all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+            && segment.chars().next().is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
+    })
 }
 
 /// Parse a line of the form `Module::Name->import(literal list);`.
@@ -430,9 +442,10 @@ fn parse_literal_require_line(line: &str) -> Option<&str> {
 /// expected module name with only literal arguments (`qw(...)`, `'x'`, `"x"`).
 /// Returns `None` when the line does not match or contains dynamic arguments.
 fn parse_literal_import_call(line: &str, expected_module: &str) -> Option<Vec<String>> {
-    // Line must start with `Module->import(` (possibly with whitespace).
-    let prefix = format!("{}->import(", expected_module);
-    let after_open = line.strip_prefix(prefix.as_str())?;
+    let after_module = line.strip_prefix(expected_module)?.trim_start();
+    let after_arrow = after_module.strip_prefix("->")?.trim_start();
+    let after_method = after_arrow.strip_prefix("import")?.trim_start();
+    let after_open = after_method.strip_prefix('(')?;
 
     // Find the matching close paren.
     let close_idx = after_open.rfind(')')?;
@@ -458,8 +471,7 @@ fn parse_literal_arg_list(args: &str) -> Option<Vec<String>> {
         return Some(Vec::new());
     }
 
-    // qw(...) form.
-    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
+    if let Some(inner) = parse_qw_literal(trimmed) {
         let words: Vec<String> =
             inner.split_whitespace().filter(|w| !w.is_empty()).map(|w| w.to_string()).collect();
         return Some(words);
@@ -493,6 +505,20 @@ fn parse_literal_arg_list(args: &str) -> Option<Vec<String>> {
     }
 
     Some(symbols)
+}
+
+fn parse_qw_literal(trimmed: &str) -> Option<&str> {
+    let after_qw = trimmed.strip_prefix("qw")?;
+    let delimiter = after_qw.chars().next()?;
+    let close = match delimiter {
+        '(' => ')',
+        '[' => ']',
+        '{' => '}',
+        '<' => '>',
+        '/' => '/',
+        _ => return None,
+    };
+    after_qw[delimiter.len_utf8()..].strip_suffix(close)
 }
 
 /// Return true when `line` indicates a new statement boundary that should stop

--- a/crates/perl-module/tests/require_import_extractor.rs
+++ b/crates/perl-module/tests/require_import_extractor.rs
@@ -213,3 +213,44 @@ fn require_without_import_produces_no_entries() -> Result<(), String> {
     }
     Ok(())
 }
+
+#[test]
+fn whitespace_around_import_method_call_is_tolerated() -> Result<(), String> {
+    let source = "require Foo::Bar;\nFoo::Bar  ->  import  ( 'alpha', \"beta\" );\n";
+    let entries = extract_require_import_symbols(source);
+
+    if entries.len() != 2 {
+        return Err(format!("expected 2 entries, got {}: {entries:?}", entries.len()));
+    }
+    let names: Vec<&str> = entries.iter().map(|e| e.symbol.as_str()).collect();
+    if !names.contains(&"alpha") || !names.contains(&"beta") {
+        return Err(format!("missing symbols in {names:?}"));
+    }
+    Ok(())
+}
+
+#[test]
+fn alternate_qw_delimiters_produce_entries() -> Result<(), String> {
+    let source =
+        "require Foo;\nFoo->import(qw/alpha beta/);\nrequire Bar;\nBar->import(qw[gamma delta]);\n";
+    let entries = extract_require_import_symbols(source);
+
+    let names: Vec<&str> = entries.iter().map(|e| e.symbol.as_str()).collect();
+    for expected in ["alpha", "beta", "gamma", "delta"] {
+        if !names.contains(&expected) {
+            return Err(format!("missing {expected:?} in {names:?}"));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn malformed_module_separator_is_rejected() -> Result<(), String> {
+    let source = "require Foo::::Bar;\nFoo::::Bar->import('x');\n";
+    let entries = extract_require_import_symbols(source);
+
+    if !entries.is_empty() {
+        return Err(format!("expected malformed module name to be rejected, got {entries:?}"));
+    }
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- The text-level `require Module; Module->import(...)` extractor missed valid real-world forms where whitespace appears around the method call and where `qw` uses alternate delimiters, and it accepted malformed module separators like `Foo::::Bar` as valid names.

### Description

- Tolerate whitespace around the receiver arrow, method name, and open-paren in `Module->import(...)` parsing by trimming and stepping through `->` / `import` / `(` components instead of matching a single compact prefix. 
- Recognise common non-parenthesized `qw` delimiters (`()`, `[]`, `{}`, `<>`, and `/.../`) via a new `parse_qw_literal` helper and accept those forms when extracting symbol lists. 
- Tighten literal `require` validation with a new `is_literal_module_name` predicate to reject malformed separator sequences and invalid segment forms. 
- Add documentation clarifications and three regression tests: `whitespace_around_import_method_call_is_tolerated`, `alternate_qw_delimiters_produce_entries`, and `malformed_module_separator_is_rejected` in `crates/perl-module/tests/require_import_extractor.rs`.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-module --profile agent --locked` and all unit tests for `perl-module` passed. 
- Ran `./scripts/cargo-safe fmt --check`, `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-module --profile agent --locked`, and `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-module --profile agent --locked -- -D warnings -A missing_docs`, and they all completed without errors. 
- Ran `./scripts/storage-doctor`; environment `just agent-pr-fast` could not be executed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb6008308333bc9104a1fcafb566)