### PR TITLE
docs(source): expose source-of-truth stack (#0000)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,36 @@ Use this directory as the short docs front door. It tells you where to go next
 without making you learn the workspace layout first. For the full Diataxis-style
 map of the docs tree, use [INDEX.md](INDEX.md).
 
+
+## Source-of-Truth Stack for Long-Lived Work
+
+For long-lived work, use the repository source-of-truth stack instead of
+encoding the lane in chat history or a single local plan:
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+| Layer | Owns | Storage |
+| --- | --- | --- |
+| Roadmap | Release direction and active milestone | [project/ROADMAP.md](project/ROADMAP.md) |
+| Proposal / PRD | Why the lane exists, user value, alternatives, claim boundary | [proposals/](proposals/) |
+| Spec | Behavior contract, acceptance, proof requirements, claim limits | [specs/](specs/) |
+| ADR | Durable architecture or operating decision | [adr/](adr/) |
+| Implementation plan | PR-sized sequence, proof commands, rollback, handoff state | [../plans/](../plans/) |
+| Active goal manifest | Machine-readable current agent state | [../.perl-lsp/goals/](../.perl-lsp/goals/) |
+| Status / support tiers | Current truth and public claim proof | [project/status/](project/status/) |
+| Policy ledgers | CI, lint, file, and package exceptions with receipts | [`../policy/`](../policy/), [`../.ci/`](../.ci/) |
+| Closeout / handoff | What happened, what remains, and proof | [../plans/](../plans/), [forensics/](forensics/) |
+
+The Real Perl Editor Trust lane is the current worked example: its lane plan in
+[../plans/real-perl-editor-trust/](../plans/real-perl-editor-trust/) links
+`PLSP-PROP-0001`, `PLSP-SPEC-0001` through `PLSP-SPEC-0004`,
+`PLSP-ADR-0001`, `PLSP-ADR-0002`, generated status receipts, and the active
+goal manifest. New lanes should follow the same PLSP proposal/spec/ADR/plan/goal
+shape without copying generated status tables. See
+[reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md) for the authoring contract.
+
 ## Diataxis in This Repository
 
 When adding or moving docs, choose the content type first, then the file:
@@ -24,6 +54,9 @@ If a doc starts mixing multiple intents, split it and cross-link the parts.
 | Current release line | [`../Cargo.toml`](../Cargo.toml) | Workspace manifest |
 | Metrics and receipts | [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md) | `just status-update` and `just status-check` |
 | Roadmap and active milestone | [project/ROADMAP.md](project/ROADMAP.md) | Human review |
+| Long-lived lane contract | [reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md) | Proposal/spec/ADR/plan/goal links |
+| Implementation plans | [../plans/README.md](../plans/README.md) | PR sequencing and proof commands |
+| Active agent goal | [../.perl-lsp/goals/README.md](../.perl-lsp/goals/README.md) | Machine-readable manifest |
 | Capability catalog | [`../features.toml`](../features.toml) | `just ci-gate` |
 | Local validation flow | [project/CI_LOCAL_VALIDATION.md](project/CI_LOCAL_VALIDATION.md) | `just ci-gate` |
 
@@ -47,6 +80,9 @@ Start here if you need to orient quickly before diving into a crate:
 | `crates/tree-sitter-perl-c/` | C tree-sitter grammar binding | Compatibility for tree-sitter consumers |
 | `crates/tree-sitter-perl-rs/` | Rust-native tree-sitter-style facade over v3 parser | Tree-sitter ergonomics on native parser stack |
 | `docs/project/` | Status, roadmap, process, governance docs | "What is true now?" and "what ships next?" |
+| `docs/proposals/`, `docs/specs/`, `docs/adr/` | PLSP lane motivation, contracts, and durable decisions | Long-lived source-of-truth artifacts |
+| `plans/` | Lane implementation plans and closeout handoffs | PR order, proof commands, rollback, current handoff |
+| `.perl-lsp/goals/` | Active and archived machine-readable goal manifests | Current agent state and lane pointers |
 | `docs/reference/` | Contract-style reference docs | Command/config/API behavior lookups |
 | `docs/how-to/`, `docs/tutorials/`, `docs/explanation/` | Task guides, walkthroughs, rationale | Learning and operational guidance |
 
@@ -69,6 +105,7 @@ For complete workspace membership and canonical crate/version truth, use [`../Ca
 | tune performance or threading | [how-to/PERFORMANCE_TUNING.md](how-to/PERFORMANCE_TUNING.md), [how-to/THREADING_CONFIGURATION_GUIDE.md](how-to/THREADING_CONFIGURATION_GUIDE.md) |
 | work with DAP workflows | [tutorials/DAP_USER_GUIDE.md](tutorials/DAP_USER_GUIDE.md) |
 | understand project architecture | [reference/ARCHITECTURE_OVERVIEW.md](reference/ARCHITECTURE_OVERVIEW.md), [reference/CRATE_ARCHITECTURE_GUIDE.md](reference/CRATE_ARCHITECTURE_GUIDE.md) |
+| author or consume proposal/spec/ADR/plan/goal lanes | [reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md), [proposals/README.md](proposals/README.md), [specs/README.md](specs/README.md), [adr/README.md](adr/README.md), [../plans/README.md](../plans/README.md), [../.perl-lsp/goals/README.md](../.perl-lsp/goals/README.md) |
 | understand measured editor trust and the long-term Rust Perl path | [explanation/MEASURED_PERL_EDITOR_TRUST.md](explanation/MEASURED_PERL_EDITOR_TRUST.md) |
 | check known limitations and parser support | [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md) |
 | see what is true now | [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md) |
@@ -84,8 +121,8 @@ For complete workspace membership and canonical crate/version truth, use [`../Ca
 
 - Tutorials: [tutorials/GETTING_STARTED.md](tutorials/GETTING_STARTED.md), [tutorials/LSP_DEVELOPMENT_GUIDE.md](tutorials/LSP_DEVELOPMENT_GUIDE.md), [tutorials/DAP_USER_GUIDE.md](tutorials/DAP_USER_GUIDE.md), [tutorials/COMPREHENSIVE_TESTING_GUIDE.md](tutorials/COMPREHENSIVE_TESTING_GUIDE.md)
 - How-to: [how-to/INSTALLATION.md](how-to/INSTALLATION.md), [how-to/GITHUB_ACTIONS.md](how-to/GITHUB_ACTIONS.md), [how-to/EDITOR_SETUP.md](how-to/EDITOR_SETUP.md), [how-to/TROUBLESHOOTING.md](how-to/TROUBLESHOOTING.md), [how-to/CONTINUOUS_TESTING.md](how-to/CONTINUOUS_TESTING.md), [how-to/UPGRADING.md](how-to/UPGRADING.md), [how-to/PRE_COMMIT.md](how-to/PRE_COMMIT.md), [how-to/PERFORMANCE_TUNING.md](how-to/PERFORMANCE_TUNING.md), [how-to/THREADING_CONFIGURATION_GUIDE.md](how-to/THREADING_CONFIGURATION_GUIDE.md), [how-to/SECURITY_DEVELOPMENT_GUIDE.md](how-to/SECURITY_DEVELOPMENT_GUIDE.md)
-- Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md), [reference/ARCHITECTURE_OVERVIEW.md](reference/ARCHITECTURE_OVERVIEW.md), [reference/CRATE_ARCHITECTURE_GUIDE.md](reference/CRATE_ARCHITECTURE_GUIDE.md), [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md), [reference/MISSING_DOCUMENTATION_GUIDE.md](reference/MISSING_DOCUMENTATION_GUIDE.md), [reference/API_DOCUMENTATION_STANDARDS.md](reference/API_DOCUMENTATION_STANDARDS.md), [reference/DIATAXIS_GUIDE.md](reference/DIATAXIS_GUIDE.md), [reference/DOCUMENTATION_GUIDE.md](reference/DOCUMENTATION_GUIDE.md), [reference/FAQ.md](reference/FAQ.md)
-- Project, specs, and explanations: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/COMPILER_BACKED_LSP_ROADMAP.md](project/COMPILER_BACKED_LSP_ROADMAP.md), [project/CI.md](project/CI.md), [project/FEATURE_GOVERNANCE.md](project/FEATURE_GOVERNANCE.md), [explanation/MEASURED_PERL_EDITOR_TRUST.md](explanation/MEASURED_PERL_EDITOR_TRUST.md), [explanation/LSP_DOCUMENTATION.md](explanation/LSP_DOCUMENTATION.md)
+- Reference: [reference/COMMANDS_REFERENCE.md](reference/COMMANDS_REFERENCE.md), [reference/CONFIG.md](reference/CONFIG.md), [reference/LSP_FEATURES.md](reference/LSP_FEATURES.md), [reference/ARCHITECTURE_OVERVIEW.md](reference/ARCHITECTURE_OVERVIEW.md), [reference/CRATE_ARCHITECTURE_GUIDE.md](reference/CRATE_ARCHITECTURE_GUIDE.md), [reference/KNOWN_LIMITATIONS.md](reference/KNOWN_LIMITATIONS.md), [reference/PARSER_FEATURE_MATRIX.md](reference/PARSER_FEATURE_MATRIX.md), [reference/MISSING_DOCUMENTATION_GUIDE.md](reference/MISSING_DOCUMENTATION_GUIDE.md), [reference/API_DOCUMENTATION_STANDARDS.md](reference/API_DOCUMENTATION_STANDARDS.md), [reference/DIATAXIS_GUIDE.md](reference/DIATAXIS_GUIDE.md), [reference/DOCUMENTATION_GUIDE.md](reference/DOCUMENTATION_GUIDE.md), [reference/FAQ.md](reference/FAQ.md), [reference/SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md)
+- Project, specs, and explanations: [INDEX.md](INDEX.md), [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), [project/ROADMAP.md](project/ROADMAP.md), [project/COMPILER_BACKED_LSP_ROADMAP.md](project/COMPILER_BACKED_LSP_ROADMAP.md), [project/CI.md](project/CI.md), [project/FEATURE_GOVERNANCE.md](project/FEATURE_GOVERNANCE.md), [proposals/README.md](proposals/README.md), [specs/README.md](specs/README.md), [adr/README.md](adr/README.md), [../plans/README.md](../plans/README.md), [explanation/MEASURED_PERL_EDITOR_TRUST.md](explanation/MEASURED_PERL_EDITOR_TRUST.md), [explanation/LSP_DOCUMENTATION.md](explanation/LSP_DOCUMENTATION.md)
 
 ## Maintenance
 
