### PR TITLE
fix(parser): treat word operators as builtin terminators (#2622)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -92,6 +92,9 @@ impl<'a> Parser<'a> {
                 | TokenKind::RightParen
                 | TokenKind::Comma
                 | TokenKind::Eof => return false,
+                // Word operators bind below list operators, so they terminate
+                // a zero-arg builtin call instead of starting an indirect object.
+                kind if kind.is_low_precedence_word_operator() => return false,
                 _ => {}
             }
 

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -847,6 +847,12 @@ impl<'a> Parser<'a> {
                         | Some(TokenKind::Foreach)
                         | Some(TokenKind::RightBrace)
                         | Some(TokenKind::Eof)
+                        // Word operators bind below list operators, so they terminate a
+                        // zero-argument builtin call instead of starting its arguments.
+                        | Some(TokenKind::WordOr)
+                        | Some(TokenKind::WordAnd)
+                        | Some(TokenKind::WordXor)
+                        | Some(TokenKind::WordNot)
                         | None => {
                             // No arguments - return as function call with empty args
                             let end = self.previous_position();

--- a/crates/perl-parser-core/tests/fix_print_word_op_or.rs
+++ b/crates/perl-parser-core/tests/fix_print_word_op_or.rs
@@ -1,0 +1,35 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn print_or_die_in_while_is_clean() {
+    // Pod::Perldoc.pm pattern: zero-arg print, then low-precedence word-or.
+    assert_clean_parse(
+        r#"
+while (<$fh>) {
+    print or die "Can't print: $!";
+}
+"#,
+    );
+}
+
+#[test]
+fn close_fh_or_die_is_clean() {
+    assert_clean_parse(r#"close $fh or die "Can't close: $!";"#);
+}
+
+#[test]
+fn bare_zero_arg_builtins_before_word_operators_are_clean() {
+    assert_clean_parse(r#"print or die "error";"#);
+    assert_clean_parse(r#"say or die "error";"#);
+    assert_clean_parse(r#"write or die "Can't write";"#);
+    assert_clean_parse(r#"print and next;"#);
+}
+
+#[test]
+fn print_with_actual_args_still_parses() {
+    assert_clean_parse(r#"print "hello\n";"#);
+    assert_clean_parse(r#"print $fh "hello\n";"#);
+    assert_clean_parse(r#"print $_ or die "error";"#);
+    assert_clean_parse(r#"print STDOUT "hello\n";"#);
+}


### PR DESCRIPTION
Problem: zero-argument list builtins such as print could consume low-precedence word operators as call arguments, so real Perl idioms like print or die parsed as errors. Fix: terminate zero-argument builtin parsing at low-precedence word operators and avoid treating those operators as indirect-call starts; add parser-core regressions for print/say/write/close patterns and actual-argument cases. Verification: git diff --check; ./scripts/storage-doctor; MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt; MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-parser-core --test fix_print_word_op_or --profile agent --locked -- --nocapture; MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe check --all-targets -p perl-parser-core --profile agent --locked; MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-parser-core --profile agent --locked; MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe clippy -p perl-parser-core --profile agent --locked -- -D warnings -A missing_docs; common_corpus_clean receipt /home/steven/.cache/devplane/perl-lsp/target/receipts/9167-word-operator-common-corpus-clean-rebased.json. Overlap: ports the useful #9167 draft behavior onto current master without stale branch changes that would conflict with recent parser recovery work; recommend closing #9167 as superseded after this merges.