### PR TITLE
fix(parser): allow comments before tr replacement (#2732)

### DIFF
--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -127,7 +127,7 @@ pub fn extract_substitution_parts_strict(
     } else {
         // Paired pattern delimiters still allow either paired or non-paired delimiters
         // for the replacement side (e.g. s{foo}/bar/ and s[foo]{bar}).
-        let trimmed = skip_paired_substitution_replacement_gap(rest1);
+        let trimmed = skip_paired_replacement_gap(rest1);
         if let Some(rd) = trimmed.chars().next() {
             let repl_closing = get_closing_delimiter(rd);
             extract_delimited_content_strict(trimmed, rd, repl_closing)
@@ -154,7 +154,7 @@ pub fn extract_substitution_parts_strict(
     Ok((pattern, replacement, modifiers))
 }
 
-fn skip_paired_substitution_replacement_gap(mut text: &str) -> &str {
+fn skip_paired_replacement_gap(mut text: &str) -> &str {
     let mut comment_eligible = false;
     loop {
         let trimmed = text.trim_start_matches(char::is_whitespace);
@@ -461,7 +461,7 @@ pub fn extract_transliteration_parts_strict(
         let (body, rest, found_closing) = extract_unpaired_body_skip_strings(rest1, closing);
         (body, rest, found_closing)
     } else {
-        let trimmed = rest1.trim_start();
+        let trimmed = skip_paired_replacement_gap(rest1);
         if let Some(repl_delimiter) = trimmed.chars().next() {
             // After a paired search delimiter (e.g. `{...}`), the replacement must
             // also start with a valid non-alphanumeric, non-whitespace delimiter.

--- a/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
+++ b/crates/perl-parser-core/tests/fix_transliteration_strict_parsing.rs
@@ -38,6 +38,12 @@ fn transliteration_strict_handles_edge_cases() {
 }
 
 #[test]
+fn transliteration_allows_line_comment_between_paired_delimiters() {
+    assert_clean_parse("$x =~ tr{abc} # document replacement list\n {xyz};");
+    assert_clean_parse("$x =~ y[abc] # document replacement list\n {xyz}r;");
+}
+
+#[test]
 fn transliteration_supports_mixed_paired_delimiters() {
     assert_clean_parse(r#"$x =~ tr[a-z]{A-Z}d;"#);
     assert_clean_parse(r#"$x =~ y<abc>[xyz]r;"#);


### PR DESCRIPTION
Problem: Paired transliteration delimiters rejected a line comment before the replacement delimiter, even though the substitution parser already allowed that gap.\nFix: Share the paired replacement gap skipper between substitution and transliteration parsing so whitespace plus a line comment can appear before the replacement delimiter.\nVerification: git diff --check; ./scripts/storage-doctor; ./scripts/cargo-safe xtask fmt; ./scripts/cargo-safe check --all-targets -p perl-parser-core --profile agent --locked; ./scripts/cargo-safe test -p perl-parser-core --test fix_transliteration_strict_parsing --profile agent --locked -- transliteration_allows_line_comment_between_paired_delimiters --nocapture; ./scripts/cargo-safe test -p perl-parser-core --profile agent --locked; ./scripts/cargo-safe clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs; ./scripts/cargo-safe xtask gates --gate common_corpus_clean --receipt --receipt-path /home/steven/.cache/devplane/perl-lsp/target/receipts/9139-common-corpus-clean.json.