### PR TITLE
refactor(corpus): split index writers by responsibility

### DIFF
--- a/crates/perl-corpus/src/index.rs
+++ b/crates/perl-corpus/src/index.rs
@@ -1,129 +1,16 @@
 use crate::meta::Section;
 use anyhow::Result;
-use serde::Serialize;
-use std::{collections::BTreeMap, fs, path::Path};
+use std::path::Path;
 
-#[derive(Serialize)]
-struct IndexEntry<'a> {
-    id: &'a str,
-    file: &'a str,
-    title: &'a str,
-    tags: &'a [String],
-    perl: &'a Option<String>,
-    flags: &'a [String],
-}
+mod coverage;
+mod flat;
+mod tags;
 
 /// Write index files and coverage report
 pub fn write_indices(dir: &Path, sections: &[Section]) -> Result<()> {
-    // Build flat index
-    let index: Vec<IndexEntry> = sections
-        .iter()
-        .map(|s| IndexEntry {
-            id: &s.id,
-            file: &s.file,
-            title: &s.title,
-            tags: &s.tags,
-            perl: &s.perl,
-            flags: &s.flags,
-        })
-        .collect();
-
-    // Write _index.json
-    let idx_path = dir.join("_index.json");
-    fs::write(&idx_path, serde_json::to_vec_pretty(&index)?)?;
-
-    // Build tag map
-    let mut tagmap: BTreeMap<String, Vec<&str>> = BTreeMap::new();
-    for s in sections {
-        for tag in &s.tags {
-            tagmap.entry(tag.clone()).or_default().push(&s.id);
-        }
-    }
-
-    // Write _tags.json
-    let tags_path = dir.join("_tags.json");
-    fs::write(&tags_path, serde_json::to_vec_pretty(&tagmap)?)?;
-
-    // Generate coverage summary
-    write_coverage_summary(dir, sections)?;
-
-    Ok(())
-}
-
-fn write_coverage_summary(dir: &Path, sections: &[Section]) -> Result<()> {
-    let mut lines = vec![
-        "# Corpus Coverage Summary".to_string(),
-        String::new(),
-        format!("Generated: {}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S")),
-        String::new(),
-    ];
-
-    // Stats by file
-    let mut by_file: BTreeMap<&str, usize> = BTreeMap::new();
-    for s in sections {
-        *by_file.entry(&s.file).or_default() += 1;
-    }
-
-    lines.push("## By File".to_string());
-    lines.push(String::new());
-    lines.push("| File | Sections |".to_string());
-    lines.push("|------|----------|".to_string());
-    for (file, count) in by_file {
-        lines.push(format!("| {} | {} |", file, count));
-    }
-
-    // Stats by tag
-    let mut by_tag: BTreeMap<&str, usize> = BTreeMap::new();
-    for s in sections {
-        for tag in &s.tags {
-            *by_tag.entry(tag).or_default() += 1;
-        }
-    }
-
-    lines.push(String::new());
-    lines.push("## By Tag (Top 20)".to_string());
-    lines.push(String::new());
-    lines.push("| Tag | Count |".to_string());
-    lines.push("|-----|-------|".to_string());
-
-    let mut tag_counts: Vec<_> = by_tag.into_iter().collect();
-    tag_counts.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
-    for (tag, count) in tag_counts.iter().take(20) {
-        lines.push(format!("| {} | {} |", tag, count));
-    }
-
-    // Stats by flag
-    let mut by_flag: BTreeMap<&str, usize> = BTreeMap::new();
-    for s in sections {
-        for flag in &s.flags {
-            *by_flag.entry(flag).or_default() += 1;
-        }
-    }
-
-    if !by_flag.is_empty() {
-        lines.push(String::new());
-        lines.push("## By Flag".to_string());
-        lines.push(String::new());
-        lines.push("| Flag | Count |".to_string());
-        lines.push("|------|-------|".to_string());
-        for (flag, count) in by_flag {
-            lines.push(format!("| {} | {} |", flag, count));
-        }
-    }
-
-    // Summary stats
-    lines.push(String::new());
-    lines.push("## Summary".to_string());
-    lines.push(String::new());
-    lines.push(format!("- Total sections: {}", sections.len()));
-    lines.push(format!(
-        "- Total files: {}",
-        sections.iter().map(|s| &s.file).collect::<std::collections::HashSet<_>>().len()
-    ));
-    lines.push(format!("- Unique tags: {}", tag_counts.len()));
-
-    let report_path = dir.join("COVERAGE_SUMMARY.md");
-    fs::write(report_path, lines.join("\n") + "\n")?;
+    flat::write_flat_index(dir, sections)?;
+    tags::write_tag_index(dir, sections)?;
+    coverage::write_coverage_summary(dir, sections)?;
 
     Ok(())
 }

