### PR TITLE
fix(perl-pragma): preserve warning category toggles (#9133)

### DIFF
--- a/crates/perl-pragma/src/range_builder/directives.rs
+++ b/crates/perl-pragma/src/range_builder/directives.rs
@@ -22,9 +22,7 @@ pub(super) fn apply_use_directive(
             push_state(range, state, ranges);
         }
         "warnings" => {
-            state.warnings = true;
-            state.disabled_warning_categories.clear();
-            push_state(range, state, ranges);
+            apply_use_warnings(range, args, state, ranges);
         }
         "utf8" => {
             state.utf8 = true;
@@ -146,8 +144,7 @@ fn apply_conditional_use_target(
     match module {
         "strict" => set_strict_categories(state, args, true),
         "warnings" => {
-            state.warnings = true;
-            state.disabled_warning_categories.clear();
+            enable_warnings_categories(args, state);
         }
         "utf8" => state.utf8 = true,
         "encoding" => state.encoding = first_normalized_arg(args),
@@ -219,6 +216,31 @@ fn set_strict_categories(state: &mut PragmaState, args: &[String], enabled: bool
     }
 }
 
+fn apply_use_warnings(
+    range: Range<usize>,
+    args: &[String],
+    state: &mut PragmaState,
+    ranges: &mut Vec<(Range<usize>, PragmaState)>,
+) {
+    enable_warnings_categories(args, state);
+    push_state(range, state, ranges);
+}
+
+fn enable_warnings_categories(args: &[String], state: &mut PragmaState) {
+    state.warnings = true;
+
+    if args.is_empty() {
+        state.disabled_warning_categories.clear();
+        return;
+    }
+
+    for arg in args {
+        for category in pragma_arg_items(arg) {
+            state.disabled_warning_categories.retain(|disabled| disabled != &category);
+        }
+    }
+}
+
 fn apply_no_warnings(
     range: Range<usize>,
     args: &[String],
@@ -248,7 +270,9 @@ fn disable_warnings_categories(args: &[String], state: &mut PragmaState) {
     }
 
     for arg in args {
-        add_disabled_warning_category(state, normalized_pragma_token(arg));
+        for category in pragma_arg_items(arg) {
+            add_disabled_warning_category(state, &category);
+        }
     }
 }
 

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -551,3 +551,37 @@ fn given_cursor_when_explicit_map_offset_is_before_first_pragma_then_default_sna
     assert_eq!(state, map.state_at(5));
     assert!(!state.strict_vars, "no pragma has started at offset 5");
 }
+
+#[test]
+fn given_use_warnings_when_qw_categories_are_disabled_then_each_category_is_tracked()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 15),
+        no_node("warnings", &["qw(uninitialized deprecated)"], 16, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 30);
+    assert!(state.warnings);
+    assert!(!state.is_warning_active("uninitialized"));
+    assert!(!state.is_warning_active("deprecated"));
+    assert!(state.is_warning_active("void"));
+    Ok(())
+}
+
+#[test]
+fn given_disabled_warning_categories_when_specific_category_is_reenabled_then_other_disabled_categories_remain()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 15),
+        no_node("warnings", &["qw(uninitialized deprecated)"], 16, 55),
+        use_node("warnings", &["'deprecated'"], 56, 84),
+    ]);
+    let map = PragmaTracker::build(&ast);
+
+    let state = PragmaTracker::state_for_offset(&map, 70);
+    assert!(state.warnings);
+    assert!(!state.is_warning_active("uninitialized"));
+    assert!(state.is_warning_active("deprecated"));
+    Ok(())
+}

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -1334,6 +1334,47 @@ fn no_warnings_multiple_categories_all_recorded() -> Result<(), Box<dyn std::err
 }
 
 #[test]
+fn no_warnings_qw_categories_are_recorded_individually() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 15),
+        no_node("warnings", &["qw(uninitialized redefine)"], 16, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+
+    assert!(state.warnings, "category disables must preserve global warnings");
+    assert_eq!(
+        state.disabled_warning_categories,
+        vec!["uninitialized".to_string(), "redefine".to_string()],
+        "qw(...) warning categories should be expanded before tracking"
+    );
+    assert!(!state.is_warning_active("uninitialized"));
+    assert!(!state.is_warning_active("redefine"));
+    assert!(state.is_warning_active("deprecated"));
+    Ok(())
+}
+
+#[test]
+fn no_warnings_space_separated_category_string_is_split() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 15),
+        no_node("warnings", &["'uninitialized redefine'"], 16, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+
+    assert_eq!(
+        state.disabled_warning_categories,
+        vec!["uninitialized".to_string(), "redefine".to_string()],
+        "quoted warning category lists should match strict/feature argument splitting"
+    );
+    assert!(!state.is_warning_active("uninitialized"));
+    assert!(!state.is_warning_active("redefine"));
+    Ok(())
+}
+
+#[test]
 fn no_warnings_category_tracking_is_bounded() -> Result<(), Box<dyn std::error::Error>> {
     let mut statements = Vec::new();
     statements.push(use_node("warnings", &[], 0, 15));


### PR DESCRIPTION
### Motivation

- `perl-pragma` previously treated grouped warning category arguments (e.g. `qw(...)`) as single tokens and a category-specific `use warnings` call cleared the whole disabled-category list, which loses other disabled categories.

### Description

- Replace the previous one-shot `use warnings` behavior with `apply_use_warnings` that re-enables only the requested categories and preserves other disabled categories.
- Add `enable_warnings_categories` which parses grouped/listed pragma arguments with the shared parser (`pragma_arg_items`) and selectively removes matching entries from `disabled_warning_categories` while setting the global `warnings` flag.
- Update `disable_warnings_categories` to parse grouped arguments (using `pragma_arg_items`) and add each category individually via `add_disabled_warning_category` to keep behavior consistent and bounded.
- Add two BDD-style behavior tests in `crates/perl-pragma/tests/behavior_spec_tests.rs` that cover `qw(...)` disabling and selective re-enabling of specific warning categories.

### Testing

- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo test -p perl-pragma --profile agent --locked`, and the crate's unit and behavior tests completed successfully.
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo clippy -p perl-pragma --profile agent --locked -- -D warnings -A missing_docs`, and the lint run completed successfully.
- Ran `./scripts/cargo-safe fmt --check --all`, and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb0840a48333877089bb2cd1be3b)