### PR TITLE
fix(parser): close empty quoted substitutions (#2732)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -3062,7 +3062,15 @@ impl<'a> PerlLexer<'a> {
         quote: char,
         delim: char,
     ) -> Option<(usize, bool)> {
+        // Adjacent quotes are literal replacement text (for example s/"/""/g),
+        // not a string literal to skip while hunting for the replacement delimiter.
+        if self.input.get(..start).and_then(|text| text.chars().next_back()) == Some(quote) {
+            return None;
+        }
         let mut pos = start.checked_add(quote.len_utf8())?;
+        if self.input.get(pos..).is_some_and(|text| text.starts_with(quote)) {
+            return None;
+        }
         let mut escaped = false;
         let mut contains_delim = false;
 

--- a/crates/perl-lexer/tests/quote_like_recovery_tests.rs
+++ b/crates/perl-lexer/tests/quote_like_recovery_tests.rs
@@ -44,3 +44,26 @@ fn unclosed_quote_like_tokens_return_unclosed_error() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn substitution_empty_quoted_replacement_closes_before_next_statement() -> TestResult {
+    let source = r#"if ($def =~ /=/) { $def =~ s/"/""/g; $def = qq["$def"]; }"#;
+    let mut lexer = PerlLexer::new(source);
+    let mut saw_substitution = false;
+
+    while let Some(token) = lexer.next_token() {
+        if matches!(token.token_type, TokenType::Error(_)) {
+            return Err(format!("unexpected lexer error token: {token:?}").into());
+        }
+        if matches!(token.token_type, TokenType::Substitution) {
+            assert_eq!(token.text.as_ref(), r#"s/"/""/g"#);
+            saw_substitution = true;
+        }
+        if matches!(token.token_type, TokenType::EOF) {
+            break;
+        }
+    }
+
+    assert!(saw_substitution, "expected substitution token in {source}");
+    Ok(())
+}

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -597,8 +597,16 @@ fn scan_inner_string(
     quote: char,
     delimiter: char,
 ) -> Option<(usize, bool)> {
+    // Adjacent quotes are literal replacement text (for example s/"/""/g),
+    // not a string literal to skip while hunting for the replacement delimiter.
+    if text.get(..pos).and_then(|prefix| prefix.chars().next_back()) == Some(quote) {
+        return None;
+    }
     let start = pos + quote.len_utf8();
     let rest = text.get(start..)?;
+    if rest.starts_with(quote) {
+        return None;
+    }
     let mut escaped = false;
     let mut contains_delim = false;
     let mut end_of_string = None;

--- a/crates/perl-parser-core/tests/fix_delimiter_owner_buckets.rs
+++ b/crates/perl-parser-core/tests/fix_delimiter_owner_buckets.rs
@@ -123,3 +123,8 @@ fn malformed_tie_missing_paren_emits_inserted_closer() {
         "Parser must return a Program node for tie with missing ')'"
     );
 }
+
+#[test]
+fn bucket_substitution_empty_quoted_replacement_before_next_statement_is_clean() {
+    assert_clean_parse(r#"if ($def =~ /=/) { $def =~ s/"/""/g; $def = qq["$def"]; }"#);
+}


### PR DESCRIPTION
### Motivation

- The lexer could misinterpret adjacent quotes in substitutions like `s/"/""/g` as an inner string literal and consume the real replacement delimiter, producing an `Error` token instead of a valid `Substitution` token.
- The parser-core quote helpers must mirror lexer behavior so strict substitution extraction stays consistent and corpus-driven clean-parse assertions hold.

### Description

- Add an adjacent-quote guard in the lexer `scan_inner_string_for_delimiter` so that quotes immediately next to the substitution replacement are treated as literal replacement text rather than as the start of an inner string to skip (`crates/perl-lexer/src/lib.rs`).
- Mirror the same guard in parser-core's `scan_inner_string` to keep `extract_substitution_parts*` behavior aligned (`crates/perl-parser-core/src/syntax/quote.rs`).
- Add a focused lexer regression test `substitution_empty_quoted_replacement_closes_before_next_statement` to verify `s/"/""/g` closes before the following `qq[...]` and emits `TokenType::Substitution` (`crates/perl-lexer/tests/quote_like_recovery_tests.rs`).
- Add a parser-core clean-parse regression asserting the same pattern parses without ERROR nodes (`crates/perl-parser-core/tests/fix_delimiter_owner_buckets.rs`).

### Testing

- Ran `./scripts/cargo-safe test -p perl-lexer --test quote_like_recovery_tests --profile agent --locked` and the lexer regression passed.
- Ran `./scripts/cargo-safe test -p perl-parser-core --test fix_delimiter_owner_buckets --profile agent --locked` and the parser-core regression passed.
- Ran formatter and static checks: `./scripts/cargo-safe xtask fmt` and `./scripts/cargo-safe clippy -p perl-lexer` and `./scripts/cargo-safe clippy -p perl-parser-core`, all of which passed after the change.
- Ran the corpus sweep receipt via `./scripts/cargo-safe run -p xtask -- parser-corpus-sweep --receipt` to ensure no regression across system modules and it completed successfully.
- Note: a workspace-wide `./scripts/cargo-safe test -p perl-parser` attempt failed due to a pre-existing package ID/name mismatch in a separate test (`perl-lsp` vs `perllsp`) and is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a084327f3248333873bdb9c39587e5e)