### PR TITLE
feat(perl-ast): add deepest node lookup (#0000)

### DIFF
--- a/crates/perl-ast/src/ast.rs
+++ b/crates/perl-ast/src/ast.rs
@@ -1413,6 +1413,41 @@ impl Node {
         self.location.end.saturating_sub(self.location.start)
     }
 
+    /// Find the deepest descendant whose source span contains `offset`.
+    ///
+    /// Returns `None` when `offset` is outside this node's span. If multiple
+    /// nested nodes contain the offset, the most-specific descendant is returned;
+    /// otherwise this node is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use perl_ast::{Node, NodeKind, SourceLocation};
+    ///
+    /// let outer = SourceLocation { start: 0, end: 5 };
+    /// let inner = SourceLocation { start: 1, end: 4 };
+    /// let child = Node::new(NodeKind::Identifier { name: "foo".to_string() }, inner);
+    /// let node = Node::new(NodeKind::Block { statements: vec![child] }, outer);
+    ///
+    /// assert_eq!(node.deepest_node_at_offset(2).map(|n| n.kind.kind_name()), Some("Identifier"));
+    /// assert_eq!(node.deepest_node_at_offset(4).map(|n| n.kind.kind_name()), Some("Block"));
+    /// assert!(node.deepest_node_at_offset(5).is_none());
+    /// ```
+    #[inline]
+    pub fn deepest_node_at_offset(&self, offset: usize) -> Option<&Node> {
+        if !self.contains_offset(offset) {
+            return None;
+        }
+
+        let mut result = self;
+        self.for_each_child(|child| {
+            if let Some(found) = child.deepest_node_at_offset(offset) {
+                result = found;
+            }
+        });
+        Some(result)
+    }
+
     /// Get the last direct child node, if any.
     ///
     /// Optimized to avoid allocating the children vector.

--- a/crates/perl-ast/tests/ast_behavior_spec_tests.rs
+++ b/crates/perl-ast/tests/ast_behavior_spec_tests.rs
@@ -231,3 +231,59 @@ fn when_requesting_last_child_on_program_then_last_statement_is_returned() {
 
     assert_eq!(child.map(|c| c.kind.kind_name()), Some("Identifier"));
 }
+
+#[test]
+fn when_finding_deepest_node_at_offset_then_most_specific_descendant_is_returned() {
+    let node = Node::new(
+        NodeKind::Program {
+            statements: vec![Node::new(
+                NodeKind::ExpressionStatement {
+                    expression: Box::new(Node::new(
+                        NodeKind::Binary {
+                            op: "+".to_string(),
+                            left: Box::new(Node::new(
+                                NodeKind::Identifier { name: "x".to_string() },
+                                loc(2, 3),
+                            )),
+                            right: Box::new(Node::new(
+                                NodeKind::Number { value: "42".to_string() },
+                                loc(6, 8),
+                            )),
+                        },
+                        loc(2, 8),
+                    )),
+                },
+                loc(2, 8),
+            )],
+        },
+        loc(0, 10),
+    );
+
+    let found = node.deepest_node_at_offset(6);
+
+    assert_eq!(found.map(|n| n.kind.kind_name()), Some("Number"));
+}
+
+#[test]
+fn when_finding_deepest_node_at_offset_in_operator_gap_then_containing_expression_is_returned() {
+    let node = Node::new(
+        NodeKind::Binary {
+            op: "+".to_string(),
+            left: Box::new(Node::new(NodeKind::Identifier { name: "x".to_string() }, loc(2, 3))),
+            right: Box::new(Node::new(NodeKind::Number { value: "42".to_string() }, loc(6, 8))),
+        },
+        loc(2, 8),
+    );
+
+    let found = node.deepest_node_at_offset(4);
+
+    assert_eq!(found.map(|n| n.kind.kind_name()), Some("Binary"));
+}
+
+#[test]
+fn when_finding_deepest_node_at_offset_outside_span_then_none_is_returned() {
+    let node = Node::new(NodeKind::Identifier { name: "foo".to_string() }, loc(3, 6));
+
+    assert!(node.deepest_node_at_offset(6).is_none());
+    assert!(node.deepest_node_at_offset(2).is_none());
+}


### PR DESCRIPTION
### Motivation
- Consumers need a convenient way to resolve the most specific AST node that covers a given byte offset for editor features like go-to, hover, and diagnostics.

### Description
- Add `Node::deepest_node_at_offset(&self, offset: usize) -> Option<&Node>` to return the most-specific descendant whose span contains `offset` (returns `None` when outside the node span) in `crates/perl-ast/src/ast.rs`.
- Implement depth-first descent using the existing `for_each_child` traversal to prefer deeper matches.
- Add behavior tests in `crates/perl-ast/tests/ast_behavior_spec_tests.rs` covering nested nodes, operator-gap offsets that should map to the containing expression, and out-of-span offsets.
- Keep public API and formatting consistent with existing crate conventions and doc examples.

### Testing
- Ran unit tests with `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-ast --profile agent --locked`, and all `perl-ast` tests passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-ast --profile agent --locked`, and the crate checks passed.
- Ran `./scripts/cargo-safe xtask fmt` and `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-ast --profile agent --locked -- -D warnings -A missing_docs`, and formatting and lints passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ca9e40648333a7e1f0db249bea82)