### PR TITLE
feat(vscode): expose missing-module explanation (#8197)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -798,6 +798,12 @@
         "icon": "$(checklist)"
       },
       {
+        "command": "perl-lsp.explainMissingModuleLookup",
+        "title": "Explain Missing Module Lookup",
+        "category": "Perl LSP",
+        "icon": "$(search)"
+      },
+      {
         "command": "perl-lsp.reportIssue",
         "title": "Report Issue",
         "category": "Perl",
@@ -913,6 +919,10 @@
         {
           "command": "perl-lsp.showWorkspaceTrustReport",
           "when": "workspaceFolderCount >= 1"
+        },
+        {
+          "command": "perl-lsp.explainMissingModuleLookup",
+          "when": "editorLangId == perl"
         },
         {
           "command": "perl-lsp.reportIssue"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -369,6 +369,33 @@ function activeSafeDeletePreviewArgument(): Record<string, unknown> | undefined 
     };
 }
 
+function isPerlModuleName(value: string): boolean {
+    return /^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$/.test(value);
+}
+
+function moduleNameAtCursor(editor: vscode.TextEditor): string | undefined {
+    const selectedText = editor.document.getText(editor.selection).trim();
+    if (isPerlModuleName(selectedText)) {
+        return selectedText;
+    }
+
+    const active = editor.selection.active;
+    const lineText = editor.document.lineAt(active.line).text;
+    const modulePattern = /[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)+/g;
+    for (const match of lineText.matchAll(modulePattern)) {
+        const start = match.index ?? 0;
+        const end = start + match[0].length;
+        if (active.character >= start && active.character <= end) {
+            return match[0];
+        }
+    }
+
+    const useStatement = lineText.match(
+        /\b(?:use|require)\s+([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)/
+    );
+    return useStatement?.[1];
+}
+
 function trustOutputChannel(): vscode.OutputChannel {
     return outputChannel ?? vscode.window.createOutputChannel('Perl LSP Trust');
 }
@@ -534,6 +561,62 @@ function formatWorkspaceTrustReport(result: unknown): string {
     return lines.join('\n');
 }
 
+function formatMissingModuleLookup(result: unknown): string {
+    const report = asObject(result);
+    const moduleResolution = asObject(report?.module_resolution);
+    const lookupResult = asObject(moduleResolution?.result);
+    const includePaths = arrayField(moduleResolution, 'effective_include_paths');
+
+    const lines = [
+        'Perl LSP Missing Module Lookup',
+        '',
+        `Module: ${stringField(report, 'requested_module') ?? '(unknown)'}`,
+        `Expected path: ${stringField(report, 'expected_relative_path') ?? '(unknown)'}`,
+        `Result: ${stringField(lookupResult, 'status') ?? 'unknown'}`,
+        `Why: ${stringField(lookupResult, 'why') ?? 'No lookup reason reported.'}`,
+        '',
+        'Module resolution / @INC',
+        `- PERL5LIB policy: ${stringField(moduleResolution, 'perl5lib_policy') ?? 'unknown'}`,
+        `- system @INC enabled: ${String(booleanField(moduleResolution, 'use_system_inc') ?? false)}`,
+        `- include roots: ${includePaths.length}`,
+    ];
+
+    for (const entry of includePaths.slice(0, 8)) {
+        const root = asObject(entry);
+        if (!root) {
+            continue;
+        }
+
+        const source = stringField(root, 'source') ?? 'unknown source';
+        const kind = stringField(root, 'kind') ?? 'unknown kind';
+        lines.push(`- ${stringField(root, 'path') ?? '(unknown path)'} (${source}, ${kind})`);
+
+        for (const candidate of arrayField(root, 'candidate_paths').slice(0, 2)) {
+            const candidateObject = asObject(candidate);
+            if (!candidateObject) {
+                continue;
+            }
+            const exists = booleanField(candidateObject, 'exists') === true ? 'exists' : 'missing';
+            lines.push(`  candidate: ${stringField(candidateObject, 'path') ?? '(unknown)'} [${exists}]`);
+        }
+    }
+
+    if (includePaths.length > 8) {
+        lines.push(`- ... and ${includePaths.length - 8} more include roots`);
+    }
+
+    lines.push(
+        '',
+        'Claim boundary',
+        stringField(report, 'claim_boundary') ?? 'This explanation is bounded to current runtime state.',
+        '',
+        'Raw lookup JSON',
+        providerDecisionJson(result),
+    );
+
+    return lines.join('\n');
+}
+
 export async function showWorkspaceTrustReportCommand(
     activeClient: LspExecuteCommandClient | undefined = client
 ): Promise<void> {
@@ -546,6 +629,60 @@ export async function showWorkspaceTrustReportCommand(
     channel.appendLine('');
     channel.appendLine(formatWorkspaceTrustReport(result));
     channel.show();
+}
+
+export async function explainMissingModuleLookupCommand(
+    activeClient: LspExecuteCommandClient | undefined = client,
+    moduleOverride?: string
+): Promise<unknown | undefined> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'perl') {
+        vscode.window.showErrorMessage('Explain Missing Module Lookup requires an active Perl file.');
+        return undefined;
+    }
+
+    const moduleName = moduleOverride ?? moduleNameAtCursor(editor) ?? await vscode.window.showInputBox({
+        placeHolder: 'Missing::Module',
+        prompt: 'Module name to explain with perl-lsp @INC lookup state',
+        validateInput: value => {
+            if (!value.trim()) {
+                return 'Enter a Perl module name.';
+            }
+            return isPerlModuleName(value.trim()) ? undefined : 'Enter a valid Perl module name.';
+        },
+    });
+    if (!moduleName) {
+        return undefined;
+    }
+
+    const result = await executeLspCommand(activeClient, 'perl.explainMissingModuleLookup', {
+        module: moduleName.trim(),
+        textDocument: { uri: editor.document.uri.toString() },
+        position: {
+            line: editor.selection.active.line,
+            character: editor.selection.active.character,
+        },
+    });
+    if (result === undefined) {
+        return undefined;
+    }
+
+    const resultObject = asObject(result);
+    const message = stringField(resultObject, 'user_message') ?? 'Missing-module lookup explained.';
+    const status = stringField(asObject(asObject(resultObject?.module_resolution)?.result), 'status');
+    const channel = trustOutputChannel();
+    channel.appendLine('');
+    channel.appendLine(formatMissingModuleLookup(result));
+
+    const action = status === 'resolved'
+        ? await vscode.window.showInformationMessage(message, 'Show Output')
+        : await vscode.window.showWarningMessage(message, 'Show Output');
+
+    if (action === 'Show Output') {
+        channel.show();
+    }
+
+    return result;
 }
 
 export async function explainProviderDecisionCommand(
@@ -929,6 +1066,16 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     );
 
