### PR TITLE
refactor(perl-dap): split process perl launch helpers

### DIFF
--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -1,133 +1,14 @@
 //! Process lifecycle management: initialize, launch, attach, disconnect, terminate, restart.
 
 use super::*;
-use crate::platform::PerlInterpreterResult;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
-use std::time::SystemTime;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct PerlBinaryFingerprint {
-    len: u64,
-    modified: Option<SystemTime>,
-}
+mod perl_info;
+mod perl_spawn;
 
-static PERL_VERSION_CACHE: LazyLock<
-    Mutex<HashMap<PathBuf, (PerlBinaryFingerprint, Option<String>)>>,
-> = LazyLock::new(|| Mutex::new(HashMap::new()));
-
-fn perl_binary_fingerprint(perl_path: &Path) -> Option<PerlBinaryFingerprint> {
-    let metadata = std::fs::metadata(perl_path).ok()?;
-    let modified = metadata.modified().ok();
-    Some(PerlBinaryFingerprint { len: metadata.len(), modified })
-}
-
-fn detect_perl_version_cached(perl_path: &Path) -> Option<String> {
-    let fingerprint = perl_binary_fingerprint(perl_path)?;
-
-    if let Ok(cache) = PERL_VERSION_CACHE.lock()
-        && let Some((cached_fingerprint, cached_version)) = cache.get(perl_path)
-        && *cached_fingerprint == fingerprint
-    {
-        return cached_version.clone();
-    }
-
-    // PerlOracleEnv denies PERL5LIB/PERL5OPT so the version number is
-    // deterministic regardless of the editor's ambient environment (#8688).
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let oracle =
-        perl_lsp_rs_core::config::PerlOracleEnv::for_version_probe(perl_path.to_path_buf(), cwd);
-    let detected_version =
-        oracle.into_command().arg("-e").arg("print $]").output().ok().and_then(|out| {
-            if out.status.success() { String::from_utf8(out.stdout).ok() } else { None }
-        });
-
-    if let Ok(mut cache) = PERL_VERSION_CACHE.lock() {
-        cache.insert(perl_path.to_path_buf(), (fingerprint, detected_version.clone()));
-    }
-
-    detected_version
-}
-
-/// Try to detect the Perl interpreter available on the system and return a human-readable
-/// summary string.
-///
-/// Uses `resolve_perl_path_with_toolchain()` to find Perl (checks perlbrew, plenv, then PATH),
-/// then runs `perl -e 'print $]'` to get the version number.  Returns a string describing what
-/// was found, or a "not found" / install-hint message suitable for inclusion in error messages.
-fn detect_perl_info() -> String {
-    match crate::platform::find_perl_interpreter_cached(None) {
-        PerlInterpreterResult::ConfiguredPath(path)
-        | PerlInterpreterResult::FoundOnPath(path)
-        | PerlInterpreterResult::FoundViaFallback { path, .. } => {
-            match detect_perl_version_cached(&path) {
-                Some(v) if !v.trim().is_empty() => {
-                    format!("Found Perl at {} (version {})", path.display(), v.trim())
-                }
-                _ => format!("Found Perl at {}", path.display()),
-            }
-        }
-        PerlInterpreterResult::NotFound { .. } => {
-            #[cfg(windows)]
-            {
-                "Perl was not found on PATH. Install Perl from https://strawberryperl.com \
-                 or set a custom path."
-                    .to_string()
-            }
-            #[cfg(not(windows))]
-            {
-                "Perl was not found on PATH. Install Perl via your package manager \
-                 (e.g. `apt install perl` or `brew install perl`) or set a custom path."
-                    .to_string()
-            }
-        }
-    }
-}
-
-fn is_valid_perl_interpreter(perl_interpreter: &str) -> bool {
-    let trimmed = perl_interpreter.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-
-    let candidate = Path::new(trimmed)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(trimmed)
-        .to_ascii_lowercase();
-
-    let candidate = candidate.strip_suffix(".exe").unwrap_or(&candidate);
-    candidate == "perl" || candidate.starts_with("perl")
-}
-
-fn format_perl_spawn_error(perl_interpreter: &str, error: &std::io::Error) -> String {
-    if error.kind() == std::io::ErrorKind::NotFound {
-        #[cfg(windows)]
-        {
-            return format!(
-                "Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl from \
-                    https://strawberryperl.com (or ActivePerl), then reload VS Code. \
-                    You can also set `perl-lsp.perl.path` or launch.json `perl` to a full Perl path."
-            );
-        }
-        #[cfg(not(windows))]
-        {
-            return format!(
-                "Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl with your package manager \
-                    (for example `brew install perl`, `apt install perl`, or your distro equivalent), \
-                    then reload VS Code. You can also set `perl-lsp.perl.path` or launch.json `perl` \
-                    to a full Perl path."
-            );
-        }
-    }
-
-    format!(
-        "Perl executable ('{perl_interpreter}') could not be started: {}. \
-         Check file permissions, antivirus/AppLocker policy, and sandbox restrictions.",
-        error
-    )
-}
+use perl_info::detect_perl_info;
+use perl_spawn::{format_perl_spawn_error, is_valid_perl_interpreter};
 
 impl DebugAdapter {
     /// Handle initialize request

--- a/crates/perl-dap/src/debug_adapter/process/perl_info.rs
+++ b/crates/perl-dap/src/debug_adapter/process/perl_info.rs
@@ -1,0 +1,85 @@
+//! Perl interpreter discovery and version reporting for process launch diagnostics.
+
+use crate::platform::PerlInterpreterResult;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PerlBinaryFingerprint {
+    len: u64,
+    modified: Option<SystemTime>,
+}
+
+static PERL_VERSION_CACHE: LazyLock<
+    Mutex<HashMap<PathBuf, (PerlBinaryFingerprint, Option<String>)>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn perl_binary_fingerprint(perl_path: &Path) -> Option<PerlBinaryFingerprint> {
+    let metadata = std::fs::metadata(perl_path).ok()?;
+    let modified = metadata.modified().ok();
+    Some(PerlBinaryFingerprint { len: metadata.len(), modified })
+}
+
+fn detect_perl_version_cached(perl_path: &Path) -> Option<String> {
+    let fingerprint = perl_binary_fingerprint(perl_path)?;
+
+    if let Ok(cache) = PERL_VERSION_CACHE.lock()
+        && let Some((cached_fingerprint, cached_version)) = cache.get(perl_path)
+        && *cached_fingerprint == fingerprint
+    {
+        return cached_version.clone();
+    }
+
+    // PerlOracleEnv denies PERL5LIB/PERL5OPT so the version number is
+    // deterministic regardless of the editor's ambient environment (#8688).
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let oracle =
+        perl_lsp_rs_core::config::PerlOracleEnv::for_version_probe(perl_path.to_path_buf(), cwd);
+    let detected_version =
+        oracle.into_command().arg("-e").arg("print $]").output().ok().and_then(|out| {
+            if out.status.success() { String::from_utf8(out.stdout).ok() } else { None }
+        });
+
+    if let Ok(mut cache) = PERL_VERSION_CACHE.lock() {
+        cache.insert(perl_path.to_path_buf(), (fingerprint, detected_version.clone()));
+    }
+
+    detected_version
+}
+
+/// Try to detect the Perl interpreter available on the system and return a human-readable
+/// summary string.
+///
+/// Uses `resolve_perl_path_with_toolchain()` to find Perl (checks perlbrew, plenv, then PATH),
+/// then runs `perl -e 'print $]'` to get the version number.  Returns a string describing what
+/// was found, or a "not found" / install-hint message suitable for inclusion in error messages.
+pub(super) fn detect_perl_info() -> String {
+    match crate::platform::find_perl_interpreter_cached(None) {
+        PerlInterpreterResult::ConfiguredPath(path)
+        | PerlInterpreterResult::FoundOnPath(path)
+        | PerlInterpreterResult::FoundViaFallback { path, .. } => {
+            match detect_perl_version_cached(&path) {
+                Some(v) if !v.trim().is_empty() => {
+                    format!("Found Perl at {} (version {})", path.display(), v.trim())
+                }
+                _ => format!("Found Perl at {}", path.display()),
+            }
+        }
+        PerlInterpreterResult::NotFound { .. } => {
+            #[cfg(windows)]
+            {
+                "Perl was not found on PATH. Install Perl from https://strawberryperl.com \
+                 or set a custom path."
+                    .to_string()
+            }
+            #[cfg(not(windows))]
+            {
+                "Perl was not found on PATH. Install Perl via your package manager \
+                 (e.g. `apt install perl` or `brew install perl`) or set a custom path."
+                    .to_string()
+            }
+        }
+    }
+}

--- a/crates/perl-dap/src/debug_adapter/process/perl_spawn.rs
+++ b/crates/perl-dap/src/debug_adapter/process/perl_spawn.rs
@@ -1,0 +1,47 @@
+//! Perl executable validation and spawn-error formatting for process launch.
+
+use std::path::Path;
+
+pub(super) fn is_valid_perl_interpreter(perl_interpreter: &str) -> bool {
+    let trimmed = perl_interpreter.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let candidate = Path::new(trimmed)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(trimmed)
+        .to_ascii_lowercase();
+
+    let candidate = candidate.strip_suffix(".exe").unwrap_or(&candidate);
+    candidate == "perl" || candidate.starts_with("perl")
+}
+
+pub(super) fn format_perl_spawn_error(perl_interpreter: &str, error: &std::io::Error) -> String {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        #[cfg(windows)]
+        {
+            return format!(
+                "Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl from \
+                    https://strawberryperl.com (or ActivePerl), then reload VS Code. \
+                    You can also set `perl-lsp.perl.path` or launch.json `perl` to a full Perl path."
+            );
+        }
+        #[cfg(not(windows))]
+        {
+            return format!(
+                "Perl executable ('{perl_interpreter}') is not available on PATH. Install Perl with your package manager \
+                    (for example `brew install perl`, `apt install perl`, or your distro equivalent), \
+                    then reload VS Code. You can also set `perl-lsp.perl.path` or launch.json `perl` \
+                    to a full Perl path."
+            );
+        }
+    }
+
+    format!(
+        "Perl executable ('{perl_interpreter}') could not be started: {}. \
+         Check file permissions, antivirus/AppLocker policy, and sandbox restrictions.",
+        error
+    )
+}


