### PR TITLE
docs(roadmap): build out planning lanes (#0000)

### DIFF
--- a/NOW_NEXT_LATER.md
+++ b/NOW_NEXT_LATER.md
@@ -5,39 +5,39 @@ This file is the short planning snapshot for sequencing work. Use
 plan and [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) for
 evidence-backed status and release facts.
 
-## DONE — v0.12.2 through v0.12.8 (consolidated and shipped)
+## DONE — public-alpha foundation through v0.13.x
 
-- Work consolidated and merged 2026-04-02 (~70 PRs): CI gates, error handling, test coverage, parser confidence, performance, distribution, AI inline completion, packaging, announcement polish
-- `v0.12.3` is the live GitHub/editor release line as of 2026-04-09 with binaries, SBOM, SHA256SUMS, VS Code Marketplace, and Open VSX published
-- crates.io intentionally remains on `v0.12.2` while the registry window is deferred
+- v0.12.x built confidence across parser corpus, diagnostics, refactoring, distribution, AI inline completion, packaging, and announcement polish
+- v0.13.x carried that public-alpha foundation forward into the current release-prep line
+- CI/control-plane Wave 2 substrate landed: gate timeout receipts, bounded build storage contracts, UX receipt upload path, PR-fast planner coverage, and tokmd advisory instrumentation
+- Compiler-backed LSP substrate now has fixture-backed semantic facts, fact-source traces, and live-with-fallback slices for narrow diagnostics, hover, definition, and references
 
-## NOW — post-v0.12.3 / pre-announcement cleanup
+## NOW — v0.14.0 public-alpha patch prep
 
-- License badge fixed (canonical SPDX text in all 126 LICENSE files), GitHub now reports `Apache-2.0` instead of `NOASSERTION`
-- Docker arm64 timeout fix landed (Dockerfile MSRV pin + workflow timeout bump)
-- Dependency triage complete: 7 dependabot PRs merged including 3 majors (eslint v10, actions/cache v5, similar 3.0.0)
-- Keep public guidance explicit about the current channel split: GitHub Releases plus editor marketplaces are on `v0.12.3`; crates.io remains on `v0.12.2`
-- SRP microcrate extractions in flight (anti_pattern_detector, bench_parser) to free the dead `tree-sitter-perl-rs` harness for archival
-- Publishing the modern parsers as `tree-sitter-perl-c` (C tree-sitter FFI) and a new `tree-sitter-perl-rs` (Rust v3 facade with tree-sitter-compatible output)
-- Per-crate publish blockers cleared (perl-lsp-ai-provider unblocked, perl-heredoc-anti-patterns extraction in progress)
+- Treat `v0.14.0` as the active public-alpha release train; do not describe it as stable/GA
+- Complete RP-2 dry-run publish readiness before tag, channel dispatch, or announcement operations
+- Keep install-channel receipts explicit for crates.io, GitHub Release assets, Docker, VS Code Marketplace, Open VSX, and Homebrew (`brew install effortlessmetrics/tap/perllsp`)
+- Run the next CI/control-plane slice first: `update-status --write` progress streaming and failure attribution
+- Keep compiler-backed provider work evidence-gated: live paths need provenance and fallback receipts; uncertain paths remain shadow-only
 
-## NEXT — v0.13.0 public alpha announcement
+## NEXT — after v0.14.0 receipts close
 
-- Re-trigger crates.io publish after the SRP extractions and harness archival land
-- Final smoke test across all distribution channels
-- Bump workspace to `0.13.0`
-- Announcement blog post / release notes
+- Resume parser, corpus, semantic, and DAP hardening in narrow reviewable slices
+- Promote compiler-backed completion, rename, safe-delete, workspace symbols, document symbols, and semantic tokens only after source/freshness receipts are strong enough
+- Execute the editor-trust wave with one canonical lane per UX area and deterministic real-project receipts before CI ratchets
+- Continue quality cleanup: production-code `unwrap()` / `expect()` audit, temporary allow burndown, dependency triage, and install-surface checks
 
-## LATER — beyond v0.13.0
+## LATER — v1.0 runway
 
-- Stability contract for APIs and advertised wire behavior
-- Performance hardening for larger workspaces
-- Security posture and documentation hardening
-- Path to `v1.0.0`
+- Define the stable Rust API surface and the internal crate boundary
+- Define advertised LSP/DAP wire-behavior compatibility and fallback semantics
+- Establish large-workspace performance and memory budgets that respect agent build-storage limits
+- Document subprocess, Perl environment, and extension-distribution security expectations
+- Pick a `v1.0.0` date only after those contracts have reviewable acceptance criteria
 
 ## Working Rules
 
-- Last updated: `2026-04-09`
+- Last updated: `2026-05-16`
 - Keep “current release line” separate from “next milestone”.
 - Put receipts and computed metrics in [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), not here.
 - Put detailed milestone criteria in [docs/project/ROADMAP.md](docs/project/ROADMAP.md), not here.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,30 +11,34 @@ project docs when you need exact release facts, receipts, or milestone detail.
 
 - Active milestone plan: [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
 - Current truth and receipts: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md)
+- v0.14.0 release notes and claim boundary: [docs/releases/v0.14.0.md](docs/releases/v0.14.0.md)
 - Compiler-backed LSP build-out: [docs/project/COMPILER_BACKED_LSP_ROADMAP.md](docs/project/COMPILER_BACKED_LSP_ROADMAP.md)
+- Editor trust wave: [docs/project/EDITOR_TRUST_WAVE.md](docs/project/EDITOR_TRUST_WAVE.md)
+- CI/control-plane wave: [docs/project/CI_WAVE_EXECUTION_PLAN.md](docs/project/CI_WAVE_EXECUTION_PLAN.md)
 - Published release tracking: [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
 
-## Now (post-v0.12.3 ship / pre-announcement cleanup)
+## Now (v0.14.0 public-alpha patch prep)
 
-- `v0.12.3` shipped to GitHub Releases, VS Code Marketplace, and Open VSX on 2026-04-09
-- crates.io intentionally remains on `0.12.2` while the registry window is still deferred
-- Pre-announcement plumbing: license badge fix, Docker arm64 timeout fix, dependency triage, harness archival, SRP microcrate extractions
-- Distribution channel verification across GitHub Releases, VS Code Marketplace, Open VSX, Docker Hub, and the delayed crates.io line
-- See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) "Now (post-v0.12.3 / pre-v0.13.0)" for the active item list
+- Workspace version line is `v0.14.0`; keep public language as public alpha, not stable/GA
+- Finish RP-2 dry-run publish readiness before tag, publish, or announcement operations
+- Verify install-channel receipts across crates.io, GitHub Release assets, Docker, VS Code Marketplace, Open VSX, and Homebrew
+- Keep the release notes tied to shipped receipts and move deferred work to successor issues instead of expanding the train
+- Continue the top CI/control-plane urgency lane: `update-status --write` progress streaming and failure attribution
 
-## Next (v0.13.0 — public alpha announcement)
+## Next (post-v0.14.0)
 
-- 0.12.x line built confidence across parser, diagnostics, refactoring, distribution, AI inline completion
-- Quality cleanup PRs land, version bump to 0.13.0
-- Seamless install story verified across all distribution channels
-- Announcement blog post / release notes
+- Resume compiler-backed provider cutovers only where provenance and fallback receipts show equal-or-better behavior
+- Run the editor-trust wave through one canonical lane per UX area, with deterministic receipts before CI ratchets
+- Continue quality cleanup in focused crate-sized PRs: production panic/unwrap audit, temporary allow burndown, dependency triage, and install-surface verification
+- Keep release guidance copy-pasteable for users while preserving the public-alpha claim boundary
 
-## Beyond v0.13.0
+## Later (v1.0 runway)
 
-- Stability contract for APIs and advertised wire behavior
-- Performance hardening for larger workspaces
-- Security posture and documentation hardening
-- Path to `v1.0.0`
+- Define the stable Rust API surface versus internal implementation crates
+- Define advertised LSP/DAP wire behavior and fallback compatibility promises
+- Establish large-workspace performance and memory budgets that can run safely in agent worktrees
+- Document security expectations for subprocess execution, Perl environment construction, and extension distribution
+- Set a `v1.0.0` target only after the API, wire-behavior, performance, and security contracts have reviewable acceptance criteria
 
 ## Update Rules
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -97,6 +97,126 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Public install language must say public alpha, not stable/GA
 - Follow-on quality cleanup resumes after the release-channel receipts are closed
 
+## Roadmap Build-Out
+
+Use this section to route follow-up work after reading the generated status files.
+It is intentionally outcome-oriented: every lane names the source of truth, the
+next reviewable slice, and the stop condition that prevents roadmap work from
+becoming an unbounded rewrite.
+
+### Release Proof Lane — finish `v0.14.0` without changing the product posture
+
+**Goal:** close the public-alpha release proof for the Rust 1.95 line while
+keeping tag/publish/announcement operations separate from documentation changes.
+
+- Source of truth: [docs/releases/v0.14.0.md](../releases/v0.14.0.md),
+  [status/release.md](status/release.md), and
+  [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md).
+- Next slices:
+  1. RP-2 dry-run publish readiness: verify the 31-crate allowlist, generated
+     package contents, and failure receipts before any tag or channel dispatch.
+  2. Install-channel receipt pass: record the exact verification commands for
+     crates.io, GitHub Release assets, Docker, VS Code Marketplace, Open VSX,
+     and Homebrew without claiming stable/GA readiness.
+  3. Release-note claim audit: keep the changelog tied to shipped receipts and
+     move deferred work to successor issues rather than expanding the train.
+- Stop condition: do not dispatch or announce while any release-channel receipt
+  is missing, stale, or only inferred from local state.
+
+### Compiler-Backed LSP Lane — move providers by evidence, not aspiration
+
+**Goal:** continue replacing heuristic provider behavior with compiler-backed
+facts only where the shadow receipts show equal-or-better behavior.
+
+- Source of truth: [COMPILER_BACKED_LSP_ROADMAP.md](COMPILER_BACKED_LSP_ROADMAP.md),
+  [COMPILER_CAPABILITY_STATUS.md](COMPILER_CAPABILITY_STATUS.md),
+  [status/compiler_facts.md](status/compiler_facts.md), and
+  [status/provider_cutover.md](status/provider_cutover.md).
+- Next slices:
+  1. Keep diagnostics, hover, definition, and references live-with-fallback
+     paths covered by provenance receipts before widening their surface area.
+  2. Promote completion, rename, safe-delete, workspace symbols, document
+     symbols, and semantic tokens only after shadow receipts demonstrate source
+     freshness and explainable fallback behavior.
+  3. Expand real-Perl conformance under the existing #8199 lane rather than
+     adding one-off fixtures that cannot become ratchets.
+- Stop condition: if a compiler-backed path cannot explain its fact source or
+  fallback decision, keep it shadow-only.
+
+### Editor Trust Lane — make real-project behavior boring
+
+**Goal:** prove editor behavior against real Perl workspaces without turning the
+UX effort into broad provider rewrites.
+
+- Source of truth: [EDITOR_TRUST_WAVE.md](EDITOR_TRUST_WAVE.md),
+  [status/real_perl_editor_trust_v1.md](status/real_perl_editor_trust_v1.md),
+  and [status/editor_ux.json](status/editor_ux.json).
+- Next slices:
+  1. Preserve one canonical lane per trust area: completions, diagnostics,
+     parser recovery, UX evidence, and `@INC` consistency.
+  2. Add receipts that describe what a user would see in the editor, not only
+     which internal helper returned a value.
+  3. Convert passing real-project scenarios into ratchets only after their
+     inputs and expected behavior are stable enough for CI.
+- Stop condition: do not promote exploratory real-project checks to required CI
+  until they are deterministic across Linux CI and local agent profiles.
+
+### CI / Control-Plane Lane — improve operator feedback in narrow steps
+
+**Goal:** keep the automation reliable for humans and agents without building a
+full merge bot or broad CI redesign.
+
+- Source of truth: [CI_WAVE_EXECUTION_PLAN.md](CI_WAVE_EXECUTION_PLAN.md),
+  [protocols/verification.md](protocols/verification.md), and the generated
+  status files under [status/](status/).
+- Next slices:
+  1. Land `update-status --write` progress streaming and failure attribution
+     before lower-urgency control-plane polish.
+  2. Add CI trigger regression linting for `pull_request:labeled|unlabeled` and
+     `cancel-in-progress` as an independent guardrail.
+  3. Normalize expected-skip/stale-check reporting so merge-ready automation
+     reports evidence state rather than guessing intent from labels.
+  4. Keep tokmd advisory until signal quality is proven; advisory output must
+     not become a surprise release blocker.
+- Stop condition: reject slices that require global pre-push hooks, bulk stale
+  closure, or a single PR that rewrites the workflow architecture.
+
+### Quality, Security, and Distribution Lane — keep alpha safe to install
+
+**Goal:** maintain install confidence while public-alpha semantics remain clear.
+
+- Source of truth: [CURRENT_STATUS.md](CURRENT_STATUS.md),
+  [status/quality.md](status/quality.md),
+  [docs/reference/COMMANDS_REFERENCE.md](../reference/COMMANDS_REFERENCE.md),
+  and channel receipts linked from [RELEASE_HISTORY.md](../../RELEASE_HISTORY.md).
+- Next slices:
+  1. Continue production-code `unwrap()` / `expect()` and temporary-allow
+     burndown in focused crate-sized PRs.
+  2. Keep dependency triage per release train, separating urgent security fixes
+     from opportunistic churn.
+  3. Verify Docker, Homebrew, editor marketplaces, and crates.io as install
+     surfaces with commands users can copy.
+- Stop condition: do not describe the project as stable/GA until the stability
+  contract is written, reviewed, and reflected across release surfaces.
+
+### v1.0 Runway — define the contract before declaring stability
+
+**Goal:** turn the public-alpha learning loop into a deliberate stability plan.
+
+- Source of truth: this roadmap plus future stability-contract documents linked
+  from [docs/project/](.).
+- Next slices:
+  1. Define which Rust crates expose stable public APIs and which remain
+     internal implementation crates.
+  2. Define advertised LSP/DAP behavior that must remain backward compatible,
+     including fallback semantics for compiler-backed providers.
+  3. Establish performance and memory budgets for large workspaces that can be
+     checked without unbounded build output in agent worktrees.
+  4. Document security expectations for subprocess execution, Perl environment
+     construction, and extension distribution.
+- Stop condition: do not set a `v1.0.0` target date until the API, wire-behavior,
+  performance, and security contracts have reviewable acceptance criteria.
+
 ## Now / Next / Later
 
 ### Now (v0.14.0 public-alpha patch prep)
@@ -219,4 +339,4 @@ For live capability posture, run `just status-check` or read [CURRENT_STATUS.md]
 | Evidence-backed metrics | [CURRENT_STATUS.md](CURRENT_STATUS.md) |
 | Top-level summary docs | [../../ROADMAP.md](../../ROADMAP.md), [../../NOW_NEXT_LATER.md](../../NOW_NEXT_LATER.md) |
 
-<!-- Last Updated: 2026-05-12 -->
+<!-- Last Updated: 2026-05-16 -->


### PR DESCRIPTION
### Motivation

- The canonical roadmap and short Now/Next/Later snapshots were still centered on older v0.12/v0.13 framing and lacked an explicit, outcome-oriented follow-up plan. 
- The project needs a small, reviewable set of lanes that name sources of truth, next reviewable slices, and stop conditions so roadmap work remains narrow and verifiable. 
- This change bundles only documentation planning updates to make the v0.14.0 public-alpha train and compiler/editor/CI lanes explicit.

### Description

- Added a new "Roadmap Build-Out" section to `docs/project/ROADMAP.md` that defines outcome-oriented lanes: Release Proof, Compiler-Backed LSP, Editor Trust, CI/Control-Plane, Quality/Security/Distribution, and the v1.0 runway. 
- Updated the top-level `ROADMAP.md` to point to the v0.14.0 release notes and to surface the Editor Trust and CI/Control-Plane wave docs. 
- Rewrote `NOW_NEXT_LATER.md` to reflect the active `v0.14.0` public-alpha patch-prep posture and post-v0.14.0 sequencing instead of older v0.12/v0.13 wording. 
- Bumped the "Last Updated" timestamps to `2026-05-16` and committed the changes as `docs(roadmap): build out planning lanes (#0000)`.

### Testing

- Ran `git diff --check` which returned no whitespace or diff-check errors. 
- Verified staged changes and committed locally with `git commit` and the intended commit title. 
- Attempted `just agent-pr-fast` but could not run it in this environment because `just` is not installed; no code/test artifacts were modified so no crate tests were required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ab690c8333b6b23bbb08383e07)