### PR TITLE
docs(status): align workspace-symbol next proof (#8197)

### DIFF
--- a/docs/project/status/real_perl_editor_trust_v1.md
+++ b/docs/project/status/real_perl_editor_trust_v1.md
@@ -213,8 +213,9 @@ ready-index queries only. Generated/framework symbols are virtual, labeled, and
 anchored to framework declarations rather than exact generated method bodies.
 Empty-query, partial-index, open-document fallback, generated/no-source, stale,
 dynamic, ambiguous, and fallback/noise candidates remain fallback or gated.
-The next workspace-symbol proof is a scoped generated-symbol cutover receipt;
-another rank/noise receipt alone is no longer the promotion blocker.
+The scoped generated-symbol cutover receipt is now recorded; the next
+workspace-symbol proof is another generated-symbol class receipt before
+broader generated workspace-symbol expansion.
 
 ## Promotion Rules
 


### PR DESCRIPTION
Problem: The workspace-symbol status text still described the generated-symbol cutover receipt as future work after #9275 merged it. 
Fix: Update the Real Perl Editor Trust status paragraph so the recorded cutover receipt is current evidence and the next proof is another generated-symbol class receipt before broader expansion. 
Verification: git diff --check; cargo xtask check-provider-confidence-matrix; cargo xtask check-support-claims.