### PR TITLE
feat(diagnostics): add explain diagnostic payload (#8197)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -19,6 +19,9 @@ use std::sync::OnceLock;
 use std::time::Instant;
 
 static INLINE_VALUE_REGEX: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
+const DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION: &str = "diagnostic_explanation.v1";
+const MAX_DIAGNOSTIC_EXPLANATIONS: usize = 8;
+const MAX_REPORTED_INC_PATHS: usize = 8;
 
 struct LiveProviderResultShape {
     decision: &'static str,
@@ -102,6 +105,251 @@ fn live_provider_value_shape(value: &Value) -> (&'static str, usize) {
     ("scalar", 1)
 }
 
+fn diagnostic_explanation_payload(
+    method: &str,
+    result: &Result<Option<Value>, JsonRpcError>,
+) -> Option<(Value, String, bool)> {
+    if !matches!(method, "textDocument/diagnostic" | "workspace/diagnostic") {
+        return None;
+    }
+    let Ok(Some(value)) = result else {
+        return None;
+    };
+
+    let diagnostics = collect_diagnostic_values(value);
+    let diagnostic_count = diagnostics.len();
+    let explanations: Vec<Value> = diagnostics
+        .iter()
+        .take(MAX_DIAGNOSTIC_EXPLANATIONS)
+        .map(|diagnostic| diagnostic_explanation(diagnostic))
+        .collect();
+
+    let truncated = diagnostic_count.saturating_sub(explanations.len());
+    let user_message = diagnostic_explanation_user_message(diagnostic_count, &explanations);
+    let has_dynamic_boundary = explanations.iter().any(|explanation| {
+        explanation.get("trust_boundary").and_then(Value::as_str) == Some("dynamic_boundary")
+    });
+
+    Some((
+        json!({
+            "schema_version": DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION,
+            "provider_action": method,
+            "diagnostic_count": diagnostic_count,
+            "diagnostic_explanations": explanations,
+            "truncated_diagnostic_explanations": truncated,
+            "dynamic_boundary_detected": has_dynamic_boundary,
+            "claim_boundary": "explains returned diagnostics only; no new suppression, severity, or support-tier promotion",
+        }),
+        user_message,
+        has_dynamic_boundary,
+    ))
+}
+
+fn collect_diagnostic_values(value: &Value) -> Vec<&Value> {
+    let Some(items) = value.get("items").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    let mut nested = Vec::new();
+    for item in items {
+        if let Some(document_items) = item.get("items").and_then(Value::as_array) {
+            nested.extend(document_items);
+        }
+    }
+
+    if nested.is_empty() { items.iter().collect() } else { nested }
+}
+
+fn diagnostic_explanation(diagnostic: &Value) -> Value {
+    let code = diagnostic_code(diagnostic);
+    let message = diagnostic.get("message").and_then(Value::as_str).unwrap_or("");
+    let trust_boundary = diagnostic_trust_boundary(code.as_deref(), message);
+    let mut explanation = serde_json::Map::new();
+
+    if let Some(code) = code {
+        explanation.insert("code".to_string(), json!(code));
+    }
+    explanation.insert("trust_boundary".to_string(), json!(trust_boundary));
+    explanation.insert("severity".to_string(), json!(diagnostic_severity_label(diagnostic)));
+    explanation.insert("summary".to_string(), json!(diagnostic_summary(message)));
+    explanation.insert("reason".to_string(), json!(diagnostic_trust_reason(trust_boundary)));
+
+    if trust_boundary == "module_resolution" {
+        explanation.insert("module_resolution".to_string(), pl701_module_resolution(message));
+    }
+
+    Value::Object(explanation)
+}
+
+fn diagnostic_code(diagnostic: &Value) -> Option<String> {
+    diagnostic
+        .get("code")
+        .and_then(|code| {
+            code.as_str()
+                .map(str::to_string)
+                .or_else(|| code.as_i64().map(|value| value.to_string()))
+        })
+        .or_else(|| diagnostic.pointer("/data/code").and_then(Value::as_str).map(str::to_string))
+}
+
+fn diagnostic_trust_boundary(code: Option<&str>, message: &str) -> &'static str {
+    if code == Some("PL701") {
+        return "module_resolution";
+    }
+
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("dynamic boundary") || lower.contains("dynamic-boundary") {
+        "dynamic_boundary"
+    } else if lower.contains("low-confidence") || lower.contains("low confidence") {
+        "low_confidence"
+    } else if lower.contains("ambiguous") {
+        "ambiguous_evidence"
+    } else if lower.contains("stale") {
+        "stale_fact"
+    } else if lower.contains("generated")
+        || lower.contains("no-source")
+        || lower.contains("not source-backed")
+    {
+        "generated_or_not_source_backed"
+    } else {
+        "conservative_diagnostic"
+    }
+}
+
+fn diagnostic_trust_reason(trust_boundary: &str) -> &'static str {
+    match trust_boundary {
+        "module_resolution" => {
+            "Missing-module diagnostic; inspect the reported @INC search context and include-path policy."
+        }
+        "dynamic_boundary" => {
+            "Dynamic Perl boundary prevents static confirmation, so the diagnostic stays conservative."
+        }
+        "low_confidence" => {
+            "Low-confidence evidence is visible and does not silently suppress the diagnostic."
+        }
+        "ambiguous_evidence" => {
+            "Ambiguous evidence is visible and does not silently suppress the diagnostic."
+        }
+        "stale_fact" => "Stale facts are not trusted as fresh diagnostic evidence.",
+        "generated_or_not_source_backed" => {
+            "Generated or non-source-backed evidence is not treated as an exact static fact."
+        }
+        _ => {
+            "Diagnostic was returned by the live provider; no stronger trust boundary was inferred."
+        }
+    }
+}
+
+fn diagnostic_severity_label(diagnostic: &Value) -> &'static str {
+    match diagnostic.get("severity").and_then(Value::as_u64) {
+        Some(1) => "error",
+        Some(2) => "warning",
+        Some(3) => "information",
+        Some(4) => "hint",
+        _ => "unknown",
+    }
+}
+
+fn diagnostic_summary(message: &str) -> String {
+    message.lines().next().unwrap_or("").chars().take(200).collect()
+}
+
+fn pl701_module_resolution(message: &str) -> Value {
+    let requested_module = extract_between(message, "Module '", "'");
+    let expected_relative_path =
+        requested_module.as_ref().map(|module| format!("{}.pm", module.replace("::", "/")));
+    let reported_inc_paths = reported_inc_paths(message);
+    let effective_include_paths_reported = !reported_inc_paths.is_empty();
+    let workspace_include_paths_labeled = message.contains("workspace includePaths");
+    let perl5lib_policy = if message.contains("PERL5LIB") {
+        "reported_in_effective_search_context"
+    } else {
+        "not_reported_in_diagnostic_search_context"
+    };
+
+    json!({
+        "requested_module": requested_module,
+        "expected_relative_path": expected_relative_path,
+        "reported_inc_paths": reported_inc_paths,
+        "effective_include_paths_reported": effective_include_paths_reported,
+        "workspace_include_paths_labeled": workspace_include_paths_labeled,
+        "perl5lib_policy": perl5lib_policy,
+        "searched_inc_reported": message.contains("Searched @INC"),
+    })
+}
+
+fn extract_between(message: &str, prefix: &str, suffix: &str) -> Option<String> {
+    let start = message.find(prefix)? + prefix.len();
+    let rest = &message[start..];
+    let end = rest.find(suffix)?;
+    Some(rest[..end].to_string())
+}
+
+fn reported_inc_paths(message: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    for line in message.lines() {
+        let trimmed = line.trim();
+        if let Some(path) = trimmed.strip_prefix("- ") {
+            paths.push(path.to_string());
+        }
+        if paths.len() >= MAX_REPORTED_INC_PATHS {
+            return paths;
+        }
+    }
+
+    if paths.is_empty() {
+        if let Some(after_inc) = message.split_once("Searched @INC:").map(|(_, rest)| rest) {
+            let before_suggestion =
+                after_inc.split_once("Suggestion:").map(|(search, _)| search).unwrap_or(after_inc);
+            let before_sentence = before_suggestion
+                .split_once(". Add")
+                .map(|(search, _)| search)
+                .unwrap_or(before_suggestion);
+            paths.extend(
+                before_sentence
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|path| !path.is_empty())
+                    .take(MAX_REPORTED_INC_PATHS)
+                    .map(str::to_string),
+            );
+        }
+    }
+
+    paths
+}
+
+fn diagnostic_explanation_user_message(count: usize, explanations: &[Value]) -> String {
+    if count == 0 {
+        return "Diagnostics returned no findings for this request.".to_string();
+    }
+
+    let has_pl701 = explanations.iter().any(|explanation| {
+        explanation.get("trust_boundary").and_then(Value::as_str) == Some("module_resolution")
+    });
+    if has_pl701 {
+        return format!(
+            "Diagnostics returned {count} item(s). PL701 includes missing-module @INC lookup context so users can distinguish code issues from include-path setup."
+        );
+    }
+
+    let has_dynamic_or_low_confidence = explanations.iter().any(|explanation| {
+        matches!(
+            explanation.get("trust_boundary").and_then(Value::as_str),
+            Some("dynamic_boundary" | "low_confidence" | "ambiguous_evidence")
+        )
+    });
+    if has_dynamic_or_low_confidence {
+        return format!(
+            "Diagnostics returned {count} item(s). Dynamic, low-confidence, or ambiguous evidence is labeled and kept conservative."
+        );
+    }
+
+    format!(
+        "Diagnostics returned {count} item(s). This receipt explains the returned diagnostics without changing suppression or severity."
+    )
+}
+
 fn unresolved_debug_perl_error(resolved: &std::path::Path) -> JsonRpcError {
     JsonRpcError {
         code: -32603,
@@ -183,6 +431,25 @@ impl LspServer {
                 "records live provider request shape only; compiler-fact trust remains gated by surface receipts"
             ),
         );
+        if let Some((diagnostic_payload, user_message, has_dynamic_boundary)) =
+            diagnostic_explanation_payload(method, result)
+        {
+            receipt.insert(
+                "diagnostic_explanation_schema".to_string(),
+                json!(DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION),
+            );
+            receipt.insert("diagnostic_explanation".to_string(), diagnostic_payload);
+            receipt.insert("user_message".to_string(), json!(user_message));
+            if has_dynamic_boundary {
+                receipt.insert("dynamic_boundary".to_string(), json!(true));
+            }
+            receipt.insert(
+                "claim_boundary".to_string(),
+                json!(
+                    "records live diagnostic explanation payload only; no new suppression, severity, or support-tier promotion"
+                ),
+            );
+        }
         if let Some(error) = shape.error {
             receipt.insert("provider_error".to_string(), error);
         }

--- a/crates/perl-lsp-rs/src/runtime/language/provider_decision_live_trace_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/provider_decision_live_trace_tests.rs
@@ -19,6 +19,7 @@ my $ready = 1;
 my $call = target();
 my $prefix = $re;
 "#;
+const MISSING_MODULE_DIAGNOSTIC_DOC: &str = "use Missing::Payload;\n";
 
 const WORKSPACE_SYMBOL_URI: &str = "file:///workspace/lib/Trace/Symbols.pm";
 const WORKSPACE_SYMBOL_DOC: &str = r#"package Trace::Symbols;
@@ -137,6 +138,41 @@ fn open_trace_document(server: &LspServer) -> Result<(), Box<dyn std::error::Err
         }
     })))?;
     Ok(())
