### PR TITLE
test(perl-refactoring): cover import_optimizer submodules

### DIFF
--- a/crates/perl-refactoring/src/refactor/import_optimizer/duplicates.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/duplicates.rs
@@ -18,3 +18,67 @@ pub(super) fn find_duplicate_imports(imports: &[ImportEntry]) -> Vec<DuplicateIm
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(module: &str, line: usize) -> ImportEntry {
+        ImportEntry { module: module.to_string(), symbols: vec![], line }
+    }
+
+    #[test]
+    fn test_find_duplicate_imports_empty_returns_empty() {
+        let result = find_duplicate_imports(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_duplicate_imports_no_duplicates_returns_empty() {
+        let imports =
+            vec![make_entry("strict", 1), make_entry("warnings", 2), make_entry("Data::Dumper", 3)];
+        let result = find_duplicate_imports(&imports);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_find_duplicate_imports_single_duplicate_detected() {
+        let imports = vec![
+            make_entry("strict", 1),
+            make_entry("Data::Dumper", 2),
+            make_entry("Data::Dumper", 5),
+        ];
+        let result = find_duplicate_imports(&imports);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].module, "Data::Dumper");
+        assert_eq!(result[0].lines.len(), 2);
+        assert!(result[0].lines.contains(&2));
+        assert!(result[0].lines.contains(&5));
+    }
+
+    #[test]
+    fn test_find_duplicate_imports_can_merge_is_always_true() {
+        let imports = vec![make_entry("JSON", 1), make_entry("JSON", 4)];
+        let result = find_duplicate_imports(&imports);
+        assert_eq!(result.len(), 1);
+        assert!(result[0].can_merge);
+    }
+
+    #[test]
+    fn test_find_duplicate_imports_multiple_duplicates() {
+        let imports = vec![
+            make_entry("strict", 1),
+            make_entry("JSON", 2),
+            make_entry("JSON", 3),
+            make_entry("YAML", 4),
+            make_entry("YAML", 5),
+            make_entry("YAML", 6),
+        ];
+        let result = find_duplicate_imports(&imports);
+        assert_eq!(result.len(), 2);
+        let json_dup = result.iter().find(|d| d.module == "JSON");
+        assert!(json_dup.is_some());
+        let yaml_dup = result.iter().find(|d| d.module == "YAML");
+        assert!(yaml_dup.is_some_and(|d| d.lines.len() == 3));
+    }
+}

