### PR TITLE
feat(perl-token): expose canonical spellings (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -795,6 +795,29 @@ impl TokenKind {
         TokenKindMetadata { category: self.category(), display_name: self.display_name() }
     }
 
+    /// Return the canonical source spelling for token kinds that have one.
+    ///
+    /// This is intended for lexer/parser diagnostics and conformance tests that
+    /// need the exact spelling used in Perl source. Literal families, generic
+    /// identifiers, EOF, and recovery tokens do not have a single canonical
+    /// source spelling and therefore return `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use perl_token::TokenKind;
+    ///
+    /// assert_eq!(TokenKind::Sub.canonical_spelling(), Some("sub"));
+    /// assert_eq!(TokenKind::LeftBrace.canonical_spelling(), Some("{"));
+    /// assert_eq!(TokenKind::Identifier.canonical_spelling(), None);
+    /// ```
+    pub fn canonical_spelling(self) -> Option<&'static str> {
+        canonical_spelling_in(KEYWORD_SPELLINGS, self)
+            .or_else(|| canonical_spelling_in(OPERATOR_SPELLINGS, self))
+            .or_else(|| canonical_spelling_in(DELIMITER_SPELLINGS, self))
+            .or_else(|| canonical_spelling_in(SIGIL_SPELLINGS, self))
+    }
+
     /// Return the high-level category for this token kind.
     pub const fn category(self) -> TokenCategory {
         match self {
@@ -1403,6 +1426,13 @@ impl TokenKind {
             TokenKind::Unknown => "unknown token",
         }
     }
+}
+
+fn canonical_spelling_in(
+    spellings: &'static [(&'static str, TokenKind)],
+    needle: TokenKind,
+) -> Option<&'static str> {
+    spellings.iter().find_map(|(spelling, kind)| (*kind == needle).then_some(*spelling))
 }
 
 const TOKEN_KIND_ALL: [TokenKind; 132] = [

--- a/crates/perl-token/tests/token_kind_mapping_tests.rs
+++ b/crates/perl-token/tests/token_kind_mapping_tests.rs
@@ -52,3 +52,38 @@ fn category_helpers_align_with_category_method() {
         assert_eq!(kind.is_special(), kind.category() == perl_token::TokenCategory::Special);
     }
 }
+
+#[test]
+fn canonical_spelling_round_trips_parser_facing_tables() {
+    for &(spelling, kind) in KEYWORD_SPELLINGS {
+        assert_eq!(kind.canonical_spelling(), Some(spelling), "keyword: {spelling}");
+    }
+    for &(spelling, kind) in OPERATOR_SPELLINGS {
+        assert_eq!(kind.canonical_spelling(), Some(spelling), "operator: {spelling}");
+    }
+    for &(spelling, kind) in DELIMITER_SPELLINGS {
+        assert_eq!(kind.canonical_spelling(), Some(spelling), "delimiter: {spelling}");
+    }
+    for &(spelling, kind) in SIGIL_SPELLINGS {
+        assert_eq!(kind.canonical_spelling(), Some(spelling), "sigil: {spelling}");
+    }
+}
+
+#[test]
+fn canonical_spelling_is_absent_for_non_canonical_token_families() {
+    for kind in [
+        TokenKind::Identifier,
+        TokenKind::Number,
+        TokenKind::String,
+        TokenKind::Regex,
+        TokenKind::HeredocBody,
+        TokenKind::FormatBody,
+        TokenKind::DataBody,
+        TokenKind::UnknownRest,
+        TokenKind::HeredocDepthLimit,
+        TokenKind::Eof,
+        TokenKind::Unknown,
+    ] {
+        assert_eq!(kind.canonical_spelling(), None, "{kind:?} should not have canonical spelling");
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a single public API to obtain the canonical Perl source spelling for parser-facing token kinds so consumers do not need to re-traverse the spelling tables themselves.

### Description

- Add `TokenKind::canonical_spelling()`, which returns the canonical source spelling for keyword/operator/delimiter/sigil token kinds and `None` for literals, identifiers, EOF, and recovery tokens.
- Add a small private helper `canonical_spelling_in(...)` to deduplicate lookup logic across the existing spelling tables (`KEYWORD_SPELLINGS`, `OPERATOR_SPELLINGS`, `DELIMITER_SPELLINGS`, `SIGIL_SPELLINGS`).
- Add unit tests in `crates/perl-token/tests/token_kind_mapping_tests.rs` to validate round-trip coverage for parser-facing tables and to assert absence of canonical spellings for non-canonical token families.

### Testing

- Ran `./scripts/cargo-safe test -p perl-token --profile agent --locked` and all crate unit tests and doctests passed.
- Ran `./scripts/cargo-safe check --all-targets -p perl-token --profile agent --locked` and type checks passed.
- Ran `./scripts/cargo-safe clippy -p perl-token --profile agent --locked -- -D warnings -A missing_docs` and lint checks passed.
- Ran `./scripts/cargo-safe fmt -- --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb173824833381034772071030be)