### PR TITLE
refactor(ux-tests): share fixture loading helpers (#0000)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -69,7 +69,8 @@ pub use workspace::FakeWorkspace;
 use anyhow::{Context, Result, anyhow};
 use serde_json::{Value, json};
 use std::collections::HashMap;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
 use url::Url;
@@ -938,6 +939,86 @@ impl FormatResult {
     pub fn has_edits(&self) -> bool {
         matches!(self, Self::Edits(v) if !v.is_empty())
     }
+}
+
+// ───────────────────────────── Real-project fixture loading ─────────────────
+
+/// A Perl source file loaded from a committed real-project UX fixture.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct FixtureFile {
+    /// Slash-normalized path relative to the fixture project root.
+    pub relative_path: String,
+    /// Complete file contents.
+    pub content: String,
+}
+
+/// Return whether the UX harness can resolve a runnable perl-lsp binary.
+pub fn binary_available() -> bool {
+    resolve_binary().is_ok()
+}
+
+/// Standard skip reason for scenarios that require a runnable perl-lsp binary.
+pub fn missing_binary_skip() -> UxScenarioSkip {
+    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
+}
+
+/// Resolve the workspace root from this crate's manifest directory.
+pub fn workspace_root() -> Result<PathBuf> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
+}
+
+/// Resolve a committed real-project fixture root by directory name.
+pub fn real_project_fixture_root(project_dir: &str) -> Result<PathBuf> {
+    Ok(workspace_root()?.join("test_corpus").join("real_projects").join(project_dir))
+}
+
+/// Load all Perl source files from a committed real-project fixture.
+pub fn load_real_project_fixture_files(project_dir: &str) -> Result<Vec<FixtureFile>> {
+    let root = real_project_fixture_root(project_dir)?;
+    let mut files = Vec::new();
+    collect_perl_files(&root, &root, &mut files)?;
+    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(files)
+}
+
+/// Return one loaded fixture file's content by relative path.
+pub fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
+    files
+        .iter()
+        .find(|file| file.relative_path == relative_path)
+        .map(|file| file.content.as_str())
+        .with_context(|| format!("missing fixture file {relative_path}"))
+}
+
+fn is_perl_source(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
+}
+
+fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_perl_files(root, &path, files)?;
+        } else if is_perl_source(&path) {
+            let relative_path = path
+                .strip_prefix(root)
+                .with_context(|| format!("stripping fixture root from {}", path.display()))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            let content =
+                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+            files.push(FixtureFile { relative_path, content });
+        }
+    }
+    Ok(())
 }
 
 // ─────────────────────────────── Binary Resolution ───────────────────────────

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_28_mojolicious_completion_ranking.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_28_mojolicious_completion_ranking.rs
@@ -10,24 +10,17 @@
 //! - generated-candidate and provenance-label coverage
 //! - dynamic/fallback label coverage when the provider exposes it
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_28_mojolicious_completion_ranking.rs";
 const TOP_N: usize = 10;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct CompletionProbe {
@@ -56,60 +49,6 @@ struct CompletionProbeReport {
     generated_candidate_hits: Vec<String>,
     generated_provenance_label_hits: Vec<String>,
     dynamic_or_fallback_label_hits: Vec<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
 }
 
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
@@ -306,7 +245,7 @@ fn scenario_28_mojolicious_visible_symbol_ranking_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_29_mojolicious_hover_provenance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_29_mojolicious_hover_provenance.rs
@@ -14,22 +14,15 @@
 
 use anyhow::{Context, Result};
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_29_mojolicious_hover_provenance.rs";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct HoverProbe {
@@ -76,60 +69,6 @@ struct HoverProbeReport {
     fallback_label_hits: Vec<String>,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -146,14 +85,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn resolve_probe_position(files: &[FixtureFile], probe: &HoverProbe) -> Result<ProbePosition> {
@@ -353,7 +284,7 @@ fn scenario_29_mojolicious_hover_provenance_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_30_mojolicious_navigation_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_30_mojolicious_navigation_quality.rs
@@ -13,22 +13,15 @@
 
 use anyhow::{Context, Result};
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_30_mojolicious_navigation_quality.rs";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -75,60 +68,6 @@ struct NavigationProbeReport {
     fallback_or_empty: bool,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -145,14 +84,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn resolve_probe_position(files: &[FixtureFile], probe: &NavigationProbe) -> Result<ProbePosition> {
@@ -352,7 +283,7 @@ fn scenario_30_mojolicious_navigation_quality_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_31_mojolicious_diagnostics_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_31_mojolicious_diagnostics_quality.rs
@@ -12,15 +12,14 @@
 //! - mixed project-shaped files keep present modules clean while reporting a
 //!   genuinely missing module
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use perl_lsp_ux_tests::{
-    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_31_mojolicious_diagnostics_quality.rs";
@@ -46,12 +45,6 @@ sub mixed_diagnostic_probe {
 
 1;
 "#;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct DiagnosticProbe {
@@ -82,60 +75,6 @@ struct DiagnosticProbeReport {
     dynamic_boundary_label_hits: Vec<String>,
     message_excerpts: Vec<String>,
     fallback_or_empty: bool,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
 }
 
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
@@ -405,7 +344,7 @@ fn scenario_31_mojolicious_diagnostics_quality_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_32_mojolicious_document_symbols_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_32_mojolicious_document_symbols_quality.rs
@@ -12,25 +12,18 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - freshness after editing a document so stale symbol names disappear
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_32_mojolicious_document_symbols_quality.rs";
 const FRESHNESS_FILE: &str = "lib/Mojolicious/Static.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct DocumentSymbolProbe {
@@ -82,60 +75,6 @@ struct FreshnessReport {
     after_invalid_shape_count: usize,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -152,14 +91,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn is_valid_position(position: &Value) -> bool {
@@ -386,7 +317,7 @@ fn scenario_32_mojolicious_document_symbols_quality_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_33_mojolicious_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_33_mojolicious_workspace_symbol_noise.rs
@@ -11,26 +11,19 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const SCENARIO_FILE: &str = "ux_scenario_33_mojolicious_workspace_symbol_noise.rs";
 const TOP_N: usize = 12;
 const FRESHNESS_FILE: &str = "lib/Mojolicious/Static.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct WorkspaceSymbolProbe {
@@ -85,60 +78,6 @@ struct TimedSymbols {
     latency_ms: u128,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -155,14 +94,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn timed_workspace_symbols(harness: &UxHarness, query: &str) -> Result<TimedSymbols> {
@@ -412,7 +343,7 @@ fn scenario_33_mojolicious_workspace_symbol_noise_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_34_mojolicious_semantic_tokens_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_34_mojolicious_semantic_tokens_quality.rs
@@ -13,13 +13,12 @@
 
 use anyhow::{Context, Result, anyhow};
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_34_mojolicious_semantic_tokens_quality.rs";
@@ -52,12 +51,6 @@ const TOKEN_TYPE_NAMES: [&str; 23] = [
 ];
 
 const TOKEN_MODIFIER_COUNT: u32 = 13;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct SemanticTokenProbe {
@@ -126,60 +119,6 @@ struct FreshnessReport {
     after_overlap_count: usize,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -196,14 +135,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn semantic_tokens(harness: &UxHarness, relative_path: &str) -> Result<Value> {
@@ -580,7 +511,7 @@ fn scenario_34_mojolicious_semantic_tokens_quality_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_35_mojolicious_rename_unsafe_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_35_mojolicious_rename_unsafe_edit.rs
@@ -12,24 +12,17 @@
 
 use anyhow::{Context, Result, anyhow};
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_35_mojolicious_rename_unsafe_edit.rs";
 const STATIC_FILE: &str = "lib/Mojolicious/Static.pm";
 const ROUTES_FILE: &str = "lib/Mojolicious/Routes.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -111,60 +104,6 @@ struct FreshnessReport {
     error_message: Option<String>,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -181,14 +120,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn resolve_probe_position(files: &[FixtureFile], probe: &RenameProbe) -> Result<ProbePosition> {
@@ -559,7 +490,7 @@ fn scenario_35_mojolicious_rename_unsafe_edit_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_36_mojolicious_safe_delete_warning.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_36_mojolicious_safe_delete_warning.rs
@@ -13,24 +13,17 @@
 
 use anyhow::{Context, Result};
 use perl_lsp_ux_tests::{
-    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_36_mojolicious_safe_delete_warning.rs";
 const DELETE_TARGET: &str = "lib/Mojolicious/Static.pm";
 const DEPENDENT_FILE: &str = "lib/Mojolicious.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug, Serialize)]
 struct SafeDeleteWarningReport {
@@ -41,60 +34,6 @@ struct SafeDeleteWarningReport {
     warning_seen: bool,
     dependent_warning_seen: bool,
     warning_messages: Vec<String>,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn mojolicious_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("mojolicious_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_mojolicious_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = mojolicious_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
 }
 
 fn create_mojolicious_harness(files: &[FixtureFile]) -> Result<UxHarness> {
@@ -113,14 +52,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn assert_fixture_dependency(files: &[FixtureFile]) -> Result<()> {
@@ -195,7 +126,7 @@ fn scenario_36_mojolicious_safe_delete_warning_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_mojolicious_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("mojolicious_skeleton")?;
             recorder
                 .check("mojolicious fixture has committed Perl files", !fixture_files.is_empty())?;
             assert_fixture_dependency(&fixture_files)?;

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_37_dancer2_rename_unsafe_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_37_dancer2_rename_unsafe_edit.rs
@@ -12,24 +12,17 @@
 
 use anyhow::{Context, Result, anyhow};
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_37_dancer2_rename_unsafe_edit.rs";
 const APP_FILE: &str = "lib/Dancer2/Core/App.pm";
 const PLUGIN_FILE: &str = "lib/Dancer2/Plugin.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -111,60 +104,6 @@ struct FreshnessReport {
     error_message: Option<String>,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn dancer2_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("dancer2_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_dancer2_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = dancer2_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_dancer2_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -181,14 +120,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn resolve_probe_position(files: &[FixtureFile], probe: &RenameProbe) -> Result<ProbePosition> {
@@ -558,7 +489,7 @@ fn scenario_37_dancer2_rename_unsafe_edit_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_dancer2_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("dancer2_skeleton")?;
             recorder
                 .check("dancer2 fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_38_dancer2_semantic_tokens_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_38_dancer2_semantic_tokens_quality.rs
@@ -13,13 +13,12 @@
 
 use anyhow::{Context, Result, anyhow};
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_38_dancer2_semantic_tokens_quality.rs";
@@ -52,12 +51,6 @@ const TOKEN_TYPE_NAMES: [&str; 23] = [
 ];
 
 const TOKEN_MODIFIER_COUNT: u32 = 13;
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct SemanticTokenProbe {
@@ -126,60 +119,6 @@ struct FreshnessReport {
     after_overlap_count: usize,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn dancer2_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("dancer2_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_dancer2_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = dancer2_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_dancer2_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -196,14 +135,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn semantic_tokens(harness: &UxHarness, relative_path: &str) -> Result<Value> {
@@ -587,7 +518,7 @@ fn scenario_38_dancer2_semantic_tokens_quality_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_dancer2_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("dancer2_skeleton")?;
             recorder
                 .check("dancer2 fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_39_dancer2_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_39_dancer2_workspace_symbol_noise.rs
@@ -11,26 +11,19 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const SCENARIO_FILE: &str = "ux_scenario_39_dancer2_workspace_symbol_noise.rs";
 const TOP_N: usize = 12;
 const FRESHNESS_FILE: &str = "lib/Dancer2/Plugin.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct WorkspaceSymbolProbe {
@@ -85,60 +78,6 @@ struct TimedSymbols {
     latency_ms: u128,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn dancer2_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("dancer2_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_dancer2_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = dancer2_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_dancer2_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -155,14 +94,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn timed_workspace_symbols(harness: &UxHarness, query: &str) -> Result<TimedSymbols> {
@@ -407,7 +338,7 @@ fn scenario_39_dancer2_workspace_symbol_noise_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_dancer2_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("dancer2_skeleton")?;
             recorder
                 .check("dancer2 fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_40_dancer2_diagnostics_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_40_dancer2_diagnostics_quality.rs
@@ -12,15 +12,14 @@
 //! - mixed project-shaped files keep present modules clean while reporting a
 //!   genuinely missing module
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use perl_lsp_ux_tests::{
-    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const SCENARIO_FILE: &str = "ux_scenario_40_dancer2_diagnostics_quality.rs";
@@ -51,12 +50,6 @@ sub mixed_diagnostic_probe {
 "#;
 
 #[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
-
-#[derive(Debug)]
 struct DiagnosticProbe {
     name: &'static str,
     category: &'static str,
@@ -85,60 +78,6 @@ struct DiagnosticProbeReport {
     dynamic_boundary_label_hits: Vec<String>,
     message_excerpts: Vec<String>,
     fallback_or_empty: bool,
-}
-
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn dancer2_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("dancer2_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_dancer2_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = dancer2_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
 }
 
 fn create_dancer2_harness(files: &[FixtureFile]) -> Result<UxHarness> {
@@ -410,7 +349,7 @@ fn scenario_40_dancer2_diagnostics_quality_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_dancer2_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("dancer2_skeleton")?;
             recorder
                 .check("dancer2 fixture has committed Perl files", !fixture_files.is_empty())?;
 

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_41_catalyst_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_41_catalyst_workspace_symbol_noise.rs
@@ -11,26 +11,19 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use perl_lsp_ux_tests::{
-    ScenarioConfig, UxCiTier, UxComponent, UxHarness, UxScenarioSkip, run_ux_scenario,
+    FixtureFile, ScenarioConfig, UxCiTier, UxComponent, UxHarness, binary_available,
+    fixture_content, load_real_project_fixture_files, missing_binary_skip, run_ux_scenario,
 };
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::BTreeSet;
-use std::fs;
-use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const SCENARIO_FILE: &str = "ux_scenario_41_catalyst_workspace_symbol_noise.rs";
 const TOP_N: usize = 12;
 const FRESHNESS_FILE: &str = "lib/Catalyst/Dispatcher.pm";
-
-#[derive(Debug)]
-struct FixtureFile {
-    relative_path: String,
-    content: String,
-}
 
 #[derive(Debug)]
 struct WorkspaceSymbolProbe {
@@ -86,60 +79,6 @@ struct TimedSymbols {
     latency_ms: u128,
 }
 
-fn binary_available() -> bool {
-    perl_lsp_ux_tests::resolve_binary().is_ok()
-}
-
-fn missing_binary_skip() -> UxScenarioSkip {
-    UxScenarioSkip::infra("PERL_LSP_BIN not set and target/debug/perl-lsp not found")
-}
-
-fn workspace_root() -> Result<PathBuf> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .map(Path::to_path_buf)
-        .context("CARGO_MANIFEST_DIR must be nested under the workspace root")
-}
-
-fn catalyst_fixture_root() -> Result<PathBuf> {
-    Ok(workspace_root()?.join("test_corpus").join("real_projects").join("catalyst_skeleton"))
-}
-
-fn is_perl_source(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "pm" | "pl" | "t"))
-}
-
-fn collect_perl_files(root: &Path, dir: &Path, files: &mut Vec<FixtureFile>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
-        let entry = entry.with_context(|| format!("reading an entry under {}", dir.display()))?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_perl_files(root, &path, files)?;
-        } else if is_perl_source(&path) {
-            let relative_path = path
-                .strip_prefix(root)
-                .with_context(|| format!("stripping fixture root from {}", path.display()))?
-                .to_string_lossy()
-                .replace('\\', "/");
-            let content =
-                fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-            files.push(FixtureFile { relative_path, content });
-        }
-    }
-    Ok(())
-}
-
-fn load_catalyst_fixture_files() -> Result<Vec<FixtureFile>> {
-    let root = catalyst_fixture_root()?;
-    let mut files = Vec::new();
-    collect_perl_files(&root, &root, &mut files)?;
-    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(files)
-}
-
 fn create_catalyst_harness(files: &[FixtureFile]) -> Result<UxHarness> {
     let mut config = ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
         .env("PERL_LSP_WORKSPACE", "1");
@@ -156,14 +95,6 @@ fn open_all_fixture_files(harness: &UxHarness, files: &[FixtureFile]) -> Result<
         harness.open_file(&file.relative_path, &file.content)?;
     }
     Ok(())
-}
-
-fn fixture_content<'a>(files: &'a [FixtureFile], relative_path: &str) -> Result<&'a str> {
-    files
-        .iter()
-        .find(|file| file.relative_path == relative_path)
-        .map(|file| file.content.as_str())
-        .with_context(|| format!("missing fixture file {relative_path}"))
 }
 
 fn timed_workspace_symbols(harness: &UxHarness, query: &str) -> Result<TimedSymbols> {
@@ -462,7 +393,7 @@ fn scenario_41_catalyst_workspace_symbol_noise_receipt() {
                 return Err(missing_binary_skip().into());
             }
 
-            let fixture_files = load_catalyst_fixture_files()?;
+            let fixture_files = load_real_project_fixture_files("catalyst_skeleton")?;
             recorder
                 .check("Catalyst fixture has committed Perl files", !fixture_files.is_empty())?;
 


### PR DESCRIPTION
### Motivation
- Reduce duplication across real-project UX scenarios by centralizing fixture-loading and binary-skip helpers used by many tests.
- Make scenario files smaller and easier to maintain by removing repeated filesystem traversal and binary resolution code.

### Description
- Add shared helpers to `crates/perl-lsp-ux-tests/src/lib.rs`: `FixtureFile`, `binary_available`, `missing_binary_skip`, `workspace_root`, `real_project_fixture_root`, `load_real_project_fixture_files`, `fixture_content`, `is_perl_source`, and `collect_perl_files` to centralize fixture discovery and loading logic.
- Update Mojolicious, Dancer2, and Catalyst scenario tests to import and use the shared helpers (replace local `FixtureFile`/`collect_*`/`workspace_root`/`binary_*` duplications) in the following files: `crates/perl-lsp-ux-tests/tests/ux_scenario_28_*`, `ux_scenario_29_*`, `ux_scenario_30_*`, `ux_scenario_31_*`, `ux_scenario_32_*`, `ux_scenario_33_*`, `ux_scenario_34_*`, `ux_scenario_35_*`, `ux_scenario_36_*`, `ux_scenario_37_*`, `ux_scenario_38_*`, `ux_scenario_39_*`, `ux_scenario_40_*`, and `ux_scenario_41_*`.
- Remove the duplicated helper implementations from the per-scenario test files and wire them to `load_real_project_fixture_files("<project>_skeleton")` and `fixture_content` as appropriate.
- Commit recorded as: `refactor(ux-tests): share fixture loading helpers (#0000)`.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` which completed successfully.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo clippy -p perl-lsp-ux-tests --profile agent --locked -- -D warnings -A missing_docs` which completed successfully.
- Ran unit and many integration tests via `CARGO_TARGET_DIR=/tmp/perl-lsp-agent-target cargo test -p perl-lsp-ux-tests --profile agent --locked`; most tests passed, and targeted scenario tests (for example `ux_scenario_28_mojolicious_completion_ranking`) passed; one unrelated UX scenario (`ux_scenario_22_template_language_mode`) failed due to a missing `perl-lsp` binary in the environment rather than this refactor.
- Ran formatting and hygiene checks (`./scripts/cargo-safe xtask fmt`, `./scripts/storage-doctor`) which completed; a full `./scripts/cargo-safe test -p perl-lsp-ux-tests` was blocked by the repository storage guard in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b8793ed8833395b8ddc7ffa3cd08)