### PR TITLE
refactor(ci-hygiene): split badge generation command

### DIFF
--- a/crates/perl-ci-hygiene/src/commands/badges/facts.rs
+++ b/crates/perl-ci-hygiene/src/commands/badges/facts.rs
@@ -1,0 +1,36 @@
+use color_eyre::eyre::{Context, Result};
+use std::path::{Path, PathBuf};
+use toml::Value as TomlValue;
+
+pub(super) struct VscodeMarketplaceInstalls {
+    pub(super) value: u32,
+    pub(super) facts_file: PathBuf,
+}
+
+pub(super) fn read_vscode_marketplace_installs(
+    repo_root: &Path,
+) -> Result<VscodeMarketplaceInstalls> {
+    let facts_file = repo_root.join("docs/project/publication-facts.toml");
+    let facts_content = std::fs::read_to_string(&facts_file)
+        .with_context(|| format!("reading facts file {:?}", facts_file))?;
+    let facts: TomlValue = toml::from_str(&facts_content)
+        .with_context(|| format!("parsing facts file {:?}", facts_file))?;
+
+    let installs_i64 = facts
+        .get("external")
+        .and_then(|e| e.get("vscode_marketplace_installs"))
+        .and_then(|v| v.get("value"))
+        .and_then(|v| v.as_integer())
+        .ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "Could not read vscode_marketplace_installs.value from {}",
+                facts_file.display()
+            )
+        })?;
+
+    let value = u32::try_from(installs_i64).with_context(|| {
+        format!("vscode_marketplace_installs value {} is out of range for u32", installs_i64)
+    })?;
+
+    Ok(VscodeMarketplaceInstalls { value, facts_file })
+}

--- a/crates/perl-ci-hygiene/src/commands/badges/mod.rs
+++ b/crates/perl-ci-hygiene/src/commands/badges/mod.rs
@@ -1,0 +1,90 @@
+mod facts;
+mod readme;
+
+use color_eyre::eyre::{Context, Result};
+use std::path::Path;
+
+use crate::{GREEN, NC, RED};
+
+pub(crate) fn generate(repo_root: &Path, check_mode: bool) -> Result<i32> {
+    let installs = facts::read_vscode_marketplace_installs(repo_root)?;
+    let badge_url = format!(
+        "https://img.shields.io/badge/VS%20Marketplace-{}%20installs-0078D4",
+        installs.value
+    );
+
+    let root_readme = repo_root.join("README.md");
+    let ext_readme = repo_root.join("vscode-extension/README.md");
+
+    if check_mode {
+        return check_badges([root_readme.as_path(), ext_readme.as_path()], &installs, &badge_url);
+    }
+
+    update_badges([root_readme.as_path(), ext_readme.as_path()], installs.value, &badge_url)
+}
+
+fn check_badges<const N: usize>(
+    readme_paths: [&Path; N],
+    installs: &facts::VscodeMarketplaceInstalls,
+    badge_url: &str,
+) -> Result<i32> {
+    let mut has_drift = false;
+    for readme_path in readme_paths {
+        if !readme_path.exists() {
+            continue;
+        }
+
+        let content = std::fs::read_to_string(readme_path)?;
+        if content.contains(badge_url) {
+            continue;
+        }
+
+        eprintln!("{}VS Marketplace badge drift in {}{}", RED, readme_path.display(), NC);
+        eprintln!("  expected installs: {} from {}", installs.value, installs.facts_file.display());
+
+        if let Some(found) = readme::stale_installs_value(&content) {
+            eprintln!(
+                "  stale badge found: {} but expected {} in {}",
+                found,
+                installs.value,
+                readme_path.display()
+            );
+        }
+        has_drift = true;
+    }
+
+    if has_drift {
+        eprintln!("Run: cargo xtask ci-hygiene generate-badges");
+        return Ok(1);
+    }
+
+    println!("{}✓ VS Marketplace badge check passed{}", GREEN, NC);
+    Ok(0)
+}
+
+fn update_badges<const N: usize>(
+    readme_paths: [&Path; N],
+    vscode_installs: u32,
+    badge_url: &str,
+) -> Result<i32> {
+    for readme_path in readme_paths {
+        if !readme_path.exists() {
+            continue;
+        }
+
+        let content = std::fs::read_to_string(readme_path)?;
+        let updated = readme::update_badge_in_content(&content, badge_url)?;
+
+        if updated != content {
+            std::fs::write(readme_path, &updated)
+                .with_context(|| format!("writing updated badge to {:?}", readme_path))?;
+            println!("{}✓ Updated VS Marketplace badge in {}{}", GREEN, readme_path.display(), NC);
+        }
+    }
+
+    println!(
+        "{}✓ Badges updated from value {} in publication-facts.toml{}",
+        GREEN, vscode_installs, NC
+    );
+    Ok(0)
+}

