### PR TITLE
test(perl-incremental-parsing): cover LineIndex CRLF/boundary, Edit None branch, identity edits, and UTF-8 boundaries (#6754)

### DIFF
--- a/crates/perl-incremental-parsing/src/lib.rs
+++ b/crates/perl-incremental-parsing/src/lib.rs
@@ -36,8 +36,9 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
-    fn max_edit_size_is_64kb() {
+    fn max_edit_size_is_64kb() -> Result<(), Box<dyn std::error::Error>> {
         assert_eq!(MAX_EDIT_SIZE, 64 * 1024);
+        Ok(())
     }
 
     // -------------------------------------------------------------------------
@@ -45,45 +46,51 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
-    fn line_index_byte_zero_is_line_zero_col_zero() {
+    fn line_index_byte_zero_is_line_zero_col_zero() -> Result<(), Box<dyn std::error::Error>> {
         let li = LineIndex::new("hello");
         assert_eq!(li.byte_to_position(0), (0, 0));
+        Ok(())
     }
 
     #[test]
-    fn line_index_position_to_byte_last_column_on_last_line() {
+    fn line_index_position_to_byte_last_column_on_last_line()
+    -> Result<(), Box<dyn std::error::Error>> {
         // "ab" — last column is col 2 (one past 'b'), still within the single line
         let li = LineIndex::new("ab");
         assert_eq!(li.position_to_byte(0, 2), Some(2));
         // col 3 is beyond the text length → None
         assert_eq!(li.position_to_byte(0, 3), None);
+        Ok(())
     }
 
     #[test]
-    fn line_index_crlf_line_boundary() {
+    fn line_index_crlf_line_boundary() -> Result<(), Box<dyn std::error::Error>> {
         // "\r\n" counts as two bytes; only '\n' starts the new line.
         // "a\r\nb" — '\n' is at byte 2, so line 1 starts at byte 3.
         let li = LineIndex::new("a\r\nb");
         assert_eq!(li.byte_to_position(3), (1, 0));
         assert_eq!(li.position_to_byte(1, 0), Some(3));
+        Ok(())
     }
 
     #[test]
-    fn line_index_empty_string_position_to_byte() {
+    fn line_index_empty_string_position_to_byte() -> Result<(), Box<dyn std::error::Error>> {
         let li = LineIndex::new("");
         // Only line 0 exists with zero width; col 0 maps to byte 0.
         assert_eq!(li.position_to_byte(0, 0), Some(0));
         // No line 1.
         assert_eq!(li.position_to_byte(1, 0), None);
+        Ok(())
     }
 
     #[test]
-    fn line_index_trailing_newline_empty_final_line() {
+    fn line_index_trailing_newline_empty_final_line() -> Result<(), Box<dyn std::error::Error>> {
         // "x\n" — line 1 is empty; col 0 maps to byte 2 (end of string).
         let li = LineIndex::new("x\n");
         assert_eq!(li.position_to_byte(1, 0), Some(2));
         // col 1 is beyond the empty final line → None
         assert_eq!(li.position_to_byte(1, 1), None);
+        Ok(())
     }
 
     // -------------------------------------------------------------------------
@@ -91,7 +98,8 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
-    fn edit_from_lsp_change_returns_none_for_out_of_range_line() {
+    fn edit_from_lsp_change_returns_none_for_out_of_range_line()
+    -> Result<(), Box<dyn std::error::Error>> {
         use lsp_types::{Range as LspRange, TextDocumentContentChangeEvent};
 
         let old = "hello";
@@ -106,6 +114,7 @@ mod tests {
         };
         let result = Edit::from_lsp_change(&change, &li, old);
         assert!(result.is_none());
+        Ok(())
     }
 
     // -------------------------------------------------------------------------
@@ -113,13 +122,14 @@ mod tests {
     // -------------------------------------------------------------------------
 
     #[test]
-    fn incremental_state_clone_equals_original() {
+    fn incremental_state_clone_equals_original() -> Result<(), Box<dyn std::error::Error>> {
         let src = "my $x = 1;";
         let state = IncrementalState::new(src.to_string());
         let cloned = state.clone();
         assert_eq!(cloned.source, state.source);
         assert_eq!(cloned.tokens.len(), state.tokens.len());
         assert_eq!(cloned.lex_checkpoints.len(), state.lex_checkpoints.len());
+        Ok(())
     }
 
     // -------------------------------------------------------------------------

--- a/crates/perl-incremental-parsing/src/lib.rs
+++ b/crates/perl-incremental-parsing/src/lib.rs
@@ -25,3 +25,194 @@ pub use perl_parser::incremental;
 
 #[doc(inline)]
 pub use perl_parser::incremental::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use incremental::{Edit, IncrementalState, LineIndex, MAX_EDIT_SIZE, apply_edits};
+
+    // -------------------------------------------------------------------------
+    // Constant sanity
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn max_edit_size_is_64kb() {
+        assert_eq!(MAX_EDIT_SIZE, 64 * 1024);
+    }
+
+    // -------------------------------------------------------------------------
+    // LineIndex — start-of-file, end-of-file, and CRLF boundary positions
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn line_index_byte_zero_is_line_zero_col_zero() {
+        let li = LineIndex::new("hello");
+        assert_eq!(li.byte_to_position(0), (0, 0));
+    }
+
+    #[test]
+    fn line_index_position_to_byte_last_column_on_last_line() {
+        // "ab" — last column is col 2 (one past 'b'), still within the single line
+        let li = LineIndex::new("ab");
+        assert_eq!(li.position_to_byte(0, 2), Some(2));
+        // col 3 is beyond the text length → None
+        assert_eq!(li.position_to_byte(0, 3), None);
+    }
+
+    #[test]
+    fn line_index_crlf_line_boundary() {
+        // "\r\n" counts as two bytes; only '\n' starts the new line.
+        // "a\r\nb" — '\n' is at byte 2, so line 1 starts at byte 3.
+        let li = LineIndex::new("a\r\nb");
+        assert_eq!(li.byte_to_position(3), (1, 0));
+        assert_eq!(li.position_to_byte(1, 0), Some(3));
+    }
+
+    #[test]
+    fn line_index_empty_string_position_to_byte() {
+        let li = LineIndex::new("");
+        // Only line 0 exists with zero width; col 0 maps to byte 0.
+        assert_eq!(li.position_to_byte(0, 0), Some(0));
+        // No line 1.
+        assert_eq!(li.position_to_byte(1, 0), None);
+    }
+
+    #[test]
+    fn line_index_trailing_newline_empty_final_line() {
+        // "x\n" — line 1 is empty; col 0 maps to byte 2 (end of string).
+        let li = LineIndex::new("x\n");
+        assert_eq!(li.position_to_byte(1, 0), Some(2));
+        // col 1 is beyond the empty final line → None
+        assert_eq!(li.position_to_byte(1, 1), None);
+    }
+
+    // -------------------------------------------------------------------------
+    // Edit::from_lsp_change — None branch (out-of-range line)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn edit_from_lsp_change_returns_none_for_out_of_range_line() {
+        use lsp_types::{Range as LspRange, TextDocumentContentChangeEvent};
+
+        let old = "hello";
+        let li = LineIndex::new(old);
+        let change = TextDocumentContentChangeEvent {
+            range: Some(LspRange {
+                start: lsp_types::Position { line: 99, character: 0 },
+                end: lsp_types::Position { line: 99, character: 1 },
+            }),
+            range_length: None,
+            text: "x".to_string(),
+        };
+        let result = Edit::from_lsp_change(&change, &li, old);
+        assert!(result.is_none());
+    }
+
+    // -------------------------------------------------------------------------
+    // IncrementalState — clone preserves source and token count
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn incremental_state_clone_equals_original() {
+        let src = "my $x = 1;";
+        let state = IncrementalState::new(src.to_string());
+        let cloned = state.clone();
+        assert_eq!(cloned.source, state.source);
+        assert_eq!(cloned.tokens.len(), state.tokens.len());
+        assert_eq!(cloned.lex_checkpoints.len(), state.lex_checkpoints.len());
+    }
+
+    // -------------------------------------------------------------------------
+    // apply_edits — identity edit (empty replacement) leaves source unchanged
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn apply_edits_identity_edit_leaves_source_unchanged() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let src = "my $x = 1;";
+        let mut state = IncrementalState::new(src.to_string());
+        // Replace bytes 4..4 (zero-width) with "" — pure identity
+        let edit =
+            Edit { start_byte: 4, old_end_byte: 4, new_end_byte: 4, new_text: String::new() };
+        apply_edits(&mut state, &[edit])?;
+        assert_eq!(state.source, src);
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // apply_edits — single-char insertion at start of file (byte 0)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn apply_edits_single_char_at_start_of_file() -> Result<(), Box<dyn std::error::Error>> {
+        let src = "x = 1;";
+        let mut state = IncrementalState::new(src.to_string());
+        // Prepend '#' — comment out the line
+        let edit =
+            Edit { start_byte: 0, old_end_byte: 0, new_end_byte: 1, new_text: "#".to_string() };
+        apply_edits(&mut state, &[edit])?;
+        assert_eq!(state.source.as_bytes().first(), Some(&b'#'));
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // apply_edits — single-char deletion at end of file
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn apply_edits_single_char_deletion_at_end_of_file() -> Result<(), Box<dyn std::error::Error>> {
+        let src = "my $x = 1;";
+        let end = src.len();
+        let mut state = IncrementalState::new(src.to_string());
+        // Delete the trailing semicolon
+        let edit = Edit {
+            start_byte: end - 1,
+            old_end_byte: end,
+            new_end_byte: end - 1,
+            new_text: String::new(),
+        };
+        apply_edits(&mut state, &[edit])?;
+        assert!(!state.source.ends_with(';'));
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // apply_edits — UTF-8 multi-byte boundary: edit touching a multi-byte char
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn apply_edits_replaces_ascii_adjacent_to_multibyte_char()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // "é" is two bytes (0xC3 0xA9).  We insert ASCII after it, leaving é intact.
+        let src = "éx";
+        let mut state = IncrementalState::new(src.to_string());
+        // Replace 'x' (bytes 2..3) with 'y'
+        let edit =
+            Edit { start_byte: 2, old_end_byte: 3, new_end_byte: 3, new_text: "y".to_string() };
+        apply_edits(&mut state, &[edit])?;
+        assert_eq!(&state.source, "éy");
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // apply_edits — ReparseResult fields after full reparse
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn apply_edits_full_reparse_reparsed_bytes_matches_source_len()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let src = "my $x = 1;";
+        let mut state = IncrementalState::new(src.to_string());
+        // A multi-line edit forces a full reparse.
+        let new_text = "my $a = 1;\n".repeat(15);
+        let new_len = new_text.len();
+        let edit = Edit { start_byte: 0, old_end_byte: src.len(), new_end_byte: new_len, new_text };
+        let result = apply_edits(&mut state, &[edit])?;
+        // After full reparse the result covers the whole new source.
+        assert_eq!(result.reparsed_bytes, state.source.len());
+        assert_eq!(result.changed_ranges.len(), 1);
+        assert_eq!(result.changed_ranges[0].start, 0);
+        assert_eq!(result.changed_ranges[0].end, state.source.len());
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 13 inline `mod tests` to `crates/perl-incremental-parsing/src/lib.rs` (previously 0 inline tests)
- Covers `MAX_EDIT_SIZE` constant value, `LineIndex` start-of-file / end-of-file / CRLF / trailing-newline boundary positions, `Edit::from_lsp_change` returning `None` for an out-of-range LSP line, `IncrementalState` clone semantics, and `apply_edits` with identity edits, single-char edits at file boundaries, ASCII replacement adjacent to a multi-byte UTF-8 character, and `ReparseResult` field values after a forced full reparse

## Test plan

- [x] `cargo test -p perl-incremental-parsing --lib` — 13 new tests, all pass
- [x] `cargo clippy -p perl-incremental-parsing --lib -- -D warnings` — clean
- [x] `cargo fmt -p perl-incremental-parsing` — no diff after formatting

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVVCN6cXLcJ8pKckV13rCC)_