### PR TITLE
test(perl-dap): cover non-notfound spawn errors (#8197)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -1948,4 +1948,24 @@ mod tests {
             "expected perl-lsp.perl.path guidance, got: {message}"
         );
     }
+
+    #[test]
+    fn format_perl_spawn_error_preserves_non_not_found_error_detail() {
+        let error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied");
+        let message = format_perl_spawn_error("/secure/perl", &error);
+
+        assert!(message.contains("/secure/perl"), "expected interpreter path, got: {message}");
+        assert!(
+            message.contains("permission denied"),
+            "expected original error detail, got: {message}"
+        );
+        assert!(
+            message.contains("file permissions"),
+            "expected permission remediation guidance, got: {message}"
+        );
+        assert!(
+            !message.contains("Install Perl"),
+            "non-NotFound errors should not use missing-perl guidance, got: {message}"
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure `format_perl_spawn_error` preserves original OS error details and provides appropriate remediation for non-`NotFound` spawn failures (e.g., `PermissionDenied`) instead of showing missing-Perl guidance.

### Description
- Add a unit test `format_perl_spawn_error_preserves_non_not_found_error_detail` in `crates/perl-dap/src/debug_adapter/process.rs` that asserts the message contains the interpreter path, the original OS error text, permission remediation guidance, and does not contain missing-Perl install guidance.

### Testing
- Ran `./scripts/cargo-safe xtask fmt` which completed successfully.
- Ran the new unit test with `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-dap format_perl_spawn_error_preserves_non_not_found_error_detail --profile agent --locked` which passed.
- Ran `MIN_FREE_GB=15 ./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` which passed.
- Ran `MIN_FREE_GB=15 ./scripts/cargo-safe clippy -p perl-dap --profile agent --locked -- -D warnings -A missing_docs` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07fb51d378833384c920b880d78f09)