--- a/crates/perl-ci-hygiene/src/commands/badges/readme.rs
+++ b/crates/perl-ci-hygiene/src/commands/badges/readme.rs
@@ -1,0 +1,46 @@
+use color_eyre::eyre::Result;
+use regex::Regex;
+use std::sync::LazyLock;
+
+static VS_MARKETPLACE_INSTALLS_BADGE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"VS%20Marketplace-(\d+)%20installs").unwrap_or_else(|error| {
+        unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_RE is a known-good static pattern: {error}")
+    })
+});
+
+static VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?s)<!-- perl-lsp:vs-marketplace-installs-badge:start -->.*?<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+    )
+    .unwrap_or_else(|error| {
+        unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE is a known-good static pattern: {error}")
+    })
+});
+
+pub(super) fn stale_installs_value(content: &str) -> Option<String> {
+    VS_MARKETPLACE_INSTALLS_BADGE_RE
+        .captures(content)
+        .and_then(|caps| caps.get(1).map(|found| found.as_str().to_string()))
+}
+
+pub(super) fn update_badge_in_content(content: &str, badge_url: &str) -> Result<String> {
+    if !VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.is_match(content) {
+        return Ok(content.to_string());
+    }
+
+    if content.contains("href=\"https://marketplace.visualstudio.com") {
+        let replacement = format!(
+            "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n  <a href=\"https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs\"><img src=\"{}\" alt=\"VS Marketplace installs\" /></a>\n  <!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+            badge_url
+        );
+        return Ok(VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE
+            .replace_all(content, replacement)
+            .into_owned());
+    }
+
+    let replacement = format!(
+        "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n[![VS Marketplace Installs (manual)]({})](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)\n<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
+        badge_url
+    );
+    Ok(VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.replace_all(content, replacement).into_owned())
+}

--- a/crates/perl-ci-hygiene/src/commands/mod.rs
+++ b/crates/perl-ci-hygiene/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod badges;
 pub(crate) mod doc_paths;

--- a/crates/perl-ci-hygiene/src/main.rs
+++ b/crates/perl-ci-hygiene/src/main.rs
@@ -14,7 +14,6 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::LazyLock;
 use toml::Value as TomlValue;
 use walkdir::{DirEntry, WalkDir};
 
@@ -30,21 +29,6 @@ const GREEN: &str = "\x1b[0;32m";
 const YELLOW: &str = "\x1b[0;33m";
 const BLUE: &str = "\x1b[0;34m";
 const NC: &str = "\x1b[0m";
