### PR TITLE
feat(semantic): add type facts environment (#0000)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/mod.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/mod.rs
@@ -27,6 +27,8 @@ pub mod scope_analyzer;
 pub mod semantic;
 /// Symbol extraction and symbol table construction.
 pub mod symbol;
+/// Rich expression facts layered on top of coarse Perl types.
+pub mod type_facts;
 /// Type inference engine for Perl variable analysis.
 pub mod type_inference;
 /// Lightweight value-shape inference from constructor calls, bless, and `$self`.

--- a/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
@@ -1,0 +1,205 @@
+//! Rich expression facts layered on top of coarse Perl types.
+
+use super::type_inference::{PerlType, ScalarType};
+use perl_semantic_facts::Confidence;
+use std::collections::BTreeMap;
+
+/// A coarse Perl type enriched with confidence, evidence, and optional shape data.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct TypeFact {
+    /// The erased, compatibility-preserving Perl type.
+    pub ty: PerlType,
+    /// Confidence in the fact.
+    pub confidence: Confidence,
+    /// Static evidence that produced this fact.
+    pub evidence: Vec<TypeEvidence>,
+    /// Dynamic boundary that prevented precise inference, when present.
+    pub dynamic_boundary: Option<DynamicBoundary>,
+    /// Optional structural information for aggregate and object values.
+    pub shape: Option<ShapeFact>,
+}
+
+impl TypeFact {
+    /// Returns the coarse Perl type for compatibility with existing APIs.
+    pub fn erased_type(&self) -> PerlType {
+        self.ty.clone()
+    }
+
+    /// Creates a high-confidence literal fact.
+    pub fn literal(ty: PerlType) -> Self {
+        Self {
+            ty,
+            confidence: Confidence::High,
+            evidence: vec![TypeEvidence::Literal],
+            dynamic_boundary: None,
+            shape: None,
+        }
+    }
+
+    /// Creates an unknown fact.
+    pub fn unknown() -> Self {
+        Self::any_low_confidence(TypeEvidence::Heuristic { reason: "unknown type".to_string() })
+    }
+
+    /// Creates a low-confidence `Any` fact with the supplied evidence.
+    pub fn any_low_confidence(evidence: TypeEvidence) -> Self {
+        Self {
+            ty: PerlType::Any,
+            confidence: Confidence::Low,
+            evidence: vec![evidence],
+            dynamic_boundary: None,
+            shape: None,
+        }
+    }
+
+    /// Creates an unknown fact that records the dynamic boundary encountered.
+    pub fn dynamic(boundary: DynamicBoundary) -> Self {
+        Self {
+            ty: PerlType::Any,
+            confidence: Confidence::Low,
+            evidence: vec![TypeEvidence::Heuristic { reason: "dynamic boundary".to_string() }],
+            dynamic_boundary: Some(boundary),
+            shape: None,
+        }
+    }
+
+    /// Creates an unknown hash fact for declarations without initializers.
+    pub fn unknown_hash() -> Self {
+        Self {
+            ty: PerlType::Hash {
+                key: Box::new(PerlType::Scalar(ScalarType::String)),
+                value: Box::new(PerlType::Any),
+            },
+            confidence: Confidence::Low,
+            evidence: vec![TypeEvidence::Heuristic { reason: "uninitialized hash".to_string() }],
+            dynamic_boundary: None,
+            shape: Some(ShapeFact::Hash(HashShape {
+                slots: BTreeMap::new(),
+                fallback_value: None,
+            })),
+        }
+    }
+}
+
+/// Optional structural shape attached to a type fact.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ShapeFact {
+    /// Hash shape with known static slots.
+    Hash(HashShape),
+    /// Array shape with known indexes and/or homogeneous element type.
+    Array(ArrayShape),
+    /// Object shape with known fields.
+    Object(ObjectShape),
+}
+
+/// Static hash shape facts.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct HashShape {
+    /// Known static slots by key.
+    pub slots: BTreeMap<String, TypeFact>,
+    /// Fallback value type for unknown static slots.
+    pub fallback_value: Option<Box<TypeFact>>,
+}
+
+/// Static array shape facts.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ArrayShape {
+    /// Known indexed elements.
+    pub indexed: BTreeMap<usize, TypeFact>,
+    /// Homogeneous element fallback.
+    pub element: Option<Box<TypeFact>>,
+}
+
+/// Static object shape facts.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ObjectShape {
+    /// Package/class name for the object.
+    pub package: String,
+    /// Known object fields by field name.
+    pub fields: BTreeMap<String, TypeFact>,
+}
+
+/// Evidence that contributed to a type fact.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum TypeEvidence {
+    /// Literal syntax.
+    Literal,
+    /// Variable initializer evidence.
+    VariableInitializer {
+        /// Variable name initialized.
+        name: String,
+    },
+    /// Assignment evidence.
+    Assignment {
+        /// Variable name assigned.
+        name: String,
+    },
+    /// Plain hash slot evidence.
+    HashSlot {
+        /// Hash variable name.
+        hash: String,
+        /// Static hash key.
+        key: String,
+    },
+    /// Hash-reference slot evidence.
+    HashRefSlot {
+        /// Base receiver expression label.
+        base: String,
+        /// Static hash key.
+        key: String,
+    },
+    /// Constructor call evidence.
+    ConstructorCall {
+        /// Constructed package name.
+        package: String,
+    },
+    /// Bless literal evidence.
+    BlessLiteral {
+        /// Blessed package name.
+        package: String,
+    },
+    /// Moose/Moo `isa` metadata evidence.
+    MooseIsa {
+        /// Attribute name.
+        attr: String,
+        /// Declared `isa` type.
+        isa: String,
+    },
+    /// Object::Pad field evidence.
+    ObjectPadField {
+        /// Field name.
+        field: String,
+    },
+    /// Workspace symbol evidence.
+    WorkspaceSymbol {
+        /// Resolved package name.
+        package: String,
+    },
+    /// Heuristic evidence with a reason.
+    Heuristic {
+        /// Explanation for the heuristic.
+        reason: String,
+    },
+}
+
+/// Dynamic boundary that prevents precise static inference.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum DynamicBoundary {
+    /// Hash key is not statically known.
+    DynamicHashKey,
+    /// Bless class is not statically known.
+    DynamicBlessClass,
+    /// Method name is not statically known.
+    DynamicMethodName,
+    /// Import is resolved at runtime.
+    RuntimeImport,
+    /// Receiver expression is unknown.
+    UnknownReceiver,
+}

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -1,3 +1,4 @@
+use crate::analysis::type_facts::TypeFact;
 use crate::ast::{Node, NodeKind};
 use std::collections::HashMap;
 use std::fmt;
