### PR TITLE
feat(semantic): add receiver type facts (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/mod.rs
@@ -20,6 +20,8 @@ pub mod index;
 /// Package graph edge extraction from inheritance and role-composition patterns.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod package_graph_extractor;
+/// Receiver facts for method-call completion and navigation.
+pub mod receiver_facts;
 /// Scope analysis for variable and subroutine resolution.
 #[allow(missing_docs)]
 pub mod scope_analyzer;
@@ -27,6 +29,8 @@ pub mod scope_analyzer;
 pub mod semantic;
 /// Symbol extraction and symbol table construction.
 pub mod symbol;
+/// Rich type facts for expression and receiver inference.
+pub mod type_facts;
 /// Type inference engine for Perl variable analysis.
 pub mod type_inference;
 /// Lightweight value-shape inference from constructor calls, bless, and `$self`.

--- a/crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs
@@ -1,0 +1,109 @@
+//! Receiver facts for method-call completion and navigation.
+//!
+//! A receiver fact is the semantic-layer contract between expression inference
+//! and consumers that need to resolve a method receiver to a package.
+
+use crate::analysis::type_facts::TypeFact;
+use crate::analysis::type_inference::{PerlType, TypeEnvironment, TypeInferenceEngine};
+use crate::ast::{Node, NodeKind};
+
+/// Inferred fact for a method-call receiver.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ReceiverFact {
+    /// Syntactic receiver expression classification.
+    pub receiver: ReceiverExpr,
+    /// Rich type fact inferred for the receiver expression.
+    pub fact: TypeFact,
+    /// Resolved package when the receiver is statically known as an object.
+    pub package: Option<String>,
+}
+
+/// Syntactic classification of a method receiver expression.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ReceiverExpr {
+    /// Static package receiver such as `MyApp::Service`.
+    StaticPackage(String),
+    /// Variable receiver such as `$service`.
+    Variable(String),
+    /// Plain hash slot receiver such as `$services{db}`.
+    HashSlot {
+        /// Hash variable name.
+        base: String,
+        /// Static hash key.
+        key: String,
+    },
+    /// Hash-reference slot receiver such as `$services->{db}`.
+    HashRefSlot {
+        /// Base receiver expression.
+        base: Box<ReceiverExpr>,
+        /// Static hash key.
+        key: String,
+    },
+    /// Method-call receiver such as `$self->db`.
+    MethodCall {
+        /// Base receiver expression.
+        receiver: Box<ReceiverExpr>,
+        /// Method name.
+        method: String,
+    },
+    /// Unknown receiver syntax.
+    Unknown,
+}
+
+impl TypeInferenceEngine {
+    /// Infer a receiver fact for a method-call object expression.
+    pub fn receiver_fact_for_method_call(
+        &mut self,
+        object: &Node,
+        env: &mut TypeEnvironment,
+    ) -> ReceiverFact {
+        let fact = self.infer_expr_fact(object, env);
+        let package = match &fact.ty {
+            PerlType::Object(package) => Some(package.clone()),
+            PerlType::Reference(inner) => match inner.as_ref() {
+                PerlType::Object(package) => Some(package.clone()),
+                _ => None,
+            },
+            _ => None,
+        };
+
+        ReceiverFact { receiver: receiver_expr_from_node(object), fact, package }
+    }
+}
+
+fn receiver_expr_from_node(node: &Node) -> ReceiverExpr {
+    match &node.kind {
+        NodeKind::Identifier { name } => ReceiverExpr::StaticPackage(name.clone()),
+        NodeKind::Variable { name, .. } => ReceiverExpr::Variable(name.clone()),
+        NodeKind::Binary { op, left, right } if op == "{}" => {
+            let Some(key) = static_key(right) else {
+                return ReceiverExpr::Unknown;
+            };
+            let NodeKind::Variable { name, .. } = &left.kind else {
+                return ReceiverExpr::Unknown;
+            };
+            ReceiverExpr::HashSlot { base: name.clone(), key }
+        }
+        NodeKind::Binary { op, left, right } if op == "->{}" => {
+            let Some(key) = static_key(right) else {
+                return ReceiverExpr::Unknown;
+            };
+            ReceiverExpr::HashRefSlot { base: Box::new(receiver_expr_from_node(left)), key }
+        }
+        NodeKind::MethodCall { object, method, .. } => ReceiverExpr::MethodCall {
+            receiver: Box::new(receiver_expr_from_node(object)),
+            method: method.clone(),
+        },
+        _ => ReceiverExpr::Unknown,
+    }
+}
+
+fn static_key(node: &Node) -> Option<String> {
+    match &node.kind {
+        NodeKind::Identifier { name } => Some(name.clone()),
+        NodeKind::String { value, .. } | NodeKind::Number { value } => Some(value.clone()),
+        _ => None,
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
@@ -1,0 +1,198 @@
+//! Rich expression type facts layered on top of [`PerlType`].
+//!
+//! These facts keep the existing coarse type model stable while preserving the
+//! evidence, confidence, dynamic-boundary, and container-shape information needed
+//! by receiver-aware features such as method completion.
+
+use crate::analysis::type_inference::{PerlType, ScalarType};
+use perl_semantic_facts::Confidence;
+use std::collections::BTreeMap;
+
+/// A typed fact inferred for an expression or variable.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct TypeFact {
+    /// The coarse type used by existing public APIs.
+    pub ty: PerlType,
+    /// Confidence in the static inference.
+    pub confidence: Confidence,
+    /// Evidence explaining why this fact was produced.
+    pub evidence: Vec<TypeEvidence>,
+    /// Dynamic boundary that prevented precise inference, if any.
+    pub dynamic_boundary: Option<DynamicBoundary>,
+    /// Optional structural shape for containers and objects.
+    pub shape: Option<ShapeFact>,
+}
+
+/// Structural information attached to a type fact.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ShapeFact {
+    /// Statically-known hash slots.
+    Hash(HashShape),
+    /// Statically-known array indexes or element type.
+    Array(ArrayShape),
+    /// Statically-known object fields.
+    Object(ObjectShape),
+}
+
+/// Statically-known hash shape.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct HashShape {
+    /// Per-key slot facts for static keys.
+    pub slots: BTreeMap<String, TypeFact>,
+    /// Fallback value fact when a static key is not present.
+    pub fallback_value: Option<Box<TypeFact>>,
+}
+
+/// Statically-known array shape.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ArrayShape {
+    /// Per-index facts for static indexes.
+    pub indexed: BTreeMap<usize, TypeFact>,
+    /// Fallback element fact when a static index is not present.
+    pub element: Option<Box<TypeFact>>,
+}
+
+/// Statically-known object shape.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ObjectShape {
+    /// Package represented by this object shape.
+    pub package: String,
+    /// Per-field facts for statically-known fields.
+    pub fields: BTreeMap<String, TypeFact>,
+}
+
+/// Evidence carried by a type fact.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum TypeEvidence {
+    /// Literal syntax produced the fact.
+    Literal,
+    /// A variable initializer produced the fact.
+    VariableInitializer {
+        /// Variable name.
+        name: String,
+    },
+    /// An assignment produced the fact.
+    Assignment {
+        /// Assigned variable name.
+        name: String,
+    },
+    /// A hash slot produced the fact.
+    HashSlot {
+        /// Hash variable or literal marker.
+        hash: String,
+        /// Static hash key.
+        key: String,
+    },
+    /// A hash-reference slot produced the fact.
+    HashRefSlot {
+        /// Base receiver expression label.
+        base: String,
+        /// Static hash key.
+        key: String,
+    },
+    /// A constructor call produced the fact.
+    ConstructorCall {
+        /// Constructed package name.
+        package: String,
+    },
+    /// A bless literal produced the fact.
+    BlessLiteral {
+        /// Blessed package name.
+        package: String,
+    },
+    /// Moose/Moo `isa` metadata produced the fact.
+    MooseIsa {
+        /// Attribute name.
+        attr: String,
+        /// Moose/Moo isa string.
+        isa: String,
+    },
+    /// Object::Pad field metadata produced the fact.
+    ObjectPadField {
+        /// Field name.
+        field: String,
+    },
+    /// Workspace symbols produced the fact.
+    WorkspaceSymbol {
+        /// Workspace package symbol name.
+        package: String,
+    },
+    /// A heuristic produced the fact.
+    Heuristic {
+        /// Heuristic explanation.
+        reason: String,
+    },
+}
+
+/// Dynamic boundary that prevented precise inference.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum DynamicBoundary {
+    /// Hash key expression is not statically known.
+    DynamicHashKey,
+    /// Bless class expression is not statically known.
+    DynamicBlessClass,
+    /// Method name expression is not statically known.
+    DynamicMethodName,
+    /// Runtime import prevents exact static knowledge.
+    RuntimeImport,
+    /// Receiver expression could not be identified.
+    UnknownReceiver,
+}
+
+impl TypeFact {
+    /// Return the coarse type used by existing type APIs.
+    pub fn erased_type(&self) -> PerlType {
+        self.ty.clone()
+    }
+
+    /// Build a fact with high confidence and no shape.
+    pub fn high(ty: PerlType, evidence: Vec<TypeEvidence>) -> Self {
+        Self { ty, confidence: Confidence::High, evidence, dynamic_boundary: None, shape: None }
+    }
+
+    /// Build a low-confidence `Any` fact.
+    pub fn unknown() -> Self {
+        Self {
+            ty: PerlType::Any,
+            confidence: Confidence::Low,
+            evidence: vec![TypeEvidence::Heuristic { reason: "unknown expression".to_string() }],
+            dynamic_boundary: None,
+            shape: None,
+        }
+    }
+
+    /// Build a low-confidence fact for a dynamic boundary.
+    pub fn dynamic(boundary: DynamicBoundary) -> Self {
+        Self {
+            ty: PerlType::Any,
+            confidence: Confidence::Low,
+            evidence: vec![TypeEvidence::Heuristic { reason: "dynamic boundary".to_string() }],
+            dynamic_boundary: Some(boundary),
+            shape: None,
+        }
+    }
+
+    /// Build an unknown hash fact.
+    pub fn unknown_hash() -> Self {
+        Self {
+            ty: PerlType::Hash {
+                key: Box::new(PerlType::Scalar(ScalarType::String)),
+                value: Box::new(PerlType::Any),
+            },
+            confidence: Confidence::Low,
+            evidence: vec![TypeEvidence::Heuristic { reason: "unknown hash".to_string() }],
+            dynamic_boundary: None,
+            shape: Some(ShapeFact::Hash(HashShape {
+                slots: BTreeMap::new(),
+                fallback_value: None,
+            })),
+        }
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -1,5 +1,9 @@
+use crate::analysis::type_facts::{
+    ArrayShape, DynamicBoundary, HashShape, ShapeFact, TypeEvidence, TypeFact,
+};
 use crate::ast::{Node, NodeKind};
-use std::collections::HashMap;
+use perl_semantic_facts::Confidence;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::sync::Arc;
 
@@ -100,6 +104,93 @@ impl fmt::Display for PerlType {
     }
 }
 
+fn confidence_rank(confidence: Confidence) -> u8 {
+    match confidence {
+        Confidence::High => 2,
+        Confidence::Medium => 1,
+        Confidence::Low => 0,
+    }
+}
+
+fn lower_confidence(left: Confidence, right: Confidence) -> Confidence {
+    if confidence_rank(left) <= confidence_rank(right) { left } else { right }
+}
+
+fn unify_type_facts(facts: &[TypeFact]) -> TypeFact {
+    if facts.is_empty() {
+        return TypeFact::unknown();
+    }
+
+    let mut tys = Vec::new();
+    let mut confidence = Confidence::High;
+    let mut evidence = Vec::new();
+    let mut dynamic_boundary = None;
+
+    for fact in facts {
+        if !tys.iter().any(|ty| ty == &fact.ty) {
+            tys.push(fact.ty.clone());
+        }
+        confidence = lower_confidence(confidence, fact.confidence);
+        evidence.extend(fact.evidence.clone());
+        if dynamic_boundary.is_none() {
+            dynamic_boundary = fact.dynamic_boundary.clone();
+        }
+    }
+
+    let ty = match tys.as_slice() {
+        [] => PerlType::Any,
+        [only] => only.clone(),
+        _ => PerlType::Union(tys),
+    };
+
+    TypeFact { ty, confidence, evidence, dynamic_boundary, shape: None }
+}
+
+fn append_evidence(mut evidence: Vec<TypeEvidence>, next: TypeEvidence) -> Vec<TypeEvidence> {
+    evidence.push(next);
+    evidence
+}
+
+fn static_hash_key(node: &Node) -> Option<String> {
+    match &node.kind {
+        NodeKind::Identifier { name } => Some(name.clone()),
+        NodeKind::String { value, .. } | NodeKind::Number { value } => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn looks_like_package(name: &str) -> bool {
+    name.contains("::") || name.chars().next().is_some_and(char::is_uppercase)
+}
+
+fn static_package_expr(node: &Node) -> Option<String> {
+    match &node.kind {
+        NodeKind::Identifier { name } if looks_like_package(name) => Some(name.clone()),
+        _ => None,
+    }
+}
+
+fn plain_hash_slot(node: &Node) -> Option<(String, String)> {
+    let NodeKind::Binary { op, left, right } = &node.kind else {
+        return None;
+    };
+
+    if op != "{}" {
+        return None;
+    }
+
+    let NodeKind::Variable { sigil, name } = &left.kind else {
+        return None;
+    };
+
+    if sigil != "$" {
+        return None;
+    }
+
+    let key = static_hash_key(right)?;
+    Some((name.clone(), key))
+}
+
 /// Type constraint for type checking
 #[derive(Debug, Clone)]
 pub struct TypeConstraint {
@@ -131,6 +222,8 @@ pub struct TypeLocation {
 pub struct TypeEnvironment {
     /// Variable types in current scope
     variables: HashMap<String, PerlType>,
+    /// Rich variable facts in current scope
+    variable_facts: HashMap<String, TypeFact>,
     /// Subroutine signatures
     subroutines: HashMap<String, PerlType>,
     /// Parent scope (for nested scopes)
@@ -146,13 +239,19 @@ impl Default for TypeEnvironment {
 impl TypeEnvironment {
     /// Creates a new empty type environment
     pub fn new() -> Self {
-        Self { variables: HashMap::new(), subroutines: HashMap::new(), parent: None }
+        Self {
+            variables: HashMap::new(),
+            variable_facts: HashMap::new(),
+            subroutines: HashMap::new(),
+            parent: None,
+        }
     }
 
     /// Creates a new type environment with a parent scope
     pub fn with_parent(parent: TypeEnvironment) -> Self {
         Self {
             variables: HashMap::new(),
+            variable_facts: HashMap::new(),
             subroutines: HashMap::new(),
             parent: Some(Box::new(parent)),
         }
@@ -163,9 +262,48 @@ impl TypeEnvironment {
         self.variables.insert(name, ty);
     }
 
+    /// Sets the rich type fact for a variable in the current scope.
+    pub fn set_variable_fact(&mut self, name: String, fact: TypeFact) {
+        self.variables.insert(name.clone(), fact.erased_type());
+        self.variable_facts.insert(name, fact);
+    }
+
     /// Gets the type of a variable, searching parent scopes if needed
     pub fn get_variable(&self, name: &str) -> Option<&PerlType> {
         self.variables.get(name).or_else(|| self.parent.as_ref().and_then(|p| p.get_variable(name)))
+    }
+
+    /// Gets the rich type fact for a variable, searching parent scopes if needed.
+    pub fn get_variable_fact(&self, name: &str) -> Option<&TypeFact> {
+        self.variable_facts
+            .get(name)
+            .or_else(|| self.parent.as_ref().and_then(|p| p.get_variable_fact(name)))
+    }
+
+    /// Gets a cloned rich type fact for a variable.
+    pub fn get_fact_at(&self, name: &str) -> Option<TypeFact> {
+        self.get_variable_fact(name).cloned()
+    }
+
+    /// Updates or creates a static hash slot fact in the current scope.
+    pub fn update_hash_slot(&mut self, name: &str, key: &str, fact: TypeFact) {
+        let mut base_fact =
+            self.get_variable_fact(name).cloned().unwrap_or_else(TypeFact::unknown_hash);
+        let mut shape = match base_fact.shape.take() {
+            Some(ShapeFact::Hash(shape)) => shape,
+            _ => HashShape { slots: BTreeMap::new(), fallback_value: None },
+        };
+
+        shape.slots.insert(key.to_string(), fact);
+        let slot_facts: Vec<TypeFact> = shape.slots.values().cloned().collect();
+        let fallback = unify_type_facts(&slot_facts);
+        base_fact.ty = PerlType::Hash {
+            key: Box::new(PerlType::Scalar(ScalarType::String)),
+            value: Box::new(fallback.ty.clone()),
+        };
+        shape.fallback_value = Some(Box::new(fallback));
+        base_fact.shape = Some(ShapeFact::Hash(shape));
+        self.set_variable_fact(name.to_string(), base_fact);
     }
 
     /// Sets the type signature for a subroutine in the current scope
@@ -278,6 +416,394 @@ impl TypeInferenceEngine {
             "defined".to_string(),
             Subroutine { params: vec![Any], returns: vec![Scalar(Boolean)] },
         );
+    }
+
+    /// Infer a rich type fact for an expression node.
+    pub fn infer_expr_fact(&mut self, node: &Node, env: &mut TypeEnvironment) -> TypeFact {
+        match &node.kind {
+            NodeKind::Program { statements } | NodeKind::Block { statements } => {
+                let mut last = TypeFact::high(PerlType::Void, Vec::new());
+                for statement in statements {
+                    last = self.infer_expr_fact(statement, env);
+                }
+                last
+            }
+            NodeKind::ExpressionStatement { expression } => self.infer_expr_fact(expression, env),
+            NodeKind::Variable { sigil, name } => {
+                if let Some(fact) = env.get_variable_fact(name) {
+                    return fact.clone();
+                }
+
+                let ty = match sigil.as_str() {
+                    "$" => PerlType::Scalar(ScalarType::Mixed),
+                    "@" => PerlType::Array(Box::new(PerlType::Any)),
+                    "%" => PerlType::Hash {
+                        key: Box::new(PerlType::Scalar(ScalarType::String)),
+                        value: Box::new(PerlType::Any),
+                    },
+                    "*" => PerlType::Glob,
+                    _ => PerlType::Any,
+                };
+                TypeFact::high(ty, Vec::new())
+            }
+            NodeKind::Number { value } => {
+                let scalar = if value.contains('.') || value.contains('e') || value.contains('E') {
+                    ScalarType::Float
+                } else {
+                    ScalarType::Integer
+                };
+                TypeFact::high(PerlType::Scalar(scalar), vec![TypeEvidence::Literal])
+            }
+            NodeKind::String { .. } => {
+                TypeFact::high(PerlType::Scalar(ScalarType::String), vec![TypeEvidence::Literal])
+            }
+            NodeKind::Undef => {
+                TypeFact::high(PerlType::Scalar(ScalarType::Undef), vec![TypeEvidence::Literal])
+            }
+            NodeKind::HashLiteral { pairs } => self.infer_hash_literal_fact(pairs, env),
+            NodeKind::ArrayLiteral { elements } => self.infer_array_literal_fact(elements, env),
+            NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
+                self.apply_assignment_fact(lhs, rhs, env)
+            }
+            NodeKind::Binary { op, left, right } if op == "=" => {
+                self.apply_assignment_fact(left, right, env)
+            }
+            NodeKind::VariableDeclaration { variable, initializer, .. } => {
+                self.infer_variable_declaration_fact(variable, initializer.as_deref(), env)
+            }
+            NodeKind::MethodCall { object, method, args } => {
+                self.infer_method_call_fact(object, method, args, env)
+            }
+            NodeKind::FunctionCall { name, args } => self.infer_function_call_fact(name, args, env),
+            NodeKind::Binary { op, left, right } if op == "{}" => {
+                self.infer_plain_hash_slot(left, right, env)
+            }
+            NodeKind::Binary { op, left, right } if op == "->{}" => {
+                self.infer_hashref_slot(left, right, env)
+            }
+            NodeKind::Binary { op, left, right } if op == "[]" || op == "->[]" => {
+                self.infer_array_slot_fact(op, left, right, env)
+            }
+            _ => TypeFact::unknown(),
+        }
+    }
+
+    fn infer_variable_declaration_fact(
+        &mut self,
+        variable: &Node,
+        initializer: Option<&Node>,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let NodeKind::Variable { sigil, name } = &variable.kind else {
+            return TypeFact::unknown();
+        };
+
+        let mut fact = if sigil == "%" {
+            initializer
+                .map(|init| self.infer_hash_initializer_fact(init, env))
+                .unwrap_or_else(TypeFact::unknown_hash)
+        } else {
+            initializer.map(|init| self.infer_expr_fact(init, env)).unwrap_or_else(|| {
+                TypeFact::high(PerlType::Scalar(ScalarType::Undef), vec![TypeEvidence::Literal])
+            })
+        };
+
+        fact.evidence = append_evidence(
+            fact.evidence,
+            TypeEvidence::VariableInitializer { name: name.clone() },
+        );
+        env.set_variable_fact(name.clone(), fact.clone());
+        self.global_env.set_variable_fact(name.clone(), fact.clone());
+        fact
+    }
+
+    fn infer_hash_initializer_fact(&mut self, init: &Node, env: &mut TypeEnvironment) -> TypeFact {
+        match &init.kind {
+            NodeKind::HashLiteral { pairs } => self.infer_hash_literal_fact(pairs, env),
+            NodeKind::ArrayLiteral { elements } => {
+                self.infer_hash_from_array_elements(elements, env)
+            }
+            _ => self.infer_expr_fact(init, env),
+        }
+    }
+
+    fn infer_hash_literal_fact(
+        &mut self,
+        pairs: &[(Node, Node)],
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let mut slots = BTreeMap::new();
+        let mut value_facts = Vec::new();
+
+        for (key_node, value_node) in pairs {
+            let value_fact = self.infer_expr_fact(value_node, env);
+            value_facts.push(value_fact.clone());
+
+            if let Some(key) = static_hash_key(key_node) {
+                slots.insert(
+                    key.clone(),
+                    TypeFact {
+                        evidence: append_evidence(
+                            value_fact.evidence.clone(),
+                            TypeEvidence::HashSlot { hash: "<literal>".to_string(), key },
+                        ),
+                        ..value_fact
+                    },
+                );
+            }
+        }
+
+        self.hash_fact_from_slots(slots, value_facts)
+    }
+
+    fn infer_hash_from_array_elements(
+        &mut self,
+        elements: &[Node],
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let mut slots = BTreeMap::new();
+        let mut value_facts = Vec::new();
+
+        for pair in elements.chunks(2) {
+            let Some(value_node) = pair.get(1) else {
+                continue;
+            };
+            let value_fact = self.infer_expr_fact(value_node, env);
+            value_facts.push(value_fact.clone());
+
+            if let Some(key_node) = pair.first() {
+                if let Some(key) = static_hash_key(key_node) {
+                    slots.insert(
+                        key.clone(),
+                        TypeFact {
+                            evidence: append_evidence(
+                                value_fact.evidence.clone(),
+                                TypeEvidence::HashSlot { hash: "<literal>".to_string(), key },
+                            ),
+                            ..value_fact
+                        },
+                    );
+                }
+            }
+        }
+
+        self.hash_fact_from_slots(slots, value_facts)
+    }
+
+    fn hash_fact_from_slots(
+        &self,
+        slots: BTreeMap<String, TypeFact>,
+        value_facts: Vec<TypeFact>,
+    ) -> TypeFact {
+        let fallback = unify_type_facts(&value_facts);
+        TypeFact {
+            ty: PerlType::Hash {
+                key: Box::new(PerlType::Scalar(ScalarType::String)),
+                value: Box::new(fallback.ty.clone()),
+            },
+            confidence: Confidence::High,
+            evidence: vec![TypeEvidence::Literal],
+            dynamic_boundary: None,
+            shape: Some(ShapeFact::Hash(HashShape {
+                slots,
+                fallback_value: Some(Box::new(fallback)),
+            })),
+        }
+    }
+
+    fn infer_array_literal_fact(
+        &mut self,
+        elements: &[Node],
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let mut indexed = BTreeMap::new();
+        let mut element_facts = Vec::new();
+        for (index, element) in elements.iter().enumerate() {
+            let fact = self.infer_expr_fact(element, env);
+            indexed.insert(index, fact.clone());
+            element_facts.push(fact);
+        }
+        let element = unify_type_facts(&element_facts);
+        TypeFact {
+            ty: PerlType::Array(Box::new(element.ty.clone())),
+            confidence: Confidence::High,
+            evidence: vec![TypeEvidence::Literal],
+            dynamic_boundary: None,
+            shape: Some(ShapeFact::Array(ArrayShape { indexed, element: Some(Box::new(element)) })),
+        }
+    }
+
+    fn apply_assignment_fact(
+        &mut self,
+        lhs: &Node,
+        rhs: &Node,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let rhs_fact = self.infer_expr_fact(rhs, env);
+
+        if let Some((base_name, key)) = plain_hash_slot(lhs) {
+            let slot_fact = TypeFact {
+                evidence: append_evidence(
+                    rhs_fact.evidence.clone(),
+                    TypeEvidence::HashSlot { hash: base_name.clone(), key: key.clone() },
+                ),
+                ..rhs_fact.clone()
+            };
+            env.update_hash_slot(&base_name, &key, slot_fact.clone());
+            self.global_env.update_hash_slot(&base_name, &key, slot_fact);
+            return rhs_fact;
+        }
+
+        if let NodeKind::Variable { name, .. } = &lhs.kind {
+            let mut assigned = rhs_fact.clone();
+            assigned.evidence =
+                append_evidence(assigned.evidence, TypeEvidence::Assignment { name: name.clone() });
+            env.set_variable_fact(name.clone(), assigned.clone());
+            self.global_env.set_variable_fact(name.clone(), assigned);
+        }
+
+        rhs_fact
+    }
+
+    fn infer_plain_hash_slot(
+        &mut self,
+        left: &Node,
+        right: &Node,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let Some(key) = static_hash_key(right) else {
+            return TypeFact::dynamic(DynamicBoundary::DynamicHashKey);
+        };
+
+        let NodeKind::Variable { sigil, name } = &left.kind else {
+            return TypeFact::unknown();
+        };
+
+        if sigil != "$" {
+            return TypeFact::unknown();
+        }
+
+        let Some(base_fact) = env.get_variable_fact(name) else {
+            return TypeFact::unknown();
+        };
+
+        match &base_fact.shape {
+            Some(ShapeFact::Hash(shape)) => shape
+                .slots
+                .get(&key)
+                .cloned()
+                .or_else(|| shape.fallback_value.as_ref().map(|fact| (**fact).clone()))
+                .map(|fact| TypeFact {
+                    evidence: append_evidence(
+                        fact.evidence,
+                        TypeEvidence::HashSlot { hash: name.clone(), key },
+                    ),
+                    ..fact
+                })
+                .unwrap_or_else(TypeFact::unknown),
+            _ => TypeFact::unknown(),
+        }
+    }
+
+    fn infer_hashref_slot(
+        &mut self,
+        left: &Node,
+        right: &Node,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let Some(key) = static_hash_key(right) else {
+            return TypeFact::dynamic(DynamicBoundary::DynamicHashKey);
+        };
+
+        let base_fact = self.infer_expr_fact(left, env);
+        match &base_fact.shape {
+            Some(ShapeFact::Hash(shape)) => shape
+                .slots
+                .get(&key)
+                .cloned()
+                .or_else(|| shape.fallback_value.as_ref().map(|fact| (**fact).clone()))
+                .map(|fact| TypeFact {
+                    evidence: append_evidence(
+                        fact.evidence,
+                        TypeEvidence::HashRefSlot { base: "<expr>".to_string(), key },
+                    ),
+                    ..fact
+                })
+                .unwrap_or_else(TypeFact::unknown),
+            Some(ShapeFact::Object(object)) => {
+                object.fields.get(&key).cloned().unwrap_or_else(TypeFact::unknown)
+            }
+            _ => TypeFact::unknown(),
+        }
+    }
+
+    fn infer_array_slot_fact(
+        &mut self,
+        _op: &str,
+        left: &Node,
+        right: &Node,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let base_fact = self.infer_expr_fact(left, env);
+        let index = static_hash_key(right).and_then(|value| value.parse::<usize>().ok());
+        match (&base_fact.shape, index) {
+            (Some(ShapeFact::Array(shape)), Some(index)) => shape
+                .indexed
+                .get(&index)
+                .cloned()
+                .or_else(|| shape.element.as_ref().map(|fact| (**fact).clone()))
+                .unwrap_or_else(TypeFact::unknown),
+            (Some(ShapeFact::Array(shape)), None) => shape
+                .element
+                .as_ref()
+                .map(|fact| (**fact).clone())
+                .unwrap_or_else(TypeFact::unknown),
+            _ => TypeFact::unknown(),
+        }
+    }
+
+    fn infer_method_call_fact(
+        &mut self,
+        object: &Node,
+        method: &str,
+        _args: &[Node],
+        _env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        if method == "new" {
+            if let Some(package) = static_package_expr(object) {
+                return TypeFact::high(
+                    PerlType::Object(package.clone()),
+                    vec![TypeEvidence::ConstructorCall { package }],
+                );
+            }
+        }
+
+        TypeFact::unknown()
+    }
+
+    fn infer_function_call_fact(
+        &mut self,
+        name: &str,
+        _args: &[Node],
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        if let Some(sig) = self.builtins.get(name) {
+            if let PerlType::Subroutine { returns, .. } = sig {
+                return TypeFact::high(
+                    returns.first().cloned().unwrap_or(PerlType::Void),
+                    vec![TypeEvidence::Heuristic { reason: format!("builtin {name}") }],
+                );
+            }
+        }
+
+        if let Some(PerlType::Subroutine { returns, .. }) = env.get_subroutine(name) {
+            return TypeFact::high(
+                returns.first().cloned().unwrap_or(PerlType::Void),
+                vec![TypeEvidence::Heuristic { reason: format!("subroutine {name}") }],
+            );
+        }
+
+        TypeFact::unknown()
     }
 
     /// Infer types for an AST
@@ -468,7 +994,9 @@ impl TypeInferenceEngine {
 
                     // Assignment operators
                     "=" | "+=" | "-=" | "*=" | "/=" | ".=" => {
-                        env.set_variable(self.extract_var_name(left), right_ty.clone());
+                        let name = self.extract_var_name(left);
+                        env.set_variable(name.clone(), right_ty.clone());
+                        env.set_variable_fact(name, TypeFact::high(right_ty.clone(), Vec::new()));
                         Ok(right_ty)
                     }
 
@@ -621,9 +1149,17 @@ impl TypeInferenceEngine {
                         }
                     };
 
-                    // Store in both environments using the name WITHOUT sigil
-                    self.global_env.set_variable(clean_name.to_string(), inferred_type.clone());
-                    env.set_variable(clean_name.to_string(), inferred_type.clone());
+                    // Store in both environments using the name WITHOUT sigil.
+                    let fact = if sigil == "%" {
+                        initializer
+                            .as_deref()
+                            .map(|init| self.infer_hash_initializer_fact(init, env))
+                            .unwrap_or_else(TypeFact::unknown_hash)
+                    } else {
+                        TypeFact::high(inferred_type.clone(), Vec::new())
+                    };
+                    self.global_env.set_variable_fact(clean_name.to_string(), fact.clone());
+                    env.set_variable_fact(clean_name.to_string(), fact);
 
                     inferred_type
                 } else {
@@ -851,6 +1387,11 @@ impl TypeInferenceEngine {
     /// Gets the inferred type for a variable by name
     pub fn get_type_at(&self, name: &str) -> Option<PerlType> {
         self.global_env.get_variable(name).cloned()
+    }
+
+    /// Gets the inferred rich fact for a variable by name.
+    pub fn get_fact_at(&self, name: &str) -> Option<TypeFact> {
+        self.global_env.get_fact_at(name)
     }
 
     /// Returns a human-readable type label for use in hover text.

--- a/crates/perl-semantic-analyzer/tests/receiver_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/receiver_facts.rs
@@ -1,0 +1,163 @@
+use perl_semantic_analyzer::analysis::receiver_facts::ReceiverFact;
+use perl_semantic_analyzer::analysis::type_facts::{DynamicBoundary, TypeEvidence};
+use perl_semantic_analyzer::analysis::type_inference::{TypeEnvironment, TypeInferenceEngine};
+use perl_semantic_analyzer::{Node, NodeKind, Parser};
+use perl_semantic_facts::Confidence;
+use perl_tdd_support::{must, must_some};
+
+fn receiver_fact_for_connect(code: &str) -> ReceiverFact {
+    let mut parser = Parser::new(code);
+    let ast = must(parser.parse());
+    let mut engine = TypeInferenceEngine::new();
+    let mut env = TypeEnvironment::new();
+    engine.infer_expr_fact(&ast, &mut env);
+    let object = must_some(find_method_object(&ast, "connect"));
+    engine.receiver_fact_for_method_call(object, &mut env)
+}
+
+fn find_method_object<'a>(node: &'a Node, method: &str) -> Option<&'a Node> {
+    if let NodeKind::MethodCall { object, method: found, .. } = &node.kind {
+        if found == method {
+            return Some(object);
+        }
+    }
+
+    for child in children(node) {
+        if let Some(found) = find_method_object(child, method) {
+            return Some(found);
+        }
+    }
+
+    None
+}
+
+fn children(node: &Node) -> Vec<&Node> {
+    match &node.kind {
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            statements.iter().collect()
+        }
+        NodeKind::ExpressionStatement { expression } => vec![expression],
+        NodeKind::VariableDeclaration { variable, initializer, .. } => {
+            let mut children = vec![variable.as_ref()];
+            if let Some(initializer) = initializer {
+                children.push(initializer);
+            }
+            children
+        }
+        NodeKind::Assignment { lhs, rhs, .. } | NodeKind::Binary { left: lhs, right: rhs, .. } => {
+            vec![lhs, rhs]
+        }
+        NodeKind::MethodCall { object, args, .. } => {
+            let mut children = vec![object.as_ref()];
+            children.extend(args.iter());
+            children
+        }
+        NodeKind::FunctionCall { args, .. } | NodeKind::ArrayLiteral { elements: args } => {
+            args.iter().collect()
+        }
+        NodeKind::HashLiteral { pairs } => {
+            pairs.iter().flat_map(|(key, value)| [key, value]).collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn has_constructor_evidence(fact: &ReceiverFact, package: &str) -> bool {
+    fact.fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::ConstructorCall { package: found } if found == package)
+    })
+}
+
+fn has_hash_slot_evidence(fact: &ReceiverFact, hash: &str, key: &str) -> bool {
+    fact.fact.evidence.iter().any(|evidence| {
+        matches!(
+            evidence,
+            TypeEvidence::HashSlot { hash: found_hash, key: found_key }
+                if found_hash == hash && found_key == key
+        )
+    })
+}
+
+#[test]
+fn hash_literal_slot_resolves_constructor_receiver_fact() {
+    let fact = receiver_fact_for_connect(
+        r#"
+package MyApp::DB;
+sub connect {}
+
+package main;
+my %services = (
+    db => MyApp::DB->new,
+);
+
+$services{db}->connect;
+"#,
+    );
+
+    assert_eq!(fact.package.as_deref(), Some("MyApp::DB"));
+    assert_eq!(fact.fact.confidence, Confidence::High);
+    assert!(has_hash_slot_evidence(&fact, "services", "db"));
+    assert!(has_constructor_evidence(&fact, "MyApp::DB"));
+}
+
+#[test]
+fn hash_slot_assignment_resolves_constructor_receiver_fact() {
+    let fact = receiver_fact_for_connect(
+        r#"
+package MyApp::DB;
+sub connect {}
+
+package main;
+my %services;
+$services{db} = MyApp::DB->new;
+$services{db}->connect;
+"#,
+    );
+
+    assert_eq!(fact.package.as_deref(), Some("MyApp::DB"));
+    assert_eq!(fact.fact.confidence, Confidence::High);
+    assert!(has_hash_slot_evidence(&fact, "services", "db"));
+    assert!(has_constructor_evidence(&fact, "MyApp::DB"));
+}
+
+#[test]
+fn hashref_literal_slot_resolves_constructor_receiver_fact() {
+    let fact = receiver_fact_for_connect(
+        r#"
+package MyApp::DB;
+sub connect {}
+
+package main;
+my $services = {
+    db => MyApp::DB->new,
+};
+
+$services->{db}->connect;
+"#,
+    );
+
+    assert_eq!(fact.package.as_deref(), Some("MyApp::DB"));
+    assert_eq!(fact.fact.confidence, Confidence::High);
+    assert!(has_constructor_evidence(&fact, "MyApp::DB"));
+}
+
+#[test]
+fn dynamic_hash_key_fails_closed() {
+    let fact = receiver_fact_for_connect(
+        r#"
+package MyApp::DB;
+sub connect {}
+
+package main;
+my %services = (
+    db => MyApp::DB->new,
+);
+my $name = 'db';
+
+$services{$name}->connect;
+"#,
+    );
+
+    assert_eq!(fact.package, None);
+    assert_eq!(fact.fact.dynamic_boundary, Some(DynamicBoundary::DynamicHashKey));
+}


### PR DESCRIPTION
### Motivation

- Provide a narrow, testable pipeline that infers rich receiver facts from the existing AST shapes (including `Binary` ops like `{}` and `->{}`) so completion can resolve `$hash{key}` / `$hashref->{key}` receivers without rewriting the parser.
- Capture confidence, evidence, dynamic-boundary, and per-slot/object shapes so downstream completion/hover can rank and explain suggestions precisely.

### Description

- Add a facts model in `crates/perl-semantic-analyzer/src/analysis/type_facts.rs` defining `TypeFact`, `ShapeFact` (Hash/Array/Object), `TypeEvidence`, and `DynamicBoundary`, and helpers like `erased_type`, `unknown_hash`, and constructors for common fact shapes.
- Extend `TypeEnvironment` (in `type_inference.rs`) with `variable_facts: HashMap<String, TypeFact>`, `set_variable_fact`, `get_variable_fact`, `get_fact_at`, and `update_hash_slot` to persist expression-level facts alongside existing `PerlType` storage.
- Implement expression-level inference APIs in `TypeInferenceEngine`: `infer_expr_fact` and helpers that handle `HashLiteral`, `ArrayLiteral`, `VariableDeclaration`, assignments, `MethodCall` constructors (`Class->new`), plain hash slot (`{}`), hashref slot (`->{}`), array slots, and unify/merge logic for slot fallback types.
- Add the `ReceiverFact` contract and `ReceiverExpr` enum in `crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs` with `receiver_fact_for_method_call` to classify receiver syntax and expose inferred package when available.
- Wire the new modules into the analyzer (`analysis/mod.rs`) and add focused, facts-only fixtures in `crates/perl-semantic-analyzer/tests/receiver_facts.rs` that assert hash-literal slots, slot assignment, hashref literal slots, and dynamic-key fail-closed behavior.

### Testing

- Ran the focused test suite `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-semantic-analyzer --test receiver_facts --profile agent --locked` and all added receiver facts tests passed.
- Performed `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked` which completed successfully for the crate after using a temporary `CARGO_TARGET_DIR` due to environment storage guards.
- Ran clippy (`CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-semantic-analyzer --all-targets --profile agent --locked -- -D warnings -A missing_docs`) and the crate passed with the allowed `missing_docs` exception for some small test structs; `rustfmt --check` also passed for the changed files.

Notes: `just agent-pr-fast` was not executed in this environment because `just` is not installed; some CI-friendly helper invocations were done with `CARGO_TARGET_DIR=/tmp/perl-lsp-target` to avoid local storage guard failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1d976a5c8333b81d84649d0a92bf)