### PR TITLE
feat(semantic): add type facts foundation (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/mod.rs
@@ -27,6 +27,8 @@ pub mod scope_analyzer;
 pub mod semantic;
 /// Symbol extraction and symbol table construction.
 pub mod symbol;
+/// Rich type facts for expression-level inference.
+pub mod type_facts;
 /// Type inference engine for Perl variable analysis.
 pub mod type_inference;
 /// Lightweight value-shape inference from constructor calls, bless, and `$self`.

--- a/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
@@ -1,0 +1,197 @@
+//! Rich type facts layered on top of coarse Perl types.
+//!
+//! This module preserves the existing [`PerlType`] API as the erased type
+//! representation while carrying confidence, evidence, dynamic-boundary, and
+//! shape details for expression-level inference.
+
+use crate::analysis::type_inference::{PerlType, ScalarType};
+use perl_semantic_facts::Confidence;
+use std::collections::BTreeMap;
+
+/// Rich type information inferred for an expression or variable.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeFact {
+    /// Existing coarse Perl type, kept for compatibility with current APIs.
+    pub ty: PerlType,
+    /// Confidence in this fact.
+    pub confidence: Confidence,
+    /// Evidence that produced this fact.
+    pub evidence: Vec<TypeEvidence>,
+    /// Dynamic boundary that prevented precise static inference.
+    pub dynamic_boundary: Option<DynamicBoundary>,
+    /// Optional structural shape associated with the value.
+    pub shape: Option<ShapeFact>,
+}
+
+/// Structural shape information for aggregate and object values.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ShapeFact {
+    /// Hash slots and fallback value type.
+    Hash(HashShape),
+    /// Array indexes and fallback element type.
+    Array(ArrayShape),
+    /// Object fields inferred from constructors or class metadata.
+    Object(ObjectShape),
+}
+
+/// Known slot facts for a hash value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HashShape {
+    /// Facts for statically known hash slots.
+    pub slots: BTreeMap<String, TypeFact>,
+    /// Fallback fact for unknown/static-but-unlisted keys.
+    pub fallback_value: Option<Box<TypeFact>>,
+}
+
+/// Known index facts for an array value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ArrayShape {
+    /// Facts for statically known array indexes.
+    pub indexed: BTreeMap<usize, TypeFact>,
+    /// Fallback fact for unknown indexes.
+    pub element: Option<Box<TypeFact>>,
+}
+
+/// Known field facts for an object value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectShape {
+    /// Package this object shape belongs to.
+    pub package: String,
+    /// Facts for statically known fields.
+    pub fields: BTreeMap<String, TypeFact>,
+}
+
+/// Evidence source for a type fact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeEvidence {
+    /// Literal expression evidence.
+    Literal,
+    /// Variable initializer evidence.
+    VariableInitializer {
+        /// Variable name initialized by the evidence.
+        name: String,
+    },
+    /// Assignment evidence.
+    Assignment {
+        /// Variable or slot name assigned by the evidence.
+        name: String,
+    },
+    /// Plain hash slot evidence, such as `$hash{key}`.
+    HashSlot {
+        /// Hash variable name.
+        hash: String,
+        /// Statically known hash key.
+        key: String,
+    },
+    /// Hash-reference slot evidence, such as `$hashref->{key}`.
+    HashRefSlot {
+        /// Hash-reference base expression label.
+        base: String,
+        /// Statically known hash key.
+        key: String,
+    },
+    /// Constructor call evidence, such as `Package->new`.
+    ConstructorCall {
+        /// Constructed package name.
+        package: String,
+    },
+    /// Literal bless evidence.
+    BlessLiteral {
+        /// Blessed package name.
+        package: String,
+    },
+    /// Moose/Moo `isa` evidence for an attribute.
+    MooseIsa {
+        /// Moose/Moo attribute name.
+        attr: String,
+        /// Declared `isa` type string.
+        isa: String,
+    },
+    /// Object::Pad field evidence.
+    ObjectPadField {
+        /// Object::Pad field name.
+        field: String,
+    },
+    /// Workspace symbol evidence.
+    WorkspaceSymbol {
+        /// Package name from the workspace symbol index.
+        package: String,
+    },
+    /// Heuristic evidence.
+    Heuristic {
+        /// Human-readable heuristic reason.
+        reason: String,
+    },
+}
+
+/// Dynamic boundary that prevented exact static inference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DynamicBoundary {
+    /// Hash key is not statically known.
+    DynamicHashKey,
+    /// Bless target package is dynamic.
+    DynamicBlessClass,
+    /// Method name is dynamic.
+    DynamicMethodName,
+    /// Runtime import prevents static symbol knowledge.
+    RuntimeImport,
+    /// Receiver expression could not be inferred.
+    UnknownReceiver,
+}
+
+impl TypeFact {
+    /// Returns the coarse type that existing APIs expose.
+    pub fn erased_type(&self) -> PerlType {
+        self.ty.clone()
+    }
+
+    /// Builds a fact from an existing coarse type with low-confidence heuristic evidence.
+    pub fn from_erased_type(ty: PerlType) -> Self {
+        Self {
+            ty,
+            confidence: Confidence::Low,
+            evidence: vec![TypeEvidence::Heuristic { reason: "erased type".to_string() }],
+            dynamic_boundary: None,
+            shape: None,
+        }
+    }
+
+    /// Builds an unknown low-confidence fact.
+    pub fn unknown() -> Self {
+        Self {
+            ty: PerlType::Any,
+            confidence: Confidence::Low,
+            evidence: Vec::new(),
+            dynamic_boundary: None,
+            shape: None,
+        }
+    }
+
+    /// Builds an unknown fact with a dynamic boundary.
+    pub fn dynamic(boundary: DynamicBoundary) -> Self {
+        Self {
+            ty: PerlType::Any,
+            confidence: Confidence::Low,
+            evidence: Vec::new(),
+            dynamic_boundary: Some(boundary),
+            shape: None,
+        }
+    }
+
+    /// Builds an unknown hash fact for declarations without initializers.
+    pub fn unknown_hash() -> Self {
+        Self {
+            ty: PerlType::Hash {
+                key: Box::new(PerlType::Scalar(ScalarType::String)),
+                value: Box::new(PerlType::Any),
+            },
+            confidence: Confidence::Low,
+            evidence: Vec::new(),
+            dynamic_boundary: None,
+            shape: Some(ShapeFact::Hash(HashShape {
+                slots: BTreeMap::new(),
+                fallback_value: Some(Box::new(Self::unknown())),
+            })),
+        }
+    }
+}

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -1,3 +1,4 @@
+use crate::analysis::type_facts::TypeFact;
 use crate::ast::{Node, NodeKind};
 use std::collections::HashMap;
 use std::fmt;