-
-static VS_MARKETPLACE_INSTALLS_BADGE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"VS%20Marketplace-(\d+)%20installs").unwrap_or_else(|error| {
-        unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_RE is a known-good static pattern: {error}")
-    })
-});
-
-static VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
-        r"(?s)<!-- perl-lsp:vs-marketplace-installs-badge:start -->.*?<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
-    )
-    .unwrap_or_else(|error| {
-        unreachable!("VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE is a known-good static pattern: {error}")
-    })
-});
 
 fn main() -> std::process::ExitCode {
     if let Err(err) = color_eyre::install() {
@@ -1504,122 +1488,7 @@ fn find_cancel_test_binary(repo_root: &Path) -> Option<PathBuf> {
 }
 
 fn cmd_generate_badges(repo_root: &Path, check_mode: bool) -> Result<i32> {
-    let facts_file = repo_root.join("docs/project/publication-facts.toml");
-    let facts_content = fs::read_to_string(&facts_file)
-        .with_context(|| format!("reading facts file {:?}", facts_file))?;
-    let facts: TomlValue = toml::from_str(&facts_content)
-        .with_context(|| format!("parsing facts file {:?}", facts_file))?;
-
-    let vscode_installs_i64 = facts
-        .get("external")
-        .and_then(|e| e.get("vscode_marketplace_installs"))
-        .and_then(|v| v.get("value"))
-        .and_then(|v| v.as_integer())
-        .ok_or_else(|| {
-            color_eyre::eyre::eyre!(
-                "Could not read vscode_marketplace_installs.value from {}",
-                facts_file.display()
-            )
-        })?;
-
-    let vscode_installs = u32::try_from(vscode_installs_i64).with_context(|| {
-        format!("vscode_marketplace_installs value {} is out of range for u32", vscode_installs_i64)
-    })?;
-
-    let badge_url = format!(
-        "https://img.shields.io/badge/VS%20Marketplace-{}%20installs-0078D4",
-        vscode_installs
-    );
-
-    let root_readme = repo_root.join("README.md");
-    let ext_readme = repo_root.join("vscode-extension/README.md");
-
-    if check_mode {
-        let mut has_drift = false;
-        for readme_path in [&root_readme, &ext_readme] {
-            if readme_path.exists() {
-                let content = fs::read_to_string(readme_path)?;
-                if !content.contains(&badge_url) {
-                    eprintln!(
-                        "{}VS Marketplace badge drift in {}{}",
-                        RED,
-                        readme_path.display(),
-                        NC
-                    );
-                    eprintln!(
-                        "  expected installs: {} from {}",
-                        vscode_installs,
-                        facts_file.display()
-                    );
-
-                    if let Some(caps) = VS_MARKETPLACE_INSTALLS_BADGE_RE.captures(&content)
-                        && let Some(found) = caps.get(1)
-                    {
-                        eprintln!(
-                            "  stale badge found: {} but expected {} in {}",
-                            found.as_str(),
-                            vscode_installs,
-                            readme_path.display()
-                        );
-                    }
-                    has_drift = true;
-                }
-            }
-        }
-        if has_drift {
-            eprintln!("Run: cargo xtask ci-hygiene generate-badges");
-            return Ok(1);
-        }
-        println!("{}✓ VS Marketplace badge check passed{}", GREEN, NC);
-        return Ok(0);
-    }
-
-    // Generate mode: update badges
-    for readme_path in [&root_readme, &ext_readme] {
-        if !readme_path.exists() {
-            continue;
-        }
-
-        let content = fs::read_to_string(readme_path)?;
-        let updated = update_badge_in_content(&content, &badge_url)?;
-
-        if updated != content {
-            fs::write(readme_path, &updated)
-                .with_context(|| format!("writing updated badge to {:?}", readme_path))?;
-            println!("{}✓ Updated VS Marketplace badge in {}{}", GREEN, readme_path.display(), NC);
-        }
-    }
-
-    println!(
-        "{}✓ Badges updated from value {} in publication-facts.toml{}",
-        GREEN, vscode_installs, NC
-    );
-    Ok(0)
-}
-
-fn update_badge_in_content(content: &str, badge_url: &str) -> Result<String> {
-    if !VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.is_match(content) {
-        return Ok(content.to_string());
-    }
-
-    // Determine if we're dealing with HTML or Markdown format
-    if content.contains("href=\"https://marketplace.visualstudio.com") {
-        // HTML format
-        let replacement = format!(
-            "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n  <a href=\"https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs\"><img src=\"{}\" alt=\"VS Marketplace installs\" /></a>\n  <!-- perl-lsp:vs-marketplace-installs-badge:end -->",
-            badge_url
-        );
-        return Ok(VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE
-            .replace_all(content, replacement)
-            .into_owned());
-    }
-
-    // Markdown format
-    let replacement = format!(
-        "<!-- perl-lsp:vs-marketplace-installs-badge:start -->\n[![VS Marketplace Installs (manual)]({})](https://marketplace.visualstudio.com/items?itemName=EffortlessMetrics.perl-lsp-rs)\n<!-- perl-lsp:vs-marketplace-installs-badge:end -->",
-        badge_url
-    );
-    Ok(VS_MARKETPLACE_INSTALLS_BADGE_BLOCK_RE.replace_all(content, replacement).into_owned())
+    commands::badges::generate(repo_root, check_mode)
 }
 
 fn pre_push_hook_script() -> &'static str {


### PR DESCRIPTION
### Motivation
- Reduce the responsibilities of the large `perl-ci-hygiene` binary by extracting badge generation into SRP submodules to improve maintainability and testability.
- Isolate facts parsing (publication-facts TOML) and README badge rewriting logic so each piece can be reasoned about and tested independently.

### Description
- Add a new `commands::badges` module with `mod.rs`, `facts.rs`, and `readme.rs` to host badge orchestration, facts loading, and README badge handling respectively (files under `crates/perl-ci-hygiene/src/commands/badges/`).
- Move publication-facts parsing and install-count validation into `facts.rs` as `read_vscode_marketplace_installs` and `VscodeMarketplaceInstalls`.
- Move the badge regexes and replacement logic into `readme.rs` with `stale_installs_value` and `update_badge_in_content` and use `LazyLock<Regex>` there instead of `main.rs`.
- Replace the inlined implementation in `main.rs` with a thin dispatcher that calls `commands::badges::generate(repo_root, check_mode)` and add `pub(crate) mod badges;` to `commands/mod.rs`.

### Testing
- Ran `MIN_FREE_GB=1 ./scripts/cargo-safe check -p perl-ci-hygiene --all-targets --profile agent --locked` and it passed.
- Ran `MIN_FREE_GB=1 ./scripts/cargo-safe test -p perl-ci-hygiene --profile agent --locked` and all unit tests (including `badge_generation_test.rs`) passed.
- Ran `./scripts/cargo-safe xtask fmt` and `MIN_FREE_GB=1 ./scripts/cargo-safe clippy -p perl-ci-hygiene --profile agent --locked -- -D warnings -A missing_docs` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ddc8828483339920a3cc8442d570)