### PR TITLE
feat(perl-token): expose canonical token spellings (#6462)

### DIFF
--- a/crates/perl-token/README.md
+++ b/crates/perl-token/README.md
@@ -23,6 +23,7 @@ only change with explicit, reviewed intent.
 - **`Token`** -- a token with `kind: TokenKind`, `text: Arc<str>`, `start: usize`, `end: usize`
 - **`TokenRef<'src>`** -- borrowed token view with `kind`, `text: &'src str`, `start`, `end` for allocation-sensitive paths
 - **`TokenKind`** -- enum classifying every Perl token: keywords, operators, delimiters, literals, sigils, and special tokens
+- **Spelling tables** -- `KEYWORD_SPELLINGS`, `OPERATOR_SPELLINGS`, `DELIMITER_SPELLINGS`, and `SIGIL_SPELLINGS` define fixed source spellings and power `TokenKind::canonical_spelling()`
 
 ## Usage
 
@@ -35,6 +36,16 @@ assert_eq!(tok.kind, TokenKind::Identifier);
 let borrowed = TokenRef::new(TokenKind::Identifier, "foo", 0, 3);
 let owned = borrowed.to_owned_token();
 assert_eq!(owned, tok);
+```
+
+Fixed-spelling token metadata:
+
+```rust
+use perl_token::TokenKind;
+
+assert_eq!(TokenKind::Sub.canonical_spelling(), Some("sub"));
+assert_eq!(TokenKind::LeftBrace.canonical_spelling(), Some("{"));
+assert_eq!(TokenKind::Identifier.canonical_spelling(), None);
 ```
 
 Borrowed view from owned tokens:

--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -1095,6 +1095,29 @@ impl TokenKind {
         self == TokenKind::Semicolon || self.is_close_delimiter() || self == TokenKind::Eof
     }
 
+    /// Return the canonical source spelling for fixed-spelling token kinds.
+    ///
+    /// This returns `None` for value-carrying tokens (such as identifiers,
+    /// numbers, strings, regexes, heredocs, and recovery sentinels) because
+    /// those spellings come from the original source text rather than a stable
+    /// token-kind table.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use perl_token::TokenKind;
+    ///
+    /// assert_eq!(TokenKind::Sub.canonical_spelling(), Some("sub"));
+    /// assert_eq!(TokenKind::LeftBrace.canonical_spelling(), Some("{"));
+    /// assert_eq!(TokenKind::Identifier.canonical_spelling(), None);
+    /// ```
+    pub fn canonical_spelling(self) -> Option<&'static str> {
+        spelling_for_kind(self, KEYWORD_SPELLINGS)
+            .or_else(|| spelling_for_kind(self, OPERATOR_SPELLINGS))
+            .or_else(|| spelling_for_kind(self, DELIMITER_SPELLINGS))
+            .or_else(|| spelling_for_kind(self, SIGIL_SPELLINGS))
+    }
+
     /// Map a canonical keyword spelling to its [`TokenKind`].
     ///
     /// This mapping is case-sensitive and only recognizes canonical Perl
@@ -1403,6 +1426,13 @@ impl TokenKind {
             TokenKind::Unknown => "unknown token",
         }
     }
