### PR TITLE
docs: expose perl-lsp source-of-truth stack (#0000)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,40 @@ Use this directory as the short docs front door. It tells you where to go next
 without making you learn the workspace layout first. For the full Diataxis-style
 map of the docs tree, use [INDEX.md](INDEX.md).
 
+## Long-Lived Source-of-Truth Stack
+
+For long-lived work, use this path through the repository:
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+This is the canonical source-of-truth system for `perl-lsp` lanes. It keeps
+product motivation, behavior contracts, architecture decisions, implementation
+sequencing, machine-readable agent state, and evidence-backed receipts in
+separate artifacts. The Real Perl Editor Trust lane is the current example of
+this pattern: its proposal, specs, ADRs, implementation plan, and active goal
+manifest are linked through the same chain future lanes should follow.
+
+| Layer | Owns | Storage |
+| --- | --- | --- |
+| Roadmap | Release direction and active milestone | [`project/ROADMAP.md`](project/ROADMAP.md) |
+| Proposal / PRD | Why the lane exists, user value, alternatives, and claim boundary | [`proposals/`](proposals/) |
+| Spec | Behavior contract, acceptance, proof, status interpretation, and claim limits | [`specs/`](specs/) |
+| ADR | Durable architecture or operating decision | [`adr/`](adr/) |
+| Implementation plan | PR-sized sequence, proof commands, rollback, and handoff state | [`../plans/`](../plans/) |
+| Active goal manifest | Machine-readable current agent state | [`../.perl-lsp/goals/`](../.perl-lsp/goals/) |
+| Status / support tiers | Current truth and claim proof | [`project/status/`](project/status/) |
+| Policy ledgers | CI, lint, file, package, and exception receipts | [`../policy/`](../policy/) and [`../.ci/`](../.ci/) |
+| Closeout / handoff | What happened, what remains, and proof | `../plans/<lane>/closeout.md` or [`forensics/`](forensics/) |
+
+Read [reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md) before creating a new
+proposal/spec/ADR/plan/goal lane. The artifact-specific entry points are
+[proposals/README.md](proposals/README.md), [specs/README.md](specs/README.md),
+[adr/README.md](adr/README.md), [../plans/README.md](../plans/README.md),
+[../plans/real-perl-editor-trust/README.md](../plans/real-perl-editor-trust/README.md),
+and [../.perl-lsp/goals/README.md](../.perl-lsp/goals/README.md).
+
 ## Diataxis in This Repository
 
 When adding or moving docs, choose the content type first, then the file:
@@ -47,6 +81,7 @@ Start here if you need to orient quickly before diving into a crate:
 | `crates/tree-sitter-perl-c/` | C tree-sitter grammar binding | Compatibility for tree-sitter consumers |
 | `crates/tree-sitter-perl-rs/` | Rust-native tree-sitter-style facade over v3 parser | Tree-sitter ergonomics on native parser stack |
 | `docs/project/` | Status, roadmap, process, governance docs | "What is true now?" and "what ships next?" |
+| `../plans/` | Lane implementation plans | PR sequence, proof commands, rollback, and handoff for long-lived work |
 | `docs/reference/` | Contract-style reference docs | Command/config/API behavior lookups |
 | `docs/how-to/`, `docs/tutorials/`, `docs/explanation/` | Task guides, walkthroughs, rationale | Learning and operational guidance |
 
@@ -65,6 +100,7 @@ For complete workspace membership and canonical crate/version truth, use [`../Ca
 | troubleshoot a broken setup | [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md) |
 | enforce public API docs coverage in CI | [reference/MISSING_DOCUMENTATION_GUIDE.md](reference/MISSING_DOCUMENTATION_GUIDE.md) |
 | learn API docs writing standards | [reference/API_DOCUMENTATION_STANDARDS.md](reference/API_DOCUMENTATION_STANDARDS.md) |
+| author a long-lived proposal/spec/ADR/plan lane | [reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md), [proposals/README.md](proposals/README.md), [specs/README.md](specs/README.md), [adr/README.md](adr/README.md), [../plans/README.md](../plans/README.md) |
 | choose the right Diátaxis doc type before writing | [reference/DOCUMENTATION_GUIDE.md](reference/DOCUMENTATION_GUIDE.md) |
 | tune performance or threading | [how-to/PERFORMANCE_TUNING.md](how-to/PERFORMANCE_TUNING.md), [how-to/THREADING_CONFIGURATION_GUIDE.md](how-to/THREADING_CONFIGURATION_GUIDE.md) |
 | work with DAP workflows | [tutorials/DAP_USER_GUIDE.md](tutorials/DAP_USER_GUIDE.md) |
@@ -84,7 +120,7 @@ For complete workspace membership and canonical crate/version truth, use [`../Ca
 
 - Tutorials: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md), [tutorials/LSP_DEVELOPMENT_GUIDE.md](tutorials/LSP_DEVELOPMENT_GUIDE.md), [tutorials/DAP_USER_GUIDE.md](tutorials/DAP_USER_GUIDE.md), [tutorials/COMPREHENSIVE_TESTING_GUIDE.md](tutorials/COMPREHENSIVE_TESTING_GUIDE.md)
 - How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/CONTINUOUS_TESTING.md](how-to/CONTINUOUS_TESTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md), [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md), [how-to/PERFORMANCE_TUNING.md](how-to/PERFORMANCE_TUNING.md), [how-to/THREADING_CONFIGURATION_GUIDE.md](how-to/THREADING_CONFIGURATION_GUIDE.md), [how-to/SECURITY_DEVELOPMENT_GUIDE.md](how-to/SECURITY_DEVELOPMENT_GUIDE.md)
-- Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md), [reference/ARCHITECTURE_OVERVIEW.md](reference/ARCHITECTURE_OVERVIEW.md), [reference/CRATE_ARCHITECTURE_GUIDE.md](reference/CRATE_ARCHITECTURE_GUIDE.md), [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md), [reference/MISSING_DOCUMENTATION_GUIDE.md](reference/MISSING_DOCUMENTATION_GUIDE.md), [reference/API_DOCUMENTATION_STANDARDS.md](reference/API_DOCUMENTATION_STANDARDS.md), [reference/DIATAXIS_GUIDE.md](reference/DIATAXIS_GUIDE.md), [reference/DOCUMENTATION_GUIDE.md](reference/DOCUMENTATION_GUIDE.md), [reference/FAQ.md](reference/FAQ.md)
+- Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md), [reference/ARCHITECTURE_OVERVIEW.md](reference/ARCHITECTURE_OVERVIEW.md), [reference/CRATE_ARCHITECTURE_GUIDE.md](reference/CRATE_ARCHITECTURE_GUIDE.md), [reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md), [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md), [reference/MISSING_DOCUMENTATION_GUIDE.md](reference/MISSING_DOCUMENTATION_GUIDE.md), [reference/API_DOCUMENTATION_STANDARDS.md](reference/API_DOCUMENTATION_STANDARDS.md), [reference/DIATAXIS_GUIDE.md](reference/DIATAXIS_GUIDE.md), [reference/DOCUMENTATION_GUIDE.md](reference/DOCUMENTATION_GUIDE.md), [reference/FAQ.md](reference/FAQ.md)
 - Project, specs, and explanations: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/COMPILER_BACKED_LSP_ROADMAP.md](project/COMPILER_BACKED_LSP_ROADMAP.md), [project/CI.md](project/CI.md), [project/FEATURE_GOVERNANCE.md](project/FEATURE_GOVERNANCE.md), [explanation/MEASURED_PERL_EDITOR_TRUST.md](explanation/MEASURED_PERL_EDITOR_TRUST.md), [explanation/LSP_DOCUMENTATION.md](explanation/LSP_DOCUMENTATION.md)
 
 ## Maintenance

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,220 @@
+# perl-lsp Source-of-Truth System
+
+This guide defines how `perl-lsp` authors and consumes long-lived work. It is a
+contract for source-of-truth artifacts, not a project status page. Use it when a
+change needs a lane that outlives one pull request or affects public claims,
+provider behavior, parser/semantic contracts, architecture, release direction, or
+agent handoff.
+
+The stack is:
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+Each layer has one job. Do not duplicate generated status tables, metric counts,
+or support-tier state across layers; link to the generated status surface instead.
+
+## Artifact Roles
+
+| Layer | Owns | Storage | Must not do |
+| --- | --- | --- | --- |
+| Roadmap | Release direction and active milestone | `docs/project/ROADMAP.md` | Replace lane proposals, specs, or plans |
+| Proposal / PRD | User problem, success criteria, alternatives, risks, and claim boundary | `docs/proposals/PLSP-PROP-*.md` | Define PR order or copy generated metrics |
+| Spec | Behavior contract, acceptance examples, proof requirements, status interpretation, and claim limits | `docs/specs/PLSP-SPEC-*.md` | Justify product motivation or sequence implementation PRs |
+| ADR | Durable architecture or operating decision with consequences | `docs/adr/PLSP-ADR-*.md` | Become a raw worklist or point-in-time metric report |
+| Implementation plan | PR-sized sequence, proof commands, rollback, dependencies, and handoff state | `plans/<lane>/implementation-plan.md` | Redefine behavior contracts or architecture decisions |
+| Active goal manifest | Machine-readable current lane state, active work items, pointers, and proof commands | `.perl-lsp/goals/active.toml` | Store prose-only strategy or generated status content |
+| Status / support tiers | Current truth and evidence-backed claim proof | `docs/project/status/*.md` | Carry durable design rationale or implementation sequencing |
+| Policy ledgers | CI, lint, file/package exceptions, and enforcement receipts | `policy/*.toml`, `.ci/**` | Replace specs or status docs |
+| Closeout / handoff | What happened, what remains, and proof | `plans/<lane>/closeout.md` or `docs/forensics/` | Reopen the lane's source-of-truth contracts |
+
+## ID Naming
+
+Use `PLSP-*` IDs for the lane source-of-truth stack:
+
+- Proposals: `PLSP-PROP-####-short-name.md`
+- Specs: `PLSP-SPEC-####-short-name.md`
+- ADRs: `PLSP-ADR-####-short-name.md`
+- Plan directories: `plans/<kebab-case-lane>/`
+- Active goal IDs: `plsp-<kebab-case-lane>` in `.perl-lsp/goals/active.toml`
+
+Choose the next available number within the artifact family. Do not guess issue
+numbers in titles or file names; use `#0000` in PR titles when the issue tracker
+is unavailable.
+
+## Required Headers
+
+New PLSP source-of-truth artifacts should start with enough metadata for agents
+and reviewers to route them without reading the full file.
+
+### Proposal header
+
+```md
+# PLSP-PROP-####: Title
+
+Status: Proposed | Accepted | Superseded | Completed
+Owner: lane or team name
+Created: YYYY-MM-DD
+Related specs:
+Related ADRs:
+Related plan:
+Current status:
+```
+
+A proposal must define why the lane exists, who benefits, success criteria,
+non-goals, alternatives considered, risks, and the claim boundary.
+
+### Spec header
+
+```md
+# PLSP-SPEC-####: Title
+
+Status: Proposed | Accepted | Superseded | Completed
+Proposal: docs/proposals/PLSP-PROP-####-short-name.md
+Related ADRs:
+Related plan:
+Status sources:
+```
+
+A spec must define the behavior contract, acceptance examples, proof commands or
+receipt requirements, fallback behavior, status interpretation, and what the
+spec does not claim.
+
+### ADR header
+
+```md
+# PLSP-ADR-####: Title
+
+Status: Proposed | Accepted | Superseded | Deprecated
+Date: YYYY-MM-DD
+Related proposal:
+Related specs:
+Related plan:
+```
+
+An ADR must capture context, decision, alternatives, consequences, and migration
+or compatibility notes when relevant.
+
+### Plan header
+
+```md
+# Lane Title Implementation Plan
+
+Status: Active | Planned | Completed | Deferred
+Proposal:
+Specs:
+ADRs:
+Active goal:
+Status sources:
+```
+
+A plan must break work into PR-sized units and include proof commands, rollback,
+and handoff state for each unit.
+
+## When to Create Which Artifact
+
+Create a proposal when the work needs product motivation, user value, success
+criteria, alternatives, or a claim boundary that should outlive a single PR.
+
+Create a spec when reviewers need a stable behavior contract: inputs, outputs,
+acceptance examples, proof requirements, fallback behavior, and limits on what
+`perl-lsp` may claim.
+
+Create an ADR when the work makes a durable architecture or operating decision
+that future maintainers should not rediscover through commit history.
+
+Create an implementation plan when the lane is too large for one PR and needs a
+sequenced path with proof commands and rollback notes.
+
+Create or update an active goal manifest only when the lane becomes the current
+machine-readable execution state for agents.
+
+## Linking Status Without Copying Truth
+
+Generated status docs and support-tier dashboards are the current truth for
+metrics and receipts. Source-of-truth artifacts should link to them instead of
+copying their tables.
+
+Preferred status surfaces include:
+
+- `docs/project/CURRENT_STATUS.md`
+- `docs/project/ROADMAP.md`
+- `docs/project/status/SUPPORT_TIERS.md`
+- `docs/project/status/provider_confidence_matrix.md`
+- `docs/project/status/semantic_scorecard.md`
+- `docs/project/status/semantic_shadow_compare.md`
+- `docs/project/status/ux_capability_dashboard.md`
+
+If a number, count, or support claim matters, verify it against its status source
+before citing it. Do not hand-edit generated status sections.
+
+## Active Goals
+
+`.perl-lsp/goals/active.toml` is the current machine-readable lane manifest. It
+should identify the active lane, objective, end state, current work items,
+source-of-truth links, status pointers, and proof commands.
+
+Archive an old manifest under `.perl-lsp/goals/archive/` when it is no longer the
+operative lane and historical state should be preserved. Do not change the active
+goal just because a proposal or spec was added; change it when execution state
+moves.
+
+## PR Body Structure
+
+For source-of-truth documentation PRs, keep the PR body short and evidence-based:
+
+```text
+Problem: <one sentence>
+Fix: <one sentence>
+Verification: `git diff --check` passes
+```
+
+Use a focused title with the repository title convention, for example:
+
+```text
+docs: expose perl-lsp source-of-truth stack (#0000)
+docs(proposal): add semantic receiver facts proposal (#0000)
+docs(spec): add receiver fact contract (#0000)
+docs(adr): require receiver facts before method completion cutover (#0000)
+```
+
+One semantic documentation artifact per PR keeps review scope clear. A PR that
+exposes the system may touch front-door/index docs together, but should not also
+add a new proposal, spec, ADR, plan, or active-goal change.
+
+## Agent Consumption Rules
+
+Codex, Claude, and other implementation agents should consume the stack in this
+order:
+
+1. Read `docs/project/ROADMAP.md` for release direction.
+2. Read the lane proposal for motivation, success criteria, alternatives, and
+   claim boundary.
+3. Read linked specs for behavior contracts, acceptance, proof, and fallback
+   boundaries.
+4. Read linked ADRs for durable decisions and constraints.
+5. Read `plans/<lane>/implementation-plan.md` for PR-sized sequence, rollback,
+   and handoff state.
+6. Read `.perl-lsp/goals/active.toml` only when current execution state matters.
+7. Verify current truth in `docs/project/status/*.md` and policy ledgers instead
+   of trusting copied metrics.
+8. Land one focused PR and report exact proof commands.
+
+Agents must not implement semantic/type-engine behavior while authoring proposal,
+spec, ADR, or source-of-truth-discovery PRs unless the assigned task explicitly
+asks for implementation.
+
+## Current Example
+
+The Real Perl Editor Trust lane demonstrates the pattern:
+
+- `docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md`
+- `docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md`
+- `docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md`
+- `docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md`
+- `docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md`
+- `docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md`
+- `docs/adr/PLSP-ADR-0002-confidence-before-cutover.md`
+- `plans/real-perl-editor-trust/implementation-plan.md`
+- `.perl-lsp/goals/active.toml`

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,79 @@
+# Implementation Plans
+
+`plans/<lane>/` is where implementation plans live. Plans translate proposals,
+specs, ADRs, and current receipts into a reviewable PR sequence that agents can
+execute without relying on chat history.
+
+Plans are not specs. Specs define behavior contracts, acceptance, proof, and
+claim boundaries. Plans define how to land those contracts: PR order, work-item
+scope, proof commands, rollback notes, and handoff state.
+
+## Source-of-Truth Position
+
+Long-lived work should move through the repository in this order:
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+The plan layer is responsible for connecting durable source-of-truth artifacts to
+short-lived implementation work. It should link to status docs and receipts, not
+copy generated metric tables or support-tier state.
+
+| Layer | Owns | Must not do |
+| --- | --- | --- |
+| Plan | PR order, work-item decomposition, proof commands, rollback notes, issue/PR handoff state | Product motivation, durable architecture decisions, generated metric content |
+
+## Lane Directory Shape
+
+Use one directory per lane:
+
+```text
+plans/<lane>/
+  README.md
+  implementation-plan.md
+  closeout.md          # optional, when the lane is completed or handed off
+```
+
+A lane `README.md` should state the lane scope and link to the proposal, specs,
+ADRs, status docs, and active goal manifest. `implementation-plan.md` should hold
+PR-sized work items with proof commands and rollback notes.
+
+## Work Item Shape
+
+Each implementation-plan work item should include:
+
+```md
+## Work item: short-id
+
+Status:
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+Goal
+Production delta
+Non-goals
+Acceptance
+Proof commands
+Rollback
+```
+
+## Current Lanes
+
+- [Real Perl Editor Trust](real-perl-editor-trust/) demonstrates the current
+  source-of-truth stack with linked proposal, specs, ADRs, plan, status receipts,
+  and active goal manifest.
+
+## Related Source-of-Truth Docs
+
+- [docs/README.md](../docs/README.md) — documentation front door and stack map
+- [docs/reference/SPEC_SYSTEM.md](../docs/reference/SPEC_SYSTEM.md) — reusable
+  proposal/spec/ADR/plan/goal operating guide
+- [docs/proposals/README.md](../docs/proposals/README.md) — proposal ownership
+- [docs/specs/README.md](../docs/specs/README.md) — spec ownership
+- [docs/adr/README.md](../docs/adr/README.md) — ADR ownership
+- [.perl-lsp/goals/README.md](../.perl-lsp/goals/README.md) — active goal
+  manifest contract


