### PR TITLE
fix(parser): recover missing declaration arg initializers (#0000)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -467,14 +467,31 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Parse an optional declaration initializer in argument context.
+    ///
+    /// Uses `parse_assignment()` for any present initializer so that commas are
+    /// treated as argument separators rather than being consumed by the
+    /// comma operator. Missing RHS operands are recovered as `MissingExpression`
+    /// placeholders instead of aborting the surrounding argument/block parse.
+    fn parse_optional_declaration_initializer(&mut self) -> ParseResult<Option<Box<Node>>> {
+        if self.peek_kind() != Some(TokenKind::Assign) {
+            return Ok(None);
+        }
+
+        let assign_token = self.tokens.next()?; // consume =
+        let rhs = if let Some(missing) = self.recover_missing_infix_rhs(assign_token.start) {
+            missing
+        } else {
+            self.parse_assignment()?
+        };
+
+        Ok(Some(Box::new(rhs)))
+    }
+
     /// Parse a variable declaration as a function argument.
     ///
     /// Handles `my $x`, `our @arr`, `local $var`, `state $count` inside
     /// parenthesized argument lists (e.g. `foo(my $x, $y)`).
-    ///
-    /// Uses `parse_assignment()` for any initializer so that commas are
-    /// treated as argument separators rather than being consumed by the
-    /// comma operator.
     fn parse_declaration_arg(&mut self) -> ParseResult<Node> {
         let start = self.current_position();
         let declarator_token = self.consume_token()?;
@@ -496,12 +513,7 @@ impl<'a> Parser<'a> {
             let variable = self.parse_assignment()?;
             self.expect_closing_delimiter(TokenKind::RightParen)?;
 
-            let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
-                self.tokens.next()?; // consume =
-                Some(Box::new(self.parse_assignment()?))
-            } else {
-                None
-            };
+            let initializer = self.parse_optional_declaration_initializer()?;
 
             let end = self.previous_position();
             Ok(Node::new(
@@ -535,12 +547,7 @@ impl<'a> Parser<'a> {
 
             self.expect_closing_delimiter(TokenKind::RightParen)?; // consume )
 
-            let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
-                self.tokens.next()?; // consume =
-                Some(Box::new(self.parse_assignment()?))
-            } else {
-                None
-            };
+            let initializer = self.parse_optional_declaration_initializer()?;
 
             let end = self.previous_position();
             Ok(Node::new(
@@ -560,12 +567,7 @@ impl<'a> Parser<'a> {
                 self.parse_variable()?
             };
 
-            let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
-                self.tokens.next()?; // consume =
-                Some(Box::new(self.parse_assignment()?))
-            } else {
-                None
-            };
+            let initializer = self.parse_optional_declaration_initializer()?;
 
             let end = self.previous_position();
             Ok(Node::new(


### PR DESCRIPTION
### Motivation

- Declaration-argument initializers (`=`) that are followed by statement boundaries could abort nested block/argument parsing instead of emitting a recoverable diagnostic and inserting a `MissingExpression` placeholder.

### Description

- Add `parse_optional_declaration_initializer` which consumes an optional `=` and returns either a parsed RHS or a `MissingExpression` placeholder via `recover_missing_infix_rhs`.
- Replace ad-hoc initializer handling in `parse_declaration_arg` (complex `local(...)`, list declarations, and single declarations) to call `parse_optional_declaration_initializer` and reuse the recovery logic in one place.
- Change localized to use the recovery helper so missing-RHS cases record recovery diagnostics instead of aborting parsing; change is limited to `crates/perl-parser-core/src/engine/parser/expressions/calls.rs`.

### Testing

- Ran `./scripts/cargo-safe test -p perl-parser-core --profile agent --locked`, and all tests passed.
- Ran `./scripts/cargo-safe check --all-targets -p perl-parser-core --profile agent --locked`, `./scripts/cargo-safe clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs`, and `./scripts/cargo-safe xtask fmt`, and each completed successfully.
- Ran the corpus audit via `./scripts/cargo-safe run -p xtask -- corpus-audit --fresh --corpus-path . --output corpus_audit_report.json`, and the audit reported `96 OK / 0 errors`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084327f3248333873bdb9c39587e5e)