+}
+
+fn open_missing_module_diagnostic_document(
+    server: &LspServer,
+) -> Result<(tempfile::TempDir, String), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().join("workspace");
+    std::fs::create_dir_all(workspace.join("lib"))?;
+    let script = workspace.join("script.pl");
+    let uri =
+        url::Url::from_file_path(&script).map_err(|()| "failed to build script URI")?.to_string();
+    let folder_uri = url::Url::from_directory_path(&workspace)
+        .map_err(|()| "failed to build workspace URI")?
+        .to_string();
+
+    *server.root_path.lock() = Some(workspace.clone());
+    let mut config = perl_lsp_rs_core::config::WorkspaceConfig::default();
+    config.include_paths = vec!["lib".to_string()];
+    config.use_system_inc = false;
+    config.use_perl5lib = false;
+    server.workspace_folders.lock().push(
+        crate::runtime::workspace_folder::WorkspaceFolderState::new(folder_uri)
+            .with_path(workspace)
+            .with_effective_workspace_config(config),
+    );
+
+    server.test_handle_did_open(Some(json!({
+        "textDocument": {
+            "uri": uri,
+            "text": MISSING_MODULE_DIAGNOSTIC_DOC,
+            "languageId": "perl",
+            "version": 1
+        }
+    })))?;
+    Ok((temp, uri))
 }
 
 fn open_workspace_symbol_document(server: &LspServer) -> Result<(), Box<dyn std::error::Error>> {
@@ -456,6 +492,101 @@ fn live_diagnostic_request_persists_provider_trace() -> Result<(), Box<dyn std::
     let receipt = request_receipt(&explanation, "diagnostics")?;
     assert_live_trace(receipt, "diagnostics", "textDocument/diagnostic");
     assert_eq!(receipt.get("live_provider_result_kind").and_then(Value::as_str), Some("items"));
+    Ok(())
+}
+
+#[test]
+fn live_diagnostic_request_attaches_explainable_payload() -> Result<(), Box<dyn std::error::Error>>
+{
+    let server = create_server();
+    initialize(&server)?;
+    let (_temp, uri) = open_missing_module_diagnostic_document(&server)?;
+
+    let diagnostic_result = response_result(
+        server.handle_request(request(
+            5,
+            "textDocument/diagnostic",
+            Some(json!({
+                "textDocument": {"uri": uri}
+            })),
+        )),
+        "diagnostic",
+    )?;
+    let diagnostics = diagnostic_result
+        .get("items")
+        .and_then(Value::as_array)
+        .ok_or("diagnostic result missing items")?;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.get("code").and_then(Value::as_str) == Some("PL701")),
+        "diagnostic request must return PL701 for the missing module fixture: {diagnostic_result}"
+    );
+
+    let explanation = explain_provider_decision(&server, "diagnostics")?;
+    let receipt = request_receipt(&explanation, "diagnostics")?;
+    assert_live_trace(receipt, "diagnostics", "textDocument/diagnostic");
+    assert_eq!(
+        receipt.get("diagnostic_explanation_schema").and_then(Value::as_str),
+        Some("diagnostic_explanation.v1")
+    );
+    assert_eq!(
+        receipt.get("claim_boundary").and_then(Value::as_str),
+        Some(
+            "records live diagnostic explanation payload only; no new suppression, severity, or support-tier promotion"
+        )
+    );
+    let diagnostic_explanation =
+        receipt.get("diagnostic_explanation").ok_or("missing diagnostic explanation payload")?;
+    assert_eq!(
+        diagnostic_explanation.get("schema_version").and_then(Value::as_str),
+        Some("diagnostic_explanation.v1")
+    );
+    let explanations = diagnostic_explanation
+        .get("diagnostic_explanations")
+        .and_then(Value::as_array)
+        .ok_or("missing diagnostic explanation items")?;
+    let pl701 = explanations
+        .iter()
+        .find(|item| item.get("code").and_then(Value::as_str) == Some("PL701"))
+        .ok_or("missing PL701 diagnostic explanation")?;
+    assert_eq!(pl701.get("trust_boundary").and_then(Value::as_str), Some("module_resolution"));
+    let module_resolution =
+        pl701.get("module_resolution").ok_or("missing PL701 module-resolution explanation")?;
+    assert_eq!(
+        module_resolution.get("requested_module").and_then(Value::as_str),
+        Some("Missing::Payload")
+    );
+    assert_eq!(
+        module_resolution.get("expected_relative_path").and_then(Value::as_str),
+        Some("Missing/Payload.pm")
+    );
+    assert_eq!(
+        module_resolution.get("effective_include_paths_reported").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(module_resolution.get("searched_inc_reported").and_then(Value::as_bool), Some(true));
+    let reported_inc_paths = module_resolution
+        .get("reported_inc_paths")
+        .and_then(Value::as_array)
+        .ok_or("missing reported @INC paths")?;
+    assert!(
+        reported_inc_paths
+            .iter()
+            .any(|path| path.as_str().is_some_and(|path| path.contains("lib"))),
+        "PL701 explanation should keep reported @INC path context: {module_resolution}"
+    );
+    assert!(
+        receipt
+            .get("user_message")
+            .and_then(Value::as_str)
+            .is_some_and(|message| message.contains("PL701")),
+        "diagnostic receipt should include a user-facing PL701 summary: {receipt}"
+    );
+    let copyable_receipt = explanation
+        .pointer("/copyable_payload/request_receipt/diagnostic_explanation/schema_version")
+        .and_then(Value::as_str);
+    assert_eq!(copyable_receipt, Some("diagnostic_explanation.v1"));
     Ok(())
 }
 


