### PR TITLE
test(perl-parser-bench): cover directory and error paths (#0000)

### DIFF
--- a/crates/perl-parser-bench/tests/smoke.rs
+++ b/crates/perl-parser-bench/tests/smoke.rs
@@ -3,11 +3,24 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-fn write_temp_perl_file() -> Result<PathBuf, Box<dyn std::error::Error>> {
+fn temp_path(kind: &str, extension: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let mut path = std::env::temp_dir();
     let unique = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
-    path.push(format!("perl-parser-bench-smoke-{}-{unique}.pl", std::process::id()));
+    path.push(format!("perl-parser-bench-{kind}-{}-{unique}.{extension}", std::process::id()));
+    Ok(path)
+}
+
+fn write_temp_perl_file() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path = temp_path("smoke", "pl")?;
     fs::write(&path, "use strict;\nprint \"hello\\n\";\n")?;
+    Ok(path)
+}
+
+fn create_temp_perl_dir() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path = temp_path("dir", "d")?;
+    fs::create_dir(&path)?;
+    fs::write(path.join("one.pl"), "use strict;\nmy $x = 1;\n")?;
+    fs::write(path.join("two.pm"), "package Two;\nsub value { 2 }\n1;\n")?;
     Ok(path)
 }
 
@@ -23,5 +36,47 @@ fn file_smoke_reports_success() -> Result<(), Box<dyn std::error::Error>> {
     let stdout = String::from_utf8(output.stdout)?;
     assert!(stdout.contains("status=success"), "expected the success status line");
     assert!(stdout.contains("error=false"), "expected a non-error parse result");
+    Ok(())
+}
+
+#[test]
+fn directory_smoke_reports_aggregate_success() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = create_temp_perl_dir()?;
+    let output = Command::new(env!("CARGO_BIN_EXE_perl-parser-bench")).arg(&dir).output()?;
+
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(output.status.success(), "benchmark binary should succeed on a directory");
+
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("total_files=2"), "expected both files to be counted: {stdout}");
+    assert!(stdout.contains("error_files=0"), "expected valid files to parse cleanly: {stdout}");
+    assert!(
+        stdout.contains("success_rate=100.0"),
+        "expected all valid files to count as successful: {stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn missing_path_reports_error_status() -> Result<(), Box<dyn std::error::Error>> {
+    let missing = temp_path("missing", "pl")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_perl-parser-bench")).arg(&missing).output()?;
+
+    assert!(!output.status.success(), "missing path should fail");
+
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("Path does not exist"), "expected missing-path diagnostic: {stderr}");
+    Ok(())
+}
+
+#[test]
+fn missing_argument_reports_usage_error() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new(env!("CARGO_BIN_EXE_perl-parser-bench")).output()?;
+
+    assert!(!output.status.success(), "missing argument should fail");
+
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("Usage: perl-parser-bench"), "expected usage diagnostic: {stderr}");
     Ok(())
 }


### PR DESCRIPTION
### Motivation

- Problem: the `perl-parser-bench` smoke test only exercised a successful single-file run and did not cover directory aggregation or CLI error modes.
- Goal: increase coverage for directory traversal, missing-path failures, and missing-argument usage diagnostics to catch regressions in CLI behavior.

### Description

- Add a reusable `temp_path` helper and `create_temp_perl_dir` to produce isolated temp files and directories for tests.
- Add tests that assert directory aggregation output contains `total_files=2`, `error_files=0`, and `success_rate=100.0` for a valid directory.
- Add tests that assert a missing path produces a failing exit and the message `Path does not exist`, and that running with no arguments emits the `Usage: perl-parser-bench` diagnostic.
- Changes are limited to `crates/perl-parser-bench/tests/smoke.rs` and add no production code.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-parser-bench --profile agent --locked` and all new and existing tests passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-parser-bench --profile agent --locked`, `MIN_FREE_GB=20 ./scripts/cargo-safe xtask fmt`, and `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-parser-bench --profile agent --locked -- -D warnings -A missing_docs`, which all completed successfully.
- `just agent-pr-fast` could not be run in the container because `just` is not installed, noted as an environmental limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c92bb4288333ba0d65907c8a88c6)