### PR TITLE
feat(perl-token): add span helper predicates (#8197)

### DIFF
--- a/crates/perl-token/src/token.rs
+++ b/crates/perl-token/src/token.rs
@@ -40,6 +40,44 @@ impl TokenSpan {
     pub const fn range(self) -> Range<usize> {
         self.start..self.end
     }
+
+    /// Return whether `offset` is inside this half-open span.
+    ///
+    /// The start is inclusive and the end is exclusive, matching Rust
+    /// [`Range`] semantics. Empty spans contain no offsets.
+    pub const fn contains(self, offset: usize) -> bool {
+        self.start <= offset && offset < self.end
+    }
+
+    /// Return whether `offset` touches this span, including the end boundary.
+    ///
+    /// This is useful for cursor-oriented callers that need positions at token
+    /// boundaries to resolve to the adjacent token. Empty spans touch exactly
+    /// their single boundary offset.
+    pub const fn touches(self, offset: usize) -> bool {
+        self.start <= offset && offset <= self.end
+    }
+
+    /// Return whether this span overlaps `other`.
+    ///
+    /// Spans are treated as half-open byte ranges, so adjacent spans such as
+    /// `0..2` and `2..4` do not overlap. Empty spans never overlap.
+    pub const fn overlaps(self, other: Self) -> bool {
+        !self.is_empty() && !other.is_empty() && self.start < other.end && other.start < self.end
+    }
+
+    /// Return the smallest span covering both spans.
+    pub const fn cover(self, other: Self) -> Self {
+        Self { start: min_usize(self.start, other.start), end: max_usize(self.end, other.end) }
+    }
+}
+
+const fn min_usize(left: usize, right: usize) -> usize {
+    if left <= right { left } else { right }
+}
+
+const fn max_usize(left: usize, right: usize) -> usize {
+    if left >= right { left } else { right }
 }
 
 /// Error type for checked token/span constructors.

--- a/crates/perl-token/tests/span_helper_tests.rs
+++ b/crates/perl-token/tests/span_helper_tests.rs
@@ -1,0 +1,54 @@
+use perl_token::TokenSpan;
+use std::error::Error;
+
+#[test]
+fn contains_uses_half_open_range_semantics() -> Result<(), Box<dyn Error>> {
+    let span = TokenSpan::new(3, 7);
+
+    assert!(!span.contains(2));
+    assert!(span.contains(3));
+    assert!(span.contains(6));
+    assert!(!span.contains(7));
+
+    Ok(())
+}
+
+#[test]
+fn touches_includes_boundaries_for_cursor_resolution() -> Result<(), Box<dyn Error>> {
+    let span = TokenSpan::new(3, 7);
+
+    assert!(!span.touches(2));
+    assert!(span.touches(3));
+    assert!(span.touches(7));
+    assert!(!span.touches(8));
+
+    let empty = TokenSpan::new(5, 5);
+    assert!(!empty.contains(5));
+    assert!(empty.touches(5));
+
+    Ok(())
+}
+
+#[test]
+fn overlaps_distinguishes_overlap_from_adjacency() -> Result<(), Box<dyn Error>> {
+    let span = TokenSpan::new(10, 20);
+
+    assert!(span.overlaps(TokenSpan::new(15, 25)));
+    assert!(span.overlaps(TokenSpan::new(5, 11)));
+    assert!(!span.overlaps(TokenSpan::new(20, 30)));
+    assert!(!span.overlaps(TokenSpan::new(0, 10)));
+    assert!(!span.overlaps(TokenSpan::new(12, 12)));
+
+    Ok(())
+}
+
+#[test]
+fn cover_returns_smallest_span_covering_both_inputs() -> Result<(), Box<dyn Error>> {
+    let left = TokenSpan::new(8, 12);
+    let right = TokenSpan::new(2, 20);
+
+    assert_eq!(left.cover(right), TokenSpan::new(2, 20));
+    assert_eq!(right.cover(left), TokenSpan::new(2, 20));
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Callers frequently need common byte-span checks (containment, boundary-touch, overlap, and covering spans) and were hand-rolling them, risking inconsistent semantics around half-open ranges and empty spans.

### Description

- Added const helpers to `TokenSpan` in `crates/perl-token/src/lib.rs`: `contains`, `touches`, `overlaps`, and `cover`, plus `min_usize`/`max_usize` helpers for `cover`.
- Implemented half-open range semantics where `contains` is `[start, end)` and `touches` includes the end boundary, and made `overlaps` explicitly exclude empty spans.
- Added focused regression tests in `crates/perl-token/tests/span_helper_tests.rs` exercising adjacency, empty spans, and `cover` behavior, and ran formatting.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-token --profile agent --locked`, which passed including the new tests.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-token --profile agent --locked`, `./scripts/cargo-safe xtask fmt`, and `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-token --profile agent --locked -- -D warnings -A missing_docs`, all of which passed.
- Ran `git diff --check` and `./scripts/storage-doctor` with no issues; `just agent-pr-fast` could not be run because `just` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb173824833381034772071030be)