### PR DESCRIPTION
Problem: Diagnostic provider explanations recorded only generic request-shape traces, so copied receipts could not explain PL701/module lookup context.
Fix: Add an additive diagnostic_explanation.v1 payload to live diagnostic provider traces, including PL701 module lookup summary, reported @INC paths, trust-boundary labels, and a user_message copied through perl.explainProviderDecision.
Claim boundary: Explanation payload only; no diagnostic suppression, severity, support-tier promotion, or provider behavior change.
Verification: cargo test -p perl-lsp-rs --profile agent --locked --lib live_diagnostic_request_attaches_explainable_payload -- --nocapture --test-threads=1; cargo test -p perl-lsp-rs --profile agent --locked --lib runtime::language::provider_decision_live_trace_tests -- --nocapture --test-threads=1; cargo check -p perl-lsp-rs --lib --all-features --profile agent --locked; cargo test -p perl-lsp-rs-core --lib diagnostics --profile agent --locked -- --nocapture; cargo test -p perl-lsp-ux-tests --test ux_scenario_31_mojolicious_diagnostics_quality --profile agent --locked -- --nocapture --test-threads=1; cargo test -p perl-lsp-ux-tests --test ux_scenario_40_dancer2_diagnostics_quality --profile agent --locked -- --nocapture --test-threads=1; cargo xtask check-provider-confidence-matrix; cargo xtask check-support-claims; cargo xtask semantic-scorecard --check; cargo xtask semantic-shadow-compare --check; cargo xtask fmt --check; git diff --check.