### PR TITLE
fix(parser): recognize Filter::Simple block calls (#9296)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/builtin_block_list_tests.rs
+++ b/crates/perl-parser-core/src/engine/parser/builtin_block_list_tests.rs
@@ -11,6 +11,28 @@ mod tests {
     use crate::parser::Parser;
     use perl_tdd_support::must;
 
+    #[test]
+    fn filter_simple_uppercase_block_call() {
+        let code = r#"FILTER {
+    s/BANG!/return "excited"/g;
+    s/MAGIC/42/g;
+};"#;
+        let mut parser = Parser::new(code);
+        let ast = must(parser.parse());
+        assert!(
+            parser.errors().is_empty(),
+            "should not record parser errors: {:?}",
+            parser.errors()
+        );
+        let sexp = ast.to_sexp();
+        assert!(!sexp.contains("ERROR"), "should not contain ERROR: {}", sexp);
+        assert!(
+            sexp.contains("ambiguous_function_call_expression"),
+            "should parse FILTER as a block call: {}",
+            sexp
+        );
+    }
+
     // ---- grep ----
 
     #[test]

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -915,6 +915,14 @@ impl<'a> Parser<'a> {
         if name.contains("::") {
             return true;
         }
+
+        // Filter::Simple exports an uppercase FILTER block form:
+        // `FILTER { s/foo/bar/g; };`. Treat only that DSL keyword as a
+        // bare block call so ordinary uppercase constants remain expressions.
+        if name == "FILTER" {
+            return true;
+        }
+
         // Only lowercase/underscore-leading identifiers
         name.starts_with(|c: char| c.is_ascii_lowercase() || c == '_')
     }


### PR DESCRIPTION
### Motivation
- Filter::Simple exposes an uppercase `FILTER { ... }` DSL form that was being treated as a bareword expression plus braces, producing recovery errors in corpus parsing and noisy parser diagnostics.

### Description
- Treat the specific uppercase keyword `FILTER` as a bare block-call name by updating `looks_like_block_call_name` in `crates/perl-parser-core/src/engine/parser/helpers.rs` so `{ ... }` after `FILTER` is parsed as a block argument.
- Add a regression test `filter_simple_uppercase_block_call` in `crates/perl-parser-core/src/engine/parser/builtin_block_list_tests.rs` that verifies a `FILTER` block with substitutions parses without parser diagnostics or `ERROR` nodes.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-parser-core --profile agent --locked filter_simple_uppercase_block_call -- --nocapture`, which passed.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check -p perl-parser-core --all-targets --profile agent --locked`, which passed.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-parser-core --all-targets --profile agent --locked -- -D warnings -A missing_docs`, which passed.
- Ran `cargo fmt --check`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084327f3248333873bdb9c39587e5e)