### PR TITLE
fix(parser): ignore non-code import usages (#8197)

### DIFF
--- a/crates/perl-parser/src/refactor/import_optimizer.rs
+++ b/crates/perl-parser/src/refactor/import_optimizer.rs
@@ -247,6 +247,17 @@ fn get_known_module_exports(module: &str) -> Option<Vec<&'static str>> {
     }
 }
 
+fn strip_non_code_content(
+    content: &str,
+    string_literal_re: &Regex,
+    regex_literal_re: &Regex,
+    comment_re: &Regex,
+) -> String {
+    let stripped = string_literal_re.replace_all(content, " ").to_string();
+    let stripped = regex_literal_re.replace_all(&stripped, " ").to_string();
+    comment_re.replace_all(&stripped, " ").to_string()
+}
+
 impl ImportOptimizer {
     /// Create a new import optimizer for Analyze-stage refactorings.
     ///
@@ -345,19 +356,18 @@ impl ImportOptimizer {
             })
             .collect::<Vec<_>>();
 
-        // Build content without `use` lines for symbol usage detection
+        // Build stripped non-import content for symbol usage detection.
         let non_use_content = content
             .lines()
-            .filter(
-                |line| {
-                    !line.trim_start().starts_with("use ") && !line.trim_start().starts_with("#")
-                }, // Exclude comment lines
-            )
+            .filter(|line| !line.trim_start().starts_with("use "))
             .collect::<Vec<_>>()
-            .join(
-                "
-",
-            );
+            .join("\n");
+        let non_use_content = strip_non_code_content(
+            &non_use_content,
+            string_literal_re,
+            regex_literal_re,
+            comment_re,
+        );
 
         // Determine unused symbols for each import entry
         let mut unused_imports = Vec::new();
@@ -373,22 +383,7 @@ impl ImportOptimizer {
                     }
                 }
             } else {
-                // Skip pragma modules like strict, warnings, etc.
-                let is_pragma = matches!(
-                    imp.module.as_str(),
-                    "strict"
-                        | "warnings"
-                        | "utf8"
-                        | "bytes"
-                        | "integer"
-                        | "locale"
-                        | "overload"
-                        | "sigtrap"
-                        | "subs"
-                        | "vars"
-                );
-
-                if !is_pragma {
+                if !is_pragma_module(&imp.module) {
                     // For bare imports (without qw()), check if the module or any of its known exports are used
                     let (is_known_module, known_exports) =
                         match get_known_module_exports(&imp.module) {
@@ -444,10 +439,9 @@ impl ImportOptimizer {
         let imported_modules: BTreeSet<String> =
             imports.iter().map(|imp| imp.module.clone()).collect();
 
-        // Strip strings and comments before scanning for Module::symbol patterns
-        let stripped = string_literal_re.replace_all(content, " ").to_string();
-        let stripped = regex_literal_re.replace_all(&stripped, " ").to_string();
-        let stripped = comment_re.replace_all(&stripped, " ").to_string();
+        // Strip strings and comments before scanning for Module::symbol patterns.
+        let stripped =
+            strip_non_code_content(content, string_literal_re, regex_literal_re, comment_re);
         let mut usage_map: BTreeMap<String, Vec<String>> = BTreeMap::new();
         for caps in module_usage_re.captures_iter(&stripped) {
             // Only process if both capture groups matched

--- a/crates/perl-parser/tests/import_optimizer_tests.rs
+++ b/crates/perl-parser/tests/import_optimizer_tests.rs
@@ -266,3 +266,49 @@ z();
     assert!(lines[2].contains("Zebra"));
     Ok(())
 }
+
+#[test]
+fn ignores_symbols_mentioned_in_inline_comments_and_strings() -> TestResult {
+    let code = r#"use Test::Helpers qw(real_helper comment_helper string_helper regex_helper);
+
+real_helper(); # comment_helper should not count as a real usage
+my $message = "string_helper appears only in a string";
+my $pattern = qr/regex_helper/;
+"#;
+
+    let optimizer = ImportOptimizer::new();
+    let analysis = optimizer.analyze_content(code)?;
+
+    let unused = analysis
+        .unused_imports
+        .iter()
+        .find(|entry| entry.module == "Test::Helpers")
+        .ok_or("Missing Test::Helpers unused imports")?;
+
+    assert!(!unused.symbols.contains(&"real_helper".to_string()));
+    assert!(unused.symbols.contains(&"comment_helper".to_string()));
+    assert!(unused.symbols.contains(&"string_helper".to_string()));
+    assert!(unused.symbols.contains(&"regex_helper".to_string()));
+    Ok(())
+}
+
+#[test]
+fn ignores_known_exports_mentioned_only_in_non_code_text() -> TestResult {
+    let code = r#"use LWP::UserAgent;
+
+# LWP::UserAgent appears only in a comment.
+my $message = "LWP::UserAgent appears only in a string";
+"#;
+
+    let optimizer = ImportOptimizer::new();
+    let analysis = optimizer.analyze_content(code)?;
+
+    let unused = analysis
+        .unused_imports
+        .iter()
+        .find(|entry| entry.module == "LWP::UserAgent")
+        .ok_or("Missing LWP::UserAgent unused import")?;
+
+    assert!(unused.symbols.contains(&"(bare import)".to_string()));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Import analysis was treating symbols mentioned only inside strings, regex literals, or comments as real usages, causing incorrect unused/missing import decisions.

### Description

- Add `strip_non_code_content`, `contains_bare_word`, and small identifier-boundary helpers to ignore strings, regex literals, and comments when scanning for usages.
- Replace per-symbol dynamic `Regex::new` checks with boundary-aware `contains_bare_word` matching for explicit symbols, module references, and known exports.
- Reuse the non-code stripping helper for `Module::symbol` detection so `Module::symbol` mentions in non-code text are ignored consistently.
- Add regression tests in `import_optimizer_tests.rs` that ensure inline comments, string literals, and regex literals no longer count as usages.

### Testing

- Ran targeted tests with `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-parser --profile agent --locked --test import_optimizer_tests` and all tests passed (`10 passed`).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-parser --profile agent --locked` which completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-parser --profile agent --locked -- -D warnings -A missing_docs` and `./scripts/cargo-safe xtask fmt`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cafee47c8333ac059295fdebaa90)