### PR TITLE
test(pod): add formatted heading coverage (#0000)

### DIFF
--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -133,7 +133,7 @@ pub fn extract_pod(source: &str) -> PodDoc {
         if let Some(heading) = line.strip_prefix("=head2") {
             flush_section(&mut doc, &current_section, &body, false);
             body.clear();
-            let heading = heading.trim().to_string();
+            let heading = strip_pod_formatting(heading.trim());
             current_section = Some(Section::Method(heading));
             continue;
         }

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -570,3 +570,52 @@ sub run { }
     assert_eq!(doc.name.as_deref(), Some("Multi - Multiple POD blocks"));
     assert!(doc.methods.contains_key("run"));
 }
+
+#[test]
+fn formatted_head2_heading_uses_plain_method_key() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+=head2 C<new>
+
+Creates a new instance.
+
+=head2 B<parse> E<lt>inputE<gt>
+
+Parses input values.
+
+=cut
+"#;
+    let doc = extract_pod(source);
+
+    assert!(doc.methods.contains_key("new"), "formatted C<> heading should be normalized");
+    assert!(
+        doc.methods.contains_key("parse <input>"),
+        "formatted B<> and E<> heading should be normalized"
+    );
+    assert!(!doc.methods.contains_key("C<new>"));
+    Ok(())
+}
+
+#[test]
+fn nested_link_display_text_is_escaped() -> Result<(), Box<dyn std::error::Error>> {
+    let doc = extract_pod("=head1 NAME\n\nL<B<click [here]>|File::Path>\n\n=cut\n");
+    let name = doc.name.as_deref().ok_or("expected NAME section")?;
+
+    assert!(
+        name.contains("[click \\[here\\]](perl-module://File::Path)"),
+        "expected nested display formatting to be stripped before markdown escaping; got: {name}"
+    );
+    Ok(())
+}
+
+#[test]
+fn extract_pod_from_file_reads_pod_documentation() -> Result<(), Box<dyn std::error::Error>> {
+    let mut path = std::env::temp_dir();
+    path.push(format!("perl-pod-test-{}.pm", std::process::id()));
+    std::fs::write(&path, "=head1 NAME\n\nTemp::Module - Loaded from disk\n\n=cut\n")?;
+
+    let doc = extract_pod_from_file(&path)?;
+    std::fs::remove_file(&path)?;
+
+    assert_eq!(doc.name.as_deref(), Some("Temp::Module - Loaded from disk"));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- POD `=head2` headings containing inline formatting were being used as raw keys (e.g. `C<new>`), making method lookup noisy and brittle.
- The module lacked focused unit tests for formatted `=head2` headings, nested formatted display text in `L<>` links, and the `extract_pod_from_file` path.

### Description

- Normalize `=head2` method headings by applying the existing `strip_pod_formatting` when constructing `Section::Method` keys in `extract_pod`.  (`crates/perl-pod/src/lib.rs`)
- Add unit tests that cover formatted `=head2` headings, nested formatted link display escaping, and reading POD from a temporary file.  (`crates/perl-pod/tests/pod_extraction_tests.rs`)

### Testing

- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-pod --profile agent --locked` which executed the test binary and all `pod_extraction_tests.rs` tests and passed (43 tests, 0 failed).
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-pod --profile agent --locked` which completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-pod --profile agent --locked -- -D warnings -A missing_docs` which completed with no errors.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe xtask fmt` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ead192008333bb1d6ba5ddd2d3cf)