### PR TITLE
fix(parser): normalize backslash heredoc delimiters (#8197)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/heredoc.rs
+++ b/crates/perl-parser-core/src/engine/parser/heredoc.rs
@@ -71,9 +71,15 @@ fn parse_heredoc_delimiter(s: &str) -> (String, bool, bool, bool) {
         return (String::new(), true, indented, false);
     }
 
-    // Check quoting to determine interpolation and command execution
+    // Check quoting to determine interpolation and command execution.
+    // `<<\EOF` is Perl's backslash-quoted heredoc form: the terminator is
+    // `EOF`, and the body is not interpolated. The lexer accepts this spelling
+    // and includes the leading backslash in token text, so normalize it here
+    // before the AST node and collector are populated.
     let (delimiter, interpolated, command) =
-        if rest.starts_with('"') && rest.ends_with('"') && rest.len() >= 2 {
+        if let Some(label) = rest.strip_prefix('\\') {
+            (label.to_string(), false, false)
+        } else if rest.starts_with('"') && rest.ends_with('"') && rest.len() >= 2 {
             // Double-quoted: interpolated, unescape label
             (unescape_label(&rest[1..rest.len() - 1]), true, false)
         } else if rest.starts_with('\'') && rest.ends_with('\'') && rest.len() >= 2 {
@@ -97,7 +103,7 @@ fn map_heredoc_quote_kind(text: &str, _interpolated: bool) -> heredoc_collector:
     // Skip << and optional ~
     let rest = text.trim_start_matches('<').trim_start_matches('~').trim();
 
-    if rest.starts_with('\'') && rest.ends_with('\'') {
+    if rest.starts_with('\\') || rest.starts_with('\'') && rest.ends_with('\'') {
         heredoc_collector::QuoteKind::Single
     } else if rest.starts_with('"') && rest.ends_with('"') {
         heredoc_collector::QuoteKind::Double

--- a/crates/perl-parser-core/tests/fix_backslash_heredoc_tests.rs
+++ b/crates/perl-parser-core/tests/fix_backslash_heredoc_tests.rs
@@ -1,0 +1,31 @@
+use perl_parser_core::{Node, NodeKind, Parser};
+use perl_tdd_support::must;
+
+fn find_first_heredoc(node: &Node) -> Option<&NodeKind> {
+    if matches!(node.kind, NodeKind::Heredoc { .. }) {
+        return Some(&node.kind);
+    }
+
+    node.children().into_iter().find_map(find_first_heredoc)
+}
+
+#[test]
+fn backslash_heredoc_uses_unescaped_delimiter_and_disables_interpolation()
+-> Result<(), Box<dyn std::error::Error>> {
+    let source = "my $text = <<\\EOF;\nhello $name\nEOF\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+
+    let heredoc = find_first_heredoc(&ast).ok_or("expected heredoc node")?;
+    match heredoc {
+        NodeKind::Heredoc { delimiter, interpolated, content, .. } => {
+            assert_eq!(delimiter, "EOF");
+            assert!(!interpolated, "backslash heredocs should be non-interpolating");
+            assert_eq!(content, "hello $name");
+        }
+        other => return Err(format!("expected heredoc node, got {other:?}").into()),
+    }
+
+    assert!(parser.errors().is_empty(), "unexpected parser errors: {:?}", parser.errors());
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Backslash-quoted heredocs like `<<\EOF` were preserved with the leading backslash in the AST and were treated as interpolating, which is incorrect for Perl backslash-style heredocs.

### Description

- Normalize backslash-quoted heredoc labels in `parse_heredoc_delimiter` so `<<\EOF` produces a delimiter of `EOF` and is marked non-interpolating in the parser AST (`crates/perl-parser-core/src/engine/parser/heredoc.rs`).
- Treat backslash-delimited heredocs as single-quote-style for the collector by updating `map_heredoc_quote_kind` to recognize a leading backslash as a single-quoted kind.
- Add a regression test `fix_backslash_heredoc_tests.rs` that asserts the delimiter is unescaped, interpolation is disabled, the body content is preserved, and no parser errors are emitted (`crates/perl-parser-core/tests/fix_backslash_heredoc_tests.rs`).

### Testing

- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-parser-core --test fix_backslash_heredoc_tests --profile agent --locked`, and the new test passed.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check --all-targets -p perl-parser-core --profile agent --locked`, which completed successfully.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`, and clippy passed with no new warnings.
- Ran `./scripts/cargo-safe xtask fmt` to format changes and it completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ca24a1cc8333936e8932d1561b61)