--- a/crates/perl-refactoring/src/refactor/import_optimizer/parsing.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/parsing.rs
@@ -30,3 +30,105 @@ pub(super) fn non_use_content(content: &str) -> String {
         .collect::<Vec<_>>()
         .join("\n")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_imports_bare_pragma() -> Result<(), String> {
+        let content = "use strict;\nuse warnings;\n";
+        let imports = parse_imports(content)?;
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].module, "strict");
+        assert!(imports[0].symbols.is_empty());
+        assert_eq!(imports[0].line, 1);
+        assert_eq!(imports[1].module, "warnings");
+        assert_eq!(imports[1].line, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_imports_with_qw_symbols() -> Result<(), String> {
+        let content = "use List::Util qw(first max min);\n";
+        let imports = parse_imports(content)?;
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].module, "List::Util");
+        assert_eq!(imports[0].symbols, vec!["first", "max", "min"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_imports_mixed_module_name_formats() -> Result<(), String> {
+        // Module names with double-colon namespacing
+        let content = "use Data::Dumper;\nuse Scalar::Util qw(blessed weaken);\n";
+        let imports = parse_imports(content)?;
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].module, "Data::Dumper");
+        assert!(imports[0].symbols.is_empty());
+        assert_eq!(imports[1].module, "Scalar::Util");
+        assert_eq!(imports[1].symbols, vec!["blessed", "weaken"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_imports_line_numbers_are_one_indexed() -> Result<(), String> {
+        let content = "#!/usr/bin/perl\nuse strict;\nuse warnings;\n";
+        let imports = parse_imports(content)?;
+        // The shebang line is line 1, so imports start at line 2
+        assert_eq!(imports[0].line, 2);
+        assert_eq!(imports[1].line, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_imports_empty_content_returns_empty() -> Result<(), String> {
+        let imports = parse_imports("")?;
+        assert!(imports.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_imports_no_use_statements_returns_empty() -> Result<(), String> {
+        let content = "my $x = 42;\nprint \"hello\\n\";\n";
+        let imports = parse_imports(content)?;
+        assert!(imports.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_non_use_content_removes_use_lines() {
+        let content = "use strict;\nmy $x = 1;\nuse warnings;\nprint $x;\n";
+        let result = non_use_content(content);
+        assert!(!result.contains("use strict"));
+        assert!(!result.contains("use warnings"));
+        assert!(result.contains("my $x = 1"));
+        assert!(result.contains("print $x"));
+    }
+
+    #[test]
+    fn test_non_use_content_removes_comment_lines() {
+        let content = "# This is a comment\nmy $x = 1;\n# Another comment\n";
+        let result = non_use_content(content);
+        assert!(!result.contains("# This is a comment"));
+        assert!(!result.contains("# Another comment"));
+        assert!(result.contains("my $x = 1"));
+    }
+
+    #[test]
+    fn test_non_use_content_preserves_indented_use_in_code() {
+        // A 'use' that appears mid-line (not as trim_start prefix) is kept
+        let content = "my $s = \"use something\";\nuse strict;\n";
+        let result = non_use_content(content);
+        // The string line does NOT start with "use " so it is kept
+        assert!(result.contains("my $s"));
+        // The actual use statement is removed
+        assert!(!result.contains("use strict"));
+    }
+
+    #[test]
+    fn test_non_use_content_empty_input_returns_empty() {
+        let result = non_use_content("");
+        assert!(result.is_empty());
+    }
+}

--- a/crates/perl-refactoring/src/refactor/import_optimizer/suggestions.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/suggestions.rs
@@ -62,3 +62,95 @@ fn symbols_need_organization(imp: &ImportEntry) -> bool {
     sorted.dedup();
     sorted != imp.symbols
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(module: &str, symbols: &[&str]) -> ImportEntry {
+        ImportEntry {
+            module: module.to_string(),
+            symbols: symbols.iter().map(|s| s.to_string()).collect(),
+            line: 1,
+        }
+    }
+
+    fn make_dup(module: &str) -> DuplicateImport {
+        DuplicateImport { module: module.to_string(), lines: vec![1, 3], can_merge: true }
+    }
+
+    #[test]
+    fn test_organization_suggestions_empty_imports_no_suggestions() {
+        let result = organization_suggestions(&[], &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_organization_suggestions_sorted_imports_no_sort_suggestion() {
+        // Already sorted alphabetically — no sort suggestion expected
+        let imports = vec![make_entry("Data::Dumper", &[]), make_entry("JSON", &[])];
+        let result = organization_suggestions(&imports, &[]);
+        assert!(!result.iter().any(|s| s.description.contains("Sort import")));
+    }
+
+    #[test]
+    fn test_organization_suggestions_unsorted_imports_triggers_sort_suggestion() {
+        // "warnings" before "strict" is not alphabetical
+        let imports = vec![make_entry("warnings", &[]), make_entry("strict", &[])];
+        let result = organization_suggestions(&imports, &[]);
+        assert!(result.iter().any(|s| s.description.contains("Sort import")));
+        // The sort suggestion has Low priority
+        let sort_sugg = result.iter().find(|s| s.description.contains("Sort import"));
+        assert!(sort_sugg.is_some_and(|s| s.priority == SuggestionPriority::Low));
+    }
+
+    #[test]
+    fn test_organization_suggestions_duplicate_imports_triggers_dedupe_suggestion() {
+        let imports = vec![make_entry("JSON", &[])];
+        let dups = vec![make_dup("JSON")];
+        let result = organization_suggestions(&imports, &dups);
+        assert!(result.iter().any(|s| s.description.contains("Remove duplicate imports")));
+        let dup_sugg = result.iter().find(|s| s.description.contains("Remove duplicate imports"));
+        assert!(dup_sugg.is_some_and(|s| s.priority == SuggestionPriority::Medium));
+    }
+
+    #[test]
+    fn test_organization_suggestions_unsorted_symbols_triggers_symbol_suggestion() {
+        // "min" before "max" is unsorted
+        let imports = vec![make_entry("List::Util", &["min", "max"])];
+        let result = organization_suggestions(&imports, &[]);
+        assert!(result.iter().any(|s| s.description.contains("Sort and deduplicate symbols")));
+    }
+
+    #[test]
+    fn test_organization_suggestions_duplicate_symbols_triggers_symbol_suggestion() {
+        // "max" appears twice — dedup needed
+        let imports = vec![make_entry("List::Util", &["max", "max", "min"])];
+        let result = organization_suggestions(&imports, &[]);
+        assert!(result.iter().any(|s| s.description.contains("Sort and deduplicate symbols")));
+    }
+
+    #[test]
+    fn test_organization_suggestions_single_symbol_no_symbol_suggestion() {
+        // Single symbol cannot be unsorted/deduplicated
+        let imports = vec![make_entry("Carp", &["croak"])];
+        let result = organization_suggestions(&imports, &[]);
+        assert!(!result.iter().any(|s| s.description.contains("Sort and deduplicate symbols")));
+    }
+
+    #[test]
+    fn test_organization_suggestions_no_symbols_no_symbol_suggestion() {
+        let imports = vec![make_entry("strict", &[])];
+        let result = organization_suggestions(&imports, &[]);
+        assert!(!result.iter().any(|s| s.description.contains("Sort and deduplicate symbols")));
+    }
+
+    #[test]
+    fn test_organization_suggestions_duplicate_module_name_in_description() {
+        let imports = vec![make_entry("JSON", &[])];
+        let dups = vec![make_dup("JSON")];
+        let result = organization_suggestions(&imports, &dups);
+        let dup_sugg = result.iter().find(|s| s.description.contains("Remove duplicate imports"));
+        assert!(dup_sugg.is_some_and(|s| s.description.contains("JSON")));
+    }
+}

--- a/crates/perl-refactoring/src/refactor/import_optimizer/usage.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer/usage.rs
@@ -126,3 +126,137 @@ fn contains_word(haystack: &str, needle: &str) -> bool {
 fn is_word_char(ch: Option<char>) -> bool {
     ch.is_some_and(|c| c.is_ascii_alphanumeric() || c == '_')
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(module: &str, symbols: &[&str], line: usize) -> ImportEntry {
+        ImportEntry {
+            module: module.to_string(),
+            symbols: symbols.iter().map(|s| s.to_string()).collect(),
+            line,
+        }
+    }
+
+    // --- find_unused_imports tests ---
+
+    #[test]
+    fn test_find_unused_imports_empty_imports_returns_empty() -> Result<(), String> {
+        let result = find_unused_imports(&[], "some code here")?;
+        assert!(result.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_unused_imports_bare_pragma_not_reported_unused() -> Result<(), String> {
+        // Pragma modules (strict, warnings) are never unused
+        let imports = vec![make_entry("strict", &[], 1), make_entry("warnings", &[], 2)];
+        let result = find_unused_imports(&imports, "my $x = 1;")?;
+        assert!(result.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_unused_imports_used_symbol_not_reported() -> Result<(), String> {
+        // "first" is used in the non-use content
+        let imports = vec![make_entry("List::Util", &["first", "max"], 1)];
+        let content = "my $f = first { $_ > 0 } @items;\nmy $m = max(@nums);\n";
+        let result = find_unused_imports(&imports, content)?;
+        assert!(result.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_unused_imports_unused_symbol_reported() -> Result<(), String> {
+        // "min" is imported but never appears in the content
+        let imports = vec![make_entry("List::Util", &["max", "min"], 1)];
+        let content = "my $m = max(1, 2);";
+        let result = find_unused_imports(&imports, content)?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].module, "List::Util");
+        assert_eq!(result[0].symbols, vec!["min"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_unused_imports_all_symbols_used_no_report() -> Result<(), String> {
+        let imports = vec![make_entry("Scalar::Util", &["blessed", "reftype"], 1)];
+        let content = "my $b = blessed($obj);\nmy $r = reftype($ref);\n";
+        let result = find_unused_imports(&imports, content)?;
+        assert!(result.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_unused_imports_word_boundary_prevents_false_positive() -> Result<(), String> {
+        // "max" appears as part of "maximum" — must not count as used
+        let imports = vec![make_entry("List::Util", &["max"], 1)];
+        let content = "my $x = maximum_value();";
+        let result = find_unused_imports(&imports, content)?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].symbols, vec!["max"]);
+        Ok(())
+    }
+
+    // --- find_missing_imports tests ---
+
+    #[test]
+    fn test_find_missing_imports_no_qualified_usage_returns_empty() -> Result<(), String> {
+        let content = "use strict;\nmy $x = 1;\n";
+        let imports = vec![make_entry("strict", &[], 1)];
+        let result = find_missing_imports(content, &imports)?;
+        assert!(result.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_missing_imports_already_imported_module_not_reported() -> Result<(), String> {
+        let content = "use JSON;\nmy $j = JSON::encode_json({});\n";
+        let imports = vec![make_entry("JSON", &[], 1)];
+        let result = find_missing_imports(content, &imports)?;
+        assert!(result.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_missing_imports_unimported_module_detected() -> Result<(), String> {
+        let content = "use strict;\nmy $r = HTTP::Tiny::new();\n";
+        let imports = vec![make_entry("strict", &[], 1)];
+        let result = find_missing_imports(content, &imports)?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].module, "HTTP::Tiny");
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_missing_imports_suggested_location_after_last_import() -> Result<(), String> {
+        let content = "use strict;\nuse warnings;\nmy $r = HTTP::Tiny::new();\n";
+        let imports = vec![make_entry("strict", &[], 1), make_entry("warnings", &[], 2)];
+        let result = find_missing_imports(content, &imports)?;
+        assert_eq!(result.len(), 1);
+        // suggested_location = last import line + 1 = 2 + 1 = 3
+        assert_eq!(result[0].suggested_location, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_missing_imports_qualified_usage_in_string_not_reported() -> Result<(), String> {
+        // Module usage inside a string literal should not trigger a missing import
+        let content = "use strict;\nmy $s = \"JSON::encode_json is a function\";\n";
+        let imports = vec![make_entry("strict", &[], 1)];
+        let result = find_missing_imports(content, &imports)?;
+        assert!(result.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_missing_imports_confidence_is_positive() -> Result<(), String> {
+        let content = "use strict;\nmy $r = HTTP::Tiny::new();\n";
+        let imports = vec![make_entry("strict", &[], 1)];
+        let result = find_missing_imports(content, &imports)?;
+        assert_eq!(result.len(), 1);
+        assert!(result[0].confidence > 0.0);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- Adds tests for `import_optimizer/` submodules — `parsing.rs`, `duplicates.rs`, `suggestions.rs`, `usage.rs` (each previously had 0 tests)
- Test-only PR — no production code changes
- Specific functions/behaviors covered:
  - `parsing::parse_imports` — bare pragmas, `qw()` symbol lists, line-number accuracy, empty input
  - `parsing::non_use_content` — filters `use` lines and comment lines while preserving non-import code
  - `duplicates::find_duplicate_imports` — no duplicates, single duplicate, multi-occurrence duplicates, `can_merge` always true
  - `suggestions::organization_suggestions` — sort suggestion on unsorted modules, dedupe suggestion on duplicate imports, symbol-organization suggestion for unsorted/duplicate symbols within a single import
  - `usage::find_unused_imports` — pragmas never flagged, used symbols pass, unused symbols detected, word-boundary check prevents false positives on substrings
  - `usage::find_missing_imports` — qualified usage in strings stripped, already-imported modules skipped, `suggested_location` computed as last-import-line + 1

## Test plan
- [x] `cargo test -p perl-refactoring` — all green (151 + other suites pass, 0 failed)
- [x] `cargo clippy -p perl-refactoring --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p perl-refactoring` — clean
- [x] No production code modified
- [x] No `unwrap()`/`expect()`/`panic!()`/`dbg!()` in new tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwcWNqGWwJAnpgHmV21Fox)_