### PR TITLE
feat(vscode): show workspace trust report (#8197)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -792,6 +792,12 @@
         "icon": "$(copy)"
       },
       {
+        "command": "perl-lsp.showWorkspaceTrustReport",
+        "title": "Show Workspace Trust Report",
+        "category": "Perl LSP",
+        "icon": "$(checklist)"
+      },
+      {
         "command": "perl-lsp.reportIssue",
         "title": "Report Issue",
         "category": "Perl",
@@ -903,6 +909,10 @@
         {
           "command": "perl-lsp.copyProviderDecisionReceipt",
           "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.showWorkspaceTrustReport",
+          "when": "workspaceFolderCount >= 1"
         },
         {
           "command": "perl-lsp.reportIssue"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -384,6 +384,21 @@ function stringField(value: Record<string, unknown> | undefined, field: string):
     return typeof fieldValue === 'string' ? fieldValue : undefined;
 }
 
+function numberField(value: Record<string, unknown> | undefined, field: string): number | undefined {
+    const fieldValue = value?.[field];
+    return typeof fieldValue === 'number' ? fieldValue : undefined;
+}
+
+function booleanField(value: Record<string, unknown> | undefined, field: string): boolean | undefined {
+    const fieldValue = value?.[field];
+    return typeof fieldValue === 'boolean' ? fieldValue : undefined;
+}
+
+function arrayField(value: Record<string, unknown> | undefined, field: string): unknown[] {
+    const fieldValue = value?.[field];
+    return Array.isArray(fieldValue) ? fieldValue : [];
+}
+
 function providerDecisionJson(value: unknown): string {
     return JSON.stringify(value, null, 2);
 }
@@ -391,7 +406,7 @@ function providerDecisionJson(value: unknown): string {
 async function executeLspCommand(
     activeClient: LspExecuteCommandClient | undefined,
     command: string,
-    argument: Record<string, unknown>
+    argument?: Record<string, unknown>
 ): Promise<unknown | undefined> {
     if (!activeClient) {
         vscode.window.showWarningMessage(serverNotRunningMessage());
@@ -401,7 +416,7 @@ async function executeLspCommand(
     try {
         return await activeClient.sendRequest('workspace/executeCommand', {
             command,
-            arguments: [argument],
+            arguments: argument === undefined ? [] : [argument],
         });
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
@@ -436,6 +451,101 @@ async function showProviderDecisionResult(title: string, result: unknown): Promi
     if (action === 'Show Output') {
         channel.show();
     }
+}
+
+function appendSupportTierLines(lines: string[], supportTiers: Record<string, unknown> | undefined): void {
+    if (!supportTiers) {
+        lines.push('- support tiers: unavailable');
+        return;
+    }
+
+    for (const [surface, tier] of Object.entries(supportTiers).sort(([left], [right]) => left.localeCompare(right))) {
+        if (typeof tier === 'string') {
+            lines.push(`- ${surface}: ${tier}`);
+        }
+    }
+}
+
+function formatWorkspaceTrustReport(result: unknown): string {
+    const report = asObject(result);
+    const workspace = asObject(report?.workspace);
+    const moduleResolution = asObject(report?.module_resolution);
+    const globalConfig = asObject(moduleResolution?.global_workspace_config);
+    const index = asObject(report?.index);
+    const providers = asObject(report?.providers);
+    const supportTiers = asObject(providers?.support_tiers);
+    const dynamicBoundaries = asObject(report?.dynamic_boundaries);
+
+    const rootPath = stringField(workspace, 'root_path') ?? '(none)';
+    const folderCount = numberField(workspace, 'workspace_folder_count') ?? 0;
+    const openDocumentCount = numberField(workspace, 'open_document_count') ?? 0;
+    const includePaths = arrayField(globalConfig, 'include_paths');
+    const effectiveIncludePaths = arrayField(globalConfig, 'effective_include_paths');
+    const usePerl5lib = booleanField(globalConfig, 'use_perl5lib');
+    const perl5libCount = numberField(globalConfig, 'perl5lib_entry_count') ?? 0;
+    const indexState = stringField(index, 'state') ?? 'unknown';
+    const indexAvailability = stringField(index, 'availability') ?? 'unknown';
+    const indexedFileCount = numberField(index, 'indexed_file_count') ?? 0;
+    const indexedSymbolCount = numberField(index, 'indexed_symbol_count') ?? 0;
+    const traceCount = numberField(providers, 'decision_trace_count') ?? 0;
+
+    const lines = [
+        'Perl LSP Trust Report',
+        '',
+        `Schema: ${stringField(report, 'schema_version') ?? 'unknown'}`,
+        `Root: ${rootPath}`,
+        `Workspace folders: ${folderCount}`,
+        `Open documents: ${openDocumentCount}`,
+        '',
+        'Module resolution / @INC',
+        `- configured include paths: ${includePaths.length}`,
+        `- effective include paths: ${effectiveIncludePaths.length}`,
+        `- system @INC: ${stringField(globalConfig, 'system_inc_status') ?? 'unknown'}`,
+        `- PERL5LIB enabled: ${usePerl5lib === undefined ? 'unknown' : String(usePerl5lib)}`,
+        `- PERL5LIB entries: ${perl5libCount}`,
+        `- perl.path: ${stringField(globalConfig, 'perl_path') ?? '(unconfigured)'}`,
+        '',
+        'Index',
+        `- state: ${indexState}`,
+        `- availability: ${indexAvailability}`,
+        `- indexed files: ${indexedFileCount}`,
+        `- indexed symbols: ${indexedSymbolCount}`,
+        '',
+        'Provider support tiers',
+    ];
+
+    appendSupportTierLines(lines, supportTiers);
+
+    lines.push(
+        '',
+        'Provider decision traces',
+        `- persisted trace keys: ${traceCount}`,
+        '',
+        'Dynamic boundaries',
+        `- ${stringField(dynamicBoundaries, 'policy') ?? 'Generated, dynamic, stale, low-confidence, ambiguous, and fallback facts remain bounded by provider policy.'}`,
+        '',
+        'Claim boundary',
+        stringField(report, 'claim_boundary') ?? 'This report is bounded to current runtime state.',
+        '',
+        'Raw report JSON',
+        providerDecisionJson(result),
+    );
+
+    return lines.join('\n');
+}
+
+export async function showWorkspaceTrustReportCommand(
+    activeClient: LspExecuteCommandClient | undefined = client
+): Promise<void> {
+    const result = await executeLspCommand(activeClient, 'perl.workspaceTrustReport');
+    if (result === undefined) {
+        return;
+    }
+
+    const channel = trustOutputChannel();
+    channel.appendLine('');
+    channel.appendLine(formatWorkspaceTrustReport(result));
+    channel.show();
 }
 
 export async function explainProviderDecisionCommand(
@@ -812,6 +922,13 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     );
 
+    const showWorkspaceTrustReportCommandDisposable = vscode.commands.registerCommand(
+        'perl-lsp.showWorkspaceTrustReport',
+        async () => {
+            await showWorkspaceTrustReportCommand(client);
+        }
+    );
+
     const whatsNewManager = new WhatsNewManager(context, outputChannel);
     const showWhatsNewCommand = vscode.commands.registerCommand('perl-lsp.showWhatsNew', async () => {
         await whatsNewManager.showWhatsNew();
@@ -1120,6 +1237,7 @@ export async function activate(context: vscode.ExtensionContext) {
         explainProviderDecisionCommandDisposable,
         previewSafeDeleteCommandDisposable,
         copyProviderDecisionReceiptCommandDisposable,
+        showWorkspaceTrustReportCommandDisposable,
         showVersionCommand,
         statusMenuCommand,
         reinstallCommand,

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -371,6 +371,7 @@ describe('perl-lsp trust explanation commands', () => {
     ['perl-lsp.explainProviderDecision', 'Explain Provider Decision'],
     ['perl-lsp.previewSafeDelete', 'Preview Safe Delete'],
     ['perl-lsp.copyProviderDecisionReceipt', 'Copy Provider Decision Receipt'],
+    ['perl-lsp.showWorkspaceTrustReport', 'Show Workspace Trust Report'],
   ])('%s is declared as a Perl LSP command', (id, title) => {
     const cmd = pkg.contributes.commands.find((c: any) => c.command === id);
     expect(commandIds).toContain(id);
@@ -387,6 +388,12 @@ describe('perl-lsp trust explanation commands', () => {
     const entry = paletteEntries.find((e: any) => e.command === id);
     expect(entry).toBeDefined();
     expect(entry.when).toContain('editorLangId == perl');
+  });
+
+  test('workspace trust report is available when a workspace is open', () => {
+    const entry = paletteEntries.find((e: any) => e.command === 'perl-lsp.showWorkspaceTrustReport');
+    expect(entry).toBeDefined();
+    expect(entry.when).toContain('workspaceFolderCount');
   });
 });
 

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -21,6 +21,7 @@ import {
   copyProviderDecisionReceiptCommand,
   explainProviderDecisionCommand,
   previewSafeDeleteCommand,
+  showWorkspaceTrustReportCommand,
   validateIncludePaths,
   runPerlCriticOnActiveFile,
   setPerlCriticSeverity,
@@ -612,5 +613,66 @@ describe('extension UX warnings', () => {
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
       'Provider decision receipt copied.'
     );
+  });
+
+  test('shows the workspace trust report in the trust output channel', async () => {
+    const outputChannel = {
+      appendLine: jest.fn(),
+      show: jest.fn(),
+      dispose: jest.fn(),
+    };
+    (vscode.window.createOutputChannel as jest.Mock).mockReturnValueOnce(outputChannel);
+    const sendRequest = jest.fn(async () => ({
+      schema_version: 'workspace_trust_report.v1',
+      workspace: {
+        root_path: '/workspace',
+        workspace_folder_count: 1,
+        open_document_count: 2,
+      },
+      module_resolution: {
+        global_workspace_config: {
+          include_paths: ['lib'],
+          effective_include_paths: ['lib', 'local/lib/perl5'],
+          system_inc_status: 'configured_not_probed_by_report',
+          use_perl5lib: false,
+          perl5lib_entry_count: 0,
+          perl_path: '/usr/bin/perl',
+        },
+      },
+      index: {
+        state: 'ready',
+        availability: 'full',
+        indexed_file_count: 42,
+        indexed_symbol_count: 137,
+      },
+      providers: {
+        support_tiers: {
+          completion: 'partial-live-with-fallback',
+          workspace_trust_report: 'partial-live-with-fallback',
+        },
+        decision_trace_count: 3,
+      },
+      dynamic_boundaries: {
+        policy: 'Dynamic facts remain labeled.',
+      },
+      claim_boundary: 'Aggregates current runtime state only.',
+    }));
+
+    await showWorkspaceTrustReportCommand({ sendRequest } as any);
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'workspace/executeCommand',
+      {
+        command: 'perl.workspaceTrustReport',
+        arguments: [],
+      }
+    );
+    const rendered = outputChannel.appendLine.mock.calls
+      .map((call: unknown[]) => call[0])
+      .join('\n');
+    expect(rendered).toContain('Perl LSP Trust Report');
+    expect(rendered).toContain('completion: partial-live-with-fallback');
+    expect(rendered).toContain('Aggregates current runtime state only.');
+    expect(outputChannel.show).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Problem: Users need the workspace trust report to be visible from the editor instead of only through the LSP backend.
Fix: Add a VS Code command-palette entry that calls perl.workspaceTrustReport, formats a compact trust report into the Perl LSP output channel, and keeps raw JSON in the report for bug reports.
Claim boundary: Extension UX only. This does not change server/provider behavior, scan files, probe Perl, refresh parser receipts, or promote support tiers.
Verification:
- 
pm --prefix vscode-extension test -- --runTestsByPath src/test/commands.test.ts src/test/extensionUx.test.ts`n- 
pm --prefix vscode-extension run compile`n- 
pm --prefix vscode-extension run lint`n- git diff --check`n
Note: 
pm ci emitted existing dependency deprecation/audit warnings while installing test dependencies; no lockfile changes were made.