### PR TITLE
fix(lsp): improve client compatibility for JetBrains and Sublime Text

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -15,6 +15,18 @@ fn is_opencode_client(params: &Value) -> bool {
         .unwrap_or(false)
 }
 
+fn is_jetbrains_client(params: &Value) -> bool {
+    params
+        .get("clientInfo")
+        .and_then(|info| info.get("name"))
+        .and_then(|name| name.as_str())
+        .map(|name| {
+            let lower = name.to_ascii_lowercase();
+            lower.contains("jetbrains") || lower.contains("intellij") || lower.contains("idea")
+        })
+        .unwrap_or(false)
+}
+
 impl LspServer {
     /// Handle initialize request
     pub(crate) fn handle_initialize(
@@ -80,6 +92,14 @@ impl LspServer {
                     .and_then(|d| d.get("dynamicRegistration"))
                     .and_then(|b| b.as_bool())
                     .unwrap_or(false);
+
+                // JetBrains-family IDEs (IntelliJ IDEA, etc.) advertise dynamic watcher
+                // registration but their registration flow is unreliable and can degrade LSP
+                // startup behavior. Force-disable for these clients regardless of what the
+                // capabilities object claims.
+                if is_jetbrains_client(params) {
+                    caps.dynamic_registration_support = false;
+                }
 
                 caps.workspace_configuration_support = params
                     .get("capabilities")
@@ -572,7 +592,7 @@ mod init_options_tests {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_disabled_feature_id, is_opencode_client};
+    use super::{apply_disabled_feature_id, is_jetbrains_client, is_opencode_client};
     use crate::LspServer;
     use crate::protocol::capabilities::BuildFlags;
     use perl_workspace::folder::root_path_to_file_uri;
@@ -825,6 +845,66 @@ mod tests {
             }
         });
         assert!(is_opencode_client(&params));
+    }
+
+    #[test]
+    fn jetbrains_client_detection_matches_jetbrains_intellij_idea_names() {
+        for name in &["JetBrains", "IntelliJ IDEA", "idea", "JetBrains Client"] {
+            let params = json!({ "clientInfo": { "name": name } });
+            assert!(is_jetbrains_client(&params), "should detect JetBrains client: {name}");
+        }
+        let non_jetbrains = json!({ "clientInfo": { "name": "vscode" } });
+        assert!(!is_jetbrains_client(&non_jetbrains));
+        assert!(!is_jetbrains_client(&json!({})));
+    }
+
+    #[test]
+    fn initialize_disables_dynamic_registration_for_jetbrains_clients() {
+        let server = LspServer::new();
+        let params = json!({
+            "clientInfo": {
+                "name": "JetBrains"
+            },
+            "capabilities": {
+                "workspace": {
+                    "didChangeWatchedFiles": {
+                        "dynamicRegistration": true
+                    }
+                }
+            }
+        });
+
+        let _ = server.handle_initialize(Some(params));
+
+        assert!(
+            !server.client_capabilities.lock().dynamic_registration_support,
+            "JetBrains clients must have dynamic_registration_support forced to false \
+             even when the capabilities object claims support"
+        );
+    }
+
+    #[test]
+    fn initialize_preserves_dynamic_registration_for_non_jetbrains_clients() {
+        let server = LspServer::new();
+        let params = json!({
+            "clientInfo": {
+                "name": "vscode"
+            },
+            "capabilities": {
+                "workspace": {
+                    "didChangeWatchedFiles": {
+                        "dynamicRegistration": true
+                    }
+                }
+            }
+        });
+
+        let _ = server.handle_initialize(Some(params));
+
+        assert!(
+            server.client_capabilities.lock().dynamic_registration_support,
+            "non-JetBrains clients that advertise dynamic registration must have it enabled"
+        );
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/workspace.rs
@@ -511,4 +511,58 @@ include_paths = ["other_lib"]
         );
         Ok(())
     }
+
+    #[test]
+    fn did_change_configuration_accepts_unwrapped_perl_settings() {
+        // Sublime Text's LSP package sends settings without the outer "perl" wrapper:
+        //   {"settings": {"workspace": {"includePaths": [...], "useSystemInc": false}}}
+        // rather than the standard:
+        //   {"settings": {"perl": {"workspace": {"includePaths": [...], "useSystemInc": false}}}}
+        // Both forms must be accepted and applied.
+        let server = LspServer::new();
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "workspace": {
+                    "includePaths": ["vendor/lib"],
+                    "useSystemInc": false
+                }
+            }
+        })));
+
+        let workspace_config = server.workspace_config.lock();
+        assert!(
+            workspace_config.include_paths.contains(&"vendor/lib".to_string()),
+            "unwrapped Sublime-style settings must apply includePaths; got: {:?}",
+            workspace_config.include_paths
+        );
+        assert!(
+            !workspace_config.use_system_inc,
+            "unwrapped Sublime-style settings must apply useSystemInc=false"
+        );
+    }
+
+    #[test]
+    fn did_change_configuration_wrapped_form_still_works() {
+        // Ensure the standard wrapped form continues to work after the Sublime fix.
+        let server = LspServer::new();
+
+        server.handle_did_change_configuration(Some(serde_json::json!({
+            "settings": {
+                "perl": {
+                    "workspace": {
+                        "includePaths": ["lib/wrapped"],
+                        "useSystemInc": false
+                    }
+                }
+            }
+        })));
+
+        let workspace_config = server.workspace_config.lock();
+        assert!(
+            workspace_config.include_paths.contains(&"lib/wrapped".to_string()),
+            "standard wrapped settings must still apply includePaths; got: {:?}",
+            workspace_config.include_paths
+        );
+    }
 }

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -898,7 +898,23 @@ impl LspServer {
 
         Ok(Some(json!([])))
     }
