### PR TITLE
fix(parser): treat word operators as zero-arg terminators for builtin calls

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -91,7 +91,13 @@ impl<'a> Parser<'a> {
                 | TokenKind::RightBrace
                 | TokenKind::RightParen
                 | TokenKind::Comma
-                | TokenKind::Eof => return false,
+                | TokenKind::Eof
+                // Word operators terminate a zero-arg list; they never begin an indirect object.
+                // e.g. `print or die "msg"` → `(print) or (die "msg")`
+                | TokenKind::WordOr
+                | TokenKind::WordAnd
+                | TokenKind::WordXor
+                | TokenKind::WordNot => return false,
                 _ => {}
             }
 

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -847,7 +847,14 @@ impl<'a> Parser<'a> {
                         | Some(TokenKind::Foreach)
                         | Some(TokenKind::RightBrace)
                         | Some(TokenKind::Eof)
-                        | None => {
+                        | None
+                        // Word operators bind less tightly than any list operator, so they
+                        // terminate a zero-argument builtin call rather than starting its args.
+                        // e.g. `print or die "msg"` → `(print) or (die "msg")`
+                        | Some(TokenKind::WordOr)
+                        | Some(TokenKind::WordAnd)
+                        | Some(TokenKind::WordXor)
+                        | Some(TokenKind::WordNot) => {
                             // No arguments - return as function call with empty args
                             let end = self.previous_position();
                             Ok(Node::new(

--- a/crates/perl-parser-core/tests/fix_print_word_op_or.rs
+++ b/crates/perl-parser-core/tests/fix_print_word_op_or.rs
@@ -1,0 +1,51 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_print_or_die_in_while() {
+    // Pod::Perldoc.pm pattern: print with no args (prints $_) followed by word-or
+    assert_clean_parse(
+        r#"
+while (<$fh>) {
+    print or die "Can't print: $!";
+}
+"#,
+    );
+}
+
+#[test]
+fn test_close_fh_or_die() {
+    // Pod::Perldoc.pm pattern: close with filehandle arg followed by word-or
+    assert_clean_parse(r#"close $fh or die "Can't close: $!";"#);
+}
+
+#[test]
+fn test_print_or_die_bare() {
+    // Minimal regression for word-or after zero-arg builtin
+    assert_clean_parse(r#"print or die "error";"#);
+}
+
+#[test]
+fn test_say_or_die() {
+    assert_clean_parse(r#"say or die "error";"#);
+}
+
+#[test]
+fn test_print_and_next() {
+    // word-and variant
+    assert_clean_parse(r#"print and next;"#);
+}
+
+#[test]
+fn test_write_or_die() {
+    assert_clean_parse(r#"write or die "Can't write";"#);
+}
+
+#[test]
+fn test_print_with_args_still_works() {
+    // Regression: print with actual args should not be broken
+    assert_clean_parse(r#"print "hello\n";"#);
+    assert_clean_parse(r#"print $fh "hello\n";"#);
+    assert_clean_parse(r#"print $_ or die "error";"#);
+    assert_clean_parse(r#"print STDOUT "hello\n";"#);
+}


### PR DESCRIPTION
## Summary

Fixes the `unexpected_word_op_or` parser-corpus failure bucket. The pattern `print or die "msg"` — a zero-argument builtin call immediately followed by a low-precedence word operator — was producing:

```
ERROR "expected expression, found 'or' at position 6"
```

Because the parser treated the word operator as the start of an argument list rather than a binary operator terminating the call. This affected **Pod::Perldoc.pm** and 3 other files in the Ubuntu system-Perl corpus (4 total in the `unexpected_word_op_or` bucket).

## Root Cause

In `parse_simple_statement`, after consuming a builtin function name, the parser checks the next token to decide "does this call have arguments?" The check was:

```rust
match self.peek_kind() {
    Some(Semicolon) | Some(If) | ... | None => { /* zero-arg call */ }
    _                                        => { /* parse arguments */ }
}
```

`WordOr` (`or`), `WordAnd`, `WordXor`, `WordNot` were not in the "no arguments" arm, so `print or die "msg"` tried to parse `or die "msg"` as arguments — and `or` cannot start an expression.

A parallel gap existed in `is_indirect_call_pattern` in `calls.rs`: the early-return guard for tokens that cannot begin an indirect object didn't include word operators, so `print or …` fell through the full heuristic unnecessarily.

## Fix

Two-site change:

**`statements.rs`** — add the four word-operator kinds to the zero-arg terminator arm:
```rust
| Some(TokenKind::WordOr)
| Some(TokenKind::WordAnd)
| Some(TokenKind::WordXor)
| Some(TokenKind::WordNot) => {
    // No arguments - return as function call with empty args
```

**`calls.rs`** (`is_indirect_call_pattern`) — add the same four kinds to the "cannot start an indirect object" early-return guard:
```rust
| TokenKind::WordOr
| TokenKind::WordAnd
| TokenKind::WordXor
| TokenKind::WordNot => return false,
```

Word operators have the lowest precedence of all Perl operators (lower than the comma operator), so `print or die` always means `(print) or (die)`, never `print(or die)`.

## Patterns fixed

```perl
# print with no args (implicitly prints $_) + word-or error handler
while (<$fh>) {
    print or $self->die("Can't print to stdout: $!");
}

# close + word-or error handler  
close $fh or $self->die("Can't close $output: $!");

# Any zero-arg builtin + word operator
say or die "error";
write or die "Can't write";
flush or warn "flush failed";
```

## Tests

New file `crates/perl-parser-core/tests/fix_print_word_op_or.rs` covers:
- `print or die` bare
- `print or die` inside a `while (<$fh>)` loop (the actual Pod::Perldoc.pm context)
- `say or die`, `write or die` (other zero-arg builtins)
- `print and next` (word-and variant)
- Regression: `print "hello\n"`, `print $fh "hello\n"`, `print $_ or die` — all still work

## Verification

```
cargo fmt --all          ✓
cargo clippy -p perl-parser-core --tests  ✓
cargo test -p perl-parser-core            ✓ (only pre-existing parser_ac3 failure unrelated to this change)
Pod::Perldoc.pm (2140 lines)              ✓ parses cleanly
```

## Corpus impact

Clears all 4 files in the `unexpected_word_op_or` failure bucket from `.ci/parser-corpus-baseline.json`. These 4 files were all caused by the same pattern in Pod::Perldoc.pm (`print or $self->die(...)` and `close $fh or $self->die(...)`).

https://claude.ai/code/session_01HAow3XLoujT6o5hA17NeYA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAow3XLoujT6o5hA17NeYA)_