### PR TITLE
chore(devex): route recipes through cargo-safe (#0000)

### DIFF
--- a/justfile
+++ b/justfile
@@ -440,7 +440,7 @@ doctor-env:
     @echo "=============================================="
     @echo "  perl-lsp developer environment doctor"
     @echo "=============================================="
-    @cargo xtask devex-doctor
+    @{{cargo_safe}} xtask devex-doctor
 
 # Short alias for the developer environment quick check
 devex: doctor-env
@@ -804,7 +804,7 @@ devex-targeted base='' mode='all':
         exit 1
     fi
     echo "Running targeted checks (base=$base, mode={{mode}})..."
-    cargo xtask targeted-checks --base "$base" --mode "{{mode}}"
+    {{cargo_safe}} xtask targeted-checks --base "$base" --mode "{{mode}}"
 
 # Show recent upstream commits using an auto-detected base ref.
 # Helpful in detached or minimal-clone environments where origin/master may not exist.


### PR DESCRIPTION
### Motivation
- Ensure developer-facing `just` recipes use the repo-safe build/cache routing (`scripts/cargo-safe`) so developer checks do not bypass the bounded devplane cache/target settings.

### Description
- Route `doctor-env`/`devex` and `devex-targeted` recipes to invoke `{{cargo_safe}} xtask ...` instead of calling `cargo xtask` directly in `justfile`.

### Testing
- Ran `./scripts/cargo-safe xtask devex-doctor` which completed successfully.
- Ran `./scripts/cargo-safe xtask targeted-checks --base HEAD --mode all` which completed successfully.
- Ran `./scripts/cargo-safe xtask fmt` and `git diff --check`, both succeeded.
- `just devex` was not executed because `just` is not installed in the test container (observed and noted during verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a083e0771e48333bb8d7f6ad32415e6)