### PR TITLE
fix(tests): initialize document link harness (#9293)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_document_links_test.rs
+++ b/crates/perl-lsp-rs/tests/lsp_document_links_test.rs
@@ -35,13 +35,10 @@ impl Scenario {
     }
 }
 
-fn first_link_of_type<'a>(links: &'a [Value], kind: &str) -> Option<&'a Value> {
-    links.iter().find(|link| link.pointer("/data/type").and_then(Value::as_str) == Some(kind))
-}
-
 #[test]
-fn textDocument_documentLink_responds_with_deferred_links() -> TestResult {
+fn text_document_document_link_responds_with_deferred_links() -> TestResult {
     let mut harness = LspHarness::new();
+    harness.initialize(None)?;
     let scenario = Scenario::new("use qw + use Data::Dumper resolve workflow");
 
     scenario.given("a document with use qw imports and other use statements");
@@ -76,8 +73,9 @@ my @modules = qw(Data::Dumper Getopt::Long);
 }
 
 #[test]
-fn textDocument_documentLink_resolvesTo_module_paths() -> TestResult {
+fn text_document_document_link_resolves_to_module_paths() -> TestResult {
     let mut harness = LspHarness::new();
+    harness.initialize(None)?;
     let scenario = Scenario::new("documentLink/resolve workflow");
 
     scenario.given("deferred DocumentLink from documentLink response");
@@ -98,7 +96,7 @@ use JSON::PP;
     assert!(!links.is_empty(), "expected deferred links");
 
     scenario.when("resolving the first link");
-    let first_link = &links[0];
+    let first_link = links.first().ok_or("expected first deferred link")?;
     let resolved = harness.request("documentLink/resolve", first_link.clone())?;
 
     scenario.then("received resolved link contains target module path");
@@ -112,8 +110,9 @@ use JSON::PP;
 }
 
 #[test]
-fn textDocument_documentLink_handles_missing_modules() -> TestResult {
+fn text_document_document_link_handles_missing_modules() -> TestResult {
     let mut harness = LspHarness::new();
+    harness.initialize(None)?;
     let scenario = Scenario::new("missing module graceful handling");
 
     scenario.given("document with use statement for non-existent module");


### PR DESCRIPTION
### Motivation

- Document-link UX tests were sending `textDocument/documentLink` and `documentLink/resolve` requests before the LSP initialize handshake completed, causing `Server not initialized` errors and noisy test warnings.
- A DAP deep-truncation test contained an incorrect run hint and an unused `mod common` import that should be cleaned for test hygiene.

### Description

- Call `initialize(None)?` on the `LspHarness` in each document-link scenario so the server handshake completes before requests are sent.
- Rename document-link tests to snake_case and replace direct indexing with the safe accessor `links.first().ok_or(...)?` to avoid panics.
- Remove the unused helper `first_link_of_type` from the document-link test file.
- Adjust `crates/perl-dap/tests/variables_deep_truncation.rs` by fixing the run hint comment and removing the unused `mod common` import.

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-rs --test lsp_document_links_test --profile agent --locked`, which passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-dap --test variables_deep_truncation --profile agent --locked`, which passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked && MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked && ./scripts/cargo-safe fmt --check`, which completed successfully.
- `clippy` across all targets for `perl-lsp-rs` reported existing unrelated lint failures (e.g. `expect_used` and other warnings) and therefore a full `clippy -D warnings` run failed; these issues are pre-existing and outside the scope of this focused test-fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084334af488333a02f494c5ce6de26)