### PR TITLE
refactor(ux-tests): centralize binary availability helper (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -942,6 +942,14 @@ impl FormatResult {
 
 // ─────────────────────────────── Binary Resolution ───────────────────────────
 
+/// Return whether the perl-lsp binary can be resolved for UX scenario tests.
+///
+/// This is a lightweight guard for integration tests that need to skip when the
+/// server binary has not been built in the current environment.
+pub fn binary_available() -> bool {
+    resolve_binary().is_ok()
+}
+
 /// Resolve the path to the perl-lsp binary.
 ///
 /// Resolution order:

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs
@@ -13,13 +13,10 @@
 //! - No crash signatures in the event log.
 //! - Completion request does not crash.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn missing_binary_skip() -> UxScenarioSkip {
     UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_02_missing_perltidy.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_02_missing_perltidy.rs
@@ -12,11 +12,8 @@
 //! - No Rust panic traces in error messages.
 //! - The server MUST still be alive after the failed formatting request.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{FormatResult, ScenarioConfig, UxHarness};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn config_without_perltidy() -> ScenarioConfig {
     // Exclude only perltidy from PATH, leaving perl and other tools available.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_03_missing_perl.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_03_missing_perl.rs
@@ -11,12 +11,9 @@
 //! - Server MUST NOT crash during initialization.
 //! - Hover and completion may return null/empty — that is acceptable.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn config_without_perl() -> ScenarioConfig {
     ScenarioConfig { path_restriction: Some(Vec::new()), ..Default::default() }

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_04_missing_perlcritic.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_04_missing_perlcritic.rs
@@ -11,12 +11,9 @@
 //! - Server MUST NOT crash when it tries to run perlcritic and fails.
 //! - Server must remain responsive after the diagnostic pass.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn config_without_perlcritic() -> ScenarioConfig {
     // Exclude only perlcritic from PATH, leaving perl and other tools available.

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_05_bad_config.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_05_bad_config.rs
@@ -10,11 +10,8 @@
 //! - Error messages MUST NOT contain raw Rust panic traces.
 //! - Server MUST remain responsive after the config error.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn config_with_bad_tool_paths() -> ScenarioConfig {
     ScenarioConfig::default()

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_06_large_file.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_06_large_file.rs
@@ -10,12 +10,9 @@
 //! The gate allows the scenario to appear in the default test run (with a
 //! reduced 1k-line version) so CI always exercises the code path.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn generate_source(line_count: usize) -> String {
     let mut buf = String::with_capacity(line_count * 40);

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_07_multi_file_workspace.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_07_multi_file_workspace.rs
@@ -11,12 +11,9 @@
 //! - `textDocument/definition` MUST NOT crash (empty result is acceptable).
 //! - Server remains responsive after workspace indexing.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 #[test]
 fn scenario_07_multi_file_workspace_opens_without_crash() {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_08_shebang_detection.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_08_shebang_detection.rs
@@ -10,11 +10,8 @@
 //! - Hover, completion MUST NOT crash.
 //! - Null results are acceptable.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 #[test]
 fn scenario_08_shebang_file_without_pl_extension() {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_09_encoding.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_09_encoding.rs
@@ -11,11 +11,8 @@
 //! - No error-level `window/showMessage` for encoding issues.
 //! - Hover and completion MUST NOT crash (empty results OK).
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 #[test]
 fn scenario_09_utf8_bom_file_does_not_crash() {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -5,6 +5,7 @@
 //! Given/When/Then language and avoids duplicated harness boilerplate.
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
 use std::time::Duration;
@@ -40,10 +41,6 @@ use Counter;
 my $value = Counter->increment(3);
 print "$value\n";
 "#;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 struct DefinitionScenario {
     harness: UxHarness,

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
@@ -13,12 +13,9 @@
 //! - A null/empty result is acceptable (degraded mode).
 //! - No crash signatures after the request.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 /// Perl source with a clearly-named sub and variable for hover targets.
 const HOVER_SOURCE: &str = "\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_12_diagnostics_strict.rs
@@ -15,12 +15,9 @@
 //!   `range` and `message` fields.
 //! - A clean file MAY produce zero diagnostics — that is acceptable.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 /// Source that is syntactically valid Perl — should produce no parse errors.
 const CLEAN_SOURCE: &str = "\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
@@ -13,12 +13,9 @@
 //! - An empty result is acceptable for degraded-mode servers.
 //! - No crash signatures after the request.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 /// Source with two named subs and a package declaration — rich symbol table.
 const SYMBOLS_SOURCE: &str = "\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_14_inc_conformance.rs
@@ -46,13 +46,10 @@
 //! consumers. The test never panics due to a missing binary — it skips with a
 //! clear message.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::json;
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 /// Diagnostic code for missing module — PL701.
 const PL701: &str = "PL701";

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
@@ -7,14 +7,11 @@
 //! workspace and that same-named symbols from different folders remain
 //! disambiguatable via `workspaceFolderUri`.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const RUNNER_A: &str = "\
 package Runner;\n\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_16_workspace_folder_removal.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_16_workspace_folder_removal.rs
@@ -7,13 +7,10 @@
 //! evicts its symbols from `workspace/symbol` results instead of leaving stale
 //! cross-folder state behind.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
 use std::time::{Duration, Instant};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const MODULE_A: &str = "\
 package ModuleA;\n\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
@@ -6,14 +6,11 @@
 //! Verifies that a real `workspace/didChangeWatchedFiles` Deleted event removes
 //! stale search results and cross-file definitions from the UX surface.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
 use serde_json::json;
 use std::time::{Duration, Instant};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const MODULE_SOURCE: &str = "\
 package ModuleGone;\n\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
@@ -6,12 +6,9 @@
 //! Verifies that the UX harness can drive a real edit cycle and observe
 //! follow-up `textDocument/publishDiagnostics` updates for the edited file.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::time::{Duration, Instant};
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 // NOTE: BROKEN_SOURCE contains a genuine Perl syntax error — the incomplete
 // expression `(1 +` triggers a parse failure under `use strict`.  A missing

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
@@ -10,6 +10,7 @@
 //!   `targetRange` for links, or `uri` + `range` for locations).
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 
 const DECLARATION_FIXTURE: &str = r#"use strict;
@@ -25,10 +26,6 @@ sub inc {
 my $result = inc($value);
 print "$result\n";
 "#;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 #[test]
 fn scenario_18_declaration_request_does_not_error() -> Result<()> {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_real_repo_perf.rs
@@ -5,6 +5,7 @@
 #![cfg(feature = "integration-test")]
 
 use anyhow::{Context, Result, bail};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -22,10 +23,6 @@ const REAL_WORLD_FIXTURES: &[&str] = &[
     "test_corpus/real_world/web_framework_patterns.pl",
     "test_corpus/real_world/medium_module.pl",
 ];
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn repo_root() -> Result<PathBuf> {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_core.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_core.rs
@@ -10,6 +10,7 @@
 //! - No crash signatures after repeated completion requests.
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 
 const COMPLETION_FIXTURE: &str = r#"use strict;
@@ -20,10 +21,6 @@ pri
 my $value = 42;
 my $display = $val
 "#;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn create_harness() -> Result<UxHarness> {
     UxHarness::new(ScenarioConfig::default().with_file("completion.pl", COMPLETION_FIXTURE))

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
@@ -32,12 +32,9 @@
 //!                        from an analysis that was already running when the
 //!                        fix arrived. Only then enter the clean-window check.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const BROKEN_SOURCE: &str = "use strict;\nuse warnings;\nmy $x = ;\n";
 const FIXED_SOURCE: &str = "use strict;\nuse warnings;\nmy $x = 1;\nprint $x;\n";

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_text_sync.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_text_sync.rs
@@ -8,6 +8,7 @@
 //! - When the user fixes the document and the editor emits didChange,
 //! - Then diagnostics should recover and the server should keep serving requests.
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::time::{Duration, Instant};
 
@@ -26,10 +27,6 @@ use warnings;\n\
 my $value = 42;\n\
 print $value;\n\
 ";
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn has_parse_like_diagnostic(diagnostics: &[serde_json::Value]) -> bool {
     diagnostics.iter().any(|diag| {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_workspace_folder_addition.rs
@@ -12,6 +12,7 @@
 //!   `workspaceFolderUri`.
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -36,10 +37,6 @@ sub shared_action_4481 {\n\
 \n\
 1;\n\
 ";
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const CORE_MODULE: &str = "\
 package CoreModule;\n\

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_20_real_workspace_providers.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_20_real_workspace_providers.rs
@@ -42,6 +42,7 @@
 //!     --test ux_scenario_20_real_workspace_providers -- --nocapture --test-threads=1
 //! ```
 
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -131,10 +132,6 @@ fn fixture_root() -> PathBuf {
 }
 
 // ── Harness factory ──────────────────────────────────────────────────────────
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn create_harness() -> anyhow::Result<UxHarness> {
     UxHarness::new(

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
@@ -9,13 +9,10 @@
 //!   MUST target the opened file and update multiple occurrences.
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
@@ -8,12 +8,9 @@
 //!   result (degraded mode).
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const UNDECLARED_SOURCE: &str = r#"use strict;
 use warnings;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_25_signature_help.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_25_signature_help.rs
@@ -8,6 +8,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 
@@ -20,10 +21,6 @@ my @arr = (3, 1, 2);
 push(@arr, 4);
 my $str = join(", ", @arr);
 "#;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 fn builtin_harness() -> Result<UxHarness> {
     let harness =

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs
@@ -12,13 +12,10 @@
 //!   (idempotency guard).
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs
@@ -13,13 +13,10 @@
 //! - The server MUST remain stable after repeated fold requests.
 
 use anyhow::Result;
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use serde_json::{Value, json};
 use std::time::Duration;
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_28_mojolicious_completion_ranking.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_28_mojolicious_completion_ranking.rs
@@ -11,6 +11,7 @@
 //! - dynamic/fallback label coverage when the provider exposes it
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -56,10 +57,6 @@ struct CompletionProbeReport {
     generated_candidate_hits: Vec<String>,
     generated_provenance_label_hits: Vec<String>,
     dynamic_or_fallback_label_hits: Vec<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_29_mojolicious_hover_provenance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_29_mojolicious_hover_provenance.rs
@@ -13,6 +13,7 @@
 //! - generated, dynamic-boundary, and fallback label coverage when present
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -74,10 +75,6 @@ struct HoverProbeReport {
     generated_label_hits: Vec<String>,
     dynamic_boundary_label_hits: Vec<String>,
     fallback_label_hits: Vec<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_30_mojolicious_navigation_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_30_mojolicious_navigation_quality.rs
@@ -12,6 +12,7 @@
 //! - fallback/empty counts for uncertain dynamic or unsupported surfaces
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -73,10 +74,6 @@ struct NavigationProbeReport {
     expected_target_hits: Vec<String>,
     missing_expected_uri_suffixes: Vec<String>,
     fallback_or_empty: bool,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_31_mojolicious_diagnostics_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_31_mojolicious_diagnostics_quality.rs
@@ -13,6 +13,7 @@
 //!   genuinely missing module
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -82,10 +83,6 @@ struct DiagnosticProbeReport {
     dynamic_boundary_label_hits: Vec<String>,
     message_excerpts: Vec<String>,
     fallback_or_empty: bool,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_32_mojolicious_document_symbols_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_32_mojolicious_document_symbols_quality.rs
@@ -13,6 +13,7 @@
 //! - freshness after editing a document so stale symbol names disappear
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -80,10 +81,6 @@ struct FreshnessReport {
     before_hits: Vec<String>,
     after_hits: Vec<String>,
     after_invalid_shape_count: usize,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_33_mojolicious_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_33_mojolicious_workspace_symbol_noise.rs
@@ -12,6 +12,7 @@
 //! - stale/fresh query behavior after editing an open document
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -83,10 +84,6 @@ struct FreshnessReport {
 struct TimedSymbols {
     symbols: Vec<Value>,
     latency_ms: u128,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_34_mojolicious_semantic_tokens_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_34_mojolicious_semantic_tokens_quality.rs
@@ -12,6 +12,7 @@
 //! - freshness after editing a document so stale token text disappears
 
 use anyhow::{Context, Result, anyhow};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -124,10 +125,6 @@ struct FreshnessReport {
     after_hits: Vec<String>,
     after_invalid_tuple_count: usize,
     after_overlap_count: usize,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_35_mojolicious_rename_unsafe_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_35_mojolicious_rename_unsafe_edit.rs
@@ -11,6 +11,7 @@
 //! - after an open-document edit, rename does not act on stale source text
 
 use anyhow::{Context, Result, anyhow};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -109,10 +110,6 @@ struct FreshnessReport {
     touched_source_texts: Vec<String>,
     new_texts: Vec<String>,
     error_message: Option<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_36_mojolicious_safe_delete_warning.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_36_mojolicious_safe_delete_warning.rs
@@ -12,6 +12,7 @@
 //! - the receipt boundary remains file-delete warning proof only
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -41,10 +42,6 @@ struct SafeDeleteWarningReport {
     warning_seen: bool,
     dependent_warning_seen: bool,
     warning_messages: Vec<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_37_dancer2_rename_unsafe_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_37_dancer2_rename_unsafe_edit.rs
@@ -11,6 +11,7 @@
 //! - after an open-document edit, rename does not act on stale source text
 
 use anyhow::{Context, Result, anyhow};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -109,10 +110,6 @@ struct FreshnessReport {
     touched_source_texts: Vec<String>,
     new_texts: Vec<String>,
     error_message: Option<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_38_dancer2_semantic_tokens_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_38_dancer2_semantic_tokens_quality.rs
@@ -12,6 +12,7 @@
 //! - freshness after editing a document so stale token text disappears
 
 use anyhow::{Context, Result, anyhow};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -124,10 +125,6 @@ struct FreshnessReport {
     after_hits: Vec<String>,
     after_invalid_tuple_count: usize,
     after_overlap_count: usize,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_39_dancer2_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_39_dancer2_workspace_symbol_noise.rs
@@ -12,6 +12,7 @@
 //! - stale/fresh query behavior after editing an open document
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -83,10 +84,6 @@ struct FreshnessReport {
 struct TimedSymbols {
     symbols: Vec<Value>,
     latency_ms: u128,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_40_dancer2_diagnostics_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_40_dancer2_diagnostics_quality.rs
@@ -13,6 +13,7 @@
 //!   genuinely missing module
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -85,10 +86,6 @@ struct DiagnosticProbeReport {
     dynamic_boundary_label_hits: Vec<String>,
     message_excerpts: Vec<String>,
     fallback_or_empty: bool,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_41_catalyst_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_41_catalyst_workspace_symbol_noise.rs
@@ -12,6 +12,7 @@
 //! - stale/fresh query behavior after editing an open document
 
 use anyhow::{Context, Result};
+use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{
     ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
 };
@@ -84,10 +85,6 @@ struct FreshnessReport {
 struct TimedSymbols {
     symbols: Vec<Value>,
     latency_ms: u128,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
 }
 
 fn missing_binary_skip() -> UxScenarioSkip {


### PR DESCRIPTION
### Motivation

- Many UX scenario tests duplicated the same `binary_available()` guard (`resolve_binary().is_ok()`), violating DRY and increasing maintenance surface.

### Description

- Add a shared `pub fn binary_available() -> bool` to `crates/perl-lsp-ux-tests/src/lib.rs` that returns `resolve_binary().is_ok()`.
- Replace per-file duplicated `fn binary_available() -> bool { ... }` implementations by importing the shared helper via `use perl_lsp_ux_tests::binary_available;` across scenario tests.
- Remove the now-redundant local helper functions from multiple `crates/perl-lsp-ux-tests/tests/*.rs` files, preserving test behavior and skip semantics.
- Change scope is a focused refactor of the UX test harness; no test logic or assertions were altered.

### Testing

- Ran `./scripts/cargo-safe xtask fmt` which completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-lsp-ux-tests --profile agent --locked` which passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-ux-tests --lib --profile agent --locked` which passed unit/lib tests; a full integration run `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-ux-tests --profile agent --locked` encountered one failing scenario due to an unresolved `perl-lsp` binary in the environment (test failure: `perl-lsp binary not found`).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-lsp-ux-tests --profile agent --locked -- -D warnings -A missing_docs` which passed; `git diff --check` and `./scripts/storage-doctor` also reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b8793ed8833395b8ddc7ffa3cd08)