### PR TITLE
fix(perl-module): handle escaped use lib quotes (#0000)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -403,12 +403,32 @@ fn extract_one_quoted(s: &str) -> Option<(String, bool, &str)> {
     };
 
     let inner = &s[1..];
-    let end = inner.find(quote)?;
+    let end = find_unescaped_quote(inner, quote)?;
     let content = &inner[..end];
-    let rest = &inner[end + 1..];
+    let rest = &inner[end + quote.len_utf8()..];
 
     let (path, from_findbin) = resolve_findbin_in_string(content);
     Some((path, from_findbin, rest))
+}
+
+fn find_unescaped_quote(s: &str, quote: char) -> Option<usize> {
+    let mut escaped = false;
+    for (idx, ch) in s.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if ch == quote {
+            return Some(idx);
+        }
+    }
+    None
 }
 
 fn resolve_findbin_in_string(s: &str) -> (String, bool) {

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -507,15 +507,18 @@ fn escaped_backslash_at_end_of_path() {
 #[test]
 fn double_quoted_path_with_escaped_double_quote() {
     // Edge case: double-quoted string containing an escaped quote.
-    // The statement splitter must handle the escaped quote so it doesn't
-    // terminate the string prematurely.
-    let source = r#"use lib "path/to/lib"; use lib 'also';"#;
+    // The extractor must not terminate the path at the escaped quote.
+    let source = r#"use lib "path/with\"quote"; use lib 'also';"#;
 
     let paths = extract_use_lib_paths(source);
 
-    assert_eq!(paths.len(), 2);
-    assert!(paths.iter().any(|p| p.path.contains("lib")));
-    assert!(paths.iter().any(|p| p.path.contains("also")));
+    assert_eq!(
+        paths,
+        vec![
+            UseLibPath { path: r#"path/with\"quote"#.to_string(), from_findbin: false },
+            UseLibPath { path: "also".to_string(), from_findbin: false },
+        ]
+    );
 }
 
 #[test]
@@ -526,8 +529,13 @@ fn single_quoted_path_with_escaped_single_quote() {
 
     let paths = extract_use_lib_paths(source);
 
-    // Should extract both paths without being confused by the \' in the first path.
-    assert!(paths.len() >= 2, "Expected at least 2 paths, got {}", paths.len());
+    assert_eq!(
+        paths,
+        vec![
+            UseLibPath { path: r"it\'s; a path".to_string(), from_findbin: false },
+            UseLibPath { path: "also".to_string(), from_findbin: false },
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Quoted `use lib` arguments could be terminated prematurely when the quoted path contained an escaped quote, causing incorrect path extraction and resolution.
- Tests needed to assert exact behavior for escaped single- and double-quoted paths to prevent regressions.

### Description
- Update `extract_one_quoted` to locate the closing quote using a new helper `find_unescaped_quote` that ignores escaped quote characters when scanning the quoted content in `crates/perl-module/src/resolution/use_lib.rs`.
- Add the helper function `find_unescaped_quote` which tracks backslash escaping and returns the index of the first unescaped matching quote character.
- Adjust `extract_one_quoted` to advance the remainder slice by `quote.len_utf8()` to correctly skip the closing quote when continuing parsing.
- Tighten regression tests in `crates/perl-module/tests/use_lib_resolution_unit_tests.rs` to assert exact extracted paths for escaped double- and single-quoted `use lib` cases.

### Testing
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo test -p perl-module --profile agent --locked` and all tests in the `perl-module` crate passed.
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo check --all-targets -p perl-module --profile agent --locked` and it passed.
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo clippy -p perl-module --profile agent --locked -- -D warnings -A missing_docs` and it passed.
- Ran `./scripts/cargo-safe xtask fmt` and formatting checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb6008308333bc9104a1fcafb566)