### PR TITLE
fix(parser): recover missing declaration args (#426)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -497,8 +497,13 @@ impl<'a> Parser<'a> {
             self.expect_closing_delimiter(TokenKind::RightParen)?;
 
             let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
-                self.tokens.next()?; // consume =
-                Some(Box::new(self.parse_assignment()?))
+                let op_token = self.tokens.next()?; // consume =
+                let rhs = if let Some(missing) = self.recover_missing_infix_rhs(op_token.start) {
+                    missing
+                } else {
+                    self.parse_assignment()?
+                };
+                Some(Box::new(rhs))
             } else {
                 None
             };
@@ -536,8 +541,13 @@ impl<'a> Parser<'a> {
             self.expect_closing_delimiter(TokenKind::RightParen)?; // consume )
 
             let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
-                self.tokens.next()?; // consume =
-                Some(Box::new(self.parse_assignment()?))
+                let op_token = self.tokens.next()?; // consume =
+                let rhs = if let Some(missing) = self.recover_missing_infix_rhs(op_token.start) {
+                    missing
+                } else {
+                    self.parse_assignment()?
+                };
+                Some(Box::new(rhs))
             } else {
                 None
             };
@@ -561,8 +571,13 @@ impl<'a> Parser<'a> {
             };
 
             let initializer = if self.peek_kind() == Some(TokenKind::Assign) {
-                self.tokens.next()?; // consume =
-                Some(Box::new(self.parse_assignment()?))
+                let op_token = self.tokens.next()?; // consume =
+                let rhs = if let Some(missing) = self.recover_missing_infix_rhs(op_token.start) {
+                    missing
+                } else {
+                    self.parse_assignment()?
+                };
+                Some(Box::new(rhs))
             } else {
                 None
             };

--- a/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
+++ b/crates/perl-parser-core/tests/parser_panic_mode_recovery.rs
@@ -84,11 +84,17 @@ fn parser_ac3_prevent_recursive_recovery() -> ParseResult<()> {
     // AC:AC3
     let code = "my $x = { { { my $y = ; } } }";
     let mut parser = Parser::new(code);
-    let _ast = parser.parse()?;
+    let ast = parser.parse()?;
 
-    // Should have recorded errors but not entered infinite loop
+    // Should have recorded errors but not entered infinite loop or silently
+    // discarded the malformed declaration inside nested brace expressions.
     let errors = parser.errors();
     assert!(!errors.is_empty(), "Should have error records");
+    let sexp = ast.to_sexp();
+    assert!(
+        sexp.contains("missing_expression"),
+        "Nested declaration recovery should preserve the missing initializer: {sexp}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Problem: Expression-context lexical declarations with a missing initializer could be accepted silently inside nested brace expressions, dropping the malformed declaration from the AST.\nFix: Reuse structured missing-RHS recovery in parse_declaration_arg so semicolon/brace followers produce MissingExpression and parser.errors() evidence.\nVerification: git diff --check; ./scripts/storage-doctor; ./scripts/cargo-safe xtask fmt; ./scripts/cargo-safe check --all-targets -p perl-parser-core --profile agent --locked; ./scripts/cargo-safe test -p perl-parser-core --test parser_panic_mode_recovery --profile agent --locked; ./scripts/cargo-safe test -p perl-parser-core --profile agent --locked; ./scripts/cargo-safe clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs; ./scripts/cargo-safe xtask gates --gate common_corpus_clean --receipt --receipt-path /home/steven/.cache/devplane/perl-lsp/target/receipts/declaration-arg-missing-rhs-common-corpus-clean.json.