### PR TITLE
refactor(code-actions): split provider routing modules (#8197)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -65,23 +65,12 @@
 //! # }
 //! ```
 
-use super::modernize;
-use super::quick_fixes;
-use super::refactors;
-use super::types::QuickFixDiagnostic;
+use super::{diagnostic_routes, source_actions};
 
 pub use super::types::{CodeAction, CodeActionKind};
 
 use crate::providers::diagnostics::Diagnostic;
-use perl_diagnostics::codes::DiagnosticCode;
 use perl_parser_core::Node;
-
-/// Convert Diagnostic to QuickFixDiagnostic
-///
-/// Since Diagnostic already uses byte offsets, this is a simple copy.
-fn to_quick_fix_diagnostic(diag: &Diagnostic) -> QuickFixDiagnostic {
-    QuickFixDiagnostic { range: diag.range, message: diag.message.clone(), code: diag.code.clone() }
-}
 
 /// Code actions provider
 ///
@@ -104,200 +93,11 @@ impl CodeActionsProvider {
         range: (usize, usize),
         diagnostics: &[Diagnostic],
     ) -> Vec<CodeAction> {
-        let mut actions = Vec::new();
+        let mut actions = diagnostic_routes::quick_fixes_for_diagnostics(&self.source, diagnostics);
 
-        // Get quick fixes for diagnostics
-        for diagnostic in diagnostics {
-            let qf_diag = to_quick_fix_diagnostic(diagnostic);
-            if let Some(code) = &diagnostic.code {
-                let policy_code =
-                    code.strip_prefix("Perl::Critic::Policy::").unwrap_or(code.as_str());
-
-                match policy_code {
-                    // PL103: Undefined/undeclared variable
-                    c if c == DiagnosticCode::UndefinedVariable.as_str() => {
-                        actions.extend(quick_fixes::fix_undefined_variable(&self.source, &qf_diag));
-                    }
-                    // PL102: Unused variable
-                    c if c == DiagnosticCode::UnusedVariable.as_str() => {
-                        actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
-                    }
-                    "native.variables.unused_lexical" => {
-                        actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
-                    }
-                    // PL403: Assignment in condition
-                    c if c == DiagnosticCode::AssignmentInCondition.as_str()
-                        || c == "native.common.assignment_in_condition" =>
-                    {
-                        actions.extend(quick_fixes::fix_assignment_in_condition(
-                            &self.source,
-                            &qf_diag,
-                        ));
-                    }
-                    // PL100: Missing use strict
-                    c if c == DiagnosticCode::MissingStrict.as_str() => {
-                        actions.extend(quick_fixes::add_use_strict());
-                    }
-                    // PL101: Missing use warnings
-                    c if c == DiagnosticCode::MissingWarnings.as_str() => {
-                        actions.extend(quick_fixes::add_use_warnings());
-                    }
-                    // PL502: Phase-scoped use strict misconception
-                    c if c == DiagnosticCode::PhaseScopedStrictPragma.as_str() => {
-                        actions.extend(quick_fixes::move_use_strict_to_file_scope(
-                            &self.source,
-                            &qf_diag,
-                        ));
-                    }
-                    // PL503: Phase-scoped use warnings misconception
-                    c if c == DiagnosticCode::PhaseScopedWarningsPragma.as_str() => {
-                        actions.extend(quick_fixes::move_use_warnings_to_file_scope(
-                            &self.source,
-                            &qf_diag,
-                        ));
-                    }
-                    // PL500: Deprecated defined()
-                    c if c == DiagnosticCode::DeprecatedDefined.as_str()
-                        || c == "native.common.deprecated_defined" =>
-                    {
-                        actions.extend(quick_fixes::fix_deprecated_defined(&self.source, &qf_diag));
-                    }
-                    // PL404: Numeric comparison with undef
-                    "native.common.undef_comparison" => {
-                        actions.extend(quick_fixes::fix_native_undef_comparison(
-                            &self.source,
-                            &qf_diag,
-                        ));
-                    }
-                    c if c == DiagnosticCode::NumericComparisonWithUndef.as_str() => {
-                        actions.extend(quick_fixes::fix_numeric_undef(&self.source, &qf_diag));
-                    }
-                    // PL109: Unquoted bareword
-                    c if c == DiagnosticCode::UnquotedBareword.as_str() => {
-                        actions.extend(quick_fixes::fix_bareword(&self.source, &qf_diag));
-                    }
-                    // PL001: General parse error (stable code)
-                    // PL002: Syntax error — same quick-fix routing as PL001
-                    c if c == DiagnosticCode::ParseError.as_str()
-                        || c == DiagnosticCode::SyntaxError.as_str() =>
-                    {
-                        actions.extend(quick_fixes::fix_parse_error(&self.source, &qf_diag, c));
-                    }
-                    // parse-error-* subcodes (legacy subtype codes from error classifier)
-                    c if c.starts_with("parse-error-") => {
-                        actions.extend(quick_fixes::fix_parse_error(&self.source, &qf_diag, c));
-                    }
-                    // PL108: Unused parameter
-                    c if c == DiagnosticCode::UnusedParameter.as_str()
-                        || c == "native.variables.unused_parameter" =>
-                    {
-                        actions.extend(quick_fixes::fix_unused_parameter(&qf_diag));
-                    }
-                    // PL107: Duplicate parameter
-                    c if c == DiagnosticCode::DuplicateParameter.as_str()
-                        || c == "native.variables.duplicate_parameter" =>
-                    {
-                        actions.extend(quick_fixes::fix_duplicate_parameter(&qf_diag));
-                    }
-                    // PL110: Parameter shadows outer/global variable
-                    c if c == DiagnosticCode::ParameterShadowsGlobal.as_str()
-                        || c == "native.variables.parameter_shadows_global" =>
-                    {
-                        actions.extend(quick_fixes::fix_parameter_shadowing(&qf_diag));
-                    }
-                    // PL104: Variable shadowing
-                    c if c == DiagnosticCode::VariableShadowing.as_str()
-                        || c == "native.variables.shadowed_lexical" =>
-                    {
-                        actions.extend(quick_fixes::fix_variable_shadowing(&qf_diag));
-                    }
-                    // PL400: Bareword filehandle
-                    c if c == DiagnosticCode::BarewordFilehandle.as_str()
-                        || c == "native.io.bareword_filehandle" =>
-                    {
-                        actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
-                    }
-                    // Perl::Critic policy alias for bareword filehandle.
-                    "InputOutput::ProhibitBarewordFileHandles" => {
-                        actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
-                    }
-                    // PL401: Two-arg open
-                    c if c == DiagnosticCode::TwoArgOpen.as_str()
-                        || c == "native.io.two_arg_open" =>
-                    {
-                        actions.extend(quick_fixes::fix_two_arg_open(&self.source, &qf_diag));
-                    }
-                    // Perl::Critic policy aliases for two-arg open.
-                    "InputOutput::ProhibitTwoArgOpen"
-                    | "InputOutput::RequireBriefOpen"
-                    | "InputOutput::RequireThreeArgOpen" => {
-                        actions.extend(quick_fixes::fix_two_arg_open(&self.source, &qf_diag));
-                    }
-                    // Perl::Critic/native critic policies for missing strict/warnings.
-                    "TestingAndDebugging::RequireUseStrict"
-                    | "native.testing.require_use_strict" => {
-                        actions.extend(quick_fixes::add_use_strict());
-                    }
-                    "TestingAndDebugging::RequireUseWarnings"
-                    | "native.testing.require_use_warnings" => {
-                        actions.extend(quick_fixes::add_use_warnings());
-                    }
-                    // Perl::Critic policy alias for unused variables.
-                    "Variables::ProhibitUnusedVariables" => {
-                        actions.extend(quick_fixes::fix_unused_variable(&self.source, &qf_diag));
-                    }
-                    // PL200: Missing package declaration
-                    c if c == DiagnosticCode::MissingPackageDeclaration.as_str() => {
-                        actions.extend(quick_fixes::fix_missing_package_declaration(&self.source));
-                    }
-                    // PL105: Variable redeclaration (duplicate my)
-                    c if c == DiagnosticCode::VariableRedeclaration.as_str()
-                        || c == "native.variables.duplicate_lexical" =>
-                    {
-                        actions.extend(quick_fixes::fix_variable_redeclaration(
-                            &self.source,
-                            &qf_diag,
-                        ));
-                    }
-                    // PL111: Misspelled pragma
-                    c if c == DiagnosticCode::MisspelledPragma.as_str() => {
-                        actions.extend(quick_fixes::fix_misspelled_pragma(&self.source, &qf_diag));
-                    }
-                    // PL406: Unreachable code
-                    c if c == DiagnosticCode::UnreachableCode.as_str()
-                        || c == "native.common.unreachable_code" =>
-                    {
-                        actions.extend(quick_fixes::fix_unreachable_code(&self.source, &qf_diag));
-                    }
-                    // PL300: Duplicate subroutine
-                    c if c == DiagnosticCode::DuplicateSubroutine.as_str() => {
-                        actions.extend(quick_fixes::fix_duplicate_subroutine(&qf_diag));
-                    }
-                    // PL301: Missing return statement
-                    c if c == DiagnosticCode::MissingReturn.as_str() => {
-                        actions.extend(quick_fixes::fix_missing_return(&self.source, &qf_diag));
-                    }
-                    // PL408: Duplicate hash key
-                    c if c == DiagnosticCode::DuplicateHashKey.as_str() => {
-                        actions
-                            .extend(quick_fixes::fix_duplicate_hash_keys(&self.source, &qf_diag));
-                    }
-                    _ => {}
-                }
-            }
-        }
-
-        // Source-level lints (not diagnostic-driven)
-        // Only suggest shebang fix when the range includes the first line
-        if range.0 == 0 || !self.source[..range.0].contains('\n') {
-            actions.extend(quick_fixes::fix_hardcoded_shebang(&self.source));
-        }
-
-        // Get refactoring actions for selection
-        actions.extend(refactors::get_refactoring_actions(&self.source, ast, range));
-
-        // Get modernization suggestions
-        actions.extend(modernize::get_modernize_actions(&self.source));
+        actions.extend(source_actions::get_source_actions(&self.source, range));
+        actions.extend(super::refactors::get_refactoring_actions(&self.source, ast, range));
+        actions.extend(super::modernize::get_modernize_actions(&self.source));
 
         actions
     }

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -1,0 +1,191 @@
+//! Diagnostic-code routing for code-action quick fixes.
+
+use super::quick_fixes;
+use super::types::{CodeAction, QuickFixDiagnostic};
+use crate::providers::diagnostics::Diagnostic;
+use perl_diagnostics::codes::DiagnosticCode;
+
+/// Convert Diagnostic to QuickFixDiagnostic.
+///
+/// Since Diagnostic already uses byte offsets, this is a simple copy.
+fn to_quick_fix_diagnostic(diag: &Diagnostic) -> QuickFixDiagnostic {
+    QuickFixDiagnostic { range: diag.range, message: diag.message.clone(), code: diag.code.clone() }
+}
+
+pub(super) fn quick_fixes_for_diagnostics(
+    source: &str,
+    diagnostics: &[Diagnostic],
+) -> Vec<CodeAction> {
+    let mut actions = Vec::new();
+
+    for diagnostic in diagnostics {
+        actions.extend(quick_fixes_for_diagnostic(source, diagnostic));
+    }
+
+    actions
+}
+
+fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<CodeAction> {
+    let mut actions = Vec::new();
+    let qf_diag = to_quick_fix_diagnostic(diagnostic);
+
+    let Some(code) = &diagnostic.code else {
+        return actions;
+    };
+
+    let policy_code = code.strip_prefix("Perl::Critic::Policy::").unwrap_or(code.as_str());
+
+    match policy_code {
+        // PL103: Undefined/undeclared variable
+        c if c == DiagnosticCode::UndefinedVariable.as_str() => {
+            actions.extend(quick_fixes::fix_undefined_variable(source, &qf_diag));
+        }
+        // PL102: Unused variable
+        c if c == DiagnosticCode::UnusedVariable.as_str() => {
+            actions.extend(quick_fixes::fix_unused_variable(source, &qf_diag));
+        }
+        "native.variables.unused_lexical" => {
+            actions.extend(quick_fixes::fix_unused_variable(source, &qf_diag));
+        }
+        // PL403: Assignment in condition
+        c if c == DiagnosticCode::AssignmentInCondition.as_str()
+            || c == "native.common.assignment_in_condition" =>
+        {
+            actions.extend(quick_fixes::fix_assignment_in_condition(source, &qf_diag));
+        }
+        // PL100: Missing use strict
+        c if c == DiagnosticCode::MissingStrict.as_str() => {
+            actions.extend(quick_fixes::add_use_strict());
+        }
+        // PL101: Missing use warnings
+        c if c == DiagnosticCode::MissingWarnings.as_str() => {
+            actions.extend(quick_fixes::add_use_warnings());
+        }
+        // PL502: Phase-scoped use strict misconception
+        c if c == DiagnosticCode::PhaseScopedStrictPragma.as_str() => {
+            actions.extend(quick_fixes::move_use_strict_to_file_scope(source, &qf_diag));
+        }
+        // PL503: Phase-scoped use warnings misconception
+        c if c == DiagnosticCode::PhaseScopedWarningsPragma.as_str() => {
+            actions.extend(quick_fixes::move_use_warnings_to_file_scope(source, &qf_diag));
+        }
+        // PL500: Deprecated defined()
+        c if c == DiagnosticCode::DeprecatedDefined.as_str()
+            || c == "native.common.deprecated_defined" =>
+        {
+            actions.extend(quick_fixes::fix_deprecated_defined(source, &qf_diag));
+        }
+        // PL404: Numeric comparison with undef
+        "native.common.undef_comparison" => {
+            actions.extend(quick_fixes::fix_native_undef_comparison(source, &qf_diag));
+        }
+        c if c == DiagnosticCode::NumericComparisonWithUndef.as_str() => {
+            actions.extend(quick_fixes::fix_numeric_undef(source, &qf_diag));
+        }
+        // PL109: Unquoted bareword
+        c if c == DiagnosticCode::UnquotedBareword.as_str() => {
+            actions.extend(quick_fixes::fix_bareword(source, &qf_diag));
+        }
+        // PL001: General parse error (stable code)
+        // PL002: Syntax error — same quick-fix routing as PL001
+        c if c == DiagnosticCode::ParseError.as_str()
+            || c == DiagnosticCode::SyntaxError.as_str() =>
+        {
+            actions.extend(quick_fixes::fix_parse_error(source, &qf_diag, c));
+        }
+        // parse-error-* subcodes (legacy subtype codes from error classifier)
+        c if c.starts_with("parse-error-") => {
+            actions.extend(quick_fixes::fix_parse_error(source, &qf_diag, c));
+        }
+        // PL108: Unused parameter
+        c if c == DiagnosticCode::UnusedParameter.as_str()
+            || c == "native.variables.unused_parameter" =>
+        {
+            actions.extend(quick_fixes::fix_unused_parameter(&qf_diag));
+        }
+        // PL107: Duplicate parameter
+        c if c == DiagnosticCode::DuplicateParameter.as_str()
+            || c == "native.variables.duplicate_parameter" =>
+        {
+            actions.extend(quick_fixes::fix_duplicate_parameter(&qf_diag));
+        }
+        // PL110: Parameter shadows outer/global variable
+        c if c == DiagnosticCode::ParameterShadowsGlobal.as_str()
+            || c == "native.variables.parameter_shadows_global" =>
+        {
+            actions.extend(quick_fixes::fix_parameter_shadowing(&qf_diag));
+        }
+        // PL104: Variable shadowing
+        c if c == DiagnosticCode::VariableShadowing.as_str()
+            || c == "native.variables.shadowed_lexical" =>
+        {
+            actions.extend(quick_fixes::fix_variable_shadowing(&qf_diag));
+        }
+        // PL400: Bareword filehandle
+        c if c == DiagnosticCode::BarewordFilehandle.as_str()
+            || c == "native.io.bareword_filehandle" =>
+        {
+            actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
+        }
+        // Perl::Critic policy alias for bareword filehandle.
+        "InputOutput::ProhibitBarewordFileHandles" => {
+            actions.extend(quick_fixes::fix_bareword_filehandle(&qf_diag));
+        }
+        // PL401: Two-arg open
+        c if c == DiagnosticCode::TwoArgOpen.as_str() || c == "native.io.two_arg_open" => {
+            actions.extend(quick_fixes::fix_two_arg_open(source, &qf_diag));
+        }
+        // Perl::Critic policy aliases for two-arg open.
+        "InputOutput::ProhibitTwoArgOpen"
+        | "InputOutput::RequireBriefOpen"
+        | "InputOutput::RequireThreeArgOpen" => {
+            actions.extend(quick_fixes::fix_two_arg_open(source, &qf_diag));
+        }
+        // Perl::Critic/native critic policies for missing strict/warnings.
+        "TestingAndDebugging::RequireUseStrict" | "native.testing.require_use_strict" => {
+            actions.extend(quick_fixes::add_use_strict());
+        }
+        "TestingAndDebugging::RequireUseWarnings" | "native.testing.require_use_warnings" => {
+            actions.extend(quick_fixes::add_use_warnings());
+        }
+        // Perl::Critic policy alias for unused variables.
+        "Variables::ProhibitUnusedVariables" => {
+            actions.extend(quick_fixes::fix_unused_variable(source, &qf_diag));
+        }
+        // PL200: Missing package declaration
+        c if c == DiagnosticCode::MissingPackageDeclaration.as_str() => {
+            actions.extend(quick_fixes::fix_missing_package_declaration(source));
+        }
+        // PL105: Variable redeclaration (duplicate my)
+        c if c == DiagnosticCode::VariableRedeclaration.as_str()
+            || c == "native.variables.duplicate_lexical" =>
+        {
+            actions.extend(quick_fixes::fix_variable_redeclaration(source, &qf_diag));
+        }
+        // PL111: Misspelled pragma
+        c if c == DiagnosticCode::MisspelledPragma.as_str() => {
+            actions.extend(quick_fixes::fix_misspelled_pragma(source, &qf_diag));
+        }
+        // PL406: Unreachable code
+        c if c == DiagnosticCode::UnreachableCode.as_str()
+            || c == "native.common.unreachable_code" =>
+        {
+            actions.extend(quick_fixes::fix_unreachable_code(source, &qf_diag));
+        }
+        // PL300: Duplicate subroutine
+        c if c == DiagnosticCode::DuplicateSubroutine.as_str() => {
+            actions.extend(quick_fixes::fix_duplicate_subroutine(&qf_diag));
+        }
+        // PL301: Missing return statement
+        c if c == DiagnosticCode::MissingReturn.as_str() => {
+            actions.extend(quick_fixes::fix_missing_return(source, &qf_diag));
+        }
+        // PL408: Duplicate hash key
+        c if c == DiagnosticCode::DuplicateHashKey.as_str() => {
+            actions.extend(quick_fixes::fix_duplicate_hash_keys(source, &qf_diag));
+        }
+        _ => {}
+    }
+
+    actions
+}

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/mod.rs
@@ -20,10 +20,12 @@
 
 #[allow(clippy::module_inception)]
 mod code_actions;
+mod diagnostic_routes;
 mod enhanced;
 mod modernize;
 mod quick_fixes;
 mod refactors;
+mod source_actions;
 mod types;
 
 pub use code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/source_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/source_actions.rs
@@ -1,0 +1,15 @@
+//! Whole-source code actions that are not tied to diagnostics or selections.
+
+use super::quick_fixes;
+use super::types::CodeAction;
+
+pub(super) fn get_source_actions(source: &str, range: (usize, usize)) -> Vec<CodeAction> {
+    let mut actions = Vec::new();
+
+    // Only suggest shebang fixes when the requested range includes the first line.
+    if range.0 == 0 || !source[..range.0].contains('\n') {
+        actions.extend(quick_fixes::fix_hardcoded_shebang(source));
+    }
+
+    actions
+}


### PR DESCRIPTION
## Summary

Refactor the `perl-lsp-rs-core` code-action provider into private routing modules while preserving runtime behavior.

classification: refactor
risk tier: provider/runtime refactor
public API unchanged: yes (`CodeActionsProvider`, `CodeAction`, and `CodeActionKind` re-exports are unchanged)
behavior unchanged: yes; diagnostic quick-fix routing, source-level shebang actions, refactors, and modernize actions are still invoked in the same order.
files moved: diagnostic quick-fix dispatch to `diagnostic_routes.rs`; whole-source shebang actions to `source_actions.rs`.
semantic risk: medium; code actions are user-visible, so focused code-action tests and touched-crate gates were rerun after rebase.
rollback: revert this PR; no data or API migration involved.

## Rebase Notes

Current master had added PL408 duplicate-hash-key quick fixes after this branch was created. The rebase preserves that behavior by routing PL408 through the new `diagnostic_routes` module, and the existing PL408 tests pass.

## Verification

- `MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe test -p perl-lsp-rs-core --lib providers::code_actions::code_actions::tests --profile agent --locked -- --nocapture` (37 passed)
- `MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe check --all-targets -p perl-lsp-rs-core --profile agent --locked`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe xtask fmt --check`
- `git diff --check`
- `./scripts/storage-doctor`

## Disposition

overlap checked: code-actions routing cluster; retained because it preserves current PL408 behavior and stays refactor-only.
current master already contains: PL408 duplicate hash key quick-fix routing and tests; preserved in this refactor.
retained branch: this PR, rebased and retitled to #8197.
close/merge rationale: merge if hosted checks pass; this satisfies PLSP-SPEC-0014 for a provider/runtime refactor with behavior proof.
follow-up: continue #9354 perl-token facade split next.