### PR TITLE
fix(perl-uri): encode legacy Windows URI keys (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -107,10 +107,12 @@ fn normalize_unc_path_to_key(path: &str) -> Option<String> {
     let share = parts.next()?;
     let rest = parts.collect::<Vec<_>>().join("/");
 
+    let encoded_share = percent_encode_uri_path_component(share);
     if rest.is_empty() {
-        Some(format!("file://{server}/{share}"))
+        Some(format!("file://{server}/{encoded_share}"))
     } else {
-        Some(format!("file://{server}/{share}/{rest}"))
+        let encoded_rest = percent_encode_uri_path(&rest);
+        Some(format!("file://{server}/{encoded_share}/{encoded_rest}"))
     }
 }
 
@@ -144,9 +146,40 @@ fn normalize_windows_path_to_key(path: &str) -> Option<String> {
         normalized.insert(2, '/');
     }
 
-    // Lowercase the drive letter.
+    // Lowercase the drive letter and percent-encode characters that are not
+    // valid in URI paths (spaces, fragments, non-ASCII bytes, etc.).
     let drive = normalized[0..1].to_ascii_lowercase();
-    Some(format!("file:///{drive}{}", &normalized[1..]))
+    let path = format!("{drive}{}", &normalized[1..]);
+    Some(format!("file:///{}", percent_encode_uri_path(&path)))
+}
+
+fn percent_encode_uri_path(path: &str) -> String {
+    path.split('/').map(percent_encode_uri_path_component).collect::<Vec<_>>().join("/")
+}
+
+fn percent_encode_uri_path_component(component: &str) -> String {
+    let mut encoded = String::with_capacity(component.len());
+    for byte in component.as_bytes() {
+        match *byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b':' => {
+                encoded.push(char::from(*byte))
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push(hex_digit(byte >> 4));
+                encoded.push(hex_digit(byte & 0x0f));
+            }
+        }
+    }
+    encoded
+}
+
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => char::from(b'0' + nibble),
+        10..=15 => char::from(b'A' + (nibble - 10)),
+        _ => '0',
+    }
 }
 
 /// Check if a URI uses the `file://` scheme.
@@ -232,6 +265,15 @@ mod tests {
     }
 
     #[test]
+    fn percent_encodes_legacy_windows_path_keys() {
+        assert_eq!(
+            uri_key(r"C:\Users\dev\my script #1.pl"),
+            "file:///c:/Users/dev/my%20script%20%231.pl"
+        );
+        assert_eq!(uri_key(r"file://C:\Users\dev\café.pl"), "file:///c:/Users/dev/caf%C3%A9.pl");
+    }
+
+    #[test]
     fn normalizes_legacy_file_uri_two_slashes_forward_slash() {
         // Some clients emit `file://C:/...` (two slashes, forward slashes) instead of
         // the canonical three-slash form.  The pre-pass handles both backslash and
@@ -281,6 +323,14 @@ mod tests {
         assert_eq!(
             uri_key(r"file://\\server\share\folder\file.pl"),
             "file://server/share/folder/file.pl"
+        );
+    }
+
+    #[test]
+    fn percent_encodes_legacy_unc_path_keys() {
+        assert_eq!(
+            uri_key(r"\\server\shared docs\café scripts\hello world.pl"),
+            "file://server/shared%20docs/caf%C3%A9%20scripts/hello%20world.pl"
         );
     }
 


### PR DESCRIPTION
### Motivation

- Legacy Windows and UNC path normalization could produce `file://` keys containing raw spaces, `#` fragments, and non-ASCII bytes, which breaks stable cache keys and lookups.
- The change preserves existing drive-letter canonicalization while ensuring generated URI keys are safe and consistent across platforms.

### Description

- Updated `normalize_unc_path_to_key` to percent-encode the share and the remainder path components before building `file://server/...` keys.
- Updated `normalize_windows_path_to_key` to percent-encode the post-drive path after lowercasing the drive letter and assembling the canonical `file:///c:/...` key.
- Added helper functions `percent_encode_uri_path`, `percent_encode_uri_path_component`, and `hex_digit` to perform component-wise percent-encoding.
- Added unit tests `percent_encodes_legacy_windows_path_keys` and `percent_encodes_legacy_unc_path_keys` in `crates/perl-uri/src/classify.rs` to cover spaces, `#`, and Unicode characters.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-uri --profile agent --locked` and all unit tests and doctests passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-uri --profile agent --locked` and the type/check pass succeeded.
- Ran `./scripts/cargo-safe xtask fmt` and formatting completed successfully, and ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-uri --profile agent --locked -- -D warnings -A missing_docs` with no warnings.
- Attempted `just agent-pr-fast` but it could not be run in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ca2d0d6c83339d7211454fe18cbf)