### PR TITLE
fix(pragma): refresh feature bundle tracking (#9134)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -326,6 +326,7 @@ impl PragmaState {
     /// Returns `true` if the given feature name is currently enabled.
     #[must_use]
     pub fn has_feature(&self, feature: &str) -> bool {
+        let feature = canonical_feature_query(feature);
         self.features.contains(&feature)
     }
 
@@ -378,58 +379,191 @@ pub fn version_implies_warnings(version: PerlVersion) -> bool {
 ///
 /// Mirrors the Perl `feature` pragma bundle semantics: each `use vX.Y`
 /// declaration implicitly enables the same features as `use feature ':X.Y'`.
-/// Features that were removed from a bundle (e.g. `switch` removed in v5.38)
-/// are **not** included for that version and above.
+/// Features that were removed from a bundle (for example `switch` removed in
+/// v5.36 and `smartmatch` removed in v5.42) are **not** included for that
+/// version and above. Versions older than v5.10 load the `:default` bundle.
 ///
 /// Reference: <https://perldoc.perl.org/feature#FEATURE-BUNDLES>
 #[must_use]
 pub fn features_enabled_by_version(version: PerlVersion) -> Vec<&'static str> {
-    let mut features = Vec::new();
+    let bundle = if version < PerlVersion::new(5, 10) {
+        DEFAULT_FEATURES
+    } else if version >= PerlVersion::new(5, 42) {
+        BUNDLE_5_42_FEATURES
+    } else if version >= PerlVersion::new(5, 40) {
+        BUNDLE_5_40_FEATURES
+    } else if version >= PerlVersion::new(5, 38) {
+        BUNDLE_5_38_FEATURES
+    } else if version >= PerlVersion::new(5, 36) {
+        BUNDLE_5_36_FEATURES
+    } else if version >= PerlVersion::new(5, 34) {
+        BUNDLE_5_34_FEATURES
+    } else if version >= PerlVersion::new(5, 28) {
+        BUNDLE_5_28_FEATURES
+    } else if version >= PerlVersion::new(5, 24) {
+        BUNDLE_5_24_FEATURES
+    } else if version >= PerlVersion::new(5, 16) {
+        BUNDLE_5_16_FEATURES
+    } else if version >= PerlVersion::new(5, 12) {
+        BUNDLE_5_12_FEATURES
+    } else {
+        BUNDLE_5_10_FEATURES
+    };
 
-    // v5.10 bundle: say, state, switch (given/when)
-    if version >= PerlVersion::new(5, 10) {
-        features.extend_from_slice(&["say", "state", "switch"]);
-    }
-
-    // v5.12 bundle adds: unicode_strings
-    if version >= PerlVersion::new(5, 12) {
-        features.push("unicode_strings");
-    }
-
-    // v5.16 bundle adds: unicode_eval, evalbytes, current_sub, fc
-    if version >= PerlVersion::new(5, 16) {
-        features.extend_from_slice(&["unicode_eval", "evalbytes", "current_sub", "fc"]);
-    }
-
-    // v5.20 bundle adds: postfix_deref (experimental; stable-bundled at v5.26)
-    // We track it from v5.20 so explicit `use feature 'postfix_deref'` on v5.20 works.
-    if version >= PerlVersion::new(5, 20) {
-        features.push("postfix_deref");
-    }
-
-    // v5.34 bundle adds: try (experimental)
-    if version >= PerlVersion::new(5, 34) {
-        features.push("try");
-    }
-
-    // v5.36 bundle adds: signatures (stable), defer, isa
-    if version >= PerlVersion::new(5, 36) {
-        features.extend_from_slice(&["signatures", "defer", "isa"]);
-    }
-
-    // v5.38 bundle adds: class, field, method; removes: switch (given/when deprecated)
-    if version >= PerlVersion::new(5, 38) {
-        features.extend_from_slice(&["class", "field", "method"]);
-        features.retain(|&f| f != "switch");
-    }
-
-    // v5.40 bundle adds: builtin
-    if version >= PerlVersion::new(5, 40) {
-        features.push("builtin");
-    }
-
-    features
+    bundle.to_vec()
 }
+
+const DEFAULT_FEATURES: &[&str] = &[
+    "indirect",
+    "multidimensional",
+    "bareword_filehandles",
+    "apostrophe_as_package_separator",
+    "smartmatch",
+];
+
+const BUNDLE_5_10_FEATURES: &[&str] = &[
+    "apostrophe_as_package_separator",
+    "bareword_filehandles",
+    "indirect",
+    "multidimensional",
+    "say",
+    "smartmatch",
+    "state",
+    "switch",
+];
+
+const BUNDLE_5_12_FEATURES: &[&str] = &[
+    "apostrophe_as_package_separator",
+    "bareword_filehandles",
+    "indirect",
+    "multidimensional",
+    "say",
+    "smartmatch",
+    "state",
+    "switch",
+    "unicode_strings",
+];
+
+const BUNDLE_5_16_FEATURES: &[&str] = &[
+    "apostrophe_as_package_separator",
+    "bareword_filehandles",
+    "current_sub",
+    "evalbytes",
+    "fc",
+    "indirect",
+    "multidimensional",
+    "say",
+    "smartmatch",
+    "state",
+    "switch",
+    "unicode_eval",
+    "unicode_strings",
+];
+
+const BUNDLE_5_24_FEATURES: &[&str] = &[
+    "apostrophe_as_package_separator",
+    "bareword_filehandles",
+    "current_sub",
+    "evalbytes",
+    "fc",
+    "indirect",
+    "multidimensional",
+    "postderef_qq",
+    "say",
+    "smartmatch",
+    "state",
+    "switch",
+    "unicode_eval",
+    "unicode_strings",
+];
+
+const BUNDLE_5_28_FEATURES: &[&str] = &[
+    "apostrophe_as_package_separator",
+    "bareword_filehandles",
+    "bitwise",
+    "current_sub",
+    "evalbytes",
+    "fc",
+    "indirect",
+    "multidimensional",
+    "postderef_qq",
+    "say",
+    "smartmatch",
+    "state",
+    "switch",
+    "unicode_eval",
+    "unicode_strings",
+];
+
+const BUNDLE_5_34_FEATURES: &[&str] = BUNDLE_5_28_FEATURES;
+
+const BUNDLE_5_36_FEATURES: &[&str] = &[
+    "apostrophe_as_package_separator",
+    "bareword_filehandles",
+    "bitwise",
+    "current_sub",
+    "evalbytes",
+    "fc",
+    "isa",
+    "postderef_qq",
+    "say",
+    "signatures",
+    "smartmatch",
+    "state",
+    "unicode_eval",
+    "unicode_strings",
+];
+
+const BUNDLE_5_38_FEATURES: &[&str] = &[
+    "apostrophe_as_package_separator",
+    "bitwise",
+    "current_sub",
+    "evalbytes",
+    "fc",
+    "isa",
+    "module_true",
+    "postderef_qq",
+    "say",
+    "signatures",
+    "smartmatch",
+    "state",
+    "unicode_eval",
+    "unicode_strings",
+];
+
+const BUNDLE_5_40_FEATURES: &[&str] = &[
+    "apostrophe_as_package_separator",
+    "bitwise",
+    "current_sub",
+    "evalbytes",
+    "fc",
+    "isa",
+    "module_true",
+    "postderef_qq",
+    "say",
+    "signatures",
+    "smartmatch",
+    "state",
+    "try",
+    "unicode_eval",
+    "unicode_strings",
+];
+
+const BUNDLE_5_42_FEATURES: &[&str] = &[
+    "bitwise",
+    "current_sub",
+    "evalbytes",
+    "fc",
+    "isa",
+    "module_true",
+    "postderef_qq",
+    "say",
+    "signatures",
+    "state",
+    "try",
+    "unicode_eval",
+    "unicode_strings",
+];
 
 pub(crate) fn enable_effective_version_semantics(state: &mut PragmaState, version: PerlVersion) {
     if version_implies_strict(version) {
@@ -456,12 +590,18 @@ fn known_feature_name(name: &str) -> Option<&'static str> {
         "say" => Some("say"),
         "state" => Some("state"),
         "switch" => Some("switch"),
+        "smartmatch" => Some("smartmatch"),
         "unicode_strings" => Some("unicode_strings"),
         "unicode_eval" => Some("unicode_eval"),
         "evalbytes" => Some("evalbytes"),
         "current_sub" => Some("current_sub"),
         "fc" => Some("fc"),
-        "postfix_deref" => Some("postfix_deref"),
+        "lexical_subs" => Some("lexical_subs"),
+        "postderef" => Some("postderef"),
+        "postderef_qq" | "postfix_deref" => Some("postderef_qq"),
+        "refaliasing" => Some("refaliasing"),
+        "bitwise" => Some("bitwise"),
+        "declared_refs" => Some("declared_refs"),
         "try" => Some("try"),
         "signatures" => Some("signatures"),
         "defer" => Some("defer"),
@@ -469,7 +609,14 @@ fn known_feature_name(name: &str) -> Option<&'static str> {
         "class" => Some("class"),
         "field" => Some("field"),
         "method" => Some("method"),
-        "builtin" => Some("builtin"),
+        "builtin" | "module_true" => Some("module_true"),
+        "indirect" => Some("indirect"),
+        "multidimensional" => Some("multidimensional"),
+        "bareword_filehandles" => Some("bareword_filehandles"),
+        "extra_paired_delimiters" => Some("extra_paired_delimiters"),
+        "apostrophe_as_package_separator" => Some("apostrophe_as_package_separator"),
+        "keyword_any" => Some("keyword_any"),
+        "keyword_all" => Some("keyword_all"),
         _ => None,
     }
 }
@@ -477,22 +624,43 @@ fn known_feature_name(name: &str) -> Option<&'static str> {
 const ALL_KNOWN_FEATURES: &[&str] = &[
     "say",
     "state",
+    "smartmatch",
     "switch",
     "unicode_strings",
     "unicode_eval",
     "evalbytes",
     "current_sub",
     "fc",
-    "postfix_deref",
-    "try",
+    "lexical_subs",
+    "postderef",
+    "postderef_qq",
     "signatures",
-    "defer",
+    "refaliasing",
+    "bitwise",
+    "declared_refs",
     "isa",
+    "indirect",
+    "multidimensional",
+    "bareword_filehandles",
+    "try",
+    "defer",
+    "extra_paired_delimiters",
+    "module_true",
     "class",
     "field",
     "method",
-    "builtin",
+    "apostrophe_as_package_separator",
+    "keyword_any",
+    "keyword_all",
 ];
+
+fn canonical_feature_query(feature: &str) -> &str {
+    match feature {
+        "builtin" => "module_true",
+        "postfix_deref" => "postderef_qq",
+        _ => feature,
+    }
+}
 
 fn enable_feature_name(state: &mut PragmaState, name: &str) -> bool {
     if name == "signatures" {
@@ -531,10 +699,11 @@ fn disable_feature_name(state: &mut PragmaState, name: &str) -> bool {
 
 pub(crate) fn apply_feature_state(state: &mut PragmaState, args: &[String], enabled: bool) -> bool {
     if !enabled && args.is_empty() {
+        let default_features = DEFAULT_FEATURES.to_vec();
         let changed =
-            !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
-        state.features.clear();
-        state.unicode_strings = false;
+            state.features != default_features || state.unicode_strings || state.signatures_strict;
+        state.features = default_features;
+        state.unicode_strings = state.has_feature("unicode_strings");
         state.signatures_strict = false;
         return changed;
     }
@@ -550,6 +719,13 @@ pub(crate) fn apply_feature_state(state: &mut PragmaState, args: &[String], enab
                 continue;
             }
 
+            if enabled && item == ":default" {
+                for feature in DEFAULT_FEATURES {
+                    changed |= enable_feature_name(state, feature);
+                }
+                continue;
+            }
+
             if !enabled && item == ":all" {
                 let had_features =
                     !state.features.is_empty() || state.unicode_strings || state.signatures_strict;
@@ -557,6 +733,13 @@ pub(crate) fn apply_feature_state(state: &mut PragmaState, args: &[String], enab
                 state.unicode_strings = false;
                 state.signatures_strict = false;
                 changed |= had_features;
+                continue;
+            }
+
+            if !enabled && item == ":default" {
+                for feature in DEFAULT_FEATURES {
+                    changed |= disable_feature_name(state, feature);
+                }
                 continue;
             }
 

--- a/crates/perl-pragma/tests/behavior_spec_tests.rs
+++ b/crates/perl-pragma/tests/behavior_spec_tests.rs
@@ -205,15 +205,15 @@ fn given_use_feature_signatures_when_querying_state_then_effective_strict_modes_
 }
 
 #[test]
-fn given_use_v5_38_when_querying_state_then_switch_feature_is_not_available_but_modern_features_are()
- {
+fn given_use_v5_38_when_querying_state_then_removed_features_are_absent_but_modern_features_are() {
     let ast = program(vec![use_node("v5.38", &[], 0, 10)]);
     let map = PragmaTracker::build(&ast);
 
     let state = PragmaTracker::state_for_offset(&map, 5);
-    assert!(state.has_feature("class"));
-    assert!(state.has_feature("method"));
+    assert!(state.has_feature("module_true"));
+    assert!(state.has_feature("signatures"));
     assert!(!state.has_feature("switch"));
+    assert!(!state.has_feature("bareword_filehandles"));
 }
 
 #[test]

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -716,10 +716,12 @@ fn feature_bundle_can_be_reenabled_after_no_feature_all() -> Result<(), Box<dyn 
 }
 
 #[test]
-fn no_feature_without_args_clears_bundle_features() -> Result<(), Box<dyn std::error::Error>> {
+fn no_feature_without_args_restores_default_features() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("v5.40", &[], 0, 12), no_node("feature", &[], 13, 23)]);
     let map = PragmaTracker::build(&ast);
     let state = &map[1].1;
+    assert!(state.has_feature("smartmatch"));
+    assert!(state.has_feature("indirect"));
     assert!(!state.has_feature("say"));
     assert!(!state.has_feature("switch"));
     assert!(!state.has_feature("builtin"));
@@ -1603,11 +1605,11 @@ fn v5_14_enables_unicode_strings() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn v5_26_enables_unicode_eval_and_postfix_deref() -> Result<(), Box<dyn std::error::Error>> {
+fn v5_26_enables_unicode_eval_and_postderef_qq() -> Result<(), Box<dyn std::error::Error>> {
     let features = features_enabled_by_version(PerlVersion::new(5, 26));
     assert!(features.contains(&"say"), "v5.26 should retain v5.10 features");
     assert!(features.contains(&"unicode_strings"), "v5.26 should retain v5.14 features");
-    assert!(features.contains(&"postfix_deref"), "v5.26 must enable 'postfix_deref'");
+    assert!(features.contains(&"postderef_qq"), "v5.26 must enable 'postderef_qq'");
     assert!(
         features.contains(&"unicode_eval"),
         "v5.26 must enable 'unicode_eval' (disables /xx is separate feature)"
@@ -1616,18 +1618,18 @@ fn v5_26_enables_unicode_eval_and_postfix_deref() -> Result<(), Box<dyn std::err
 }
 
 #[test]
-fn v5_36_enables_signatures_defer_isa() -> Result<(), Box<dyn std::error::Error>> {
+fn v5_36_enables_signatures_and_isa() -> Result<(), Box<dyn std::error::Error>> {
     let features = features_enabled_by_version(PerlVersion::new(5, 36));
     assert!(features.contains(&"signatures"), "v5.36 must enable 'signatures'");
-    assert!(features.contains(&"defer"), "v5.36 must enable 'defer'");
     assert!(features.contains(&"isa"), "v5.36 must enable 'isa'");
+    assert!(!features.contains(&"switch"), "v5.36 must omit removed 'switch'");
     Ok(())
 }
 
 #[test]
-fn v5_40_enables_builtin() -> Result<(), Box<dyn std::error::Error>> {
+fn v5_40_enables_module_true() -> Result<(), Box<dyn std::error::Error>> {
     let features = features_enabled_by_version(PerlVersion::new(5, 40));
-    assert!(features.contains(&"builtin"), "v5.40 must enable 'builtin'");
+    assert!(features.contains(&"module_true"), "v5.40 must enable 'module_true'");
     // Should also retain all v5.36 features
     assert!(features.contains(&"signatures"), "v5.40 should retain 'signatures'");
     assert!(features.contains(&"isa"), "v5.40 should retain 'isa'");
@@ -1636,20 +1638,20 @@ fn v5_40_enables_builtin() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn v5_12_retains_switch_from_v5_10() -> Result<(), Box<dyn std::error::Error>> {
-    // switch was inherited from v5.10 and not removed until v5.38
+    // switch was inherited from v5.10 and not removed until v5.36
     let features_v12 = features_enabled_by_version(PerlVersion::new(5, 12));
     assert!(
         features_v12.contains(&"switch"),
-        "v5.12 should include 'switch' (inherited from v5.10, removed at v5.38)"
+        "v5.12 should include 'switch' (inherited from v5.10, removed at v5.36)"
     );
     Ok(())
 }
 
 #[test]
-fn v5_38_removes_switch() -> Result<(), Box<dyn std::error::Error>> {
-    // switch (given/when) was removed from the bundle in v5.38
-    let features = features_enabled_by_version(PerlVersion::new(5, 38));
-    assert!(!features.contains(&"switch"), "v5.38 should not include 'switch' (removed)");
+fn v5_36_removes_switch() -> Result<(), Box<dyn std::error::Error>> {
+    // switch (given/when) is removed from bundles starting in v5.36.
+    let features = features_enabled_by_version(PerlVersion::new(5, 36));
+    assert!(!features.contains(&"switch"), "v5.36 should not include 'switch' (removed)");
     Ok(())
 }
 
@@ -1711,13 +1713,13 @@ fn use_v5_10_state_has_say_state_switch() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
-fn use_v5_36_state_has_signatures_defer_isa() -> Result<(), Box<dyn std::error::Error>> {
+fn use_v5_36_state_has_signatures_and_isa() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("v5.36", &[], 0, 12)]);
     let map = PragmaTracker::build(&ast);
     let state = &map[0].1;
     assert!(state.has_feature("signatures"), "v5.36 state must have 'signatures'");
-    assert!(state.has_feature("defer"), "v5.36 state must have 'defer'");
     assert!(state.has_feature("isa"), "v5.36 state must have 'isa'");
+    assert!(!state.has_feature("switch"), "v5.36 state must not have removed switch");
     // v5.36 also implies strict and warnings
     assert!(state.strict_vars, "v5.36 implies strict");
     assert!(state.warnings, "v5.36 implies warnings");
@@ -1725,11 +1727,16 @@ fn use_v5_36_state_has_signatures_defer_isa() -> Result<(), Box<dyn std::error::
 }
 
 #[test]
-fn use_v5_40_state_has_builtin() -> Result<(), Box<dyn std::error::Error>> {
+fn use_v5_40_state_has_module_true_alias_builtin() -> Result<(), Box<dyn std::error::Error>> {
     let ast = program(vec![use_node("v5.40", &[], 0, 12)]);
     let map = PragmaTracker::build(&ast);
     let state = &map[0].1;
-    assert!(state.has_feature("builtin"), "v5.40 state must have 'builtin'");
+    assert!(state.has_feature("module_true"), "v5.40 state must have 'module_true'");
+    assert!(state.has_feature("builtin"), "legacy builtin query should alias module_true");
+    assert!(
+        state.has_feature("postfix_deref"),
+        "legacy postfix_deref query should alias postderef_qq"
+    );
     assert!(!state.has_builtin_import("floor"), "v5.40 should not imply lexical builtin imports");
     assert!(state.builtin_imports.is_empty(), "v5.40 should not populate lexical builtin imports");
     Ok(())
@@ -2049,5 +2056,64 @@ fn package_block_pragma_inside_is_visible_at_inner_offset() -> Result<(), Box<dy
 
     let inside = PragmaTracker::state_for_offset(&map, 30);
     assert!(inside.strict_vars, "strict_vars declared inside package block must be visible");
+    Ok(())
+}
+
+#[test]
+fn v5_42_removes_smartmatch_and_apostrophe_package_separator()
+-> Result<(), Box<dyn std::error::Error>> {
+    let features = features_enabled_by_version(PerlVersion::new(5, 42));
+    assert!(!features.contains(&"smartmatch"));
+    assert!(!features.contains(&"apostrophe_as_package_separator"));
+    assert!(features.contains(&"module_true"));
+    assert!(features.contains(&"try"));
+    Ok(())
+}
+
+#[test]
+fn no_feature_without_args_restores_default_feature_set_after_all()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast =
+        program(vec![use_node("feature", &["':all'"], 0, 20), no_node("feature", &[], 21, 32)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(state.has_feature("smartmatch"));
+    assert!(state.has_feature("indirect"));
+    assert!(!state.has_feature("say"));
+    assert!(!state.has_feature("module_true"));
+    Ok(())
+}
+
+#[test]
+fn use_feature_default_enables_default_features() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &["':default'"], 0, 24)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+
+    assert!(state.has_feature("smartmatch"));
+    assert!(state.has_feature("indirect"));
+    assert!(state.has_feature("multidimensional"));
+    assert!(state.has_feature("bareword_filehandles"));
+    assert!(state.has_feature("apostrophe_as_package_separator"));
+    assert!(!state.has_feature("say"));
+    Ok(())
+}
+
+#[test]
+fn no_feature_default_disables_only_default_features() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("feature", &["':all'"], 0, 20),
+        no_node("feature", &["':default'"], 21, 42),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+
+    assert!(!state.has_feature("smartmatch"));
+    assert!(!state.has_feature("indirect"));
+    assert!(!state.has_feature("multidimensional"));
+    assert!(!state.has_feature("bareword_filehandles"));
+    assert!(!state.has_feature("apostrophe_as_package_separator"));
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("module_true"));
     Ok(())
 }

--- a/crates/perl-pragma/tests/coverage_gap_tests.rs
+++ b/crates/perl-pragma/tests/coverage_gap_tests.rs
@@ -5,12 +5,12 @@
 //! - `use if` / `no if` with `utf8`, `encoding`, and `locale` targets (conditional arms)
 //! - `use if` / `no if` with no recognized target (no-op paths)
 //! - `no feature ':VERSION'` bundle disable (feature_state `disable_feature_name` bundle path)
-//! - `apply_feature_state` no-args disabled path with nothing to clear (unchanged path)
+//! - `apply_feature_state` no-args disabled path restoring the default feature bundle
 //! - `apply_no_directive` for feature when no state change (no push path)
 //! - `LabeledStatement` and `StatementModifier` AST traversal
 //! - `PragmaSnapshot`/`PragmaState` conversions (`From` impls)
 //! - `PragmaMap::state_at`, `PragmaStateQuery` methods, `PragmaSnapshot` methods
-//! - `features_enabled_by_version` intermediate bundles (v5.16, v5.20, v5.34)
+//! - `features_enabled_by_version` documented bundle boundaries
 //! - `parse_perl_version` major-only without 'v' prefix
 //! - `normalize_snapshot` propagation of `signatures_strict`
 //! - `builtin_import_names` double-quoted single name
@@ -199,12 +199,27 @@ fn no_feature_version_bundle_only_removes_bundle_features() -> Result<(), Box<dy
 // ===========================================================================
 
 #[test]
-fn no_feature_bare_on_empty_state_is_noop() -> Result<(), Box<dyn std::error::Error>> {
-    // `no feature` with no args when features is empty — changed=false, no entry pushed
+fn no_feature_bare_on_empty_state_restores_default_bundle() -> Result<(), Box<dyn std::error::Error>>
+{
+    // `no feature` with no args resets to the documented :default bundle.
     let ast = program(vec![no_node("feature", &[], 0, 11)]);
     let map = PragmaTracker::build(&ast);
-    // apply_feature_state returns false (nothing to clear) → no entry pushed
-    assert!(map.is_empty(), "no feature on empty state must produce no map entry");
+    let state = PragmaTracker::state_for_offset(&map, 5);
+    assert!(state.has_feature("indirect"), "no feature must restore :default indirect");
+    assert!(
+        state.has_feature("multidimensional"),
+        "no feature must restore :default multidimensional"
+    );
+    assert!(
+        state.has_feature("bareword_filehandles"),
+        "no feature must restore :default bareword_filehandles"
+    );
+    assert!(
+        state.has_feature("apostrophe_as_package_separator"),
+        "no feature must restore :default apostrophe package separator"
+    );
+    assert!(state.has_feature("smartmatch"), "no feature must restore :default smartmatch");
+    assert!(!state.has_feature("say"), "no feature must not restore non-default say");
     Ok(())
 }
 
@@ -414,9 +429,12 @@ fn v5_16_enables_unicode_eval_evalbytes_current_sub_fc() -> Result<(), Box<dyn s
 }
 
 #[test]
-fn v5_20_enables_postfix_deref() -> Result<(), Box<dyn std::error::Error>> {
+fn v5_20_omits_postderef_bundle_feature() -> Result<(), Box<dyn std::error::Error>> {
     let features = features_enabled_by_version(PerlVersion::new(5, 20));
-    assert!(features.contains(&"postfix_deref"), "v5.20 must enable postfix_deref");
+    assert!(
+        !features.contains(&"postderef_qq"),
+        "v5.20 feature bundle must not include postderef_qq"
+    );
     // Should retain v5.16 features
     assert!(features.contains(&"unicode_eval"), "v5.20 must retain unicode_eval");
     assert!(features.contains(&"current_sub"), "v5.20 must retain current_sub");
@@ -424,35 +442,46 @@ fn v5_20_enables_postfix_deref() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn v5_34_enables_try() -> Result<(), Box<dyn std::error::Error>> {
+fn v5_34_omits_try_but_retains_5_28_bundle() -> Result<(), Box<dyn std::error::Error>> {
     let features = features_enabled_by_version(PerlVersion::new(5, 34));
-    assert!(features.contains(&"try"), "v5.34 must enable try");
+    assert!(!features.contains(&"try"), "v5.34 feature bundle must not include try");
     // Should retain earlier features
-    assert!(features.contains(&"postfix_deref"), "v5.34 must retain postfix_deref");
+    assert!(features.contains(&"postderef_qq"), "v5.34 must retain postderef_qq");
     assert!(features.contains(&"unicode_eval"), "v5.34 must retain unicode_eval");
-    // switch still present before v5.38
+    // switch still present before v5.36
     assert!(features.contains(&"switch"), "v5.34 must retain switch (not yet removed)");
     Ok(())
 }
 
 #[test]
-fn v5_38_enables_class_field_method_removes_switch() -> Result<(), Box<dyn std::error::Error>> {
+fn v5_38_enables_module_true_without_class_features() -> Result<(), Box<dyn std::error::Error>> {
     let features = features_enabled_by_version(PerlVersion::new(5, 38));
-    assert!(features.contains(&"class"), "v5.38 must enable class");
-    assert!(features.contains(&"field"), "v5.38 must enable field");
-    assert!(features.contains(&"method"), "v5.38 must enable method");
+    assert!(features.contains(&"module_true"), "v5.38 must enable module_true");
+    assert!(!features.contains(&"class"), "v5.38 feature bundle must not include class");
+    assert!(!features.contains(&"field"), "v5.38 feature bundle must not include field");
+    assert!(!features.contains(&"method"), "v5.38 feature bundle must not include method");
     assert!(!features.contains(&"switch"), "v5.38 must remove switch");
-    // try and signatures should be retained
-    assert!(features.contains(&"try"), "v5.38 must retain try from v5.34");
+    assert!(!features.contains(&"try"), "v5.38 feature bundle must not include try");
     assert!(features.contains(&"signatures"), "v5.38 must retain signatures from v5.36");
     Ok(())
 }
 
 #[test]
-fn v5_9_returns_empty_feature_set() -> Result<(), Box<dyn std::error::Error>> {
-    // Versions before v5.10 have no feature bundles
+fn v5_9_returns_default_feature_set() -> Result<(), Box<dyn std::error::Error>> {
+    // Versions before v5.10 implicitly load the :default bundle.
     let features = features_enabled_by_version(PerlVersion::new(5, 9));
-    assert!(features.is_empty(), "v5.9 must return empty feature set");
+    assert!(features.contains(&"indirect"), "v5.9 must include :default indirect");
+    assert!(features.contains(&"multidimensional"), "v5.9 must include :default multidimensional");
+    assert!(
+        features.contains(&"bareword_filehandles"),
+        "v5.9 must include :default bareword_filehandles"
+    );
+    assert!(
+        features.contains(&"apostrophe_as_package_separator"),
+        "v5.9 must include :default apostrophe package separator"
+    );
+    assert!(features.contains(&"smartmatch"), "v5.9 must include :default smartmatch");
+    assert!(!features.contains(&"say"), "v5.9 must not include v5.10 say");
     Ok(())
 }
 


### PR DESCRIPTION
### Motivation
- Bring `perl-pragma` feature-bundle semantics in line with recent Perl changes (removals and renames) and avoid surprising behavior when `no feature` is used with no args. 
- Ensure downstream consumers and diagnostics rely on canonical feature names and a stable default bundle instead of clearing the feature set on bare `no feature`.

### Description
- Replace incremental feature construction with explicit versioned bundles (`DEFAULT_FEATURES`, `BUNDLE_5_10` .. `BUNDLE_5_42`) and return the appropriate bundle from `features_enabled_by_version`. 
- Canonicalize legacy/renamed queries by adding `canonical_feature_query` and map `builtin` → `module_true` and `postfix_deref` → `postderef_qq`. 
- Expand the known feature name table and `ALL_KNOWN_FEATURES` to cover additional features and alias forms, and update `enable/disable` logic to use these canonical names. 
- Change bare `no feature` semantics to restore the default feature bundle instead of clearing everything, and add `:default` handling for explicit toggles; update and add tests to reflect the new expectations.

### Testing
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-pragma --profile agent --locked`, which passed (all tests succeeded). 
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-pragma --profile agent --locked`, which passed. 
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-pragma --profile agent --locked -- -D warnings -A missing_docs`, which passed. 
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe xtask fmt`, which passed; `just agent-pr-fast` was not run because `just` is not available in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb0840a48333877089bb2cd1be3b)