### PR TITLE
refactor(ux-tests): centralize real-project helpers (#8197)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -47,6 +47,7 @@
 pub mod client;
 pub mod diagnostics;
 pub mod env;
+pub mod project_fixture;
 pub mod recorder;
 pub mod scorecard;
 pub mod taxonomy;
@@ -55,6 +56,11 @@ pub mod workspace;
 pub use client::{LspEvent, UxClient};
 pub use diagnostics::DiagnosticsTracker;
 pub use env::{PathGuard, RestrictedPath};
+pub use project_fixture::{
+    ProjectFixtureFile, create_fixture_harness, fixture_content, fixture_scenario_config,
+    load_catalyst_fixture_files, load_dancer2_fixture_files, load_mojolicious_fixture_files,
+    open_all_fixture_files, workspace_root,
+};
 pub use recorder::{
     AssertionBasis, AssertionCounts, OperationTiming, RunIdentity, UxCheckFailure, UxRunRecorder,
     UxScenarioRunReceipt, UxScenarioSkip, run_ux_scenario,
@@ -941,6 +947,19 @@ impl FormatResult {
 }
 
 // ─────────────────────────────── Binary Resolution ───────────────────────────
+
+/// Return whether the perl-lsp binary can be resolved for UX scenario tests.
+///
+/// This is a lightweight guard for integration tests that need to skip when the
+/// server binary has not been built in the current environment.
+pub fn binary_available() -> bool {
+    resolve_binary().is_ok()
+}
+
+/// Standard skip reason for scenarios that require a runnable perl-lsp binary.
+pub fn missing_binary_skip() -> UxScenarioSkip {
+    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
+}
 
 /// Resolve the path to the perl-lsp binary.
 ///

--- a/crates/perl-lsp-ux-tests/src/project_fixture.rs
+++ b/crates/perl-lsp-ux-tests/src/project_fixture.rs
@@ -1,0 +1,114 @@
+//! Shared helpers for source-backed editor UX fixture projects.
+
+use crate::{ScenarioConfig, UxHarness};
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const REAL_PROJECTS_DIR: &str = "test_corpus/real_projects";
+const MOJOLICIOUS_SKELETON: &str = "mojolicious_skeleton";
+const DANCER2_SKELETON: &str = "dancer2_skeleton";
+const CATALYST_SKELETON: &str = "catalyst_skeleton";
+
+/// Source file loaded from a committed real-project UX fixture.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ProjectFixtureFile {
+    /// Fixture-relative path using `/` separators.
+    pub relative_path: String,
+    /// UTF-8 source text for the fixture file.
+    pub content: String,
+}
+
+/// Resolve the repository workspace root from this crate's manifest location.
+pub fn workspace_root() -> Result<PathBuf> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
+}
+
+/// Load all Perl source files under the Mojolicious skeleton UX fixture.
+pub fn load_mojolicious_fixture_files() -> Result<Vec<ProjectFixtureFile>> {
+    load_real_project_fixture_files(MOJOLICIOUS_SKELETON)
+}
+
+/// Load all Perl source files under the Dancer2 sample UX fixture.
+pub fn load_dancer2_fixture_files() -> Result<Vec<ProjectFixtureFile>> {
+    load_real_project_fixture_files(DANCER2_SKELETON)
+}
+
+/// Load all Perl source files under the Catalyst sample UX fixture.
+pub fn load_catalyst_fixture_files() -> Result<Vec<ProjectFixtureFile>> {
+    load_real_project_fixture_files(CATALYST_SKELETON)
+}
+
+/// Build a workspace-enabled scenario config seeded with fixture files.
+pub fn fixture_scenario_config(files: &[ProjectFixtureFile]) -> ScenarioConfig {
+    files.iter().fold(
+        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+            .env("PERL_LSP_WORKSPACE", "1"),
+        |config, file| config.with_file(&file.relative_path, &file.content),
+    )
+}
+
+/// Create a UX harness seeded with fixture files and workspace indexing enabled.
+pub fn create_fixture_harness(files: &[ProjectFixtureFile]) -> Result<UxHarness> {
+    UxHarness::new(fixture_scenario_config(files))
+}
+
+/// Open every fixture file in a harness.
+pub fn open_all_fixture_files(harness: &UxHarness, files: &[ProjectFixtureFile]) -> Result<()> {
+    for file in files {
+        harness.open_file(&file.relative_path, &file.content)?;
+    }
+    Ok(())
+}
+
+/// Find fixture content by fixture-relative path.
+pub fn fixture_content<'a>(
+    files: &'a [ProjectFixtureFile],
+    relative_path: &str,
+) -> Result<&'a str> {
+    files
+        .iter()
+        .find(|file| file.relative_path == relative_path)
+        .map(|file| file.content.as_str())
+        .with_context(|| format!("missing fixture file {relative_path}"))
+}
+
+fn load_real_project_fixture_files(fixture_name: &str) -> Result<Vec<ProjectFixtureFile>> {
+    let root = workspace_root()?.join(REAL_PROJECTS_DIR).join(fixture_name);
+    let mut files = Vec::new();
+    collect_perl_files(&root, &root, &mut files)?;
+    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(files)
+}
+
+fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<ProjectFixtureFile>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_perl_files(root, &path, files)?;
+        } else if is_perl_source(&path) {
+            let relative_path = path
+                .strip_prefix(root)
+                .with_context(|| format!("stripping fixture root from {}", path.display()))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            let content =
+                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+            files.push(ProjectFixtureFile { relative_path, content });
+        }
+    }
+    Ok(())
+}
+
+fn is_perl_source(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
+}

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs
@@ -13,17 +13,9 @@
 //! - No crash signatures in the event log.
 //! - Completion request does not crash.
 
