### PR TITLE
fix(parser): parse declaration expressions in RHS initializers (#9170)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -445,28 +445,41 @@ impl<'a> Parser<'a> {
             Some(TokenKind::My | TokenKind::Our | TokenKind::Local | TokenKind::State)
         ) && !self.is_keyword_before_fat_arrow()
         {
-            let decl = self.parse_declaration_arg()?;
-            // After a declaration that has no initializer (no `=` was consumed),
-            // binary operators like `&&`, `||`, `=~`, `?:`, etc. may follow.
-            // Apply the full binary-operator chain so that the declaration node
-            // is correctly used as the left operand.
-            //
-            // We detect the "no initializer" case by checking whether the
-            // declaration node itself contains an initializer.  If parse_declaration_arg
-            // already consumed an `=` and its rhs, parse_assignment() handled all
-            // operators inside the initializer — no further processing is needed.
-            let has_initializer = match &decl.kind {
-                NodeKind::VariableDeclaration { initializer, .. } => initializer.is_some(),
-                NodeKind::VariableListDeclaration { initializer, .. } => initializer.is_some(),
-                _ => true, // not a declaration node — treat as already-complete
-            };
-            if has_initializer {
-                Ok(decl)
-            } else {
-                self.parse_below_assignment_with(decl)
-            }
+            self.parse_declaration_expression()
         } else {
             self.parse_assignment()
+        }
+    }
+
+    /// Parse a declaration used as an expression and consume any binary operator
+    /// that binds to the declaration itself.
+    ///
+    /// This covers both argument-list contexts and RHS expression contexts:
+    ///
+    ///   `(our $AUTOLOAD =~ /pattern/)`
+    ///   `(my $field = our $AUTOLOAD) =~ s/.*://`
+    fn parse_declaration_expression(&mut self) -> ParseResult<Node> {
+        let decl = self.parse_declaration_arg()?;
+
+        // After a declaration that has no initializer (no `=` was consumed),
+        // binary operators like `&&`, `||`, `=~`, `?:`, etc. may follow.
+        // Apply the full binary-operator chain so that the declaration node
+        // is correctly used as the left operand.
+        //
+        // We detect the "no initializer" case by checking whether the
+        // declaration node itself contains an initializer. If parse_declaration_arg
+        // already consumed an `=` and its rhs, parse_assignment() handled all
+        // operators inside the initializer, so no further processing is needed.
+        let has_initializer = match &decl.kind {
+            NodeKind::VariableDeclaration { initializer, .. } => initializer.is_some(),
+            NodeKind::VariableListDeclaration { initializer, .. } => initializer.is_some(),
+            _ => true, // not a declaration node; treat as already complete
+        };
+
+        if has_initializer {
+            Ok(decl)
+        } else {
+            self.parse_below_assignment_with(decl)
         }
     }
 

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -1157,26 +1157,7 @@ impl<'a> Parser<'a> {
             }
 
             TokenKind::My | TokenKind::Our | TokenKind::State => {
-                let looks_like_declaration = self
-                    .tokens
-                    .peek_second()
-                    .ok()
-                    .is_some_and(|next| {
-                        matches!(
-                            next.kind,
-                            TokenKind::ScalarSigil
-                                | TokenKind::ArraySigil
-                                | TokenKind::HashSigil
-                                | TokenKind::SubSigil
-                                | TokenKind::GlobSigil
-                                | TokenKind::LeftParen
-                        ) || (next.kind == TokenKind::Identifier
-                            && next
-                                .text
-                                .chars()
-                                .next()
-                                .is_some_and(|c| matches!(c, '$' | '@' | '%' | '&' | '*')))
-                    });
+                let looks_like_declaration = self.next_token_starts_variable_declaration();
 
                 if self.is_keyword_before_fat_arrow() || !looks_like_declaration {
                     let token = self.tokens.next()?;
@@ -1185,7 +1166,7 @@ impl<'a> Parser<'a> {
                         SourceLocation { start: token.start, end: token.end },
                     ))
                 } else {
-                    self.parse_declaration_arg()
+                    self.parse_declaration_expression()
                 }
             }
 

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -595,6 +595,13 @@ impl<'a> Parser<'a> {
         if self.peek_kind() == Some(TokenKind::Sub) && self.next_token_starts_anonymous_sub() {
             return false;
         }
+        if matches!(
+            self.peek_kind(),
+            Some(TokenKind::My | TokenKind::Our | TokenKind::State)
+        ) && self.next_token_starts_variable_declaration()
+        {
+            return false;
+        }
 
         match self.peek_kind() {
             Some(kind) if kind.is_recovery_boundary() => true,
@@ -619,6 +626,25 @@ impl<'a> Parser<'a> {
             | None => true,
             _ => false,
         }
+    }
+
+    fn next_token_starts_variable_declaration(&mut self) -> bool {
+        self.tokens.peek_second().ok().is_some_and(|next| {
+            matches!(
+                next.kind,
+                TokenKind::ScalarSigil
+                    | TokenKind::ArraySigil
+                    | TokenKind::HashSigil
+                    | TokenKind::SubSigil
+                    | TokenKind::GlobSigil
+                    | TokenKind::LeftParen
+            ) || (next.kind == TokenKind::Identifier
+                && next
+                    .text
+                    .chars()
+                    .next()
+                    .is_some_and(|c| matches!(c, '$' | '@' | '%' | '&' | '*')))
+        })
     }
 
     /// Returns true when `sub` is followed by tokens that start an anonymous

--- a/crates/perl-parser-core/tests/fix_unexpected_rparen_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rparen_expr.rs
@@ -482,3 +482,10 @@ fn test_data_compare_percent_y_hash_copy_clean() {
     // The `%y` declaration must not degrade into the `y///` transliteration alias.
     assert_no_errors("sub f { my %x = %$x; my %y = %$y; }");
 }
+
+#[test]
+fn test_debconf_autoload_my_from_our_binding_clean() {
+    // Debconf::Base::AUTOLOAD derives a field name from a localized package
+    // variable and immediately applies a substitution to the declaration expr.
+    assert_no_errors(r#"(my $field = our $AUTOLOAD) =~ s/.*://;"#);
+}


### PR DESCRIPTION
Problem: Current WSL system-corpus evidence routes the parser lane to `unexpected_rparen_expr`; Debconf AUTOLOAD declarations like `(my $field = our $AUTOLOAD) =~ s/.*://` were parsed as a missing `my` initializer followed by a stray `our` declaration.
Fix: Reuse the declaration-expression parser in generic RHS expression contexts and keep missing-RHS recovery from treating real `my`/`our`/`state` declarations as absent operands. Add a Debconf-derived regression fixture.
Verification: `cargo test -p perl-parser-core --test fix_unexpected_rparen_expr --profile agent --locked`; `cargo test -p perl-parser-core --test fix_unclosed_paren_decl_as_expr --profile agent --locked`; `cargo check --all-targets -p perl-parser-core --profile agent --locked`; `cargo clippy -p perl-parser-core --profile agent --locked`; `cargo xtask fmt --check`; `cargo xtask parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt`; `cargo xtask update-status --only parser --check`; `cargo xtask metrics parser-accuracy --check`; `cargo xtask metrics ratchet-check parser_accuracy`.

Source-backed corpus receipt: WSL sweep for the seven current Debconf `unexpected_rparen_expr` files is clean 7/7 with 0 error nodes. Full WSL system sweep improves to 7011/7095 clean, 36 dirty files, 170 ERROR nodes; `unexpected_rparen_expr` is no longer a ratchet violation. Full WSL enforcement still fails on the separate remaining `unexpected_rbrace_expr` bucket (8 current vs 6 baseline), so this PR does not update corpus baselines or parser status.

Control-plane deltas: denominator unchanged at 50 fixtures / 29 families / 139 scored lines / 117 scored symbols; failure packets unchanged at 0 active; provider-row delta n/a; parser_accuracy ratchet unchanged/all floor metrics passed.

Validation gap: full local Windows `cargo test -p perl-parser-core --profile agent --locked` still hits unrelated `path_security_mutation_hardening::safe_relative_path_resolves_under_workspace` path-prefix assertion; all other observed parser-core test suites completed cleanly.