### PR TITLE
test(workspace-symbols): add generated no-source receipt (#8197)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/workspace_symbols/mod.rs
@@ -517,8 +517,9 @@ fn workspace_symbol_shadow_note(
     let generated_label_count = compiler_candidates
         .iter()
         .filter(|candidate| {
-            candidate.source == ProviderFactSourceKind::FrameworkAdapter
-                || candidate.identity.starts_with("generated:")
+            candidate.fallback_state != ProviderFallbackState::Blocked
+                && (candidate.source == ProviderFactSourceKind::FrameworkAdapter
+                    || candidate.identity.starts_with("generated:"))
         })
         .count();
     let dynamic_boundary_blockers = compiler_candidates

--- a/crates/perl-lsp-rs/src/runtime/language/symbols_runtime_quality_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/symbols_runtime_quality_tests.rs
@@ -78,6 +78,19 @@ has status => (is => 'rw', predicate => 1);
 1;
 "#;
 
+const NOSOURCE_MODULE_URI: &str = "file:///workspace/lib/Symbols/NoSourceRuntime.pm";
+
+const NOSOURCE_MODULE: &str = r#"package Symbols::NoSourceRuntime;
+use Moo;
+
+my $runtime_method = 'runtime_only';
+__PACKAGE__->meta->add_method($runtime_method => sub {
+    return 'dynamic';
+});
+
+1;
+"#;
+
 fn create_server() -> LspServer {
     let output =
         Arc::new(Mutex::new(Box::new(Cursor::new(Vec::new())) as Box<dyn std::io::Write + Send>));
@@ -131,6 +144,11 @@ fn open_generated_symbol_workspace(server: &LspServer) -> Result<(), Box<dyn std
 
 fn open_predicate_symbol_workspace(server: &LspServer) -> Result<(), Box<dyn std::error::Error>> {
     open_document(server, PREDICATE_MODULE_URI, PREDICATE_MODULE)?;
+    Ok(())
+}
+
+fn open_no_source_symbol_workspace(server: &LspServer) -> Result<(), Box<dyn std::error::Error>> {
+    open_document(server, NOSOURCE_MODULE_URI, NOSOURCE_MODULE)?;
     Ok(())
 }
 
@@ -726,6 +744,85 @@ fn workspace_symbols_runtime_quality_receipt_proves_predicate_generated_symbol_c
     assert!(
         boundary.contains("remain gated outside the labeled source-backed generated pilot"),
         "predicate proof must keep unproven generated-symbol expansion gated: {boundary}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn workspace_symbols_runtime_quality_receipt_blocks_generated_no_source_candidate()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    open_no_source_symbol_workspace(&server)?;
+    let params = json!({"query": "runtime_only"});
+
+    let receipt = server
+        .test_workspace_symbols_runtime_quality_receipt(Some(params))?
+        .ok_or("missing no-source workspace symbols receipt")?;
+
+    assert_eq!(
+        receipt.get("shadow_state").and_then(Value::as_str),
+        Some("shadowed"),
+        "runtime-installed no-source method must not enter the generated-label live pilot"
+    );
+    assert_eq!(
+        receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "generated/no-source proof must not broaden live workspace-symbol behavior"
+    );
+    assert_eq!(
+        receipt.get("compiler_receipt"),
+        Some(&Value::Null),
+        "no-source runtime-generated method must not produce source-backed compiler receipt"
+    );
+
+    let live_symbols = receipt
+        .get("live_provider_result")
+        .and_then(Value::as_array)
+        .ok_or("missing no-source live provider result")?;
+    assert!(
+        live_symbols.iter().all(|symbol| {
+            symbol_name(symbol) != Some("runtime_only")
+                && symbol_name(symbol) != Some("runtime_only [generated/framework]")
+        }),
+        "generated/no-source method must not appear as exact or labeled workspace symbol: {live_symbols:?}"
+    );
+
+    let expansion_receipt =
+        receipt.get("gated_expansion_receipt").ok_or("missing gated expansion receipt")?;
+    assert_eq!(
+        expansion_receipt.get("generated_no_source_candidate_count").and_then(Value::as_u64),
+        Some(1),
+        "receipt must measure the generated/no-source candidate separately"
+    );
+    assert_eq!(
+        expansion_receipt.get("generated_no_source_blocker_count").and_then(Value::as_u64),
+        Some(1),
+        "generated/no-source candidate must stay blocked"
+    );
+    assert_eq!(
+        expansion_receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "generated/no-source blocker receipt must be proof-only"
+    );
+    let boundary = expansion_receipt
+        .get("claim_boundary")
+        .and_then(Value::as_str)
+        .ok_or("missing boundary")?;
+    assert!(
+        boundary.contains("generated/no-source false-exact candidates")
+            && boundary.contains("remain gated"),
+        "claim boundary must keep generated/no-source candidates gated: {boundary}"
+    );
+
+    let shadow_receipt = expansion_receipt.get("shadow_receipt").ok_or("missing shadow receipt")?;
+    let traces = shadow_receipt
+        .get("fact_source_traces")
+        .and_then(Value::as_array)
+        .ok_or("missing fact-source traces")?;
+    assert!(
+        trace_with_fields(traces, "FrameworkAdapter", "FrameworkSynthesis", "Blocked"),
+        "generated/no-source framework candidate must stay blocked: {traces:?}"
     );
 
     Ok(())

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -490,7 +490,14 @@ impl LspServer {
 fn workspace_symbols_generated_dynamic_noise_receipt(query: &str) -> (Value, usize) {
     let candidates = vec![
         perl_lsp_rs_core::providers::workspace_symbols::WorkspaceSymbolShadowCandidate::shadow(
-            "generated:no-source:workspace-symbol:framework_accessor:virtual",
+            "generated:source-anchor:workspace-symbol:framework_accessor:virtual",
+            ProviderFactSourceKind::FrameworkAdapter,
+            Provenance::FrameworkSynthesis,
+            Confidence::Medium,
+            ProviderFactFreshness::Fresh,
+        ),
+        perl_lsp_rs_core::providers::workspace_symbols::WorkspaceSymbolShadowCandidate::blocked(
+            "generated:no-source:workspace-symbol:runtime_installed_method:unanchored",
             ProviderFactSourceKind::FrameworkAdapter,
             Provenance::FrameworkSynthesis,
             Confidence::Medium,
@@ -522,7 +529,18 @@ fn workspace_symbols_generated_dynamic_noise_receipt(query: &str) -> (Value, usi
 
     let generated_candidate_count = candidates
         .iter()
-        .filter(|candidate| candidate.source == ProviderFactSourceKind::FrameworkAdapter)
+        .filter(|candidate| {
+            candidate.source == ProviderFactSourceKind::FrameworkAdapter
+                && candidate.fallback_state != ProviderFallbackState::Blocked
+        })
+        .count();
+    let generated_no_source_blocker_count = candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.source == ProviderFactSourceKind::FrameworkAdapter
+                && candidate.fallback_state == ProviderFallbackState::Blocked
+                && candidate.identity.contains(":no-source:")
+        })
         .count();
     let dynamic_boundary_blocker_count = candidates
         .iter()
@@ -559,6 +577,8 @@ fn workspace_symbols_generated_dynamic_noise_receipt(query: &str) -> (Value, usi
             "receipt_kind": "generated_dynamic_noise_expansion",
             "generated_candidate_count": generated_candidate_count,
             "generated_false_exact_candidate_count": generated_candidate_count,
+            "generated_no_source_candidate_count": generated_no_source_blocker_count,
+            "generated_no_source_blocker_count": generated_no_source_blocker_count,
             "generated_location_semantics": "source_anchor_not_exact_generated_body",
             "dynamic_boundary_blocker_count": dynamic_boundary_blocker_count,
             "dynamic_false_exact_blocker_count": dynamic_boundary_blocker_count,

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_43_modern_oo_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_43_modern_oo_workspace_symbol_noise.rs
@@ -9,6 +9,7 @@
 //! - query latency and repeated-request candidate-count delta
 //! - useful source-backed hits versus unrelated/noisy hits for representative queries
 //! - generated/framework candidate names plus explicitly labeled generated pilot symbols
+//! - generated/no-source candidate names kept out of live exact workspace-symbol output
 //! - role/delegation/modifier boundary shapes observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
@@ -40,6 +41,7 @@ struct WorkspaceSymbolProbe {
     query: &'static str,
     useful_substrings: &'static [&'static str],
     generated_candidate_names: &'static [&'static str],
+    generated_no_source_candidate_names: &'static [&'static str],
     boundary_source_shapes: &'static [&'static str],
 }
 
@@ -61,6 +63,8 @@ struct WorkspaceSymbolProbeReport {
     unrelated_hit_count: usize,
     generated_candidate_count: usize,
     generated_candidate_live_hits: Vec<String>,
+    generated_no_source_candidate_count: usize,
+    generated_no_source_live_hits: Vec<String>,
     generated_label_hits: Vec<String>,
     first_useful_source_rank: Option<usize>,
     first_generated_label_rank: Option<usize>,
@@ -311,6 +315,11 @@ fn run_probe(
         probe.generated_candidate_names,
         probe.useful_substrings,
     );
+    let generated_no_source_live_hits = exact_unproven_generated_name_hits(
+        &first.symbols,
+        probe.generated_no_source_candidate_names,
+        probe.useful_substrings,
+    );
     let generated_label_hits = matching_symbol_names(
         &first.symbols,
         &["generated", "framework", "virtual", "FrameworkAdapter"],
@@ -360,6 +369,8 @@ fn run_probe(
         ),
         generated_candidate_count: probe.generated_candidate_names.len(),
         generated_candidate_live_hits,
+        generated_no_source_candidate_count: probe.generated_no_source_candidate_names.len(),
+        generated_no_source_live_hits,
         generated_label_hits,
         first_useful_source_rank,
         first_generated_label_rank,
@@ -420,6 +431,10 @@ fn workspace_symbol_probes() -> Vec<WorkspaceSymbolProbe> {
                 "clear_email",
                 "has_email",
             ],
+            generated_no_source_candidate_names: &[
+                "MooseExample::User::meta_generated_accessor",
+                "MooseExample::User::runtime_role_method",
+            ],
             boundary_source_shapes: &[
                 "before 'set_email'",
                 "after 'set_email'",
@@ -432,6 +447,10 @@ fn workspace_symbol_probes() -> Vec<WorkspaceSymbolProbe> {
             query: "role",
             useful_substrings: &["has_admin_role", "RoleExample", "roles"],
             generated_candidate_names: &["add_role", "has_role", "role_count", "all_roles"],
+            generated_no_source_candidate_names: &[
+                "RoleExample::Generated::role_runtime_handle",
+                "RoleExample::Generated::autoloaded_role_method",
+            ],
             boundary_source_shapes: &["handles  => {", "add_role     =>", "role_count   =>"],
         },
         WorkspaceSymbolProbe {
@@ -447,6 +466,10 @@ fn workspace_symbol_probes() -> Vec<WorkspaceSymbolProbe> {
                 "categories",
                 "attributes",
             ],
+            generated_no_source_candidate_names: &[
+                "MooExample::Product::price_runtime_coercion",
+                "MooExample::Product::generated_price_writer",
+            ],
             boundary_source_shapes: &["die \"Price must be numeric\"", "$self->price($price)"],
         },
         WorkspaceSymbolProbe {
@@ -460,6 +483,10 @@ fn workspace_symbol_probes() -> Vec<WorkspaceSymbolProbe> {
                 "load_config",
             ],
             generated_candidate_names: &["config", "log_level", "name"],
+            generated_no_source_candidate_names: &[
+                "RoleExample::Configurable::config_runtime_accessor",
+                "RoleExample::Configurable::generated_config_loader",
+            ],
             boundary_source_shapes: &[
                 "with 'RoleExample::Loggable'",
                 "requires 'load_config'",
@@ -502,7 +529,7 @@ fn scenario_43_modern_oo_workspace_symbol_noise_receipt() {
                     recorder.mark_first_useful_result(probe.name);
                 }
                 eprintln!(
-                    "workspace_symbol_probe={} query={} count={} useful_hits={:?} top_noise={} unrelated={} generated_live_hits={:?} generated_labels={:?}",
+                    "workspace_symbol_probe={} query={} count={} useful_hits={:?} top_noise={} unrelated={} generated_live_hits={:?} generated_no_source_live_hits={:?} generated_labels={:?}",
                     report.name,
                     report.query,
                     report.first_count,
@@ -510,6 +537,7 @@ fn scenario_43_modern_oo_workspace_symbol_noise_receipt() {
                     report.top_n_noise_count,
                     report.unrelated_hit_count,
                     report.generated_candidate_live_hits,
+                    report.generated_no_source_live_hits,
                     report.generated_label_hits
                 );
                 reports.push(report);
@@ -544,6 +572,10 @@ fn scenario_43_modern_oo_workspace_symbol_noise_receipt() {
                 reports.iter().map(|report| report.generated_candidate_count).sum();
             let generated_live_symbol_total: usize =
                 reports.iter().map(|report| report.generated_candidate_live_hits.len()).sum();
+            let generated_no_source_candidate_total: usize =
+                reports.iter().map(|report| report.generated_no_source_candidate_count).sum();
+            let generated_no_source_live_symbol_total: usize =
+                reports.iter().map(|report| report.generated_no_source_live_hits.len()).sum();
             let generated_label_total: usize =
                 reports.iter().map(|report| report.generated_label_hits.len()).sum();
             let generated_label_names_are_labeled = reports.iter().all(|report| {
@@ -576,6 +608,18 @@ fn scenario_43_modern_oo_workspace_symbol_noise_receipt() {
                 &fixture.content,
                 probes.iter().flat_map(|probe| probe.generated_candidate_names.iter().copied()),
             );
+            let generated_no_source_source_hits = source_shape_hits(
+                &fixture.content,
+                probes
+                    .iter()
+                    .flat_map(|probe| probe.generated_no_source_candidate_names.iter().copied()),
+            );
+            let generated_no_source_source_missing = missing_source_shapes(
+                &fixture.content,
+                probes
+                    .iter()
+                    .flat_map(|probe| probe.generated_no_source_candidate_names.iter().copied()),
+            );
             let stale_or_fallback_label_total: usize =
                 reports.iter().map(|report| report.stale_or_fallback_label_hits.len()).sum();
             let max_latency_ms = reports
@@ -600,6 +644,10 @@ fn scenario_43_modern_oo_workspace_symbol_noise_receipt() {
                 "invalid_shape_total": invalid_shape_total,
                 "generated_candidate_total": generated_candidate_total,
                 "generated_live_symbol_total": generated_live_symbol_total,
+                "generated_no_source_candidate_total": generated_no_source_candidate_total,
+                "generated_no_source_live_symbol_total": generated_no_source_live_symbol_total,
+                "generated_no_source_source_hits": generated_no_source_source_hits,
+                "generated_no_source_source_missing": generated_no_source_source_missing,
                 "generated_label_total": generated_label_total,
                 "generated_label_rank_proof_count": generated_label_rank_proof_count,
                 "generated_label_before_useful_source_total": generated_label_before_useful_source_total,
@@ -649,6 +697,11 @@ fn scenario_43_modern_oo_workspace_symbol_noise_receipt() {
                 generated_candidate_total > 0 && generated_live_symbol_total == 0,
             )?;
             recorder.check(
+                "receipt recorded generated/no-source candidates without live exact promotion",
+                generated_no_source_candidate_total > 0
+                    && generated_no_source_live_symbol_total == 0,
+            )?;
+            recorder.check(
                 "generated-label pilot surfaced explicitly labeled Modern OO symbols",
                 generated_label_total > 0 && generated_label_names_are_labeled,
             )?;
@@ -660,6 +713,11 @@ fn scenario_43_modern_oo_workspace_symbol_noise_receipt() {
             recorder.check(
                 "configured generated candidates are backed by Modern OO source",
                 !generated_source_hits.is_empty() && generated_source_missing.is_empty(),
+            )?;
+            recorder.check(
+                "configured generated/no-source candidates have no Modern OO source anchor",
+                generated_no_source_source_hits.is_empty()
+                    && !generated_no_source_source_missing.is_empty(),
             )?;
             recorder.check(
                 "receipt covered role/delegation/modifier boundary shapes",


### PR DESCRIPTION
Problem: Workspace-symbol generated-label support still needed project-shaped proof that generated/no-source candidates remain gated instead of becoming exact symbols.\n\nFix: Add a blocked generated/no-source candidate to the workspace-symbol gated receipt, prove it with a runtime receipt test, and extend Modern OO scenario 43 to record generated/no-source candidates with zero live exact promotion.\n\nClaim boundary: Receipt only. No broader generated-symbol expansion, no exact generated method-body locations, no empty-query or partial-index promotion, and no support-tier promotion.\n\nVerification:\n- rtk cargo test -p perl-lsp-rs --lib workspace_symbols_runtime_quality_receipt_blocks_generated_no_source_candidate --profile agent --locked -- --nocapture --test-threads=1\n- rtk cargo test -p perl-lsp-rs-core --lib workspace_symbol_shadow --profile agent --locked -- --nocapture\n- rtk cargo build -p perl-lsp-rs --bin perl-lsp --profile agent --locked\n- PERL_LSP_BIN=H:\\Code\\Rust2\\.cargo-target\\perl-lsp-agent\\agent\\perl-lsp.exe rtk cargo test -p perl-lsp-ux-tests --test ux_scenario_43_modern_oo_workspace_symbol_noise --profile agent --locked -- --nocapture --test-threads=1\n- rtk cargo test -p perl-lsp-rs --lib workspace_symbols_runtime_quality_receipt --profile agent --locked -- --nocapture --test-threads=1\n- rtk cargo check -p perl-lsp-rs --lib --all-features --profile agent --locked\n- rtk cargo xtask check-support-claims\n- rtk cargo xtask check-provider-confidence-matrix\n- rtk cargo xtask semantic-shadow-compare --check\n- rtk cargo xtask fmt --check\n- rtk git diff --check