### PR TITLE
test(perl-workspace): tighten fallible test paths (#0000)

### DIFF
--- a/crates/perl-workspace/src/bin/workspace_memory_profile.rs
+++ b/crates/perl-workspace/src/bin/workspace_memory_profile.rs
@@ -36,10 +36,9 @@
 //!
 //! Requires the `memory-profiling` feature.
 
-#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
-
 use perl_workspace::workspace::memory::{MemorySnapshot, ScaleReport};
 use perl_workspace::workspace_index::WorkspaceIndex;
+use std::error::Error;
 use std::time::Instant;
 use url::Url;
 
@@ -47,9 +46,8 @@ use url::Url;
 ///
 /// Each module contains 5 public symbols:
 /// `new`, `method_a_N`, `method_b_N`, `method_c_N`, `_private_N`.
-fn generate_module(idx: usize) -> (Url, String) {
-    let uri = Url::parse(&format!("file:///lib/Gen/Module{}.pm", idx))
-        .expect("valid uri for synthetic module");
+fn generate_module(idx: usize) -> Result<(Url, String), Box<dyn Error>> {
+    let uri = Url::parse(&format!("file:///lib/Gen/Module{}.pm", idx))?;
     let src = format!(
         r#"package Gen::Module{idx};
 use strict;
@@ -84,28 +82,28 @@ sub _private_{idx} {{
 1;
 "#
     );
-    (uri, src)
+    Ok((uri, src))
 }
 
 /// Build a [`WorkspaceIndex`] containing `file_count` synthetic modules.
-fn build_index_at_scale(file_count: usize) -> WorkspaceIndex {
+fn build_index_at_scale(file_count: usize) -> Result<WorkspaceIndex, Box<dyn Error>> {
     let index = WorkspaceIndex::new();
     for i in 0..file_count {
-        let (uri, src) = generate_module(i);
-        index.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index.index_file(uri, src)?;
     }
-    index
+    Ok(index)
 }
 
 /// Run the profiling harness and return a populated [`ScaleReport`].
 ///
 /// `scales` is the list of file-count checkpoints to measure.
-fn run_profile(scales: &[usize]) -> ScaleReport {
+fn run_profile(scales: &[usize]) -> Result<ScaleReport, Box<dyn Error>> {
     let mut report = ScaleReport::new();
 
     for &scale in scales {
         let t0 = Instant::now();
-        let index = build_index_at_scale(scale);
+        let index = build_index_at_scale(scale)?;
         let build_ms = t0.elapsed().as_millis();
 
         let snap = MemorySnapshot::capture(&index);
@@ -122,7 +120,7 @@ fn run_profile(scales: &[usize]) -> ScaleReport {
         report.add_checkpoint(scale, snap);
     }
 
-    report
+    Ok(report)
 }
 
 /// Emit the report as newline-delimited JSON to stdout.
@@ -145,7 +143,7 @@ fn print_json(report: &ScaleReport) {
     }
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = std::env::args().collect();
 
     let mut emit_json = false;
@@ -171,11 +169,13 @@ fn main() {
         None => default_scales,
     };
 
-    let report = run_profile(&scales);
+    let report = run_profile(&scales)?;
 
     if emit_json {
         print_json(&report);
     } else {
         println!("{}", report);
     }
+
+    Ok(())
 }

--- a/crates/perl-workspace/src/semantic/queries.rs
+++ b/crates/perl-workspace/src/semantic/queries.rs
@@ -4539,15 +4539,17 @@ mod tests {
                         .edits
                         .iter()
                         .find(|e| e.anchor_id == *anchor_id);
-                    prop_assert!(
-                        matching_edit.is_some(),
-                        "expected an edit for anchor {:?} with category {:?}, \
-                         but no matching edit found in plan. edits: {:?}",
-                        anchor_id,
-                        expected_cat,
-                        plan.edits,
-                    );
-                    let edit = matching_edit.expect("checked above");
+                    let Some(edit) = matching_edit else {
+                        prop_assert!(
+                            false,
+                            "expected an edit for anchor {:?} with category {:?}, \
+                             but no matching edit found in plan. edits: {:?}",
+                            anchor_id,
+                            expected_cat,
+                            plan.edits,
+                        );
+                        continue;
+                    };
                     prop_assert_eq!(
                         edit.category,
                         *expected_cat,

--- a/crates/perl-workspace/src/semantic/visibility.rs
+++ b/crates/perl-workspace/src/semantic/visibility.rs
@@ -1235,13 +1235,10 @@ mod tests {
 
                 // Every explicitly imported symbol must appear with ExplicitImport source.
                 for sym_name in &symbols {
-                    let found = visible.iter().find(|v| v.name == *sym_name);
-                    prop_assert!(
-                        found.is_some(),
-                        "explicit import '{}' should be visible",
-                        sym_name
-                    );
-                    let vs = found.expect("checked above");
+                    let Some(vs) = visible.iter().find(|v| v.name == *sym_name) else {
+                        prop_assert!(false, "explicit import '{}' should be visible", sym_name);
+                        continue;
+                    };
                     prop_assert_eq!(
                         &vs.source,
                         &VisibleSymbolSource::ExplicitImport,
@@ -1249,10 +1246,12 @@ mod tests {
                         sym_name
                     );
                     // Context should carry the source module.
-                    let ctx = vs.context.as_ref();
-                    prop_assert!(ctx.is_some(), "explicit import should have context");
+                    let Some(ctx) = vs.context.as_ref() else {
+                        prop_assert!(false, "explicit import should have context");
+                        continue;
+                    };
                     prop_assert_eq!(
-                        ctx.expect("checked above").source_module.as_deref(),
+                        ctx.source_module.as_deref(),
                         Some(module_name.as_str()),
                         "context source_module should match import module"
                     );
@@ -1312,23 +1311,22 @@ mod tests {
 
                 // Every default export must appear with DefaultExport source.
                 for sym_name in &default_exports {
-                    let found = visible.iter().find(|v| v.name == *sym_name);
-                    prop_assert!(
-                        found.is_some(),
-                        "default export '{}' should be visible",
-                        sym_name
-                    );
-                    let vs = found.expect("checked above");
+                    let Some(vs) = visible.iter().find(|v| v.name == *sym_name) else {
+                        prop_assert!(false, "default export '{}' should be visible", sym_name);
+                        continue;
+                    };
                     prop_assert_eq!(
                         &vs.source,
                         &VisibleSymbolSource::DefaultExport,
                         "default export '{}' should have DefaultExport source",
                         sym_name
                     );
-                    let ctx = vs.context.as_ref();
-                    prop_assert!(ctx.is_some(), "default export should have context");
+                    let Some(ctx) = vs.context.as_ref() else {
+                        prop_assert!(false, "default export should have context");
+                        continue;
+                    };
                     prop_assert_eq!(
-                        ctx.expect("checked above").source_module.as_deref(),
+                        ctx.source_module.as_deref(),
                         Some(module_name.as_str()),
                         "context source_module should match export module"
                     );
@@ -1404,24 +1402,27 @@ mod tests {
 
                 // Every tag member must appear with ExportTag source.
                 for sym_name in &tag_members {
-                    let found = visible.iter().find(|v| v.name == *sym_name);
-                    prop_assert!(
-                        found.is_some(),
-                        "tag member '{}' should be visible via :{} tag",
-                        sym_name,
-                        tag_name
-                    );
-                    let vs = found.expect("checked above");
+                    let Some(vs) = visible.iter().find(|v| v.name == *sym_name) else {
+                        prop_assert!(
+                            false,
+                            "tag member '{}' should be visible via :{} tag",
+                            sym_name,
+                            tag_name
+                        );
+                        continue;
+                    };
                     prop_assert_eq!(
                         &vs.source,
                         &VisibleSymbolSource::ExportTag,
                         "tag member '{}' should have ExportTag source",
                         sym_name
                     );
-                    let ctx = vs.context.as_ref();
-                    prop_assert!(ctx.is_some(), "tag export should have context");
+                    let Some(ctx) = vs.context.as_ref() else {
+                        prop_assert!(false, "tag export should have context");
+                        continue;
+                    };
                     prop_assert_eq!(
-                        ctx.expect("checked above").source_module.as_deref(),
+                        ctx.source_module.as_deref(),
                         Some(module_name.as_str()),
                         "context source_module should match export module"
                     );

--- a/crates/perl-workspace/src/workspace/workspace_index.rs
+++ b/crates/perl-workspace/src/workspace/workspace_index.rs
@@ -4794,11 +4794,10 @@ my $var = 42;
         must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
 
         let symbols = index.file_symbols(uri);
-        let pkg_sym = symbols.iter().find(|s| s.name == "Foo" && s.kind == SymbolKind::Package);
-        assert!(pkg_sym.is_some(), "Package symbol not found");
+        let pkg_sym =
+            must_some(symbols.iter().find(|s| s.name == "Foo" && s.kind == SymbolKind::Package));
         assert_eq!(
-            pkg_sym.unwrap().container_name,
-            None,
+            pkg_sym.container_name, None,
             "Package symbol must not carry a container (was 'main')"
         );
     }
@@ -4815,13 +4814,8 @@ my $var = 42;
         must(index.index_file(must(url::Url::parse(uri)), code.to_string()));
 
         let symbols = index.file_symbols(uri);
-        let var_sym = symbols.iter().find(|s| s.name == "$x" && s.kind.is_variable());
-        assert!(var_sym.is_some(), "$x variable not indexed");
-        assert_eq!(
-            var_sym.unwrap().qualified_name,
-            None,
-            "my variable must not have a qualified_name"
-        );
+        let var_sym = must_some(symbols.iter().find(|s| s.name == "$x" && s.kind.is_variable()));
+        assert_eq!(var_sym.qualified_name, None, "my variable must not have a qualified_name");
 
         // `find_definition("Foo::x")` must not accidentally resolve to a lexical variable.
         assert!(

--- a/crates/perl-workspace/tests/memory_profiling_test.rs
+++ b/crates/perl-workspace/tests/memory_profiling_test.rs
@@ -6,15 +6,16 @@
 //! Requires the `memory-profiling` feature.
 
 #![cfg(feature = "memory-profiling")]
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use perl_workspace::workspace::memory::{MemorySnapshot, ScaleReport};
 use perl_workspace::workspace_index::WorkspaceIndex;
 use url::Url;
 
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
 /// Generate a synthetic Perl module with a known number of symbols (5 per module).
-fn generate_module(idx: usize) -> (Url, String) {
-    let uri = Url::parse(&format!("file:///lib/Profile/Module{}.pm", idx)).expect("valid uri");
+fn generate_module(idx: usize) -> Result<(Url, String), Box<dyn std::error::Error>> {
+    let uri = Url::parse(&format!("file:///lib/Profile/Module{}.pm", idx))?;
     let src = format!(
         r#"package Profile::Module{idx};
 use strict;
@@ -49,11 +50,11 @@ sub _private_{idx} {{
 1;
 "#
     );
-    (uri, src)
+    Ok((uri, src))
 }
 
 #[test]
-fn memory_snapshot_is_zero_for_empty_index() {
+fn memory_snapshot_is_zero_for_empty_index() -> TestResult {
     let index = WorkspaceIndex::new();
     let snap = MemorySnapshot::capture(&index);
 
@@ -62,16 +63,18 @@ fn memory_snapshot_is_zero_for_empty_index() {
     assert_eq!(snap.files_bytes, 0, "empty index should report 0 bytes for files map");
     assert_eq!(snap.symbols_bytes, 0, "empty index should report 0 bytes for symbols map");
     assert_eq!(snap.total_estimated_bytes(), 0, "total should be 0 for empty index");
+
+    Ok(())
 }
 
 #[test]
-fn memory_snapshot_grows_with_files() {
+fn memory_snapshot_grows_with_files() -> TestResult {
     let index = WorkspaceIndex::new();
 
     // Index 10 files
     for i in 0..10 {
-        let (uri, src) = generate_module(i);
-        index.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index.index_file(uri, src)?;
     }
 
     let snap = MemorySnapshot::capture(&index);
@@ -81,23 +84,25 @@ fn memory_snapshot_grows_with_files() {
     assert!(snap.files_bytes > 0, "files_bytes should be positive after indexing");
     assert!(snap.symbols_bytes > 0, "symbols_bytes should be positive after indexing");
     assert!(snap.total_estimated_bytes() > 0, "total should be positive after indexing");
+
+    Ok(())
 }
 
 #[test]
-fn memory_snapshot_scales_linearly_with_file_count() {
+fn memory_snapshot_scales_linearly_with_file_count() -> TestResult {
     let index_small = WorkspaceIndex::new();
     let index_large = WorkspaceIndex::new();
 
     // Index 10 files in small
     for i in 0..10 {
-        let (uri, src) = generate_module(i);
-        index_small.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index_small.index_file(uri, src)?;
     }
 
     // Index 100 files in large
     for i in 0..100 {
-        let (uri, src) = generate_module(i);
-        index_large.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index_large.index_file(uri, src)?;
     }
 
     let snap_small = MemorySnapshot::capture(&index_small);
@@ -114,14 +119,16 @@ fn memory_snapshot_scales_linearly_with_file_count() {
 
     assert!(snap_large.file_count == 100, "large index should have 100 files");
     assert!(snap_small.file_count == 10, "small index should have 10 files");
+
+    Ok(())
 }
 
 #[test]
-fn memory_snapshot_display_is_human_readable() {
+fn memory_snapshot_display_is_human_readable() -> TestResult {
     let index = WorkspaceIndex::new();
     for i in 0..5 {
-        let (uri, src) = generate_module(i);
-        index.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index.index_file(uri, src)?;
     }
 
     let snap = MemorySnapshot::capture(&index);
@@ -131,17 +138,19 @@ fn memory_snapshot_display_is_human_readable() {
     assert!(display.contains("files"), "display should mention files component");
     assert!(display.contains("symbols"), "display should mention symbols component");
     assert!(display.contains("total"), "display should mention total");
+
+    Ok(())
 }
 
 #[test]
-fn scale_report_captures_multiple_checkpoints() {
+fn scale_report_captures_multiple_checkpoints() -> TestResult {
     let mut report = ScaleReport::new();
 
     for scale in [10usize, 50, 100] {
         let index = WorkspaceIndex::new();
         for i in 0..scale {
-            let (uri, src) = generate_module(i);
-            index.index_file(uri, src).ok();
+            let (uri, src) = generate_module(i)?;
+            index.index_file(uri, src)?;
         }
         let snap = MemorySnapshot::capture(&index);
         report.add_checkpoint(scale, snap);
@@ -158,16 +167,18 @@ fn scale_report_captures_multiple_checkpoints() {
         "memory should increase monotonically: {:?}",
         mems
     );
+
+    Ok(())
 }
 
 #[test]
-fn memory_snapshot_bytes_per_symbol_is_reasonable() {
+fn memory_snapshot_bytes_per_symbol_is_reasonable() -> TestResult {
     let index = WorkspaceIndex::new();
 
     // Index 100 files, each with ~5 symbols => ~500 symbols
     for i in 0..100 {
-        let (uri, src) = generate_module(i);
-        index.index_file(uri, src).ok();
+        let (uri, src) = generate_module(i)?;
+        index.index_file(uri, src)?;
     }
 
     let snap = MemorySnapshot::capture(&index);
@@ -186,4 +197,6 @@ fn memory_snapshot_bytes_per_symbol_is_reasonable() {
         "bytes per symbol should be at most 10,000: got {}",
         bytes_per_symbol
     );
+
+    Ok(())
 }

--- a/crates/perl-workspace/tests/workspace_folder_bdd.rs
+++ b/crates/perl-workspace/tests/workspace_folder_bdd.rs
@@ -15,11 +15,13 @@ fn given_file_uri_when_resolving_then_path_is_returned() {
 }
 
 #[test]
-fn given_file_uri_with_unresolvable_path_when_resolving_then_scheme_is_stripped() {
+fn given_file_uri_with_remote_host_when_resolving_then_remote_host_is_not_pathified() {
     let parsed = workspace_folder_to_path("file://relative/example");
-    assert!(!parsed.to_string_lossy().contains("file://"));
-    // On Windows, file://host/path resolves as a UNC path \\host\path;
-    // on other platforms the fallback strips "file://" and returns "relative/example".
-    // Either way the path must contain "example".
-    assert!(parsed.to_string_lossy().contains("example"));
+    let path = parsed.to_string_lossy();
+
+    // Remote file URI hosts must not be stripped into a path component that a caller
+    // could accidentally open as a local/UNC path. Keeping the raw URI makes the
+    // unresolved authority explicit while preserving the original value for diagnostics.
+    assert!(path.contains("file://relative/example"));
+    assert!(!path.starts_with("relative"));
 }


### PR DESCRIPTION
### Motivation

- Tests and a profiling harness assumed infallible URL parsing / indexing and used `expect`/`unwrap`, making them brittle and violating the workspace test style. 
- A workspace-folder BDD fixture expected non-local `file://` authorities to be converted into local paths, which is unsafe and inconsistent with hardened behavior. 

### Description

- Convert the memory-profiling harness to propagate errors by returning `Result` from `generate_module`, `build_index_at_scale`, `run_profile`, and `main`, and replace `expect`/`ok()` cruft with `?`. 
- Update memory-profiling tests to return `Result` and propagate failures using `?`, removing infallible assumptions. 
- Replace checked `expect`/`unwrap` assertions in property/unit tests with safe `let Some(...)` pattern matches (with `prop_assert!`/`continue` or `must_some`) to preserve diagnostic messages while avoiding panics. 
- Harden the workspace-folder BDD: remote/non-local `file://` authorities are not pathified; the test now asserts the raw URI is preserved instead of being trimmed into a local-looking path. 

### Testing

- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo test -p perl-workspace --profile agent --locked` which executed the crate test-suite and passed (all relevant tests passed). 
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo check -p perl-workspace --all-targets --features memory-profiling --profile agent --locked` and it passed. 
- Ran `CARGO_TARGET_DIR=/root/.cache/devplane/perl-lsp/target cargo clippy -p perl-workspace --all-targets --features memory-profiling --profile agent --locked -- -D warnings -A missing_docs` and it passed. 
- Ran formatting via `./scripts/cargo-safe xtask fmt` and `./scripts/storage-doctor`; formatting and storage checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cb1063a483339486f6311da45cca)