### PR TITLE
test(refactoring): cover edit plan validation edges (#0000)

### DIFF
--- a/crates/perl-refactoring/src/refactor/refactor_validation.rs
+++ b/crates/perl-refactoring/src/refactor/refactor_validation.rs
@@ -87,4 +87,60 @@ mod tests {
         assert_eq!(validate_plan(&plan).len(), 1);
         Ok(())
     }
+
+    #[test]
+    fn validate_plan_accepts_empty_edit_batches() -> Result<(), Box<dyn std::error::Error>> {
+        let plan = RefactorPlan {
+            operation: RefactorOperationKind::OptimizeImports,
+            edits: vec![FileEdit { file_path: PathBuf::from("empty.pm"), edits: vec![] }],
+            diagnostics: vec![],
+            confidence: RefactorConfidence::Exact,
+            safety: RefactorSafety::Safe,
+            stats: RefactorStats { files_changed: 0, edits_count: 0 },
+        };
+        assert!(validate_plan(&plan).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_plan_rejects_reversed_edit_ranges() -> Result<(), Box<dyn std::error::Error>> {
+        let plan = RefactorPlan {
+            operation: RefactorOperationKind::OptimizeImports,
+            edits: vec![FileEdit {
+                file_path: PathBuf::from("reversed.pm"),
+                edits: vec![TextEdit { start: 4, end: 2, new_text: "x".to_string() }],
+            }],
+            diagnostics: vec![],
+            confidence: RefactorConfidence::Exact,
+            safety: RefactorSafety::Safe,
+            stats: RefactorStats { files_changed: 1, edits_count: 1 },
+        };
+        let diagnostics = validate_plan(&plan);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "edit_overlap_or_order");
+        assert!(diagnostics[0].message.contains("reversed.pm"));
+        Ok(())
+    }
+
+    #[test]
+    fn validate_plan_accepts_adjacent_zero_length_edits() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let plan = RefactorPlan {
+            operation: RefactorOperationKind::OptimizeImports,
+            edits: vec![FileEdit {
+                file_path: PathBuf::from("zero-length.pm"),
+                edits: vec![
+                    TextEdit { start: 0, end: 0, new_text: "use strict;\n".to_string() },
+                    TextEdit { start: 0, end: 0, new_text: "use warnings;\n".to_string() },
+                    TextEdit { start: 3, end: 3, new_text: "# marker".to_string() },
+                ],
+            }],
+            diagnostics: vec![],
+            confidence: RefactorConfidence::Exact,
+            safety: RefactorSafety::Safe,
+            stats: RefactorStats { files_changed: 1, edits_count: 3 },
+        };
+        assert!(validate_plan(&plan).is_empty());
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Motivation

- Increase unit test coverage for refactor plan validation to exercise edge cases around empty edit batches, reversed ranges, and adjacent zero-length edits.

### Description

- Added focused unit tests in `crates/perl-refactoring/src/refactor/refactor_validation.rs` to assert that empty edit batches are ignored by `validate_plan` and produce no diagnostics.
- Added a test asserting that reversed edit ranges (`start > end`) produce an `edit_overlap_or_order` diagnostic and that the diagnostic message includes the file path.
- Added a test verifying adjacent zero-length edits (insertion-only edits at the same boundary) are considered valid and do not produce diagnostics.

### Testing

- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-refactoring --profile agent --locked` and the `perl-refactoring` test suite passed (all added tests succeeded).
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check --all-targets -p perl-refactoring --profile agent --locked` and it passed.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-refactoring --profile agent --locked -- -D warnings -A missing_docs` and it passed.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo xtask fmt` and `./scripts/storage-doctor` and both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c92bb4288333ba0d65907c8a88c6)