### PR TITLE
fix(position): exclude CRLF from UTF-16 line columns (#2108)

### DIFF
--- a/crates/perl-position-tracking/src/convert.rs
+++ b/crates/perl-position-tracking/src/convert.rs
@@ -4,19 +4,35 @@
 //! where lines and columns are zero-based and columns are measured in UTF-16
 //! code units.
 
+fn line_content_end(line: &str) -> usize {
+    let without_lf = line.strip_suffix('\n').unwrap_or(line);
+    without_lf.strip_suffix('\r').unwrap_or(without_lf).len()
+}
+
+fn text_end_utf16_line_col(text: &str) -> (u32, u32) {
+    if text.is_empty() {
+        return (0, 0);
+    }
+    if text.ends_with('\n') {
+        return (text.split_inclusive('\n').count() as u32, 0);
+    }
+
+    let mut last_line = 0u32;
+    let mut last_col = 0u32;
+    for (idx, line) in text.split_inclusive('\n').enumerate() {
+        last_line = idx as u32;
+        last_col = line[..line_content_end(line)].encode_utf16().count() as u32;
+    }
+    (last_line, last_col)
+}
+
 /// Converts a byte offset into `(line, column_utf16)` coordinates.
 ///
 /// Offsets beyond the end of the document are clamped to the last valid
 /// position.
 pub fn offset_to_utf16_line_col(text: &str, offset: usize) -> (u32, u32) {
-    if offset > text.len() {
-        let lines: Vec<&str> = text.lines().collect();
-        let last_line = lines.len().saturating_sub(1) as u32;
-        let last_col = lines.last().map(|l| l.encode_utf16().count()).unwrap_or(0) as u32;
-        return (last_line, last_col);
-    }
-    if offset == text.len() && (text.ends_with('\n') || text.ends_with("\r\n")) {
-        return (text.split_inclusive('\n').count() as u32, 0);
+    if offset >= text.len() {
+        return text_end_utf16_line_col(text);
     }
     let mut acc = 0usize;
     for (line_idx, line) in text.split_inclusive('\n').enumerate() {
@@ -26,8 +42,10 @@ pub fn offset_to_utf16_line_col(text: &str, offset: usize) -> (u32, u32) {
             if rel == 0 {
                 return (line_idx as u32, 0);
             }
-            if rel >= line.len() {
-                return (line_idx as u32, line.encode_utf16().count() as u32);
+
+            let content_end = line_content_end(line);
+            if rel >= content_end {
+                return (line_idx as u32, line[..content_end].encode_utf16().count() as u32);
             }
             if line.is_char_boundary(rel) {
                 return (line_idx as u32, line[..rel].encode_utf16().count() as u32);
@@ -42,8 +60,7 @@ pub fn offset_to_utf16_line_col(text: &str, offset: usize) -> (u32, u32) {
         }
         acc = next;
     }
-    let last_line = text.lines().count().saturating_sub(1) as u32;
-    (last_line, text.lines().last().map(|l| l.encode_utf16().count()).unwrap_or(0) as u32)
+    text_end_utf16_line_col(text)
 }
 
 /// Converts `(line, column_utf16)` coordinates into a byte offset.
@@ -57,8 +74,10 @@ pub fn utf16_line_col_to_offset(text: &str, line: u32, col: u32) -> usize {
             if col == 0 {
                 return offset;
             }
+            let line_end = line_content_end(lt);
+            let line_content = &lt[..line_end];
             let mut up = 0u32;
-            for (bi, ch) in lt.char_indices() {
+            for (bi, ch) in line_content.char_indices() {
                 if up == col {
                     return offset + bi;
                 }
@@ -70,8 +89,7 @@ pub fn utf16_line_col_to_offset(text: &str, line: u32, col: u32) -> usize {
                     return offset + bi;
                 }
             }
-            let lcl = if lt.ends_with('\n') { lt.len() - 1 } else { lt.len() };
-            return offset + lcl.min(text.len() - offset);
+            return offset + line_end.min(text.len() - offset);
         }
         offset += lt.len();
     }
@@ -114,6 +132,11 @@ mod tests {
     fn offset_to_utf16_reports_new_empty_line_for_terminal_newline() {
         let text = "one\ntwo\n";
         assert_eq!(offset_to_utf16_line_col(text, text.len()), (2, 0));
+        assert_eq!(offset_to_utf16_line_col(text, text.len() + 25), (2, 0));
+
+        let crlf_text = "one\r\ntwo\r\n";
+        assert_eq!(offset_to_utf16_line_col(crlf_text, crlf_text.len()), (2, 0));
+        assert_eq!(offset_to_utf16_line_col(crlf_text, crlf_text.len() + 25), (2, 0));
     }
 
     #[test]
@@ -139,7 +162,21 @@ mod tests {
 
         assert_eq!(offset_to_utf16_line_col(text, 3), (1, 0));
         assert_eq!(offset_to_utf16_line_col(text, 8), (1, 3));
+        assert_eq!(offset_to_utf16_line_col(text, 9), (1, 4));
+        assert_eq!(offset_to_utf16_line_col(text, 10), (1, 4));
         assert_eq!(utf16_line_col_to_offset(text, 1, 2), 4);
         assert_eq!(utf16_line_col_to_offset(text, 1, 3), 8);
+        assert_eq!(utf16_line_col_to_offset(text, 1, 4), 9);
+        assert_eq!(utf16_line_col_to_offset(text, 1, 99), 9);
+    }
+
+    #[test]
+    fn utf16_helpers_exclude_crlf_from_line_columns() {
+        let text = "ab\r\ncd";
+
+        assert_eq!(offset_to_utf16_line_col(text, 2), (0, 2));
+        assert_eq!(offset_to_utf16_line_col(text, 3), (0, 2));
+        assert_eq!(utf16_line_col_to_offset(text, 0, 2), 2);
+        assert_eq!(utf16_line_col_to_offset(text, 0, 99), 2);
     }
 }

--- a/crates/perl-position-tracking/src/mapper.rs
+++ b/crates/perl-position-tracking/src/mapper.rs
@@ -335,6 +335,7 @@ pub fn last_line_column_utf8(text: &str) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use perl_tdd_support::must_some;
 
     #[test]
     fn test_lf_positions() {
@@ -582,7 +583,7 @@ mod tests {
         // positions at the start of each character.
         for (byte_offset, col) in [(0u32, 0u32), (1, 1), (3, 2), (7, 4)] {
             let pos = Position { line: 0, character: col };
-            let got_byte = mapper.lsp_pos_to_byte(pos).expect("valid position must return Some");
+            let got_byte = must_some(mapper.lsp_pos_to_byte(pos));
             assert_eq!(
                 got_byte, byte_offset as usize,
                 "lsp_pos_to_byte for col {col} should be byte {byte_offset}"
@@ -604,9 +605,7 @@ mod tests {
         let mapper = PositionMapper::new(text);
 
         // lsp_pos_to_char: line 0, col 1 (UTF-16) → é starts at char index 1
-        let char_idx = mapper
-            .lsp_pos_to_char(Position { line: 0, character: 1 })
-            .expect("valid position must return Some");
+        let char_idx = must_some(mapper.lsp_pos_to_char(Position { line: 0, character: 1 }));
         assert_eq!(char_idx, 1, "char index of 'é' is 1");
 
         // char_to_lsp_pos: char index 1 → line 0, col 1 (UTF-16)
@@ -614,9 +613,7 @@ mod tests {
         assert_eq!(pos, Position { line: 0, character: 1 });
 
         // Another round: 'b' is char index 2
-        let char_b = mapper
-            .lsp_pos_to_char(Position { line: 0, character: 2 })
-            .expect("valid position must return Some");
+        let char_b = must_some(mapper.lsp_pos_to_char(Position { line: 0, character: 2 }));
         assert_eq!(char_b, 2);
         assert_eq!(mapper.char_to_lsp_pos(char_b), Position { line: 0, character: 2 });
     }
@@ -670,9 +667,7 @@ mod tests {
 
         // "hello\n" has 5 visible chars (cols 0..5) + newline.
         // Asking for col 9999 should clamp to the newline / end of line content.
-        let clamped = mapper
-            .lsp_pos_to_byte(Position { line: 0, character: 9999 })
-            .expect("out-of-bounds column must return Some (clamped)");
+        let clamped = must_some(mapper.lsp_pos_to_byte(Position { line: 0, character: 9999 }));
 
         // The byte returned must be within the span of line 0 (bytes 0..6 inclusive,
         // where byte 5 is '\n').  We accept anything in [0, 6].

--- a/crates/perl-position-tracking/tests/prop_utf16_roundtrip.rs
+++ b/crates/perl-position-tracking/tests/prop_utf16_roundtrip.rs
@@ -55,7 +55,8 @@ proptest! {
     ) {
         for (line, line_text) in s.split_inclusive('\n').enumerate() {
             let line = line as u32;
-            let utf16_len = line_text.trim_end_matches('\n').encode_utf16().count() as u32;
+            let line_content = line_text.trim_end_matches('\n').trim_end_matches('\r');
+            let utf16_len = line_content.encode_utf16().count() as u32;
             // Test col = 0, midpoint, and end
             for col in [0, utf16_len / 2, utf16_len, utf16_len + 1] {
                 let offset = utf16_line_col_to_offset(&s, line, col);
@@ -71,7 +72,7 @@ proptest! {
 
         for (line, line_text) in s.split_inclusive('\n').enumerate() {
             let line = line as u32;
-            let line_content = line_text.trim_end_matches('\n');
+            let line_content = line_text.trim_end_matches('\n').trim_end_matches('\r');
             let utf16_len = line_content.encode_utf16().count() as u32;
             let line_end = line_start + line_content.len();
 


### PR DESCRIPTION
### Motivation
- UTF-16 position conversion was counting CR/LF bytes at CRLF boundaries as visible LSP columns, producing incorrect LSP column values and off-by-one behavior for CRLF lines. 
- Tests and clippy enforcement flagged unsafe uses of `expect()` in unit tests which violate repo lint rules.

### Description
- Add helper `fn line_content_end(line: &str) -> usize` and use it in `offset_to_utf16_line_col` to clamp column computation to the line content before any `\r`/`\n` terminator. 
- Update `utf16_line_col_to_offset` to operate on the trimmed line content (exclude CR/LF) and clamp returned offsets to the content boundary. 
- Add targeted tests for CRLF + surrogate-pair cases and an explicit test to ensure CRLF bytes are not counted as visible UTF-16 columns in `crates/perl-position-tracking/src/convert.rs`. 
- Replace `expect(...)` uses in `crates/perl-position-tracking/src/mapper.rs` tests with `perl_tdd_support::must_some` and adjust `proptest` helpers to trim `\r` where appropriate to satisfy clippy and test invariants.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-position-tracking --locked` and all tests passed. 
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-position-tracking --all-targets --profile agent --locked -- -D warnings -A missing_docs` and clippy passed. 
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check -p perl-position-tracking --all-targets --locked` and `cargo fmt --check` and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084334af488333a02f494c5ce6de26)