### PR TITLE
ci(fuzz): keep bounded targets in sync (#9321)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -696,11 +696,22 @@ jobs:
       matrix:
         target: [
           builtin_functions,
+          dap_eval_validator,
+          dap_stack_parser,
+          declaration_parsing,
           heredoc_parsing,
+          incremental_edit_sequences,
+          lexer_tokenization,
           lsp_cancellation_registry,
           lsp_navigation,
+          parser_integration,
+          quote_operators,
+          semantic_model,
+          structured_perl_programs,
           substitution_parsing,
-          unicode_positions
+          symbol_query_ranking,
+          unicode_positions,
+          utf16_roundtrip
         ]
 
     steps:
@@ -725,7 +736,7 @@ jobs:
     - name: Run fuzzer
       run: |
         DURATION=${{ github.event.inputs.duration || '600' }}
-        cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=$DURATION -max_len=1000 -timeout=25
+        ./scripts/fuzz-bounded --duration "$DURATION" -- ${{ matrix.target }}
 
     - name: Upload crash artifacts
       if: failure()

--- a/justfile
+++ b/justfile
@@ -369,24 +369,7 @@ mutation-regression:
 
 # Bounded fuzz run (quick fuzzing for CI/nightly)
 fuzz-bounded:
-    @echo "🔥 Running bounded fuzz testing (60 seconds per target)..."
-    @cargo +nightly fuzz run builtin_functions -- -max_total_time=60 || echo "  Builtin functions fuzzing complete"
-    @cargo +nightly fuzz run declaration_parsing -- -max_total_time=60 || echo "  Declaration parsing fuzzing complete"
-    @cargo +nightly fuzz run heredoc_parsing -- -max_total_time=60 || echo "  Heredoc fuzzing complete"
-    @cargo +nightly fuzz run incremental_edit_sequences -- -max_total_time=60 || echo "  Incremental edit sequences fuzzing complete"
-    @cargo +nightly fuzz run lsp_cancellation_registry -- -max_total_time=60 || echo "  LSP cancellation registry fuzzing complete"
-    @cargo +nightly fuzz run lsp_navigation -- -max_total_time=60 || echo "  LSP navigation fuzzing complete"
-    @cargo +nightly fuzz run parser_integration -- -max_total_time=60 || echo "  Parser integration fuzzing complete"
-    @cargo +nightly fuzz run quote_operators -- -max_total_time=60 || echo "  Quote operators fuzzing complete"
-    @cargo +nightly fuzz run semantic_model -- -max_total_time=60 || echo "  Semantic model fuzzing complete"
-    @cargo +nightly fuzz run symbol_query_ranking -- -max_total_time=60 || echo "  Symbol query ranking fuzzing complete"
-    @cargo +nightly fuzz run substitution_parsing -- -max_total_time=60 || echo "  Substitution fuzzing complete"
-    @cargo +nightly fuzz run utf16_roundtrip -- -max_total_time=60 || echo "  UTF-16 roundtrip fuzzing complete"
-    @cargo +nightly fuzz run unicode_positions -- -max_total_time=60 || echo "  Unicode positions fuzzing complete"
-    @cargo +nightly fuzz run lexer_tokenization -- -max_total_time=60 || echo "  Lexer tokenization fuzzing complete"
-    @cargo +nightly fuzz run dap_eval_validator -- -max_total_time=60 || echo "  DAP eval validator fuzzing complete"
-    @cargo +nightly fuzz run dap_stack_parser -- -max_total_time=60 || echo "  DAP stack parser fuzzing complete"
-    @echo "✅ Fuzz testing complete"
+    @./scripts/fuzz-bounded --duration 60
 
 # `bench` is the canonical benchmark target; keep this as a compatibility alias.
 benchmarks: bench

--- a/scripts/fuzz-bounded
+++ b/scripts/fuzz-bounded
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/fuzz-bounded [--list] [--duration SECONDS] [-- TARGET...]
+
+Runs every cargo-fuzz binary declared in fuzz/Cargo.toml with a bounded time
+budget. Set FUZZ_MAX_LEN and FUZZ_TIMEOUT to override libFuzzer limits.
+USAGE
+}
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+duration=${FUZZ_DURATION:-60}
+list_only=0
+targets=()
+
+while (($#)); do
+    case "$1" in
+        --list)
+            list_only=1
+            shift
+            ;;
+        --duration)
+            if (($# < 2)); then
+                echo "error: --duration requires a value" >&2
+                usage >&2
+                exit 2
+            fi
+            duration=$2
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            targets+=("$@")
+            break
+            ;;
+        *)
+            targets+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ ! $duration =~ ^[0-9]+$ ]] || ((duration == 0)); then
+    echo "error: duration must be a positive integer number of seconds" >&2
+    exit 2
+fi
+
+mapfile -t discovered_targets < <(
+    cargo metadata \
+        --manifest-path "$repo_root/fuzz/Cargo.toml" \
+        --no-deps \
+        --format-version 1 \
+    | python3 -c 'import json, sys
+metadata = json.load(sys.stdin)
+targets = sorted(
+    target["name"]
+    for package in metadata["packages"]
+    for target in package["targets"]
+    if "bin" in target["kind"]
+)
+print("\n".join(targets))'
+)
+
+if ((${#targets[@]} == 0)); then
+    targets=("${discovered_targets[@]}")
+fi
+
+if ((list_only)); then
+    printf '%s\n' "${targets[@]}"
+    exit 0
+fi
+
+declare -A known=()
+for target in "${discovered_targets[@]}"; do
+    known["$target"]=1
+done
+
+unknown=()
+for target in "${targets[@]}"; do
+    if [[ -z ${known[$target]+x} ]]; then
+        unknown+=("$target")
+    fi
+done
+
+if ((${#unknown[@]} > 0)); then
+    echo "error: unknown fuzz target(s): ${unknown[*]}" >&2
+    echo "known targets:" >&2
+    printf '  %s\n' "${discovered_targets[@]}" >&2
+    exit 2
+fi
+
+max_len=${FUZZ_MAX_LEN:-1000}
+timeout=${FUZZ_TIMEOUT:-25}
+
+echo "🔥 Running ${#targets[@]} fuzz target(s) for ${duration}s each"
+for target in "${targets[@]}"; do
+    echo ">>> cargo +nightly fuzz run $target -- -max_total_time=$duration -max_len=$max_len -timeout=$timeout"
+    cargo +nightly fuzz run "$target" -- \
+        -max_total_time="$duration" \
+        -max_len="$max_len" \
+        -timeout="$timeout"
+done
+echo "✅ Bounded fuzz testing complete"


### PR DESCRIPTION
### Motivation

- Prevent drift between the CI/just bounded fuzz runner and the actual `fuzz/Cargo.toml` manifest and ensure nightly fuzz coverage includes all current fuzz binaries.
- Fix a compilation failure in one fuzz target caused by invalid Rust string escapes so the fuzz crate builds in CI.

### Description

- Add `scripts/fuzz-bounded`, a manifest-driven bounded fuzz runner that discovers fuzz binaries from `fuzz/Cargo.toml`, validates requested targets, and runs `cargo +nightly fuzz run` with consistent libFuzzer limits.
- Replace the hard-coded multi-line fuzz sequence in `justfile` with an invocation of `./scripts/fuzz-bounded --duration 60` to eliminate duplicated target lists.
- Expand the nightly CI fuzz matrix and route the matrix runner through `./scripts/fuzz-bounded` so each matrix entry executes via the shared helper in `.github/workflows/ci-nightly.yml`.
- Fix `fuzz/fuzz_targets/declaration_parsing.rs` by switching problematic `format!` literals to raw string literals to correctly escape Perl sigils (`$`, `@`, `%`) so the fuzz crate compiles.

### Testing

- Ran `bash -n scripts/fuzz-bounded` which succeeded to validate shell syntax.
- Ran `./scripts/fuzz-bounded --list` which returned the expected fuzz target list and `./scripts/fuzz-bounded` unknown-target validation produced the expected error for invalid targets.
- Ran `cargo check --manifest-path fuzz/Cargo.toml --bins --locked` which completed successfully for the fuzz crate after the literal fixes.
- Ran `./scripts/cargo-safe xtask fmt --check` and `./scripts/storage-doctor` which completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07fb3964dc8333b482c871815455a1)