### PR TITLE
fix(perl-pragma): split warning category lists (#0000)

### DIFF
--- a/crates/perl-pragma/src/range_builder/directives.rs
+++ b/crates/perl-pragma/src/range_builder/directives.rs
@@ -248,7 +248,9 @@ fn disable_warnings_categories(args: &[String], state: &mut PragmaState) {
     }
 
     for arg in args {
-        add_disabled_warning_category(state, normalized_pragma_token(arg));
+        for category in pragma_arg_items(arg) {
+            add_disabled_warning_category(state, &category);
+        }
     }
 }
 

--- a/crates/perl-pragma/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-pragma/tests/comprehensive_unit_tests.rs
@@ -1334,6 +1334,47 @@ fn no_warnings_multiple_categories_all_recorded() -> Result<(), Box<dyn std::err
 }
 
 #[test]
+fn no_warnings_qw_categories_are_recorded_individually() -> Result<(), Box<dyn std::error::Error>> {
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 15),
+        no_node("warnings", &["qw(uninitialized redefine)"], 16, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+
+    assert!(state.warnings, "category disables must preserve global warnings");
+    assert_eq!(
+        state.disabled_warning_categories,
+        vec!["uninitialized".to_string(), "redefine".to_string()],
+        "qw(...) warning categories should be expanded before tracking"
+    );
+    assert!(!state.is_warning_active("uninitialized"));
+    assert!(!state.is_warning_active("redefine"));
+    assert!(state.is_warning_active("deprecated"));
+    Ok(())
+}
+
+#[test]
+fn no_warnings_space_separated_category_string_is_split() -> Result<(), Box<dyn std::error::Error>>
+{
+    let ast = program(vec![
+        use_node("warnings", &[], 0, 15),
+        no_node("warnings", &["'uninitialized redefine'"], 16, 55),
+    ]);
+    let map = PragmaTracker::build(&ast);
+    let state = &map[1].1;
+
+    assert_eq!(
+        state.disabled_warning_categories,
+        vec!["uninitialized".to_string(), "redefine".to_string()],
+        "quoted warning category lists should match strict/feature argument splitting"
+    );
+    assert!(!state.is_warning_active("uninitialized"));
+    assert!(!state.is_warning_active("redefine"));
+    Ok(())
+}
+
+#[test]
 fn no_warnings_category_tracking_is_bounded() -> Result<(), Box<dyn std::error::Error>> {
     let mut statements = Vec::new();
     statements.push(use_node("warnings", &[], 0, 15));


### PR DESCRIPTION
### Motivation

- `no warnings` handlers recorded grouped or space-separated category arguments as a single literal token, causing categories like `qw(uninitialized redefine)` to be treated incorrectly.

### Description

- Update `disable_warnings_categories` in `crates/perl-pragma/src/range_builder/directives.rs` to reuse `pragma_arg_items` and expand each argument into individual categories before recording them.
- Add regression tests in `crates/perl-pragma/tests/comprehensive_unit_tests.rs` to assert `no warnings qw(...)` and quoted space-separated category strings are split and tracked as separate disabled categories.
- Keep behavior for bare `no warnings` (clear global warnings) unchanged and preserve the existing cap on tracked categories.

### Testing

- Ran unit tests for the crate with `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-pragma --profile agent --locked`, and all tests passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-pragma --profile agent --locked`, and checks passed.
- Ran formatter via `MIN_FREE_GB=20 ./scripts/cargo-safe xtask fmt`, and formatting succeeded.
- Ran lints via `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-pragma --profile agent --locked -- -D warnings -A missing_docs`, and clippy passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb0840a48333877089bb2cd1be3b)