### PR TITLE
feat(semantic): add type facts layer (#8197)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/mod.rs
@@ -27,6 +27,8 @@ pub mod scope_analyzer;
 pub mod semantic;
 /// Symbol extraction and symbol table construction.
 pub mod symbol;
+/// Rich type facts for expression and receiver inference.
+pub mod type_facts;
 /// Type inference engine for Perl variable analysis.
 pub mod type_inference;
 /// Lightweight value-shape inference from constructor calls, bless, and `$self`.

--- a/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
@@ -1,0 +1,221 @@
+//! Rich type facts used by expression and receiver inference.
+//!
+//! [`PerlType`] remains the erased compatibility type for existing APIs.  This
+//! module adds confidence, evidence, dynamic-boundary, and shape metadata that
+//! can be consumed by completion and other semantic features without replacing
+//! the coarse type model.
+
+use super::type_inference::{PerlType, ScalarType};
+use perl_semantic_facts::Confidence;
+use std::collections::BTreeMap;
+
+/// A type with confidence, evidence, dynamic-boundary, and shape metadata.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct TypeFact {
+    /// The erased coarse Perl type represented by this fact.
+    pub ty: PerlType,
+    /// Confidence assigned to this fact.
+    pub confidence: Confidence,
+    /// Evidence that produced or refined this fact.
+    pub evidence: Vec<TypeEvidence>,
+    /// Dynamic boundary that prevented precise inference, when applicable.
+    pub dynamic_boundary: Option<DynamicBoundary>,
+    /// Optional structural shape information for aggregate or object values.
+    pub shape: Option<ShapeFact>,
+}
+
+impl TypeFact {
+    /// Creates a type fact with the supplied coarse type and confidence.
+    pub fn new(ty: PerlType, confidence: Confidence) -> Self {
+        Self { ty, confidence, evidence: Vec::new(), dynamic_boundary: None, shape: None }
+    }
+
+    /// Creates a high-confidence fact for an existing erased type.
+    pub fn from_type(ty: PerlType) -> Self {
+        Self::new(ty, Confidence::High)
+    }
+
+    /// Creates a low-confidence unknown fact.
+    pub fn unknown() -> Self {
+        Self::new(PerlType::Any, Confidence::Low)
+    }
+
+    /// Creates a low-confidence unknown fact with a dynamic-boundary marker.
+    pub fn dynamic(boundary: DynamicBoundary) -> Self {
+        Self {
+            ty: PerlType::Any,
+            confidence: Confidence::Low,
+            evidence: Vec::new(),
+            dynamic_boundary: Some(boundary),
+            shape: None,
+        }
+    }
+
+    /// Creates a low-confidence unknown fact with heuristic evidence.
+    pub fn any_low_confidence(reason: impl Into<String>) -> Self {
+        Self {
+            evidence: vec![TypeEvidence::Heuristic { reason: reason.into() }],
+            ..Self::unknown()
+        }
+    }
+
+    /// Creates an unknown hash fact suitable for uninitialized hash variables.
+    pub fn unknown_hash() -> Self {
+        Self::new(
+            PerlType::Hash {
+                key: Box::new(PerlType::Scalar(ScalarType::String)),
+                value: Box::new(PerlType::Any),
+            },
+            Confidence::Low,
+        )
+    }
+
+    /// Returns the coarse compatibility type for existing APIs.
+    pub fn erased_type(&self) -> PerlType {
+        self.ty.clone()
+    }
+}
+
+/// Structural shape metadata attached to a type fact.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ShapeFact {
+    /// Hash shape with known slots and optional fallback value.
+    Hash(HashShape),
+    /// Array shape with known indexes and optional fallback element value.
+    Array(ArrayShape),
+    /// Object shape with known fields.
+    Object(ObjectShape),
+}
+
+/// Shape information for a Perl hash or hash-like literal.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct HashShape {
+    /// Known statically-addressable hash slots.
+    pub slots: BTreeMap<String, TypeFact>,
+    /// Fallback fact for unknown keys when the hash value type is known.
+    pub fallback_value: Option<Box<TypeFact>>,
+}
+
+impl HashShape {
+    /// Creates a hash shape from known slots and an optional fallback value.
+    pub fn new(slots: BTreeMap<String, TypeFact>, fallback_value: Option<TypeFact>) -> Self {
+        Self { slots, fallback_value: fallback_value.map(Box::new) }
+    }
+}
+
+/// Shape information for a Perl array or array-like literal.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ArrayShape {
+    /// Known statically-addressable array indexes.
+    pub indexed: BTreeMap<usize, TypeFact>,
+    /// Fallback fact for unknown indexes when the array element type is known.
+    pub element: Option<Box<TypeFact>>,
+}
+
+impl ArrayShape {
+    /// Creates an array shape from known indexes and an optional element fallback.
+    pub fn new(indexed: BTreeMap<usize, TypeFact>, element: Option<TypeFact>) -> Self {
+        Self { indexed, element: element.map(Box::new) }
+    }
+}
+
+/// Shape information for an object with field facts.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ObjectShape {
+    /// Package represented by the object shape.
+    pub package: String,
+    /// Known fields on the object.
+    pub fields: BTreeMap<String, TypeFact>,
+}
+
+impl ObjectShape {
+    /// Creates an object shape for a package from known field facts.
+    pub fn new(package: String, fields: BTreeMap<String, TypeFact>) -> Self {
+        Self { package, fields }
+    }
+}
+
+/// Evidence explaining how a type fact was produced.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum TypeEvidence {
+    /// Literal syntax provided the fact.
+    Literal,
+    /// Variable initializer provided the fact.
+    VariableInitializer {
+        /// Variable name without sigil.
+        name: String,
+    },
+    /// Assignment provided the fact.
+    Assignment {
+        /// Variable name without sigil.
+        name: String,
+    },
+    /// Plain hash slot evidence, such as `$hash{key}`.
+    HashSlot {
+        /// Hash variable or literal source.
+        hash: String,
+        /// Static hash key.
+        key: String,
+    },
+    /// Hash-reference slot evidence, such as `$hashref->{key}`.
+    HashRefSlot {
+        /// Base receiver expression label.
+        base: String,
+        /// Static hash key.
+        key: String,
+    },
+    /// Constructor call evidence, such as `Package->new`.
+    ConstructorCall {
+        /// Constructed package.
+        package: String,
+    },
+    /// Bless literal evidence.
+    BlessLiteral {
+        /// Blessed package.
+        package: String,
+    },
+    /// Moose/Moo `isa` evidence for an attribute.
+    MooseIsa {
+        /// Attribute name.
+        attr: String,
+        /// `isa` type string.
+        isa: String,
+    },
+    /// Object::Pad field evidence.
+    ObjectPadField {
+        /// Field name.
+        field: String,
+    },
+    /// Workspace symbol evidence.
+    WorkspaceSymbol {
+        /// Package resolved from workspace symbols.
+        package: String,
+    },
+    /// Heuristic fallback evidence.
+    Heuristic {
+        /// Explanation for the heuristic.
+        reason: String,
+    },
+}
+
+/// Dynamic boundary that prevented precise static inference.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum DynamicBoundary {
+    /// Hash key is computed at runtime.
+    DynamicHashKey,
+    /// Bless target package is computed at runtime.
+    DynamicBlessClass,
+    /// Method name is computed at runtime.
+    DynamicMethodName,
+    /// Import behavior is computed at runtime.
+    RuntimeImport,
+    /// Receiver expression is unknown.
+    UnknownReceiver,
+}

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -1,3 +1,4 @@
+use super::type_facts::TypeFact;
 use crate::ast::{Node, NodeKind};
 use std::collections::HashMap;
 use std::fmt;
