### PR TITLE
fix(perl-regex): respect backtracking barriers (#0000)

### DIFF
--- a/crates/perl-regex/src/validator/nested_quantifier.rs
+++ b/crates/perl-regex/src/validator/nested_quantifier.rs
@@ -6,12 +6,12 @@ pub(crate) fn find_nested_quantifier(pattern: &str, start_pos: usize) -> Option<
     let bytes = pattern.as_bytes();
     let mut i = 0;
     let mut group_stack = Vec::new();
-    let mut last_type = 0;
+    let mut last_type = TokenType::Other;
     while i < bytes.len() {
         match bytes[i] {
             b'\\' => {
                 i += 2;
-                last_type = 0;
+                last_type = TokenType::Other;
                 continue;
             }
             b'[' => {
@@ -25,51 +25,112 @@ pub(crate) fn find_nested_quantifier(pattern: &str, start_pos: usize) -> Option<
                         i += 1;
                     }
                 }
-                last_type = 0;
+                last_type = TokenType::Other;
             }
             b'(' => {
-                if i + 1 < bytes.len() && bytes[i + 1] == b'?' {
-                    i += 2;
-                    if i < bytes.len()
-                        && matches!(bytes[i], b':' | b'=' | b'!' | b'<' | b'>' | b'|' | b'P' | b'#')
-                    {
-                        i += 1;
-                    }
-                } else {
-                    i += 1;
-                }
-                group_stack.push(false);
-                last_type = 0;
+                let (group, next) = parse_group_start(bytes, i);
+                group_stack.push(group);
+                i = next;
+                last_type = TokenType::Other;
                 continue;
             }
             b')' => {
-                if let Some(has_quantifier) = group_stack.pop() {
-                    last_type = if has_quantifier { 2 } else { 0 };
+                if let Some(group) = group_stack.pop() {
+                    last_type = if group.has_backtracking_quantifier {
+                        TokenType::QuantifiedGroup
+                    } else {
+                        TokenType::Other
+                    };
                 }
             }
             b'+' | b'*' | b'?' | b'{' => {
-                if last_type == 2 {
-                    if bytes[i] == b'{' {
-                        let mut j = i + 1;
-                        if is_brace_quantifier(bytes, &mut j) {
-                            return Some(start_pos + i);
-                        }
-                        last_type = 0;
-                        i += 1;
-                        continue;
-                    }
+                let Some(quantifier) = parse_quantifier(bytes, i) else {
+                    last_type = TokenType::Other;
+                    i += 1;
+                    continue;
+                };
+
+                if last_type == TokenType::QuantifiedGroup && quantifier.allows_backtracking {
                     return Some(start_pos + i);
                 }
-                if let Some(last) = group_stack.last_mut() {
-                    *last = true;
+
+                if quantifier.allows_backtracking {
+                    if let Some(last) = group_stack.last_mut() {
+                        if !last.is_atomic {
+                            last.has_backtracking_quantifier = true;
+                        }
+                    }
                 }
-                last_type = 1;
+                i = quantifier.next;
+                last_type = TokenType::Quantifier;
+                continue;
             }
-            _ => last_type = 0,
+            _ => last_type = TokenType::Other,
         }
         i += 1;
     }
     None
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TokenType {
+    Other,
+    Quantifier,
+    QuantifiedGroup,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GroupContext {
+    has_backtracking_quantifier: bool,
+    is_atomic: bool,
+}
+
+fn parse_group_start(bytes: &[u8], offset: usize) -> (GroupContext, usize) {
+    let mut next = offset + 1;
+    let mut is_atomic = false;
+
+    if next < bytes.len() && bytes[next] == b'?' {
+        next += 1;
+        if next < bytes.len()
+            && matches!(bytes[next], b':' | b'=' | b'!' | b'<' | b'|' | b'P' | b'#')
+        {
+            next += 1;
+        } else if next < bytes.len() && bytes[next] == b'>' {
+            is_atomic = true;
+            next += 1;
+        }
+    }
+
+    (GroupContext { has_backtracking_quantifier: false, is_atomic }, next)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Quantifier {
+    allows_backtracking: bool,
+    next: usize,
+}
+
+fn parse_quantifier(bytes: &[u8], offset: usize) -> Option<Quantifier> {
+    match bytes[offset] {
+        b'+' | b'*' | b'?' => Some(quantifier_with_suffix(bytes, offset + 1)),
+        b'{' => {
+            let mut next = offset + 1;
+            if is_brace_quantifier(bytes, &mut next) {
+                Some(quantifier_with_suffix(bytes, next))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn quantifier_with_suffix(bytes: &[u8], next: usize) -> Quantifier {
+    match bytes.get(next) {
+        Some(b'+') => Quantifier { allows_backtracking: false, next: next + 1 },
+        Some(b'?') => Quantifier { allows_backtracking: true, next: next + 1 },
+        _ => Quantifier { allows_backtracking: true, next },
+    }
 }
 
 fn is_brace_quantifier(bytes: &[u8], i: &mut usize) -> bool {

--- a/crates/perl-regex/tests/comprehensive_unit_tests.rs
+++ b/crates/perl-regex/tests/comprehensive_unit_tests.rs
@@ -922,6 +922,39 @@ fn validate_rejects_word_class_quantifier_in_group() -> Result<(), Box<dyn std::
 }
 
 #[test]
+fn validate_accepts_atomic_group_with_inner_quantifier() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+
+    v.validate(r"(?>\w+)+", 0)?;
+    assert!(!v.detect_nested_quantifiers(r"(?>\w+)+"));
+
+    Ok(())
+}
+
+#[test]
+fn validate_accepts_possessive_inner_quantifier() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+
+    v.validate(r"(\w++)+", 0)?;
+    assert!(!v.detect_nested_quantifiers(r"(\w++)+"));
+
+    Ok(())
+}
+
+#[test]
+fn validate_accepts_possessive_outer_quantifier() -> Result<(), Box<dyn std::error::Error>> {
+    let v = RegexValidator::new();
+
+    v.validate(r"(\w+)++", 0)?;
+    assert!(!v.detect_nested_quantifiers(r"(\w+)++"));
+
+    v.validate(r"(\w+){2,5}+", 0)?;
+    assert!(!v.detect_nested_quantifiers(r"(\w+){2,5}+"));
+
+    Ok(())
+}
+
+#[test]
 fn validate_accepts_non_capturing_with_quantifier() -> Result<(), Box<dyn std::error::Error>> {
     let v = RegexValidator::new();
     // (?:pattern)+ is a perfectly normal Perl regex


### PR DESCRIPTION
### Motivation
- The nested-quantifier safety scan produced false positives for constructs that prevent backtracking (atomic groups and possessive quantifiers), causing valid Perl patterns to be flagged as unsafe.

### Description
- Rewrite the nested-quantifier scanner in `crates/perl-regex/src/validator/nested_quantifier.rs` to track explicit token/group context and to only report nested quantified groups when the outer quantifier allows backtracking.
- Add `GroupContext` and `TokenType` plus a `Quantifier` parser (`parse_group_start`, `parse_quantifier`, `quantifier_with_suffix`) so possessive suffixes and atomic group markers are recognized as backtracking barriers.
- Ensure inner backtracking markers inside atomic groups are ignored by not marking atomic groups as having backtracking quantifiers.
- Add regression tests in `crates/perl-regex/tests/comprehensive_unit_tests.rs` covering atomic groups and possessive quantifiers (inner and outer) to prevent future regressions.

### Testing
- Ran unit and behavior tests with `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-regex --profile agent --locked`, and all tests passed (multiple test suites: lib, behavior_spec_tests, comprehensive_unit_tests, named_capture_tests, prop_regex_validator).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-regex --profile agent --locked` and `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-regex --profile agent --locked -- -D warnings -A missing_docs`, both completed successfully.
- Ran `./scripts/cargo-safe xtask fmt` and repository checks (`git diff --check`, `./scripts/storage-doctor`) with no issues; `just agent-pr-fast` could not be executed in this environment because `just` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ca28191c8333b8035a2a2a12cbf6)