### PR TITLE
ci(gates): widen common corpus timeout (#4706)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -548,10 +548,10 @@ gates:
       cargo run --locked -p xtask
       -- parser-corpus-sweep
       --manifest .ci/common-corpus-manifest.txt --enforce --receipt
-    timeout_seconds: 120
+    timeout_seconds: 240
     retry_count: 0
     budgets:
-      max_duration_ms: 90000
+      max_duration_ms: 180000
     quarantine: false
     tags:
       - corpus

--- a/xtask/tests/gate_policy_profile_tests.rs
+++ b/xtask/tests/gate_policy_profile_tests.rs
@@ -21,6 +21,13 @@ struct PolicyGate {
     tier: String,
     #[serde(default = "default_true")]
     required: bool,
+    timeout_seconds: Option<u64>,
+    budgets: Option<GateBudgets>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GateBudgets {
+    max_duration_ms: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -55,6 +62,15 @@ fn parser_corpus_pr_policy_is_unambiguous() -> Result<(), Box<dyn std::error::Er
 
     assert_eq!(common.tier, "merge_gate");
     assert!(common.required, "common_corpus_clean must stay PR-blocking");
+    assert!(
+        common.timeout_seconds.unwrap_or_default() >= 240,
+        "common_corpus_clean timeout must include cold CI xtask startup"
+    );
+    assert!(
+        common.budgets.as_ref().and_then(|budget| budget.max_duration_ms).unwrap_or_default()
+            >= 180_000,
+        "common_corpus_clean duration budget must reflect CI startup overhead"
+    );
 
     assert_eq!(parser.tier, "merge_gate");
     assert!(!parser.required, "parser_corpus_ratchet must be advisory in PR merge-gate profile");


### PR DESCRIPTION
Problem: `common_corpus_clean` can time out on cold or partially-cold CI while `cargo run -p xtask` is still compiling the parser-corpus sweep path.
Fix: Raise the gate timeout from 120s to 240s, align the duration budget metadata, and add a policy test that keeps the common corpus timeout/budget above the observed CI startup floor.
Verification:
- `git diff --check`
- `./scripts/storage-doctor`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p xtask --test gate_policy_profile_tests --profile agent --locked`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe check --all-targets -p xtask --profile agent --locked`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe run --locked -p xtask --profile agent -- gates --gate common_corpus_clean --receipt --receipt-path /home/steven/.cache/devplane/perl-lsp/target/receipts/common-corpus-timeout-pr.json`

Context: This was found while reviewing #9281. Its current-head CI failed only because the `common_corpus_clean` gate timed out at 120s; direct reproduction passed once the gate had enough room.