### PR TITLE
test(perl-token): remove unwraps from token unit tests (#0000)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -1564,16 +1564,19 @@ mod tests {
     }
 
     #[test]
-    fn token_span_try_new_ok() {
-        let span = TokenSpan::try_new(0, 5).unwrap();
+    fn token_span_try_new_ok() -> Result<(), TokenSpanError> {
+        let span = TokenSpan::try_new(0, 5)?;
         assert_eq!(span.start, 0);
         assert_eq!(span.end, 5);
+        Ok(())
     }
 
     #[test]
     fn token_span_try_new_end_before_start_errors() {
-        let err = TokenSpan::try_new(10, 5).unwrap_err();
-        assert_eq!(err, TokenSpanError::EndBeforeStart { start: 10, end: 5 });
+        assert_eq!(
+            TokenSpan::try_new(10, 5),
+            Err(TokenSpanError::EndBeforeStart { start: 10, end: 5 })
+        );
     }
 
     #[test]
@@ -1623,24 +1626,26 @@ mod tests {
 
     #[test]
     fn token_try_new_rejects_end_before_start() {
-        let err = Token::try_new(TokenKind::Identifier, "x", 10, 5).unwrap_err();
-        assert_eq!(err, TokenSpanError::EndBeforeStart { start: 10, end: 5 });
+        assert_eq!(
+            Token::try_new(TokenKind::Identifier, "x", 10, 5),
+            Err(TokenSpanError::EndBeforeStart { start: 10, end: 5 })
+        );
     }
 
     #[test]
     fn token_new_checked_rejects_empty_non_eof() {
-        let err = Token::new_checked(TokenKind::Identifier, "", 5, 5).unwrap_err();
         assert!(matches!(
-            err,
-            TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 5 }
+            Token::new_checked(TokenKind::Identifier, "", 5, 5),
+            Err(TokenSpanError::EmptySpanNotAllowed { kind: TokenKind::Identifier, at: 5 })
         ));
     }
 
     #[test]
-    fn token_new_checked_allows_empty_eof() {
-        let tok = Token::new_checked(TokenKind::Eof, "", 5, 5).unwrap();
+    fn token_new_checked_allows_empty_eof() -> Result<(), TokenSpanError> {
+        let tok = Token::new_checked(TokenKind::Eof, "", 5, 5)?;
         assert_eq!(tok.kind, TokenKind::Eof);
         assert_eq!(tok.start, 5);
+        Ok(())
     }
 
     #[test]
@@ -1671,11 +1676,12 @@ mod tests {
     }
 
     #[test]
-    fn token_with_span_ok() {
+    fn token_with_span_ok() -> Result<(), TokenSpanError> {
         let tok = Token::new(TokenKind::String, "hello", 0, 5);
-        let moved = tok.with_span(10, 15).unwrap();
+        let moved = tok.with_span(10, 15)?;
         assert_eq!(moved.start, 10);
         assert_eq!(moved.end, 15);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Replace `unwrap()`/`unwrap_err()` usages in unit tests to comply with the repository's test-quality policy and make tests panic-free and more idiomatic.

### Description
- Updated unit tests in `crates/perl-token/src/lib.rs` to use `Result`-returning test functions or direct `Result` assertions and removed `unwrap()`/`unwrap_err()` calls in the affected tests (`token_span_try_new_ok`, `token_span_try_new_end_before_start_errors`, `token_try_new_rejects_end_before_start`, `token_new_checked_rejects_empty_non_eof`, `token_new_checked_allows_empty_eof`, `token_with_span_ok`).

### Testing
- Ran `cargo test -p perl-token --profile agent --locked` and all tests passed (all unit tests and doctests OK). 
- Ran `cargo check --all-targets -p perl-token --profile agent --locked` and `cargo clippy -p perl-token --profile agent --locked -- -D warnings -A missing_docs` and they passed. 
- Ran `cargo fmt --check` which passed; `./scripts/cargo-safe xtask fmt` was blocked by the storage guard (DENY: cache usage), and `just agent-pr-fast` was not available in this environment (`just: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088dc5cce88333a0b4a11aecce4980)