### PR TITLE
test(code-actions): remove bare unwraps (#0000)

### DIFF
--- a/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
+++ b/crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs
@@ -399,7 +399,7 @@ mod tests {
 
         assert!(actions.iter().any(|action| {
             action.title == "Remove unused variable '$unused'"
-                && action.edit.range == (source.find("my $unused").unwrap(), source.len())
+                && action.edit.range == (must_some(source.find("my $unused")), source.len())
         }));
         assert!(actions.iter().any(|action| {
             action.title == "Rename to '$_unused' (mark as intentionally unused)"
@@ -424,7 +424,7 @@ mod tests {
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Remove redundant 'my'");
-        assert_eq!(actions[0].edit.range, (source.rfind("my $dup").unwrap(), start));
+        assert_eq!(actions[0].edit.range, (must_some(source.rfind("my $dup")), start));
         assert_eq!(actions[0].edit.new_text, "");
     }
 


### PR DESCRIPTION
### Motivation
- Remove two uses of bare `unwrap()` in `perl-lsp-rs` tests to conform to repository test style that prefers `perl_tdd_support::must_some` over `unwrap()`/`expect()`.

### Description
- Replace two fixture offset lookups in `crates/perl-lsp-rs/src/features/code_actions_provider/mod.rs` from `source.find(...).unwrap()` / `source.rfind(...).unwrap()` to `must_some(...)` (from `perl_tdd_support`).

### Testing
- Ran formatter and the targeted test suite with `MIN_FREE_GB=20 ./scripts/cargo-safe xtask fmt` and `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked code_actions_provider`, and the `code_actions_provider` tests passed (88 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08caa4094c83338c2cb8984e0ca85d)