@@ -98,4 +135,5 @@ just status-check
 - Put computed metrics in [project/CURRENT_STATUS.md](project/CURRENT_STATUS.md), not scattered through the docs tree.
 - Update [project/ROADMAP.md](project/ROADMAP.md) when the active milestone or release framing changes.
 - Keep top-level summary docs short and link back to the canonical project docs.
+- For long-lived lanes, link proposal, specs, ADRs, plan, active goal, and receipts; do not duplicate generated status content.
 - Keep each doc in the correct Diataxis category; prefer cross-links over hybrid docs that try to do everything.

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,236 @@
+# perl-lsp Source-of-Truth Specification System
+
+This guide defines how perl-lsp encodes long-lived work as linked source-of-truth
+artifacts. Use it when creating or consuming proposal/spec/ADR/plan/goal lanes.
+It is an authoring contract, not a status document.
+
+For long-lived work, follow this path:
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+The Real Perl Editor Trust lane is the reference implementation: its proposal,
+four specs, two ADRs, implementation plan, status receipts, and active goal
+manifest form one discoverable chain.
+
+## Artifact Roles
+
+| Layer | Owns | Storage | Must not own |
+| --- | --- | --- | --- |
+| Roadmap | Release direction and active milestone | `docs/project/ROADMAP.md` | PR-sized sequencing or generated metrics |
+| Proposal / PRD | Why the lane exists, user value, alternatives, and claim boundary | `docs/proposals/PLSP-PROP-*.md` | Implementation order or generated status tables |
+| Spec | Behavior contract, acceptance, proof requirements, status interpretation, and claim limits | `docs/specs/PLSP-SPEC-*.md` | Product motivation or PR order |
+| ADR | Durable architecture or operating decision | `docs/adr/PLSP-ADR-*.md` | Raw worklists or point-in-time metric state |
+| Implementation plan | PR-sized sequence, proof commands, rollback, and handoff state | `plans/<lane>/implementation-plan.md` | Product claims, behavior contracts, or durable decisions |
+| Active goal manifest | Machine-readable current agent state | `.perl-lsp/goals/active.toml` | Prose-only strategy or generated status content |
+| Status / support tiers | Current truth and public claim proof | `docs/project/status/*.md` | Lane motivation or implementation sequencing |
+| Policy ledgers | CI, lint, file, package, and exception receipts | `policy/*.toml`, `.ci/**` | Narrative status or roadmap intent |
+| Closeout / handoff | What happened, what remains, and proof | `plans/<lane>/closeout.md`, `docs/forensics/` | New durable policy without an ADR |
+
+## ID Naming
+
+Use `PLSP-*` IDs for lane artifacts that are part of the durable specification
+system.
+
+| Artifact | Pattern | Example |
+| --- | --- | --- |
+| Proposal | `PLSP-PROP-####-short-name.md` | `PLSP-PROP-0001-real-perl-editor-trust.md` |
+| Spec | `PLSP-SPEC-####-short-name.md` | `PLSP-SPEC-0002-provider-confidence-receipts.md` |
+| ADR | `PLSP-ADR-####-short-name.md` | `PLSP-ADR-0002-confidence-before-cutover.md` |
+| Plan lane | `plans/<lane>/` | `plans/real-perl-editor-trust/` |
+| Active goal | `.perl-lsp/goals/active.toml` | active lane manifest |
+
+Numbers should be monotonic within the artifact family. Do not guess issue
+numbers in artifact names. If an issue reference is needed in commits or PRs and
+cannot be verified, use the repository's `#0000` placeholder convention.
+
+## Required Headers
+
+### Proposal Header
+
+A proposal should start with these fields:
+
+```md
+# PLSP-PROP-####: Title
+
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Support/status impact:
+Policy impact:
+```
+
+A proposal explains the user problem, affected users/surfaces, current evidence,
+success criteria, alternatives, risks, and claim boundary.
+
+### Spec Header
+
+A spec should start with these fields:
+
+```md
+# PLSP-SPEC-####: Title
+
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Status surfaces:
+Proof commands:
+```
+
+A spec defines the behavior contract, acceptance examples, required proof,
+status interpretation, compatibility and fallback behavior, and claim limits.
+
+### ADR Header
+
+A PLSP ADR should start with these fields:
+
+```md
+# PLSP-ADR-####: Title
+
+Status:
+Date:
+Linked proposal:
+Linked specs:
+Linked plan:
+```
+
+An ADR records context, decision, consequences, alternatives, and follow-up
+links. It should be durable enough to guide future provider, parser, semantic,
+workspace, or operations changes.
+
+### Plan Header
+
+A lane plan should identify the linked proposal/spec/ADR/status/goal artifacts
+before the work queue:
+
+```md
+# Lane implementation plan
+
+Status:
+Lane:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Active goal:
+Status sources:
+```
+
+Each work item should be PR-sized and include goal, production delta, non-goals,
+acceptance, proof commands, and rollback.
+
+### Active Goal Header
+
+The active goal manifest is TOML. It should include stable lane metadata and
+pointers before work items:
+
+```toml
+id = "plsp-lane-slug"
+title = "Lane title"
+status = "active"
+owner = "codex-swarm"
+created = "YYYY-MM-DD"
+
+proposal = "docs/proposals/PLSP-PROP-####-short-name.md"
+plan = "plans/<lane>/implementation-plan.md"
+status_pointer = "docs/project/status/..."
+```
+
+Archive inactive manifests under `.perl-lsp/goals/archive/` when another lane
+becomes the operative active goal.
+
+## When to Create Each Artifact
+
+- Create a proposal when the lane needs a durable explanation of why the work
+  matters, who benefits, what alternatives were considered, and what claims are
+  out of bounds.
+- Create a spec when reviewers and agents need a behavior contract with
+  acceptance examples, proof commands, fallback behavior, and claim limits.
+- Create an ADR when a decision changes provider architecture, parser strategy,
+  semantic model boundaries, release operations, CI policy, or another durable
+  operating rule.
+- Create or update a plan when the contract exists and the remaining work needs
+  PR-sized sequencing, proof commands, rollback notes, and handoff state.
+- Update the active goal manifest only when the lane is the current executable
+  agent state. Do not use it as a general backlog.
+- Add closeout or forensic notes when a lane closes, hands off, or leaves
+  receipts that future maintainers must be able to audit.
+
+## Linking Status Without Copying Generated Truth
+
+Status docs and support tiers own current truth. Proposals, specs, ADRs, plans,
+and active goals should link to those docs rather than copying generated tables
+or point-in-time counts.
+
+Preferred status links include:
+
+- `docs/project/CURRENT_STATUS.md` for evidence-backed overall state
+- `docs/project/ROADMAP.md` for canonical release direction
+- `docs/project/status/SUPPORT_TIERS.md` for public support claims
+- `docs/project/status/provider_confidence_matrix.md` for provider receipts
+- `docs/project/status/semantic_scorecard.md` for semantic capability proof
+- `docs/project/status/semantic_shadow_compare.md` for shadow comparison proof
+- `docs/project/status/ux_capability_dashboard.md` for user-facing capability proof
+
+If a generated metric appears stale or contradictory, refresh or verify it with
+the owning command before making a claim. Do not hand-edit generated status
+sections.
+
+## Active Goals
+
+Active goals are machine-readable manifests for the current lane. They should
+let Codex, Claude, or another agent find the objective, current work item,
+linked contracts, status pointers, and proof commands without chat history.
+
+Use `.perl-lsp/goals/active.toml` for the operative lane and
+`.perl-lsp/goals/archive/` for inactive manifests. The manifest should point to
+proposals, specs, ADRs, plans, and status docs; it should not embed generated
+metric tables or replace narrative design docs.
+
+## PR Body Structure
+
+Keep docs-system PRs focused. One semantic artifact per PR is preferred after
+the source-of-truth scaffolding exists.
+
+Use the repository PR body shape:
+
+```text
+Problem: <one sentence>
+Fix: <one sentence>
+Verification: `<command>` passes
+```
+
+For lane work, the body should mention the governing proposal/spec/ADR/plan when
+that context helps reviewers, but it should not duplicate the artifact content.
+
+## Agent Consumption Rules
+
+When an agent starts long-lived lane work:
+
+1. Read `docs/README.md` to find the source-of-truth stack.
+2. Read the active goal manifest when the task says to continue the current
+   lane.
+3. Read the linked proposal for why and claim boundaries.
+4. Read the linked specs for behavior and proof requirements.
+5. Read linked ADRs for durable design or operating constraints.
+6. Read the lane plan for PR order, proof commands, rollback, and handoff.
+7. Read status docs and receipts for current truth; do not copy generated
+   tables into new artifacts.
+8. Keep each PR to one concern and cite the proof commands that define the
+   review boundary.
+
+For the source-of-truth stack itself, use these entry points:
+
+- [proposals README](../proposals/README.md)
+- [specs README](../specs/README.md)
+- [ADR README](../adr/README.md)
+- [plans README](../../plans/README.md)
+- [active goals README](../../.perl-lsp/goals/README.md)
+- [Real Perl Editor Trust plan](../../plans/real-perl-editor-trust/README.md)

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,85 @@
+# Implementation Plans
+
+`plans/<lane>/` is where perl-lsp keeps implementation plans for long-lived
+lanes. Plans translate proposals, specs, ADRs, generated status receipts, and
+active goal manifests into reviewable PR sequences.
+
+Plans are not specs. A plan owns the implementation path: PR order, proof
+commands, rollback notes, closeout/handoff state, and links to the current truth
+sources. Product motivation belongs in proposals, behavior contracts belong in
+specs, durable decisions belong in ADRs, and generated metric truth belongs in
+status docs.
+
+## Source-of-Truth Flow
+
+```text
+Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts
+```
+
+| Artifact | Plan responsibility |
+| --- | --- |
+| Roadmap | Link the release direction or milestone that makes the lane relevant. |
+| Proposal | Link the user problem, value, alternatives, and claim boundary. |
+| Specs | Link behavior contracts and acceptance criteria the plan implements. |
+| ADRs | Link durable decisions that constrain sequencing or architecture. |
+| Status / receipts | Link generated status and proof files; do not copy their tables. |
+| Active goal | Link the machine-readable current state when the lane is active. |
+| Closeout | Record what landed, what remains, proof commands, rollback notes, and handoff. |
+
+## Lane Directory Shape
+
+A lane directory should normally contain:
+
+```text
+plans/<lane>/
+  README.md
+  implementation-plan.md
+  closeout.md              # optional, once the lane closes or hands off
+```
+
+Use short, stable lane slugs such as `real-perl-editor-trust` or
+`semantic-receiver-facts`. The lane README should explain the plan boundary and
+link the governing proposal/spec/ADR/status artifacts. The implementation plan
+should be a PR-sized work queue, not a broad design document.
+
+## Work Item Shape
+
+Each work item should make the next reviewable change obvious:
+
+```md
+## Work item: id
+
+Status:
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+Goal
+Production delta
+Non-goals
+Acceptance
+Proof commands
+Rollback
+```
+
+## Boundaries
+
+- Do not use plans to redefine user value; update or add a proposal instead.
+- Do not use plans to define behavior contracts; update or add a spec instead.
+- Do not use plans to record durable architecture policy; update or add an ADR
+  instead.
+- Do not hand-edit generated status sections or copy generated metric tables;
+  link status docs and receipts instead.
+- Do not mix unrelated lanes in one plan PR.
+
+## Current Lanes
+
+- [Real Perl Editor Trust](real-perl-editor-trust/) translates
+  `PLSP-PROP-0001`, `PLSP-SPEC-0001` through `PLSP-SPEC-0004`,
+  `PLSP-ADR-0001`, `PLSP-ADR-0002`, status receipts, and the active goal
+  manifest into PR-sized work.
+
+See [docs/reference/SPEC_SYSTEM.md](../docs/reference/SPEC_SYSTEM.md) for the
+full proposal/spec/ADR/plan/goal authoring contract.


