### PR TITLE
docs: define source-of-truth stack (#0000)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,25 @@ like (#0000) or (#9999) will fail CI.
 ## Changes
 <!-- List changed files and what each change does -->
 
+## Source-of-truth links
+<!-- Use N/A when this PR is not part of a source-of-truth lane. -->
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
 ## Test
 <!-- What test was added? Does it fail before the fix and pass after? -->
 
@@ -30,6 +49,12 @@ like (#0000) or (#9999) will fail CI.
 - [ ] Close-only behavior is distinct from delete/folder-removal behavior.
 - [ ] Delayed background work cannot repopulate stale state.
 - [ ] A regression test, receipt, snapshot counter, or debug counter covers the state.
+
+## Claim boundary
+<!-- What may be claimed after this PR? What may not be claimed yet? -->
+
+## Rollback
+<!-- How can this PR be reverted safely? -->
 
 ## What I considered but didn't do
 <!-- Alternative approaches, related issues found, scope decisions -->

--- a/.perl-lsp/goals/README.md
+++ b/.perl-lsp/goals/README.md
@@ -4,6 +4,9 @@ Active goals are machine-readable current-state manifests for `perl-lsp` lanes.
 They let agents identify the current objective, active work item, proof commands,
 and status pointers without scraping chat or hand-maintained narrative.
 
+See [SPEC_SYSTEM.md](../../docs/reference/SPEC_SYSTEM.md) for the full
+source-of-truth stack and agent workflow.
+
 | Layer | Owns | Must not do |
 |---|---|---|
 | Active goal | Machine-readable current work, status pointers, active work-item IDs, proof command list | Prose-only strategy, generated status content, durable design rationale |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,27 @@ The orchestrator reads `CLAUDE.md`. This file is for you.
 
 ---
 
+## Repo source-of-truth stack
+
+This repo uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Before changing files for lane work, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.perl-lsp/goals/active.toml`
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. linked ADRs
+
+Work on exactly one work item per PR, run the listed proof commands, and stop
+instead of guessing when linked artifacts are missing or contradictory.
+
+---
+
 ## Context you can read
 
 | Resource | Purpose |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 **Latest Release**: 0.14.0 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
 
+## Repo source-of-truth stack
+
+This repo uses a linked source-of-truth stack for lane work:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Before routing or executing lane work, use `docs/reference/SPEC_SYSTEM.md`,
+`.perl-lsp/goals/active.toml`, the linked implementation plan, linked specs,
+and linked ADRs to identify the current work item, proof commands, and claim
+boundaries.
+
 ## Orchestration Model
 
 perl-lsp's orchestration is an *Octopus Cluster* — see [docs/reference/OCTOPUS_CLUSTER.md](docs/reference/OCTOPUS_CLUSTER.md) for the umbrella framing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -2,6 +2,9 @@
 
 This directory contains Architecture Decision Records (ADRs) for significant design decisions in the Perl LSP project.
 
+See [SPEC_SYSTEM.md](../reference/SPEC_SYSTEM.md) for the full
+source-of-truth stack and agent workflow.
+
 ## Source-of-Truth Layer
 
 ADRs describe durable decisions: the architecture, policy, or operating model

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -4,6 +4,9 @@ Proposals describe why a lane exists: the user pain, product motivation,
 alternatives considered, and success criteria that make the work worth doing.
 They are the PRD layer for `perl-lsp` planning.
 
+See [SPEC_SYSTEM.md](../reference/SPEC_SYSTEM.md) for the full
+source-of-truth stack and agent workflow.
+
 | Layer | Owns | Must not do |
 |---|---|---|
 | Proposal | User problem, affected surfaces, success criteria, alternatives, non-goals, claim boundary | PR sequencing, proof command ownership, generated metric state |

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,184 @@
+# Repo source-of-truth system
+
+This repo uses a linked source-of-truth stack so contributors and agents can
+find the right kind of truth without scraping chat history or treating stale
+planning notes as current state.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+|---|---|---|
+| Roadmap | Release direction, milestone framing, lane names | PR queue, generated metrics, proof receipts |
+| Proposal | Why, users, alternatives, risks, lane success criteria | Behavior contract, task list, generated status |
+| Spec | Required behavior, acceptance, evidence, claim boundaries | Product rationale, PR sequencing, active queue |
+| ADR | Durable architecture or operating decision | Task list, implementation queue, current metric state |
+| Plan | PR order, work items, proof commands, rollback | Product rationale, durable decision record |
+| Active goal | Current machine-readable objective and work items | Long prose, generated status tables, durable rationale |
+| Support tiers | Public support claims and proof pointers | Feature design, implementation sequencing |
+| Policy ledgers | Exceptions, owners, coverage, review dates | Broad architecture or product strategy |
+
+## Rules
+
+1. One kind of truth belongs in one artifact.
+2. One semantic artifact or implementation work item belongs in one PR unless a
+   plan explicitly says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record decisions.
+5. Active goals tell agents what to execute now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier proof or an equivalent status pointer.
+8. Policy exceptions require an owner, reason, coverage, and review date.
+
+## Required headers
+
+Every new proposal, spec, ADR, and implementation plan should declare these
+fields when they apply. Use `n/a` when a field is intentionally not applicable.
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+Existing legacy artifacts may use older header names, but new source-of-truth
+artifacts should converge on this shape.
+
+## Agent workflow
+
+Agents must:
+
+1. Read repo instructions, then this document.
+2. Read `.perl-lsp/goals/active.toml`.
+3. Choose exactly one ready or assigned work item.
+4. Read the linked plan item.
+5. Read the linked spec for acceptance.
+6. Read linked ADRs for constraints.
+7. Implement only the selected work item.
+8. Run the proof commands listed for that item.
+9. Update receipts, status, or policy ledgers only when the work item requires it.
+10. Stop rather than guessing when source-of-truth artifacts are missing or contradictory.
+
+## Stop conditions
+
+Stop and report instead of inventing work when:
+
+- the active goal is missing or stale;
+- linked files do not exist;
+- generated status is dirty and no generator/check command is listed;
+- proof commands cannot run;
+- unrelated staged changes exist;
+- requested work conflicts with an ADR;
+- a public claim lacks support-tier proof or an equivalent status pointer.
+
+## Active goal lifecycle
+
+The active goal manifest lives at:
+
+```text
+.perl-lsp/goals/active.toml
+```
+
+Set `status = "active"` when the lane is executable. Set `status = "paused"`
+with a reason when no current implementation lane is selected.
+
+Archive replaced manifests under:
+
+```text
+.perl-lsp/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+Do not leave multiple active manifests.
+
+## Closeout format
+
+At the end of a lane, add or update:
+
+```text
+plans/<lane>/closeout.md
+```
+
+A closeout should include:
+
+- what shipped;
+- proof commands and receipts;
+- linked PRs and CI runs;
+- generated status, support-tier, and policy updates;
+- deferred work;
+- claim boundaries;
+- the next lane recommendation.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md` and keep the spec focused
+on behavior, examples, proof, and claim boundaries.
+
+### Plan becomes product rationale
+
+Move why-oriented text to the proposal. Keep the plan focused on work items,
+proof, dependencies, and rollback.
+
+### Active goal becomes prose
+
+Keep `.perl-lsp/goals/active.toml` machine-readable and link to prose docs
+instead of copying long generated tables or narrative state.
+
+### Generated status is hand-edited
+
+Run the named generator or check command. If a generator is unavailable, record
+that as a blocker or explicit proof limitation.
+
+### Support claims drift
+
+Require a support-tier impact header or equivalent status pointer for public
+claims, and link to proof commands or receipts.
+
+### Policy exceptions become silent debt
+
+Every exception in `policy/*.toml` needs an owner, reason, `covered_by`, and
+`review_after`; add `expires` when the exception is temporary.
+
+### Mega PR
+
+Split unrelated source-of-truth artifacts or implementation work items into
+separate PRs unless the implementation plan explicitly requires bundling them.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -3,6 +3,9 @@
 Specs define what must be true for a behavior, status surface, or proof lane.
 They are contracts for acceptance, proof requirements, and claim boundaries.
 
+See [SPEC_SYSTEM.md](../reference/SPEC_SYSTEM.md) for the full
+source-of-truth stack and agent workflow.
+
 | Layer | Owns | Must not do |
 |---|---|---|
 | Spec | Behavior contract, acceptance criteria, proof requirements, status interpretation, claim limits | Product motivation, broad roadmap, PR sequence, active queue ownership |

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,113 @@
+# Plans
+
+Plans are the sequencing layer for `perl-lsp` lanes. They translate accepted
+proposals, specs, and ADRs into PR-sized work items with proof commands and
+rollback notes.
+
+| Layer | Owns | Must not do |
+|---|---|---|
+| Plan | PR sequence, work items, dependencies, proof commands, rollback, handoff state | Product motivation, durable architecture decisions, generated status truth |
+
+## How Plans Fit the Stack
+
+The repo source-of-truth stack is documented in
+[`docs/reference/SPEC_SYSTEM.md`](../docs/reference/SPEC_SYSTEM.md):
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+A plan should link back to the proposal that explains why, the specs that define
+what must be true, and any ADRs that constrain implementation. It should also
+link forward to `.perl-lsp/goals/active.toml` when a lane is active.
+
+## Plan Layout
+
+Lane plans live under:
+
+```text
+plans/<lane>/implementation-plan.md
+```
+
+Each lane directory may also include:
+
+```text
+plans/<lane>/README.md
+plans/<lane>/closeout.md
+```
+
+Use `README.md` for lane-local orientation and `closeout.md` when a lane is
+completed or superseded.
+
+## Work Item Shape
+
+Each work item should be small enough for one focused PR and include:
+
+- status (`ready`, `active`, `blocked`, `completed`, or `superseded`);
+- linked proposal, spec, ADR, and active goal item;
+- blockers and dependencies;
+- production delta;
+- non-goals;
+- acceptance criteria;
+- proof commands;
+- rollback notes;
+- claim boundary.
+
+## Template
+
+````md
+# Lane implementation plan
+
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Active goal:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+
+## Current state
+
+Link to generated status docs and receipts instead of copying point-in-time
+metrics.
+
+## Work item: short-id
+
+Status: ready | active | blocked | completed | superseded
+Linked proposal:
+Linked spec:
+Linked ADR:
+Active goal:
+Blocks:
+Blocked by:
+
+### Goal
+
+### Production delta
+
+### Non-goals
+
+### Acceptance
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+### Claim boundary
+````
+
+## Plan Rules
+
+- Do not put product strategy in plans; move it to a proposal.
+- Do not record durable architecture choices in plans; move them to an ADR.
+- Do not copy generated status tables; link to the generated status source.
+- Do not mark work complete without proof commands or an explicit unavailable-proof note.
+- Do not mix unrelated work items into one PR.


### PR DESCRIPTION
### Motivation
- Provide a single, explicit source-of-truth reference so human reviewers and automation (agents) read the same rails for proposals, specs, ADRs, plans, active goals, and proof commands.
- Reduce agent drift and ad-hoc workflow decisions by making the first-read sequence, stop conditions, and claim boundaries machine- and human-actionable.

### Description
- Add `docs/reference/SPEC_SYSTEM.md` that defines the source-of-truth stack, artifact roles, required headers, agent workflow, stop conditions, active-goal lifecycle, closeout expectations, and common failure modes.
- Add `plans/README.md` with plan-layer guidance, work-item template, proof/rollback expectations, and plan rules.
- Update `AGENTS.md` and `CLAUDE.md` to include the source-of-truth first-read pointers and the rule to work on one plan work item per PR.
- Update `.github/PULL_REQUEST_TEMPLATE.md` to include source-of-truth links, a scope checklist, claim-boundary and rollback prompts, and cross-link the new `SPEC_SYSTEM.md` from `docs/proposals/README.md`, `docs/specs/README.md`, `docs/adr/README.md`, and `.perl-lsp/goals/README.md`.

### Testing
- Ran `git diff --check` and observed no check failures, indicating the produced docs/markdown conform to the repo checks.
- Ran `git diff --cached --check` on the staged changes and observed no check failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a17889d288333902047c864c4fd2e)