### PR TITLE
docs: expose source-of-truth stack (#0000)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,39 @@ Use this directory as the short docs front door. It tells you where to go next
 without making you learn the workspace layout first. For the full Diataxis-style
 map of the docs tree, use [INDEX.md](INDEX.md).
 
+## Source-of-Truth Stack for Long-Lived Work
+
+For durable lanes, use the existing `perl-lsp` source-of-truth chain instead
+of burying decisions inside one implementation plan:
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+| Layer | Owns | Storage |
+| --- | --- | --- |
+| Roadmap | release direction and active milestone | [project/ROADMAP.md](project/ROADMAP.md) |
+| Proposal / PRD | why the lane exists, user value, alternatives, claim boundary | [proposals/](proposals/) |
+| Spec | behavior contract, acceptance, proof, claim limits | [specs/](specs/) |
+| ADR | durable architecture or operating decision | [adr/](adr/) |
+| Implementation plan | PR-sized sequence, proof commands, rollback, handoff state | [../plans/](../plans/) |
+| Active goal manifest | machine-readable current agent state | [../.perl-lsp/goals/](../.perl-lsp/goals/) |
+| Status / support tiers | current truth and public claim proof | [project/status/](project/status/) |
+| Policy ledgers | CI, lint, file, and package exceptions or receipts | [`../policy/`](../policy/), [`../.ci/`](../.ci/) |
+| Closeout / handoff | what happened, what remains, and proof | [../plans/](../plans/) or [forensics/](forensics/) |
+
+Use [reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md) for artifact roles,
+ID naming, required headers, status-linking rules, active-goal expectations,
+and PR body guidance. The Real Perl Editor Trust lane is the current model for
+this stack: [proposals/README.md](proposals/README.md),
+[specs/README.md](specs/README.md), [adr/README.md](adr/README.md),
+[../plans/real-perl-editor-trust/README.md](../plans/real-perl-editor-trust/README.md),
+and [../.perl-lsp/goals/README.md](../.perl-lsp/goals/README.md).
+
+Do not copy generated status tables into proposals, specs, ADRs, plans, or goal
+manifests. Link to [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md),
+[project/status/](project/status/), and support-tier docs instead.
+
 ## Diataxis in This Repository
 
 When adding or moving docs, choose the content type first, then the file:

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,175 @@
+# perl-lsp Source-of-Truth and Specification System
+
+This guide defines how `perl-lsp` encodes long-lived work across proposals,
+specs, ADRs, implementation plans, active goals, status docs, and receipts. It
+is an authoring contract for maintainers and agents; it is not a generated
+status report.
+
+## The Stack
+
+Use this chain for durable lanes:
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+| Layer | Owns | Storage | Must not do |
+| --- | --- | --- | --- |
+| Roadmap | release direction and active milestone | `docs/project/ROADMAP.md` | Detailed PR sequencing or generated metrics |
+| Proposal / PRD | why the lane exists, user value, alternatives, success criteria, claim boundary | `docs/proposals/PLSP-PROP-*.md` | Behavior minutiae, proof command ownership, generated status state |
+| Spec | behavior contract, acceptance, proof requirements, status interpretation, claim limits | `docs/specs/PLSP-SPEC-*.md` | Product motivation, roadmap framing, active queue ownership |
+| ADR | durable architecture or operating decision | `docs/adr/PLSP-ADR-*.md` | Raw worklists, point-in-time metrics, temporary task tracking |
+| Implementation plan | PR-sized sequence, proof commands, rollback, handoff state | `plans/<lane>/implementation-plan.md` | Product claims, durable decisions, generated status content |
+| Active goal manifest | machine-readable current agent state | `.perl-lsp/goals/active.toml` | Prose-only strategy or duplicated generated truth |
+| Status / support tiers | current truth and public claim proof | `docs/project/status/*.md` | Roadmap promises or implementation-order decisions |
+| Policy ledgers | CI, lint, file, package, and exception receipts | `policy/*.toml`, `.ci/**` | Narrative rationale without an enforcing surface |
+| Closeout / handoff | what happened, what remains, proof, and deferred risks | `plans/<lane>/closeout.md` or `docs/forensics/` | New product scope or generated status rewrites |
+
+The Real Perl Editor Trust lane demonstrates this model through
+`docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md`, the matching
+`PLSP-SPEC-*` files, `PLSP-ADR-*` records, the
+`plans/real-perl-editor-trust/` plan, and `.perl-lsp/goals/active.toml`.
+
+## ID Naming
+
+Use stable `PLSP-*` identifiers for lane-specific source-of-truth artifacts:
+
+- Proposals: `PLSP-PROP-####-short-name.md`
+- Specs: `PLSP-SPEC-####-short-name.md`
+- ADRs: `PLSP-ADR-####-short-name.md`
+- Plans: `plans/<lane>/README.md` and `plans/<lane>/implementation-plan.md`
+- Active goal: `.perl-lsp/goals/active.toml`
+- Archived goals: `.perl-lsp/goals/archive/YYYY-MM-DD-<lane>.toml`
+
+Use the next available number in the relevant namespace. Do not guess issue
+numbers in filenames or PR titles; use `#0000` when the issue tracker is not
+available.
+
+## Required Headers
+
+Proposals should begin with:
+
+```md
+# PLSP-PROP-####: Title
+
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Support/status impact:
+Policy impact:
+```
+
+Specs should begin with:
+
+```md
+# PLSP-SPEC-####: Title
+
+Status:
+Owner:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Status impact:
+```
+
+ADRs should begin with the local ADR status fields used in `docs/adr/` and must
+include context, decision, considered options when relevant, and consequences.
+For `PLSP-ADR-*` files, link back to the proposal, specs, plan, and status
+surfaces affected by the decision.
+
+Plans should identify lane status, linked proposal, linked specs, linked ADRs,
+current work items, proof commands, rollback notes, and handoff or closeout
+state. Active goals should follow the TOML shape documented in
+`.perl-lsp/goals/README.md`.
+
+## When to Create Each Artifact
+
+Create a proposal when the work changes product direction, creates a new lane,
+or ties multiple subsystems to one user-facing outcome. The proposal answers
+"why this lane exists" and defines the claim boundary.
+
+Create a spec when future PRs need a durable behavior contract. The spec answers
+"what must be true" through acceptance criteria, proof requirements, valid and
+invalid PR shapes, and claim limits.
+
+Create an ADR when the project makes a durable architecture or operating
+decision. The ADR answers "which option did we choose and why" so future work
+can avoid re-litigating the decision.
+
+Create or update a plan when the lane needs reviewable PR sequencing, rollback
+notes, or handoff state. The plan answers "how do we land this safely" and
+should be broken into small work items.
+
+Update the active goal only when the operative lane or current machine-readable
+agent state changes. Archive the previous manifest when it is no longer the
+current lane instead of leaving stale active state in place.
+
+## Status and Generated Truth
+
+Generated and evidence-backed status docs are the current truth. Source-of-truth
+artifacts should link to them rather than copying their tables, counts, or
+support-tier matrices.
+
+Preferred status pointers include:
+
+- `docs/project/CURRENT_STATUS.md`
+- `docs/project/ROADMAP.md`
+- `docs/project/status/SUPPORT_TIERS.md`
+- `docs/project/status/provider_confidence_matrix.md`
+- `docs/project/status/semantic_scorecard.md`
+- `docs/project/status/semantic_shadow_compare.md`
+- `docs/project/status/ux_capability_dashboard.md`
+- `features.toml`
+- `policy/*.toml` and `.ci/**` enforcement receipts
+
+If a metric appears outside the generated or evidence-backed source, treat it as
+stale until reverified.
+
+## Active Goals
+
+`.perl-lsp/goals/active.toml` is for current execution state that agents can
+consume without chat history. It should contain the lane ID, objective, active
+work items, source-of-truth links, status pointers, and proof commands.
+
+Active goals are not planning essays. Keep strategy and rationale in proposals,
+specs, ADRs, and plans; keep machine-readable current state in the manifest.
+When a lane closes or another lane becomes operative, move the prior manifest to
+`.perl-lsp/goals/archive/` with a dated filename and write a new active manifest.
+
+## PR Bodies and Review Boundaries
+
+Keep documentation PRs focused on one artifact type or one source-of-truth
+system concern. Use the project PR body shape:
+
+```text
+Problem: <one sentence>
+Fix: <one sentence>
+Verification: `<command>` passes
+```
+
+For docs-only source-of-truth PRs, `git diff --check` is the minimum validation.
+Run existing docs or status checks when the changed files participate in those
+checks. Do not implement semantic behavior, type inference, provider changes, or
+status regeneration in a PR whose scope is only proposal/spec/ADR/plan cleanup.
+
+## Agent Consumption Rules
+
+Implementation agents should start with the narrowest artifact that matches the
+assigned work:
+
+1. Read the roadmap only for milestone framing.
+2. Read the proposal for user value, alternatives, and non-goals.
+3. Read the relevant specs for behavior, acceptance, proof, and claim limits.
+4. Read ADRs for durable architecture or operating constraints.
+5. Read the plan for the next PR-sized step, rollback, and handoff state.
+6. Read the active goal for current machine-readable execution state.
+7. Verify current metrics and receipts against status docs instead of trusting
+   copied numbers in narrative docs.
+
+Do not invent a new structure when an existing `PLSP-*` artifact should be
+extended or linked. Do not jam a new lane into an older proposal when the work
+has a distinct user outcome, semantic contract, or architecture decision.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,82 @@
+# Implementation Plans
+
+`plans/<lane>/` is where `perl-lsp` implementation plans live. Plans translate
+accepted proposals, specs, ADRs, generated receipts, and current status pointers
+into reviewable PR sequences.
+
+Plans are not specs. They do not own product motivation, durable architecture
+decisions, generated metric state, or public support claims.
+
+| Layer | Owns | Must not do |
+| --- | --- | --- |
+| Plan | PR order, work-item decomposition, proof commands, rollback notes, and handoff state | Product claims, durable decisions, behavior contracts, or generated status content |
+
+## Source-of-Truth Chain
+
+Long-lived work should remain connected through this stack:
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+Use:
+
+- [docs/project/ROADMAP.md](../docs/project/ROADMAP.md) for release direction
+  and active milestone framing.
+- [docs/proposals/](../docs/proposals/) for the user problem, alternatives,
+  success criteria, and claim boundary.
+- [docs/specs/](../docs/specs/) for behavior contracts, acceptance, proof, and
+  claim limits.
+- [docs/adr/](../docs/adr/) for durable architecture or operating decisions.
+- `plans/<lane>/implementation-plan.md` for PR-sized sequencing, rollback, and
+  handoff state.
+- [.perl-lsp/goals/](../.perl-lsp/goals/) for the machine-readable current
+  agent state.
+- [docs/project/status/](../docs/project/status/) for generated current truth
+  and public claim proof.
+
+For the reusable authoring contract, see
+[docs/reference/SPEC_SYSTEM.md](../docs/reference/SPEC_SYSTEM.md). For the lane
+pattern in use today, see
+[real-perl-editor-trust/README.md](real-perl-editor-trust/README.md).
+
+## Plan Shape
+
+Each lane should include a short `README.md` plus an `implementation-plan.md`.
+When a lane has closeout or handoff state that no longer belongs in the active
+plan, add `closeout.md` or link to a forensic note instead of editing generated
+status docs.
+
+Work items should include:
+
+```md
+## Work item: id
+
+Status:
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+Goal
+Production delta
+Non-goals
+Acceptance
+Proof commands
+Rollback
+```
+
+## Status Discipline
+
+Plans may summarize intent, but current facts must come from the generated or
+human-owned truth surfaces they link:
+
+- [docs/project/CURRENT_STATUS.md](../docs/project/CURRENT_STATUS.md)
+- [docs/project/ROADMAP.md](../docs/project/ROADMAP.md)
+- [docs/project/status/](../docs/project/status/)
+- policy ledgers under [policy/](../policy/) and enforcement receipts under
+  [.ci/](../.ci/)
+
+Do not copy generated tables, support-tier matrices, or point-in-time metrics
+into plan files.


### PR DESCRIPTION
### Motivation

- Make the existing proposal/spec/ADR/plan/active-goal stack discoverable from the repo-level docs so long-lived lanes are obvious rather than buried in a single plan. 
- Provide a reusable authoring contract for perl-lsp lanes so future proposals/specs/ADRs/plans follow a consistent `PLSP-*` pattern. 
- Establish a canonical place for implementation plans (`plans/<lane>/`) to reduce confusion when adding new lanes such as the planned Semantic Receiver Facts lane.

### Description

- Added a "Source-of-Truth Stack for Long-Lived Work" section to `docs/README.md` that documents the Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts flow. 
- Added `docs/reference/SPEC_SYSTEM.md`, a durable authoring guide that defines artifact roles, `PLSP-*` ID naming, required headers, active-goal rules, status-linking discipline, and agent consumption guidance. 
- Added a root `plans/README.md` describing `plans/<lane>/` intent, plan shape, proof/rollback discipline, and links to the spec system.

### Testing

- Ran `git diff --cached --check` which passed with no whitespace or check errors. 
- Attempted to run the docs path hygiene check with `cargo xtask ci-hygiene check-doc-paths docs`, which executed but failed due to pre-existing absolute-path references in archived/research docs unrelated to these changes. 
- `just ci-doc-paths` could not be executed in this environment because `just` is not available here, so that check was not run locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a13210428833390cad240e1cd9c21)