### PR TITLE
feat(perl-ast): add deepest offset lookup (#0000)

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -1413,6 +1413,54 @@ impl Node {
         self.location.end.saturating_sub(self.location.start)
     }
 
+    /// Find the deepest node whose source span contains `offset`.
+    ///
+    /// This is useful for editor features that need the most specific AST node
+    /// at a cursor byte offset without allocating a full traversal path. The
+    /// start position is inclusive and the end position is exclusive, matching
+    /// [`contains_offset`](Self::contains_offset).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::{Node, NodeKind, SourceLocation};
+    ///
+    /// let loc = SourceLocation { start: 0, end: 5 };
+    /// let expr = Node::new(
+    ///     NodeKind::Binary {
+    ///         op: "+".to_string(),
+    ///         left: Box::new(Node::new(
+    ///             NodeKind::Number { value: "1".to_string() },
+    ///             SourceLocation { start: 0, end: 1 },
+    ///         )),
+    ///         right: Box::new(Node::new(
+    ///             NodeKind::Number { value: "22".to_string() },
+    ///             SourceLocation { start: 3, end: 5 },
+    ///         )),
+    ///     },
+    ///     loc,
+    /// );
+    ///
+    /// assert_eq!(expr.find_deepest_at_offset(3).map(|n| n.span_len()), Some(2));
+    /// assert!(expr.find_deepest_at_offset(5).is_none());
+    /// ```
+    #[inline]
+    pub fn find_deepest_at_offset(&self, offset: usize) -> Option<&Node> {
+        if !self.contains_offset(offset) {
+            return None;
+        }
+
+        let mut result = self;
+        self.for_each_child(|child| {
+            if let Some(candidate) = child.find_deepest_at_offset(offset) {
+                if candidate.span_len() <= result.span_len() {
+                    result = candidate;
+                }
+            }
+        });
+        Some(result)
+    }
+
     /// Get the last direct child node, if any.
     ///
     /// Optimized to avoid allocating the children vector.

--- a/crates/perl-ast/tests/ast_behavior_spec_tests.rs
+++ b/crates/perl-ast/tests/ast_behavior_spec_tests.rs
@@ -231,3 +231,63 @@ fn when_requesting_last_child_on_program_then_last_statement_is_returned() {
 
     assert_eq!(child.map(|c| c.kind.kind_name()), Some("Identifier"));
 }
+
+#[test]
+fn when_finding_deepest_node_at_offset_then_most_specific_match_is_returned() {
+    let tree = Node::new(
+        NodeKind::Program {
+            statements: vec![Node::new(
+                NodeKind::ExpressionStatement {
+                    expression: Box::new(Node::new(
+                        NodeKind::Binary {
+                            op: "+".to_string(),
+                            left: Box::new(Node::new(
+                                NodeKind::Identifier { name: "left".to_string() },
+                                loc(0, 4),
+                            )),
+                            right: Box::new(Node::new(
+                                NodeKind::Number { value: "42".to_string() },
+                                loc(7, 9),
+                            )),
+                        },
+                        loc(0, 9),
+                    )),
+                },
+                loc(0, 10),
+            )],
+        },
+        loc(0, 10),
+    );
+
+    let node = tree.find_deepest_at_offset(8);
+
+    assert_eq!(node.map(|found| found.kind.kind_name()), Some("Number"));
+}
+
+#[test]
+fn when_finding_deepest_node_at_offset_on_gap_then_nearest_containing_ancestor_is_returned() {
+    let tree = Node::new(
+        NodeKind::Binary {
+            op: "+".to_string(),
+            left: Box::new(Node::new(NodeKind::Identifier { name: "a".to_string() }, loc(0, 1))),
+            right: Box::new(Node::new(NodeKind::Identifier { name: "b".to_string() }, loc(4, 5))),
+        },
+        loc(0, 5),
+    );
+
+    let node = tree.find_deepest_at_offset(2);
+
+    assert_eq!(node.map(|found| found.kind.kind_name()), Some("Binary"));
+}
+
+#[test]
+fn when_finding_deepest_node_at_exclusive_end_then_none_is_returned() {
+    let tree = Node::new(
+        NodeKind::Program {
+            statements: vec![Node::new(NodeKind::Number { value: "1".to_string() }, loc(0, 1))],
+        },
+        loc(0, 1),
+    );
+
+    assert!(tree.find_deepest_at_offset(1).is_none());
+}


### PR DESCRIPTION
### Motivation

- Callers that need the most specific AST node at a cursor byte offset currently must allocate traversal paths or re-traverse the tree; a small helper simplifies editor-facing lookups.

### Description

- Add `Node::find_deepest_at_offset(&self, offset: usize) -> Option<&Node>` to `crates/perl-ast/src/ast.rs` which returns the most specific node whose span contains `offset` using inclusive-start / exclusive-end semantics.
- Implement deepest-child recursion using the existing `for_each_child` traversal to avoid extra allocations and preserve current span semantics.
- Add unit tests to `crates/perl-ast/tests/ast_behavior_spec_tests.rs` covering exact child matches, ancestor fallback for inter-child gaps, and exclusive-end misses.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-ast --profile agent --locked` and all `perl-ast` tests passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-ast --profile agent --locked`, `./scripts/cargo-safe xtask fmt --check`, and `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-ast --profile agent --locked -- -D warnings -A missing_docs` and they all completed successfully.
- Doctests for `crates/perl-ast/src/ast.rs` covering the new API were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ca9e40648333a7e1f0db249bea82)