### PR TITLE
fix(parser): parse builtin hash keys before rbrace (#9170)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1313,10 +1313,11 @@ impl<'a> Parser<'a> {
     /// Parse hash subscript key expression, treating lone keywords as bare
     /// identifiers when they appear as `$h->{keyword}` or `$h{keyword}`.
     ///
-    /// Keywords like `not`, `and`, `or`, `xor`, `do`, `eval` would normally be
-    /// consumed as operators or statement keywords. When one of these appears
-    /// inside a hash subscript followed immediately by `}`, it should be treated
-    /// as a bare hash key instead.
+    /// Keywords like `not`, `and`, `or`, `xor`, `do`, `eval`, `local`, `tie`,
+    /// and `untie` would normally be consumed as operators, statement keywords,
+    /// or builtin calls. When one of these appears inside a hash subscript
+    /// followed immediately by `}`, it should be treated as a bare hash key
+    /// instead.
     ///
     /// Additionally handles quote-operator names (`m`, `s`, `q`, etc.) when used
     /// as hash subscript keys. The lexer suppresses quote-op detection inside
@@ -1324,7 +1325,8 @@ impl<'a> Parser<'a> {
     /// This function builds a proper parse tree node for them, including support
     /// for hash slices like `@h{m, s}` which require a list node.
     fn parse_hash_subscript_key(&mut self) -> ParseResult<Node> {
-        // Try keyword/operator-as-bareword first (not, and, or, xor, do, eval, cmp)
+        // Try keyword/operator-as-bareword first (not, and, or, xor, do, eval,
+        // cmp, local, tie, untie).
         if let Some(node) = self.try_parse_keyword_bareword_key()? {
             return Ok(node);
         }
@@ -1338,9 +1340,9 @@ impl<'a> Parser<'a> {
         self.parse_expression()
     }
 
-    /// Attempt to parse a keyword or word operator (`not`, `and`, `or`, `xor`,
-    /// `do`, `eval`, `cmp`) as a bareword hash key when it appears directly
-    /// before `}`.
+    /// Attempt to parse a keyword, word operator, or builtin-like word (`not`,
+    /// `and`, `or`, `xor`, `do`, `eval`, `cmp`, `local`, `tie`, `untie`) as a
+    /// bareword hash key when it appears directly before `}`.
     ///
     /// Returns `Some(Node)` if the current token is a keyword/operator followed
     /// by `}`, otherwise returns `None` to fall through to general expression
@@ -1358,10 +1360,17 @@ impl<'a> Parser<'a> {
                 | TokenKind::WordXor
                 | TokenKind::Do
                 | TokenKind::Eval
+                | TokenKind::Local
                 | TokenKind::StringCompare
         );
 
-        if !is_simple_keyword_key {
+        let is_builtin_like_key = self
+            .tokens
+            .peek()
+            .ok()
+            .is_some_and(|token| matches!(token.text.as_ref(), "tie" | "untie"));
+
+        if !is_simple_keyword_key && !is_builtin_like_key {
             return Ok(None);
         }
 

--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs
@@ -83,3 +83,38 @@ fn test_dbix_hash_splice_with_semicolon_terminated_deref_body() {
 }"#,
     );
 }
+
+#[test]
+fn test_op_private_deref_hash_slice_assignment() {
+    // From B::Op_private: generated bitfield tables assign to hash slices
+    // through a braced dereference whose inner key can be a builtin name.
+    assert_clean_parse(
+        r#"@{$bits{tie}}{3,2,1,0} = (
+    'OPpASSIGN_COMMON_SCALAR',
+    'OPpASSIGN_COMMON_RC1',
+    'OPpASSIGN_COMMON_AGG',
+    'OPpASSIGN_TRUEBOOL',
+);"#,
+    );
+}
+
+#[test]
+fn test_op_private_untie_hash_key_assignment() {
+    // From B::Op_private: `untie` is a builtin at expression start but a bare
+    // hash key inside `$bits{untie}`.
+    assert_clean_parse(r#"$bits{untie}{0} = $bf[0];"#);
+}
+
+#[test]
+fn test_dpkg_grep_block_values_hash_deref() {
+    // From Dpkg::Shlibs::Objdump::Object: grep block-list calls may take a
+    // values expression over a braced hash dereference as their list operand.
+    assert_clean_parse(
+        r#"sub get_exported_dynamic_symbols {
+    my $self = shift;
+    return grep {
+        $_->{defined} && $_->{dynamic} && !$_->{local}
+    } values %{$self->{dynsyms}};
+}"#,
+    );
+}


### PR DESCRIPTION
Problem: local, 	ie, and untie can appear as source-backed bare hash subscript keys in real Perl modules, but keyword/builtin parsing can still treat them as expressions before }.
Fix: Preserve the current comma/slice-aware hash-key parser and add the remaining local keyword case plus B::Op_private/Dpkg regression fixtures.
Verification: ./scripts/cargo-safe test -p perl-parser-core --test fix_unexpected_rbrace_expr_2404 --profile agent --locked -- --nocapture; ./scripts/cargo-safe check --all-targets -p perl-parser-core --profile agent --locked; git diff --check origin/master...HEAD.
Claim boundary: focused parser capability fixture/fix only; no generated status or corpus bucket-count claim without a fresh corpus receipt.