### PR DESCRIPTION
### Motivation

- Make the repository-level proposal/spec/ADR/plan/active-goal source-of-truth obvious from the docs front door so maintainers and agents can discover long-lived lanes without relying on chat history.
- Provide a reusable authoring contract so future lanes follow a consistent PLSP pattern (proposal → spec → ADR → plan → active goal) and avoid duplicating generated status content.

### Description

- Added a "Source-of-Truth Stack for Long-Lived Work" section to `docs/README.md` that documents the Roadmap → Proposal → Specs → ADRs → Plan → Active goal → PRs → Receipts flow and links into the existing Real Perl Editor Trust lane. 
- Added `docs/reference/SPEC_SYSTEM.md`, a durable authoring and consumption guide describing artifact roles, `PLSP-*` ID naming, required headers, active goal contract, PR body shape, and agent consumption rules.
- Added `plans/README.md` to define `plans/<lane>/` layout, lane/work-item shape, and plan responsibilities (PR sequencing, proof commands, rollback, handoff).
- No runtime/code changes; this is documentation scaffolding to promote the existing lane model and prepare for new lanes (e.g., Semantic Receiver Facts).

### Testing

- `git diff --check` passed with no issues for the modified files.
- `./scripts/storage-doctor` ran and reported healthy repo-local storage (no repo-local target dirs). 
- Attempted `./scripts/cargo-safe xtask ci-hygiene check-doc-paths docs` (via the workspace xtask); the command executed but failed due to pre-existing machine-specific absolute paths elsewhere in `docs/` that are unrelated to these changes, so the failure is external to this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a13210428833390cad240e1cd9c21)