### PR TITLE
feat(semantic-tokens): expose scoped self method-call trace (#8197)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/semantic_tokens/semantic_tokens_shadow.rs
+++ b/crates/perl-lsp-rs-core/src/providers/semantic_tokens/semantic_tokens_shadow.rs
@@ -228,6 +228,7 @@ fn semantic_token_candidate_class_is_approved(candidate: &SemanticTokenShadowCan
             candidate.identity.starts_with("token:function:")
                 || candidate.identity.starts_with("token:method_declaration:")
                 || candidate.identity.starts_with("token:method_call:")
+                || candidate.identity.starts_with("token:self_method_call:")
                 || candidate.identity.starts_with("token:package_declaration:")
                 || candidate.identity.starts_with("token:field_declaration:")
         }
@@ -766,6 +767,42 @@ mod tests {
         assert_eq!(
             result.receipt.new_result.identities,
             vec!["token:method_call:stash:compiler".to_string()]
+        );
+        assert_eq!(report.candidate_count, 1);
+        assert_eq!(report.source_backed_span_count, 1);
+        assert_eq!(report.missing_source_span_count, 0);
+        assert_eq!(report.invalid_source_span_count, 0);
+
+        let trace = first_trace(&result)?;
+        assert_eq!(trace.source, ProviderFactSourceKind::CompilerFact);
+        assert_eq!(trace.provenance, Provenance::SemanticAnalyzer);
+        assert_eq!(trace.confidence, Confidence::Medium);
+        assert_eq!(trace.freshness, ProviderFactFreshness::Fresh);
+        assert_eq!(trace.fallback_state, ProviderFallbackState::Primary);
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_token_shadow_allows_scoped_self_method_call_class()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let candidate = shadow_candidate(
+            "token:self_method_call:status:compiler",
+            ProviderFactSourceKind::CompilerFact,
+            Provenance::SemanticAnalyzer,
+            Confidence::Medium,
+            ProviderFactFreshness::Fresh,
+            Some(valid_span(4, 12, 6)),
+            ProviderFallbackState::Primary,
+        );
+        let report = semantic_token_span_invariant_report(std::slice::from_ref(&candidate));
+        let result = semantic_token_source_shadow(Vec::new(), vec![candidate], "self_method_call");
+
+        assert_eq!(result.receipt.verdict, ShadowCompareVerdict::Improved);
+        assert_eq!(result.receipt.old_result.match_count, 0);
+        assert_eq!(result.receipt.new_result.match_count, 1);
+        assert_eq!(
+            result.receipt.new_result.identities,
+            vec!["token:self_method_call:status:compiler".to_string()]
         );
         assert_eq!(report.candidate_count, 1);
         assert_eq!(report.source_backed_span_count, 1);

--- a/crates/perl-lsp-rs/src/runtime/language/provider_decision_live_trace_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/provider_decision_live_trace_tests.rs
@@ -69,6 +69,17 @@ $c->stash;
 
 1;
 "#;
+const SELF_METHOD_CALL_SEMANTIC_TOKEN_URI: &str =
+    "file:///workspace/lib/Trace/SelfMethodCallTokens.pm";
+const SELF_METHOD_CALL_SEMANTIC_TOKEN_DOC: &str = r#"package Trace::SelfMethodCallTokens;
+use strict;
+use warnings;
+
+my $self = current_object();
+$self->status;
+
+1;
+"#;
 const FIELD_SEMANTIC_TOKEN_URI: &str = "file:///workspace/lib/Trace/FieldTokens.pm";
 const FIELD_SEMANTIC_TOKEN_DOC: &str = r#"use feature 'class';
 
@@ -218,6 +229,20 @@ fn open_method_call_semantic_token_document(
         "textDocument": {
             "uri": METHOD_CALL_SEMANTIC_TOKEN_URI,
             "text": METHOD_CALL_SEMANTIC_TOKEN_DOC,
+            "languageId": "perl",
+            "version": 1
+        }
+    })))?;
+    Ok(())
+}
+
+fn open_self_method_call_semantic_token_document(
+    server: &LspServer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    server.test_handle_did_open(Some(json!({
+        "textDocument": {
+            "uri": SELF_METHOD_CALL_SEMANTIC_TOKEN_URI,
+            "text": SELF_METHOD_CALL_SEMANTIC_TOKEN_DOC,
             "languageId": "perl",
             "version": 1
         }
@@ -731,6 +756,69 @@ fn live_semantic_tokens_request_exposes_reviewed_method_call_trace()
             .and_then(Value::as_str)
             .is_some_and(|message| message.contains("compiler method-call live trace")),
         "explanation must surface the reviewed method-call trace: {explanation}"
+    );
+    Ok(())
+}
+
+#[test]
+fn live_semantic_tokens_request_exposes_reviewed_self_method_call_trace()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = create_server();
+    initialize(&server)?;
+    open_self_method_call_semantic_token_document(&server)?;
+
+    response_result(
+        server.handle_request(request(
+            5,
+            "textDocument/semanticTokens/full",
+            Some(json!({
+                "textDocument": {"uri": SELF_METHOD_CALL_SEMANTIC_TOKEN_URI, "version": 1}
+            })),
+        )),
+        "semantic tokens self method call",
+    )?;
+
+    let explanation = explain_provider_decision(&server, "semantic_tokens")?;
+    let receipt = request_receipt(&explanation, "semantic_tokens")?;
+    assert_eq!(receipt.get("schema_version").and_then(Value::as_str), Some("provider_decision.v1"));
+    assert_eq!(receipt.get("provider").and_then(Value::as_str), Some("semantic_tokens"));
+    assert_eq!(receipt.get("decision").and_then(Value::as_str), Some("acted"));
+    assert_eq!(
+        receipt.get("reason").and_then(Value::as_str),
+        Some("source_backed_compiler_token_live_slice")
+    );
+    assert_eq!(receipt.get("fact_source").and_then(Value::as_str), Some("compiler_fact"));
+    assert_eq!(receipt.get("confidence").and_then(Value::as_str), Some("high"));
+    assert_eq!(receipt.get("freshness").and_then(Value::as_str), Some("fresh"));
+    assert_eq!(receipt.get("source_backed").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        receipt.get("source_backed_state").and_then(Value::as_str),
+        Some("source_backed_self_method_call_live_token_match")
+    );
+    assert_eq!(
+        receipt.get("compiler_token_class").and_then(Value::as_str),
+        Some("self_method_call")
+    );
+    assert_eq!(receipt.get("live_token_type").and_then(Value::as_str), Some("method"));
+    assert_eq!(receipt.get("live_token_match_count").and_then(Value::as_u64), Some(1));
+    assert_eq!(receipt.get("fallback").and_then(Value::as_str), Some("none"));
+    assert_eq!(receipt.get("no_live_token_output_change").and_then(Value::as_bool), Some(true));
+
+    let boundary =
+        receipt.get("claim_boundary").and_then(Value::as_str).ok_or("missing boundary")?;
+    assert!(
+        boundary.contains("$self method-call spans")
+            && boundary.contains("broader receiver classes")
+            && boundary.contains("generated/no-source")
+            && boundary.contains("dynamic-boundary"),
+        "self method-call trace must preserve scoped blockers: {boundary}"
+    );
+    assert!(
+        explanation
+            .get("user_message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.contains("compiler $self method-call live trace")),
+        "explanation must surface the reviewed self method-call trace: {explanation}"
     );
     Ok(())
 }

--- a/crates/perl-lsp-rs/src/runtime/language/semantic_tokens.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/semantic_tokens.rs
@@ -281,6 +281,18 @@ impl LspServer {
                 "scoped compiler method-call class cutover proof only; method calls may count as compiler-token identities only when their source-backed span already matches existing live parser/HIR method tokens, and no new token output is emitted",
             ));
         }
+        if let Some(candidate) = semantic_token_self_method_call_candidate(&doc.text) {
+            receipts.push(Self::semantic_tokens_class_specific_expansion_receipt(
+                live_provider_result,
+                candidate,
+                "self_method_call",
+                "method",
+                "matched_existing_live_method_token",
+                "unmatched_existing_live_method_token",
+                true,
+                "scoped compiler self method-call class cutover proof only; $self method calls may count as compiler-token identities only when their source-backed span already matches existing live parser/HIR method tokens, and no new token output is emitted",
+            ));
+        }
         if let Some(candidate) = semantic_token_class_field_declaration_candidate(&doc.text) {
             receipts.push(Self::semantic_tokens_class_specific_expansion_receipt(
                 live_provider_result,
@@ -508,8 +520,22 @@ fn semantic_token_method_declaration_candidate(
 fn semantic_token_method_call_candidate(
     source: &str,
 ) -> Option<crate::semantic_tokens::SemanticTokenShadowCandidate> {
-    let receiver_start = source.find("$c->")?;
-    let mut name_start = receiver_start + "$c->".len();
+    semantic_token_receiver_method_call_candidate(source, "$c->", "method_call")
+}
+
+fn semantic_token_self_method_call_candidate(
+    source: &str,
+) -> Option<crate::semantic_tokens::SemanticTokenShadowCandidate> {
+    semantic_token_receiver_method_call_candidate(source, "$self->", "self_method_call")
+}
+
+fn semantic_token_receiver_method_call_candidate(
+    source: &str,
+    receiver_marker: &str,
+    token_class: &str,
+) -> Option<crate::semantic_tokens::SemanticTokenShadowCandidate> {
+    let receiver_start = source.find(receiver_marker)?;
+    let mut name_start = receiver_start + receiver_marker.len();
 
     while let Some(ch) = source[name_start..].chars().next() {
         if ch.is_whitespace() {
@@ -538,7 +564,7 @@ fn semantic_token_method_call_candidate(
     )?;
 
     Some(crate::semantic_tokens::SemanticTokenShadowCandidate::source_backed_shadow(
-        format!("token:method_call:{name}:compiler"),
+        format!("token:{token_class}:{name}:compiler"),
         ProviderFactSourceKind::CompilerFact,
         Provenance::SemanticAnalyzer,
         Confidence::Medium,
@@ -651,6 +677,24 @@ fn semantic_tokens_live_slice_provider_trace(
             source_backed_state: "source_backed_method_call_live_token_match",
             user_message: "Semantic tokens exposed the source-backed compiler method-call live trace because it matched the existing parser/HIR method token. No new semantic tokens were emitted.",
             claim_boundary: "only source-backed compiler method-call spans that exactly match existing live parser/HIR method tokens participate; generated/no-source, stale, dynamic-boundary, low-confidence, fallback, broader method classes, and unmatched compiler candidates remain blocked, fallback-only, or shadowed",
+        },
+    ) {
+        return trace;
+    }
+
+    let self_method_call_candidate = semantic_token_self_method_call_candidate(source);
+    saw_compiler_token_candidate |= self_method_call_candidate.is_some();
+    if let Some(trace) = semantic_tokens_live_slice_provider_trace_for_candidate(
+        self_method_call_candidate,
+        Some(live_provider_result),
+        live_token_count,
+        provider_action,
+        SemanticTokenLiveSliceTraceSpec {
+            live_token_type: "method",
+            compiler_token_class: "self_method_call",
+            source_backed_state: "source_backed_self_method_call_live_token_match",
+            user_message: "Semantic tokens exposed the source-backed compiler $self method-call live trace because it matched the existing parser/HIR method token. No new semantic tokens were emitted.",
+            claim_boundary: "only source-backed compiler $self method-call spans that exactly match existing live parser/HIR method tokens participate; generated/no-source, stale, dynamic-boundary, low-confidence, fallback, broader receiver classes, and unmatched compiler candidates remain blocked, fallback-only, or shadowed",
         },
     ) {
         return trace;

--- a/crates/perl-lsp-rs/src/runtime/language/semantic_tokens_runtime_quality_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/semantic_tokens_runtime_quality_tests.rs
@@ -205,6 +205,26 @@ class TokenGreeter {
 "#;
 
 /// Empty Perl file — no declarations at all.
+const SELF_METHOD_CALL_MODULE: &str = r#"package TokenSelfCall;
+use strict;
+use warnings;
+
+my $self = current_object();
+$self->status;
+
+1;
+"#;
+
+const UPDATED_SELF_METHOD_CALL_MODULE: &str = r#"package TokenSelfCall;
+use strict;
+use warnings;
+
+my $self = current_object();
+$self->status_updated;
+
+1;
+"#;
+
 const EMPTY_PERL: &str = r#"1;
 "#;
 
@@ -833,6 +853,128 @@ fn semantic_tokens_runtime_quality_receipt_proves_source_backed_method_call_comp
             .filter_map(Value::as_str)
             .any(|identity| identity == "token:method_call:stash:compiler"),
         "class-specific receipt must authorize only the method-call identity; got: {identities:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_proves_source_backed_self_method_call_compiler_token_parity()
+-> Result<(), Box<dyn Error>> {
+    let server = create_server();
+    let self_call_uri = "file:///workspace/lib/TokenSelfCall.pm";
+    open_document(&server, self_call_uri, SELF_METHOD_CALL_MODULE);
+
+    let params = json!({ "textDocument": {"uri": self_call_uri} });
+    let live_result =
+        must(server.test_handle_semantic_tokens(Some(params.clone()))).ok_or("expected tokens")?;
+    let receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(params))));
+
+    assert_eq!(
+        receipt.get("live_provider_result"),
+        Some(&live_result),
+        "self method-call class proof must compare against the exact live token output"
+    );
+    assert_eq!(
+        receipt.get("no_live_behavior_change").and_then(Value::as_bool),
+        Some(true),
+        "self method-call class receipt must not change live semantic-token behavior"
+    );
+    assert_eq!(
+        receipt.get("no_live_token_output_change").and_then(Value::as_bool),
+        Some(true),
+        "self method-call class receipt must not emit additional semantic tokens"
+    );
+
+    let (method_start, method_end, expected_line, expected_start, expected_length) =
+        method_call_name_span(SELF_METHOD_CALL_MODULE, "status")?;
+    let method_span = crate::semantic_tokens::SemanticTokenShadowSpan::from_byte_offsets(
+        SELF_METHOD_CALL_MODULE,
+        method_start,
+        method_end,
+    )
+    .ok_or("expected source-backed self method-call compiler span")?;
+    assert_eq!(method_span.range.start.line, expected_line);
+    assert_eq!(method_span.range.start.character, expected_start);
+    assert_eq!(method_span.single_line_lsp_length(), Some(expected_length));
+
+    let method_receipt = class_specific_receipt(&receipt, "self_method_call")?;
+    assert_eq!(method_receipt.get("source").and_then(Value::as_str), Some("CompilerFact"));
+    assert_eq!(method_receipt.get("provenance").and_then(Value::as_str), Some("SemanticAnalyzer"));
+    assert_eq!(method_receipt.get("freshness").and_then(Value::as_str), Some("Fresh"));
+    assert_eq!(method_receipt.get("fallback_state").and_then(Value::as_str), Some("Primary"));
+    assert_eq!(
+        method_receipt.get("approved_for_live_cutover").and_then(Value::as_bool),
+        Some(true),
+        "self method calls are the scoped class under cutover proof"
+    );
+    assert_eq!(
+        method_receipt.get("live_pilot").and_then(Value::as_bool),
+        Some(true),
+        "self method-call receipt may join the scoped compiler-token live pilot only with parity proof"
+    );
+    assert_eq!(
+        method_receipt.get("live_output_parity").and_then(Value::as_bool),
+        Some(true),
+        "source-backed self method-call compiler span must match existing live method token output"
+    );
+    assert_eq!(
+        method_receipt.get("parity_state").and_then(Value::as_str),
+        Some("matched_existing_live_method_token")
+    );
+    assert_eq!(method_receipt.get("live_token_type").and_then(Value::as_str), Some("method"));
+    assert_eq!(method_receipt.get("live_token_match_count").and_then(Value::as_u64), Some(1));
+    assert_eq!(method_receipt.get("candidate_count").and_then(Value::as_u64), Some(1));
+    assert_eq!(
+        method_receipt.get("source_backed_span_count").and_then(Value::as_u64),
+        Some(1),
+        "self method-call candidate must be source-backed"
+    );
+    assert_eq!(method_receipt.get("missing_source_span_count").and_then(Value::as_u64), Some(0));
+    assert_eq!(method_receipt.get("invalid_source_span_count").and_then(Value::as_u64), Some(0));
+    assert_eq!(
+        method_receipt.get("no_live_token_output_change").and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let method_token_type =
+        *crate::semantic_tokens::legend().map.get("method").ok_or("missing method token")?;
+    let live_match_count = decode_semantic_tokens(&live_result)?
+        .iter()
+        .filter(|token| {
+            token.line == expected_line
+                && token.start == expected_start
+                && token.length == expected_length
+                && token.token_type == method_token_type
+        })
+        .count();
+    assert_eq!(
+        live_match_count, 1,
+        "source-backed self method-call compiler span must match exactly one existing live method token"
+    );
+
+    let claim_boundary = must_some(method_receipt.get("claim_boundary").and_then(Value::as_str));
+    assert!(
+        claim_boundary.contains("$self method calls")
+            && claim_boundary.contains("no new token output is emitted"),
+        "self method-call receipt must preserve the output-neutral boundary; got: {claim_boundary}"
+    );
+
+    let shadow_receipt = must_some(method_receipt.get("shadow_receipt").and_then(Value::as_object));
+    let new_result = must_some(shadow_receipt.get("new_result").and_then(Value::as_object));
+    assert_eq!(
+        new_result.get("match_count").and_then(Value::as_u64),
+        Some(1),
+        "source-backed self method-call compiler candidates may count only through the scoped class identity"
+    );
+    let identities = must_some(new_result.get("identities").and_then(Value::as_array));
+    assert!(
+        identities
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|identity| identity == "token:self_method_call:status:compiler"),
+        "class-specific receipt must authorize only the self method-call identity; got: {identities:?}"
     );
 
     Ok(())
@@ -2005,6 +2147,70 @@ fn semantic_tokens_runtime_quality_receipt_refreshes_method_call_live_pilot_afte
         updated_method_receipt.get("live_token_match_count").and_then(Value::as_u64),
         Some(1),
         "post-edit source-backed method call must still match the live token stream"
+    );
+    assert_eq!(
+        updated_method_receipt.get("no_live_token_output_change").and_then(Value::as_bool),
+        Some(true),
+        "edit-freshness proof must remain output-neutral"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn semantic_tokens_runtime_quality_receipt_refreshes_self_method_call_live_pilot_after_edit()
+-> Result<(), Box<dyn Error>> {
+    let server = create_server();
+    let self_call_uri = "file:///workspace/lib/TokenSelfCall.pm";
+    open_document(&server, self_call_uri, SELF_METHOD_CALL_MODULE);
+
+    let params = json!({ "textDocument": {"uri": self_call_uri} });
+    let initial_live =
+        must(server.test_handle_semantic_tokens(Some(params.clone()))).ok_or("expected tokens")?;
+    let initial_receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(params.clone()))));
+    let initial_method_receipt = class_specific_receipt(&initial_receipt, "self_method_call")?;
+    let initial_identity = first_shadow_identity(initial_method_receipt)?;
+    assert!(
+        initial_identity.contains("status"),
+        "initial self method-call compiler identity should use the opened source: {initial_identity}"
+    );
+    assert_eq!(
+        initial_method_receipt.get("live_pilot").and_then(Value::as_bool),
+        Some(true),
+        "initial self method call should be the scoped class live pilot"
+    );
+
+    change_document(&server, self_call_uri, 2, UPDATED_SELF_METHOD_CALL_MODULE);
+
+    let updated_live =
+        must(server.test_handle_semantic_tokens(Some(params.clone()))).ok_or("expected tokens")?;
+    let updated_receipt =
+        must_some(must(server.test_semantic_tokens_runtime_quality_receipt(Some(params))));
+    let updated_method_receipt = class_specific_receipt(&updated_receipt, "self_method_call")?;
+    let updated_identity = first_shadow_identity(updated_method_receipt)?;
+
+    assert_ne!(
+        updated_live, initial_live,
+        "live semantic-token output must refresh after the self method-call edit"
+    );
+    assert_ne!(
+        updated_identity, initial_identity,
+        "self method-call compiler identity must refresh after didChange"
+    );
+    assert!(
+        updated_identity.contains("status_updated"),
+        "updated self method-call compiler identity should use the edited source: {updated_identity}"
+    );
+    assert_eq!(
+        updated_method_receipt.get("live_pilot").and_then(Value::as_bool),
+        Some(true),
+        "post-edit self method call should remain in the scoped class live pilot"
+    );
+    assert_eq!(
+        updated_method_receipt.get("live_token_match_count").and_then(Value::as_u64),
+        Some(1),
+        "post-edit source-backed self method call must still match the live token stream"
     );
     assert_eq!(
         updated_method_receipt.get("no_live_token_output_change").and_then(Value::as_bool),


### PR DESCRIPTION
Problem: Semantic-token compiler-backed live traces covered generic method-call spans but did not expose a separate scoped $self->method trace class. 
Fix: Add an output-neutral self_method_call trace identity for source-backed $self->... method calls that exactly match existing parser/HIR method tokens, with generated/no-source/dynamic/stale/fallback boundaries still blocked or shadowed. 
Verification: cargo test -p perl-lsp-rs-core --profile agent --locked --lib semantic_token_shadow_allows_scoped_self_method_call_class -- --nocapture; cargo test -p perl-lsp-rs --profile agent --locked --lib live_semantic_tokens_request_exposes_reviewed_self_method_call_trace -- --nocapture --test-threads=1; cargo test -p perl-lsp-rs --profile agent --locked --lib semantic_tokens_runtime_quality_tests -- --nocapture --test-threads=1; cargo test -p perl-lsp-rs-core --profile agent --locked --lib semantic_token_shadow -- --nocapture; cargo test -p perl-lsp-rs --profile agent --locked --lib provider_decision_live_trace_tests -- --nocapture --test-threads=1; cargo check -p perl-lsp-rs --lib --all-features --profile agent --locked; cargo check -p perl-lsp-rs-core --lib --all-features --profile agent --locked; cargo xtask check-provider-confidence-matrix; cargo xtask check-support-claims; cargo xtask semantic-shadow-compare --check; cargo xtask fmt --check; git diff --check.