### PR TITLE
test(debounce): cover timeout helper branches (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/diagnostic_debounce.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostic_debounce.rs
@@ -153,6 +153,38 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
+    fn earliest_timeout_reports_none_for_empty_pending_set() {
+        let pending = HashMap::new();
+
+        assert!(earliest_timeout(&pending).is_none());
+    }
+
+    #[test]
+    fn earliest_timeout_saturates_when_deadline_already_passed() {
+        let mut pending = HashMap::new();
+        pending.insert("file:///expired.pl".to_string(), Instant::now() - Duration::from_millis(5));
+
+        assert_eq!(earliest_timeout(&pending), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn fire_expired_publishes_only_ready_uris_and_keeps_pending_count() {
+        let pending_count = AtomicUsize::new(0);
+        let published = Mutex::new(Vec::<String>::new());
+        let mut pending = HashMap::new();
+        pending.insert("file:///ready.pl".to_string(), Instant::now() - Duration::from_millis(1));
+        pending.insert("file:///later.pl".to_string(), Instant::now() + Duration::from_secs(30));
+        pending_count.store(pending.len(), Ordering::SeqCst);
+
+        fire_expired(&mut pending, &|uri| published.lock().push(uri.to_string()), &pending_count);
+
+        assert_eq!(published.lock().as_slice(), ["file:///ready.pl"]);
+        assert!(!pending.contains_key("file:///ready.pl"));
+        assert!(pending.contains_key("file:///later.pl"));
+        assert_eq!(pending_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
     fn debouncer_fires_after_interval() {
         let count = Arc::new(AtomicUsize::new(0));
         let last_uri = Arc::new(Mutex::new(String::new()));

--- a/crates/perl-lsp-rs/src/runtime/file_watcher_debounce.rs
+++ b/crates/perl-lsp-rs/src/runtime/file_watcher_debounce.rs
@@ -177,6 +177,50 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
+    fn earliest_timeout_reports_none_for_empty_pending_set() {
+        let pending = HashMap::new();
+
+        assert!(earliest_timeout(&pending).is_none());
+    }
+
+    #[test]
+    fn earliest_timeout_saturates_when_deadline_already_passed() {
+        let mut pending = HashMap::new();
+        pending.insert("file:///expired.pl".to_string(), Instant::now() - Duration::from_millis(5));
+
+        assert_eq!(earliest_timeout(&pending), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn fire_expired_batches_only_ready_uris_and_keeps_pending_count() {
+        let pending_count = AtomicUsize::new(0);
+        let batches = Mutex::new(Vec::<Vec<String>>::new());
+        let mut pending = HashMap::new();
+        pending.insert("file:///ready-a.pl".to_string(), Instant::now() - Duration::from_millis(2));
+        pending.insert("file:///ready-b.pl".to_string(), Instant::now() - Duration::from_millis(1));
+        pending.insert("file:///later.pl".to_string(), Instant::now() + Duration::from_secs(30));
+        pending_count.store(pending.len(), Ordering::SeqCst);
+
+        fire_expired(
+            &mut pending,
+            &|mut uris| {
+                uris.sort();
+                batches.lock().push(uris);
+            },
+            &pending_count,
+        );
+
+        assert_eq!(
+            batches.lock().as_slice(),
+            [vec!["file:///ready-a.pl".to_string(), "file:///ready-b.pl".to_string()]]
+        );
+        assert!(!pending.contains_key("file:///ready-a.pl"));
+        assert!(!pending.contains_key("file:///ready-b.pl"));
+        assert!(pending.contains_key("file:///later.pl"));
+        assert_eq!(pending_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
     fn file_watcher_debouncer_fires_after_interval() {
         let count = Arc::new(AtomicUsize::new(0));
         let received = Arc::new(Mutex::new(Vec::<String>::new()));


### PR DESCRIPTION
### Motivation
- The debounce helpers (`earliest_timeout` and `fire_expired`) were only exercised indirectly via threaded integration tests, leaving edge branches untested.
- Add small deterministic unit tests to ensure correct behavior for empty pending sets, already-expired deadlines, and selective flushing semantics.

### Description
- Added unit tests to `crates/perl-lsp-rs/src/runtime/diagnostic_debounce.rs` covering `earliest_timeout` for empty and expired entries and `fire_expired` publishing only ready URIs while preserving `pending_count`.
- Added matching unit tests to `crates/perl-lsp-rs/src/runtime/file_watcher_debounce.rs` covering `earliest_timeout` and a batched `fire_expired` scenario that verifies removed/retained entries and `pending_count` bookkeeping.
- No behavioral code changes were made; only test coverage was expanded to exercise previously untested branches.

### Testing
- Ran `MIN_FREE_GB=1 ./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked debounce` and the debounce-related test suites passed (unit and async debounce tests reported passing).
- Ran `MIN_FREE_GB=1 MAX_USED_PCT=99 ./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` and it completed successfully.
- Ran `./scripts/cargo-safe xtask fmt` to verify formatting and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d14bc38483338443a8c1de3323d6)