### PR TITLE
test(perl-semantic-analyzer): cover semantic model, tokens, references

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/semantic/model.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/model.rs
@@ -164,3 +164,116 @@ impl SemanticModel {
         self.analyzer.resolve_parent_chain(receiver_class)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Parser;
+    use perl_tdd_support::must_some;
+
+    fn build_model(source: &str) -> Result<SemanticModel, Box<dyn std::error::Error>> {
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+        Ok(SemanticModel::build(&ast, source))
+    }
+
+    // ── tokens ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tokens_empty_source_returns_empty_slice() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("")?;
+        assert!(model.tokens().is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn tokens_nonempty_for_variable_declaration() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("my $x = 42;")?;
+        assert!(!model.tokens().is_empty());
+        Ok(())
+    }
+
+    // ── symbol_table ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn symbol_table_contains_declared_subroutine() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("sub greet { return 1; }")?;
+        let table = model.symbol_table();
+        assert!(table.symbols.contains_key("greet"), "expected 'greet' in symbol table");
+        Ok(())
+    }
+
+    #[test]
+    fn symbol_table_contains_declared_variable() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("my $counter = 0;")?;
+        let table = model.symbol_table();
+        assert!(table.symbols.contains_key("counter"), "expected 'counter' in symbol table");
+        Ok(())
+    }
+
+    // ── definition_at ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn definition_at_returns_none_past_end_of_source() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("my $x = 1;")?;
+        // Position far beyond end of source — nothing to find
+        let result = model.definition_at(99_999);
+        assert!(result.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn definition_at_returns_symbol_at_declaration_site() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let source = "my $value = 1;";
+        let model = build_model(source)?;
+        // The variable declaration starts at position 3 (after "my ")
+        let sym = model.definition_at(3);
+        assert!(sym.is_some(), "expected a symbol at the declaration site");
+        let sym = must_some(sym);
+        assert_eq!(sym.name, "value");
+        Ok(())
+    }
+
+    // ── export_metadata / package_edges / generated_members ───────────────────
+
+    #[test]
+    fn export_metadata_empty_for_plain_script() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("my $x = 42;")?;
+        // No Exporter usage → no packages in metadata
+        assert!(model.export_metadata().packages.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn package_edges_empty_for_plain_script() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("my $x = 42;")?;
+        assert!(model.package_edges().is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn generated_members_empty_for_plain_script() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("my $x = 42;")?;
+        assert!(model.generated_members().is_empty());
+        Ok(())
+    }
+
+    // ── parent_chain / hover_info_at ──────────────────────────────────────────
+
+    #[test]
+    fn parent_chain_returns_none_for_unknown_class() -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("my $x = 1;")?;
+        assert!(model.parent_chain("NoSuchClass").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn hover_info_at_returns_none_for_out_of_range_location()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let model = build_model("my $x = 1;")?;
+        let far_location = SourceLocation { start: 99_999, end: 100_000 };
+        assert!(model.hover_info_at(far_location).is_none());
+        Ok(())
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/references.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/references.rs
@@ -147,3 +147,97 @@ impl SemanticAnalyzer {
         symbol.scope_id == 0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Parser;
+
+    // Helper: build a SemanticAnalyzer from Perl source.
+    fn analyze(source: &str) -> Result<SemanticAnalyzer, Box<dyn std::error::Error>> {
+        let mut parser = Parser::new(source);
+        let ast = parser.parse()?;
+        Ok(SemanticAnalyzer::analyze_with_source(&ast, source))
+    }
+
+    // ── find_all_references ───────────────────────────────────────────────────
+
+    #[test]
+    fn find_all_references_returns_empty_for_unknown_position()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let analyzer = analyze("my $x = 1;")?;
+        // Position 9_999 is far past the end — no symbol there.
+        let refs = analyzer.find_all_references(9_999, true);
+        assert!(refs.is_empty(), "expected no references for out-of-bounds position");
+        Ok(())
+    }
+
+    #[test]
+    fn find_all_references_includes_declaration_when_requested()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // $count is declared at position 3 (after "my ") and used at position 14.
+        let source = "my $count = 0; $count + 1;";
+        let analyzer = analyze(source)?;
+
+        // Query from the declaration site (byte 3).
+        let refs_with_decl = analyzer.find_all_references(3, true);
+        let refs_without_decl = analyzer.find_all_references(3, false);
+
+        // Including the declaration must yield at least as many locations.
+        assert!(
+            refs_with_decl.len() >= refs_without_decl.len(),
+            "include_declaration=true should yield >= locations than false"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn find_all_references_omits_declaration_when_not_requested()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let source = "my $val = 42; print $val;";
+        let analyzer = analyze(source)?;
+
+        let refs_with = analyzer.find_all_references(3, true);
+        let refs_without = analyzer.find_all_references(3, false);
+
+        // When declaration is excluded the count must be <= the inclusive count.
+        assert!(refs_without.len() <= refs_with.len());
+        Ok(())
+    }
+
+    #[test]
+    fn find_all_references_finds_multiple_use_sites() -> Result<(), Box<dyn std::error::Error>> {
+        // $n is declared once but used twice after the declaration.
+        let source = "my $n = 1; my $a = $n + 1; my $b = $n * 2;";
+        let analyzer = analyze(source)?;
+
+        // Querying from the declaration site with include_declaration=true
+        // should find at least 2 locations (declaration + at least one usage).
+        let refs = analyzer.find_all_references(3, true);
+        assert!(
+            refs.len() >= 2,
+            "expected declaration + at least one use site, got {}",
+            refs.len()
+        );
+        Ok(())
+    }
+
+    // ── is_symbol_visible ─────────────────────────────────────────────────────
+    // is_symbol_visible is pub(super); we exercise it indirectly via
+    // find_all_references_for_symbol called from find_all_references above,
+    // and directly here by calling find_all_references and checking that
+    // package-level (scope 0) symbols are always reachable.
+
+    #[test]
+    fn subroutine_at_package_scope_is_visible_globally() -> Result<(), Box<dyn std::error::Error>> {
+        let source = "sub helper { return 1; } helper();";
+        let analyzer = analyze(source)?;
+
+        // The subroutine call at position 25 ("helper()") should resolve to a
+        // non-empty set of reference locations when we query from a position
+        // inside the call site.
+        let refs = analyzer.find_all_references(25, false);
+        assert!(!refs.is_empty(), "package-level subroutine should be visible at call site");
+        Ok(())
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/semantic/tokens.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/semantic/tokens.rs
@@ -116,3 +116,113 @@ pub struct SemanticToken {
     /// Additional modifiers for enhanced highlighting
     pub modifiers: Vec<SemanticTokenModifier>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── SemanticTokenType ──────────────────────────────────────────────────────
+
+    #[test]
+    fn token_type_equality_same_variant() {
+        assert_eq!(SemanticTokenType::Variable, SemanticTokenType::Variable);
+        assert_eq!(SemanticTokenType::Function, SemanticTokenType::Function);
+        assert_eq!(SemanticTokenType::Comment, SemanticTokenType::Comment);
+    }
+
+    #[test]
+    fn token_type_inequality_different_variants() {
+        assert_ne!(SemanticTokenType::Variable, SemanticTokenType::Function);
+        assert_ne!(SemanticTokenType::String, SemanticTokenType::Number);
+        assert_ne!(SemanticTokenType::Keyword, SemanticTokenType::Operator);
+    }
+
+    #[test]
+    fn token_type_is_copy() {
+        let t = SemanticTokenType::Class;
+        let t2 = t; // Copy — no move
+        assert_eq!(t, t2);
+    }
+
+    #[test]
+    fn token_type_debug_contains_variant_name() {
+        let formatted = format!("{:?}", SemanticTokenType::FunctionDeclaration);
+        assert!(formatted.contains("FunctionDeclaration"), "got: {formatted}");
+
+        let formatted2 = format!("{:?}", SemanticTokenType::CommentDoc);
+        assert!(formatted2.contains("CommentDoc"), "got: {formatted2}");
+    }
+
+    // ── SemanticTokenModifier ─────────────────────────────────────────────────
+
+    #[test]
+    fn token_modifier_equality_same_variant() {
+        assert_eq!(SemanticTokenModifier::Declaration, SemanticTokenModifier::Declaration);
+        assert_eq!(SemanticTokenModifier::Readonly, SemanticTokenModifier::Readonly);
+        assert_eq!(SemanticTokenModifier::Deprecated, SemanticTokenModifier::Deprecated);
+    }
+
+    #[test]
+    fn token_modifier_inequality_different_variants() {
+        assert_ne!(SemanticTokenModifier::Declaration, SemanticTokenModifier::Definition);
+        assert_ne!(SemanticTokenModifier::Static, SemanticTokenModifier::Async);
+        assert_ne!(SemanticTokenModifier::Documentation, SemanticTokenModifier::DefaultLibrary);
+    }
+
+    #[test]
+    fn token_modifier_is_copy() {
+        let m = SemanticTokenModifier::Modification;
+        let m2 = m; // Copy — no move
+        assert_eq!(m, m2);
+    }
+
+    #[test]
+    fn token_modifier_debug_contains_variant_name() {
+        let formatted = format!("{:?}", SemanticTokenModifier::DefaultLibrary);
+        assert!(formatted.contains("DefaultLibrary"), "got: {formatted}");
+
+        let formatted2 = format!("{:?}", SemanticTokenModifier::Abstract);
+        assert!(formatted2.contains("Abstract"), "got: {formatted2}");
+    }
+
+    // ── SemanticToken ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn semantic_token_construction_round_trips_fields() {
+        let location = SourceLocation { start: 10, end: 20 };
+        let tok = SemanticToken {
+            location,
+            token_type: SemanticTokenType::Variable,
+            modifiers: vec![SemanticTokenModifier::Declaration],
+        };
+        assert_eq!(tok.location.start, 10);
+        assert_eq!(tok.location.end, 20);
+        assert_eq!(tok.token_type, SemanticTokenType::Variable);
+        assert_eq!(tok.modifiers.len(), 1);
+        assert_eq!(tok.modifiers[0], SemanticTokenModifier::Declaration);
+    }
+
+    #[test]
+    fn semantic_token_no_modifiers() {
+        let tok = SemanticToken {
+            location: SourceLocation { start: 0, end: 5 },
+            token_type: SemanticTokenType::Keyword,
+            modifiers: Vec::new(),
+        };
+        assert!(tok.modifiers.is_empty());
+    }
+
+    #[test]
+    fn semantic_token_clone_is_independent() {
+        let original = SemanticToken {
+            location: SourceLocation { start: 1, end: 3 },
+            token_type: SemanticTokenType::Number,
+            modifiers: vec![SemanticTokenModifier::Readonly],
+        };
+        let mut cloned = original.clone();
+        cloned.modifiers.push(SemanticTokenModifier::Static);
+        // Original must not be affected by mutation of the clone
+        assert_eq!(original.modifiers.len(), 1);
+        assert_eq!(cloned.modifiers.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds tests for `analysis/semantic/model.rs`, `tokens.rs`, and `references.rs` (each previously had 0 tests)
- Test-only PR — no production code changes
- Covers:
  - `SemanticTokenType` and `SemanticTokenModifier` enum equality, copy semantics, and `Debug` formatting
  - `SemanticToken` struct construction, field round-trips, and `Clone` independence
  - `SemanticModel` facade: `tokens()`, `symbol_table()`, `definition_at()`, `export_metadata()`, `package_edges()`, `generated_members()`, `parent_chain()`, and `hover_info_at()`
  - `SemanticAnalyzer::find_all_references` for out-of-bounds positions, include/exclude declaration semantics, multi-site usage, and package-scope visibility

## Test plan
- [x] `cargo test -p perl-semantic-analyzer --lib` — all green (273 passed, 0 failed)
- [x] `cargo clippy -p perl-semantic-analyzer --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p perl-semantic-analyzer` — clean
- [x] No production code modified
- [x] No `unwrap()`/`expect()`/`panic!()`/`dbg!()` in new tests