### PR DESCRIPTION
### Motivation
- Reduce coupling in the DAP process lifecycle module by extracting Perl discovery/version reporting and spawn-related helpers into focused submodules to improve readability and testability.

### Description
- Introduce two new submodules under `crates/perl-dap/src/debug_adapter/process/`: `perl_info.rs` (Perl discovery and version cache) and `perl_spawn.rs` (interpreter validation and spawn-error formatting).
- Remove the in-file helpers and binary-fingerprint cache from `process.rs` and import only the narrow APIs via `use perl_info::detect_perl_info;` and `use perl_spawn::{format_perl_spawn_error, is_valid_perl_interpreter};`.
- Keep previous semantics and visibility by exposing the helper functions as `pub(super)` so existing callers in the DAP module continue to work.
- Run formatting on the new files to match repository style.

### Testing
- Ran `./scripts/cargo-safe check -p perl-dap --all-targets --profile agent --locked` which succeeded.
- Ran `./scripts/cargo-safe xtask fmt` which succeeded and formatted the new modules.
- Ran `./scripts/cargo-safe clippy -p perl-dap --profile agent --locked -- -D warnings -A missing_docs` which succeeded with no new lints.
- Ran targeted unit tests `./scripts/cargo-safe test -p perl-dap debug_adapter::process::tests --profile agent --locked` which passed; running the full `./scripts/cargo-safe test -p perl-dap --profile agent --locked` exercised the suite but hit a pre-existing/flaky `test_e2e_multi_breakpoint_sequence` failure unrelated to these refactor changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e745efec83338c1e400c4bed5a64)