### PR TITLE
refactor(dap): split debug adapter state modules

### DIFF
--- a/crates/perl-dap/src/debug_adapter/data_breakpoints.rs
+++ b/crates/perl-dap/src/debug_adapter/data_breakpoints.rs
@@ -1,0 +1,13 @@
+/// Stored data breakpoint record for watchpoint management
+#[derive(Debug, Clone)]
+pub(super) struct DataBreakpointRecord {
+    // Retained for future watchpoint lifecycle correlation.
+    #[allow(dead_code)]
+    pub(super) data_id: String,
+    // Retained to preserve the full DAP data-breakpoint request contract.
+    #[allow(dead_code)]
+    pub(super) access_type: Option<String>,
+    // Retained to preserve conditional-watchpoint configuration.
+    #[allow(dead_code)]
+    pub(super) condition: Option<String>,
+}

--- a/crates/perl-dap/src/debug_adapter/mod.rs
+++ b/crates/perl-dap/src/debug_adapter/mod.rs
@@ -4,6 +4,7 @@
 //! to enable debugging support in VSCode and other DAP-compatible editors.
 
 mod breakpoints;
+mod data_breakpoints;
 mod evaluation;
 mod execution;
 mod frames;
@@ -16,8 +17,10 @@ mod dispatch;
 mod parsing;
 mod regexes;
 pub(crate) mod safe_eval;
+mod session;
 mod sync_utils;
 mod transport;
+mod variable_cache;
 
 use crate::breakpoint::{AstBreakpointValidator, BreakpointValidator};
 use crate::eval::SafeEvaluator;
@@ -59,6 +62,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::breakpoints::{BreakpointHitOutcome, BreakpointStore};
+use crate::debug_adapter::data_breakpoints::DataBreakpointRecord;
+use crate::debug_adapter::session::{DebugSession, DebugState, ResumeMode};
+use crate::debug_adapter::variable_cache::{VariableCache, VariableCacheKind, slice_variables};
 use crate::security;
 #[cfg(unix)]
 use nix::sys::signal::{self, Signal};
@@ -67,17 +73,6 @@ use nix::unistd::Pid;
 use patterns::*;
 use safe_eval::validate_safe_expression;
 use sync_utils::{emit_event_safe, lock_or_recover};
