### PR TITLE
fix(refactoring): honor quoted delimiters in inliner (#3040)

### DIFF
--- a/crates/perl-refactoring/src/refactor/inline.rs
+++ b/crates/perl-refactoring/src/refactor/inline.rs
@@ -353,30 +353,78 @@ fn is_sub_opening_delimiter(after_name: &str) -> bool {
 /// Extract the text between a matching pair of braces starting at `open_pos`
 /// (the position AFTER the opening `{`).
 fn extract_balanced_braces(source: &str, open_pos: usize) -> Option<String> {
-    let mut depth = 1usize;
-    let chars: Vec<char> = source[open_pos..].chars().collect();
-    let mut end = 0;
-    let mut found = false;
-    let mut i = 0;
-    while i < chars.len() {
-        match chars[i] {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
+    let close_pos = find_matching_delimiter(source, open_pos.saturating_sub(1), '{', '}')?;
+    source.get(open_pos..close_pos).map(ToString::to_string)
+}
+
+/// Find the matching closing delimiter for the opening delimiter at byte
+/// position `open`, ignoring delimiters that appear inside Perl string
+/// literals or line comments.
+fn find_matching_delimiter(s: &str, open: usize, opening: char, closing: char) -> Option<usize> {
+    if !s.get(open..)?.starts_with(opening) {
+        return None;
+    }
+
+    let mut depth = 0usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut in_line_comment = false;
+    let mut escaped = false;
+    let mut previous = None;
+
+    for (offset, c) in s.get(open..)?.char_indices() {
+        let pos = open + offset;
+
+        if in_line_comment {
+            if c == '\n' {
+                in_line_comment = false;
+            }
+            previous = Some(c);
+            continue;
+        }
+
+        if escaped {
+            escaped = false;
+            previous = Some(c);
+            continue;
+        }
+
+        match c {
+            '\\' if in_single_quote || in_double_quote => {
+                escaped = true;
+            }
+            '#' if !in_single_quote && !in_double_quote && is_line_comment_start(previous) => {
+                in_line_comment = true;
+            }
+            '\'' if !in_double_quote => {
+                in_single_quote = !in_single_quote;
+            }
+            '"' if !in_single_quote => {
+                in_double_quote = !in_double_quote;
+            }
+            _ if in_single_quote || in_double_quote => {}
+            c if c == opening => {
+                depth += 1;
+            }
+            c if c == closing => {
+                depth = depth.checked_sub(1)?;
                 if depth == 0 {
-                    end = i;
-                    found = true;
-                    break;
+                    return Some(pos);
                 }
             }
             _ => {}
         }
-        i += 1;
+        previous = Some(c);
     }
-    if !found {
-        return None;
+
+    None
+}
+
+fn is_line_comment_start(previous: Option<char>) -> bool {
+    match previous {
+        None => true,
+        Some(c) => c.is_whitespace() || matches!(c, ';' | '{' | '(' | '[' | ',' | ')' | ']' | '}'),
     }
-    Some(chars[..end].iter().collect())
 }
 
 /// Parse out the Perl parameter-extraction line `my ($a, $b) = @_;` from the
@@ -578,24 +626,7 @@ fn extract_call_args(call_expr: &str, sub_name: &str) -> Result<Vec<String>, Inl
 
 /// Find the matching `)` for the `(` at byte position `open` in `s`.
 fn find_matching_paren(s: &str, open: usize) -> Option<usize> {
-    let bytes = s.as_bytes();
-    if bytes.get(open) != Some(&b'(') {
-        return None;
-    }
-    let mut depth = 0usize;
-    for (i, &b) in bytes.iter().enumerate().skip(open) {
-        match b {
-            b'(' => depth += 1,
-            b')' => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(i);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
+    find_matching_delimiter(s, open, '(', ')')
 }
 
 /// Split a comma-separated argument string, respecting nested parens and quotes.

--- a/crates/perl-refactoring/tests/subroutine_inline_tests.rs
+++ b/crates/perl-refactoring/tests/subroutine_inline_tests.rs
@@ -379,7 +379,7 @@ fn test_inline_sub_with_signature_parens() {
 
 #[test]
 fn test_inline_call_with_paren_in_string_argument() {
-    // The second argument is a string that contains ')' — the call-site parser
+    // The first argument is a string that contains ')' — the call-site parser
     // must correctly identify the real closing paren, not the one inside the string.
     let source = r#"sub greet {
     my ($prefix, $name) = @_;
@@ -387,12 +387,60 @@ fn test_inline_call_with_paren_in_string_argument() {
 }
 "#;
     let inliner = SubInliner::new(source);
-    // Second argument "hello)" contains ')' — naive paren-matching would split here
+    // First argument "Hi)" contains ')' — naive paren-matching would split here
     let result = inliner.inline_call("greet", r#"greet("Hi)", "World")"#);
+    let inlined = must(result);
     assert!(
-        result.is_ok(),
-        "call with ')' inside a string argument must not fail; got: {:?}",
-        result
+        inlined.contains(r#""Hi)" . "World""#),
+        "call with ')' inside a string argument must preserve both arguments; got: {inlined}"
+    );
+}
+
+#[test]
+fn test_sub_body_with_brace_in_string_literal_inlines_full_body() {
+    // A closing brace inside a string literal is not the end of the sub body.
+    // The body parser must continue to the real brace so the return statement
+    // remains available for inlining.
+    let source = r#"sub describe_brace {
+    my ($value) = @_;
+    my $template = "literal } brace";
+    return $template . $value;
+}
+"#;
+    let inliner = SubInliner::new(source);
+    let result = inliner.inline_call("describe_brace", r#"describe_brace("tail")"#);
+    let inlined = must(result);
+    assert!(
+        inlined.contains(r#"$template . "tail""#),
+        "brace inside a string literal must not truncate the parsed sub body; got: {inlined}"
+    );
+}
+
+#[test]
+fn test_sub_body_with_brace_in_line_comment_inlines_full_body() {
+    let source = r#"sub describe_commented_brace {
+    # A closing brace in a comment: }
+    return "ok";
+}
+"#;
+    let inliner = SubInliner::new(source);
+    let result = inliner.inline_call("describe_commented_brace", "describe_commented_brace()");
+    let inlined = must(result);
+    assert!(
+        inlined.contains(r#""ok""#),
+        "brace inside a line comment must not truncate the parsed sub body; got: {inlined}"
+    );
+}
+
+#[test]
+fn test_sub_body_with_hash_in_regex_on_one_line_inlines_full_body() {
+    let source = r#"sub hash_regex { return qr/#/; }"#;
+    let inliner = SubInliner::new(source);
+    let result = inliner.inline_call("hash_regex", "hash_regex()");
+    let inlined = must(result);
+    assert!(
+        inlined.contains("qr/#/"),
+        "hash inside a regex literal must not be mistaken for a line comment; got: {inlined}"
     );
 }
 


### PR DESCRIPTION
### Motivation
- The subroutine inliner could treat braces/parentheses inside string literals or line comments as real delimiters, truncating parsed sub-bodies or mis-parsing call-site arguments.
- This led to incorrect inlining or parse failures for common edge cases such as `"...)"` argument strings and `"...}"` inside sub bodies.

### Description
- Add `find_matching_delimiter` which matches opening/closing delimiters while ignoring characters inside single/double-quoted strings and line comments, and handle escapes; replace the old naive brace/parens matching with this function in `crates/perl-refactoring/src/refactor/inline.rs`.
- Replace `extract_balanced_braces` and `find_matching_paren` to delegate to the new quote/comment-aware matcher so sub-body and call-argument parsing are robust to quoted delimiters.
- Extend/refine regression tests in `crates/perl-refactoring/tests/subroutine_inline_tests.rs` to assert that a `)` inside a quoted argument and a `}` inside a quoted sub-body do not break inlining.

### Testing
- Ran formatter with `./scripts/cargo-safe xtask fmt` and it completed successfully.
- Ran the full `perl-refactoring` test-suite with `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-refactoring --profile agent --locked` and all tests passed (`115` unit tests + feature/integration test groups observed passing).
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check --all-targets -p perl-refactoring --profile agent --locked` and `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-refactoring --profile agent --locked -- -D warnings -A missing_docs` and both completed with no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cab985348333be6114a9b3b99cf7)