### PR TITLE
test(perl-pod): cover directive and link display edges (#9300)

### DIFF
--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -867,3 +867,89 @@ fn head2_formatted_heading_body_preserved() {
         "body text should be preserved after key normalization; got: {body}"
     );
 }
+
+#[test]
+fn begin_for_and_end_directives_do_not_pollute_extracted_sections() {
+    let source = r#"
+=begin html
+
+<p>This renderer-specific block is ignored.</p>
+
+=end html
+
+=for comment This single-paragraph directive is ignored too.
+
+=head1 NAME
+
+Directive::Clean - real docs
+
+=cut
+"#;
+
+    let doc = extract_pod(source);
+
+    assert_eq!(doc.name.as_deref(), Some("Directive::Clean - real docs"));
+    assert!(doc.description.is_none());
+}
+
+#[test]
+fn list_items_without_active_section_do_not_create_documentation() {
+    let source = r#"
+=over 4
+
+=item B<ghost>
+
+This item is not under a named POD section.
+
+=back
+
+=cut
+"#;
+
+    let doc = extract_pod(source);
+
+    assert!(doc.is_empty());
+}
+
+#[test]
+fn empty_method_section_is_not_inserted() {
+    let source = r#"
+=head2 empty_method
+
+=head2 documented_method
+
+This method has text.
+
+=cut
+"#;
+
+    let doc = extract_pod(source);
+
+    assert!(!doc.methods.contains_key("empty_method"));
+    assert_eq!(
+        doc.methods.get("documented_method").map(String::as_str),
+        Some("This method has text.")
+    );
+}
+
+#[test]
+fn link_display_text_backslash_is_escaped() {
+    let doc = extract_pod("=head1 NAME\n\nL<C:\\Temp|File::Spec>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+
+    assert!(
+        name.contains("[C:\\\\Temp](perl-module://File::Spec)"),
+        "expected backslash in display text to be escaped; got: {name}"
+    );
+}
+
+#[test]
+fn link_display_text_strips_nested_formatting_before_escaping() {
+    let doc = extract_pod("=head1 NAME\n\nL<B<[docs]>|File::Path>\n\n=cut\n");
+    let name = doc.name.as_deref().unwrap_or("");
+
+    assert!(
+        name.contains("[\\[docs\\]](perl-module://File::Path)"),
+        "expected nested formatting to be stripped and markdown brackets escaped; got: {name}"
+    );
+}


### PR DESCRIPTION
Problem: POD extraction had limited coverage for renderer directives, empty sections, inactive list items, and markdown-sensitive link display text. Fix: add extraction-level regression tests without production changes. Verification: cargo-safe perl-pod test/check/clippy, cargo-safe xtask fmt, git diff --check, and storage-doctor pass.