### PR TITLE
refactor(goto-label): split lint into srp modules

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label/diagnostic.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label/diagnostic.rs
@@ -1,0 +1,20 @@
+//! Diagnostic construction for undefined `goto LABEL` targets.
+
+use crate::providers::diagnostics::internal_types::{Diagnostic, RelatedInformation};
+use perl_diagnostics::codes::{DiagnosticCode, DiagnosticSeverity};
+use perl_parser_core::ast::Node;
+
+pub(crate) fn undefined_label(target: &Node, label: &str) -> Diagnostic {
+    Diagnostic {
+        range: (target.location.start, target.location.end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(DiagnosticCode::GotoUndefinedLabel.as_str().to_string()),
+        message: format!("Goto label '{label}' is not defined in this file"),
+        related_information: vec![RelatedInformation {
+            location: (target.location.start, target.location.end),
+            message: "Define the label or use a dynamic goto form only when the target is known at runtime.".to_string(),
+        }],
+        tags: Vec::new(),
+        suggestion: Some(format!("Add a '{label}:' label or remove the goto")),
+    }
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label/labels.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label/labels.rs
@@ -1,0 +1,10 @@
+//! Label lookup helpers for `goto LABEL` diagnostics.
+
+use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
+
+pub(crate) fn has_label(symbol_table: &SymbolTable, label: &str) -> bool {
+    symbol_table
+        .symbols
+        .get(label)
+        .is_some_and(|symbols| symbols.iter().any(|symbol| symbol.kind == SymbolKind::Label))
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label/mod.rs
@@ -10,27 +10,15 @@
 //! |------|----------|-------------|
 //! | `PL409` | Warning | `goto LABEL` references a label that is not defined in the file |
 
-use super::super::internal_types::{Diagnostic, RelatedInformation};
-use perl_diagnostics::codes::DiagnosticCode;
-use perl_diagnostics::codes::DiagnosticSeverity;
+mod diagnostic;
+mod labels;
+mod target;
+
+use super::super::internal_types::Diagnostic;
 use perl_parser_core::ast::{Node, NodeKind};
-use perl_semantic_analyzer::symbol::{SymbolKind, SymbolTable};
+use perl_semantic_analyzer::symbol::SymbolTable;
 
 use super::super::walker::walk_node;
-
-fn has_label(symbol_table: &SymbolTable, label: &str) -> bool {
-    symbol_table
-        .symbols
-        .get(label)
-        .is_some_and(|symbols| symbols.iter().any(|symbol| symbol.kind == SymbolKind::Label))
-}
-
-fn goto_target_is_plain_label(target: &Node) -> Option<&str> {
-    match &target.kind {
-        NodeKind::Identifier { name } => Some(name.as_str()),
-        _ => None,
-    }
-}
 
 /// Warn when a `goto LABEL` target does not have a matching label symbol.
 pub fn check_goto_labels(
@@ -43,26 +31,15 @@ pub fn check_goto_labels(
             return;
         };
 
-        let Some(label) = goto_target_is_plain_label(target) else {
+        let Some(label) = target::plain_label_name(target) else {
             return;
         };
 
-        if has_label(symbol_table, label) {
+        if labels::has_label(symbol_table, label) {
             return;
         }
 
-        diagnostics.push(Diagnostic {
-            range: (target.location.start, target.location.end),
-            severity: DiagnosticSeverity::Warning,
-            code: Some(DiagnosticCode::GotoUndefinedLabel.as_str().to_string()),
-            message: format!("Goto label '{label}' is not defined in this file"),
-            related_information: vec![RelatedInformation {
-                location: (target.location.start, target.location.end),
-                message: "Define the label or use a dynamic goto form only when the target is known at runtime.".to_string(),
-            }],
-            tags: Vec::new(),
-            suggestion: Some(format!("Add a '{label}:' label or remove the goto")),
-        });
+        diagnostics.push(diagnostic::undefined_label(target, label));
     });
 }
 

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label/target.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label/target.rs
@@ -1,0 +1,10 @@
+//! Target classification for `goto` diagnostics.
+
+use perl_parser_core::ast::{Node, NodeKind};
+
+pub(crate) fn plain_label_name(target: &Node) -> Option<&str> {
+    match &target.kind {
+        NodeKind::Identifier { name } => Some(name.as_str()),
+        _ => None,
+    }
+}

--- a/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/diagnostics/lints/mod.rs
@@ -115,7 +115,7 @@
 //! |------|----------|-------------|
 //! | `PL408` | Warning | Hash key appears more than once in the same literal |
 //!
-//! ## Goto labels (`goto_label.rs`)
+//! ## Goto labels (`goto_label/`)
 //!
 //! | Code | Severity | Description |
 //! |------|----------|-------------|


### PR DESCRIPTION
### Motivation

- Reduce single-file responsibility by separating traversal, target classification, label lookup, and diagnostic construction for the `goto` label lint. 
- Improve readability and make future unit testing and maintenance easier by applying SRP to the lint implementation.

### Description

- Split `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/goto_label.rs` into `goto_label/mod.rs` and three focused helpers: `diagnostic.rs`, `labels.rs`, and `target.rs` while keeping the public `check_goto_labels` entry point unchanged. 
- Moved diagnostic construction into `diagnostic::undefined_label`, label lookup into `labels::has_label`, and target classification into `target::plain_label_name`. 
- Updated the lint module documentation reference in `crates/perl-lsp-rs-core/src/providers/diagnostics/lints/mod.rs` to reflect the directoryized `goto_label/` layout. 
- Ran `./scripts/cargo-safe fmt` to apply formatting to new files.

### Testing

- `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked goto_label` passed (unit tests for the `goto_label` lint all passed). 
- `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-lsp-rs-core --profile agent --locked` passed. 
- `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e745efec83338c1e400c4bed5a64)