### PR TITLE
fix(refactoring): parse alternate qw delimiters (#9144)

### DIFF
--- a/crates/perl-refactoring/src/refactor/import_optimizer.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer.rs
@@ -150,14 +150,17 @@ pub enum SuggestionPriority {
 /// Import optimizer for analyzing and optimizing Perl import statements
 ///
 /// The optimizer currently supports:
-/// - Parsing basic `use Module qw(symbols)` statements
+/// - Parsing `use Module qw(...)` statements across common `qw` delimiters
 /// - Detecting unused imported symbols
 /// - Finding duplicate imports that can be merged
 /// - Generating consolidated import statements
 pub struct ImportOptimizer;
 
-static USE_STATEMENT_RE: LazyLock<Result<Regex, regex::Error>> =
-    LazyLock::new(|| Regex::new(r"^\s*use\s+([A-Za-z0-9_:]+)(?:\s+qw\(([^)]*)\))?\s*;"));
+static USE_STATEMENT_RE: LazyLock<Result<Regex, regex::Error>> = LazyLock::new(|| {
+    Regex::new(
+        r"^\s*use\s+([A-Za-z0-9_:]+)(?:\s+qw\s*(?:\(([^)]*)\)|/([^/]*)/|\[([^\]]*)\]|\{([^}]*)\}|<([^>]*)>))?\s*;",
+    )
+});
 static DUMPER_RE: LazyLock<Result<Regex, regex::Error>> =
     LazyLock::new(|| Regex::new(r"\bDumper\b"));
 static STRING_RE: LazyLock<Result<Regex, regex::Error>> =
@@ -654,6 +657,38 @@ print "First: " . first { $_ > 3 } @nums;
             .find(|u| u.module == "Scalar::Util")
             .ok_or("Scalar::Util unused imports not found")?;
         assert_eq!(scalar_util_unused.symbols, vec!["blessed", "reftype"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_qw_alternate_delimiter_import_parsing() -> Result<(), Box<dyn std::error::Error>> {
+        let optimizer = ImportOptimizer::new();
+        let content = r#"use List::Util qw/max min/;
+use Scalar::Util qw<blessed reftype>;
+use File::Spec qw[catfile catdir];
+use Data::Dumper qw{Dumper};
+
+my $max = max(1, 2);
+my $path = catfile("tmp", "file");
+print Dumper({ blessed => blessed($path) });
+"#;
+
+        let analysis = optimizer.analyze_content(content)?;
+
+        assert_eq!(analysis.imports.len(), 4);
+        assert_eq!(analysis.imports[0].symbols, vec!["max", "min"]);
+        assert_eq!(analysis.imports[1].symbols, vec!["blessed", "reftype"]);
+        assert_eq!(analysis.imports[2].symbols, vec!["catfile", "catdir"]);
+        assert_eq!(analysis.imports[3].symbols, vec!["Dumper"]);
+
+        let unused: Vec<_> = analysis
+            .unused_imports
+            .iter()
+            .flat_map(|unused| unused.symbols.iter().map(String::as_str))
+            .collect();
+        assert!(unused.contains(&"min"));
+        assert!(unused.contains(&"reftype"));
+        assert!(unused.contains(&"catdir"));
         Ok(())
     }
 

--- a/crates/perl-refactoring/src/refactor/import_optimizer/parsing.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/parsing.rs
@@ -4,19 +4,26 @@ pub(super) fn parse_imports(content: &str) -> Result<Vec<ImportEntry>, String> {
     let mut imports = Vec::new();
     for (idx, line) in content.lines().enumerate() {
         if let Some(caps) = USE_STATEMENT_RE.as_ref().map_err(|e| e.to_string())?.captures(line) {
-            let module = caps[1].to_string();
-            let symbols = caps.get(2).map_or_else(Vec::new, |m| parse_symbol_list(m.as_str()));
+            let Some(module_match) = caps.get(1) else {
+                continue;
+            };
+            let module = module_match.as_str().to_string();
+            let symbols = symbol_capture(&caps).map_or_else(Vec::new, parse_symbol_list);
             imports.push(ImportEntry { module, symbols, line: idx + 1 });
         }
     }
     Ok(imports)
 }
 
+fn symbol_capture<'a>(caps: &'a regex::Captures<'a>) -> Option<&'a str> {
+    (2..=6).find_map(|idx| caps.get(idx).map(|m| m.as_str()))
+}
+
 fn parse_symbol_list(symbols: &str) -> Vec<String> {
     symbols
         .split_whitespace()
         .filter(|s| !s.is_empty())
-        .map(|s| s.trim_matches(|c| c == ',' || c == ';' || c == '"'))
+        .map(|s| s.trim_matches(|c| c == ',' || c == ';' || c == '"' || c == '\''))
         .map(str::to_string)
         .collect()
 }


### PR DESCRIPTION
### Motivation
- The import optimizer only handled parenthesized `qw(...)` lists and missed common alternate `qw` delimiters used in Perl source, causing import parsing/analysis gaps.

### Description
- Extend the `USE_STATEMENT_RE` regex to recognize `qw` lists with delimiters `()`, `/.../`, `<...>`, `[...]`, and `{...}` in `crates/perl-refactoring/src/refactor/import_optimizer.rs`.
- Update the parser to select the populated capture group via `symbol_capture` and pass it into `parse_symbol_list` in `crates/perl-refactoring/src/refactor/import_optimizer/parsing.rs`.
- Improve `parse_symbol_list` trimming to handle both double- and single-quote punctuation and add a regression test `test_qw_alternate_delimiter_import_parsing` exercising alternate `qw` delimiters.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-refactoring --profile agent --locked` and the crate tests completed successfully (all unit and integration tests passed).
- Ran `cargo fmt --check` and `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-refactoring --profile agent --locked -- -D warnings -A missing_docs`, both of which completed without errors.
- `./scripts/cargo-safe check --all-targets -p perl-refactoring --profile agent --locked` was blocked by the environment storage guard and `just agent-pr-fast` is unavailable in this environment; other automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cab985348333be6114a9b3b99cf7)