### PR TITLE
fix(parser): preserve CRLF import edit ranges (#9320)

### DIFF
--- a/crates/perl-parser/src/refactor/import_optimizer.rs
+++ b/crates/perl-parser/src/refactor/import_optimizer.rs
@@ -680,12 +680,13 @@ impl ImportOptimizer {
         if line <= 1 {
             return 0;
         }
+
         let mut offset = 0;
-        for (idx, l) in content.lines().enumerate() {
+        for (idx, segment) in content.split_inclusive('\n').enumerate() {
             if idx + 1 >= line {
                 break;
             }
-            offset += l.len() + 1; // include newline
+            offset += segment.len();
         }
         offset
     }
@@ -1054,6 +1055,21 @@ my $result = JSON::encode_json({test => 1});
         // Should only detect the actual module usage, not the ones in strings/regex
         assert_eq!(analysis.missing_imports.len(), 1);
         assert_eq!(analysis.missing_imports[0].module, "JSON");
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_edits_preserves_crlf_import_block_range()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let optimizer = ImportOptimizer::new();
+        let content = concat!("use warnings;\r\n", "use strict;\r\n", "print qq(done);\r\n");
+        let expected_range_end = concat!("use warnings;\r\n", "use strict;\r\n").len();
+        let analysis = optimizer.analyze_content(content)?;
+
+        let edits = optimizer.generate_edits(content, &analysis);
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].range, (0, expected_range_end));
+        assert_eq!(edits[0].new_text, "use strict;\nuse warnings;\n");
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation

- Import-edit byte ranges were computed assuming a single-byte newline which produced incorrect (short) ranges for files using CRLF line endings, causing import replacement edits to miss the terminating `\r\n`.

### Description

- Update `line_offset` in `crates/perl-parser/src/refactor/import_optimizer.rs` to iterate with `content.split_inclusive('\n')` and sum `segment.len()` so newline bytes (including `\r\n`) are counted correctly. 
- Add a regression test `test_generate_edits_preserves_crlf_import_block_range` that uses `concat!("use warnings;\r\n", ...)` to verify `generate_edits` produces the correct range and normalized replacement. 
- Change is limited to `line_offset` logic and the new test in the import optimizer test module.

### Testing

- Ran formatter with `./scripts/cargo-safe xtask fmt` which passed. 
- Executed the targeted unit test with `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-parser test_generate_edits_preserves_crlf_import_block_range --profile agent --locked` which passed. 
- Ran the full `perl-parser` library tests with `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-parser --lib --profile agent --locked` which passed (141 tests). 
- Verified `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check --all-targets -p perl-parser --profile agent --locked` and `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-parser --profile agent --locked -- -D warnings -A missing_docs` which both passed; an initial test attempt was blocked by a storage quota guard but was re-run with `CARGO_TARGET_DIR` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ca24a1cc8333936e8932d1561b61)