### PR TITLE
fix(diagnostics): tighten message inference boundaries (#4926)

### DIFF
--- a/crates/perl-diagnostics/src/codes/mod.rs
+++ b/crates/perl-diagnostics/src/codes/mod.rs
@@ -238,6 +238,36 @@ pub enum DiagnosticCode {
     CriticSeverity5,
 }
 
+fn is_undefined_variable_message(msg_lower: &str) -> bool {
+    contains_diagnostic_phrase(msg_lower, "not declared")
+        || contains_diagnostic_phrase(msg_lower, "undefined variable")
+        || (contains_diagnostic_phrase(msg_lower, "undefined")
+            && (contains_diagnostic_phrase(msg_lower, "variable")
+                || contains_diagnostic_phrase(msg_lower, "global symbol")))
+}
+
+fn contains_diagnostic_phrase(haystack: &str, needle: &str) -> bool {
+    haystack.match_indices(needle).any(|(start, matched)| {
+        let end = start + matched.len();
+        has_phrase_boundary(haystack, start, end)
+    })
+}
+
+fn has_phrase_boundary(haystack: &str, start: usize, end: usize) -> bool {
+    let bytes = haystack.as_bytes();
+    let before_is_word = start
+        .checked_sub(1)
+        .and_then(|index| bytes.get(index))
+        .is_some_and(|byte| is_phrase_word_byte(*byte));
+    let after_is_word = bytes.get(end).is_some_and(|byte| is_phrase_word_byte(*byte));
+
+    !before_is_word && !after_is_word
+}
+
+fn is_phrase_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
 impl DiagnosticCode {
     /// Get the string representation of this code.
     pub fn as_str(&self) -> &'static str {
@@ -699,31 +729,42 @@ impl DiagnosticCode {
     /// Try to infer a diagnostic code from a message.
     pub fn from_message(msg: &str) -> Option<Self> {
         let msg_lower = msg.to_lowercase();
-        if msg_lower.contains("inside a begin block does not enable strict")
-            || msg_lower.contains("inside a phase block does not enable strict")
+        if contains_diagnostic_phrase(&msg_lower, "inside a begin block does not enable strict")
+            || contains_diagnostic_phrase(&msg_lower, "inside a phase block does not enable strict")
         {
             Some(Self::PhaseScopedStrictPragma)
-        } else if msg_lower.contains("inside a begin block does not enable warnings")
-            || msg_lower.contains("inside a phase block does not enable warnings")
-        {
+        } else if contains_diagnostic_phrase(
+            &msg_lower,
+            "inside a begin block does not enable warnings",
+        ) || contains_diagnostic_phrase(
+            &msg_lower,
+            "inside a phase block does not enable warnings",
+        ) {
             Some(Self::PhaseScopedWarningsPragma)
-        } else if msg_lower.contains("use strict") {
+        } else if contains_diagnostic_phrase(&msg_lower, "use strict") {
             Some(Self::MissingStrict)
-        } else if msg_lower.contains("use warnings") {
+        } else if contains_diagnostic_phrase(&msg_lower, "use warnings") {
             Some(Self::MissingWarnings)
-        } else if msg_lower.contains("unused variable") || msg_lower.contains("never used") {
+        } else if contains_diagnostic_phrase(&msg_lower, "unused variable")
+            || contains_diagnostic_phrase(&msg_lower, "never used")
+        {
             Some(Self::UnusedVariable)
-        } else if msg_lower.contains("undefined") || msg_lower.contains("not declared") {
+        } else if is_undefined_variable_message(&msg_lower) {
             Some(Self::UndefinedVariable)
-        } else if msg_lower.contains("bareword filehandle") {
+        } else if contains_diagnostic_phrase(&msg_lower, "bareword filehandle") {
             Some(Self::BarewordFilehandle)
-        } else if msg_lower.contains("two-argument") || msg_lower.contains("2-arg") {
+        } else if contains_diagnostic_phrase(&msg_lower, "two-argument")
+            || contains_diagnostic_phrase(&msg_lower, "2-argument")
+            || contains_diagnostic_phrase(&msg_lower, "2-arg")
+        {
             Some(Self::TwoArgOpen)
-        } else if msg_lower.contains("invalid prototype character")
-            || msg_lower.contains("illegal character in prototype")
+        } else if contains_diagnostic_phrase(&msg_lower, "invalid prototype character")
+            || contains_diagnostic_phrase(&msg_lower, "illegal character in prototype")
         {
             Some(Self::InvalidPrototype)
-        } else if msg_lower.contains("parse error") || msg_lower.contains("syntax error") {
+        } else if contains_diagnostic_phrase(&msg_lower, "parse error")
+            || contains_diagnostic_phrase(&msg_lower, "syntax error")
+        {
             Some(Self::ParseError)
         } else {
             None

--- a/crates/perl-diagnostics/tests/codes_comprehensive_unit_tests.rs
+++ b/crates/perl-diagnostics/tests/codes_comprehensive_unit_tests.rs
@@ -10,6 +10,8 @@ use perl_diagnostics::codes::{
     DiagnosticCategory, DiagnosticCode, DiagnosticSeverity, DiagnosticTag,
 };
 
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
 // ---------------------------------------------------------------------------
 // Helper: all DiagnosticCode variants for exhaustive iteration
 // ---------------------------------------------------------------------------
@@ -1031,6 +1033,25 @@ fn from_message_2_arg_variant() {
         DiagnosticCode::from_message("found a 2-arg open call"),
         Some(DiagnosticCode::TwoArgOpen)
     );
+    assert_eq!(
+        DiagnosticCode::from_message("found a 2-argument open call"),
+        Some(DiagnosticCode::TwoArgOpen)
+    );
+}
+
+#[test]
+fn from_message_avoids_undefined_non_variable_false_positives() -> TestResult {
+    assert_eq!(DiagnosticCode::from_message("numeric comparison with undefined value"), None);
+    assert_eq!(DiagnosticCode::from_message("Undefined subroutine &main::missing called"), None);
+    Ok(())
+}
+
+#[test]
+fn from_message_avoids_embedded_phrase_false_positives() -> TestResult {
+    assert_eq!(DiagnosticCode::from_message("found 12-arg helper"), None);
+    assert_eq!(DiagnosticCode::from_message("internal parser reports never usedful state"), None);
+    assert_eq!(DiagnosticCode::from_message("module name contains undefined_behavior"), None);
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- `DiagnosticCode::from_message` was matching diagnostic keywords embedded inside unrelated words (e.g. `12-arg`, `never usedful`, `undefined_behavior`), causing false positives. 
- Generic matches for `undefined` were mapping non-variable messages to `UndefinedVariable`, producing spurious diagnostics.

### Description
- Add phrase-boundary helpers `contains_diagnostic_phrase`, `has_phrase_boundary`, and `is_phrase_word_byte` to ensure matches are whole-phrase and not substrings. 
- Add `is_undefined_variable_message` to narrow `UndefinedVariable` inference to messages that mention `variable`, `global symbol`, or `not declared`. 
- Update `DiagnosticCode::from_message` to use the new helpers for all phrase matching. 
- Add regression tests `from_message_avoids_undefined_non_variable_false_positives` and `from_message_avoids_embedded_phrase_false_positives` and a `TestResult` alias to validate the edge cases.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-diagnostics --locked` and all tests passed. 
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check -p perl-diagnostics --all-targets --locked` and it passed. 
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-diagnostics --locked -- -D warnings -A missing_docs` and it passed. 
- Ran `./scripts/cargo-safe xtask fmt` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1eddd948333a121a65367e4e242)