### PR TITLE
fix(uri): normalize legacy file URI casing (#0000)

### DIFF
--- a/crates/perl-uri/src/classify.rs
+++ b/crates/perl-uri/src/classify.rs
@@ -74,7 +74,7 @@ fn normalize_legacy_windows_uri(uri: &str) -> Option<String> {
 
     // Strip the optional `file://` prefix (two slashes — not three).
     // A three-slash `file:///` form is already canonical and must not match here.
-    let path = if let Some(rest) = trimmed.strip_prefix("file://") {
+    let path = if let Some(rest) = strip_ascii_prefix(trimmed, "file://") {
         // Make sure we are not accidentally handling `file:///...` (three slashes).
         // After stripping `file://`, a canonical URI starts with `/` followed by
         // another `/` (the empty authority makes a third slash), so we skip it.
@@ -88,10 +88,17 @@ fn normalize_legacy_windows_uri(uri: &str) -> Option<String> {
 
     // Accept malformed localhost authorities commonly emitted by some clients,
     // e.g. `file://localhost/C:\dir\file.pl` and `file://localhost/C:/dir/file.pl`.
-    let path =
-        path.strip_prefix("localhost/").or_else(|| path.strip_prefix("LOCALHOST/")).unwrap_or(path);
+    let path = strip_ascii_prefix(path, "localhost/").unwrap_or(path);
 
     normalize_windows_path_to_key(path).or_else(|| normalize_unc_path_to_key(path))
+}
+
+fn strip_ascii_prefix<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {
+    if value.get(..prefix.len()).is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix)) {
+        value.get(prefix.len()..)
+    } else {
+        None
+    }
 }
 
 /// Convert a UNC path into canonical `file://server/share/...` key.
@@ -264,6 +271,15 @@ mod tests {
         );
         assert_eq!(
             uri_key(r"file://LOCALHOST/D:\projects\myapp\script.pl"),
+            "file:///d:/projects/myapp/script.pl"
+        );
+    }
+
+    #[test]
+    fn normalizes_legacy_windows_uri_case_insensitive_scheme_and_host() {
+        assert_eq!(uri_key(r"FILE://C:\Users\dev\example.pl"), "file:///c:/Users/dev/example.pl");
+        assert_eq!(
+            uri_key(r"File://LocalHost/D:\projects\myapp\script.pl"),
             "file:///d:/projects/myapp/script.pl"
         );
     }


### PR DESCRIPTION
### Motivation

- Legacy Windows `file://` inputs with mixed-case schemes or `localhost` authorities were not being recognized by the pre-URL normalization pass, causing some Windows-style paths to miss canonicalization.

### Description

- Add a case-insensitive ASCII prefix stripper `strip_ascii_prefix` and use it to detect and strip legacy `file://` and `localhost/` prefixes before URL parsing in `crates/perl-uri/src/classify.rs`.
- Replace prior case-sensitive `strip_prefix` calls in `normalize_legacy_windows_uri` with `strip_ascii_prefix` to correctly handle mixed-case inputs like `FILE://` and `File://LocalHost`.
- Add a regression test `normalizes_legacy_windows_uri_case_insensitive_scheme_and_host` that covers mixed-case `file://` and `localhost` inputs.

### Testing

- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-uri --profile agent --locked` and all `perl-uri` unit and doctests passed.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check -p perl-uri --all-targets --profile agent --locked`, `cargo clippy -p perl-uri --profile agent --locked -- -D warnings -A missing_docs`, and `cargo fmt --all -- --check`, and all checks passed.
- Verified `git diff --check` and `./scripts/storage-doctor` produced no issues; an initial attempt to run `./scripts/cargo-safe test -p perl-uri` was blocked by a devplane cache DENY, so the `CARGO_TARGET_DIR` workaround was used for test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084334af488333a02f494c5ce6de26)