### PR TITLE
refactor(perl-dap): split parse_scope_variables_from_lines into SRP helpers

### DIFF
--- a/crates/perl-dap/src/debug_adapter/parsing.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing.rs
@@ -1,5 +1,7 @@
 //! Debugger output parsing: normalize, infer types, parse stack frames, parse variables.
 
+mod scope_variables;
+
 use super::*;
 
 impl DebugAdapter {
@@ -119,61 +121,20 @@ impl DebugAdapter {
         start: usize,
         count: usize,
     ) -> (Vec<Variable>, HashMap<i32, Vec<Variable>>) {
-        let parser = VariableParser::new();
-        let renderer = PerlVariableRenderer::new();
         let scope_type = variables_ref % 10;
-        let mut seen = HashSet::new();
-        let mut parsed = Vec::new();
+        let parsed = scope_variables::parse_assignments(lines, scope_type);
+        let page = scope_variables::sort_and_paginate(parsed, start, count);
 
-        for line in lines.iter().rev() {
-            let normalized = Self::normalize_debugger_output_line(line);
-            let text = normalized.trim();
-            if text.is_empty() {
-                continue;
-            }
-            if let Ok((name, value)) = parser.parse_assignment(text) {
-                if !Self::scope_allows_variable_name(scope_type, &name) {
-                    continue;
-                }
-                if seen.insert(name.clone()) {
-                    parsed.push((name, value));
-                }
-                if parsed.len() >= 256 {
-                    break;
-                }
-            }
-        }
-
-        parsed.reverse();
-        parsed.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
-
-        let mut top_level = Vec::new();
+        let mut top_level = Vec::with_capacity(page.len());
         let mut child_cache = HashMap::new();
-        for (idx, (name, value)) in parsed.into_iter().skip(start).take(count).enumerate() {
-            let absolute_index = start.saturating_add(idx).saturating_add(1);
-            let child_ref =
-                variables_ref.saturating_mul(1000).saturating_add(Self::i64_to_i32_saturating(
-                    i64::try_from(absolute_index).unwrap_or(i64::from(i32::MAX)),
-                ));
-            let rendered = if value.is_expandable() {
-                renderer.render_with_reference(&name, &value, i64::from(child_ref))
-            } else {
-                renderer.render(&name, &value)
-            };
-            top_level.push(Self::rendered_to_variable(rendered));
-
-            if value.is_expandable() {
-                let children = renderer
-                    .render_children(&value, 0, 256)
-                    .into_iter()
-                    .map(Self::rendered_to_variable)
-                    .collect::<Vec<_>>();
-                if !children.is_empty() {
-                    child_cache.insert(child_ref, children);
-                }
+        for (idx, (name, value)) in page.into_iter().enumerate() {
+            let child_ref = scope_variables::compute_child_reference(variables_ref, start, idx);
+            let (top, cache_entry) = scope_variables::render_paged_variable(name, value, child_ref);
+            top_level.push(top);
+            if let Some((k, v)) = cache_entry {
+                child_cache.insert(k, v);
             }
         }
-
         (top_level, child_cache)
     }
 

--- a/crates/perl-dap/src/debug_adapter/parsing/scope_variables.rs
+++ b/crates/perl-dap/src/debug_adapter/parsing/scope_variables.rs
@@ -1,0 +1,98 @@
+//! SRP helpers for `parse_scope_variables_from_lines`.
+//!
+//! Each function owns exactly one responsibility:
+//! - [`parse_assignments`] — iterate, normalize, filter, dedupe, cap
+//! - [`sort_and_paginate`] — reverse chronological order, sort, slice
+//! - [`compute_child_reference`] — stable child-ref arithmetic
+//! - [`render_paged_variable`] — render one variable and its optional children
+
+use super::super::*;
+use crate::value::PerlValue;
+
+/// Iterate `lines` in reverse, parse variable assignments, apply scope filter,
+/// deduplicate by name, and cap at 256 entries.
+///
+/// Returns a vec built in reverse-iteration order (most-recent-first).
+/// [`sort_and_paginate`] reverses it before sorting to restore chronological order.
+pub(super) fn parse_assignments(lines: &[String], scope_type: i32) -> Vec<(String, PerlValue)> {
+    let parser = VariableParser::new();
+    let mut seen = HashSet::new();
+    let mut parsed = Vec::new();
+
+    for line in lines.iter().rev() {
+        let normalized = DebugAdapter::normalize_debugger_output_line(line);
+        let text = normalized.trim();
+        if text.is_empty() {
+            continue;
+        }
+        if let Ok((name, value)) = parser.parse_assignment(text) {
+            if !DebugAdapter::scope_allows_variable_name(scope_type, &name) {
+                continue;
+            }
+            if seen.insert(name.clone()) {
+                parsed.push((name, value));
+            }
+            if parsed.len() >= 256 {
+                break;
+            }
+        }
+    }
+
+    parsed
+}
+
+/// Reverse the vec (restoring chronological order), sort by name, then
+/// apply `skip(start).take(count)` pagination.
+pub(super) fn sort_and_paginate(
+    mut parsed: Vec<(String, PerlValue)>,
+    start: usize,
+    count: usize,
+) -> Vec<(String, PerlValue)> {
+    parsed.reverse();
+    parsed.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    parsed.into_iter().skip(start).take(count).collect()
+}
+
+/// Compute a stable child reference integer for a paged variable entry.
+///
+/// `variables_ref` is the scope reference; `start` + `idx` give the absolute
+/// position (1-based).  Arithmetic uses saturating operations throughout.
+pub(super) fn compute_child_reference(variables_ref: i32, start: usize, idx: usize) -> i32 {
+    let absolute_index = start.saturating_add(idx).saturating_add(1);
+    variables_ref.saturating_mul(1000).saturating_add(DebugAdapter::i64_to_i32_saturating(
+        i64::try_from(absolute_index).unwrap_or(i64::from(i32::MAX)),
+    ))
+}
+
+/// Render a single variable and, if expandable, its children.
+///
+/// Returns `(top_level_variable, Some((child_ref, children)))` when the value
+/// is expandable and has at least one child; otherwise `None` for the second
+/// tuple element.
+pub(super) fn render_paged_variable(
+    name: String,
+    value: PerlValue,
+    child_ref: i32,
+) -> (Variable, Option<(i32, Vec<Variable>)>) {
+    let renderer = PerlVariableRenderer::new();
+
+    let rendered = if value.is_expandable() {
+        renderer.render_with_reference(&name, &value, i64::from(child_ref))
+    } else {
+        renderer.render(&name, &value)
+    };
+    let top = DebugAdapter::rendered_to_variable(rendered);
+
+    let cache_entry = if value.is_expandable() {
+        let children = renderer
+            .render_children(&value, 0, 256)
+            .into_iter()
+            .map(DebugAdapter::rendered_to_variable)
+            .collect::<Vec<_>>();
+        if children.is_empty() { None } else { Some((child_ref, children)) }
+    } else {
+        None
+    };
+
+    (top, cache_entry)
+}


### PR DESCRIPTION
## Summary

- Extracted the 63-line `parse_scope_variables_from_lines` into four focused helpers in a new `parsing/scope_variables.rs` submodule
- Each helper owns one responsibility: `parse_assignments` (iterate, normalize, filter, dedupe, cap at 256), `sort_and_paginate` (reverse chronological order, sort, page slice), `compute_child_reference` (stable saturating index arithmetic), `render_paged_variable` (renderer + optional child cache entry)
- Parent function reduced to a ~20-line orchestrator that delegates to the four helpers; no behavior change

## Why this split

The original function mixed four concerns in 63 lines, making it hard to test or reason about each step in isolation. Each helper now has a single testable reason to change.

## Test results

All pre-existing tests pass unchanged:
- `test_parse_scope_variables_are_sorted_for_stability` — ordering semantics preserved
- `test_parse_scope_variables_child_refs_stable_across_pages` — child reference arithmetic unchanged
- `test_parse_scope_variables_from_recent_output` — full round-trip preserved
- `cargo clippy -p perl-dap -- -D warnings` — clean
- `cargo fmt --check -p perl-dap` — clean

Note: `test_e2e_multi_breakpoint_sequence` fails in this environment but was **pre-existing** before this commit (confirmed by reverting and re-running — same failure, unrelated to scope variable parsing).

---
_Generated by [Claude Code](https://claude.ai/code/session_011i2hLJLALw3YM65UgPRXm5)_