### PR TITLE
test(fuzz): add module surface target (#9328)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -704,6 +704,7 @@ jobs:
           lexer_tokenization,
           lsp_cancellation_registry,
           lsp_navigation,
+          module_surface,
           parser_integration,
           quote_operators,
           semantic_model,

--- a/docs/project/PARSER_EVOLUTION.md
+++ b/docs/project/PARSER_EVOLUTION.md
@@ -420,7 +420,7 @@ The parser is validated against a comprehensive test corpus:
 
 ### Fuzz Testing
 
-Seven fuzz targets exercise the most fragile parsing paths:
+Cargo-fuzz targets exercise the most fragile parsing paths; `fuzz/Cargo.toml` is the source of truth for the active target list. Representative targets include:
 
 - `parser_integration` -- parser, trivia, and symbol-extraction integration
 - `heredoc_parsing` -- heredoc edge cases
@@ -429,6 +429,7 @@ Seven fuzz targets exercise the most fragile parsing paths:
 - `unicode_positions` -- UTF-8/UTF-16 position mapping
 - `lsp_navigation` -- LSP feature integration
 - `lsp_cancellation_registry` -- concurrent request handling
+- `module_surface` -- module naming, import/reference extraction, token replacement, and rename helpers
 
 Bounded fuzzing runs for 60 seconds per target as part of the nightly CI.
 

--- a/docs/project/QUALITY_INFRASTRUCTURE.md
+++ b/docs/project/QUALITY_INFRASTRUCTURE.md
@@ -100,7 +100,7 @@ cargo mutants --workspace -j 2 --timeout 60
 
 ## Fuzz Testing: Finding What You Didn't Think to Test
 
-The project maintains **7 fuzz targets** powered by libFuzzer via `cargo-fuzz`, each targeting a specific attack surface:
+The project maintains fuzz targets powered by libFuzzer via `cargo-fuzz`; `fuzz/Cargo.toml` is the source of truth for the active target list. Representative targets cover these attack surfaces:
 
 | Target | Purpose |
 |--------|---------|
@@ -111,6 +111,7 @@ The project maintains **7 fuzz targets** powered by libFuzzer via `cargo-fuzz`, 
 | `unicode_positions` | UTF-16 position mapping with multi-byte characters |
 | `lsp_cancellation_registry` | Cancellation token handling under adversarial conditions |
 | `fuzz_target_1` | General parser fuzzing |
+| `module_surface` | Module naming, import/reference extraction, token replacement, and rename helpers |
 
 Each fuzz target is designed to exercise a specific bug class. For example, the heredoc fuzzer specifically targets the off-by-one boundary fix in commit `cd7a2442`, generating patterns like unterminated heredoc quotes (`<<"` without closing), empty delimiters (`<<""`), and single-character edge cases. The unicode positions fuzzer exercises UTF-16 boundary handling with emoji identifiers and multi-byte characters.
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,6 +25,9 @@ path = "../crates/perl-lexer"
 [dependencies.perl-dap]
 path = "../crates/perl-dap"
 
+[dependencies.perl-module]
+path = "../crates/perl-module"
+
 [[bin]]
 name = "substitution_parsing"
 path = "fuzz_targets/substitution_parsing.rs"
@@ -100,6 +103,13 @@ bench = false
 [[bin]]
 name = "structured_perl_programs"
 path = "fuzz_targets/structured_perl_programs.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "module_surface"
+path = "fuzz_targets/module_surface.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/module_surface.rs
+++ b/fuzz/fuzz_targets/module_surface.rs
@@ -1,0 +1,173 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use perl_module::{
+    apply_module_rename_edits, contains_module_token, contains_standalone_module_token,
+    extract_module_reference, extract_module_reference_extended, extract_require_import_symbols,
+    file_path_to_module_name, find_module_reference, find_module_reference_extended,
+    find_standalone_module_token_ranges, legacy_package_separator, line_references_isa_assignment,
+    line_references_module_import, line_references_package_declaration,
+    line_references_qualified_call, module_name_to_path, module_path_to_name, module_variant_pairs,
+    normalize_package_separator, parse_module_import_head, parse_module_token,
+    plan_module_rename_edits, replace_module_name_prefix, replace_module_token,
+    resolve_known_export_tag,
+};
+
+const MAX_INPUT_BYTES: usize = 1536;
+const MAX_SNIPPET_CHARS: usize = 160;
+const MAX_MODULE_CHARS: usize = 64;
+const MAX_CURSOR_CHECKS: usize = 96;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    let capped = if data.len() <= MAX_INPUT_BYTES { data } else { &data[..MAX_INPUT_BYTES] };
+    String::from_utf8_lossy(capped)
+}
+
+fn truncate_chars(input: &str, max_chars: usize) -> String {
+    input.chars().take(max_chars).collect()
+}
+
+fn module_name_from(input: &str, fallback: &str) -> String {
+    let mut out = String::new();
+    let mut previous_was_sep = false;
+
+    for ch in input.chars() {
+        let candidate = if ch.is_ascii_alphanumeric() || ch == '_' {
+            Some(ch)
+        } else if matches!(ch, ':' | '/' | '\\' | '-' | '.') {
+            Some(':')
+        } else {
+            None
+        };
+
+        let Some(candidate) = candidate else { continue };
+
+        if candidate == ':' {
+            if out.is_empty() || previous_was_sep {
+                continue;
+            }
+            out.push_str("::");
+            previous_was_sep = true;
+        } else {
+            out.push(candidate);
+            previous_was_sep = false;
+        }
+
+        if out.len() >= MAX_MODULE_CHARS {
+            break;
+        }
+    }
+
+    while out.ends_with(':') {
+        out.pop();
+    }
+
+    if out.is_empty() || out.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
+        fallback.to_string()
+    } else {
+        out
+    }
+}
+
+fn perl_single_quote(input: &str) -> String {
+    input.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+fn char_boundary_offsets(input: &str) -> impl Iterator<Item = usize> + '_ {
+    input.char_indices().map(|(offset, _)| offset).chain(std::iter::once(input.len()))
+}
+
+fn exercise_name_and_path(input: &str, module: &str, replacement: &str) {
+    let path = module_name_to_path(module);
+    let roundtrip_name = module_path_to_name(&path);
+    let file_name = file_path_to_module_name(&path);
+
+    let _ = normalize_package_separator(module);
+    let _ = legacy_package_separator(&roundtrip_name);
+    let _ = module_variant_pairs(module, replacement);
+    let _ = module_variant_pairs(&file_name, module);
+    let _ = module_path_to_name(input);
+    let _ = file_path_to_module_name(input);
+}
+
+fn exercise_token_surfaces(input: &str, module: &str, replacement: &str) {
+    let snippet = truncate_chars(input, MAX_SNIPPET_CHARS);
+    let line = format!("use {module}; package {module}; {module}->method(); # {snippet}");
+
+    let _ = contains_module_token(&line, module);
+    let _ = contains_standalone_module_token(&line, module);
+    let _ = line_references_module_import(&line, module);
+    let _ = line_references_package_declaration(&line, module);
+    let _ = line_references_qualified_call(&line, module);
+    let _ = line_references_isa_assignment(&format!("our @ISA = ('{module}');"), module);
+
+    let (replaced, changed) = replace_module_token(&line, module, replacement);
+    if changed {
+        let _ = contains_module_token(&replaced, replacement);
+    }
+
+    let _ = replace_module_name_prefix(&line, module, replacement);
+
+    for range in find_standalone_module_token_ranges(&line, module).take(16) {
+        let _ = &line[range.start..range.end];
+    }
+
+    for offset in char_boundary_offsets(&line).take(MAX_CURSOR_CHECKS) {
+        let _ = parse_module_token(&line, offset);
+    }
+}
+
+fn exercise_import_and_reference(input: &str, module: &str, replacement: &str) {
+    let snippet = truncate_chars(input, MAX_SNIPPET_CHARS);
+    let quoted = perl_single_quote(&snippet);
+    let source = format!(
+        "use {module};\nuse parent '{replacement}';\nuse base qw({module} {replacement});\nrequire {module};\nrequire '{quoted}.pm';\n{snippet}\n"
+    );
+
+    for line in source.lines() {
+        if let Some(head) = parse_module_import_head(line) {
+            let _ = head.kind.dispatch_semantics();
+            let _ = head.require_form();
+            let _ = head.import_list;
+        }
+    }
+
+    let _ = extract_require_import_symbols(&source);
+    let _ = resolve_known_export_tag(module, input);
+    let _ = resolve_known_export_tag("POSIX", input.trim_start_matches(':'));
+
+    for offset in char_boundary_offsets(&source).take(MAX_CURSOR_CHECKS) {
+        if let Some(reference) = find_module_reference(&source, offset) {
+            let _ = reference.canonical_module_name();
+        }
+        if let Some(reference) = find_module_reference_extended(&source, offset) {
+            let _ = reference.canonical_module_name();
+        }
+        let _ = extract_module_reference(&source, offset);
+        let _ = extract_module_reference_extended(&source, offset);
+    }
+}
+
+fn exercise_rename(input: &str, module: &str, replacement: &str) {
+    let snippet = truncate_chars(input, MAX_SNIPPET_CHARS);
+    let source = format!(
+        "package {module};\nuse {module};\nour @ISA = ('{module}');\n{module}->new();\n{snippet}\n"
+    );
+
+    let edits = plan_module_rename_edits(&source, module, replacement);
+    let renamed = apply_module_rename_edits(&source, &edits);
+    let _ = plan_module_rename_edits(&renamed, replacement, module);
+}
+
+fuzz_target!(|data: &[u8]| {
+    let input = bounded_utf8_lossy(data);
+    let source = input.as_ref();
+    let module = module_name_from(source, "Fuzz::Module");
+    let replacement =
+        module_name_from(&source.chars().rev().collect::<String>(), "Fuzz::Replacement");
+
+    exercise_name_and_path(source, &module, &replacement);
+    exercise_token_surfaces(source, &module, &replacement);
+    exercise_import_and_reference(source, &module, &replacement);
+    exercise_rename(source, &module, &replacement);
+});

