### PR TITLE
fix(dap): validate inline values source paths (#0000)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -1386,6 +1386,39 @@ mod tests {
     }
 
     #[test]
+    fn test_inline_values_rejects_traversal() -> Result<(), Box<dyn std::error::Error>> {
+        let mut adapter = DebugAdapter::new();
+        adapter.handle_request(1, "initialize", None);
+
+        let dir = tempfile::tempdir()?;
+        *lock_or_recover(&adapter.workspace_root, "test.workspace_root") =
+            Some(dir.path().to_path_buf());
+
+        let response = adapter.handle_request(
+            2,
+            "inlineValues",
+            Some(json!({
+                "source": {"path": "../../../etc/passwd"},
+                "startLine": 1,
+                "endLine": 1
+            })),
+        );
+        match response {
+            DapMessage::Response { success, command, message, .. } => {
+                assert!(!success, "inlineValues with traversal path should fail");
+                assert_eq!(command, "inlineValues");
+                let msg = message.as_deref().unwrap_or("");
+                assert!(
+                    msg.contains("Path validation failed"),
+                    "should report path validation failure, got: {msg}"
+                );
+            }
+            _ => return Err("Expected response".into()),
+        }
+        Ok(())
+    }
+
+    #[test]
     fn test_source_rejects_traversal() -> Result<(), Box<dyn std::error::Error>> {
         let mut adapter = DebugAdapter::new();
         adapter.handle_request(1, "initialize", None);

--- a/crates/perl-dap/src/debug_adapter/output.rs
+++ b/crates/perl-dap/src/debug_adapter/output.rs
@@ -62,7 +62,20 @@ impl DebugAdapter {
 
         let start_line = args.start_line.min(args.end_line);
         let end_line = args.end_line.max(args.start_line);
-        let content = match std::fs::read_to_string(&source_path) {
+        let validated_path = match self.validate_source_path(&source_path) {
+            Ok(path) => path,
+            Err(e) => {
+                return DapMessage::Response {
+                    seq,
+                    request_seq,
+                    success: false,
+                    command: "inlineValues".to_string(),
+                    body: None,
+                    message: Some(e),
+                };
+            }
+        };
+        let content = match std::fs::read_to_string(&validated_path) {
             Ok(content) => content,
             Err(e) => {
                 return DapMessage::Response {


### PR DESCRIPTION
### Motivation

- The `inlineValues` DAP handler read client-provided source paths directly, missing the workspace path validation applied elsewhere and allowing potential path-traversal reads.

### Description

- Validate `inlineValues` source paths using `self.validate_source_path()` before reading the file and return a structured failure response on validation error in `crates/perl-dap/src/debug_adapter/output.rs`.
- Add a regression test `test_inline_values_rejects_traversal` to `crates/perl-dap/src/debug_adapter/mod.rs` that verifies traversal paths are rejected when a workspace root is set.
- Changes touch only the DAP inline-values handler and its tests (`output.rs` and `mod.rs`).

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe xtask fmt` which completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-dap --profile agent --locked test_inline_values_rejects_traversal` and the new test passed.
- Ran `MIN_FREE_GB=15 ./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` which completed successfully.
- Ran `MIN_FREE_GB=15 ./scripts/cargo-safe clippy -p perl-dap --profile agent --locked -- -D warnings -A missing_docs` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ca9ab9c48333bab3f77af8bea771)