+    const explainMissingModuleLookupCommandDisposable = vscode.commands.registerCommand(
+        'perl-lsp.explainMissingModuleLookup',
+        async (moduleName?: unknown) => {
+            await explainMissingModuleLookupCommand(
+                client,
+                typeof moduleName === 'string' ? moduleName : undefined
+            );
+        }
+    );
+
     const whatsNewManager = new WhatsNewManager(context, outputChannel);
     const showWhatsNewCommand = vscode.commands.registerCommand('perl-lsp.showWhatsNew', async () => {
         await whatsNewManager.showWhatsNew();
@@ -1238,6 +1385,7 @@ export async function activate(context: vscode.ExtensionContext) {
         previewSafeDeleteCommandDisposable,
         copyProviderDecisionReceiptCommandDisposable,
         showWorkspaceTrustReportCommandDisposable,
+        explainMissingModuleLookupCommandDisposable,
         showVersionCommand,
         statusMenuCommand,
         reinstallCommand,

--- a/vscode-extension/src/test/__mocks__/vscode.ts
+++ b/vscode-extension/src/test/__mocks__/vscode.ts
@@ -124,6 +124,7 @@ export const window = {
   showWarningMessage: jest.fn(async () => undefined),
   showInformationMessage: jest.fn(async () => undefined),
   showQuickPick: jest.fn(async () => undefined),
+  showInputBox: jest.fn(async () => undefined),
   showTextDocument: jest.fn(async () => undefined),
   withProgress: jest.fn(async (_options: any, task: any) => {
     const progress = { report: jest.fn() };

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -372,6 +372,7 @@ describe('perl-lsp trust explanation commands', () => {
     ['perl-lsp.previewSafeDelete', 'Preview Safe Delete'],
     ['perl-lsp.copyProviderDecisionReceipt', 'Copy Provider Decision Receipt'],
     ['perl-lsp.showWorkspaceTrustReport', 'Show Workspace Trust Report'],
+    ['perl-lsp.explainMissingModuleLookup', 'Explain Missing Module Lookup'],
   ])('%s is declared as a Perl LSP command', (id, title) => {
     const cmd = pkg.contributes.commands.find((c: any) => c.command === id);
     expect(commandIds).toContain(id);
@@ -384,6 +385,7 @@ describe('perl-lsp trust explanation commands', () => {
     'perl-lsp.explainProviderDecision',
     'perl-lsp.previewSafeDelete',
     'perl-lsp.copyProviderDecisionReceipt',
+    'perl-lsp.explainMissingModuleLookup',
   ])('%s is available from the Perl command palette', (id) => {
     const entry = paletteEntries.find((e: any) => e.command === id);
     expect(entry).toBeDefined();

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -19,6 +19,7 @@ jest.mock('vscode-languageclient/node', () => ({
 }));
 import {
   copyProviderDecisionReceiptCommand,
+  explainMissingModuleLookupCommand,
   explainProviderDecisionCommand,
   previewSafeDeleteCommand,
   showWorkspaceTrustReportCommand,
@@ -674,5 +675,80 @@ describe('extension UX warnings', () => {
     expect(rendered).toContain('completion: partial-live-with-fallback');
     expect(rendered).toContain('Aggregates current runtime state only.');
     expect(outputChannel.show).toHaveBeenCalled();
+  });
+
+  test('explains a missing-module lookup through the LSP execute command', async () => {
+    const outputChannel = {
+      appendLine: jest.fn(),
+      show: jest.fn(),
+      dispose: jest.fn(),
+    };
+    (vscode.window.createOutputChannel as jest.Mock).mockReturnValueOnce(outputChannel);
+    const sendRequest = jest.fn(async () => ({
+      schema_version: 'missing_module_lookup_explanation.v1',
+      requested_module: 'Missing::Payload',
+      expected_relative_path: 'Missing/Payload.pm',
+      module_resolution: {
+        result: {
+          status: 'not_found',
+          why: 'No searched @INC candidate matched.',
+        },
+        effective_include_paths: [
+          {
+            path: 'lib',
+            source: 'workspace includePaths',
+            kind: 'workspace_relative',
+            candidate_paths: [
+              {
+                path: '/workspace/lib/Missing/Payload.pm',
+                exists: false,
+              },
+            ],
+          },
+        ],
+        perl5lib_policy: 'enabled_but_environment_empty',
+        use_system_inc: false,
+      },
+      user_message: 'Module Missing::Payload was not found in the current effective @INC state.',
+      claim_boundary: 'explains one missing-module lookup only',
+    }));
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        languageId: 'perl',
+        uri: vscode.Uri.file('/workspace/script.pl'),
+        getText: jest.fn(() => ''),
+        lineAt: jest.fn(() => ({ text: 'use Missing::Payload;' })),
+      },
+      selection: {
+        active: { line: 0, character: 8 },
+      },
+    };
+
+    await explainMissingModuleLookupCommand({ sendRequest } as any);
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'workspace/executeCommand',
+      {
+        command: 'perl.explainMissingModuleLookup',
+        arguments: [
+          {
+            module: 'Missing::Payload',
+            textDocument: { uri: 'file:///workspace/script.pl' },
+            position: { line: 0, character: 8 },
+          },
+        ],
+      }
+    );
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      'Module Missing::Payload was not found in the current effective @INC state.',
+      'Show Output'
+    );
+    const rendered = outputChannel.appendLine.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join('\n');
+    expect(rendered).toContain('Perl LSP Missing Module Lookup');
+    expect(rendered).toContain('Missing::Payload');
+    expect(rendered).toContain('workspace includePaths');
+    expect(rendered).toContain('Raw lookup JSON');
   });
 });


### PR DESCRIPTION
Problem: The missing-module @INC lookup explanation backend exists, but users cannot invoke it directly from the VS Code command palette.

Fix: Add `Perl LSP: Explain Missing Module Lookup`, infer the module from the selection/cursor or prompt for one, call `perl.explainMissingModuleLookup`, and render a readable Perl LSP Trust output-channel report with the raw lookup JSON.

Claim boundary: VS Code command wiring and presentation only. No backend resolver change, no diagnostic/code-action behavior change, no support-tier promotion, and no telemetry/upload behavior.

Verification:
- `npm --prefix vscode-extension ci`
- `npm --prefix vscode-extension test -- --runTestsByPath src/test/commands.test.ts src/test/extensionUx.test.ts`
- `npm --prefix vscode-extension run compile`
- `git diff --check`

Validation gap: `npm --prefix vscode-extension test` still fails on unrelated existing gherkin provider/step-definition expectations and stale configuration activation-event expectations.