### PR DESCRIPTION
### Motivation

- The repository already encodes a proposal→spec→ADR→plan→active-goal lane (Real Perl Editor Trust) but the pattern was not discoverable from the docs front door. 
- Maintainability and agent consumption require a single, reusable guide describing how to author and consume long-lived lanes so future lanes follow the same conventions. 

### Description

- Added a new reusable operating guide `docs/reference/SPEC_SYSTEM.md` that defines the source-of-truth stack, artifact roles, `PLSP-*` ID naming, required headers, PR body conventions, and the agent consumption order. 
- Promoted the long-lived source-of-truth flow into the documentation front door by updating `docs/README.md` with the `Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts` map and links to artifact entry points. 
- Added a root `plans/README.md` to document the `plans/<lane>/` layout, work-item shape, and the plan layer responsibilities (PR sequencing, proof commands, rollback, and handoff). 
- The change touches only documentation: `docs/README.md` (updated), `docs/reference/SPEC_SYSTEM.md` (new), and `plans/README.md` (new). 

### Testing

- Ran `git diff --check` to validate whitespace and simple diff issues and it passed with no warnings. 
- Verified staged diff/stat and reviewed the resulting changes locally by inspecting the modified and added files. 
- Attempted to run the repository `just`-based doc/status checks but `just` is unavailable in this environment, so CI-style checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a13210428833390cad240e1cd9c21)