-
-/// Stored data breakpoint record for watchpoint management
-#[derive(Debug, Clone)]
-struct DataBreakpointRecord {
-    #[allow(dead_code)]
-    data_id: String,
-    #[allow(dead_code)]
-    access_type: Option<String>,
-    #[allow(dead_code)]
-    condition: Option<String>,
-}
 
 /// Check if the match is an escape sequence (preceded by backslash)
 fn is_escape_sequence(s: &str, match_start: usize) -> bool {
@@ -129,100 +124,6 @@ pub struct DebugAdapter {
     next_goto_target_id: Arc<Mutex<i64>>,
     /// Workspace root for path validation (set during launch)
     workspace_root: Arc<Mutex<Option<PathBuf>>>,
-}
-
-/// Active debug session
-struct DebugSession {
-    /// Perl debugger process
-    process: Child,
-    /// Current execution state
-    state: DebugState,
-    /// Stack frames
-    stack_frames: Vec<StackFrame>,
-    /// Variables in current scope, including root scopes and child expansions.
-    variable_cache: VariableCache,
-    /// Thread ID
-    thread_id: i32,
-    /// Last resume command issued while running.
-    last_resume_mode: ResumeMode,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum VariableCacheKind {
-    Root,
-    Child,
-}
-
-#[derive(Debug, Clone)]
-struct VariableCacheEntry {
-    kind: VariableCacheKind,
-    full: Vec<Variable>,
-    page_slices: HashMap<(usize, usize), Vec<Variable>>,
-}
-
-#[derive(Debug, Default)]
-struct VariableCache {
-    entries: HashMap<i32, VariableCacheEntry>,
-}
-
-impl VariableCache {
-    fn clear(&mut self) {
-        self.entries.clear();
-    }
-
-    fn upsert(&mut self, reference: i32, kind: VariableCacheKind, variables: Vec<Variable>) {
-        let _ = self.entries.insert(
-            reference,
-            VariableCacheEntry { kind, full: variables, page_slices: HashMap::new() },
-        );
-    }
-
-    fn get_page(&mut self, reference: i32, start: usize, count: usize) -> Option<Vec<Variable>> {
-        let entry = self.entries.get_mut(&reference)?;
-        let key = (start, count);
-        if let Some(cached) = entry.page_slices.get(&key) {
-            return Some(cached.clone());
-        }
-
-        let page = slice_variables(&entry.full, start, count);
-        let _ = entry.page_slices.insert(key, page.clone());
-        Some(page)
-    }
-
-    fn all_variables(&self) -> impl Iterator<Item = &Variable> {
-        self.entries
-            .values()
-            .filter(|entry| entry.kind == VariableCacheKind::Root)
-            .chain(self.entries.values().filter(|entry| entry.kind == VariableCacheKind::Child))
-            .flat_map(|entry| entry.full.iter())
-    }
-}
-
-fn slice_variables(variables: &[Variable], start: usize, count: usize) -> Vec<Variable> {
-    variables.iter().skip(start).take(count).cloned().collect()
-}
-
-#[derive(Debug, Clone, PartialEq)]
-#[allow(dead_code)]
-enum DebugState {
-    Running,
-    Stopped,
-    Terminated,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-enum ResumeMode {
-    Continue,
-    /// Like `Continue` but auto-continues past any non-breakpoint stop.
-    /// Used when `configurationDone` runs with `stopOnEntry: false` to
-    /// silently skip the debugger's implicit first-line stop and run to
-    /// the first user-set breakpoint.
-    RunToBreakpoint,
-    Goto,
-    Next,
-    StepIn,
-    StepOut,
-    Unknown,
 }
 
 /// Represents a DAP message, which can be a request, response, or event.

--- a/crates/perl-dap/src/debug_adapter/session.rs
+++ b/crates/perl-dap/src/debug_adapter/session.rs
@@ -1,0 +1,43 @@
+use super::variable_cache::VariableCache;
+use crate::types::StackFrame;
+use std::process::Child;
+
+/// Active debug session
+pub(super) struct DebugSession {
+    /// Perl debugger process
+    pub(super) process: Child,
+    /// Current execution state
+    pub(super) state: DebugState,
+    /// Stack frames
+    pub(super) stack_frames: Vec<StackFrame>,
+    /// Variables in current scope, including root scopes and child expansions.
+    pub(super) variable_cache: VariableCache,
+    /// Thread ID
+    pub(super) thread_id: i32,
+    /// Last resume command issued while running.
+    pub(super) last_resume_mode: ResumeMode,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+// Terminated is recorded by shutdown paths even when some targets only observe Running/Stopped.
+#[allow(dead_code)]
+pub(super) enum DebugState {
+    Running,
+    Stopped,
+    Terminated,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum ResumeMode {
+    Continue,
+    /// Like `Continue` but auto-continues past any non-breakpoint stop.
+    /// Used when `configurationDone` runs with `stopOnEntry: false` to
+    /// silently skip the debugger's implicit first-line stop and run to
+    /// the first user-set breakpoint.
+    RunToBreakpoint,
+    Next,
+    StepIn,
+    StepOut,
+    Goto,
+    Unknown,
+}

--- a/crates/perl-dap/src/debug_adapter/variable_cache.rs
+++ b/crates/perl-dap/src/debug_adapter/variable_cache.rs
@@ -1,0 +1,67 @@
+use crate::types::Variable;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum VariableCacheKind {
+    Root,
+    Child,
+}
+
+#[derive(Debug, Clone)]
+struct VariableCacheEntry {
+    kind: VariableCacheKind,
+    full: Vec<Variable>,
+    page_slices: HashMap<(usize, usize), Vec<Variable>>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct VariableCache {
+    entries: HashMap<i32, VariableCacheEntry>,
+}
+
+impl VariableCache {
+    pub(super) fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    pub(super) fn upsert(
+        &mut self,
+        reference: i32,
+        kind: VariableCacheKind,
+        variables: Vec<Variable>,
+    ) {
+        let _ = self.entries.insert(
+            reference,
+            VariableCacheEntry { kind, full: variables, page_slices: HashMap::new() },
+        );
+    }
+
+    pub(super) fn get_page(
+        &mut self,
+        reference: i32,
+        start: usize,
+        count: usize,
+    ) -> Option<Vec<Variable>> {
+        let entry = self.entries.get_mut(&reference)?;
+        let key = (start, count);
+        if let Some(cached) = entry.page_slices.get(&key) {
+            return Some(cached.clone());
+        }
+
+        let page = slice_variables(&entry.full, start, count);
+        let _ = entry.page_slices.insert(key, page.clone());
+        Some(page)
+    }
+
+    pub(super) fn all_variables(&self) -> impl Iterator<Item = &Variable> {
+        self.entries
+            .values()
+            .filter(|entry| entry.kind == VariableCacheKind::Root)
+            .chain(self.entries.values().filter(|entry| entry.kind == VariableCacheKind::Child))
+            .flat_map(|entry| entry.full.iter())
+    }
+}
+
+pub(super) fn slice_variables(variables: &[Variable], start: usize, count: usize) -> Vec<Variable> {
+    variables.iter().skip(start).take(count).cloned().collect()
+}


### PR DESCRIPTION
### Motivation
- `debug_adapter/mod.rs` mixed protocol wiring with in-memory state (session, variable cache, data-breakpoint records), making the file large and violating single-responsibility boundaries.
- Split the state concerns into focused submodules to improve readability and make targeted unit testing and future refactors easier.
- Preserve existing runtime visibility and behavior while extracting the state types into dedicated files.

### Description
- Added `crates/perl-dap/src/debug_adapter/data_breakpoints.rs` to own `DataBreakpointRecord` and document retained DAP fields.
- Added `crates/perl-dap/src/debug_adapter/session.rs` to own `DebugSession`, `DebugState`, and `ResumeMode` and exported them as `pub(super)` for the adapter internals.
- Added `crates/perl-dap/src/debug_adapter/variable_cache.rs` to own the `VariableCache`, paging logic, and `slice_variables` helper.
- Updated `crates/perl-dap/src/debug_adapter/mod.rs` to declare the new `mod`s and to import the moved types via `crate::debug_adapter::{...}` while removing the long in-file definitions.

### Testing
- Ran `./scripts/cargo-safe xtask fmt`, which completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked`, which completed successfully.
- Ran `MIN_FREE_GB=15 ./scripts/cargo-safe clippy -p perl-dap --profile agent --locked -- -D warnings -A missing_docs`, which completed successfully.
- Ran `MIN_FREE_GB=20 ./scripts/cargo-safe test -p perl-dap --profile agent --locked`, which ran the crate test suite but failed an existing DAP end-to-end test `test_e2e_multi_breakpoint_sequence` (assertion: expected breakpoint line 5 but observed 4).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ddc8828483339920a3cc8442d570)