### PR TITLE
fix(workspace-symbols): dedupe candidate queries (#8378)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs
@@ -79,7 +79,7 @@ use perl_workspace::semantic_shadow_compare::{
     SemanticShadowCompareReceipt, ShadowQueryInput, ShadowQueryName, summarize_identities,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// LSP WorkspaceSymbol representing a symbol found in the workspace.
 ///
@@ -340,7 +340,12 @@ impl WorkspaceSymbolsProvider {
         candidates: &[String],
     ) -> Vec<WorkspaceSymbol> {
         let mut results = Vec::new();
+        let mut seen_candidates = HashSet::new();
         for candidate in candidates {
+            if !seen_candidates.insert(candidate.as_str()) {
+                continue;
+            }
+
             if let Some(entries) = self.symbols_by_name.get(candidate) {
                 for (uri, symbol) in entries {
                     if matches_query(&symbol.name, query) {
@@ -1298,6 +1303,29 @@ sub get_log { 3 }
 
         assert!(names.contains(&"alpha"), "alpha is a candidate match");
         assert!(!names.contains(&"apex"), "apex is not in candidate set");
+    }
+
+    #[test]
+    fn search_with_candidates_deduplicates_candidate_names() {
+        let mut provider = WorkspaceSymbolsProvider::new();
+        let mut source_map = HashMap::new();
+
+        let source = "sub alpha { 1 }\nsub beta { 2 }\n";
+        source_map.insert("file:///dedupe.pl".to_string(), source.to_string());
+
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        provider.index_document("file:///dedupe.pl", &ast, source);
+
+        let candidates = vec!["alpha".to_string(), "alpha".to_string(), "beta".to_string()];
+        let results = provider.search_with_candidates("a", &source_map, &candidates);
+        let names: Vec<&str> = results.iter().map(|s| s.name.as_str()).collect();
+
+        assert_eq!(
+            names,
+            vec!["alpha", "beta"],
+            "duplicate candidate names should not duplicate workspace/symbol results"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent duplicate candidate names from producing duplicated LSP `workspace/symbol` results when callers pass repeated symbol names as candidates.

### Description

- Add `HashSet` tracking to `search_with_candidates` to skip repeated candidate names while preserving first-seen processing order in `crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs`.
- Update imports to `use std::collections::{HashMap, HashSet};` and add a focused regression test `search_with_candidates_deduplicates_candidate_names` to assert duplicates are not returned twice.
- Keep sorting and relevance behavior unchanged and ensure UTF-16 position conversion remains handled by existing `WireRange::from_byte_offsets` logic.

### Testing

- Ran `./scripts/cargo-safe xtask fmt` and it passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-rs-core workspace_symbols --profile agent --locked`, and the provider unit tests (including `providers::workspace_symbols` tests) passed (21 passed; 0 failed).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-lsp-rs-core --profile agent --locked` and it passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08caa76f548333a5ce5ccb2ee4c4f2)