### PR TITLE
feat(perl-ast): add cursor span lookup helpers (#0000)

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -1413,6 +1413,56 @@ impl Node {
         self.location.end.saturating_sub(self.location.start)
     }
 
+    /// Returns `true` when this node has no direct child nodes.
+    ///
+    /// Optimized to avoid allocating the children vector.
+    #[inline]
+    pub fn is_leaf(&self) -> bool {
+        self.first_child().is_none()
+    }
+
+    /// Find the deepest node whose source span contains `offset`.
+    ///
+    /// This is useful for cursor-oriented LSP features that need the most
+    /// specific AST node at a byte offset. The search honors
+    /// [`contains_offset`](Self::contains_offset): starts are inclusive, ends
+    /// are exclusive, and zero-length spans do not contain any offset.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::{Node, NodeKind, SourceLocation};
+    ///
+    /// let child = Node::new(
+    ///     NodeKind::Number { value: "42".to_string() },
+    ///     SourceLocation { start: 5, end: 7 },
+    /// );
+    /// let program = Node::new(
+    ///     NodeKind::Program { statements: vec![child] },
+    ///     SourceLocation { start: 0, end: 10 },
+    /// );
+    ///
+    /// assert_eq!(
+    ///     program.find_deepest_node_at_offset(5).map(|node| node.kind.kind_name()),
+    ///     Some("Number")
+    /// );
+    /// assert_eq!(program.find_deepest_node_at_offset(10), None);
+    /// ```
+    pub fn find_deepest_node_at_offset(&self, offset: usize) -> Option<&Node> {
+        if !self.contains_offset(offset) {
+            return None;
+        }
+
+        let mut deepest = None;
+        self.for_each_child(|child| {
+            if deepest.is_none() {
+                deepest = child.find_deepest_node_at_offset(offset);
+            }
+        });
+
+        deepest.or(Some(self))
+    }
+
     /// Get the last direct child node, if any.
     ///
     /// Optimized to avoid allocating the children vector.

--- a/crates/perl-ast/tests/ast_coverage_tests.rs
+++ b/crates/perl-ast/tests/ast_coverage_tests.rs
@@ -1879,3 +1879,51 @@ fn debug_nodekind_shows_variant_fields() -> Result<(), Box<dyn std::error::Error
     assert!(dbg.contains("arr"), "got: {dbg}");
     Ok(())
 }
+
+// 11. Cursor-oriented span lookup helpers
+
+#[test]
+fn is_leaf_distinguishes_nodes_with_children() -> Result<(), Box<dyn std::error::Error>> {
+    let leaf = num("1");
+    let branch = Node::new(NodeKind::Program { statements: vec![leaf.clone()] }, loc(0, 1));
+
+    assert!(leaf.is_leaf());
+    assert!(!branch.is_leaf());
+
+    Ok(())
+}
+
+#[test]
+fn find_deepest_node_at_offset_prefers_most_specific_child()
+-> Result<(), Box<dyn std::error::Error>> {
+    let target = Node::new(NodeKind::Number { value: "42".to_string() }, loc(8, 10));
+    let expression =
+        Node::new(NodeKind::ExpressionStatement { expression: Box::new(target) }, loc(5, 11));
+    let program = Node::new(NodeKind::Program { statements: vec![expression] }, loc(0, 20));
+
+    let found = program.find_deepest_node_at_offset(8);
+
+    assert_eq!(found.map(|node| node.kind.kind_name()), Some("Number"));
+    Ok(())
+}
+
+#[test]
+fn find_deepest_node_at_offset_falls_back_to_self_when_no_child_contains_offset()
+-> Result<(), Box<dyn std::error::Error>> {
+    let child = Node::new(NodeKind::Number { value: "1".to_string() }, loc(8, 9));
+    let program = Node::new(NodeKind::Program { statements: vec![child] }, loc(0, 20));
+
+    let found = program.find_deepest_node_at_offset(3);
+
+    assert_eq!(found.map(|node| node.kind.kind_name()), Some("Program"));
+    Ok(())
+}
+
+#[test]
+fn find_deepest_node_at_offset_respects_exclusive_end_bound()
+-> Result<(), Box<dyn std::error::Error>> {
+    let program = Node::new(NodeKind::Program { statements: vec![] }, loc(0, 20));
+
+    assert!(program.find_deepest_node_at_offset(20).is_none());
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Provide a small, allocation-free helper for cursor-oriented LSP consumers to locate the most specific AST node at a byte offset.
- Preserve existing span semantics (start inclusive, end exclusive) so editor features behave predictably on boundary offsets.

### Description

- Add `Node::is_leaf(&self) -> bool` as a fast helper that avoids allocating child vectors and returns true when a node has no direct children.
- Add `Node::find_deepest_node_at_offset(&self, offset: usize) -> Option<&Node>` which returns the deepest descendant whose span contains `offset`, or `None` when `offset` is outside this node's span, and includes examples in the doc comments.
- Add unit tests in `crates/perl-ast/tests/ast_coverage_tests.rs` to cover leaf detection, deepest-child selection, fallback-to-self behavior, and exclusive end-bound handling.
- Run `xtask fmt` on the modified files; no other unrelated files were changed.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-ast --profile agent --locked` and all unit tests and doctests passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-ast --profile agent --locked` and the build check passed.
- Ran `./scripts/cargo-safe xtask fmt` and formatting completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-ast --profile agent --locked -- -D warnings -A missing_docs` and clippy checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ca9e40648333a7e1f0db249bea82)