### PR TITLE
fix(cli): reject invalid check-project paths (#4194)

### DIFF
--- a/crates/perl-lsp-rs/src/cli.rs
+++ b/crates/perl-lsp-rs/src/cli.rs
@@ -226,8 +226,25 @@ struct FileError {
 }
 
 fn run_check_project(dir: &str) -> i32 {
+    let root = Path::new(dir);
+    let metadata = match root.metadata() {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!("{dir}: directory not found");
+            return 1;
+        }
+        Err(error) => {
+            eprintln!("{dir}: cannot access directory: {error}");
+            return 1;
+        }
+    };
+    if !metadata.is_dir() {
+        eprintln!("{dir}: not a directory");
+        return 1;
+    }
+
     let extensions: &[&str] = &["pm", "pl", "t"];
-    let walker = walkdir::WalkDir::new(dir).follow_links(true).into_iter();
+    let walker = walkdir::WalkDir::new(root).follow_links(true).into_iter();
 
     let mut total = 0usize;
     let mut clean = 0usize;

--- a/crates/perl-lsp-rs/tests/cli_smoke.rs
+++ b/crates/perl-lsp-rs/tests/cli_smoke.rs
@@ -114,6 +114,37 @@ fn perlcritic_compat_report_prints_native_mapping() -> Result<(), Box<dyn std::e
 }
 
 #[test]
+fn check_project_missing_dir_errors() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let missing = dir.path().join("missing-project");
+    let missing_str = missing.to_str().ok_or("non-UTF-8 temp path")?;
+
+    let mut cmd = cargo_bin_cmd!("perl-lsp");
+    cmd.args(["--check-project", missing_str])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("directory not found"));
+
+    Ok(())
+}
+
+#[test]
+fn check_project_file_path_errors() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let file = dir.path().join("not-a-directory.pl");
+    std::fs::write(&file, "use strict;\n")?;
+    let file_str = file.to_str().ok_or("non-UTF-8 temp path")?;
+
+    let mut cmd = cargo_bin_cmd!("perl-lsp");
+    cmd.args(["--check-project", file_str])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("not a directory"));
+
+    Ok(())
+}
+
+#[test]
 fn completion_fish_produces_output() {
     let mut cmd = cargo_bin_cmd!("perl-lsp");
     cmd.args(["--completion", "fish"])


### PR DESCRIPTION
### Motivation

- `--check-project` silently treated a missing path or a file path as an empty project, producing an unhelpful successful report; users need actionable errors when the provided path is invalid.

### Description

- Validate the `--check-project` argument early in `run_check_project` by checking `Path::new(dir).exists()` and `is_dir()`, and emit clear stderr messages and non-zero exit codes for missing or non-directory paths.
- Pass the validated `root` `Path` into `walkdir::WalkDir::new(...)` instead of the raw string to avoid walking an invalid target.
- Add two CLI smoke tests (`cli_smoke.rs`) that assert `--check-project` fails with an actionable message when the path is missing or when a file path is supplied.

### Testing

- Ran `./scripts/cargo-safe xtask fmt` and it passed.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-rs --test cli_smoke --profile agent --locked` and the updated smoke tests passed (`17 passed; 0 failed`).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs` and it passed (no new clippy warnings introduced).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` and it passed; pre-existing unrelated warnings remain in other test modules.
- Ran `./scripts/storage-doctor` to verify storage constraints and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08161a97e8833389dd76cf17585623)