@@ -131,6 +132,8 @@ pub struct TypeLocation {
 pub struct TypeEnvironment {
     /// Variable types in current scope
     variables: HashMap<String, PerlType>,
+    /// Rich variable facts in current scope
+    variable_facts: HashMap<String, TypeFact>,
     /// Subroutine signatures
     subroutines: HashMap<String, PerlType>,
     /// Parent scope (for nested scopes)
@@ -146,13 +149,19 @@ impl Default for TypeEnvironment {
 impl TypeEnvironment {
     /// Creates a new empty type environment
     pub fn new() -> Self {
-        Self { variables: HashMap::new(), subroutines: HashMap::new(), parent: None }
+        Self {
+            variables: HashMap::new(),
+            variable_facts: HashMap::new(),
+            subroutines: HashMap::new(),
+            parent: None,
+        }
     }
 
     /// Creates a new type environment with a parent scope
     pub fn with_parent(parent: TypeEnvironment) -> Self {
         Self {
             variables: HashMap::new(),
+            variable_facts: HashMap::new(),
             subroutines: HashMap::new(),
             parent: Some(Box::new(parent)),
         }
@@ -160,12 +169,36 @@ impl TypeEnvironment {
 
     /// Sets the type for a variable in the current scope
     pub fn set_variable(&mut self, name: String, ty: PerlType) {
+        self.variable_facts.remove(&name);
         self.variables.insert(name, ty);
+    }
+
+    /// Sets the rich fact for a variable in the current scope.
+    pub fn set_variable_fact(&mut self, name: String, fact: TypeFact) {
+        self.variables.insert(name.clone(), fact.erased_type());
+        self.variable_facts.insert(name, fact);
+    }
+
+    /// Gets the rich fact for a variable, searching parent scopes if needed.
+    pub fn get_variable_fact(&self, name: &str) -> Option<&TypeFact> {
+        self.variable_facts
+            .get(name)
+            .or_else(|| self.parent.as_ref().and_then(|p| p.get_variable_fact(name)))
+    }
+
+    /// Gets the cloned rich fact for a variable, searching parent scopes if needed.
+    pub fn get_fact_at(&self, name: &str) -> Option<TypeFact> {
+        self.get_variable_fact(name).cloned()
     }
 
     /// Gets the type of a variable, searching parent scopes if needed
     pub fn get_variable(&self, name: &str) -> Option<&PerlType> {
         self.variables.get(name).or_else(|| self.parent.as_ref().and_then(|p| p.get_variable(name)))
+    }
+
+    /// Gets the cloned type of a variable, searching parent scopes if needed.
+    pub fn get_type_at(&self, name: &str) -> Option<PerlType> {
+        self.get_variable(name).cloned()
     }
 
     /// Sets the type signature for a subroutine in the current scope
@@ -1165,5 +1198,41 @@ mod tests {
         let hash_completions = completion.get_completions("config", "");
         assert!(hash_completions.iter().any(|c| c.label == "keys"));
         assert!(hash_completions.iter().any(|c| c.label == "values"));
+    }
+    #[test]
+    fn test_type_environment_stores_variable_facts() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::analysis::type_facts::{TypeEvidence, TypeFact};
+        use perl_semantic_facts::Confidence;
+
+        let mut env = TypeEnvironment::new();
+        let fact = TypeFact {
+            ty: PerlType::Object("MyApp::DB".to_string()),
+            confidence: Confidence::High,
+            evidence: vec![TypeEvidence::ConstructorCall { package: "MyApp::DB".to_string() }],
+            dynamic_boundary: None,
+            shape: None,
+        };
+
+        env.set_variable_fact("db".to_string(), fact.clone());
+
+        assert_eq!(env.get_type_at("db"), Some(PerlType::Object("MyApp::DB".to_string())));
+        assert_eq!(env.get_fact_at("db"), Some(fact));
+        Ok(())
+    }
+
+    #[test]
+    fn test_type_environment_fact_lookup_uses_parent_scope()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::analysis::type_facts::TypeFact;
+
+        let mut parent = TypeEnvironment::new();
+        let fact = TypeFact::literal(PerlType::Scalar(ScalarType::String));
+        parent.set_variable_fact("name".to_string(), fact.clone());
+
+        let child = TypeEnvironment::with_parent(parent);
+
+        assert_eq!(child.get_fact_at("name"), Some(fact));
+        assert_eq!(child.get_type_at("name"), Some(PerlType::Scalar(ScalarType::String)));
+        Ok(())
     }
 }

--- a/crates/perl-semantic-analyzer/src/lib.rs
+++ b/crates/perl-semantic-analyzer/src/lib.rs
@@ -72,4 +72,5 @@ pub use analysis::index;
 pub use analysis::scope_analyzer;
 pub use analysis::semantic;
 pub use analysis::symbol;
+pub use analysis::type_facts;
 pub use analysis::type_inference;


### PR DESCRIPTION
### Motivation

- Enable expression-level receiver inference by layering richer, evidence-bearing type facts on top of the existing coarse `PerlType` without changing public APIs.
- Provide the missing seam between AST-level expressions and completion/ranking logic so static hash/constructor/bless patterns can be proven and surfaced with confidence metadata.

### Description

- Add a new facts module `crates/perl-semantic-analyzer/src/analysis/type_facts.rs` introducing `TypeFact`, `ShapeFact` (`HashShape`/`ArrayShape`/`ObjectShape`), `TypeEvidence`, and `DynamicBoundary` to carry evidence, confidence, and optional structural shapes.
- Extend `TypeEnvironment` in `crates/perl-semantic-analyzer/src/analysis/type_inference.rs` with a parallel `variable_facts: HashMap<String, TypeFact>` and API methods `set_variable_fact`, `get_variable_fact`, `get_fact_at`, and `get_type_at`, while keeping `PerlType` compatibility via `TypeFact::erased_type`.
- Export the new module via `analysis::type_facts` and crate facade in `crates/perl-semantic-analyzer/src/analysis/mod.rs` and `crates/perl-semantic-analyzer/src/lib.rs`.
- Add focused unit tests in the type inference tests to validate storing and parent-scope lookup of `TypeFact` values.

### Testing

- Ran `./scripts/cargo-safe check -p perl-semantic-analyzer --all-targets --profile agent --locked` and it completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-semantic-analyzer --profile agent --locked` and all crate tests passed, including the new `TypeFact`-related unit tests.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs` and it completed successfully.
- Ran `cargo fmt --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1d976a5c8333b81d84649d0a92bf)