### PR TITLE
fix(version-sync): track flake.nix version in collect_doc_sites (#4357)

### DIFF
--- a/crates/perl-ci-hygiene/src/version_sync/mod.rs
+++ b/crates/perl-ci-hygiene/src/version_sync/mod.rs
@@ -478,6 +478,10 @@ static ROADMAP_WORKSPACE_RE: LazyLock<Regex> =
 static ROADMAP_PUBLISHED_RE: LazyLock<Regex> = LazyLock::new(|| {
     compile_regex(&format!(r"Latest published release:\s*`v({VERSION_FRAGMENT})`"))
 });
+/// Matches Nix `version = "X.Y.Z";` lines. The trailing semicolon is Nix-syntax-specific
+/// and distinguishes this pattern from TOML `version = "X.Y.Z"` lines.
+static FLAKE_NIX_VERSION_RE: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(&format!(r#"^\s*version\s*=\s*"({VERSION_FRAGMENT})"\s*;"#)));
 
 fn compile_regex(pattern: &str) -> Regex {
     match Regex::new(pattern) {
@@ -773,6 +777,17 @@ fn collect_doc_sites(repo_root: &Path, sites: &mut Vec<VersionSite>) -> Result<(
         "docs/project/ROADMAP.md",
         "ROADMAP latest published release",
         &ROADMAP_PUBLISHED_RE,
+        sites,
+    )?;
+
+    // flake.nix: `version = "X.Y.Z";` in the perl-lsp package derivation.
+    // Nix syntax uses a trailing semicolon, so FLAKE_NIX_VERSION_RE is used
+    // instead of the TOML-oriented BARE_VERSION_RE. See issue #4357.
+    collect_single_line_doc_site(
+        repo_root,
+        "flake.nix",
+        "flake.nix perl-lsp package version",
+        &FLAKE_NIX_VERSION_RE,
         sites,
     )?;
 
@@ -1234,5 +1249,92 @@ perl-token = { path = "../perl-token", version = "0.42.0" }
         assert!((2025..=2100).contains(&year), "year {year} out of expected range");
         assert!((1..=12).contains(&month), "month {month} invalid");
         assert!((1..=31).contains(&day), "day {day} invalid");
+    }
+
+    // -----------------------------------------------------------------------
+    // flake.nix version collector tests (issue #4357)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn flake_nix_re_matches_nix_version_line() {
+        // Exact format from flake.nix: leading spaces, Nix assignment, trailing semicolon.
+        let line = r#"            version = "0.14.0";  # Synced manually"#;
+        let caps = FLAKE_NIX_VERSION_RE.captures(line);
+        assert!(caps.is_some(), "FLAKE_NIX_VERSION_RE must match Nix version lines");
+        assert_eq!(&caps.unwrap()[1], "0.14.0");
+    }
+
+    #[test]
+    fn flake_nix_re_matches_pre_release_version() {
+        let line = r#"            version = "0.14.0-rc1";"#;
+        let caps = FLAKE_NIX_VERSION_RE.captures(line);
+        assert!(caps.is_some(), "FLAKE_NIX_VERSION_RE must match pre-release Nix version lines");
+        assert_eq!(&caps.unwrap()[1], "0.14.0-rc1");
+    }
+
+    #[test]
+    fn flake_nix_re_does_not_match_toml_version_line() {
+        // TOML lines do not have a trailing semicolon — must not be captured by
+        // FLAKE_NIX_VERSION_RE (BARE_VERSION_RE handles those).
+        let line = r#"version = "0.14.0""#;
+        assert!(
+            FLAKE_NIX_VERSION_RE.captures(line).is_none(),
+            "FLAKE_NIX_VERSION_RE must not match TOML-style version lines (no semicolon)"
+        );
+    }
+
+    #[test]
+    fn collect_doc_sites_discovers_flake_nix_version() -> Result<()> {
+        let repo_root = unique_temp_repo_dir("flake-nix-collect")?;
+
+        // Minimal flake.nix with the perl-lsp package version line.
+        let flake_content = r#"
+{
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
+    packages.${system}.perl-lsp = pkgs.rustPlatform.buildRustPackage {
+      pname = "perl-lsp";
+      version = "0.42.7";
+    };
+  };
+}
+"#;
+        fs::write(repo_root.join("flake.nix"), flake_content)
+            .map_err(|e| eyre!("writing flake.nix: {e}"))?;
+
+        let mut sites = Vec::new();
+        collect_doc_sites(&repo_root, &mut sites)?;
+
+        let flake_site = sites
+            .iter()
+            .find(|s| s.description.contains("flake.nix"))
+            .ok_or_else(|| eyre!("flake.nix version site should be collected"))?;
+
+        assert_eq!(flake_site.found, "0.42.7", "collector should capture the flake.nix version");
+        assert!(
+            !flake_site.channel_split,
+            "flake.nix version must not be channel-split (it must match workspace version exactly)"
+        );
+
+        fs::remove_dir_all(&repo_root).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn collect_doc_sites_skips_missing_flake_nix() -> Result<()> {
+        let repo_root = unique_temp_repo_dir("flake-nix-missing")?;
+        // Do not create flake.nix — collector must silently skip.
+        let mut sites = Vec::new();
+        collect_doc_sites(&repo_root, &mut sites)?;
+
+        assert!(
+            !sites.iter().any(|s| s.description.contains("flake.nix")),
+            "missing flake.nix must be silently skipped (some forks may not use Nix)"
+        );
+
+        fs::remove_dir_all(&repo_root).ok();
+        Ok(())
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -204,7 +204,7 @@
 
           perl-lsp = pkgs.rustPlatform.buildRustPackage {
             pname = "perl-lsp";
-            version = "0.12.4";  # Synced manually — see issue #4357 for structural fix
+            version = "0.14.0";
             src = self;
             cargoLock.lockFile = ./Cargo.lock;
 


### PR DESCRIPTION
## Summary

Closes EffortlessMetrics/perl-lsp-swarm#2956.

`flake.nix` drifted to `0.12.4` while the workspace is at `0.14.0` — a 2-minor-version gap — because `collect_doc_sites()` in `perl-ci-hygiene` never included `flake.nix` in its version-sync sweep. The file even had a `# Synced manually — see issue EffortlessMetrics/perl-lsp-swarm#2956 for structural fix` comment calling out the gap. This PR fixes the root cause and closes the issue.

## What changed

### `crates/perl-ci-hygiene/src/version_sync/mod.rs`

**New regex — `FLAKE_NIX_VERSION_RE`**

```rust
static FLAKE_NIX_VERSION_RE: LazyLock<Regex> =
    LazyLock::new(|| compile_regex(&format!(r#"^\s*version\s*=\s*"({VERSION_FRAGMENT})"\s*;"#)));
```

Nix assignment syntax uses a trailing semicolon (`version = "X.Y.Z";`) unlike TOML (`version = "X.Y.Z"`). A flake-specific regex avoids colliding with `BARE_VERSION_RE` which handles TOML-style lines throughout the workspace.

**New collector call in `collect_doc_sites()`**

```rust
collect_single_line_doc_site(
    repo_root,
    "flake.nix",
    "flake.nix perl-lsp package version",
    &FLAKE_NIX_VERSION_RE,
    sites,
)?;
```

Both `check` (CI gate) and `bump` (version bump xtask) walk the exact same site list, so `flake.nix` is now automatically updated by `cargo xtask bump-version` and caught by `cargo xtask check-version-sync` on every PR.

The site is **not** marked `channel_split` — it must match the workspace version exactly (unlike the VS Code Marketplace extension which intentionally lags during pre-release cycles).

If `flake.nix` does not exist (forks without Nix support), the call is silently skipped, matching the behaviour of other optional doc sites.

### `flake.nix` — line 207

Updated from the drifted `0.12.4` to the current workspace version `0.14.0`. The `# Synced manually…` comment is removed since the structural fix is now in place.

## Tests added (5)

| Test | What it proves |
|------|---------------|
| `flake_nix_re_matches_nix_version_line` | Regex captures the exact line format from `flake.nix` (leading spaces, semicolon, inline comment) |
| `flake_nix_re_matches_pre_release_version` | Regex handles pre-release versions (`0.14.0-rc1`) |
| `flake_nix_re_does_not_match_toml_version_line` | TOML lines without a trailing semicolon are **not** captured — no cross-format collision |
| `collect_doc_sites_discovers_flake_nix_version` | Integration: minimal `flake.nix` fixture → site collected with correct version and `channel_split = false` |
| `collect_doc_sites_skips_missing_flake_nix` | Integration: missing file → silently skipped, no site emitted |

All 63 pre-existing `perl-ci-hygiene` tests still pass. No clippy warnings. No format drift.

## Verification

```bash
cargo test -p perl-ci-hygiene flake_nix          # 5 new tests pass
cargo test -p perl-ci-hygiene                    # all 63 tests pass
cargo clippy -p perl-ci-hygiene                  # clean
cargo fmt --check -p perl-ci-hygiene             # clean
```

## Why this matters

The version-sync gate is load-bearing: it fails CI on every PR that ships with a drifted version reference. `flake.nix` was the only tracked distribution artifact excluded from that gate, creating a recurring manual-sync burden and the risk of shipping a Nix package at the wrong version tag.

With this change, `cargo xtask bump-version X.Y.Z` atomically updates `flake.nix` alongside `CLAUDE.md`, `README.md`, `ROADMAP.md`, `features.toml`, and every `Cargo.toml`, and the CI gate will catch any future drift immediately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnpCB6hDkJ5hvCCLFGaJnD)_