### PR TITLE
docs(roadmap): build out planning lanes (#0000)

### DIFF
--- a/NOW_NEXT_LATER.md
+++ b/NOW_NEXT_LATER.md
@@ -5,39 +5,37 @@ This file is the short planning snapshot for sequencing work. Use
 plan and [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md) for
 evidence-backed status and release facts.
 
-## DONE — v0.12.2 through v0.12.8 (consolidated and shipped)
+## DONE — v0.12.x through v0.13.x public-alpha foundation
 
-- Work consolidated and merged 2026-04-02 (~70 PRs): CI gates, error handling, test coverage, parser confidence, performance, distribution, AI inline completion, packaging, announcement polish
-- `v0.12.3` is the live GitHub/editor release line as of 2026-04-09 with binaries, SBOM, SHA256SUMS, VS Code Marketplace, and Open VSX published
-- crates.io intentionally remains on `v0.12.2` while the registry window is deferred
+- The 0.12.x line consolidated parser confidence, diagnostics, refactoring, distribution, AI inline completion, packaging, and announcement polish.
+- The 0.13.x line built public-alpha release-channel confidence and prepared the Rust 1.95 / v0.14.0 train.
+- Historical release receipts belong in [docs/project/status/release.md](docs/project/status/release.md) and [RELEASE_HISTORY.md](RELEASE_HISTORY.md), not this snapshot.
 
-## NOW — post-v0.12.3 / pre-announcement cleanup
+## NOW — v0.14.0 public-alpha patch prep
 
-- License badge fixed (canonical SPDX text in all 126 LICENSE files), GitHub now reports `Apache-2.0` instead of `NOASSERTION`
-- Docker arm64 timeout fix landed (Dockerfile MSRV pin + workflow timeout bump)
-- Dependency triage complete: 7 dependabot PRs merged including 3 majors (eslint v10, actions/cache v5, similar 3.0.0)
-- Keep public guidance explicit about the current channel split: GitHub Releases plus editor marketplaces are on `v0.12.3`; crates.io remains on `v0.12.2`
-- SRP microcrate extractions in flight (anti_pattern_detector, bench_parser) to free the dead `tree-sitter-perl-rs` harness for archival
-- Publishing the modern parsers as `tree-sitter-perl-c` (C tree-sitter FFI) and a new `tree-sitter-perl-rs` (Rust v3 facade with tree-sitter-compatible output)
-- Per-crate publish blockers cleared (perl-lsp-ai-provider unblocked, perl-heredoc-anti-patterns extraction in progress)
+- Treat `v0.14.0` as staged until the release-prep checks and channel receipts close.
+- Keep public install guidance explicit: this is public alpha, not stable/GA.
+- Close release proof across GitHub Releases, crates.io, VS Code Marketplace, Open VSX, Docker, and the owned `effortlessmetrics/tap/perllsp` Homebrew path.
+- Execute the next CI/control-plane wave as small lanes: status streaming, trigger lint, expected-skip/stale-check normalization, reconciler projection, disposition evidence, merge-train receipts, and tokmd advisory calibration.
+- Continue compiler-backed provider work through provenance/freshness receipts, shadow/live comparison, and explicit fallback behavior.
 
-## NEXT — v0.13.0 public alpha announcement
+## NEXT — post-v0.14.0 hardening
 
-- Re-trigger crates.io publish after the SRP extractions and harness archival land
-- Final smoke test across all distribution channels
-- Bump workspace to `0.13.0`
-- Announcement blog post / release notes
+- Resume parser and corpus ratchets from capability-gap packets, not duplicated metric tables.
+- Promote Real Perl Editor Trust v1 workflows when provider dashboards show repeatable user-visible confidence.
+- Harden DAP module-resolution and breakpoint UX while retaining the native+bridge preview stance.
+- Keep install-surface checks and release-history gates current as distribution channels move.
 
-## LATER — beyond v0.13.0
+## LATER — toward v1.0.0
 
-- Stability contract for APIs and advertised wire behavior
-- Performance hardening for larger workspaces
-- Security posture and documentation hardening
-- Path to `v1.0.0`
+- Stability contract for APIs and advertised wire behavior.
+- Performance hardening for larger workspaces.
+- Security posture and documentation hardening.
+- Graduation from public alpha only when channel reliability and editor-trust evidence support it.
 
 ## Working Rules
 
-- Last updated: `2026-04-09`
+- Last updated: `2026-05-16`.
 - Keep “current release line” separate from “next milestone”.
 - Put receipts and computed metrics in [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md), not here.
 - Put detailed milestone criteria in [docs/project/ROADMAP.md](docs/project/ROADMAP.md), not here.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,30 +11,33 @@ project docs when you need exact release facts, receipts, or milestone detail.
 
 - Active milestone plan: [docs/project/ROADMAP.md](docs/project/ROADMAP.md)
 - Current truth and receipts: [docs/project/CURRENT_STATUS.md](docs/project/CURRENT_STATUS.md)
+- Release readiness and channel proof: [docs/project/status/release.md](docs/project/status/release.md)
 - Compiler-backed LSP build-out: [docs/project/COMPILER_BACKED_LSP_ROADMAP.md](docs/project/COMPILER_BACKED_LSP_ROADMAP.md)
-- Published release tracking: [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
+- Provider cutover dashboard: [docs/project/status/provider_cutover.md](docs/project/status/provider_cutover.md)
+- Real Perl editor trust dashboard: [docs/project/status/real_perl_editor_trust_v1.md](docs/project/status/real_perl_editor_trust_v1.md)
+- Published release tracking: [RELEASE_HISTORY.md](RELEASE_HISTORY.md) and [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases)
 
-## Now (post-v0.12.3 ship / pre-announcement cleanup)
+## Now (v0.14.0 public-alpha patch prep)
 
-- `v0.12.3` shipped to GitHub Releases, VS Code Marketplace, and Open VSX on 2026-04-09
-- crates.io intentionally remains on `0.12.2` while the registry window is still deferred
-- Pre-announcement plumbing: license badge fix, Docker arm64 timeout fix, dependency triage, harness archival, SRP microcrate extractions
-- Distribution channel verification across GitHub Releases, VS Code Marketplace, Open VSX, Docker Hub, and the delayed crates.io line
-- See [docs/project/ROADMAP.md](docs/project/ROADMAP.md) "Now (post-v0.12.3 / pre-v0.13.0)" for the active item list
+- Workspace version line is `v0.14.0`; verify live channel state before claiming a release is published.
+- Release proof is the top lane: close the v0.14.0 prep checks, keep crates.io/editor/Docker/Homebrew receipts wired to the release runbook, and keep public language at public alpha.
+- CI/control-plane work is the next execution lane: streaming status output, CI trigger lint, normalized expected-skip/stale-check states, reconciler label projection, disposition evidence, merge-train receipts, and tokmd advisory calibration.
+- Compiler-backed LSP work continues through fact-source tracing, shadow/live comparison, provider cutover dashboards, and explicit fallback behavior.
+- Real-project editor trust is the user-facing promotion gate for provider changes; fixtures prove implementation, but dashboarded workflows justify release claims.
 
-## Next (v0.13.0 — public alpha announcement)
+## Next (post-v0.14.0)
 
-- 0.12.x line built confidence across parser, diagnostics, refactoring, distribution, AI inline completion
-- Quality cleanup PRs land, version bump to 0.13.0
-- Seamless install story verified across all distribution channels
-- Announcement blog post / release notes
+- Resume parser, corpus, semantic, DAP, and distribution hardening after release-channel receipts close.
+- Run the Editor Trust Wave as one lane with one canonical checklist and one verification receipt.
+- Keep install guidance verified across GitHub Releases, crates.io, VS Code Marketplace, Open VSX, Docker, and the owned Homebrew tap path.
+- Keep release notes concise, receipt-backed, and explicit about public-alpha status.
 
-## Beyond v0.13.0
+## Later (toward v1.0.0)
 
-- Stability contract for APIs and advertised wire behavior
-- Performance hardening for larger workspaces
-- Security posture and documentation hardening
-- Path to `v1.0.0`
+- Stability contract for public APIs and advertised wire behavior.
+- Performance hardening for larger workspaces.
+- Security posture and documentation hardening.
+- A measured path from public alpha to `v1.0.0` based on channel reliability and editor-trust evidence.
 
 ## Update Rules
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -97,6 +97,34 @@ Released 2026-03-30. Cleanup completed 2026-04-02.
 - Public install language must say public alpha, not stable/GA
 - Follow-on quality cleanup resumes after the release-channel receipts are closed
 
+## Roadmap Build-Out
+
+The next planning horizon is deliberately split into receipt-backed lanes. Each
+lane below should ship as small PRs with one owner, one acceptance checklist, and
+one verification receipt; do not turn any lane into a broad architecture rewrite.
+
+| Horizon | Lane | Outcome | Acceptance evidence | Primary sources |
+| --- | --- | --- | --- | --- |
+| Release closeout | v0.14.0 channel proof | Public-alpha package, editor, Docker, and Homebrew surfaces are verified before dispatch | Release-prep checks, install receipts, and cross-channel ledger entries | [v0.14.0 notes](../releases/v0.14.0.md), [release status](status/release.md) |
+| Immediate hardening | CI/control-plane Wave 3 | Agents and reviewers can tell whether a PR is merge-ready without parsing raw logs | Streaming `update-status --write`, trigger lint, normalized skip/stale-check states, and reconciler projection receipts | [CI wave execution plan](CI_WAVE_EXECUTION_PLAN.md), [CI hardening status](status/ci_hardening.md) |
+| Provider trust | Compiler-backed provider cutover | Providers prefer compiler facts only where freshness/provenance is high and keep fallback behavior explicit | Shadow/live comparison receipts, provider fact-source traces, and dashboard promotions | [compiler-backed roadmap](COMPILER_BACKED_LSP_ROADMAP.md), [provider cutover status](status/provider_cutover.md) |
+| Editor quality | Real Perl Editor Trust v1 | Common real-project editing workflows become dashboarded, reproducible, and promotable | Per-provider trust-loop receipts plus user-visible before/after scenarios | [Editor Trust Wave](EDITOR_TRUST_WAVE.md), [Real Perl Editor Trust v1](status/real_perl_editor_trust_v1.md) |
+| Language breadth | Parser/corpus ratchet | Parser confidence grows through strict-clean manifests and capability-gap packets, not raw percentage chasing | Updated parser status, corpus manifests, and targeted failure-cluster PRs | [parser status](status/parser.md), [CPAN corpus strategy](CPAN_CORPUS_STRATEGY.md) |
+| Debugger confidence | DAP module and breakpoint UX | Native+bridge preview remains shippable while module path and breakpoint behavior are hardened | DAP smoke tests, launch/attach receipts, and status updates | [DAP status](status/dap.md), [release status](status/release.md) |
+| Post-release polish | Distribution, security, and docs | Public-alpha install guidance stays accurate as channels move, and release docs avoid stale duplicated metrics | Release-history checks, install-surface checks, and links to generated status files | [publishing roadmap](PUBLISHING_ROADMAP.md), [CURRENT_STATUS.md](CURRENT_STATUS.md) |
+
+### Sequencing Rules
+
+1. Finish v0.14.0 release proof before claiming any channel as complete.
+2. Land CI/control-plane slices before increasing automation authority; labels are
+   projected state, not the source of truth.
+3. Promote compiler-backed provider behavior only when shadow/live receipts show
+   high-confidence, fresh facts and an explicit fallback path.
+4. Treat real-project editor trust as the user-facing promotion gate: fixtures can
+   justify implementation, but dashboarded workflows justify release language.
+5. Keep generated metrics in status files and keep this roadmap focused on intent,
+   sequencing, and acceptance evidence.
+
 ## Now / Next / Later
 
 ### Now (v0.14.0 public-alpha patch prep)


### PR DESCRIPTION
### Motivation

- Provide a concise, actionable planning horizon that maps lanes to acceptance evidence so work is small, verifiable, and reviewable. 
- Make the top-level and short-snapshot roadmap language reflect the active `v0.14.0` public-alpha patch-prep and the correct promotion/ sequencing rules for provider cutover and editor trust.

### Description

- Add a "Roadmap Build-Out" section with receipt-backed lanes and explicit sequencing rules to `docs/project/ROADMAP.md` to drive small PR-shaped work and verification receipts. 
- Refresh the top-level `ROADMAP.md` to reference release readiness, provider cutover, and editor-trust dashboards and to reflect the `v0.14.0` prep framing. 
- Update `NOW_NEXT_LATER.md` to the current `v0.14.0` public-alpha patch-prep / post-release-hardening / toward-v1.0 snapshot and update the "Last updated" date. 
- This is a docs-only change; no production code or tests were modified.

### Testing

- Ran `git diff --check` and a local markdown link resolver against the changed roadmap files and both checks passed. 
- Ran the local link verification script (inline Python) to ensure all relative markdown links in the edited files resolve and it passed. 
- Attempted `./scripts/cargo-safe xtask update-status --check` which exercised the `xtask` build and status generator; the run completed compilation work but exited after internal timeouts and reported generated status files as out of date, which is expected for a docs-only update and does not indicate a regression in these narrative edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ab690c8333b6b23bbb08383e07)