### PR TITLE
fix(perl-pod): strip inline formatting from head2 method keys (#8197)

### DIFF
--- a/crates/perl-pod/src/lib.rs
+++ b/crates/perl-pod/src/lib.rs
@@ -133,7 +133,7 @@ pub fn extract_pod(source: &str) -> PodDoc {
         if let Some(heading) = line.strip_prefix("=head2") {
             flush_section(&mut doc, &current_section, &body, false);
             body.clear();
-            let heading = heading.trim().to_string();
+            let heading = strip_pod_formatting(heading.trim());
             current_section = Some(Section::Method(heading));
             continue;
         }

--- a/crates/perl-pod/tests/pod_extraction_tests.rs
+++ b/crates/perl-pod/tests/pod_extraction_tests.rs
@@ -763,3 +763,72 @@ Second list:
     assert!(method_doc.contains("- two"), "second list item; got: {method_doc}");
     assert!(method_doc.contains("- three"), "third list item in second list; got: {method_doc}");
 }
+
+// --- Tests for formatted =head2 keys (#9380 bug: strip_pod_formatting not applied to heading) ---
+
+/// `=head2 C<new>` should be keyed as `new`, not `C<new>`.
+#[test]
+fn head2_code_formatted_heading_is_stripped() {
+    let source = r#"
+=head2 C<new>
+
+Constructs a new Foo object.
+
+=cut
+"#;
+    let doc = extract_pod(source);
+    assert!(
+        doc.methods.contains_key("new"),
+        "method key should be stripped bare name 'new'; keys: {:?}",
+        doc.methods.keys().collect::<Vec<_>>()
+    );
+    assert!(!doc.methods.contains_key("C<new>"), "method key must NOT be the raw 'C<new>' string");
+}
+
+/// `=head2 B<bold_method>` should strip bold markup.
+#[test]
+fn head2_bold_formatted_heading_is_stripped() {
+    let source = "=head2 B<bold_method>\n\nDoes something bold.\n\n=cut\n";
+    let doc = extract_pod(source);
+    assert!(
+        doc.methods.contains_key("bold_method"),
+        "bold markup should be stripped; keys: {:?}",
+        doc.methods.keys().collect::<Vec<_>>()
+    );
+}
+
+/// `=head2 I<italic_name>` should strip italic markup.
+#[test]
+fn head2_italic_formatted_heading_is_stripped() {
+    let source = "=head2 I<some_method>\n\nItalic method docs.\n\n=cut\n";
+    let doc = extract_pod(source);
+    assert!(
+        doc.methods.contains_key("some_method"),
+        "italic markup should be stripped; keys: {:?}",
+        doc.methods.keys().collect::<Vec<_>>()
+    );
+}
+
+/// A plain unformatted `=head2 plain` heading still works after the refactor.
+#[test]
+fn head2_plain_heading_key_unchanged() {
+    let source = "=head2 plain_method\n\nPlain docs.\n\n=cut\n";
+    let doc = extract_pod(source);
+    assert!(
+        doc.methods.contains_key("plain_method"),
+        "plain heading should still work; keys: {:?}",
+        doc.methods.keys().collect::<Vec<_>>()
+    );
+}
+
+/// `=head2 C<new>` body content is still accessible after key normalization.
+#[test]
+fn head2_formatted_heading_body_preserved() {
+    let source = "=head2 C<new>\n\nConstructs a new Foo object.\n\n=cut\n";
+    let doc = extract_pod(source);
+    let body = doc.methods.get("new").map(String::as_str).unwrap_or("");
+    assert!(
+        body.contains("Constructs"),
+        "body text should be preserved after key normalization; got: {body}"
+    );
+}


### PR DESCRIPTION
## Problem

`extract_pod` in `crates/perl-pod/src/lib.rs` used the raw trimmed string as the key when inserting a `=head2` section into `doc.methods`. This meant that headings with inline POD formatting codes produced wrong keys:

```
=head2 C<new>       → key is "C<new>"  ✗ (should be "new")
=head2 B<method>    → key is "B<method>"  ✗ (should be "method")
=head2 I<name>      → key is "I<name>"   ✗ (should be "name")
```

The LSP hover provider looks up method documentation by bare name (e.g. `new`), so hover docs were silently missing for any module that used inline formatting in its `=head2` headings — a common pattern in CPAN modules (e.g. `=head2 C<new>`, `=head2 B<parse>`, `=head2 I<method>`).

## Root Cause

```rust
// Line 136 in extract_pod() — before fix:
let heading = heading.trim().to_string();
current_section = Some(Section::Method(heading));
```

`strip_pod_formatting` was already applied to body text (line 113 applies it to `=item` content), but was not applied to the heading itself when creating the section key.

## Fix

One-line change: apply `strip_pod_formatting` to the heading before using it as the key:

```rust
// After fix:
let heading = strip_pod_formatting(heading.trim());
current_section = Some(Section::Method(heading));
```

## Tests Added

Five regression tests in `crates/perl-pod/tests/pod_extraction_tests.rs`:

| Test | Verifies |
|------|---------|
| `head2_code_formatted_heading_is_stripped` | `C<new>` → key `"new"`, not `"C<new>"` |
| `head2_bold_formatted_heading_is_stripped` | `B<bold_method>` → key `"bold_method"` |
| `head2_italic_formatted_heading_is_stripped` | `I<some_method>` → key `"some_method"` |
| `head2_plain_heading_key_unchanged` | plain `=head2 plain_method` still works |
| `head2_formatted_heading_body_preserved` | body content accessible after key normalization |

## Verification

```
cargo test -p perl-pod
# test result: ok. 57 passed; 0 failed
cargo clippy -p perl-pod --lib --tests  # clean
cargo fmt -p perl-pod -- --check        # clean
```

## Scope

- **Changed files:** `crates/perl-pod/src/lib.rs` (1 line), `crates/perl-pod/tests/pod_extraction_tests.rs` (+69 lines, 5 new tests)
- **No production behavior change** for callers that used plain unformatted `=head2` headings (zero-diff for them)
- **No API surface changes** — `PodDoc`, `extract_pod`, `extract_pod_from_file` signatures unchanged

## Related

- PR #9380 identified this same bug independently via a Codex agent pass

https://claude.ai/code/session_01WKkV2c2aqRBpepTKgQzhN7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKkV2c2aqRBpepTKgQzhN7)_