### PR TITLE
fix(perl-dead-code): handle Perl false literal branches (#9334)

### DIFF
--- a/crates/perl-dead-code/src/dead_branches.rs
+++ b/crates/perl-dead-code/src/dead_branches.rs
@@ -82,8 +82,19 @@ pub(crate) fn detect_dead_branches(file_path: &Path, text: &str, out: &mut Vec<D
 
 fn is_always_false(condition: &str) -> bool {
     let c = condition.trim();
-    matches!(c, "0" | "\"\"" | "''" | "undef")
-        || (c.starts_with('(') && c.ends_with(')') && is_always_false(&c[1..c.len() - 1]))
+    if c == "undef" {
+        return true;
+    }
+    if quoted_literal(c).is_some_and(|inner| inner.is_empty() || inner == "0") {
+        return true;
+    }
+    if c.parse::<i64>().is_ok_and(|n| n == 0) {
+        return true;
+    }
+    if c.parse::<f64>().is_ok_and(|n| n == 0.0) {
+        return true;
+    }
+    c.starts_with('(') && c.ends_with(')') && is_always_false(&c[1..c.len() - 1])
 }
 
 fn is_always_true(condition: &str) -> bool {
@@ -94,13 +105,19 @@ fn is_always_true(condition: &str) -> bool {
     if c.parse::<f64>().is_ok_and(|n| n != 0.0) {
         return true;
     }
-    if (c.starts_with('"') && c.ends_with('"') || c.starts_with('\'') && c.ends_with('\''))
-        && c.len() > 2
-    {
-        let inner = &c[1..c.len() - 1];
-        return inner != "0";
+    if let Some(inner) = quoted_literal(c) {
+        return !inner.is_empty() && inner != "0";
     }
     c.starts_with('(') && c.ends_with(')') && is_always_true(&c[1..c.len() - 1])
+}
+
+fn quoted_literal(condition: &str) -> Option<&str> {
+    let is_quoted = condition.starts_with('"') && condition.ends_with('"')
+        || condition.starts_with("'") && condition.ends_with("'");
+    if is_quoted && condition.len() >= 2 {
+        return Some(&condition[1..condition.len() - 1]);
+    }
+    None
 }
 
 fn extract_balanced_parens(s: &str) -> Option<&str> {
@@ -151,6 +168,17 @@ mod tests {
     #[test]
     fn always_false_zero() {
         assert!(is_always_false("0"));
+    }
+
+    #[test]
+    fn always_false_decimal_zero() {
+        assert!(is_always_false("0.0"));
+    }
+
+    #[test]
+    fn always_false_quoted_zero() {
+        assert!(is_always_false("\"0\""));
+        assert!(is_always_false("'0'"));
     }
 
     #[test]
@@ -277,6 +305,11 @@ mod tests {
     fn always_true_string_zero_not_true() {
         // "0" inside quotes — inner is "0" so not always true
         assert!(!is_always_true("\"0\""));
+    }
+
+    #[test]
+    fn always_true_decimal_zero_not_true() {
+        assert!(!is_always_true("0.0"));
     }
 
     #[test]

--- a/crates/perl-dead-code/tests/dead_code_behavior_tests.rs
+++ b/crates/perl-dead-code/tests/dead_code_behavior_tests.rs
@@ -207,3 +207,53 @@ fn scenario_workspace_analysis_aggregates_unreachable_and_dead_branch() -> Resul
     assert!(analysis.dead_code.iter().any(|item| item.code_type == DeadCodeType::DeadBranch));
     Ok(())
 }
+
+#[test]
+fn scenario_falsey_numeric_and_string_literals_are_dead_branches() -> Result<(), String> {
+    // Given false literals that are easy to miss when normalizing Perl truthiness
+    let cases = [
+        ("scenario_if_decimal_zero.pl", "if (0.0) {\n    print 'dead';\n}\n"),
+        ("scenario_if_double_quoted_zero.pl", "if (\"0\") {\n    print 'dead';\n}\n"),
+        ("scenario_if_single_quoted_zero.pl", "if ('0') {\n    print 'dead';\n}\n"),
+    ];
+
+    // Then each literal is classified as an always-false branch condition
+    for (source_name, source) in cases {
+        assert_has_dead_branch(source_name, source)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn scenario_unless_falsey_literals_are_not_dead_branches() -> Result<(), String> {
+    // Given unless blocks whose falsey conditions make the body reachable
+    let cases = [
+        ("scenario_unless_decimal_zero.pl", "unless (0.0) {\n    print 'live';\n}\n"),
+        ("scenario_unless_double_quoted_zero.pl", "unless (\"0\") {\n    print 'live';\n}\n"),
+        ("scenario_unless_single_quoted_zero.pl", "unless ('0') {\n    print 'live';\n}\n"),
+    ];
+
+    // Then none of those reachable unless bodies are reported as dead branches
+    for (source_name, source) in cases {
+        assert_no_dead_branch(source_name, source)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn scenario_dead_branch_accepts_open_brace_on_next_line() -> Result<(), String> {
+    // Given a style where the opening brace starts the following line
+    let detector = detector_with_single_file(
+        "file:///scenario_next_line_brace.pl",
+        "if (0)\n{\n    print 'dead';\n}\nprint 'live';\n",
+    )?;
+
+    // When dead-code analysis runs on that file
+    let dead_code = detect_for_path(&detector, "/scenario_next_line_brace.pl")?;
+
+    // Then the whole block is still reported as a dead branch
+    assert!(dead_code.iter().any(|item| {
+        item.code_type == DeadCodeType::DeadBranch && item.start_line == 1 && item.end_line == 4
+    }));
+    Ok(())
+}


### PR DESCRIPTION
Problem: dead-branch detection missed Perl false literal forms such as numeric zero floats and quoted zero strings. Fix: normalize literal truthiness through a small quoted-literal helper, add unit coverage, and add behavior tests for falsey literals, reachable unless falsey branches, and next-line opening braces. Verification: cargo-safe perl-dead-code test/check/clippy, cargo-safe xtask fmt, git diff --check, and storage-doctor pass.