+}
+
+fn spelling_for_kind(
+    kind: TokenKind,
+    spellings: &'static [(&'static str, TokenKind)],
+) -> Option<&'static str> {
+    spellings.iter().find_map(|&(spelling, candidate)| (candidate == kind).then_some(spelling))
 }
 
 const TOKEN_KIND_ALL: [TokenKind; 132] = [

--- a/crates/perl-token/tests/token_kind_mapping_tests.rs
+++ b/crates/perl-token/tests/token_kind_mapping_tests.rs
@@ -31,6 +31,65 @@ fn sigil_mapping_covers_canonical_spellings() {
 }
 
 #[test]
+fn canonical_spelling_covers_fixed_spelling_tables() {
+    for &(spelling, kind) in KEYWORD_SPELLINGS {
+        assert_eq!(kind.canonical_spelling(), Some(spelling), "keyword: {kind:?}");
+    }
+
+    for &(spelling, kind) in OPERATOR_SPELLINGS {
+        assert_eq!(kind.canonical_spelling(), Some(spelling), "operator: {kind:?}");
+    }
+
+    for &(spelling, kind) in DELIMITER_SPELLINGS {
+        assert_eq!(kind.canonical_spelling(), Some(spelling), "delimiter: {kind:?}");
+    }
+
+    for &(spelling, kind) in SIGIL_SPELLINGS {
+        assert_eq!(kind.canonical_spelling(), Some(spelling), "sigil: {kind:?}");
+    }
+}
+
+#[test]
+fn canonical_spelling_is_none_for_value_carrying_tokens() {
+    let value_carrying = [
+        TokenKind::Identifier,
+        TokenKind::Number,
+        TokenKind::String,
+        TokenKind::Regex,
+        TokenKind::Substitution,
+        TokenKind::Transliteration,
+        TokenKind::QuoteSingle,
+        TokenKind::QuoteDouble,
+        TokenKind::QuoteWords,
+        TokenKind::QuoteCommand,
+        TokenKind::HeredocStart,
+        TokenKind::HeredocBody,
+        TokenKind::FormatBody,
+        TokenKind::DataMarker,
+        TokenKind::DataBody,
+        TokenKind::VString,
+        TokenKind::UnknownRest,
+        TokenKind::HeredocDepthLimit,
+        TokenKind::Eof,
+        TokenKind::Unknown,
+    ];
+
+    for kind in value_carrying {
+        assert_eq!(kind.canonical_spelling(), None, "value-carrying token: {kind:?}");
+    }
+}
+
+#[test]
+fn canonical_spelling_preserves_contextual_sigil_kinds() {
+    assert_eq!(TokenKind::Percent.canonical_spelling(), Some("%"));
+    assert_eq!(TokenKind::HashSigil.canonical_spelling(), Some("%"));
+    assert_eq!(TokenKind::BitwiseAnd.canonical_spelling(), Some("&"));
+    assert_eq!(TokenKind::SubSigil.canonical_spelling(), Some("&"));
+    assert_eq!(TokenKind::Star.canonical_spelling(), Some("*"));
+    assert_eq!(TokenKind::GlobSigil.canonical_spelling(), Some("*"));
+}
+
+#[test]
 fn mappings_are_case_sensitive_and_contextual() {
     assert_eq!(TokenKind::from_keyword("My"), None);
     assert_eq!(TokenKind::from_keyword("begin"), None);


### PR DESCRIPTION
### Motivation

- Provide a stable, programmatic way to recover the canonical source spelling for fixed-spelling token kinds instead of parsing human-facing `display_name` strings.
- Allow callers to distinguish value-carrying tokens (identifiers, literals, heredocs, EOF/unknown) from fixed spelling tokens (keywords, symbolic operators, delimiters, sigils).

### Description

- Add `TokenKind::canonical_spelling()` which returns `Some(&'static str)` for fixed-spelling kinds and `None` for value-carrying tokens, implemented by looking up `KEYWORD_SPELLINGS`, `OPERATOR_SPELLINGS`, `DELIMITER_SPELLINGS`, and `SIGIL_SPELLINGS`.
- Add internal helper `spelling_for_kind(...)` to perform the table lookup used by the new API.
- Add unit tests covering: that `canonical_spelling()` round-trips the fixed spelling tables, returns `None` for value-carrying tokens, and preserves contextual sigil/operator spellings; and update mapping tests to exercise the new behavior.
- Document the new API and example usage in the `crates/perl-token/README.md` and run formatting.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-token --profile agent --locked`, and all crate unit tests and doctests passed (no failures).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-token --profile agent --locked`, `./scripts/cargo-safe fmt --check`, and `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-token --profile agent --locked -- -D warnings -A missing_docs`, and they all succeeded.
- `just agent-pr-fast` was not executed in this environment because `just` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb173824833381034772071030be)