### PR TITLE
fix(perl-pragma): support alternate qw delimiters (#9135)

### DIFF
--- a/crates/perl-pragma/src/lib.rs
+++ b/crates/perl-pragma/src/lib.rs
@@ -583,18 +583,13 @@ pub(crate) fn apply_feature_state(state: &mut PragmaState, args: &[String], enab
 }
 
 fn builtin_import_names(arg: &str) -> Vec<String> {
-    let trimmed = arg.trim();
+    let trimmed = normalized_pragma_token(arg);
 
-    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
-        return inner
-            .split_whitespace()
-            .filter(|name| !name.is_empty())
-            .map(|name| name.trim_matches('\'').trim_matches('"').to_string())
-            .collect();
+    if let Some(inner) = qw_list_inner(trimmed) {
+        return pragma_words(inner).into_iter().map(|name| name.to_string()).collect();
     }
 
-    let name = trimmed.trim_matches('\'').trim_matches('"');
-    if name.is_empty() { Vec::new() } else { vec![name.to_string()] }
+    if trimmed.is_empty() { Vec::new() } else { vec![trimmed.to_string()] }
 }
 
 pub(crate) fn apply_builtin_imports(state: &mut PragmaState, args: &[String]) {
@@ -641,17 +636,45 @@ pub(crate) fn remove_builtin_imports(state: &mut PragmaState, args: &[String]) {
 }
 
 pub(crate) fn pragma_arg_items(arg: &str) -> Vec<String> {
-    let trimmed = arg.trim().trim_matches('\'').trim_matches('"');
+    let trimmed = normalized_pragma_token(arg);
 
-    if let Some(inner) = trimmed.strip_prefix("qw(").and_then(|s| s.strip_suffix(')')) {
-        return inner.split_whitespace().map(|item| item.to_string()).collect();
+    if let Some(inner) = qw_list_inner(trimmed) {
+        return pragma_words(inner).into_iter().map(|item| item.to_string()).collect();
     }
 
     if trimmed.contains(char::is_whitespace) {
-        return trimmed.split_whitespace().map(|item| item.to_string()).collect();
+        return pragma_words(trimmed).into_iter().map(|item| item.to_string()).collect();
     }
 
     vec![trimmed.to_string()]
+}
+
+fn qw_list_inner(arg: &str) -> Option<&str> {
+    let rest = arg.strip_prefix("qw")?.trim_start();
+    let opener = rest.chars().next()?;
+    let closer = qw_closer(opener)?;
+    let after_opener = &rest[opener.len_utf8()..];
+
+    after_opener.strip_suffix(closer)
+}
+
+fn qw_closer(opener: char) -> Option<char> {
+    match opener {
+        '(' => Some(')'),
+        '[' => Some(']'),
+        '{' => Some('}'),
+        '<' => Some('>'),
+        delimiter if !delimiter.is_alphanumeric() && !delimiter.is_whitespace() => Some(delimiter),
+        _ => None,
+    }
+}
+
+fn pragma_words(value: &str) -> Vec<&str> {
+    value
+        .split_whitespace()
+        .map(|item| item.trim_matches('\'').trim_matches('"'))
+        .filter(|item| !item.is_empty())
+        .collect()
 }
 
 pub(crate) fn normalized_pragma_token(arg: &str) -> &str {

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -231,6 +231,29 @@ fn use_strict_mixed_grouped_and_plain_args() -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
+#[test]
+fn use_strict_slash_qw_args_enable_requested_categories() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![use_node("strict", &["qw/vars refs/"], 0, 28)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.strict_vars);
+    assert!(!state.strict_subs);
+    assert!(state.strict_refs);
+    Ok(())
+}
+
+#[test]
+fn use_feature_brace_qw_args_enable_requested_features() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![use_node("feature", &["qw{say unicode_strings}"], 0, 36)]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[0].1;
+    assert!(state.has_feature("say"));
+    assert!(state.has_feature("unicode_strings"));
+    assert!(state.unicode_strings);
+    Ok(())
+}
+
 /// `use strict qw()` — empty qw list should be a no-op, not enable-all.
 /// The empty qw expands to zero items, so no categories are toggled.
 #[test]
@@ -1735,6 +1758,21 @@ fn no_builtin_removes_selected_lexical_imports() -> Result<(), Box<dyn std::erro
     let ast = program(vec![
         use_node("builtin", &["qw(true floor ceil)"], 0, 30),
         no_node("builtin", &["qw(floor)"], 31, 50),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+    assert!(state.has_builtin_import("true"));
+    assert!(!state.has_builtin_import("floor"));
+    assert!(state.has_builtin_import("ceil"));
+    Ok(())
+}
+
+#[test]
+fn builtin_qw_alternate_delimiters_track_and_remove_imports()
+-> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("builtin", &["qw<true floor ceil>"], 0, 30),
+        no_node("builtin", &["qw[floor]"], 31, 50),
     ]);
     let map = PragmaTracker::build(&ast);
     let state = &map[1].1;


### PR DESCRIPTION
### Motivation

- Pragmas and builtin-import lists used alternate `qw` delimiters in real Perl code (e.g. `qw/.../`, `qw{...}`, `qw[...]`, `qw<...>`), but parsing only handled the parenthesis form, causing missed pragma items and incomplete builtin import tracking.
- Make pragma argument parsing robust so `strict`, `feature`, and `builtin` handling recognizes all valid `qw` delimiter forms.

### Description

- Added shared `qw`-list helpers: `qw_list_inner`, `qw_closer`, and `pragma_words` and switched `builtin_import_names` and `pragma_arg_items` to use them and `normalized_pragma_token` for consistent token normalization.
- Updated `builtin_import_names` to accept alternate-delimiter `qw` lists and to return lexical names consistently for `use builtin` and `no builtin` flows.
- Reworked `pragma_arg_items` to reuse the new `qw` parsing and normalized token handling so feature and strict arguments handle `{}`, `[]`, `<>`, `/ /`, and other delimiter forms.
- Added unit tests covering alternate `qw` delimiters for `strict`, `feature`, and `builtin` pragmas in `crates/perl-pragma/tests/comprehensive_unit_tests.rs`.

### Testing

- Ran `cargo test -p perl-pragma --profile agent --locked` and all pragma tests passed (behavior/spec + comprehensive + regressions: 174 passed, 0 failed). 
- Ran `cargo check -p perl-pragma --all-targets --profile agent --locked`, `cargo clippy -p perl-pragma --profile agent --locked -- -D warnings -A missing_docs`, and `./scripts/cargo-safe xtask fmt`, all of which succeeded.
- Verified repository hygiene with `git diff --check` and `./scripts/storage-doctor`, both reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb0840a48333877089bb2cd1be3b)