### PR TITLE
refactor(file-policy): move non-rust policy validation to xtask (#8197)

### DIFF
--- a/docs/policy/NON_RUST_POLICY.md
+++ b/docs/policy/NON_RUST_POLICY.md
@@ -15,9 +15,10 @@ docs/policy/NON_RUST_INVENTORY.md  # generated inventory (PR 3)
 Reader / writer:
 
 ```text
-cargo xtask non-rust inventory   # emit Markdown + JSON inventory
-cargo xtask non-rust propose     # propose entries for unallowlisted files
-cargo xtask check-file-policy    # enforce the allowlist
+cargo xtask non-rust inventory        # emit Markdown + JSON inventory
+cargo xtask non-rust propose          # propose entries for unallowlisted files
+cargo xtask non-rust validate-policy  # validate allowlist/debt TOML schema
+cargo xtask check-file-policy         # enforce the allowlist
 ```
 
 ## Schema

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -85,6 +85,7 @@ surface = "release"
 classification = "documentation"
 owner = "release/legal"
 reason = "Apache-2.0 and MIT license texts required by the dual-licensed Rust ecosystem; per-crate copies are required by cargo publish."
+broad_glob_reason = "License files are intentionally repeated across publishable crates; cargo publish and release/legal review own this surface."
 covered_by = [
   "cargo xtask check-file-policy",
 ]

--- a/scripts/policy/validate_non_rust_allowlist.py
+++ b/scripts/policy/validate_non_rust_allowlist.py
@@ -1,217 +1,18 @@
 #!/usr/bin/env python3
-"""Validate policy/non-rust-allowlist.toml and policy/non-rust-debt.toml.
+"""Compatibility shim for the Rust non-Rust policy schema validator.
 
-Sub-second sanity check that runs before `cargo xtask check-file-policy`
-exists (PR 4 of the file-policy rollout). Catches schema-level errors:
-
-  - TOML parses.
-  - Every [[allow]] has the required fields.
-  - `glob` and `path` are mutually exclusive on a single entry.
-  - Paths are repo-relative without leading `./` or absolute prefixes.
-  - No Windows backslashes.
-  - No duplicate ids.
-  - `created` / `review_after` / `expires` are valid YYYY-MM-DD dates.
-  - `expires` (if set) is after `created`.
-  - `review_after` is after `created`.
-  - `production` / `test` / `tooling` entries declare at least one
-    `covered_by` item.
-  - Broad globs (matching `**` at the root, or covering more than one
-    language family) declare `broad_glob_reason`.
-  - `classification` is one of the known values.
-
-This is the schema gate. The semantic gate ("this glob actually matches
-files in the repo, no tracked file is unallowlisted") lands with the Rust
-checker in PR 4.
-
-Run:
-    python3 scripts/policy/validate_non_rust_allowlist.py
-
-Exits non-zero on any violation.
+The schema validation logic lives in `cargo xtask non-rust validate-policy` so
+file-policy checks share the same Rust implementation. This wrapper preserves
+older automation that still invokes the historical Python script path.
 """
 
 from __future__ import annotations
 
 import argparse
-import datetime as dt
+import os
 import pathlib
-import re
+import subprocess
 import sys
-import tomllib
-
-REQUIRED_FIELDS = (
-    "id",
-    "kind",
-    "language",
-    "surface",
-    "classification",
-    "owner",
-    "reason",
-    "covered_by",
-    "created",
-    "review_after",
-)
-OPTIONAL_FIELDS = (
-    "glob",
-    "path",
-    "expires",
-    "broad_glob_reason",
-    "retired",
-)
-KNOWN_CLASSIFICATIONS = {
-    "production",
-    "test",
-    "tooling",
-    "config",
-    "documentation",
-}
-DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-COVERAGE_REQUIRING_CLASSIFICATIONS = {"production", "test", "tooling"}
-
-
-def parse_date(value: str, field: str, entry_id: str, errors: list[str]) -> dt.date | None:
-    if not isinstance(value, str) or not DATE_RE.match(value):
-        errors.append(
-            f"{entry_id}: `{field}` must be a YYYY-MM-DD string, got {value!r}"
-        )
-        return None
-    try:
-        return dt.date.fromisoformat(value)
-    except ValueError:
-        errors.append(f"{entry_id}: `{field}` is not a real date: {value!r}")
-        return None
-
-
-def validate_entry(entry: dict, index: int, errors: list[str]) -> None:
-    entry_id = entry.get("id", f"<unnamed entry #{index}>")
-
-    has_glob = "glob" in entry
-    has_path = "path" in entry
-    if has_glob and has_path:
-        errors.append(f"{entry_id}: cannot set both `glob` and `path`")
-    if not has_glob and not has_path:
-        errors.append(f"{entry_id}: must set either `glob` or `path`")
-
-    matcher = entry.get("glob") or entry.get("path") or ""
-    if matcher.startswith("./") or matcher.startswith("/"):
-        errors.append(
-            f"{entry_id}: matcher `{matcher}` must be repo-relative without leading `./` or `/`"
-        )
-    if "\\" in matcher:
-        errors.append(f"{entry_id}: matcher `{matcher}` contains Windows backslashes")
-    if matcher.strip() != matcher:
-        errors.append(f"{entry_id}: matcher `{matcher}` has surrounding whitespace")
-
-    for field in REQUIRED_FIELDS:
-        if field not in entry:
-            errors.append(f"{entry_id}: missing required field `{field}`")
-
-    for field in entry:
-        if field not in REQUIRED_FIELDS + OPTIONAL_FIELDS:
-            errors.append(f"{entry_id}: unknown field `{field}`")
-
-    classification = entry.get("classification")
-    if classification and classification not in KNOWN_CLASSIFICATIONS:
-        errors.append(
-            f"{entry_id}: classification `{classification}` not in "
-            f"{sorted(KNOWN_CLASSIFICATIONS)}"
-        )
-
-    covered_by = entry.get("covered_by", [])
-    if not isinstance(covered_by, list) or any(not isinstance(c, str) for c in covered_by):
-        errors.append(f"{entry_id}: `covered_by` must be a list of strings")
-    elif (
-        classification in COVERAGE_REQUIRING_CLASSIFICATIONS
-        and len(covered_by) == 0
-    ):
-        errors.append(
-            f"{entry_id}: classification `{classification}` requires at least one `covered_by` entry"
-        )
-
-    created = parse_date(entry.get("created", ""), "created", entry_id, errors)
-    review_after = parse_date(entry.get("review_after", ""), "review_after", entry_id, errors)
-    expires_raw = entry.get("expires")
-    expires = (
-        parse_date(expires_raw, "expires", entry_id, errors)
-        if expires_raw is not None
-        else None
-    )
-
-    if created and review_after and review_after <= created:
-        errors.append(f"{entry_id}: `review_after` must be after `created`")
-    if created and expires and expires <= created:
-        errors.append(f"{entry_id}: `expires` must be after `created`")
-
-    # Broad-glob heuristic: glob starting with `**`, glob matching everything
-    # below a top-level directory (`<dir>/**`), or glob containing `*.<ext>`.
-    if has_glob:
-        is_broad = (
-            matcher.startswith("**")
-            or matcher.endswith("/**")
-            or matcher == "*.md"
-            or matcher.startswith("**/")
-        )
-        if is_broad and not entry.get("broad_glob_reason"):
-            errors.append(
-                f"{entry_id}: glob `{matcher}` is broad; declare `broad_glob_reason`"
-            )
-
-    if entry.get("retired") not in (None, True, False):
-        errors.append(f"{entry_id}: `retired` must be a boolean")
-
-
-def validate_allowlist(path: pathlib.Path, errors: list[str]) -> int:
-    try:
-        data = tomllib.loads(path.read_text())
-    except Exception as exc:
-        errors.append(f"FAIL: parse {path}: {exc}")
-        return 0
-
-    entries = data.get("allow", [])
-    if not isinstance(entries, list):
-        errors.append(f"{path}: `allow` must be a list of tables")
-        return 0
-
-    seen_ids: dict[str, int] = {}
-    seen_matchers: dict[str, str] = {}
-    for index, entry in enumerate(entries):
-        validate_entry(entry, index, errors)
-        eid = entry.get("id")
-        if isinstance(eid, str):
-            if eid in seen_ids:
-                errors.append(
-                    f"{eid}: duplicate id (also at index {seen_ids[eid]})"
-                )
-            else:
-                seen_ids[eid] = index
-
-        matcher = entry.get("glob") or entry.get("path")
-        if isinstance(matcher, str):
-            if matcher in seen_matchers:
-                errors.append(
-                    f"{eid or '<unnamed>'}: duplicate matcher `{matcher}` "
-                    f"(also used by id `{seen_matchers[matcher]}`)"
-                )
-            else:
-                seen_matchers[matcher] = eid or "<unnamed>"
-
-    return len(entries)
-
-
-def validate_debt(path: pathlib.Path, errors: list[str]) -> int:
-    try:
-        data = tomllib.loads(path.read_text())
-    except Exception as exc:
-        errors.append(f"FAIL: parse {path}: {exc}")
-        return 0
-
-    entries = data.get("debt", [])
-    if not isinstance(entries, list):
-        errors.append(f"{path}: `debt` must be a list of tables")
-        return 0
-
-    # Debt entries share most schema with allow entries, minus the
-    # `classification` strictness and `covered_by` requirement.
-    return len(entries)
 
 
 def main() -> int:
@@ -228,21 +29,19 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    errors: list[str] = []
-    n_allow = validate_allowlist(args.allowlist, errors)
-    n_debt = validate_debt(args.debt, errors)
-
-    if errors:
-        print(f"FAIL: {len(errors)} non-Rust policy validation error(s):", file=sys.stderr)
-        for err in errors:
-            print(f"  - {err}", file=sys.stderr)
-        return 1
-
-    print(
-        f"OK: validated {n_allow} allow entr{'y' if n_allow == 1 else 'ies'} "
-        f"and {n_debt} debt entr{'y' if n_debt == 1 else 'ies'}."
-    )
-    return 0
+    command = [
+        "cargo",
+        "xtask",
+        "non-rust",
+        "validate-policy",
+        "--allowlist",
+        str(args.allowlist),
+        "--debt",
+        str(args.debt),
+    ]
+    env = os.environ.copy()
+    env.setdefault("CARGO_TARGET_DIR", "/tmp/perl-lsp-target")
+    return subprocess.run(command, check=False, env=env).returncode
 
 
 if __name__ == "__main__":

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1684,6 +1684,17 @@ enum NonRustCommand {
         #[arg(long, hide = true)]
         root: Option<PathBuf>,
     },
+
+    /// Validate the non-Rust allowlist/debt TOML schema without walking git.
+    ValidatePolicy {
+        /// Override the default allowlist path (`policy/non-rust-allowlist.toml`).
+        #[arg(long, default_value = "policy/non-rust-allowlist.toml")]
+        allowlist: PathBuf,
+
+        /// Override the default debt path (`policy/non-rust-debt.toml`).
+        #[arg(long, default_value = "policy/non-rust-debt.toml")]
+        debt: PathBuf,
+    },
 }
 
 /// CLI-facing grouping argument (mirrors `file_policy::ProposeGroupBy`).
@@ -3262,6 +3273,13 @@ fn main() -> Result<()> {
                     &root,
                     ProposeConfig { output_dir, group_by, root_override },
                 )
+            }
+            NonRustCommand::ValidatePolicy { allowlist, debt } => {
+                use tasks::file_policy::ValidateNonRustPolicyConfig;
+                tasks::file_policy::validate_non_rust_policy(ValidateNonRustPolicyConfig {
+                    allowlist_path: allowlist,
+                    debt_path: debt,
+                })
             }
         },
         Commands::CheckFilePolicy { mode, json, allowlist, root: root_override } => {

--- a/xtask/src/tasks/file_policy.rs
+++ b/xtask/src/tasks/file_policy.rs
@@ -371,6 +371,331 @@ pub fn non_rust_inventory(root: &Path) -> Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// validate-policy — schema-only non-Rust policy validation
+// ---------------------------------------------------------------------------
+
+const REQUIRED_ALLOW_FIELDS: &[&str] = &[
+    "id",
+    "kind",
+    "language",
+    "surface",
+    "classification",
+    "owner",
+    "reason",
+    "covered_by",
+    "created",
+    "review_after",
+];
+
+const ALLOWED_ALLOW_FIELDS: &[&str] = &[
+    "id",
+    "glob",
+    "path",
+    "kind",
+    "language",
+    "surface",
+    "classification",
+    "owner",
+    "reason",
+    "covered_by",
+    "created",
+    "review_after",
+    "expires",
+    "broad_glob_reason",
+    "retired",
+    "generated_by",
+];
+
+const KNOWN_CLASSIFICATIONS: &[&str] =
+    &["production", "test", "tooling", "config", "documentation", "generated"];
+
+const COVERAGE_REQUIRING_CLASSIFICATIONS: &[&str] = &["production", "test", "tooling"];
+
+/// Configuration for `cargo xtask non-rust validate-policy`.
+pub struct ValidateNonRustPolicyConfig {
+    /// Override the default allowlist path (`policy/non-rust-allowlist.toml`).
+    pub allowlist_path: std::path::PathBuf,
+    /// Override the default debt path (`policy/non-rust-debt.toml`).
+    pub debt_path: std::path::PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonRustPolicyValidation {
+    pub allow_entries: usize,
+    pub debt_entries: usize,
+    pub errors: Vec<String>,
+}
+
+impl NonRustPolicyValidation {
+    fn is_ok(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+/// Validate the non-Rust allowlist and debt TOML schema without walking git.
+///
+/// This is the Rust successor to `scripts/policy/validate_non_rust_allowlist.py`:
+/// fast schema validation lives next to the main file-policy engine, while the
+/// compatibility script only delegates to this command.
+pub fn validate_non_rust_policy(config: ValidateNonRustPolicyConfig) -> Result<()> {
+    let validation = validate_non_rust_policy_files(&config.allowlist_path, &config.debt_path);
+
+    if validation.is_ok() {
+        let allow_word = if validation.allow_entries == 1 { "entry" } else { "entries" };
+        let debt_word = if validation.debt_entries == 1 { "entry" } else { "entries" };
+        println!(
+            "OK: validated {} allow {} and {} debt {}.",
+            validation.allow_entries, allow_word, validation.debt_entries, debt_word
+        );
+        return Ok(());
+    }
+
+    eprintln!("FAIL: {} non-Rust policy validation error(s):", validation.errors.len());
+    for error in &validation.errors {
+        eprintln!("  - {error}");
+    }
+    Err(eyre!("non-Rust policy validation failed with {} error(s)", validation.errors.len()))
+}
+
+fn validate_non_rust_policy_files(
+    allowlist_path: &std::path::Path,
+    debt_path: &std::path::Path,
+) -> NonRustPolicyValidation {
+    let mut errors = Vec::new();
+    let allow_entries = validate_policy_table(allowlist_path, "allow", true, &mut errors);
+    let debt_entries = validate_policy_table(debt_path, "debt", false, &mut errors);
+    NonRustPolicyValidation { allow_entries, debt_entries, errors }
+}
+
+fn validate_policy_table(
+    path: &std::path::Path,
+    table_name: &str,
+    strict_allow_schema: bool,
+    errors: &mut Vec<String>,
+) -> usize {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) => {
+            errors.push(format!("FAIL: read {}: {err}", path.display()));
+            return 0;
+        }
+    };
+    let data = match toml::from_str::<toml::Value>(&text) {
+        Ok(data) => data,
+        Err(err) => {
+            errors.push(format!("FAIL: parse {}: {err}", path.display()));
+            return 0;
+        }
+    };
+
+    let Some(entries) = data.get(table_name) else {
+        return 0;
+    };
+    let Some(entries) = entries.as_array() else {
+        errors.push(format!("{}: `{table_name}` must be a list of tables", path.display()));
+        return 0;
+    };
+
+    let mut seen_ids: BTreeMap<String, usize> = BTreeMap::new();
+    let mut seen_matchers: BTreeMap<String, String> = BTreeMap::new();
+    for (index, entry) in entries.iter().enumerate() {
+        let Some(table) = entry.as_table() else {
+            errors
+                .push(format!("{}: `{table_name}` entry #{index} must be a table", path.display()));
+            continue;
+        };
+
+        if strict_allow_schema {
+            validate_allow_schema_entry(table, index, errors);
+        }
+
+        let entry_id = table
+            .get("id")
+            .and_then(toml::Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("<unnamed entry #{index}>"));
+
+        if let Some(id) = table.get("id").and_then(toml::Value::as_str) {
+            if let Some(previous) = seen_ids.insert(id.to_string(), index) {
+                errors.push(format!("{id}: duplicate id (also at index {previous})"));
+            }
+        }
+
+        let matcher = table.get("glob").or_else(|| table.get("path")).and_then(toml::Value::as_str);
+        if let Some(matcher) = matcher {
+            if let Some(previous_id) = seen_matchers.insert(matcher.to_string(), entry_id.clone()) {
+                errors.push(format!(
+                    "{entry_id}: duplicate matcher `{matcher}` (also used by id `{previous_id}`)"
+                ));
+            }
+        }
+    }
+
+    entries.len()
+}
+
+fn validate_allow_schema_entry(
+    entry: &toml::map::Map<String, toml::Value>,
+    index: usize,
+    errors: &mut Vec<String>,
+) {
+    let entry_id = entry.get("id").and_then(toml::Value::as_str).unwrap_or("<unnamed entry>");
+    let fallback_id = format!("<unnamed entry #{index}>");
+    let entry_id = if entry_id == "<unnamed entry>" { fallback_id.as_str() } else { entry_id };
+
+    let has_glob = entry.contains_key("glob");
+    let has_path = entry.contains_key("path");
+    if has_glob && has_path {
+        errors.push(format!("{entry_id}: cannot set both `glob` and `path`"));
+    }
+    if !has_glob && !has_path {
+        errors.push(format!("{entry_id}: must set either `glob` or `path`"));
+    }
+
+    if let Some(matcher) =
+        entry.get("glob").or_else(|| entry.get("path")).and_then(toml::Value::as_str)
+    {
+        validate_repo_relative_matcher(entry_id, matcher, errors);
+        if has_glob && is_policy_broad_glob(matcher) {
+            let has_reason = entry
+                .get("broad_glob_reason")
+                .and_then(toml::Value::as_str)
+                .is_some_and(|reason| !reason.trim().is_empty());
+            if !has_reason {
+                errors.push(format!(
+                    "{entry_id}: glob `{matcher}` is broad; declare `broad_glob_reason`"
+                ));
+            }
+        }
+    }
+
+    for field in REQUIRED_ALLOW_FIELDS {
+        if !entry.contains_key(*field) {
+            errors.push(format!("{entry_id}: missing required field `{field}`"));
+        }
+    }
+
+    for field in entry.keys() {
+        if !ALLOWED_ALLOW_FIELDS.contains(&field.as_str()) {
+            errors.push(format!("{entry_id}: unknown field `{field}`"));
+        }
+    }
+
+    if let Some(classification) = entry.get("classification").and_then(toml::Value::as_str) {
+        if !KNOWN_CLASSIFICATIONS.contains(&classification) {
+            errors.push(format!(
+                "{entry_id}: classification `{classification}` not in {:?}",
+                KNOWN_CLASSIFICATIONS
+            ));
+        }
+    }
+
+    validate_covered_by(entry_id, entry, errors);
+    validate_policy_dates(entry_id, entry, errors);
+
+    if let Some(retired) = entry.get("retired") {
+        if retired.as_bool().is_none() {
+            errors.push(format!("{entry_id}: `retired` must be a boolean"));
+        }
+    }
+}
+
+fn validate_repo_relative_matcher(entry_id: &str, matcher: &str, errors: &mut Vec<String>) {
+    if matcher.starts_with("./") || matcher.starts_with('/') {
+        errors.push(format!(
+            "{entry_id}: matcher `{matcher}` must be repo-relative without leading `./` or `/`"
+        ));
+    }
+    if matcher.contains('\\') {
+        errors.push(format!("{entry_id}: matcher `{matcher}` contains Windows backslashes"));
+    }
+    if matcher.trim() != matcher {
+        errors.push(format!("{entry_id}: matcher `{matcher}` has surrounding whitespace"));
+    }
+}
+
+fn validate_covered_by(
+    entry_id: &str,
+    entry: &toml::map::Map<String, toml::Value>,
+    errors: &mut Vec<String>,
+) {
+    let covered_by = entry.get("covered_by");
+    let covered_by_strings = covered_by
+        .and_then(toml::Value::as_array)
+        .map(|items| items.iter().all(|item| item.as_str().is_some()));
+    if covered_by.is_some() && covered_by_strings != Some(true) {
+        errors.push(format!("{entry_id}: `covered_by` must be a list of strings"));
+        return;
+    }
+
+    let classification = entry.get("classification").and_then(toml::Value::as_str);
+    let coverage_required = classification
+        .is_some_and(|classification| COVERAGE_REQUIRING_CLASSIFICATIONS.contains(&classification));
+    let coverage_empty = covered_by.and_then(toml::Value::as_array).is_none_or(Vec::is_empty);
+    if coverage_required && coverage_empty {
+        let classification = classification.unwrap_or("unknown");
+        errors.push(format!(
+            "{entry_id}: classification `{classification}` requires at least one `covered_by` entry"
+        ));
+    }
+}
+
+fn validate_policy_dates(
+    entry_id: &str,
+    entry: &toml::map::Map<String, toml::Value>,
+    errors: &mut Vec<String>,
+) {
+    let created = parse_policy_date(entry_id, entry, "created", errors);
+    let review_after = parse_policy_date(entry_id, entry, "review_after", errors);
+    let expires = if entry.contains_key("expires") {
+        parse_policy_date(entry_id, entry, "expires", errors)
+    } else {
+        None
+    };
+
+    if let (Some(created), Some(review_after)) = (created, review_after) {
+        if review_after <= created {
+            errors.push(format!("{entry_id}: `review_after` must be after `created`"));
+        }
+    }
+    if let (Some(created), Some(expires)) = (created, expires) {
+        if expires <= created {
+            errors.push(format!("{entry_id}: `expires` must be after `created`"));
+        }
+    }
+}
+
+fn parse_policy_date(
+    entry_id: &str,
+    entry: &toml::map::Map<String, toml::Value>,
+    field: &str,
+    errors: &mut Vec<String>,
+) -> Option<chrono::NaiveDate> {
+    let value = entry.get(field)?;
+    let Some(value) = value.as_str() else {
+        errors.push(format!("{entry_id}: `{field}` must be a YYYY-MM-DD string"));
+        return None;
+    };
+    match chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        Ok(date) => Some(date),
+        Err(_) => {
+            errors.push(format!("{entry_id}: `{field}` is not a real date: {value:?}"));
+            None
+        }
+    }
+}
+
+/// Broad-glob heuristic for policy schema validation. Mirrors the original
+/// Python gate and intentionally catches more than the strict enforcement
+/// broad-glob helper.
+fn is_policy_broad_glob(glob_str: &str) -> bool {
+    glob_str.starts_with("**")
+        || glob_str.ends_with("/**")
+        || glob_str == "*.md"
+        || glob_str.starts_with("**/")
+}
+
+// ---------------------------------------------------------------------------
 // check-file-policy — enforcement subcommand
 // ---------------------------------------------------------------------------
 
@@ -1488,6 +1813,90 @@ mod tests {
         let json = serde_json::to_string(&record)?;
         let back: FileRecord = serde_json::from_str(&json)?;
         assert_eq!(record, back);
+        Ok(())
+    }
+
+    #[test]
+    fn validate_non_rust_policy_accepts_current_schema_extensions() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let allowlist = temp.path().join("allow.toml");
+        let debt = temp.path().join("debt.toml");
+        fs::write(
+            &allowlist,
+            r#"
+[[allow]]
+id = "generated-badge"
+glob = "badges/*.json"
+kind = "generated_badge_endpoint"
+language = "json"
+surface = "docs"
+classification = "generated"
+owner = "release/ci"
+reason = "Generated badge data."
+generated_by = "cargo xtask badges"
+covered_by = []
+created = "2026-05-13"
+review_after = "2026-08-13"
+"#,
+        )?;
+        fs::write(&debt, "# empty debt ledger\n")?;
+
+        let validation = validate_non_rust_policy_files(&allowlist, &debt);
+
+        assert_eq!(validation.allow_entries, 1);
+        assert_eq!(validation.debt_entries, 0);
+        assert!(validation.errors.is_empty(), "unexpected errors: {:?}", validation.errors);
+        Ok(())
+    }
+
+    #[test]
+    fn validate_non_rust_policy_reports_schema_errors() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let allowlist = temp.path().join("allow.toml");
+        let debt = temp.path().join("debt.toml");
+        fs::write(
+            &allowlist,
+            r#"
+[[allow]]
+id = "bad"
+glob = "docs/**"
+path = "docs/README.md"
+kind = "documentation"
+language = "markdown"
+surface = "docs"
+classification = "production"
+owner = "docs"
+reason = "Broken fixture."
+covered_by = []
+created = "2026-05-13"
+review_after = "2026-05-13"
+unknown = "field"
+"#,
+        )?;
+        fs::write(&debt, "debt = []\n")?;
+
+        let validation = validate_non_rust_policy_files(&allowlist, &debt);
+
+        assert!(
+            validation.errors.iter().any(|error| error.contains("cannot set both")),
+            "missing matcher conflict error: {:?}",
+            validation.errors
+        );
+        assert!(
+            validation.errors.iter().any(|error| error.contains("requires at least one")),
+            "missing coverage requirement error: {:?}",
+            validation.errors
+        );
+        assert!(
+            validation.errors.iter().any(|error| error.contains("unknown field")),
+            "missing unknown field error: {:?}",
+            validation.errors
+        );
+        assert!(
+            validation.errors.iter().any(|error| error.contains("review_after")),
+            "missing date ordering error: {:?}",
+            validation.errors
+        );
         Ok(())
     }
 


### PR DESCRIPTION
Problem: Non-Rust policy schema validation still lived in a Python implementation, separate from the Rust file-policy control plane. Fix: Move schema validation into cargo xtask non-rust validate-policy, keep the Python path as a compatibility shim, preserve existing file-policy inventory/check behavior, add validator regression tests, and add the missing broad-glob reason required by the current license-file policy row. Verification: cargo test -p xtask file_policy --profile agent --locked passes; cargo xtask non-rust validate-policy passes; python -m py_compile scripts/policy/validate_non_rust_allowlist.py passes; python scripts/policy/validate_non_rust_allowlist.py passes; cargo check -p xtask --all-targets --profile agent --locked passes; cargo clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs -A unused_imports passes; git diff --check passes. Note: strict clippy without -A unused_imports is currently blocked by pre-existing perl-subprocess-runtime unused-import warnings on this checkout, outside this PR.