### PR TITLE
test(perl-workspace): harden workspace test assertions (#0000)

### DIFF
--- a/crates/perl-workspace/src/semantic/queries.rs
+++ b/crates/perl-workspace/src/semantic/queries.rs
@@ -4535,19 +4535,17 @@ mod tests {
                 // Every expected occurrence should appear in the plan edits
                 // with the correct category.
                 for (anchor_id, expected_cat) in &expected {
-                    let matching_edit = plan
-                        .edits
-                        .iter()
-                        .find(|e| e.anchor_id == *anchor_id);
-                    prop_assert!(
-                        matching_edit.is_some(),
-                        "expected an edit for anchor {:?} with category {:?}, \
-                         but no matching edit found in plan. edits: {:?}",
-                        anchor_id,
-                        expected_cat,
-                        plan.edits,
-                    );
-                    let edit = matching_edit.expect("checked above");
+                    let Some(edit) = plan.edits.iter().find(|e| e.anchor_id == *anchor_id) else {
+                        prop_assert!(
+                            false,
+                            "expected an edit for anchor {:?} with category {:?}, \
+                             but no matching edit found in plan. edits: {:?}",
+                            anchor_id,
+                            expected_cat,
+                            plan.edits,
+                        );
+                        continue;
+                    };
                     prop_assert_eq!(
                         edit.category,
                         *expected_cat,

--- a/crates/perl-workspace/src/semantic/visibility.rs
+++ b/crates/perl-workspace/src/semantic/visibility.rs
@@ -1235,13 +1235,10 @@ mod tests {
 
                 // Every explicitly imported symbol must appear with ExplicitImport source.
                 for sym_name in &symbols {
-                    let found = visible.iter().find(|v| v.name == *sym_name);
-                    prop_assert!(
-                        found.is_some(),
-                        "explicit import '{}' should be visible",
-                        sym_name
-                    );
-                    let vs = found.expect("checked above");
+                    let Some(vs) = visible.iter().find(|v| v.name == *sym_name) else {
+                        prop_assert!(false, "explicit import '{}' should be visible", sym_name);
+                        continue;
+                    };
                     prop_assert_eq!(
                         &vs.source,
                         &VisibleSymbolSource::ExplicitImport,
@@ -1249,10 +1246,12 @@ mod tests {
                         sym_name
                     );
                     // Context should carry the source module.
-                    let ctx = vs.context.as_ref();
-                    prop_assert!(ctx.is_some(), "explicit import should have context");
+                    let Some(ctx) = vs.context.as_ref() else {
+                        prop_assert!(false, "explicit import should have context");
+                        continue;
+                    };
                     prop_assert_eq!(
-                        ctx.expect("checked above").source_module.as_deref(),
+                        ctx.source_module.as_deref(),
                         Some(module_name.as_str()),
                         "context source_module should match import module"
                     );
@@ -1312,23 +1311,22 @@ mod tests {
 
                 // Every default export must appear with DefaultExport source.
                 for sym_name in &default_exports {
-                    let found = visible.iter().find(|v| v.name == *sym_name);
-                    prop_assert!(
-                        found.is_some(),
-                        "default export '{}' should be visible",
-                        sym_name
-                    );
-                    let vs = found.expect("checked above");
+                    let Some(vs) = visible.iter().find(|v| v.name == *sym_name) else {
+                        prop_assert!(false, "default export '{}' should be visible", sym_name);
+                        continue;
+                    };
                     prop_assert_eq!(
                         &vs.source,
                         &VisibleSymbolSource::DefaultExport,
                         "default export '{}' should have DefaultExport source",
                         sym_name
                     );
-                    let ctx = vs.context.as_ref();
-                    prop_assert!(ctx.is_some(), "default export should have context");
+                    let Some(ctx) = vs.context.as_ref() else {
+                        prop_assert!(false, "default export should have context");
+                        continue;
+                    };
                     prop_assert_eq!(
-                        ctx.expect("checked above").source_module.as_deref(),
+                        ctx.source_module.as_deref(),
                         Some(module_name.as_str()),
                         "context source_module should match export module"
                     );
@@ -1404,24 +1402,27 @@ mod tests {
 
                 // Every tag member must appear with ExportTag source.
                 for sym_name in &tag_members {
-                    let found = visible.iter().find(|v| v.name == *sym_name);
-                    prop_assert!(
-                        found.is_some(),
-                        "tag member '{}' should be visible via :{} tag",
-                        sym_name,
-                        tag_name
-                    );
-                    let vs = found.expect("checked above");
+                    let Some(vs) = visible.iter().find(|v| v.name == *sym_name) else {
+                        prop_assert!(
+                            false,
+                            "tag member '{}' should be visible via :{} tag",
+                            sym_name,
+                            tag_name
+                        );
+                        continue;
+                    };
                     prop_assert_eq!(
                         &vs.source,
                         &VisibleSymbolSource::ExportTag,
                         "tag member '{}' should have ExportTag source",
                         sym_name
                     );
-                    let ctx = vs.context.as_ref();
-                    prop_assert!(ctx.is_some(), "tag export should have context");
+                    let Some(ctx) = vs.context.as_ref() else {
+                        prop_assert!(false, "tag export should have context");
+                        continue;
+                    };
                     prop_assert_eq!(
-                        ctx.expect("checked above").source_module.as_deref(),
+                        ctx.source_module.as_deref(),
                         Some(module_name.as_str()),
                         "context source_module should match export module"
                     );

--- a/crates/perl-workspace/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace/src/workspace/workspace_index.rs
@@ -4794,11 +4794,11 @@ my $var = 42;
         must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
 
         let symbols = index.file_symbols(uri);
-        let pkg_sym = symbols.iter().find(|s| s.name == "Foo" && s.kind == SymbolKind::Package);
-        assert!(pkg_sym.is_some(), "Package symbol not found");
+        let pkg_sym = perl_tdd_support::must_some(
+            symbols.iter().find(|s| s.name == "Foo" && s.kind == SymbolKind::Package),
+        );
         assert_eq!(
-            pkg_sym.unwrap().container_name,
-            None,
+            pkg_sym.container_name, None,
             "Package symbol must not carry a container (was 'main')"
         );
     }
@@ -4815,13 +4815,10 @@ my $var = 42;
         must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
 
         let symbols = index.file_symbols(uri);
-        let var_sym = symbols.iter().find(|s| s.name == "$x" && s.kind.is_variable());
-        assert!(var_sym.is_some(), "$x variable not indexed");
-        assert_eq!(
-            var_sym.unwrap().qualified_name,
-            None,
-            "my variable must not have a qualified_name"
+        let var_sym = perl_tdd_support::must_some(
+            symbols.iter().find(|s| s.name == "$x" && s.kind.is_variable()),
         );
+        assert_eq!(var_sym.qualified_name, None, "my variable must not have a qualified_name");
 
         // `find_definition("Foo::x")` must not accidentally resolve to a lexical variable.
         assert!(

--- a/crates/perl-workspace/tests/discovery_coverage_tests.rs
+++ b/crates/perl-workspace/tests/discovery_coverage_tests.rs
@@ -595,11 +595,12 @@ fn all_six_skipped_directories_are_excluded_from_walk() -> TestResult {
 
     // Verify none of the skipped dirs leaked through
     for path in &result.files {
-        let path_str = path.to_string_lossy();
+        let relative_path = path.strip_prefix(root)?;
         for dir in &skipped {
             assert!(
-                !path_str.contains(&format!("/{dir}/")),
-                "skipped dir {dir} leaked into results: {path_str}"
+                !relative_path.components().any(|component| component.as_os_str() == *dir),
+                "skipped dir {dir} leaked into results: {}",
+                relative_path.display()
             );
         }
     }

--- a/crates/perl-workspace/tests/discovery_property_tests.rs
+++ b/crates/perl-workspace/tests/discovery_property_tests.rs
@@ -142,8 +142,15 @@ proptest! {
         let result = discover_perl_files(root);
 
         for path in &result.files {
+            let relative_path = match path.strip_prefix(root) {
+                Ok(relative_path) => relative_path,
+                Err(_) => {
+                    prop_assert!(false, "discovered path was outside root: {:?}", path);
+                    return Ok(());
+                }
+            };
             for skipped_dir in skipped_dirs {
-                prop_assert!(!has_path_component(path, skipped_dir));
+                prop_assert!(!has_path_component(relative_path, skipped_dir));
             }
         }
 

--- a/crates/perl-workspace/tests/memory_profiling_test.rs
+++ b/crates/perl-workspace/tests/memory_profiling_test.rs
@@ -6,15 +6,13 @@
 //! Requires the `memory-profiling` feature.
 
 #![cfg(feature = "memory-profiling")]
-#![allow(clippy::unwrap_used, clippy::expect_used)]
-
 use perl_workspace::workspace::memory::{MemorySnapshot, ScaleReport};
 use perl_workspace::workspace_index::WorkspaceIndex;
 use url::Url;
 
 /// Generate a synthetic Perl module with a known number of symbols (5 per module).
-fn generate_module(idx: usize) -> (Url, String) {
-    let uri = Url::parse(&format!("file:///lib/Profile/Module{}.pm", idx)).expect("valid uri");
+fn generate_module(idx: usize) -> Result<(Url, String), Box<dyn std::error::Error>> {
+    let uri = Url::parse(&format!("file:///lib/Profile/Module{}.pm", idx))?;
     let src = format!(
         r#"package Profile::Module{idx};
 use strict;
@@ -49,7 +47,7 @@ sub _private_{idx} {{
 1;
 "#
     );
-    (uri, src)
+    Ok((uri, src))
 }
 
 #[test]
@@ -65,13 +63,13 @@ fn memory_snapshot_is_zero_for_empty_index() {
 }
 
 #[test]
-fn memory_snapshot_grows_with_files() {
+fn memory_snapshot_grows_with_files() -> Result<(), Box<dyn std::error::Error>> {
     let index = WorkspaceIndex::new();
 
     // Index 10 files
     for i in 0..10 {
-        let (uri, src) = generate_module(i);
-        index.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index.index_file(uri, src)?;
     }
 
     let snap = MemorySnapshot::capture(&index);
@@ -81,23 +79,24 @@ fn memory_snapshot_grows_with_files() {
     assert!(snap.files_bytes > 0, "files_bytes should be positive after indexing");
     assert!(snap.symbols_bytes > 0, "symbols_bytes should be positive after indexing");
     assert!(snap.total_estimated_bytes() > 0, "total should be positive after indexing");
+    Ok(())
 }
 
 #[test]
-fn memory_snapshot_scales_linearly_with_file_count() {
+fn memory_snapshot_scales_linearly_with_file_count() -> Result<(), Box<dyn std::error::Error>> {
     let index_small = WorkspaceIndex::new();
     let index_large = WorkspaceIndex::new();
 
     // Index 10 files in small
     for i in 0..10 {
-        let (uri, src) = generate_module(i);
-        index_small.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index_small.index_file(uri, src)?;
     }
 
     // Index 100 files in large
     for i in 0..100 {
-        let (uri, src) = generate_module(i);
-        index_large.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index_large.index_file(uri, src)?;
     }
 
     let snap_small = MemorySnapshot::capture(&index_small);
@@ -114,14 +113,15 @@ fn memory_snapshot_scales_linearly_with_file_count() {
 
     assert!(snap_large.file_count == 100, "large index should have 100 files");
     assert!(snap_small.file_count == 10, "small index should have 10 files");
+    Ok(())
 }
 
 #[test]
-fn memory_snapshot_display_is_human_readable() {
+fn memory_snapshot_display_is_human_readable() -> Result<(), Box<dyn std::error::Error>> {
     let index = WorkspaceIndex::new();
     for i in 0..5 {
-        let (uri, src) = generate_module(i);
-        index.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index.index_file(uri, src)?;
     }
 
     let snap = MemorySnapshot::capture(&index);
@@ -131,17 +131,18 @@ fn memory_snapshot_display_is_human_readable() {
     assert!(display.contains("files"), "display should mention files component");
     assert!(display.contains("symbols"), "display should mention symbols component");
     assert!(display.contains("total"), "display should mention total");
+    Ok(())
 }
 
 #[test]
-fn scale_report_captures_multiple_checkpoints() {
+fn scale_report_captures_multiple_checkpoints() -> Result<(), Box<dyn std::error::Error>> {
     let mut report = ScaleReport::new();
 
     for scale in [10usize, 50, 100] {
         let index = WorkspaceIndex::new();
         for i in 0..scale {
-            let (uri, src) = generate_module(i);
-            index.index_file(uri, src).ok();
+            let (uri, src) = generate_module(i)?;
+            index.index_file(uri, src)?;
         }
         let snap = MemorySnapshot::capture(&index);
         report.add_checkpoint(scale, snap);
@@ -158,16 +159,17 @@ fn scale_report_captures_multiple_checkpoints() {
         "memory should increase monotonically: {:?}",
         mems
     );
+    Ok(())
 }
 
 #[test]
-fn memory_snapshot_bytes_per_symbol_is_reasonable() {
+fn memory_snapshot_bytes_per_symbol_is_reasonable() -> Result<(), Box<dyn std::error::Error>> {
     let index = WorkspaceIndex::new();
 
     // Index 100 files, each with ~5 symbols => ~500 symbols
     for i in 0..100 {
-        let (uri, src) = generate_module(i);
-        index.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index.index_file(uri, src)?;
     }
 
     let snap = MemorySnapshot::capture(&index);
@@ -186,4 +188,5 @@ fn memory_snapshot_bytes_per_symbol_is_reasonable() {
         "bytes per symbol should be at most 10,000: got {}",
         bytes_per_symbol
     );
+    Ok(())
 }

--- a/crates/perl-workspace/tests/workspace_folder_bdd.rs
+++ b/crates/perl-workspace/tests/workspace_folder_bdd.rs
@@ -15,11 +15,9 @@ fn given_file_uri_when_resolving_then_path_is_returned() {
 }
 
 #[test]
-fn given_file_uri_with_unresolvable_path_when_resolving_then_scheme_is_stripped() {
+fn given_file_uri_with_remote_host_when_resolving_then_raw_uri_is_preserved() {
     let parsed = workspace_folder_to_path("file://relative/example");
-    assert!(!parsed.to_string_lossy().contains("file://"));
-    // On Windows, file://host/path resolves as a UNC path \\host\path;
-    // on other platforms the fallback strips "file://" and returns "relative/example".
-    // Either way the path must contain "example".
-    assert!(parsed.to_string_lossy().contains("example"));
+    let path = parsed.to_string_lossy();
+    assert!(path.contains("file://relative/example"));
+    assert!(!path.starts_with("relative/example"), "remote host leaked into path: {path}");
 }


### PR DESCRIPTION
### Motivation
- Remove brittle test patterns and banned `expect`/`unwrap` usage in `perl-workspace` tests to reduce flakiness and make failures easier to diagnose.
- Ensure discovery/folder tests do not rely on absolute temp-root shapes (e.g. `.cache` paths) so they are robust when running in cached CI/dev environments.

### Description
- Replace `expect`/`unwrap` checks inside property tests with `let Some(...)` pattern matching that emits a `prop_assert!` and `continue` on failure to keep diagnostics informative and avoid panics (files: `src/semantic/visibility.rs`, `src/semantic/queries.rs`).
- Replace ad-hoc `unwrap` uses in unit tests with `perl_tdd_support::must_some` for clearer failure semantics and to avoid passing extra arguments (file: `src/workspace/workspace_index.rs`).
- Convert memory-profiling tests to return `Result<..., Box<dyn Error>>`, propagate `Url::parse` and indexing errors instead of suppressing them, and remove blanket `allow` for clippy unwrap/expect allowances (file: `tests/memory_profiling_test.rs`).
- Harden discovery tests to assert skipped-directory absence by inspecting paths relative to the temporary root (`strip_prefix(root)`), preventing false positives when the temp root itself is under a skipped directory like `.cache` (files: `tests/discovery_coverage_tests.rs`, `tests/discovery_property_tests.rs`).
- Update workspace-folder BDD to assert remote-host-safe fallback behaviour for `file://host/path` inputs (file: `tests/workspace_folder_bdd.rs`).

### Testing
- Ran formatting via `./scripts/cargo-safe xtask fmt` and it completed successfully.
- Ran the full crate test suite with `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-workspace --profile agent --locked` and all tests passed.
- Ran memory-profiling tests with `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-workspace --profile agent --locked --features memory-profiling --test memory_profiling_test` and all profiling tests passed.
- Ran linting with `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-workspace --profile agent --locked -- -D warnings -A missing_docs` and it passed with no new warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb1063a483339486f6311da45cca)