### PR TITLE
fix(package-graph): restore package after bare blocks (#7949)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/package_graph_extractor.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/package_graph_extractor.rs
@@ -46,16 +46,31 @@ struct ExtractorState {
 }
 
 impl ExtractorState {
+    /// Walk a statement list in source order using the current package context.
+    fn walk_statements(&mut self, statements: &[Node]) {
+        for stmt in statements {
+            self.walk(stmt);
+        }
+    }
+
     /// Recursive AST walker.
     fn walk(&mut self, node: &Node) {
         match &node.kind {
-            // For statement containers (Program, Block), walk statements in order
-            // so that `package Foo;` (semicolon form) updates the current package
-            // for subsequent sibling statements.
-            NodeKind::Program { statements } | NodeKind::Block { statements } => {
-                for stmt in statements {
-                    self.walk(stmt);
-                }
+            // For the top-level program, walk statements in order so that
+            // `package Foo;` (semicolon form) updates the current package for
+            // subsequent sibling statements through the end of the file.
+            NodeKind::Program { statements } => {
+                self.walk_statements(statements);
+                return;
+            }
+
+            // Bare blocks introduce a lexical package scope: `package Foo;` inside
+            // the block applies to later statements in that block, but the outer
+            // package resumes after the block.
+            NodeKind::Block { statements } => {
+                let prev_package = self.current_package.clone();
+                self.walk_statements(statements);
+                self.current_package = prev_package;
                 return;
             }
 
@@ -516,6 +531,27 @@ use parent 'Parent';
 
         assert_eq!(edge.from_package, "main");
         assert_eq!(edge.to_package, "Base");
+        Ok(())
+    }
+
+    #[test]
+    fn test_package_declaration_inside_block_restores_outer_package() -> Result<(), String> {
+        let code = r#"
+package Outer;
+{
+    package Inner;
+    use parent 'InnerBase';
+}
+use parent 'OuterBase';
+1;
+"#;
+        let edges = parse_and_extract(code);
+        assert_eq!(edges.len(), 2, "expected two inheritance edges, got {}", edges.len());
+
+        assert_eq!(edges[0].from_package, "Inner");
+        assert_eq!(edges[0].to_package, "InnerBase");
+        assert_eq!(edges[1].from_package, "Outer");
+        assert_eq!(edges[1].to_package, "OuterBase");
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- Semicolon-form `package Foo;` declarations inside bare `{ ... }` blocks were incorrectly remaining the active package after the block, causing subsequent edges to be attributed to the inner package instead of the outer one.

### Description

- Add `walk_statements` helper and split handling of `NodeKind::Program` and `NodeKind::Block` so top-level statements are walked through EOF while bare blocks restore the previous `current_package` after traversal by saving and restoring `prev_package` in `ExtractorState`.
- Preserve existing behavior for `package Foo { ... }` block-form (scoped package) and semicolon-form `package Foo;` at top-level semantics by adjusting the `walk` match arms in `crates/perl-semantic-analyzer/src/analysis/package_graph_extractor.rs`.
- Add regression test `test_package_declaration_inside_block_restores_outer_package` in the same test module to cover the inner/outer package edge attribution scenario.

### Testing

- Ran `./scripts/cargo-safe test -p perl-semantic-analyzer --profile agent --locked` and the crate's test suite completed with all tests passing (including the new regression test). 
- Ran `./scripts/cargo-safe check --all-targets -p perl-semantic-analyzer --profile agent --locked`, `./scripts/cargo-safe xtask fmt`, and `./scripts/cargo-safe clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs` and they all passed.
- Ran `./scripts/storage-doctor` and `git diff --check` with no issues; `just agent-pr-fast` could not be executed because `just` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1eddd948333a121a65367e4e242)