--- a/justfile
+++ b/justfile
@@ -2185,6 +2185,7 @@ fuzz-regression duration='30':
     @just fuzz heredoc_parsing {{duration}} || true
     @just fuzz incremental_edit_sequences {{duration}} || true
     @just fuzz lsp_cancellation_registry {{duration}} || true
+    @just fuzz module_surface {{duration}} || true
     @just fuzz parser_integration {{duration}} || true
     @just fuzz quote_operators {{duration}} || true
     @just fuzz semantic_model {{duration}} || true


### PR DESCRIPTION
### Motivation
- Add targeted fuzz coverage for the module-resolution / import / rename surface which previously had no dedicated cargo-fuzz target.
- Make the fuzz manifest (`fuzz/Cargo.toml`) the single source of truth for active libFuzzer targets and update docs accordingly.

### Description
- Add a new cargo-fuzz target `module_surface` at `fuzz/fuzz_targets/module_surface.rs` that exercises module naming/path conversion, token detection/replacement, import/reference extraction, export-tag lookup, and rename planning/apply helpers.
- Wire `perl-module` into `fuzz/Cargo.toml` and register the new `[[bin]] name = "module_surface"` entry so `cargo check --manifest-path fuzz/Cargo.toml --bin module_surface` can build the target.
- Update documentation to treat `fuzz/Cargo.toml` as the source of truth for active fuzz targets and add `module_surface` to the representative target list in `docs/project/QUALITY_INFRASTRUCTURE.md` and `docs/project/PARSER_EVOLUTION.md`.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-fuzz-target cargo check --manifest-path fuzz/Cargo.toml --bin module_surface` which completed successfully.
- Ran `CARGO_TARGET_DIR=/tmp/perl-lsp-fuzz-target cargo clippy --manifest-path fuzz/Cargo.toml --bin module_surface -- -D warnings -A missing_docs` which completed successfully.
- Ran `./scripts/cargo-safe xtask fmt` and `./scripts/storage-doctor`, both completed successfully.
- Note: `cargo-fuzz` execution (`cargo fuzz run ...`) was not available in this environment so an actual libFuzzer run was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07fb3964dc8333b482c871815455a1)