### PR TITLE
test(lsp): improve e2e diagnostics flow (#0000)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_smoke_e2e.rs
+++ b/crates/perl-lsp-rs/tests/lsp_smoke_e2e.rs
@@ -3,6 +3,7 @@
 mod common;
 
 use serde_json::{Value, json};
+use serial_test::serial;
 use std::time::{Duration, Instant};
 
 fn send_request_with_timeout(
@@ -43,7 +44,33 @@ fn completion_labels(items: &[Value]) -> Vec<&str> {
     items.iter().filter_map(|item| item.get("label").and_then(Value::as_str)).collect()
 }
 
+fn diagnostic_result(response: &Value) -> Result<&Value, Box<dyn std::error::Error>> {
+    if response.get("error").is_some() {
+        return Err(format!("diagnostic request returned error: {response:#}").into());
+    }
+
+    response.get("result").ok_or_else(|| "diagnostic response missing result".into())
+}
+
+fn diagnostic_items(response: &Value) -> Result<&[Value], Box<dyn std::error::Error>> {
+    let result = diagnostic_result(response)?;
+    result
+        .get("items")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(|| format!("diagnostic result missing items array: {result:#}").into())
+}
+
+fn diagnostic_result_id(response: &Value) -> Result<&str, Box<dyn std::error::Error>> {
+    let result = diagnostic_result(response)?;
+    result
+        .get("resultId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("diagnostic result missing resultId: {result:#}").into())
+}
+
 #[test]
+#[serial(lsp_smoke_e2e)]
 fn lsp_smoke_e2e_stdio_flow() -> Result<(), Box<dyn std::error::Error>> {
     let server = common::start_lsp_server();
     let timeout = Duration::from_secs(2);
@@ -399,6 +426,144 @@ my $value = gre
 
         std::thread::sleep(Duration::from_millis(25));
     }
+
+    Ok(())
+}
+
+#[test]
+#[serial(lsp_smoke_e2e)]
+fn lsp_smoke_e2e_pull_diagnostics_refresh_after_change() -> Result<(), Box<dyn std::error::Error>> {
+    let server = common::start_lsp_server();
+    let timeout = Duration::from_secs(2);
+    let init_timeout = common::timeout_scaler::TimeoutProfile::Initialization.timeout();
+
+    let uri = "file:///tmp/lsp_smoke_diagnostics_e2e.pl";
+    let clean_fixture = r#"use strict;
+use warnings;
+
+my $count = 1;
+print $count;
+"#;
+
+    let init_response = send_request_with_timeout(
+        &server,
+        101,
+        "initialize",
+        json!({
+            "processId": null,
+            "rootUri": null,
+            "capabilities": {
+                "textDocument": {
+                    "diagnostic": { "dynamicRegistration": true }
+                }
+            }
+        }),
+        init_timeout,
+    )?;
+    assert!(init_response.get("error").is_none(), "initialize returned error: {init_response:#}");
+
+    common::send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "initialized",
+            "params": {}
+        }),
+    );
+
+    common::send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "perl",
+                    "version": 1,
+                    "text": clean_fixture
+                }
+            }
+        }),
+    );
+
+    let clean_response = send_request_with_timeout(
+        &server,
+        102,
+        "textDocument/diagnostic",
+        json!({
+            "textDocument": { "uri": uri }
+        }),
+        timeout,
+    )?;
+    let clean_result = diagnostic_result(&clean_response)?;
+    assert_eq!(clean_result["kind"], "full", "initial diagnostics should be a full report");
+    let clean_result_id = diagnostic_result_id(&clean_response)?.to_string();
+    let clean_items = diagnostic_items(&clean_response)?;
+    assert!(
+        clean_items.is_empty(),
+        "clean fixture should not report diagnostics over stdio: {clean_items:#?}"
+    );
+
+    let broken_fixture = r#"use strict;
+use warnings;
+
+my $count = 1;
+print $missing;
+"#;
+    common::send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+                "textDocument": { "uri": uri, "version": 2 },
+                "contentChanges": [{ "text": broken_fixture }]
+            }
+        }),
+    );
+
+    let changed_response = send_request_with_timeout(
+        &server,
+        103,
+        "textDocument/diagnostic",
+        json!({
+            "textDocument": { "uri": uri },
+            "previousResultId": clean_result_id
+        }),
+        timeout,
+    )?;
+    let changed_result = diagnostic_result(&changed_response)?;
+    assert_eq!(changed_result["kind"], "full", "changed document should produce a full report");
+    let changed_result_id = diagnostic_result_id(&changed_response)?;
+    assert_ne!(
+        changed_result_id, clean_result_id,
+        "diagnostic resultId should change after didChange updates document text"
+    );
+
+    let changed_items = diagnostic_items(&changed_response)?;
+    assert!(
+        changed_items.iter().any(|item| item
+            .get("message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.contains("$missing") || message.contains("missing"))),
+        "changed fixture should report the newly introduced variable diagnostic: {changed_items:#?}"
+    );
+
+    let shutdown_response =
+        send_request_with_timeout(&server, 104, "shutdown", json!(null), timeout)?;
+    assert!(
+        shutdown_response.get("error").is_none(),
+        "shutdown returned error: {shutdown_response:#}"
+    );
+    common::send_notification(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "exit",
+            "params": null
+        }),
+    );
 
     Ok(())
 }


### PR DESCRIPTION
### Motivation
- The stdio end-to-end smoke suite lacked a deterministic pull-diagnostics lifecycle test and occasionally flaked when tests ran concurrently against live LSP server processes.
- Make diagnostics assertions more robust by centralizing result-shape checks and verifying `resultId` refresh after edits.

### Description
- Added helper functions `diagnostic_result`, `diagnostic_items`, and `diagnostic_result_id` to `crates/perl-lsp-rs/tests/lsp_smoke_e2e.rs` to validate pull-diagnostics responses and item/resultId shapes.
- Added a new serialized stdio E2E test `lsp_smoke_e2e_pull_diagnostics_refresh_after_change` that exercises a clean document, a `textDocument/didChange`, a pull diagnostics request with `previousResultId`, and asserts the refreshed `resultId` plus the introduced `$missing` diagnostic.
- Marked the stdio smoke tests as serialized with `#[serial(lsp_smoke_e2e)]` to avoid overlapping live LSP sessions and reduce flakiness.
- Kept changes scoped to the E2E test file (`crates/perl-lsp-rs/tests/lsp_smoke_e2e.rs`) only.

### Testing
- Ran the focused test binary with `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-rs --test lsp_smoke_e2e --profile agent --locked -- --nocapture` and observed all tests pass (14 passed, 0 failed).
- Verified formatting with `MIN_FREE_GB=20 ./scripts/cargo-safe xtask fmt --check` which completed successfully.
- Ran repository hygiene checks `git diff --check` and `./scripts/storage-doctor` with no blocking issues.
- All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07fb4139c88333bef23efddf3b6ad8)