### PR TITLE
docs(source-of-truth): define source-of-truth stack (#0000)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,17 +10,53 @@ like (#0000) or (#9999) will fail CI.
 ## Summary
 <!-- What changed and why. Link the issue: Fixes #NNN -->
 
-## Changes
-<!-- List changed files and what each change does -->
+## Source-of-truth links
 
-## Test
-<!-- What test was added? Does it fail before the fix and pass after? -->
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+<!-- What this PR explicitly does not do. -->
+
+## Changes
+<!-- List changed files and what each change does. -->
+
+## Proof
+<!-- Commands run, results, unavailable proof, and substitute evidence. -->
+
+```bash
+# commands run
+```
+
+Results:
+
+## Claim boundary
+<!-- What may be claimed after this PR? What may not be claimed yet? -->
+
+## Rollback
+<!-- How to revert safely. -->
 
 ## Verification
 - [ ] `cargo xtask fmt` — clean
 - [ ] I used a narrow orthogonal pass first (freshness check, truth-check, or targeted repro) before the broader gate.
 - [ ] `cargo clippy -p <crate> --tests` — clean
 - [ ] `cargo test -p <crate>` — pass
+- [ ] `git diff --check` — clean
 - [ ] This PR introduces UX-visible changes. I have verified that error messages are actionable and the UX test harness still passes.
 
 ## Retained State
@@ -32,10 +68,10 @@ like (#0000) or (#9999) will fail CI.
 - [ ] A regression test, receipt, snapshot counter, or debug counter covers the state.
 
 ## What I considered but didn't do
-<!-- Alternative approaches, related issues found, scope decisions -->
+<!-- Alternative approaches, related issues found, scope decisions. -->
 
 ## What's next
-<!-- Follow-up work, edge cases to address, related issues to file -->
+<!-- Follow-up work, edge cases to address, related issues to file. -->
 
 ## CI cost / verification note
 <!-- See docs/ci/cost-and-verification-policy.md and docs/ci/lem-budgeting.md. -->
@@ -45,4 +81,4 @@ like (#0000) or (#9999) will fail CI.
 - [ ] New CI work states the failure mode it catches and its estimated LEM.
 
 ## Agent
-<!-- If created by swarm: agent type, issue number, model tier -->
+<!-- If created by swarm: agent type, issue number, model tier. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,27 @@ The orchestrator reads `CLAUDE.md`. This file is for you.
 | `docs/articles/CONTINUOUS_REVIEW_PATTERNS.md` | The orchestration pattern used here |
 | `docs/articles/ORCHESTRATION_COUNTERINTUITIONS.md` | Lessons where the obvious rule was wrong |
 
+## Repo source-of-truth stack
+
+This repo uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before changing files, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.perl-lsp/goals/active.toml`
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Linked ADRs
+
+Work on exactly one work item per PR. Do not create a new lane, broaden support
+claims, hand-edit generated status, or add policy exceptions unless the selected
+work item explicitly requires it. If the active goal or linked artifacts are
+missing, stop and report instead of guessing.
+
 **Before starting:** check the latest upstream commits so you do not re-implement
 already-merged work.
 

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,234 @@
+# Repo source-of-truth system
+
+This repo uses a linked source-of-truth stack so humans and agents can tell
+which artifact owns each kind of truth.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+|---|---|---|
+| Roadmap | Release direction, milestone framing, lane inventory | PR queue, proof receipts, generated metrics |
+| Proposal | Why the lane exists, users, affected surfaces, alternatives, risks | Behavior contract, PR sequence, current metric state |
+| Spec | Required behavior, acceptance examples, proof requirements, claim boundaries | Product rationale, active queue, durable architecture decision |
+| ADR | Durable architecture or operating decision, context, consequences | Task list, current metric state, implementation queue |
+| Plan | PR sequence, work items, dependencies, proof commands, rollback | Product strategy, generated status truth |
+| Active goal | Current machine-readable objective, active work items, proof commands, status pointers | Long prose, generated metrics, durable decisions |
+| Support tiers | Public support claims, proof pointers, limitations, promotion requirements | Feature design, roadmap strategy |
+| Policy ledgers | Exceptions, owners, coverage, review dates, expiry | Broad architecture, undocumented debt |
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact or one implementation work item per PR unless the plan says otherwise.
+3. Proposals explain why; specs define behavior; ADRs record durable decisions.
+4. Plans define sequencing and proof; active goals tell agents what to do now.
+5. Generated status is updated by tools, not by hand.
+6. Public claims require support-tier proof or an equivalent proof pointer.
+7. Policy exceptions require an owner, reason, coverage, and review date.
+8. Claim boundaries must be explicit when proof is partial or advisory.
+
+## Required headers
+
+Use `n/a` when a header does not apply. Existing legacy artifacts may predate
+this system, but new source-of-truth artifacts should include the relevant
+headers for their layer.
+
+### Proposal headers
+
+```text
+Status:
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Support/status impact:
+Policy impact:
+```
+
+### Spec headers
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+### ADR headers
+
+```text
+Status:
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked plan:
+```
+
+### Plan headers
+
+```text
+Status:
+Owner:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Active goal:
+```
+
+## Agent workflow
+
+Agents must follow this boot order before changing files:
+
+1. Read `AGENTS.md` or `CLAUDE.md`.
+2. Read this file.
+3. Read `.perl-lsp/goals/active.toml`.
+4. Read the linked implementation plan.
+5. Read the linked proposal only for lane rationale.
+6. Read the linked spec for acceptance and proof.
+7. Read linked ADRs for constraints.
+8. Inspect the current git state and recent commits.
+9. Pick exactly one ready work item.
+10. Implement only that work item.
+11. Run the proof commands listed by the plan or active goal.
+12. Update receipts, status, or policy only when the selected work item requires it.
+
+If no ready work item is identifiable, stop and report instead of inventing one.
+
+## Stop conditions
+
+Stop and report when any of these are true:
+
+- the active goal is missing, stale, or contradictory;
+- a linked proposal, spec, ADR, or plan is missing;
+- the requested work conflicts with an accepted ADR;
+- the work item lacks proof commands;
+- proof commands cannot run and no substitute evidence is defined;
+- generated status is dirty and the plan does not direct updating it;
+- unrelated staged changes are present;
+- a public claim lacks a support-tier row or equivalent proof pointer;
+- a policy exception lacks owner, reason, coverage, or review date.
+
+## Active goal lifecycle
+
+The active goal lives at `.perl-lsp/goals/active.toml`.
+
+```toml
+status = "active"
+```
+
+Use `status = "paused"` with a reason when there is no selected implementation
+lane. Archive replaced manifests under `.perl-lsp/goals/archive/` with a dated
+filename, then create the new active manifest. Do not leave multiple active
+manifests.
+
+## Closeout format
+
+When a lane ends, add `plans/<lane>/closeout.md` with:
+
+```md
+# Lane closeout: <lane>
+
+Status: completed
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Active goal archive:
+
+## What shipped
+
+## Proof
+
+## Receipts
+
+## What did not ship
+
+## Deferred work
+
+## Claim boundary
+
+## Next lane recommendation
+```
+
+Closeout prevents the next human or agent from rediscovering completed work.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md`; keep the spec focused
+on behavior, acceptance examples, and proof.
+
+### Plan becomes product rationale
+
+Move lane motivation to `docs/proposals/`; keep the plan focused on work items,
+dependencies, proof commands, and rollback.
+
+### Active goal becomes prose
+
+Keep the manifest as TOML with stable IDs and links. Put narrative in proposals,
+specs, plans, or handoffs.
+
+### Generated status is hand-edited
+
+Run the named generator or checker. If no generator exists, record the gap in
+the plan instead of editing generated sections by hand.
+
+### Support claims drift
+
+Require support-tier impact on source-of-truth artifacts and keep public claims
+linked to proof commands, known limitations, and next promotion proof.
+
+### Policy exceptions become silent debt
+
+Every exception belongs in `policy/*.toml` with owner, reason, `covered_by`, and
+`review_after`; temporary exceptions should also include expiry.
+
+### Mega PR
+
+Split proposal, spec, ADR, plan, active-goal, runtime, policy, and support-tier
+changes unless the selected plan item explicitly says to combine them.
+
+## What good looks like
+
+A contributor or agent should be able to answer these questions without chat
+history:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions through stable IDs, explicit links, small
+work items, proof commands, claim boundaries, and stop conditions, the source-of-
+truth system is working.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,107 @@
+# Implementation Plans
+
+Implementation plans are the queue layer of the `perl-lsp` source-of-truth
+stack. They sequence focused PRs after a proposal explains why, specs define
+what must be true, and ADRs record any durable decisions.
+
+| Layer | Owns | Must not do |
+|---|---|---|
+| Plan | PR order, work items, dependencies, proof commands, rollback, status handoff | Product rationale, behavior contract, generated status truth |
+
+## How Plans Fit
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+Plans should link back to their proposal, specs, and ADRs. The active goal at
+`.perl-lsp/goals/active.toml` should point to the current plan and selected work
+items.
+
+## Directory Shape
+
+Use one directory per lane:
+
+```text
+plans/
+  <lane>/
+    README.md
+    implementation-plan.md
+    closeout.md
+```
+
+`closeout.md` is added when the lane completes.
+
+## Work Item Requirements
+
+Each work item should include:
+
+- stable ID that can be linked from `.perl-lsp/goals/active.toml`;
+- status: `ready`, `active`, `blocked`, `completed`, or `superseded`;
+- linked proposal, spec, and ADR when applicable;
+- goal and production delta;
+- non-goals and claim boundary;
+- acceptance criteria;
+- proof commands;
+- rollback notes.
+
+## Template
+
+````md
+# Lane implementation plan
+
+Status: active
+Owner:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Active goal:
+
+## Current state
+
+Link to status docs and receipts. Do not copy generated tables.
+
+## Work item: short-id
+
+Status: ready | active | blocked | completed | superseded
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+### Goal
+
+### Production delta
+
+### Non-goals
+
+### Acceptance
+
+### Proof commands
+
+```bash
+cargo test ...
+git diff --check
+```
+
+### Rollback
+
+### Notes
+````
+
+## Plan Hygiene
+
+- Keep product motivation in proposals.
+- Keep behavior contracts in specs.
+- Keep durable decisions in ADRs.
+- Keep generated metric state in generated status docs.
+- Keep the active machine-readable objective in `.perl-lsp/goals/active.toml`.
+- Do not turn a plan into a broad backlog; split unrelated lanes.


### PR DESCRIPTION
### Motivation

- Provide a durable, machine- and human-readable source-of-truth scaffold so agents and reviewers know where each kind of truth (why, what, decision, plan, active goal, proof) should live.
- Prevent agent drift and brittle PRs by encoding a tight agent boot-order, stop conditions, and claim boundaries for lanes and work items.
- Give implementers a reusable plan template and ensure PRs carry explicit source-of-truth links and proof/rollback fields so reviewers can verify claims without chat history.

### Description

- Add `docs/reference/SPEC_SYSTEM.md` with the Repo source-of-truth system, artifact roles, required headers, agent workflow, stop conditions, active-goal lifecycle, closeout format, and common failure modes.
- Add `plans/README.md` documenting the implementation-plan lane, work-item requirements, directory shape, and a reusable `implementation-plan.md` template.
- Update `AGENTS.md` to require agents to read the source-of-truth files (this repo's `SPEC_SYSTEM.md`, `.perl-lsp/goals/active.toml`, linked plan/spec/ADRs) and to enforce a one-work-item-per-PR rule and stop conditions.
- Update `.github/PULL_REQUEST_TEMPLATE.md` to include `Source-of-truth` links, a scope checklist, proof/claim/rollback sections, and `git diff --check` verification guidance; there are no runtime or behavioral code changes in this PR.

### Testing

- Ran `git diff --cached --check` as a pre-commit/style check and it passed with no whitespace or check errors.
- Verified index/status with `git status --short` to confirm the expected files were staged and there were no unexpected changes.
- Reviewed the staged diff (`git diff --cached --stat`) to ensure only the intended files (`docs/reference/SPEC_SYSTEM.md`, `plans/README.md`, `AGENTS.md`, and `.github/PULL_REQUEST_TEMPLATE.md`) were added/modified and there are no runtime modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a17889d288333902047c864c4fd2e)