### PR TITLE
fix(dead-code): correct is_always_false docstring and rename postfix modifier constant (#9009)

### DIFF
--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -239,16 +239,17 @@ fn detect_unconditional_terminator(trimmed: &str) -> Option<&str> {
         None => after_terminator,
     }
     .trim_start();
-    if contains_postfix_condition(remainder) {
+    if contains_postfix_modifier(remainder) {
         return None;
     }
 
     Some(first)
 }
 
-fn contains_postfix_condition(remainder: &str) -> bool {
-    const CONDITIONS: [&str; 7] = ["if", "unless", "when", "while", "until", "for", "foreach"];
-    CONDITIONS.iter().any(|keyword| contains_keyword(remainder, keyword))
+fn contains_postfix_modifier(remainder: &str) -> bool {
+    const POSTFIX_MODIFIERS: [&str; 7] =
+        ["if", "unless", "when", "while", "until", "for", "foreach"];
+    POSTFIX_MODIFIERS.iter().any(|keyword| contains_keyword(remainder, keyword))
 }
 
 fn contains_keyword(text: &str, keyword: &str) -> bool {
@@ -266,7 +267,10 @@ fn is_keyword_boundary(ch: Option<char>) -> bool {
 /// Returns `true` if `condition` is a trivially-false constant expression.
 ///
 /// Matches: `0`, `""`, `''`, `undef`, `(0)`, `( 0 )` — the standard Perl idioms
-/// used to write permanently-dead `if`/`while`/`for` blocks.
+/// used to write permanently-dead `if`/`while`/`elsif` blocks.
+///
+/// Note: `for (0)` is intentionally excluded — it iterates once with `$_ = 0`
+/// and is therefore not dead code.
 fn is_always_false(condition: &str) -> bool {
     let c = condition.trim();
     matches!(c, "0" | "\"\"" | "''" | "undef")

--- a/crates/perl-parser/tests/dead_code_detector.rs
+++ b/crates/perl-parser/tests/dead_code_detector.rs
@@ -214,3 +214,71 @@ fn for_loop_with_undef_is_not_dead_branch() -> TestResult {
     );
     Ok(())
 }
+
+#[test]
+fn for_loop_with_explicit_loop_var_is_not_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(
+        &index,
+        "file:///script.pl",
+        "for my $x (0) {\n    say $x;\n}\n",
+    )?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "for my $x (0) iterates once with $x = 0 — it is not dead code"
+    );
+    Ok(())
+}
+
+#[test]
+fn foreach_loop_with_explicit_loop_var_is_not_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(
+        &index,
+        "file:///script.pl",
+        "foreach my $x (0) {\n    say $x;\n}\n",
+    )?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "foreach my $x (0) iterates once with $x = 0 — it is not dead code"
+    );
+    Ok(())
+}
+
+#[test]
+fn unless_always_true_condition_is_flagged_as_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "unless (1) {\n    say 'never runs';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "unless (1) body is never executed — should be flagged as a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn until_always_true_condition_is_flagged_as_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "until (1) {\n    say 'never runs';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "until (1) body is never executed — should be flagged as a dead branch"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9009 — `for`/`foreach` loops incorrectly documented as dead-branch candidates.

The core detection fix was already in place: `detect_dead_branches` only checks `["if", "while", "elsif", "unless", "until"]` and never included `for`/`foreach`. This PR cleans up the two remaining accuracy gaps left over from that fix and hardens the test coverage.

### What changed

**1. Fix the `is_always_false` docstring** (`dead_code/mod.rs`)

The doc comment said "used to write permanently-dead `if`/`while`/`for` blocks". This is factually wrong — `for (0)` iterates once with `$_ = 0` and is *not* dead code. Updated to `if`/`while`/`elsif` and added an explicit note explaining why `for` is intentionally excluded.

**2. Rename `CONDITIONS` → `POSTFIX_MODIFIERS`** and **`contains_postfix_condition` → `contains_postfix_modifier`**

The array named `CONDITIONS` contains Perl postfix statement modifiers: `if`, `unless`, `when`, `while`, `until`, `for`, `foreach`. Including `for`/`foreach` was *correct* (a postfix `for` on a `die`/`return` line is conditional, not unconditional), but calling them "conditions" was misleading since they are list iterators, not boolean tests. Both the array and the private helper are renamed to reflect the actual semantics.

**3. Four new tests** (`tests/dead_code_detector.rs`)

| Test | Assertion |
|------|-----------|
| `for my $x (0) {}` | NOT flagged — iterates once with `$x = 0` |
| `foreach my $x (0) {}` | NOT flagged — same |
| `unless (1) {}` | IS flagged — condition always true, body never runs |
| `until (1) {}` | IS flagged — condition always true, body never runs |

The first two guard the explicit-loop-variable syntax that the earlier tests did not cover. The last two prove the symmetric `unless`/`until` detection that was implemented but untested.

## Test plan

- [x] `cargo test -p perl-parser --test dead_code_detector` — 16 tests pass (was 12)
- [x] `cargo clippy -p perl-parser` — clean
- [x] All existing detection cases unchanged: `if (0)`, `while (0)`, `for (0)`, `foreach (0)`, postfix-return, return-prefix, unreachable-after-return

## Why this matters

Documentation that says `for` blocks can be "permanently dead" will mislead anyone extending the dead-code detector. A developer reading the `is_always_false` function would reasonably conclude that calling it on a `for` condition is valid — and re-introduce the exact false-positive that issue #9009 describes. Correcting the docstring + renaming the misleading constant closes that maintenance hazard permanently.

---
_Generated by [Claude Code](https://claude.ai/code/session_018mHM44Y73LV2cgR642evoT)_