--- a/crates/perl-corpus/src/index/coverage.rs
+++ b/crates/perl-corpus/src/index/coverage.rs
@@ -1,0 +1,103 @@
+use crate::meta::Section;
+use anyhow::Result;
+use std::{collections::BTreeMap, fs, path::Path};
+
+pub(super) fn write_coverage_summary(dir: &Path, sections: &[Section]) -> Result<()> {
+    let mut lines = summary_header();
+
+    append_file_stats(&mut lines, sections);
+    let tag_count = append_tag_stats(&mut lines, sections);
+    append_flag_stats(&mut lines, sections);
+    append_summary_stats(&mut lines, sections, tag_count);
+
+    let report_path = dir.join("COVERAGE_SUMMARY.md");
+    fs::write(report_path, lines.join("\n") + "\n")?;
+
+    Ok(())
+}
+
+fn summary_header() -> Vec<String> {
+    vec![
+        "# Corpus Coverage Summary".to_string(),
+        String::new(),
+        format!("Generated: {}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S")),
+        String::new(),
+    ]
+}
+
+fn append_file_stats(lines: &mut Vec<String>, sections: &[Section]) {
+    let mut by_file: BTreeMap<&str, usize> = BTreeMap::new();
+    for section in sections {
+        *by_file.entry(&section.file).or_default() += 1;
+    }
+
+    lines.push("## By File".to_string());
+    lines.push(String::new());
+    lines.push("| File | Sections |".to_string());
+    lines.push("|------|----------|".to_string());
+    for (file, count) in by_file {
+        lines.push(format!("| {} | {} |", file, count));
+    }
+}
+
+fn append_tag_stats(lines: &mut Vec<String>, sections: &[Section]) -> usize {
+    let mut by_tag: BTreeMap<&str, usize> = BTreeMap::new();
+    for section in sections {
+        for tag in &section.tags {
+            *by_tag.entry(tag).or_default() += 1;
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("## By Tag (Top 20)".to_string());
+    lines.push(String::new());
+    lines.push("| Tag | Count |".to_string());
+    lines.push("|-----|-------|".to_string());
+
+    let unique_tag_count = by_tag.len();
+    let mut tag_counts: Vec<_> = by_tag.into_iter().collect();
+    tag_counts.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+    for (tag, count) in tag_counts.iter().take(20) {
+        lines.push(format!("| {} | {} |", tag, count));
+    }
+
+    unique_tag_count
+}
+
+fn append_flag_stats(lines: &mut Vec<String>, sections: &[Section]) {
+    let mut by_flag: BTreeMap<&str, usize> = BTreeMap::new();
+    for section in sections {
+        for flag in &section.flags {
+            *by_flag.entry(flag).or_default() += 1;
+        }
+    }
+
+    if by_flag.is_empty() {
+        return;
+    }
+
+    lines.push(String::new());
+    lines.push("## By Flag".to_string());
+    lines.push(String::new());
+    lines.push("| Flag | Count |".to_string());
+    lines.push("|------|-------|".to_string());
+    for (flag, count) in by_flag {
+        lines.push(format!("| {} | {} |", flag, count));
+    }
+}
+
+fn append_summary_stats(lines: &mut Vec<String>, sections: &[Section], unique_tag_count: usize) {
+    lines.push(String::new());
+    lines.push("## Summary".to_string());
+    lines.push(String::new());
+    lines.push(format!("- Total sections: {}", sections.len()));
+    lines.push(format!(
+        "- Total files: {}",
+        sections
+            .iter()
+            .map(|section| &section.file)
+            .collect::<std::collections::HashSet<_>>()
+            .len()
+    ));
+    lines.push(format!("- Unique tags: {}", unique_tag_count));
+}

--- a/crates/perl-corpus/src/index/flat.rs
+++ b/crates/perl-corpus/src/index/flat.rs
@@ -1,0 +1,33 @@
+use crate::meta::Section;
+use anyhow::Result;
+use serde::Serialize;
+use std::{fs, path::Path};
+
+#[derive(Serialize)]
+struct IndexEntry<'a> {
+    id: &'a str,
+    file: &'a str,
+    title: &'a str,
+    tags: &'a [String],
+    perl: &'a Option<String>,
+    flags: &'a [String],
+}
+
+pub(super) fn write_flat_index(dir: &Path, sections: &[Section]) -> Result<()> {
+    let index: Vec<IndexEntry> = sections
+        .iter()
+        .map(|section| IndexEntry {
+            id: &section.id,
+            file: &section.file,
+            title: &section.title,
+            tags: &section.tags,
+            perl: &section.perl,
+            flags: &section.flags,
+        })
+        .collect();
+
+    let idx_path = dir.join("_index.json");
+    fs::write(&idx_path, serde_json::to_vec_pretty(&index)?)?;
+
+    Ok(())
+}

--- a/crates/perl-corpus/src/index/tags.rs
+++ b/crates/perl-corpus/src/index/tags.rs
@@ -1,0 +1,17 @@
+use crate::meta::Section;
+use anyhow::Result;
+use std::{collections::BTreeMap, fs, path::Path};
+
+pub(super) fn write_tag_index(dir: &Path, sections: &[Section]) -> Result<()> {
+    let mut tagmap: BTreeMap<String, Vec<&str>> = BTreeMap::new();
+    for section in sections {
+        for tag in &section.tags {
+            tagmap.entry(tag.clone()).or_default().push(&section.id);
+        }
+    }
+
+    let tags_path = dir.join("_tags.json");
+    fs::write(&tags_path, serde_json::to_vec_pretty(&tagmap)?)?;
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The corpus index generation was a single large module handling flat index, tag index, and coverage report responsibilities, making maintenance harder and violating SRP.
- Split the logic into focused submodules to improve separation of concerns and make future changes safer.

### Description
- Introduced three submodules under `crates/perl-corpus/src/index/`: `flat.rs`, `tags.rs`, and `coverage.rs`, and kept the public API `write_indices` unchanged in `index.rs` to coordinate them.
- Moved flat `_index.json` serialization into `flat::write_flat_index` and the tag map generation into `tags::write_tag_index`.
- Moved coverage report generation and helper functions into `coverage::write_coverage_summary` with small helpers for file/tag/flag/summary sections.

### Testing
- Ran `./scripts/cargo-safe check -p perl-corpus --all-targets --profile agent --locked` which passed.
- Ran `./scripts/cargo-safe test -p perl-corpus --profile agent --locked` which passed (all unit and integration tests succeeded).
- Ran formatting and lints via `./scripts/cargo-safe xtask fmt` and `./scripts/cargo-safe clippy -p perl-corpus --profile agent --locked -- -D warnings -A missing_docs`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ddc8828483339920a3cc8442d570)