@@ -131,6 +132,8 @@ pub struct TypeLocation {
 pub struct TypeEnvironment {
     /// Variable types in current scope
     variables: HashMap<String, PerlType>,
+    /// Rich variable facts in current scope
+    variable_facts: HashMap<String, TypeFact>,
     /// Subroutine signatures
     subroutines: HashMap<String, PerlType>,
     /// Parent scope (for nested scopes)
@@ -146,13 +149,19 @@ impl Default for TypeEnvironment {
 impl TypeEnvironment {
     /// Creates a new empty type environment
     pub fn new() -> Self {
-        Self { variables: HashMap::new(), subroutines: HashMap::new(), parent: None }
+        Self {
+            variables: HashMap::new(),
+            variable_facts: HashMap::new(),
+            subroutines: HashMap::new(),
+            parent: None,
+        }
     }
 
     /// Creates a new type environment with a parent scope
     pub fn with_parent(parent: TypeEnvironment) -> Self {
         Self {
             variables: HashMap::new(),
+            variable_facts: HashMap::new(),
             subroutines: HashMap::new(),
             parent: Some(Box::new(parent)),
         }
@@ -160,12 +169,34 @@ impl TypeEnvironment {
 
     /// Sets the type for a variable in the current scope
     pub fn set_variable(&mut self, name: String, ty: PerlType) {
+        self.variable_facts.remove(&name);
         self.variables.insert(name, ty);
+    }
+
+    /// Sets the rich fact for a variable in the current scope.
+    ///
+    /// The erased type is also stored so existing type-only APIs continue to
+    /// observe the same variable.
+    pub fn set_variable_fact(&mut self, name: String, fact: TypeFact) {
+        self.variables.insert(name.clone(), fact.erased_type());
+        self.variable_facts.insert(name, fact);
     }
 
     /// Gets the type of a variable, searching parent scopes if needed
     pub fn get_variable(&self, name: &str) -> Option<&PerlType> {
         self.variables.get(name).or_else(|| self.parent.as_ref().and_then(|p| p.get_variable(name)))
+    }
+
+    /// Gets the rich fact for a variable, searching parent scopes if needed.
+    pub fn get_variable_fact(&self, name: &str) -> Option<&TypeFact> {
+        self.variable_facts
+            .get(name)
+            .or_else(|| self.parent.as_ref().and_then(|p| p.get_variable_fact(name)))
+    }
+
+    /// Gets the rich fact for a variable by name, searching parent scopes if needed.
+    pub fn get_fact_at(&self, name: &str) -> Option<TypeFact> {
+        self.get_variable_fact(name).cloned()
     }
 
     /// Sets the type signature for a subroutine in the current scope
@@ -851,6 +882,11 @@ impl TypeInferenceEngine {
     /// Gets the inferred type for a variable by name
     pub fn get_type_at(&self, name: &str) -> Option<PerlType> {
         self.global_env.get_variable(name).cloned()
+    }
+
+    /// Gets the inferred rich fact for a variable by name.
+    pub fn get_fact_at(&self, name: &str) -> Option<TypeFact> {
+        self.global_env.get_fact_at(name)
     }
 
     /// Returns a human-readable type label for use in hover text.

--- a/crates/perl-semantic-analyzer/src/lib.rs
+++ b/crates/perl-semantic-analyzer/src/lib.rs
@@ -72,4 +72,5 @@ pub use analysis::index;
 pub use analysis::scope_analyzer;
 pub use analysis::semantic;
 pub use analysis::symbol;
+pub use analysis::type_facts;
 pub use analysis::type_inference;

--- a/crates/perl-semantic-analyzer/tests/type_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/type_facts.rs
@@ -1,0 +1,69 @@
+use perl_semantic_analyzer::analysis::type_facts::{DynamicBoundary, TypeEvidence, TypeFact};
+use perl_semantic_analyzer::analysis::type_inference::{PerlType, ScalarType, TypeEnvironment};
+use perl_semantic_facts::Confidence;
+
+#[test]
+fn variable_fact_stores_erased_type_for_existing_api() -> Result<(), Box<dyn std::error::Error>> {
+    let mut env = TypeEnvironment::new();
+    let mut fact = TypeFact::from_type(PerlType::Object("MyApp::DB".to_string()));
+    fact.evidence.push(TypeEvidence::ConstructorCall { package: "MyApp::DB".to_string() });
+
+    env.set_variable_fact("db".to_string(), fact.clone());
+
+    assert_eq!(env.get_variable("db"), Some(&PerlType::Object("MyApp::DB".to_string())));
+    assert_eq!(env.get_fact_at("db"), Some(fact));
+    Ok(())
+}
+
+#[test]
+fn variable_fact_lookup_searches_parent_scopes() -> Result<(), Box<dyn std::error::Error>> {
+    let mut parent = TypeEnvironment::new();
+    let fact = TypeFact::unknown_hash();
+    parent.set_variable_fact("services".to_string(), fact.clone());
+
+    let child = TypeEnvironment::with_parent(parent);
+
+    assert_eq!(child.get_variable("services"), Some(&fact.erased_type()));
+    assert_eq!(child.get_fact_at("services"), Some(fact));
+    Ok(())
+}
+
+#[test]
+fn type_only_assignment_clears_stale_variable_fact() -> Result<(), Box<dyn std::error::Error>> {
+    let mut env = TypeEnvironment::new();
+    env.set_variable_fact(
+        "value".to_string(),
+        TypeFact::from_type(PerlType::Object("MyApp::DB".to_string())),
+    );
+
+    env.set_variable("value".to_string(), PerlType::Scalar(ScalarType::String));
+
+    assert_eq!(env.get_variable("value"), Some(&PerlType::Scalar(ScalarType::String)));
+    assert_eq!(env.get_fact_at("value"), None);
+    Ok(())
+}
+
+#[test]
+fn dynamic_fact_records_boundary_and_low_confidence() -> Result<(), Box<dyn std::error::Error>> {
+    let fact = TypeFact::dynamic(DynamicBoundary::DynamicHashKey);
+
+    assert_eq!(fact.ty, PerlType::Any);
+    assert_eq!(fact.confidence, Confidence::Low);
+    assert_eq!(fact.dynamic_boundary, Some(DynamicBoundary::DynamicHashKey));
+    Ok(())
+}
+
+#[test]
+fn unknown_hash_erases_to_string_keyed_hash() -> Result<(), Box<dyn std::error::Error>> {
+    let fact = TypeFact::unknown_hash();
+
+    assert_eq!(
+        fact.erased_type(),
+        PerlType::Hash {
+            key: Box::new(PerlType::Scalar(ScalarType::String)),
+            value: Box::new(PerlType::Any),
+        }
+    );
+    assert_eq!(fact.confidence, Confidence::Low);
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Provide a richer, composable facts layer for expression/receiver inference without replacing the existing `PerlType` API. 
- Enable precise receiver facts (shapes, evidence, dynamic boundaries) so completion can later consume an authoritative semantic contract instead of ad-hoc heuristics. 
- Keep backward compatibility with existing type lookups while creating the seam needed to join parsing → facts → completion.

### Description
- Added `crates/perl-semantic-analyzer/src/analysis/type_facts.rs` defining `TypeFact`, `ShapeFact` (Hash/Array/Object), `HashShape`/`ArrayShape`/`ObjectShape`, `TypeEvidence`, and `DynamicBoundary` to capture confidence/evidence/shape metadata. 
- Extended `TypeEnvironment` in `crates/perl-semantic-analyzer/src/analysis/type_inference.rs` with a parallel `variable_facts: HashMap<String, TypeFact>`, plus `set_variable_fact`, `get_variable_fact`, and `get_fact_at`, and made `set_variable` clear stale facts. 
- Added engine-level accessor `TypeInferenceEngine::get_fact_at` while preserving `get_type_at` and `erased_type()` on `TypeFact` so existing callers remain compatible. 
- Re-exported the facts module via the crate lib and registered it in the analysis module. 
- Added focused unit tests `crates/perl-semantic-analyzer/tests/type_facts.rs` covering erased-type compatibility, parent-scope lookup, stale-fact clearing, dynamic-boundary facts, and unknown-hash erasure.

### Testing
- Ran the new unit tests with `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-semantic-analyzer --test type_facts --profile agent --locked` and they passed. 
- Ran full crate checks with `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo check -p perl-semantic-analyzer --all-targets --profile agent --locked` and `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo test -p perl-semantic-analyzer --profile agent --locked`, both of which completed successfully. 
- Ran lints/formatting via `CARGO_TARGET_DIR=/tmp/perl-lsp-target cargo clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs` and `./scripts/cargo-safe xtask fmt`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1d976a5c8333b81d84649d0a92bf)