+}
 
+/// Extract the perl-specific settings object from a `workspace/didChangeConfiguration` payload.
+///
+/// Accepts both the standard wrapped form `{"perl": {...}}` and the unwrapped form `{...}` used
+/// by clients such as Sublime Text's LSP package that omit the outer `"perl"` key.
+fn extract_perl_settings(settings: &Value) -> Option<&Value> {
+    if let Some(perl) = settings.get("perl") {
+        if perl.is_object() {
+            return Some(perl);
+        }
+    }
+    // Unwrapped: the settings object itself contains perl config keys directly.
+    if settings.is_object() { Some(settings) } else { None }
+}
+
+impl LspServer {
     /// Handle workspace/didChangeConfiguration notification
     ///
     /// Updates both ServerConfig and WorkspaceConfig when the client
@@ -908,8 +924,12 @@ impl LspServer {
             if let Some(settings) = params.get("settings") {
                 tracing::debug!("Configuration changed, updating server settings");
 
-                // Read perl settings once and update both configs
-                if let Some(perl) = settings.get("perl") {
+                // Read perl settings once and update both configs.
+                // Some clients (e.g. Sublime Text's LSP package) send settings without
+                // wrapping them under a top-level "perl" key. Accept both shapes:
+                //   - Wrapped:   {"perl": { "workspace": { "includePaths": [...] } }}
+                //   - Unwrapped: { "workspace": { "includePaths": [...] } }
+                if let Some(perl) = extract_perl_settings(settings) {
                     // Check whether any perlcritic-related setting is changing before
                     // updating config so we can decide whether to reset the shared
                     // CriticAnalyzer.  The analyzer is config-bound (severity, profile)


### PR DESCRIPTION
## Summary

Fixes two LSP client compatibility issues that caused silent degraded behavior in specific editor environments. Both fixes are re-implementations of original PRs #7505 and #7502 that were filed as unrebaseable `[resubmit]` issues.

## Problem 1: JetBrains dynamic watcher registration (re: #7505)

JetBrains-family IDEs (IntelliJ IDEA, etc.) advertise `dynamicRegistration: true` for `workspace/didChangeWatchedFiles` in their capability payload, but their actual registration flow is unreliable and can degrade LSP startup. When the server attempted to register file watchers via dynamic registration, JetBrains clients sometimes failed to complete the registration — leaving the server without file-change notifications for the session.

**Fix:** Adds `is_jetbrains_client` detection in `capabilities.rs` (matches `"jetbrains"`, `"intellij"`, or `"idea"` in `clientInfo.name`, case-insensitive) and force-overrides `dynamic_registration_support = false` for these clients even when their capabilities object claims support. This is the same pattern already used by `is_opencode_client` for the pull-diagnostics override.

## Problem 2: Sublime Text unwrapped settings (re: #7502)

Sublime Text's LSP package sends `workspace/didChangeConfiguration` without wrapping config under a top-level `"perl"` key:

```json
{"settings": {"workspace": {"includePaths": ["vendor/lib"]}}}
```

instead of the standard form:

```json
{"settings": {"perl": {"workspace": {"includePaths": ["vendor/lib"]}}}}
```

Because `handle_did_change_configuration` only looked for `settings.get("perl")`, all configuration updates from Sublime clients were silently dropped — `includePaths`, `useSystemInc`, and every other setting were ignored for the session.

**Fix:** Adds `extract_perl_settings(settings: &Value) -> Option<&Value>` free function in `workspace.rs` that accepts both payload shapes. The wrapped form `{"perl": {...}}` takes priority; if no `"perl"` key is present the settings object itself is used as the perl config. The function is wired into `handle_did_change_configuration` replacing the raw `.get("perl")` call.

## What changed

### `crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs`
- Added `is_jetbrains_client(params: &Value) -> bool` alongside existing `is_opencode_client`
- Added JetBrains override block after `dynamic_registration_support` is read from capabilities
- Added 3 new tests: detection, disable for JetBrains, preserve for non-JetBrains

### `crates/perl-lsp-rs/src/runtime/workspace.rs`
- Added `extract_perl_settings(settings: &Value) -> Option<&Value>` free function
- Updated `handle_did_change_configuration` to use `extract_perl_settings` with an explanatory comment

### `crates/perl-lsp-rs/src/runtime/lifecycle/workspace.rs`
- Added 2 new tests: unwrapped Sublime-style payload applies settings; wrapped form still works

## Test plan

- [x] `cargo test -p perl-lsp-rs --lib -- initialize_disables_dynamic_registration_for_jetbrains` — passes
- [x] `cargo test -p perl-lsp-rs --lib -- initialize_preserves_dynamic_registration_for_non_jetbrains` — passes
- [x] `cargo test -p perl-lsp-rs --lib -- jetbrains_client_detection` — passes
- [x] `cargo test -p perl-lsp-rs --lib -- did_change_configuration_accepts_unwrapped` — passes
- [x] `cargo test -p perl-lsp-rs --lib -- did_change_configuration_wrapped_form_still_works` — passes
- [x] Full `cargo test -p perl-lsp-rs --lib` — **682 passed, 0 failed**
- [x] `cargo clippy -p perl-lsp-rs --lib -- -D warnings -A missing_docs` — clean

## Closes

- Re-implements #7505 (JetBrains watcher compatibility)
- Re-implements #7502 (Sublime unwrapped settings)

https://claude.ai/code/session_01BWGUjZ6fpsmztqykUiHPCj

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGUjZ6fpsmztqykUiHPCj)_