### PR TITLE
fix(lexer): keep sigil-prefixed y names out of transliteration (#9170)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1650,6 +1650,15 @@ impl<'a> PerlLexer<'a> {
         !c.is_ascii_alphanumeric() && !c.is_whitespace()
     }
 
+    #[inline]
+    fn immediately_follows_sigil_prefix(&self, start: usize) -> bool {
+        start > 0
+            && matches!(
+                Self::byte_at(self.input_bytes, start.saturating_sub(1)),
+                b'$' | b'@' | b'%' | b'&' | b'*'
+            )
+    }
+
     /// Try to parse a v-string (version string) like `v5.26.0` or `v5.10`.
     ///
     /// A v-string starts with `v` followed by one or more digits, then optionally
@@ -1746,21 +1755,25 @@ impl<'a> PerlLexer<'a> {
             // Special case: substitution/transliteration with single-quote delimiter
             // The single quote is considered an identifier continuation, so we need to
             // detect these operators before consuming it as part of an identifier.
-            if !self.after_arrow
+            let follows_sigil_prefix = self.immediately_follows_sigil_prefix(start);
+            if !follows_sigil_prefix
+                && !self.after_arrow
                 && self.hash_brace_depth == 0
                 && ch == 's'
                 && self.peek_char(1) == Some('\'')
             {
                 self.advance(); // consume 's'
                 return self.parse_substitution(start);
-            } else if !self.after_arrow
+            } else if !follows_sigil_prefix
+                && !self.after_arrow
                 && self.hash_brace_depth == 0
                 && ch == 'y'
                 && self.peek_char(1) == Some('\'')
             {
                 self.advance(); // consume 'y'
                 return self.parse_transliteration(start);
-            } else if !self.after_arrow
+            } else if !follows_sigil_prefix
+                && !self.after_arrow
                 && self.hash_brace_depth == 0
                 && ch == 't'
                 && self.peek_char(1) == Some('r')
@@ -1900,6 +1913,7 @@ impl<'a> PerlLexer<'a> {
             #[allow(clippy::collapsible_if)]
             if !self.after_sub
                 && !self.after_arrow
+                && !follows_sigil_prefix
                 && self.hash_brace_depth == 0
                 && matches!(text, "s" | "tr" | "y")
             {
@@ -1973,6 +1987,7 @@ impl<'a> PerlLexer<'a> {
                     // quote expressions in slices (`@h{qw/a b/}`).
                     op if !self.after_sub
                         && !self.after_arrow
+                        && !follows_sigil_prefix
                         && quote_handler::is_quote_operator(op)
                         && (self.hash_brace_depth == 0
                             || matches!(op, "q" | "qq" | "qw" | "qr" | "qx")) =>

--- a/crates/perl-lexer/tests/focused_regression_contracts.rs
+++ b/crates/perl-lexer/tests/focused_regression_contracts.rs
@@ -196,6 +196,26 @@ fn y_alias_for_tr_is_transliteration_token() -> TestResult {
 }
 
 #[test]
+fn percent_y_hash_name_is_not_transliteration() -> TestResult {
+    let input = "my %y = %$y;";
+    let mut lexer = PerlLexer::new(input);
+
+    while let Some(token) = next_non_trivia(&mut lexer) {
+        if token.token_type == TokenType::EOF {
+            break;
+        }
+        assert!(
+            !matches!(token.token_type, TokenType::Transliteration | TokenType::Error(_)),
+            "`%y` hash variable must not trigger y/// transliteration; got {:?} from {:?}",
+            token.token_type,
+            token.text
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
 fn qr_with_modifier_flag_is_quote_regex_token() -> TestResult {
     // `qr//i` — regex with ignore-case flag; modifier must be part of the token.
     let input = "qr/hello world/i";

--- a/crates/perl-parser-core/tests/fix_unexpected_rparen_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rparen_expr.rs
@@ -475,3 +475,10 @@ fn test_subst_double_quoted_replacement_no_delimiter() {
 fn test_split_single_quote_string_without_space() {
     assert_no_errors(r#"@names = split' ', $val;"#);
 }
+
+#[test]
+fn test_data_compare_percent_y_hash_copy_clean() {
+    // Data::Compare::_Compare copies hashrefs into `%x` and `%y`.
+    // The `%y` declaration must not degrade into the `y///` transliteration alias.
+    assert_no_errors("sub f { my %x = %$x; my %y = %$y; }");
+}


### PR DESCRIPTION
Problem: Data::Compare-style `%y` hash declarations could degrade into `y///` transliteration detection and cascade into the fresh `unexpected_rparen_expr` bucket.
Fix: Suppress quote-like operator detection for identifiers immediately adjacent to sigil prefixes, and add lexer/parser regressions for `%y` hash names.
Verification: `cargo test -p perl-lexer --test focused_regression_contracts --profile agent --locked`; `cargo test -p perl-parser-core --test fix_unexpected_rparen_expr --profile agent --locked`; `cargo check --all-targets -p perl-lexer --profile agent --locked`; `cargo check --all-targets -p perl-parser-core --profile agent --locked`; `cargo clippy -p perl-lexer --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked`; `cargo xtask fmt --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`; WSL `parser-corpus-sweep` for `/usr/share/perl5/Data/Compare.pm` is clean 1/1 with 0 error nodes after the fix.

Parser accuracy denominator/status: unchanged at 50 fixtures across 29 families; no provider row changes; failure-packet delta unchanged at 0 active; no broad corpus baseline or parser status promotion.

Validation gap: full `cargo test -p perl-parser-core --profile agent --locked` hits unrelated Windows path-prefix assertion `path_security_mutation_hardening::safe_relative_path_resolves_under_workspace`, confirmed by targeted rerun.