### PR TITLE
test(fuzz): cover semantic model fuzzing (#0000)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -105,6 +105,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "semantic_model"
+path = "fuzz_targets/semantic_model.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "incremental_edit_sequences"
 path = "fuzz_targets/incremental_edit_sequences.rs"
 test = false

--- a/fuzz/corpus/semantic_model/basic_symbols.pl
+++ b/fuzz/corpus/semantic_model/basic_symbols.pl
@@ -1,0 +1,6 @@
+package Fuzz::Basic;
+use strict;
+use warnings;
+my $value = 42;
+sub add { my ($left, $right) = @_; return $left + $right + $value; }
+add(1, 2);

--- a/fuzz/corpus/semantic_model/exporter_metadata.pl
+++ b/fuzz/corpus/semantic_model/exporter_metadata.pl
@@ -1,0 +1,6 @@
+package Fuzz::Exporter;
+use Exporter 'import';
+our @EXPORT = qw(default_func);
+our @EXPORT_OK = qw(optional_func);
+sub default_func { return 'default' }
+sub optional_func { return 'optional' }

--- a/fuzz/corpus/semantic_model/inheritance_and_methods.pl
+++ b/fuzz/corpus/semantic_model/inheritance_and_methods.pl
@@ -1,0 +1,6 @@
+package Fuzz::Parent;
+sub new { bless {}, shift }
+sub parent_method { return 1 }
+package Fuzz::Child;
+our @ISA = qw(Fuzz::Parent);
+sub child_method { my $self = shift; return $self->parent_method; }

--- a/fuzz/fuzz_targets/declaration_parsing.rs
+++ b/fuzz/fuzz_targets/declaration_parsing.rs
@@ -10,11 +10,7 @@ fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
         return std::borrow::Cow::Borrowed("");
     }
 
-    let capped = if data.len() <= MAX_INPUT_BYTES {
-        data
-    } else {
-        &data[..MAX_INPUT_BYTES]
-    };
+    let capped = if data.len() <= MAX_INPUT_BYTES { data } else { &data[..MAX_INPUT_BYTES] };
 
     String::from_utf8_lossy(capped)
 }
