### PR TITLE
ci(gates): reuse cargo-safe xtask for release history (#4706)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -155,10 +155,10 @@ gates:
     description: "Validate release-history surfaces"
     required: true
     command: just ci-release-history
-    timeout_seconds: 60
+    timeout_seconds: 120
     retry_count: 0
     budgets:
-      max_duration_ms: 30000
+      max_duration_ms: 90000
     quarantine: false
     tags:
       - release
@@ -251,10 +251,10 @@ gates:
     description: "Check release-history drift"
     required: true
     command: just ci-release-history-check
-    timeout_seconds: 60
+    timeout_seconds: 120
     retry_count: 0
     budgets:
-      max_duration_ms: 30000
+      max_duration_ms: 90000
     quarantine: false
     tags:
       - release

--- a/scripts/check_release_history.sh
+++ b/scripts/check_release_history.sh
@@ -180,15 +180,22 @@ run_install_surface_check() {
         ! find Cargo.toml Cargo.lock xtask/Cargo.toml xtask/src -type f -newer "$bin" -print -quit | grep -q .
     }
 
-    if xtask_binary_is_fresh target/debug/xtask; then
-        target/debug/xtask install-surface-check
-        return
+    local candidate
+    if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+        for candidate in "$CARGO_TARGET_DIR/debug/xtask" "$CARGO_TARGET_DIR/debug/xtask.exe"; do
+            if xtask_binary_is_fresh "$candidate"; then
+                "$candidate" install-surface-check
+                return
+            fi
+        done
     fi
 
-    if xtask_binary_is_fresh target/debug/xtask.exe; then
-        target/debug/xtask.exe install-surface-check
-        return
-    fi
+    for candidate in target/debug/xtask target/debug/xtask.exe; do
+        if xtask_binary_is_fresh "$candidate"; then
+            "$candidate" install-surface-check
+            return
+        fi
+    done
 
     if cargo metadata --no-deps --format-version 1 >/dev/null 2>&1; then
         cargo xtask install-surface-check

--- a/xtask/tests/gate_policy_profile_tests.rs
+++ b/xtask/tests/gate_policy_profile_tests.rs
@@ -82,6 +82,35 @@ fn parser_corpus_pr_policy_is_unambiguous() -> Result<(), Box<dyn std::error::Er
 }
 
 #[test]
+fn release_history_pr_gates_have_realistic_timeout_headroom()
+-> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let policy_path = root.join(".ci/gate-policy.yaml");
+    let content = fs::read_to_string(policy_path)?;
+    let parsed: GatePolicyDoc = serde_yaml_ng::from_str(&content)?;
+
+    let gates: HashMap<_, _> =
+        parsed.gates.into_iter().map(|gate| (gate.name.clone(), gate)).collect();
+
+    for gate_name in ["release_history", "release_history_check"] {
+        let gate = gates.get(gate_name).ok_or_else(|| format!("missing {gate_name} gate"))?;
+        assert_eq!(gate.tier, "pr_fast", "{gate_name} must stay in pr-fast");
+        assert!(gate.required, "{gate_name} must stay PR-blocking");
+        assert!(
+            gate.timeout_seconds.unwrap_or_default() >= 120,
+            "{gate_name} timeout must include cold or partially-cold xtask startup"
+        );
+        assert!(
+            gate.budgets.as_ref().and_then(|budget| budget.max_duration_ms).unwrap_or_default()
+                >= 90_000,
+            "{gate_name} duration budget must reflect observed pr-fast runtime"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
 fn gate_registry_alignment_prevents_stale_parser_wiring() -> Result<(), Box<dyn std::error::Error>>
 {
     let root = project_root();


### PR DESCRIPTION
Problem: `pr-fast` can fail on `release_history` because `scripts/check_release_history.sh` ignores the cargo-safe `CARGO_TARGET_DIR` prebuilt `xtask` and may rebuild the helper inside a 60s gate window.
Fix: Prefer fresh `xtask` binaries from `CARGO_TARGET_DIR` before repo-local `target/debug`, and widen the two release-history PR-fast timeout/budget values to match observed runtime headroom. Added a policy test so the gates do not drift back to the too-tight timeout.
Verification:
- `git diff --check`
- `bash -n scripts/check_release_history.sh`
- `./scripts/storage-doctor`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p xtask --test gate_policy_profile_tests --profile agent --locked`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe check --all-targets -p xtask --profile agent --locked`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe clippy -p xtask --profile agent --locked -- -D warnings -A missing_docs`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask gates --gate release_history --receipt --receipt-path /home/steven/.cache/devplane/perl-lsp/target/receipts/release-history-timeout-pr.json`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask gates --gate release_history_check --receipt --receipt-path /home/steven/.cache/devplane/perl-lsp/target/receipts/release-history-check-timeout-pr.json`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask gates --tier pr-fast --receipt --receipt-path /home/steven/.cache/devplane/perl-lsp/target/receipts/pr-fast-release-history-timeout-pr.json`

Context: This was found after #9141 when the broad `pr-fast` checkpoint failed only because `release_history` timed out. After this patch, full `pr-fast` passed locally with 10 passed / 0 failed, and the release-history gates ran in about 15s each inside the batch.