### PR TITLE
docs(source): define source-of-truth stack (#0000)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,37 @@ like (#0000) or (#9999) will fail CI.
 ## Summary
 <!-- What changed and why. Link the issue: Fixes #NNN -->
 
+## Source-of-truth links
+<!-- Use n/a when this PR is outside the source-of-truth stack. -->
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+<!-- What this PR explicitly does not do. -->
+
+## Proof
+<!-- Commands run, results, unavailable proof, and substitute evidence. -->
+
+## Claim boundary
+<!-- What may be claimed after this PR? What may not be claimed yet? -->
+
+## Rollback
+<!-- How to revert safely. -->
+
 ## Changes
 <!-- List changed files and what each change does -->
 

--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,7 @@ agents/
 # Old review/planning artifacts
 review/
 plans/*
+!plans/README.md
 !plans/real-perl-editor-trust/
 !plans/real-perl-editor-trust/README.md
 !plans/real-perl-editor-trust/implementation-plan.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,37 @@ The orchestrator reads `CLAUDE.md`. This file is for you.
 | `docs/project/FRICTION_LOG.md` | Platform quirks and known workarounds |
 | `docs/articles/CONTINUOUS_REVIEW_PATTERNS.md` | The orchestration pattern used here |
 | `docs/articles/ORCHESTRATION_COUNTERINTUITIONS.md` | Lessons where the obvious rule was wrong |
+| `docs/reference/SPEC_SYSTEM.md` | Source-of-truth stack: proposal/spec/ADR/plan/active-goal roles |
+| `.perl-lsp/goals/active.toml` | Machine-readable active lane and proof commands |
+
+## Repo source-of-truth stack
+
+This repo uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before changing files for lane work, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.perl-lsp/goals/active.toml`
+3. the linked implementation plan
+4. the linked spec for the selected work item
+5. linked ADRs
+
+Work on exactly one work item per PR. Docs-only artifacts should stay separate:
+proposal PRs explain why, spec PRs define behavior, ADR PRs record durable
+decisions, plan PRs define sequencing, and active-goal PRs define current
+execution state. Runtime/code PRs should link to the spec and plan item they
+implement.
+
+Run the proof commands listed in the selected plan item. If a command cannot run,
+record the command, the reason it is unavailable, substitute evidence if any, and
+whether the missing proof blocks merge. Do not hand-edit generated status; run the
+generator or checker named in the plan. If you add a policy exception, update the
+relevant `policy/*.toml` ledger with owner, reason, coverage, creation date, and
+review date.
 
 **Before starting:** check the latest upstream commits so you do not re-implement
 already-merged work.

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,179 @@
+# Repo source-of-truth system
+
+This repo uses a linked source-of-truth stack so humans and agents can find the
+right kind of truth in the right artifact instead of reconstructing context from
+chat history or stale status notes.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+|---|---|---|
+| Roadmap | Release direction, milestone framing, lane inventory | Detailed PR queue, live generated metrics, proof receipts |
+| Proposal | Why the lane exists, affected users and surfaces, alternatives, risks, success criteria | Behavior contract, implementation sequence, current generated status |
+| Spec | Required behavior, acceptance examples, proof requirements, claim boundaries | Product rationale, active queue, PR order |
+| ADR | Durable architecture or operating decision, context, consequences, rejected alternatives | Task list, current metric state, implementation queue |
+| Plan | PR order, work items, dependencies, proof commands, rollback, handoff | Product motivation, durable architecture, generated status truth |
+| Active goal | Current machine-readable objective, active work items, proof commands, status pointers | Long prose, generated metrics, durable design rationale |
+| Support tiers | Public support claims, evidence, limitations, next promotion proof | Feature design, roadmap, implementation sequencing |
+| Policy ledgers | Exceptions, CI/policy intent, owner, reason, coverage, review/expiry | Broad architecture, product rationale |
+
+## Rules
+
+1. One kind of truth belongs in one artifact.
+2. One semantic artifact or one implementation work item belongs in one PR unless a plan explicitly says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record durable decisions.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier proof or an equivalent evidence pointer.
+8. Policy exceptions require owner, reason, coverage, and review date.
+
+## Required headers
+
+Every new proposal, spec, ADR, and plan should include the applicable source-of-truth links. Use `n/a` when a link is not applicable.
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support-tier impact:
+Policy impact:
+```
+
+Existing legacy artifacts may use older headers. When touching them for lane work,
+prefer moving them toward this shape instead of duplicating their truth elsewhere.
+
+## Agent workflow
+
+Agents must:
+
+1. Read repo instructions (`AGENTS.md` for implementation agents; `CLAUDE.md` for the orchestrator).
+2. Read this file.
+3. Read `.perl-lsp/goals/active.toml`.
+4. Read the linked implementation plan.
+5. Read the linked proposal only for why.
+6. Read the linked spec for acceptance.
+7. Read linked ADRs for constraints.
+8. Inspect git status and recent commits.
+9. Select exactly one ready or active work item.
+10. Implement only that item.
+11. Run the listed proof commands or record why a command is unavailable.
+12. Update status, receipts, or policy ledgers only when the selected work item requires it.
+13. Commit one focused change and open one focused PR.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal is missing or stale;
+- linked proposal, spec, ADR, or plan files do not exist;
+- the selected work item is missing or contradictory;
+- proof commands cannot run and no substitute evidence is defined;
+- generated status differs from committed status before the work starts;
+- unrelated staged changes exist;
+- requested work conflicts with an ADR;
+- a public claim lacks support-tier proof.
+
+## Active goal lifecycle
+
+The active manifest lives at:
+
+```text
+.perl-lsp/goals/active.toml
+```
+
+Use `status = "active"` for a current execution lane. Use `status = "paused"`
+with a reason when no lane is selected. Archive replaced goals under:
+
+```text
+.perl-lsp/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+Do not leave multiple active manifests.
+
+## Closeout format
+
+At the end of a lane, add or update:
+
+```text
+plans/<lane>/closeout.md
+```
+
+A closeout should record what shipped, proof commands, receipts, PRs, generated
+status updates, support-tier or policy updates, deferred work, claim boundaries,
+and the next lane recommendation.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md`; keep the spec focused on
+behavior, examples, proof, and claim boundaries.
+
+### Plan becomes product rationale
+
+Move why and alternatives to the proposal; keep the plan focused on work items,
+proof commands, dependencies, and rollback.
+
+### Active goal becomes prose
+
+Keep `.perl-lsp/goals/active.toml` machine-readable and link to prose artifacts.
+Do not copy generated tables into the manifest.
+
+### Agent hand-edits generated status
+
+Run the generator or checker named by the plan. If the command cannot run, record
+that explicitly instead of editing generated output by hand.
+
+### Support claims drift
+
+Add or update support-tier evidence before broadening README, release, or user
+claims.
+
+### Policy exceptions become silent debt
+
+Every policy exception needs owner, reason, `covered_by`, and `review_after`; add
+an expiry for temporary exceptions.
+
+### Mega PR
+
+Split by semantic artifact or by one implementation work item. Do not bundle
+proposal, spec, ADR, plan, active goal, runtime changes, and policy updates unless
+the selected plan item explicitly requires that shape.
+
+## What good looks like
+
+A contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,81 @@
+# Plans
+
+Plans are the sequencing layer for `perl-lsp` work. They translate accepted
+proposals, specs, and ADRs into reviewable PR-sized work items with proof
+commands and rollback notes.
+
+| Layer | Owns | Must not do |
+|---|---|---|
+| Plan | PR order, work items, dependencies, acceptance, proof commands, rollback, handoff | Product rationale, durable architecture decisions, generated status truth |
+
+## Current Lanes
+
+| Lane | Plan | Active goal |
+|---|---|---|
+| Real Perl editor trust | [implementation plan](real-perl-editor-trust/implementation-plan.md) | [`.perl-lsp/goals/active.toml`](../.perl-lsp/goals/active.toml) |
+
+## Plan Contract
+
+A plan should include:
+
+- source-of-truth links to the proposal, specs, ADRs, and active goal;
+- a factual current-state baseline that links to status docs instead of copying generated tables;
+- one section per work item using a stable anchor;
+- status for each work item (`ready`, `active`, `blocked`, `completed`, `superseded`, or `deferred`);
+- production delta and non-goals;
+- acceptance criteria;
+- proof commands;
+- rollback guidance.
+
+Plans answer **what PR lands next**. If plan text starts explaining why the lane
+exists, move that material to `docs/proposals/`. If it records a durable
+architecture constraint, move that material to `docs/adr/`.
+
+## Work Item Template
+
+````md
+## Work item: short-id
+
+Status: ready
+Linked proposal: docs/proposals/PLSP-PROP-####-lane.md
+Linked spec: docs/specs/PLSP-SPEC-####-contract.md
+Linked ADR: docs/adr/PLSP-ADR-####-decision.md
+Blocks: n/a
+Blocked by: n/a
+
+### Goal
+
+One paragraph.
+
+### Production delta
+
+What files, commands, APIs, workflows, or behavior change?
+
+### Non-goals
+
+What is explicitly out of scope?
+
+### Acceptance
+
+What must be true for the PR to merge?
+
+### Proof commands
+
+```bash
+git diff --check
+```
+
+### Rollback
+
+How to undo this PR safely.
+
+### Notes
+
+Optional.
+````
+
+## Closeout
+
+When a lane ends, add `plans/<lane>/closeout.md` with shipped work, proof,
+receipts, generated status updates, support-tier or policy changes, deferred
+items, claim boundaries, and the next recommended lane.


### PR DESCRIPTION
### Motivation
- Provide a canonical, linked source-of-truth for proposals, specs, ADRs, plans, and active goals so agents and reviewers know where each kind of truth belongs. 
- Reduce agent drift and accidental hand-editing of generated status by giving a clear agent boot/first-read sequence and proof/claim rules. 

### Description
- Add `docs/reference/SPEC_SYSTEM.md` describing the repo source-of-truth stack, artifact roles, required headers, agent workflow, stop conditions, active-goal lifecycle, closeout format, and common failure modes. 
- Add `plans/README.md` defining the plans layer, plan contract, work-item template, and a current-lane index. 
- Update `AGENTS.md` to include the source-of-truth first-read flow, one-work-item scope rule, proof rule, generated-status rule, and policy-ledger guidance. 
- Extend `.github/PULL_REQUEST_TEMPLATE.md` with source-of-truth links, a scope checklist, and explicit sections for proof, claim boundary, and rollback. 
- Adjust `.gitignore` to permit committing `plans/README.md` while preserving existing ignored plan artifacts. 

### Testing
- Ran `git diff --check` and no diff-check issues were reported. 
- Changes are documentation-only and did not require runtime or crate tests as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a17889d288333902047c864c4fd2e)