### PR TITLE
fix(import-optimizer): handle CRLF edit offsets (#9283)

### DIFF
--- a/crates/perl-refactoring/src/refactor/import_optimizer.rs
+++ b/crates/perl-refactoring/src/refactor/import_optimizer.rs
@@ -448,14 +448,18 @@ impl ImportOptimizer {
         if line <= 1 {
             return 0;
         }
-        let mut offset = 0;
-        for (idx, l) in content.lines().enumerate() {
-            if idx + 1 >= line {
-                break;
+
+        let mut seen_newlines = 0;
+        for (idx, ch) in content.char_indices() {
+            if ch == '\n' {
+                seen_newlines += 1;
+                if seen_newlines == line - 1 {
+                    return idx + ch.len_utf8();
+                }
             }
-            offset += l.len() + 1; // include newline
         }
-        offset
+
+        content.len()
     }
 }
 

--- a/crates/perl-refactoring/tests/edge_case_coverage.rs
+++ b/crates/perl-refactoring/tests/edge_case_coverage.rs
@@ -930,6 +930,31 @@ fn import_optimizer_edits_have_correct_byte_ranges() -> Result<(), Box<dyn std::
 }
 
 #[test]
+fn import_optimizer_edits_cover_crlf_import_block() -> Result<(), Box<dyn std::error::Error>> {
+    let optimizer = ImportOptimizer::new();
+    let content = "use strict;\r\nuse warnings;\r\nuse JSON qw(encode_json decode_json);\r\n\r\nmy $json = encode_json({ ok => 1 });\r\n";
+
+    let analysis = optimizer.analyze_content(content)?;
+    let edits = optimizer.generate_edits(content, &analysis);
+
+    assert_eq!(edits.len(), 1, "Should produce one import-block replacement edit");
+    let edit = &edits[0];
+    let expected_end =
+        content.find("\r\n\r\n").ok_or("blank line after import block not found")? + "\r\n".len();
+
+    assert_eq!(edit.range, (0, expected_end), "CRLF ranges should cover full import lines");
+
+    let mut rewritten = content.to_string();
+    rewritten.replace_range(edit.range.0..edit.range.1, &edit.new_text);
+    assert!(
+        rewritten
+            .starts_with("use JSON qw(encode_json);\nuse strict;\nuse warnings;\n\r\nmy $json"),
+        "replacement should not leave stray carriage returns before the preserved body: {rewritten:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn import_optimizer_no_edits_for_clean_file() -> Result<(), Box<dyn std::error::Error>> {
     let optimizer = ImportOptimizer::new();
     let content = "use strict;\nuse warnings;\n\nprint \"hello\";\n";


### PR DESCRIPTION
### Motivation

- Avoid incorrect byte ranges when generating import-block edits for files using CRLF line endings that could leave replacement boundaries inside the import block.

### Description

- Replace the previous `line_offset` implementation with a newline-byte-position-driven implementation that scans `content.char_indices()` and returns the byte offset of the Nth newline to correctly handle both LF and CRLF content, in `crates/perl-refactoring/src/refactor/import_optimizer.rs`.
- Add a regression test `import_optimizer_edits_cover_crlf_import_block` that verifies `generate_edits` covers the full CRLF import block and does not leave stray `\r` characters, in `crates/perl-refactoring/tests/edge_case_coverage.rs`.

### Testing

- Ran the crate test matrix with `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-refactoring --profile agent --locked` and the updated perl-refactoring test suite passed (all tests in the crate passed); the added CRLF regression test also passed.
- Verified formatting and static checks with `cargo fmt --package perl-refactoring --check`, `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check --all-targets -p perl-refactoring --profile agent --locked`, and `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-refactoring --profile agent --locked -- -D warnings -A missing_docs`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1eddd948333a121a65367e4e242)