-use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
-};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
 
 #[test]
 fn scenario_01_server_starts_and_accepts_open() {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_02_missing_perltidy.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_02_missing_perltidy.rs
@@ -12,11 +12,8 @@
 //! - No Rust panic traces in error messages.
 //! - The server MUST still be alive after the failed formatting request.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{FormatResult, ScenarioConfig, UxHarness};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn config_without_perltidy() -> ScenarioConfig {
     // Exclude only perltidy from PATH, leaving perl and other tools available.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_03_missing_perl.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_03_missing_perl.rs
@@ -11,12 +11,9 @@
 //! - Server MUST NOT crash during initialization.
 //! - Hover and completion may return null/empty — that is acceptable.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn config_without_perl() -> ScenarioConfig {
     ScenarioConfig { path_restriction: Some(Vec::new()), ..Default::default() }

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_04_missing_perlcritic.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_04_missing_perlcritic.rs
@@ -11,12 +11,9 @@
 //! - Server MUST NOT crash when it tries to run perlcritic and fails.
 //! - Server must remain responsive after the diagnostic pass.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn config_without_perlcritic() -> ScenarioConfig {
     // Exclude only perlcritic from PATH, leaving perl and other tools available.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_05_bad_config.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_05_bad_config.rs
@@ -10,11 +10,8 @@
 //! - Error messages MUST NOT contain raw Rust panic traces.
 //! - Server MUST remain responsive after the config error.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn config_with_bad_tool_paths() -> ScenarioConfig {
     ScenarioConfig::default()

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_06_large_file.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_06_large_file.rs
@@ -10,12 +10,9 @@
 //! The gate allows the scenario to appear in the default test run (with a
 //! reduced 1k-line version) so CI always exercises the code path.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn generate_source(line_count: usize) -> String {
     let mut buf = String::with_capacity(line_count * 40);

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_07_multi_file_workspace.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_07_multi_file_workspace.rs
@@ -11,12 +11,9 @@
 //! - `textDocument/definition` MUST NOT crash (empty result is acceptable).
 //! - Server remains responsive after workspace indexing.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 #[test]
 fn scenario_07_multi_file_workspace_opens_without_crash() {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_08_shebang_detection.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_08_shebang_detection.rs
@@ -10,11 +10,8 @@
 //! - Hover, completion MUST NOT crash.
 //! - Null results are acceptable.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 #[test]
 fn scenario_08_shebang_file_without_pl_extension() {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_09_encoding.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_09_encoding.rs
@@ -11,11 +11,8 @@
 //! - No error-level `window/showMessage` for encoding issues.
 //! - Hover and completion MUST NOT crash (empty results OK).
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 #[test]
 fn scenario_09_utf8_bom_file_does_not_crash() {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -5,6 +5,7 @@
 //! Given/When/Then language and avoids duplicated harness boilerplate.
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
 use std::time::Duration;
@@ -40,10 +41,6 @@ use Counter;
 my $value = Counter->increment(3);
 print "$value\n";
 "#;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 struct DefinitionScenario {
     harness: UxHarness,

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
@@ -13,12 +13,9 @@
 //! - A null/empty result is acceptable (degraded mode).
 //! - No crash signatures after the request.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 /// Perl source with a clearly-named sub and variable for hover targets.
 const HOVER_SOURCE: &str = "\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs
@@ -15,12 +15,9 @@
 //!   `range` and `message` fields.
 //! - A clean file MAY produce zero diagnostics — that is acceptable.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 /// Source that is syntactically valid Perl — should produce no parse errors.
 const CLEAN_SOURCE: &str = "\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
@@ -13,12 +13,9 @@
 //! - An empty result is acceptable for degraded-mode servers.
 //! - No crash signatures after the request.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 /// Source with two named subs and a package declaration — rich symbol table.
 const SYMBOLS_SOURCE: &str = "\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
@@ -46,13 +46,10 @@
 //! consumers. The test never panics due to a missing binary — it skips with a
 //! clear message.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::json;
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 /// Diagnostic code for missing module — PL701.
 const PL701: &str = "PL701";

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
@@ -7,14 +7,11 @@
 //! workspace and that same-named symbols from different folders remain
 //! disambiguatable via `workspaceFolderUri`.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const RUNNER_A: &str = "\
 package Runner;\n\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_16_workspace_folder_removal.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_16_workspace_folder_removal.rs
@@ -7,13 +7,10 @@
 //! evicts its symbols from `workspace/symbol` results instead of leaving stale
 //! cross-folder state behind.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
 use std::time::{Duration, Instant};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const MODULE_A: &str = "\
 package ModuleA;\n\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
@@ -6,14 +6,11 @@
 //! Verifies that a real `workspace/didChangeWatchedFiles` Deleted event removes
 //! stale search results and cross-file definitions from the UX surface.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
 use serde_json::json;
 use std::time::{Duration, Instant};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const MODULE_SOURCE: &str = "\
 package ModuleGone;\n\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
@@ -6,12 +6,9 @@
 //! Verifies that the UX harness can drive a real edit cycle and observe
 //! follow-up `textDocument/publishDiagnostics` updates for the edited file.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::time::{Duration, Instant};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 // NOTE: BROKEN_SOURCE contains a genuine Perl syntax error — the incomplete
 // expression `(1 +` triggers a parse failure under `use strict`.  A missing

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
@@ -10,6 +10,7 @@
 //!   `targetRange` for links, or `uri` + `range` for locations).
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 
 const DECLARATION_FIXTURE: &str = r#"use strict;
@@ -25,10 +26,6 @@ sub inc {
 my $result = inc($value);
 print "$result\n";
 "#;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 #[test]
 fn scenario_18_declaration_request_does_not_error() -> Result<()> {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs
@@ -5,6 +5,7 @@
 #![cfg(feature = "integration-test")]
 
 use anyhow::{Context, Result, bail};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -22,10 +23,6 @@ const REAL_WORLD_FIXTURES: &[&str] = &[
     "test_corpus/real_world/web_framework_patterns.pl",
     "test_corpus/real_world/medium_module.pl",
 ];
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn repo_root() -> Result<PathBuf> {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_core.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_core.rs
@@ -10,6 +10,7 @@
 //! - No crash signatures after repeated completion requests.
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 
 const COMPLETION_FIXTURE: &str = r#"use strict;
@@ -20,10 +21,6 @@ pri
 my $value = 42;
 my $display = $val
 "#;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn create_harness() -> Result<UxHarness> {
     UxHarness::new(ScenarioConfig::default().with_file("completion.pl", COMPLETION_FIXTURE))

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
@@ -32,12 +32,9 @@
 //!                        from an analysis that was already running when the
 //!                        fix arrived. Only then enter the clean-window check.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const BROKEN_SOURCE: &str = "use strict;\nuse warnings;\nmy $x = ;\n";
 const FIXED_SOURCE: &str = "use strict;\nuse warnings;\nmy $x = 1;\nprint $x;\n";

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_text_sync.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_text_sync.rs
@@ -6,6 +6,7 @@
 //! - Then diagnostics should recover and the server should keep serving requests.
 
 use anyhow::{Context, Result, ensure};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::time::{Duration, Instant};
 
@@ -24,10 +25,6 @@ use warnings;\n\
 my $value = 42;\n\
 print $value;\n\
 ";
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn has_parse_like_diagnostic(diagnostics: &[serde_json::Value]) -> bool {
     diagnostics.iter().any(|diag| {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs
@@ -12,6 +12,7 @@
 //!   `workspaceFolderUri`.
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -36,10 +37,6 @@ sub shared_action_4481 {\n\
 \n\
 1;\n\
 ";
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const CORE_MODULE: &str = "\
 package CoreModule;\n\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_20_real_workspace_providers.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_20_real_workspace_providers.rs
@@ -42,6 +42,7 @@
 //!     --test ux_scenario_20_real_workspace_providers -- --nocapture --test-threads=1
 //! ```
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -131,10 +132,6 @@ fn fixture_root() -> PathBuf {
 }
 
 // ── Harness factory ──────────────────────────────────────────────────────────
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn create_harness() -> anyhow::Result<UxHarness> {
     UxHarness::new(

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
@@ -9,13 +9,10 @@
 //!   MUST target the opened file and update multiple occurrences.
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
@@ -8,12 +8,9 @@
 //!   result (degraded mode).
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const UNDECLARED_SOURCE: &str = r#"use strict;
 use warnings;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_25_signature_help.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_25_signature_help.rs
@@ -8,6 +8,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 
@@ -20,10 +21,6 @@ my @arr = (3, 1, 2);
 push(@arr, 4);
 my $str = join(", ", @arr);
 "#;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn builtin_harness() -> Result<UxHarness> {
     let harness =

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs
@@ -12,13 +12,10 @@
 //!   (idempotency guard).
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs
@@ -13,13 +13,10 @@
 //! - The server MUST remain stable after repeated fold requests.
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_28_mojolicious_completion_ranking.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_28_mojolicious_completion_ranking.rs
@@ -10,24 +10,19 @@
 //! - generated-candidate and provenance-label coverage
 //! - dynamic/fallback label coverage when the provider exposes it
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    UxCiTier, UxComponent, UxHarness, create_fixture_harness, load_mojolicious_fixture_files,
+    open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_28_mojolicious_completion_ranking.rs";
 const TOP_N: usize = 10;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct CompletionProbe {
@@ -56,78 +51,6 @@ struct CompletionProbeReport {
     generated_candidate_hits: Vec<String>,
     generated_provenance_label_hits: Vec<String>,
     dynamic_or_fallback_label_hits: Vec<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
 }
 
 fn completion_label(item: &Value) -> Option<String> {
@@ -310,7 +233,7 @@ fn scenario_28_mojolicious_visible_symbol_ranking_receipt() {
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_mojolicious_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_29_mojolicious_hover_provenance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_29_mojolicious_hover_provenance.rs
@@ -13,23 +13,18 @@
 //! - generated, dynamic-boundary, and fallback label coverage when present
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_mojolicious_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_29_mojolicious_hover_provenance.rs";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct HoverProbe {
@@ -74,86 +69,6 @@ struct HoverProbeReport {
     generated_label_hits: Vec<String>,
     dynamic_boundary_label_hits: Vec<String>,
     fallback_label_hits: Vec<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn resolve_probe_position(files: &[FixtureFile], probe: &HoverProbe) -> Result<ProbePosition> {
@@ -357,7 +272,7 @@ fn scenario_29_mojolicious_hover_provenance_receipt() {
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_mojolicious_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_30_mojolicious_navigation_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_30_mojolicious_navigation_quality.rs
@@ -12,23 +12,18 @@
 //! - fallback/empty counts for uncertain dynamic or unsupported surfaces
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_mojolicious_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_30_mojolicious_navigation_quality.rs";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -73,86 +68,6 @@ struct NavigationProbeReport {
     expected_target_hits: Vec<String>,
     missing_expected_uri_suffixes: Vec<String>,
     fallback_or_empty: bool,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn resolve_probe_position(files: &[FixtureFile], probe: &NavigationProbe) -> Result<ProbePosition> {
@@ -356,7 +271,7 @@ fn scenario_30_mojolicious_navigation_quality_receipt() {
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_mojolicious_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_31_mojolicious_diagnostics_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_31_mojolicious_diagnostics_quality.rs
@@ -12,15 +12,17 @@
 //! - mixed project-shaped files keep present modules clean while reporting a
 //!   genuinely missing module
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    LspEvent, ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness,
+    fixture_scenario_config, load_mojolicious_fixture_files, open_all_fixture_files,
+    run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_31_mojolicious_diagnostics_quality.rs";
@@ -46,12 +48,6 @@ sub mixed_diagnostic_probe {
 
 1;
 "#;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct DiagnosticProbe {
@@ -84,80 +80,12 @@ struct DiagnosticProbeReport {
     fallback_or_empty: bool,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1")
+    let config = fixture_scenario_config(files)
         .with_file(MISSING_MODULE_PROBE_PATH, MISSING_MODULE_PROBE_SOURCE)
         .with_file(MIXED_MODULE_PROBE_PATH, MIXED_MODULE_PROBE_SOURCE);
 
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
     UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    harness.open_file(MISSING_MODULE_PROBE_PATH, MISSING_MODULE_PROBE_SOURCE)?;
-    harness.open_file(MIXED_MODULE_PROBE_PATH, MIXED_MODULE_PROBE_SOURCE)?;
-    Ok(())
 }
 
 fn diagnostic_probes() -> Vec<DiagnosticProbe> {
@@ -411,6 +339,8 @@ fn scenario_31_mojolicious_diagnostics_quality_receipt() {
 
             let harness = create_mojolicious_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
+            harness.open_file(MISSING_MODULE_PROBE_PATH, MISSING_MODULE_PROBE_SOURCE)?;
+            harness.open_file(MIXED_MODULE_PROBE_PATH, MIXED_MODULE_PROBE_SOURCE)?;
             std::thread::sleep(Duration::from_millis(800));
 
             let probes = diagnostic_probes();

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_32_mojolicious_document_symbols_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_32_mojolicious_document_symbols_quality.rs
@@ -12,25 +12,20 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - freshness after editing a document so stale symbol names disappear
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_mojolicious_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_32_mojolicious_document_symbols_quality.rs";
 const FRESHNESS_FILE: &str = "lib/Mojolicious/Static.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct DocumentSymbolProbe {
@@ -80,86 +75,6 @@ struct FreshnessReport {
     before_hits: Vec<String>,
     after_hits: Vec<String>,
     after_invalid_shape_count: usize,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn is_valid_position(position: &Value) -> bool {
@@ -390,7 +305,7 @@ fn scenario_32_mojolicious_document_symbols_quality_receipt() {
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_mojolicious_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_33_mojolicious_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_33_mojolicious_workspace_symbol_noise.rs
@@ -11,26 +11,21 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_mojolicious_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const SCENARIO_FILE: &str = "ux_scenario_33_mojolicious_workspace_symbol_noise.rs";
 const TOP_N: usize = 12;
 const FRESHNESS_FILE: &str = "lib/Mojolicious/Static.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct WorkspaceSymbolProbe {
@@ -84,86 +79,6 @@ struct FreshnessReport {
 struct TimedSymbols {
     symbols: Vec<Value>,
     latency_ms: u128,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn timed_workspace_symbols(harness: &UxHarness, query: &str) -> Result<TimedSymbols> {
@@ -439,7 +354,7 @@ fn scenario_33_mojolicious_workspace_symbol_noise_receipt() {
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_mojolicious_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_34_mojolicious_semantic_tokens_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_34_mojolicious_semantic_tokens_quality.rs
@@ -12,14 +12,15 @@
 //! - freshness after editing a document so stale token text disappears
 
 use anyhow::{Context, Result, anyhow};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_mojolicious_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_34_mojolicious_semantic_tokens_quality.rs";
@@ -52,12 +53,6 @@ const TOKEN_TYPE_NAMES: [&str; 23] = [
 ];
 
 const TOKEN_MODIFIER_COUNT: u32 = 13;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct SemanticTokenProbe {
@@ -124,86 +119,6 @@ struct FreshnessReport {
     after_hits: Vec<String>,
     after_invalid_tuple_count: usize,
     after_overlap_count: usize,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn semantic_tokens(harness: &UxHarness, relative_path: &str) -> Result<Value> {
@@ -584,7 +499,7 @@ fn scenario_34_mojolicious_semantic_tokens_quality_receipt() {
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_mojolicious_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_35_mojolicious_rename_unsafe_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_35_mojolicious_rename_unsafe_edit.rs
@@ -11,25 +11,20 @@
 //! - after an open-document edit, rename does not act on stale source text
 
 use anyhow::{Context, Result, anyhow};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_mojolicious_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_35_mojolicious_rename_unsafe_edit.rs";
 const STATIC_FILE: &str = "lib/Mojolicious/Static.pm";
 const ROUTES_FILE: &str = "lib/Mojolicious/Routes.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -109,86 +104,6 @@ struct FreshnessReport {
     touched_source_texts: Vec<String>,
     new_texts: Vec<String>,
     error_message: Option<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn resolve_probe_position(files: &[FixtureFile], probe: &RenameProbe) -> Result<ProbePosition> {
@@ -563,7 +478,7 @@ fn scenario_35_mojolicious_rename_unsafe_edit_receipt() {
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_mojolicious_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_36_mojolicious_safe_delete_warning.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_36_mojolicious_safe_delete_warning.rs
@@ -12,25 +12,21 @@
 //! - the receipt boundary remains file-delete warning proof only
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    LspEvent, ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness,
+    create_fixture_harness, fixture_content, load_mojolicious_fixture_files,
+    open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_36_mojolicious_safe_delete_warning.rs";
 const DELETE_TARGET: &str = "lib/Mojolicious/Static.pm";
 const DEPENDENT_FILE: &str = "lib/Mojolicious.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug, Serialize)]
 struct SafeDeleteWarningReport {
@@ -41,86 +37,6 @@ struct SafeDeleteWarningReport {
     warning_seen: bool,
     dependent_warning_seen: bool,
     warning_messages: Vec<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn assert_fixture_dependency(files: &[FixtureFile]) -> Result<()> {
@@ -209,7 +125,7 @@ fn scenario_36_mojolicious_safe_delete_warning_receipt() {
                 fixture_paths.contains(DELETE_TARGET) && fixture_paths.contains(DEPENDENT_FILE),
             )?;
 
-            let harness = create_mojolicious_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_37_dancer2_rename_unsafe_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_37_dancer2_rename_unsafe_edit.rs
@@ -11,25 +11,20 @@
 //! - after an open-document edit, rename does not act on stale source text
 
 use anyhow::{Context, Result, anyhow};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_dancer2_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_37_dancer2_rename_unsafe_edit.rs";
 const APP_FILE: &str = "lib/Dancer2/Core/App.pm";
 const PLUGIN_FILE: &str = "lib/Dancer2/Plugin.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -109,86 +104,6 @@ struct FreshnessReport {
     touched_source_texts: Vec<String>,
     new_texts: Vec<String>,
     error_message: Option<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn dancer2_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("dancer2_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_dancer2_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = dancer2_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_dancer2_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn resolve_probe_position(files: &[FixtureFile], probe: &RenameProbe) -> Result<ProbePosition> {
@@ -562,7 +477,7 @@ fn scenario_37_dancer2_rename_unsafe_edit_receipt() {
             recorder
                 .check("dancer2 fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_dancer2_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_38_dancer2_semantic_tokens_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_38_dancer2_semantic_tokens_quality.rs
@@ -12,14 +12,15 @@
 //! - freshness after editing a document so stale token text disappears
 
 use anyhow::{Context, Result, anyhow};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_dancer2_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_38_dancer2_semantic_tokens_quality.rs";
@@ -52,12 +53,6 @@ const TOKEN_TYPE_NAMES: [&str; 23] = [
 ];
 
 const TOKEN_MODIFIER_COUNT: u32 = 13;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct SemanticTokenProbe {
@@ -124,86 +119,6 @@ struct FreshnessReport {
     after_hits: Vec<String>,
     after_invalid_tuple_count: usize,
     after_overlap_count: usize,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn dancer2_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("dancer2_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_dancer2_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = dancer2_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_dancer2_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn semantic_tokens(harness: &UxHarness, relative_path: &str) -> Result<Value> {
@@ -591,7 +506,7 @@ fn scenario_38_dancer2_semantic_tokens_quality_receipt() {
             recorder
                 .check("dancer2 fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_dancer2_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_39_dancer2_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_39_dancer2_workspace_symbol_noise.rs
@@ -11,26 +11,21 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_dancer2_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const SCENARIO_FILE: &str = "ux_scenario_39_dancer2_workspace_symbol_noise.rs";
 const TOP_N: usize = 12;
 const FRESHNESS_FILE: &str = "lib/Dancer2/Plugin.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct WorkspaceSymbolProbe {
@@ -84,86 +79,6 @@ struct FreshnessReport {
 struct TimedSymbols {
     symbols: Vec<Value>,
     latency_ms: u128,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn dancer2_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("dancer2_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_dancer2_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = dancer2_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_dancer2_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn timed_workspace_symbols(harness: &UxHarness, query: &str) -> Result<TimedSymbols> {
@@ -434,7 +349,7 @@ fn scenario_39_dancer2_workspace_symbol_noise_receipt() {
             recorder
                 .check("dancer2 fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_dancer2_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_40_dancer2_diagnostics_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_40_dancer2_diagnostics_quality.rs
@@ -12,15 +12,16 @@
 //! - mixed project-shaped files keep present modules clean while reporting a
 //!   genuinely missing module
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    LspEvent, ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness,
+    fixture_scenario_config, load_dancer2_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_40_dancer2_diagnostics_quality.rs";
@@ -49,12 +50,6 @@ sub mixed_diagnostic_probe {
 
 1;
 "#;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct DiagnosticProbe {
@@ -87,80 +82,12 @@ struct DiagnosticProbeReport {
     fallback_or_empty: bool,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn dancer2_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("dancer2_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_dancer2_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = dancer2_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_dancer2_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1")
+    let config = fixture_scenario_config(files)
         .with_file(MISSING_MODULE_PROBE_PATH, MISSING_MODULE_PROBE_SOURCE)
         .with_file(MIXED_MODULE_PROBE_PATH, MIXED_MODULE_PROBE_SOURCE);
 
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
     UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    harness.open_file(MISSING_MODULE_PROBE_PATH, MISSING_MODULE_PROBE_SOURCE)?;
-    harness.open_file(MIXED_MODULE_PROBE_PATH, MIXED_MODULE_PROBE_SOURCE)?;
-    Ok(())
 }
 
 fn diagnostic_probes() -> Vec<DiagnosticProbe> {
@@ -416,6 +343,8 @@ fn scenario_40_dancer2_diagnostics_quality_receipt() {
 
             let harness = create_dancer2_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
+            harness.open_file(MISSING_MODULE_PROBE_PATH, MISSING_MODULE_PROBE_SOURCE)?;
+            harness.open_file(MIXED_MODULE_PROBE_PATH, MIXED_MODULE_PROBE_SOURCE)?;
             std::thread::sleep(Duration::from_millis(800));
 
             let probes = diagnostic_probes();

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_41_catalyst_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_41_catalyst_workspace_symbol_noise.rs
@@ -11,26 +11,21 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    ProjectFixtureFile as FixtureFile, UxCiTier, UxComponent, UxHarness, create_fixture_harness,
+    fixture_content, load_catalyst_fixture_files, open_all_fixture_files, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const SCENARIO_FILE: &str = "ux_scenario_41_catalyst_workspace_symbol_noise.rs";
 const TOP_N: usize = 12;
 const FRESHNESS_FILE: &str = "lib/Catalyst/Dispatcher.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct WorkspaceSymbolProbe {
@@ -88,86 +83,6 @@ struct FreshnessReport {
 struct TimedSymbols {
     symbols: Vec<Value>,
     latency_ms: u128,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn catalyst_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("catalyst_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_catalyst_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = catalyst_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
-fn create_catalyst_harness(files: &[FixtureFile]) -> Result<UxHarness> {
-    let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-        .env("PERL_LSP_WORKSPACE", "1");
-
-    for file in files {
-        config = config.with_file(&file.relative_path, &file.content);
-    }
-
-    UxHarness::new(config)
-}
-
-fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<()> {
-    for file in files {
-        harness.open_file(&file.relative_path, &file.content)?;
-    }
-    Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn timed_workspace_symbols(harness: &UxHarness, query: &str) -> Result<TimedSymbols> {
@@ -517,7 +432,7 @@ fn scenario_41_catalyst_workspace_symbol_noise_receipt() {
             recorder
                 .check("Catalyst fixture has committed Perl files", !fixture_files.is_empty())?;
 
-            let harness = create_catalyst_harness(&fixture_files)?;
+            let harness = create_fixture_harness(&fixture_files)?;
             open_all_fixture_files(&harness, &fixture_files)?;
             std::thread::sleep(Duration::from_millis(500));
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_42_catalyst_semantic_tokens_false_exact_freshness.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_42_catalyst_semantic_tokens_false_exact_freshness.rs
@@ -6,9 +6,9 @@
 //! exact symbol tokens, and an edit must refresh token text.
 
 use anyhow::{Context, Result, anyhow};
-use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
-};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
@@ -104,14 +104,6 @@ struct FreshnessReport {
     after_hits: Vec<String>,
     after_invalid_tuple_count: usize,
     after_overlap_count: usize,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
 }
 
 fn workspace_root() -> Result<PathBuf> {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_43_modern_oo_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_43_modern_oo_workspace_symbol_noise.rs
@@ -14,9 +14,9 @@
 //! - stale/fresh query behavior after editing an open document
 
 use anyhow::{Context, Result};
-use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
-};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -92,14 +92,6 @@ struct FreshnessReport {
 struct TimedSymbols {
     symbols: Vec<Value>,
     latency_ms: u128,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
 }
 
 fn workspace_root() -> Result<PathBuf> {


### PR DESCRIPTION
﻿Problem: Real-project UX scenarios duplicated fixture loading, workspace seeding, and binary-availability guards across scenario files.
Fix: Rebased onto current master, retained #9269 as the structured fixture-module branch, ported the shared binary guard helpers from the overlapping sibling PRs, and corrected stale Dancer2/Catalyst fixture directory names during review.
Verification: git diff --check; ./scripts/storage-doctor; MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe xtask fmt; MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe check --all-targets -p perl-lsp-ux-tests --profile agent --locked; MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe test -p perl-lsp-ux-tests --lib --profile agent --locked; MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe clippy -p perl-lsp-ux-tests --profile agent --locked -- -D warnings -A missing_docs; built perl-lsp with cargo-safe and ran scenario 01, 28, 40, and 41 with PERL_LSP_BIN set to the built binary.
Disposition: Retained branch for the #9269/#9270/#9271 UX helper cluster. Close #9270 and #9271 as superseded after this lands.