@@ -37,8 +33,8 @@ fuzz_target!(|data: &[u8]| {
         format!("require {short};"),
         format!("use {short} qw({short});"),
         format!("no {short} qw({short});"),
-        format!("use {short} ({short}, \\\${short}, \%{short});"),
-        format!("no {short} ({short}, \\\@{short}, \&{short});"),
+        format!(r"use {short} ({short}, \${short}, \%{short});"),
+        format!(r"no {short} ({short}, \@{short}, \&{short});"),
         format!("use {short} '{{{short}}}', \"{escaped_double}\", '{escaped_single}';"),
         format!("use if {short}, {short}, qw({short});"),
         format!("use lib '{escaped_single}', \"{escaped_double}\";"),

--- a/fuzz/fuzz_targets/semantic_model.rs
+++ b/fuzz/fuzz_targets/semantic_model.rs
@@ -1,0 +1,81 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use perl_parser::{Parser, SemanticModel, SourceLocation};
+
+const MAX_INPUT_BYTES: usize = 2048;
+const MAX_QUERY_POSITIONS: usize = 64;
+const MAX_SNIPPET_CHARS: usize = 256;
+
+fn bounded_utf8_lossy(data: &[u8]) -> std::borrow::Cow<'_, str> {
+    if data.is_empty() {
+        return std::borrow::Cow::Borrowed("");
+    }
+
+    let capped = if data.len() <= MAX_INPUT_BYTES { data } else { &data[..MAX_INPUT_BYTES] };
+
+    String::from_utf8_lossy(capped)
+}
+
+fn safe_snippet(input: &str) -> String {
+    input.chars().take(MAX_SNIPPET_CHARS).filter(|ch| *ch != '\0').collect()
+}
+
+fn query_model(model: &SemanticModel, source: &str) {
+    let symbol_table = model.symbol_table();
+
+    let mut positions = source
+        .char_indices()
+        .map(|(offset, _)| offset)
+        .take(MAX_QUERY_POSITIONS)
+        .collect::<Vec<_>>();
+    positions.push(source.len());
+
+    for position in positions {
+        let location = SourceLocation { start: position, end: position };
+        let _ = model.hover_info_at(location);
+        let _ = model.definition_at(position);
+
+        for symbols in symbol_table.symbols.values() {
+            for symbol in symbols.iter().take(4) {
+                let _ = symbol_table.find_references(symbol);
+            }
+        }
+    }
+
+    for name in symbol_table.symbols.keys().take(16) {
+        let _ = model.resolve_inherited_method_location(name, "new");
+        let _ = model.resolve_inherited_method_location(name, "BUILD");
+        let _ = model.parent_chain(name);
+    }
+
+    let _ = model.tokens();
+    let _ = model.export_metadata();
+    let _ = model.package_edges();
+    let _ = model.generated_members();
+}
+
+fn parse_and_query(source: &str) {
+    let mut parser = Parser::new(source);
+    let Ok(ast) = parser.parse() else { return };
+
+    let model = SemanticModel::build(&ast, source);
+    query_model(&model, source);
+}
+
+fuzz_target!(|data: &[u8]| {
+    let input = bounded_utf8_lossy(data);
+    let snippet = safe_snippet(&input);
+
+    let variants = [
+        snippet.clone(),
+        format!("package Fuzz::Pkg;\nuse strict;\nuse warnings;\nmy $value = q{{{snippet}}};\n$value;\n"),
+        format!("package Parent; sub new {{ bless {{}}, shift }}\npackage Child; our @ISA = qw(Parent); sub method {{ my ($self) = @_; return $self->new({snippet}); }}\n"),
+        format!("package RoleUser;\nuse Moo;\nhas field => (is => 'rw');\nsub run {{ my $self = shift; return $self->field({snippet}); }}\n"),
+        format!("use Exporter 'import';\nour @EXPORT_OK = qw(fuzzed);\nsub fuzzed {{ return q{{{snippet}}}; }}\n"),
+    ];
+
+    for source in &variants {
+        parse_and_query(source);
+    }
+});

--- a/justfile
+++ b/justfile
@@ -378,6 +378,7 @@ fuzz-bounded:
     @cargo +nightly fuzz run lsp_navigation -- -max_total_time=60 || echo "  LSP navigation fuzzing complete"
     @cargo +nightly fuzz run parser_integration -- -max_total_time=60 || echo "  Parser integration fuzzing complete"
     @cargo +nightly fuzz run quote_operators -- -max_total_time=60 || echo "  Quote operators fuzzing complete"
+    @cargo +nightly fuzz run semantic_model -- -max_total_time=60 || echo "  Semantic model fuzzing complete"
     @cargo +nightly fuzz run symbol_query_ranking -- -max_total_time=60 || echo "  Symbol query ranking fuzzing complete"
     @cargo +nightly fuzz run substitution_parsing -- -max_total_time=60 || echo "  Substitution fuzzing complete"
     @cargo +nightly fuzz run utf16_roundtrip -- -max_total_time=60 || echo "  UTF-16 roundtrip fuzzing complete"
@@ -2203,6 +2204,7 @@ fuzz-regression duration='30':
     @just fuzz lsp_cancellation_registry {{duration}} || true
     @just fuzz parser_integration {{duration}} || true
     @just fuzz quote_operators {{duration}} || true
+    @just fuzz semantic_model {{duration}} || true
     @just fuzz symbol_query_ranking {{duration}} || true
     @just fuzz substitution_parsing {{duration}} || true
     @just fuzz lsp_navigation {{duration}} || true


### PR DESCRIPTION
Problem: The semantic model surface had deterministic tests, but no bounded fuzz target that builds `SemanticModel` and exercises its query APIs.
Fix: Add a `semantic_model` cargo-fuzz target with seed corpus entries, register it in fuzz recipes, and keep declaration parsing snippets compilable with raw-string escaping.
Verification: `git diff --check origin/master..HEAD` passes; `rustfmt --check fuzz/fuzz_targets/semantic_model.rs fuzz/fuzz_targets/declaration_parsing.rs` passes; `./scripts/cargo-safe check --manifest-path fuzz/Cargo.toml --locked` passes; `cargo +nightly fuzz list` includes `semantic_model`; `cargo +nightly fuzz build semantic_model` and `cargo +nightly fuzz build declaration_parsing` pass. Local `cargo +nightly fuzz run semantic_model -- -max_total_time=1` built the target but could not execute on this Windows host due `STATUS_DLL_NOT_FOUND`; the same runtime failure reproduces on existing `declaration_parsing`, so this appears to be a local cargo-fuzz runtime seam rather than a new-target crash.