@@ -131,6 +132,8 @@ pub struct TypeLocation {
 pub struct TypeEnvironment {
     /// Variable types in current scope
     variables: HashMap<String, PerlType>,
+    /// Rich variable facts in current scope
+    variable_facts: HashMap<String, TypeFact>,
     /// Subroutine signatures
     subroutines: HashMap<String, PerlType>,
     /// Parent scope (for nested scopes)
@@ -146,13 +149,19 @@ impl Default for TypeEnvironment {
 impl TypeEnvironment {
     /// Creates a new empty type environment
     pub fn new() -> Self {
-        Self { variables: HashMap::new(), subroutines: HashMap::new(), parent: None }
+        Self {
+            variables: HashMap::new(),
+            variable_facts: HashMap::new(),
+            subroutines: HashMap::new(),
+            parent: None,
+        }
     }
 
     /// Creates a new type environment with a parent scope
     pub fn with_parent(parent: TypeEnvironment) -> Self {
         Self {
             variables: HashMap::new(),
+            variable_facts: HashMap::new(),
             subroutines: HashMap::new(),
             parent: Some(Box::new(parent)),
         }
@@ -160,12 +169,26 @@ impl TypeEnvironment {
 
     /// Sets the type for a variable in the current scope
     pub fn set_variable(&mut self, name: String, ty: PerlType) {
-        self.variables.insert(name, ty);
+        self.variables.insert(name.clone(), ty.clone());
+        self.variable_facts.insert(name, TypeFact::from_erased_type(ty));
+    }
+
+    /// Sets the rich type fact for a variable in the current scope.
+    pub fn set_variable_fact(&mut self, name: String, fact: TypeFact) {
+        self.variables.insert(name.clone(), fact.erased_type());
+        self.variable_facts.insert(name, fact);
     }
 
     /// Gets the type of a variable, searching parent scopes if needed
     pub fn get_variable(&self, name: &str) -> Option<&PerlType> {
         self.variables.get(name).or_else(|| self.parent.as_ref().and_then(|p| p.get_variable(name)))
+    }
+
+    /// Gets the rich type fact for a variable, searching parent scopes if needed.
+    pub fn get_variable_fact(&self, name: &str) -> Option<&TypeFact> {
+        self.variable_facts
+            .get(name)
+            .or_else(|| self.parent.as_ref().and_then(|p| p.get_variable_fact(name)))
     }
 
     /// Sets the type signature for a subroutine in the current scope
@@ -851,6 +874,11 @@ impl TypeInferenceEngine {
     /// Gets the inferred type for a variable by name
     pub fn get_type_at(&self, name: &str) -> Option<PerlType> {
         self.global_env.get_variable(name).cloned()
+    }
+
+    /// Gets the inferred rich type fact for a variable by name.
+    pub fn get_fact_at(&self, name: &str) -> Option<TypeFact> {
+        self.global_env.get_variable_fact(name).cloned()
     }
 
     /// Returns a human-readable type label for use in hover text.

--- a/crates/perl-semantic-analyzer/tests/type_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/type_facts.rs
@@ -1,0 +1,49 @@
+use perl_semantic_analyzer::analysis::type_facts::{HashShape, ShapeFact, TypeFact};
+use perl_semantic_analyzer::analysis::type_inference::{PerlType, ScalarType, TypeEnvironment};
+use perl_semantic_facts::Confidence;
+use std::collections::BTreeMap;
+
+#[test]
+fn type_fact_erases_to_existing_perl_type() -> Result<(), Box<dyn std::error::Error>> {
+    let fact = TypeFact::from_erased_type(PerlType::Scalar(ScalarType::String));
+
+    assert_eq!(fact.erased_type(), PerlType::Scalar(ScalarType::String));
+    assert_eq!(fact.confidence, Confidence::Low);
+    Ok(())
+}
+
+#[test]
+fn type_environment_stores_rich_fact_and_erased_type() -> Result<(), Box<dyn std::error::Error>> {
+    let mut env = TypeEnvironment::new();
+    let fact = TypeFact {
+        ty: PerlType::Hash {
+            key: Box::new(PerlType::Scalar(ScalarType::String)),
+            value: Box::new(PerlType::Any),
+        },
+        confidence: Confidence::High,
+        evidence: Vec::new(),
+        dynamic_boundary: None,
+        shape: Some(ShapeFact::Hash(HashShape {
+            slots: BTreeMap::new(),
+            fallback_value: Some(Box::new(TypeFact::unknown())),
+        })),
+    };
+
+    env.set_variable_fact("services".to_string(), fact.clone());
+
+    assert_eq!(env.get_variable("services"), Some(&fact.ty));
+    assert_eq!(env.get_variable_fact("services"), Some(&fact));
+    Ok(())
+}
+
+#[test]
+fn type_environment_finds_parent_fact() -> Result<(), Box<dyn std::error::Error>> {
+    let mut parent = TypeEnvironment::new();
+    let fact = TypeFact::from_erased_type(PerlType::Object("MyApp::DB".to_string()));
+    parent.set_variable_fact("db".to_string(), fact.clone());
+
+    let child = TypeEnvironment::with_parent(parent);
+
+    assert_eq!(child.get_variable_fact("db"), Some(&fact));
+    Ok(())
+}


### PR DESCRIPTION
### Motivation

- Receiver/method completion needs richer, expression-level type facts (confidence, evidence, shapes, dynamic boundaries) to resolve receivers like `$hash{key}` without changing the parser or replacing `PerlType`.
- Preserve existing `PerlType` APIs while layering structural and provenance information to feed completion, hover, and future method-return rules.

### Description

- Add a new analysis module `crates/perl-semantic-analyzer/src/analysis/type_facts.rs` defining `TypeFact`, `ShapeFact` (Hash/Array/Object), `HashShape`/`ArrayShape`/`ObjectShape`, `TypeEvidence`, and `DynamicBoundary` with helpers like `from_erased_type`, `unknown`, `dynamic`, and `unknown_hash`.
- Export the new module from `analysis/mod.rs` and extend `TypeEnvironment` in `type_inference.rs` with a parallel `variable_facts: HashMap<String, TypeFact>` plus `set_variable_fact` and `get_variable_fact` while keeping the existing erased `variables: HashMap<String, PerlType>` behavior intact.
- Add `TypeInferenceEngine::get_fact_at` to fetch rich facts, and include focused unit tests in `crates/perl-semantic-analyzer/tests/type_facts.rs` that validate fact erasure, storage, and parent-scope lookup.

### Testing

- Ran the focused test: `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-semantic-analyzer --profile agent --locked --test type_facts`, and it passed (3 tests ran and succeeded).
- Ran full crate checks and linters: `MIN_FREE_GB=20 ./scripts/cargo-safe check -p perl-semantic-analyzer --all-targets --profile agent --locked`, `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs`, and `./scripts/cargo-safe xtask fmt`, and they completed successfully (warnings about doc comments were present but permitted by current lint exceptions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1d976a5c8333b81d84649d0a92bf)