### PR TITLE
fix(perl-module): respect escaped use-lib quotes (#7456)

### DIFF
--- a/crates/perl-module/src/resolution/use_lib.rs
+++ b/crates/perl-module/src/resolution/use_lib.rs
@@ -403,12 +403,34 @@ fn extract_one_quoted(s: &str) -> Option<(String, bool, &str)> {
     };
 
     let inner = &s[1..];
-    let end = inner.find(quote)?;
+    let end = find_unescaped_quote(inner, quote)?;
     let content = &inner[..end];
-    let rest = &inner[end + 1..];
+    let rest = &inner[end + quote.len_utf8()..];
 
     let (path, from_findbin) = resolve_findbin_in_string(content);
     Some((path, from_findbin, rest))
+}
+
+fn find_unescaped_quote(s: &str, quote: char) -> Option<usize> {
+    let mut escaped = false;
+
+    for (idx, ch) in s.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if ch == quote {
+            return Some(idx);
+        }
+    }
+
+    None
 }
 
 fn resolve_findbin_in_string(s: &str) -> (String, bool) {

--- a/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
+++ b/crates/perl-module/tests/use_lib_resolution_unit_tests.rs
@@ -519,15 +519,38 @@ fn double_quoted_path_with_escaped_double_quote() {
 }
 
 #[test]
-fn single_quoted_path_with_escaped_single_quote() {
+fn double_quoted_path_with_escaped_double_quote_and_semicolon()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"use lib "path/\"with;quote"; use lib 'also';"#;
+
+    let paths = extract_use_lib_paths(source);
+
+    assert_eq!(
+        paths,
+        vec![
+            UseLibPath { path: r#"path/\"with;quote"#.to_string(), from_findbin: false },
+            UseLibPath { path: "also".to_string(), from_findbin: false },
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn single_quoted_path_with_escaped_single_quote() -> Result<(), Box<dyn std::error::Error>> {
     // Edge case: single-quoted string with escaped single quote.
     // In Perl, only \\ and \' are special in single quotes.
     let source = r"use lib 'it\'s; a path'; use lib 'also';";
 
     let paths = extract_use_lib_paths(source);
 
-    // Should extract both paths without being confused by the \' in the first path.
-    assert!(paths.len() >= 2, "Expected at least 2 paths, got {}", paths.len());
+    assert_eq!(
+        paths,
+        vec![
+            UseLibPath { path: r"it\'s; a path".to_string(), from_findbin: false },
+            UseLibPath { path: "also".to_string(), from_findbin: false },
+        ]
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Quoted `use lib` arguments were truncated when they contained escaped quotes or embedded semicolons because the parser treated any matching quote as a terminator regardless of escaping.
- The change ensures `use lib` path extraction correctly handles escaped quotes so real-world paths like `"path/\"with;quote"` are preserved.

### Description

- Add `find_unescaped_quote(s, quote)` helper to scan for the first matching quote that is not escaped.
- Update `extract_one_quoted` to use `find_unescaped_quote` and advance the rest slice by `quote.len_utf8()` so escaped quotes do not prematurely terminate parsing.
- Add a regression test `double_quoted_path_with_escaped_double_quote_and_semicolon` that contains an escaped double quote and a semicolon inside the quoted path.
- Tighten the single-quoted escaped-quote test to assert the exact extracted paths and convert the two modified tests to return `Result<(), Box<dyn std::error::Error>>` for test harness compatibility.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-module --profile agent --locked --test use_lib_resolution_unit_tests`, which completed successfully (`51 passed`).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-module --profile agent --locked`, which completed successfully (crate test-suite passed).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-module --profile agent --locked`, which completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-module --profile agent --locked -- -D warnings -A missing_docs`, which completed successfully.
- Ran `./scripts/cargo-safe xtask fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08caac6bc48333bbe42524f010317d)