### PR TITLE
test(perl-symbol): cover cursor helpers, CursorSymbolKind traits, and type serde/hash (#6754)

### DIFF
--- a/crates/perl-symbol/src/cursor/mod.rs
+++ b/crates/perl-symbol/src/cursor/mod.rs
@@ -218,22 +218,27 @@ mod tests {
     }
 
     #[test]
-    fn token_under_cursor_returns_none_for_out_of_range_line() {
+    fn token_under_cursor_returns_none_for_out_of_range_line()
+    -> Result<(), Box<dyn std::error::Error>> {
         let text = "my $value = 1;\n";
         assert_eq!(token_under_cursor(text, 99, 0), None);
+        Ok(())
     }
 
     #[test]
-    fn token_under_cursor_returns_none_for_empty_line() {
+    fn token_under_cursor_returns_none_for_empty_line() -> Result<(), Box<dyn std::error::Error>> {
         let text = "\n";
         assert_eq!(token_under_cursor(text, 0, 0), None);
+        Ok(())
     }
 
     #[test]
-    fn token_under_cursor_handles_array_and_hash_sigils() {
+    fn token_under_cursor_handles_array_and_hash_sigils() -> Result<(), Box<dyn std::error::Error>>
+    {
         let text = "push @items, %opts;\n";
         assert_eq!(token_under_cursor(text, 0, 5), Some("@items".to_string()));
         assert_eq!(token_under_cursor(text, 0, 13), Some("%opts".to_string()));
+        Ok(())
     }
 
     #[test]
@@ -247,15 +252,17 @@ mod tests {
     }
 
     #[test]
-    fn byte_offset_utf16_past_end_returns_len() {
+    fn byte_offset_utf16_past_end_returns_len() -> Result<(), Box<dyn std::error::Error>> {
         let line = "abc";
         assert_eq!(byte_offset_utf16(line, 100), 3);
+        Ok(())
     }
 
     #[test]
-    fn byte_offset_utf16_empty_string_returns_zero() {
+    fn byte_offset_utf16_empty_string_returns_zero() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(byte_offset_utf16("", 0), 0);
         assert_eq!(byte_offset_utf16("", 5), 0);
+        Ok(())
     }
 
     #[test]
@@ -266,33 +273,38 @@ mod tests {
     }
 
     #[test]
-    fn word_boundary_at_start_and_end_of_text() {
+    fn word_boundary_at_start_and_end_of_text() -> Result<(), Box<dyn std::error::Error>> {
         // Match at position 0 — no preceding character, boundary is at start.
         assert!(is_word_boundary(b"foo bar", 0, 3));
         // Match at very end — end position equals text length.
         assert!(is_word_boundary(b"hello foo", 6, 3));
+        Ok(())
     }
 
     #[test]
-    fn word_boundary_false_when_trailing_modchar() {
+    fn word_boundary_false_when_trailing_modchar() -> Result<(), Box<dyn std::error::Error>> {
         // "foo" at pos 0 in "foobar" is not a boundary because 'b' follows.
         assert!(!is_word_boundary(b"foobar", 0, 3));
+        Ok(())
     }
 
     // ── is_modchar ────────────────────────────────────────────────────────────
 
     #[test]
-    fn is_modchar_accepts_alphanumeric_and_colon_and_underscore() {
+    fn is_modchar_accepts_alphanumeric_and_colon_and_underscore()
+    -> Result<(), Box<dyn std::error::Error>> {
         assert!(is_modchar(b'a'));
         assert!(is_modchar(b'Z'));
         assert!(is_modchar(b'0'));
         assert!(is_modchar(b'9'));
         assert!(is_modchar(b'_'));
         assert!(is_modchar(b':'));
+        Ok(())
     }
 
     #[test]
-    fn is_modchar_rejects_sigils_spaces_and_punctuation() {
+    fn is_modchar_rejects_sigils_spaces_and_punctuation() -> Result<(), Box<dyn std::error::Error>>
+    {
         assert!(!is_modchar(b'$'));
         assert!(!is_modchar(b'@'));
         assert!(!is_modchar(b'%'));
@@ -303,85 +315,102 @@ mod tests {
         assert!(!is_modchar(b'.'));
         assert!(!is_modchar(b'('));
         assert!(!is_modchar(b')'));
+        Ok(())
     }
 
     // ── extract_symbol_from_source ────────────────────────────────────────────
 
     #[test]
-    fn extract_symbol_recognizes_scalar_sigil_before_name() {
+    fn extract_symbol_recognizes_scalar_sigil_before_name() -> Result<(), Box<dyn std::error::Error>>
+    {
         // Cursor on 'v' of "$value" — sigil is the preceding char.
         let source = "$value";
         let result = extract_symbol_from_source(1, source);
         assert_eq!(result, Some(("value".to_string(), CursorSymbolKind::Scalar)));
+        Ok(())
     }
 
     #[test]
-    fn extract_symbol_recognizes_array_sigil_before_name() {
+    fn extract_symbol_recognizes_array_sigil_before_name() -> Result<(), Box<dyn std::error::Error>>
+    {
         let source = "@items";
         let result = extract_symbol_from_source(1, source);
         assert_eq!(result, Some(("items".to_string(), CursorSymbolKind::Array)));
+        Ok(())
     }
 
     #[test]
-    fn extract_symbol_recognizes_hash_sigil_before_name() {
+    fn extract_symbol_recognizes_hash_sigil_before_name() -> Result<(), Box<dyn std::error::Error>>
+    {
         let source = "%opts";
         let result = extract_symbol_from_source(1, source);
         assert_eq!(result, Some(("opts".to_string(), CursorSymbolKind::Hash)));
+        Ok(())
     }
 
     #[test]
-    fn extract_symbol_recognizes_subroutine_sigil_before_name() {
+    fn extract_symbol_recognizes_subroutine_sigil_before_name()
+    -> Result<(), Box<dyn std::error::Error>> {
         let source = "&callback";
         let result = extract_symbol_from_source(1, source);
         assert_eq!(result, Some(("callback".to_string(), CursorSymbolKind::Subroutine)));
+        Ok(())
     }
 
     #[test]
-    fn extract_symbol_cursor_on_sigil_itself() {
+    fn extract_symbol_cursor_on_sigil_itself() -> Result<(), Box<dyn std::error::Error>> {
         // Cursor at position 0, which is the '$' sigil character.
         let source = "$foo";
         let result = extract_symbol_from_source(0, source);
         assert_eq!(result, Some(("foo".to_string(), CursorSymbolKind::Scalar)));
+        Ok(())
     }
 
     #[test]
-    fn extract_symbol_cursor_past_end_returns_none() {
+    fn extract_symbol_cursor_past_end_returns_none() -> Result<(), Box<dyn std::error::Error>> {
         let source = "$foo";
         assert_eq!(extract_symbol_from_source(10, source), None);
+        Ok(())
     }
 
     #[test]
-    fn extract_symbol_on_non_name_character_returns_none() {
+    fn extract_symbol_on_non_name_character_returns_none() -> Result<(), Box<dyn std::error::Error>>
+    {
         // Space at position 2 — not alphanumeric/underscore, no sigil context.
         let source = "my $x";
         // Position 2 is ' ', no sigil before it and not alphanumeric.
         assert_eq!(extract_symbol_from_source(2, source), None);
+        Ok(())
     }
 
     #[test]
-    fn extract_symbol_no_sigil_defaults_to_subroutine() {
+    fn extract_symbol_no_sigil_defaults_to_subroutine() -> Result<(), Box<dyn std::error::Error>> {
         // A bare identifier with no sigil context defaults to Subroutine kind.
         let source = "greet";
         let result = extract_symbol_from_source(0, source);
         assert_eq!(result, Some(("greet".to_string(), CursorSymbolKind::Subroutine)));
+        Ok(())
     }
 
     #[test]
-    fn extract_symbol_handles_underscore_and_digits_in_name() {
+    fn extract_symbol_handles_underscore_and_digits_in_name()
+    -> Result<(), Box<dyn std::error::Error>> {
         let source = "$my_var2";
         let result = extract_symbol_from_source(1, source);
         assert_eq!(result, Some(("my_var2".to_string(), CursorSymbolKind::Scalar)));
+        Ok(())
     }
 
     // ── get_symbol_range_at_position ──────────────────────────────────────────
 
     #[test]
-    fn symbol_range_past_end_returns_none() {
+    fn symbol_range_past_end_returns_none() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(get_symbol_range_at_position(100, "foo"), None);
+        Ok(())
     }
 
     #[test]
-    fn symbol_range_includes_preceding_sigil() {
+    fn symbol_range_includes_preceding_sigil() -> Result<(), Box<dyn std::error::Error>> {
         // Position 1 is 'f' in "$foo"; the range should include the '$' at 0.
         let source = "$foo";
         let range = get_symbol_range_at_position(1, source);
@@ -389,10 +418,11 @@ mod tests {
         let (start, end) = range.unwrap_or((0, 0));
         assert_eq!(start, 0, "range must include the leading sigil");
         assert_eq!(end, 4);
+        Ok(())
     }
 
     #[test]
-    fn symbol_range_on_bare_identifier_no_sigil() {
+    fn symbol_range_on_bare_identifier_no_sigil() -> Result<(), Box<dyn std::error::Error>> {
         let source = "greet";
         let range = get_symbol_range_at_position(0, source);
         assert!(range.is_some());
@@ -400,34 +430,38 @@ mod tests {
         assert_eq!(end, 5);
         // start ≤ 0 (could be 0 when no sigil precedes)
         assert!(start <= 1);
+        Ok(())
     }
 
     // ── CursorSymbolKind derive traits ────────────────────────────────────────
 
     #[test]
-    fn cursor_symbol_kind_derives_debug() {
+    fn cursor_symbol_kind_derives_debug() -> Result<(), Box<dyn std::error::Error>> {
         let formatted = format!("{:?}", CursorSymbolKind::Scalar);
         assert_eq!(formatted, "Scalar");
+        Ok(())
     }
 
     #[test]
-    fn cursor_symbol_kind_derives_clone_and_copy() {
+    fn cursor_symbol_kind_derives_clone_and_copy() -> Result<(), Box<dyn std::error::Error>> {
         let original = CursorSymbolKind::Array;
         let cloned = original.clone();
         let copied: CursorSymbolKind = original;
         assert_eq!(cloned, CursorSymbolKind::Array);
         assert_eq!(copied, CursorSymbolKind::Array);
+        Ok(())
     }
 
     #[test]
-    fn cursor_symbol_kind_derives_partial_eq() {
+    fn cursor_symbol_kind_derives_partial_eq() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(CursorSymbolKind::Scalar, CursorSymbolKind::Scalar);
         assert_ne!(CursorSymbolKind::Scalar, CursorSymbolKind::Array);
         assert_ne!(CursorSymbolKind::Hash, CursorSymbolKind::Subroutine);
+        Ok(())
     }
 
     #[test]
-    fn cursor_symbol_kind_all_variants_are_distinct() {
+    fn cursor_symbol_kind_all_variants_are_distinct() -> Result<(), Box<dyn std::error::Error>> {
         let variants = [
             CursorSymbolKind::Scalar,
             CursorSymbolKind::Array,
@@ -443,5 +477,6 @@ mod tests {
                 }
             }
         }
+        Ok(())
     }
 }

--- a/crates/perl-symbol/src/cursor/mod.rs
+++ b/crates/perl-symbol/src/cursor/mod.rs
@@ -181,7 +181,10 @@ pub fn is_word_boundary(text: &[u8], pos: usize, word_len: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{byte_offset_utf16, is_word_boundary, token_under_cursor};
+    use super::{
+        CursorSymbolKind, byte_offset_utf16, extract_symbol_from_source,
+        get_symbol_range_at_position, is_modchar, is_word_boundary, token_under_cursor,
+    };
 
     #[test]
     fn token_under_cursor_extracts_perl_module_token() {
@@ -215,6 +218,25 @@ mod tests {
     }
 
     #[test]
+    fn token_under_cursor_returns_none_for_out_of_range_line() {
+        let text = "my $value = 1;\n";
+        assert_eq!(token_under_cursor(text, 99, 0), None);
+    }
+
+    #[test]
+    fn token_under_cursor_returns_none_for_empty_line() {
+        let text = "\n";
+        assert_eq!(token_under_cursor(text, 0, 0), None);
+    }
+
+    #[test]
+    fn token_under_cursor_handles_array_and_hash_sigils() {
+        let text = "push @items, %opts;\n";
+        assert_eq!(token_under_cursor(text, 0, 5), Some("@items".to_string()));
+        assert_eq!(token_under_cursor(text, 0, 13), Some("%opts".to_string()));
+    }
+
+    #[test]
     fn utf16_col_to_byte_offset_handles_surrogate_pairs() {
         let line = "A😀B";
         assert_eq!(byte_offset_utf16(line, 0), 0);
@@ -225,9 +247,201 @@ mod tests {
     }
 
     #[test]
+    fn byte_offset_utf16_past_end_returns_len() {
+        let line = "abc";
+        assert_eq!(byte_offset_utf16(line, 100), 3);
+    }
+
+    #[test]
+    fn byte_offset_utf16_empty_string_returns_zero() {
+        assert_eq!(byte_offset_utf16("", 0), 0);
+        assert_eq!(byte_offset_utf16("", 5), 0);
+    }
+
+    #[test]
     fn word_boundary_detects_embedded_word() {
         let text = b"fooDemo::Workerbar";
         assert!(!is_word_boundary(text, 3, "Demo::Worker".len()));
         assert!(is_word_boundary(b" Demo::Worker ", 1, "Demo::Worker".len()));
+    }
+
+    #[test]
+    fn word_boundary_at_start_and_end_of_text() {
+        // Match at position 0 — no preceding character, boundary is at start.
+        assert!(is_word_boundary(b"foo bar", 0, 3));
+        // Match at very end — end position equals text length.
+        assert!(is_word_boundary(b"hello foo", 6, 3));
+    }
+
+    #[test]
+    fn word_boundary_false_when_trailing_modchar() {
+        // "foo" at pos 0 in "foobar" is not a boundary because 'b' follows.
+        assert!(!is_word_boundary(b"foobar", 0, 3));
+    }
+
+    // ── is_modchar ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_modchar_accepts_alphanumeric_and_colon_and_underscore() {
+        assert!(is_modchar(b'a'));
+        assert!(is_modchar(b'Z'));
+        assert!(is_modchar(b'0'));
+        assert!(is_modchar(b'9'));
+        assert!(is_modchar(b'_'));
+        assert!(is_modchar(b':'));
+    }
+
+    #[test]
+    fn is_modchar_rejects_sigils_spaces_and_punctuation() {
+        assert!(!is_modchar(b'$'));
+        assert!(!is_modchar(b'@'));
+        assert!(!is_modchar(b'%'));
+        assert!(!is_modchar(b'&'));
+        assert!(!is_modchar(b' '));
+        assert!(!is_modchar(b'\n'));
+        assert!(!is_modchar(b'-'));
+        assert!(!is_modchar(b'.'));
+        assert!(!is_modchar(b'('));
+        assert!(!is_modchar(b')'));
+    }
+
+    // ── extract_symbol_from_source ────────────────────────────────────────────
+
+    #[test]
+    fn extract_symbol_recognizes_scalar_sigil_before_name() {
+        // Cursor on 'v' of "$value" — sigil is the preceding char.
+        let source = "$value";
+        let result = extract_symbol_from_source(1, source);
+        assert_eq!(result, Some(("value".to_string(), CursorSymbolKind::Scalar)));
+    }
+
+    #[test]
+    fn extract_symbol_recognizes_array_sigil_before_name() {
+        let source = "@items";
+        let result = extract_symbol_from_source(1, source);
+        assert_eq!(result, Some(("items".to_string(), CursorSymbolKind::Array)));
+    }
+
+    #[test]
+    fn extract_symbol_recognizes_hash_sigil_before_name() {
+        let source = "%opts";
+        let result = extract_symbol_from_source(1, source);
+        assert_eq!(result, Some(("opts".to_string(), CursorSymbolKind::Hash)));
+    }
+
+    #[test]
+    fn extract_symbol_recognizes_subroutine_sigil_before_name() {
+        let source = "&callback";
+        let result = extract_symbol_from_source(1, source);
+        assert_eq!(result, Some(("callback".to_string(), CursorSymbolKind::Subroutine)));
+    }
+
+    #[test]
+    fn extract_symbol_cursor_on_sigil_itself() {
+        // Cursor at position 0, which is the '$' sigil character.
+        let source = "$foo";
+        let result = extract_symbol_from_source(0, source);
+        assert_eq!(result, Some(("foo".to_string(), CursorSymbolKind::Scalar)));
+    }
+
+    #[test]
+    fn extract_symbol_cursor_past_end_returns_none() {
+        let source = "$foo";
+        assert_eq!(extract_symbol_from_source(10, source), None);
+    }
+
+    #[test]
+    fn extract_symbol_on_non_name_character_returns_none() {
+        // Space at position 2 — not alphanumeric/underscore, no sigil context.
+        let source = "my $x";
+        // Position 2 is ' ', no sigil before it and not alphanumeric.
+        assert_eq!(extract_symbol_from_source(2, source), None);
+    }
+
+    #[test]
+    fn extract_symbol_no_sigil_defaults_to_subroutine() {
+        // A bare identifier with no sigil context defaults to Subroutine kind.
+        let source = "greet";
+        let result = extract_symbol_from_source(0, source);
+        assert_eq!(result, Some(("greet".to_string(), CursorSymbolKind::Subroutine)));
+    }
+
+    #[test]
+    fn extract_symbol_handles_underscore_and_digits_in_name() {
+        let source = "$my_var2";
+        let result = extract_symbol_from_source(1, source);
+        assert_eq!(result, Some(("my_var2".to_string(), CursorSymbolKind::Scalar)));
+    }
+
+    // ── get_symbol_range_at_position ──────────────────────────────────────────
+
+    #[test]
+    fn symbol_range_past_end_returns_none() {
+        assert_eq!(get_symbol_range_at_position(100, "foo"), None);
+    }
+
+    #[test]
+    fn symbol_range_includes_preceding_sigil() {
+        // Position 1 is 'f' in "$foo"; the range should include the '$' at 0.
+        let source = "$foo";
+        let range = get_symbol_range_at_position(1, source);
+        assert!(range.is_some());
+        let (start, end) = range.unwrap_or((0, 0));
+        assert_eq!(start, 0, "range must include the leading sigil");
+        assert_eq!(end, 4);
+    }
+
+    #[test]
+    fn symbol_range_on_bare_identifier_no_sigil() {
+        let source = "greet";
+        let range = get_symbol_range_at_position(0, source);
+        assert!(range.is_some());
+        let (start, end) = range.unwrap_or((0, 0));
+        assert_eq!(end, 5);
+        // start ≤ 0 (could be 0 when no sigil precedes)
+        assert!(start <= 1);
+    }
+
+    // ── CursorSymbolKind derive traits ────────────────────────────────────────
+
+    #[test]
+    fn cursor_symbol_kind_derives_debug() {
+        let formatted = format!("{:?}", CursorSymbolKind::Scalar);
+        assert_eq!(formatted, "Scalar");
+    }
+
+    #[test]
+    fn cursor_symbol_kind_derives_clone_and_copy() {
+        let original = CursorSymbolKind::Array;
+        let cloned = original.clone();
+        let copied: CursorSymbolKind = original;
+        assert_eq!(cloned, CursorSymbolKind::Array);
+        assert_eq!(copied, CursorSymbolKind::Array);
+    }
+
+    #[test]
+    fn cursor_symbol_kind_derives_partial_eq() {
+        assert_eq!(CursorSymbolKind::Scalar, CursorSymbolKind::Scalar);
+        assert_ne!(CursorSymbolKind::Scalar, CursorSymbolKind::Array);
+        assert_ne!(CursorSymbolKind::Hash, CursorSymbolKind::Subroutine);
+    }
+
+    #[test]
+    fn cursor_symbol_kind_all_variants_are_distinct() {
+        let variants = [
+            CursorSymbolKind::Scalar,
+            CursorSymbolKind::Array,
+            CursorSymbolKind::Hash,
+            CursorSymbolKind::Subroutine,
+        ];
+        for (i, a) in variants.iter().enumerate() {
+            for (j, b) in variants.iter().enumerate() {
+                if i == j {
+                    assert_eq!(a, b);
+                } else {
+                    assert_ne!(a, b);
+                }
+            }
+        }
     }
 }

--- a/crates/perl-symbol/src/types/mod.rs
+++ b/crates/perl-symbol/src/types/mod.rs
@@ -314,4 +314,122 @@ mod tests {
         assert!(SymbolKind::Role.is_namespace());
         assert!(!SymbolKind::Subroutine.is_namespace());
     }
+
+    #[test]
+    fn test_category_predicates_exhaustive() {
+        // is_variable: all three VarKind variants
+        assert!(SymbolKind::Variable(VarKind::Array).is_variable());
+        assert!(SymbolKind::Variable(VarKind::Hash).is_variable());
+        // non-variable kinds including Import/Export/Label/Format
+        assert!(!SymbolKind::Import.is_variable());
+        assert!(!SymbolKind::Export.is_variable());
+        assert!(!SymbolKind::Label.is_variable());
+        assert!(!SymbolKind::Format.is_variable());
+        assert!(!SymbolKind::Constant.is_variable());
+
+        // is_callable: non-callable kinds
+        assert!(!SymbolKind::Package.is_callable());
+        assert!(!SymbolKind::Import.is_callable());
+        assert!(!SymbolKind::Label.is_callable());
+        assert!(!SymbolKind::Constant.is_callable());
+
+        // is_namespace: non-namespace kinds
+        assert!(!SymbolKind::Subroutine.is_namespace());
+        assert!(!SymbolKind::Import.is_namespace());
+        assert!(!SymbolKind::Label.is_namespace());
+        assert!(!SymbolKind::Format.is_namespace());
+    }
+
+    #[test]
+    fn test_non_variable_sigil_is_none() {
+        // sigil() returns None for every non-Variable variant
+        for kind in [
+            SymbolKind::Package,
+            SymbolKind::Import,
+            SymbolKind::Export,
+            SymbolKind::Label,
+            SymbolKind::Format,
+            SymbolKind::Constant,
+        ] {
+            assert_eq!(kind.sigil(), None, "{kind:?} should have sigil None");
+        }
+    }
+
+    // ── VarKind: Copy / Hash / Eq semantics ───────────────────────────────────
+
+    #[test]
+    fn var_kind_is_copy() {
+        let a = VarKind::Scalar;
+        let b = a; // copy — not move
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn var_kind_hash_and_eq_consistency() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(VarKind::Scalar);
+        set.insert(VarKind::Array);
+        set.insert(VarKind::Hash);
+        // Inserting again must not grow the set
+        set.insert(VarKind::Scalar);
+        assert_eq!(set.len(), 3);
+        assert!(set.contains(&VarKind::Scalar));
+        assert!(set.contains(&VarKind::Array));
+        assert!(set.contains(&VarKind::Hash));
+    }
+
+    #[test]
+    fn symbol_kind_hash_and_eq_consistency() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(SymbolKind::Package);
+        set.insert(SymbolKind::Variable(VarKind::Scalar));
+        set.insert(SymbolKind::Variable(VarKind::Array));
+        set.insert(SymbolKind::Package); // duplicate
+        assert_eq!(set.len(), 3);
+        assert!(set.contains(&SymbolKind::Variable(VarKind::Scalar)));
+        // Variable(Scalar) != Variable(Array)
+        assert_ne!(SymbolKind::Variable(VarKind::Scalar), SymbolKind::Variable(VarKind::Array));
+    }
+
+    // ── Serde roundtrips ──────────────────────────────────────────────────────
+
+    #[test]
+    fn var_kind_serde_roundtrip() {
+        let serialized = serde_json::to_string(&VarKind::Scalar).expect("serialization failed");
+        let deserialized: VarKind =
+            serde_json::from_str(&serialized).expect("deserialization failed");
+        assert_eq!(deserialized, VarKind::Scalar);
+
+        let serialized = serde_json::to_string(&VarKind::Hash).expect("serialization failed");
+        let deserialized: VarKind =
+            serde_json::from_str(&serialized).expect("deserialization failed");
+        assert_eq!(deserialized, VarKind::Hash);
+    }
+
+    #[test]
+    fn symbol_kind_serde_roundtrip_all_variants() {
+        let variants = [
+            SymbolKind::Package,
+            SymbolKind::Class,
+            SymbolKind::Role,
+            SymbolKind::Subroutine,
+            SymbolKind::Method,
+            SymbolKind::Variable(VarKind::Scalar),
+            SymbolKind::Variable(VarKind::Array),
+            SymbolKind::Variable(VarKind::Hash),
+            SymbolKind::Constant,
+            SymbolKind::Import,
+            SymbolKind::Export,
+            SymbolKind::Label,
+            SymbolKind::Format,
+        ];
+        for kind in variants {
+            let serialized = serde_json::to_string(&kind).expect("serialization must succeed");
+            let deserialized: SymbolKind =
+                serde_json::from_str(&serialized).expect("deserialization must succeed");
+            assert_eq!(deserialized, kind, "roundtrip failed for {kind:?}");
+        }
+    }
 }

--- a/crates/perl-symbol/src/types/mod.rs
+++ b/crates/perl-symbol/src/types/mod.rs
@@ -316,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn test_category_predicates_exhaustive() {
+    fn test_category_predicates_exhaustive() -> Result<(), Box<dyn std::error::Error>> {
         // is_variable: all three VarKind variants
         assert!(SymbolKind::Variable(VarKind::Array).is_variable());
         assert!(SymbolKind::Variable(VarKind::Hash).is_variable());
@@ -338,10 +338,11 @@ mod tests {
         assert!(!SymbolKind::Import.is_namespace());
         assert!(!SymbolKind::Label.is_namespace());
         assert!(!SymbolKind::Format.is_namespace());
+        Ok(())
     }
 
     #[test]
-    fn test_non_variable_sigil_is_none() {
+    fn test_non_variable_sigil_is_none() -> Result<(), Box<dyn std::error::Error>> {
         // sigil() returns None for every non-Variable variant
         for kind in [
             SymbolKind::Package,
@@ -353,19 +354,21 @@ mod tests {
         ] {
             assert_eq!(kind.sigil(), None, "{kind:?} should have sigil None");
         }
+        Ok(())
     }
 
     // ── VarKind: Copy / Hash / Eq semantics ───────────────────────────────────
 
     #[test]
-    fn var_kind_is_copy() {
+    fn var_kind_is_copy() -> Result<(), Box<dyn std::error::Error>> {
         let a = VarKind::Scalar;
         let b = a; // copy — not move
         assert_eq!(a, b);
+        Ok(())
     }
 
     #[test]
-    fn var_kind_hash_and_eq_consistency() {
+    fn var_kind_hash_and_eq_consistency() -> Result<(), Box<dyn std::error::Error>> {
         use std::collections::HashSet;
         let mut set = HashSet::new();
         set.insert(VarKind::Scalar);
@@ -377,10 +380,11 @@ mod tests {
         assert!(set.contains(&VarKind::Scalar));
         assert!(set.contains(&VarKind::Array));
         assert!(set.contains(&VarKind::Hash));
+        Ok(())
     }
 
     #[test]
-    fn symbol_kind_hash_and_eq_consistency() {
+    fn symbol_kind_hash_and_eq_consistency() -> Result<(), Box<dyn std::error::Error>> {
         use std::collections::HashSet;
         let mut set = HashSet::new();
         set.insert(SymbolKind::Package);
@@ -391,25 +395,25 @@ mod tests {
         assert!(set.contains(&SymbolKind::Variable(VarKind::Scalar)));
         // Variable(Scalar) != Variable(Array)
         assert_ne!(SymbolKind::Variable(VarKind::Scalar), SymbolKind::Variable(VarKind::Array));
+        Ok(())
     }
 
     // ── Serde roundtrips ──────────────────────────────────────────────────────
 
     #[test]
-    fn var_kind_serde_roundtrip() {
-        let serialized = serde_json::to_string(&VarKind::Scalar).expect("serialization failed");
-        let deserialized: VarKind =
-            serde_json::from_str(&serialized).expect("deserialization failed");
+    fn var_kind_serde_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+        let serialized = serde_json::to_string(&VarKind::Scalar)?;
+        let deserialized: VarKind = serde_json::from_str(&serialized)?;
         assert_eq!(deserialized, VarKind::Scalar);
 
-        let serialized = serde_json::to_string(&VarKind::Hash).expect("serialization failed");
-        let deserialized: VarKind =
-            serde_json::from_str(&serialized).expect("deserialization failed");
+        let serialized = serde_json::to_string(&VarKind::Hash)?;
+        let deserialized: VarKind = serde_json::from_str(&serialized)?;
         assert_eq!(deserialized, VarKind::Hash);
+        Ok(())
     }
 
     #[test]
-    fn symbol_kind_serde_roundtrip_all_variants() {
+    fn symbol_kind_serde_roundtrip_all_variants() -> Result<(), Box<dyn std::error::Error>> {
         let variants = [
             SymbolKind::Package,
             SymbolKind::Class,
@@ -426,10 +430,10 @@ mod tests {
             SymbolKind::Format,
         ];
         for kind in variants {
-            let serialized = serde_json::to_string(&kind).expect("serialization must succeed");
-            let deserialized: SymbolKind =
-                serde_json::from_str(&serialized).expect("deserialization must succeed");
+            let serialized = serde_json::to_string(&kind)?;
+            let deserialized: SymbolKind = serde_json::from_str(&serialized)?;
             assert_eq!(deserialized, kind, "roundtrip failed for {kind:?}");
         }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Add 32 focused inline unit tests to `cursor/mod.rs` and `types/mod.rs` covering paths that had no `mod tests` coverage.
- `cursor/mod.rs`: tests for `extract_symbol_from_source` (all four sigils, cursor-on-sigil, past-end, bare identifier default), `get_symbol_range_at_position` (past-end None, sigil inclusion, bare identifier), `is_modchar` (accept/reject cases), `byte_offset_utf16` (past-end, empty string), `is_word_boundary` (start/end boundary, trailing modchar), and `CursorSymbolKind` derived traits (`Debug`, `Clone`, `Copy`, `PartialEq`, all-variants-distinct).
- `types/mod.rs`: `VarKind` and `SymbolKind` serde roundtrips for all variants, `HashSet` consistency (Hash/Eq), `VarKind` Copy semantics, and exhaustive predicate coverage for `is_variable`/`is_callable`/`is_namespace` on `Import`/`Export`/`Label`/`Format` variants not previously hit.

## Test plan

- [ ] `cargo test -p perl-symbol --lib` passes (69 tests, up from 37)
- [ ] `cargo clippy -p perl-symbol --lib -- -D warnings` clean
- [ ] `cargo fmt -p perl-symbol -- --check` clean
- [ ] No production code modified — test-only change
- [ ] All new tests are in `mod tests` blocks inside the source files
- [ ] No `unwrap()`/`expect()` in production code; tests use `.expect()` only inside `#[test]` functions for serde calls

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVVCN6cXLcJ8pKckV13rCC)_