### PR TITLE
test(perl-token): use result-returning unit tests (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -1564,10 +1564,11 @@ mod tests {
     }
 
     #[test]
-    fn token_span_try_new_ok() {
-        let span = TokenSpan::try_new(0, 5).unwrap();
+    fn token_span_try_new_ok() -> Result<(), TokenSpanError> {
+        let span = TokenSpan::try_new(0, 5)?;
         assert_eq!(span.start, 0);
         assert_eq!(span.end, 5);
+        Ok(())
     }
 
     #[test]
@@ -1637,10 +1638,11 @@ mod tests {
     }
 
     #[test]
-    fn token_new_checked_allows_empty_eof() {
-        let tok = Token::new_checked(TokenKind::Eof, "", 5, 5).unwrap();
+    fn token_new_checked_allows_empty_eof() -> Result<(), TokenSpanError> {
+        let tok = Token::new_checked(TokenKind::Eof, "", 5, 5)?;
         assert_eq!(tok.kind, TokenKind::Eof);
         assert_eq!(tok.start, 5);
+        Ok(())
     }
 
     #[test]
@@ -1671,11 +1673,12 @@ mod tests {
     }
 
     #[test]
-    fn token_with_span_ok() {
+    fn token_with_span_ok() -> Result<(), TokenSpanError> {
         let tok = Token::new(TokenKind::String, "hello", 0, 5);
-        let moved = tok.with_span(10, 15).unwrap();
+        let moved = tok.with_span(10, 15)?;
         assert_eq!(moved.start, 10);
         assert_eq!(moved.end, 15);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Align `perl-token` unit tests with the repository's result-returning test style and avoid bare `unwrap()` calls in tests.

### Description
- Converted three unit tests to return `Result<(), TokenSpanError>` and use `?` propagation instead of `unwrap()` for success paths (`token_span_try_new_ok`, `token_new_checked_allows_empty_eof`, and `token_with_span_ok`).

### Testing
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-token --profile agent --locked`, `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-token --profile agent --locked`, `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-token --profile agent --locked -- -D warnings -A missing_docs`, and `MIN_FREE_GB=20 ./scripts/cargo-safe xtask fmt`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb173824833381034772071030be)