### PR TITLE
feat(non-rust): surface rust migration candidates (#0000)

### DIFF
--- a/xtask/src/tasks/file_policy.rs
+++ b/xtask/src/tasks/file_policy.rs
@@ -1155,6 +1155,48 @@ pub fn non_rust_propose(root: &Path, config: ProposeConfig) -> Result<()> {
     Ok(())
 }
 
+fn automation_script_extension(ext: &str) -> bool {
+    matches!(
+        ext,
+        "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" | "cmd" | "py" | "rb" | "js" | "ts"
+    )
+}
+
+fn automation_path(path: &str) -> bool {
+    let first = path.split('/').next().unwrap_or(path);
+    matches!(first, "scripts" | "bin" | "tools" | "ci" | ".ci" | ".github")
+}
+
+fn extension_for_path(path: &str) -> &str {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    basename
+        .rsplit_once('.')
+        .filter(|(stem, ext)| !stem.is_empty() && !ext.is_empty())
+        .map(|(_, ext)| ext)
+        .unwrap_or("")
+}
+
+fn rust_migration_recommendation(path: &str) -> Option<&'static str> {
+    let ext = extension_for_path(path);
+    if automation_path(path) && automation_script_extension(ext) {
+        return Some("port repo automation into `cargo xtask` Rust tasks");
+    }
+
+    if path == "install.sh" || path == "install.ps1" {
+        return Some("move installer validation and shared logic into Rust install-surface checks");
+    }
+
+    if path.starts_with("tree-sitter-perl/") && automation_script_extension(ext) {
+        return Some("move tree-sitter maintenance automation into xtask native tooling");
+    }
+
+    None
+}
+
+fn group_migration_recommendation(files: &[String]) -> Option<&'static str> {
+    files.iter().find_map(|file| rust_migration_recommendation(file))
+}
+
 /// Group files by their top-level directory component.
 fn group_by_directory(files: &[String]) -> BTreeMap<String, Vec<String>> {
     let mut groups: BTreeMap<String, Vec<String>> = BTreeMap::new();
@@ -1302,6 +1344,29 @@ fn render_proposal_markdown(
     }
     out.push('\n');
 
+    let migration_candidates: Vec<(&String, &Vec<String>, &'static str)> = groups
+        .iter()
+        .filter_map(|(group_key, files)| {
+            group_migration_recommendation(files)
+                .map(|recommendation| (group_key, files, recommendation))
+        })
+        .collect();
+
+    out.push_str("## Rust migration candidates\n\n");
+    if migration_candidates.is_empty() {
+        out.push_str("No unclassified repo-automation scripts were detected in this proposal.\n\n");
+    } else {
+        out.push_str(
+            "These groups contain non-Rust automation that should be reviewed for conversion \
+             into the core Rust/xtask design before broad allowlist promotion.\n\n",
+        );
+        out.push_str("| Group | Files | Recommended destination |\n|---|---:|---|\n");
+        for (group_key, files, recommendation) in &migration_candidates {
+            out.push_str(&format!("| `{group_key}` | {} | {recommendation} |\n", files.len()));
+        }
+        out.push('\n');
+    }
+
     out.push_str(&format!("## Groups by {group_label}\n\n"));
     for (group_key, files) in groups {
         let entry_id = entries
@@ -1316,6 +1381,9 @@ fn render_proposal_markdown(
         out.push_str(&format!("- Proposed entry: `{entry_id}`\n"));
         out.push_str("- `owner`: TBD — must be set before promotion\n");
         out.push_str("- `surface`: unclassified — must be refined\n");
+        if let Some(recommendation) = group_migration_recommendation(files) {
+            out.push_str(&format!("- Rust migration review: {recommendation}\n"));
+        }
         // Show first 10 files as examples.
         if !files.is_empty() {
             out.push_str("- Sample files:\n");

--- a/xtask/tests/non_rust_propose.rs
+++ b/xtask/tests/non_rust_propose.rs
@@ -337,6 +337,41 @@ fn propose_emits_human_markdown() -> Result<()> {
     Ok(())
 }
 
+/// `propose` highlights automation groups that should move into Rust/xtask
+/// instead of being blindly accepted as long-lived non-Rust surfaces.
+#[test]
+fn propose_highlights_rust_migration_candidates() -> Result<()> {
+    let files: Vec<(&str, &str)> = vec![
+        ("scripts/build.sh", "#!/bin/bash"),
+        ("scripts/release.py", "print('release')"),
+        ("docs/guide.md", "# guide"),
+    ];
+    let (_tmp, root) = setup_repo(&files)?;
+
+    let output = run_propose(&root, &[])?;
+    assert!(
+        output.status.success(),
+        "propose must exit 0; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let md_content = fs::read_to_string(root.join("target/policy/non-rust-proposal.md"))?;
+    assert!(
+        md_content.contains("## Rust migration candidates"),
+        "markdown must include a Rust migration candidate section"
+    );
+    assert!(
+        md_content.contains("`scripts`"),
+        "scripts group must be identified as a migration candidate: {md_content}"
+    );
+    assert!(
+        md_content.contains("port repo automation into `cargo xtask` Rust tasks"),
+        "automation scripts must recommend the xtask core design: {md_content}"
+    );
+
+    Ok(())
+}
+
 /// After `propose`, running advisory check against the proposed allowlist should
 /// exit 0 — the proposed allowlist actually covers the files it claims to.
 #[test]


### PR DESCRIPTION
### Motivation

- The `cargo xtask non-rust propose` flow grouped unclassified files for allowlist review but did not call out non-Rust automation that should be moved into the Rust/xtask core design. 
- Surfacing such candidates in the generated proposal helps reviewers avoid promoting long-lived automation scripts into the non-Rust allowlist and encourages consolidation into the repo-native Rust tooling.

### Description

- Add migration heuristics and helpers: `automation_script_extension`, `automation_path`, `extension_for_path`, `rust_migration_recommendation`, and `group_migration_recommendation` in `xtask/src/tasks/file_policy.rs`. 
- Extend the generated proposal markdown in `render_proposal_markdown` to include a new `## Rust migration candidates` section and to annotate per-group entries with `Rust migration review` notes when applicable. 
- Add an integration test `propose_highlights_rust_migration_candidates` in `xtask/tests/non_rust_propose.rs` that verifies script groups (e.g., `scripts/`) are surfaced with the recommended migration guidance.

### Testing

- Ran formatting: `./scripts/cargo-safe xtask fmt` — passed. 
- Ran the focused integration tests: `MIN_FREE_GB=20 ./scripts/cargo-safe test -p xtask --test non_rust_propose --profile agent --locked` — all tests passed (8 passed). 
- Performed a type/check build: `MIN_FREE_GB=20 ./scripts/cargo-safe check -p xtask --all-targets --profile agent --locked` — passed. 
- Ran linting: `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs` — passed; `just agent-pr-fast` was not run because `just` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d164f2988333a08a77371fa879af)