### PR TITLE
fix(parser): accept local hash subscript keys (#9170)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1388,6 +1388,7 @@ impl<'a> Parser<'a> {
                 | TokenKind::WordXor
                 | TokenKind::Do
                 | TokenKind::Eval
+                | TokenKind::Local
                 | TokenKind::Try
                 | TokenKind::Defer
                 | TokenKind::StringCompare

--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_hash_key.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_hash_key.rs
@@ -142,3 +142,12 @@ fn test_arrow_hash_key_defer_condition() {
 fn test_hash_slice_keyword_keys() {
     assert_clean_parse(r#"my @vals = @h{defer, try, eval, tie, untie};"#);
 }
+
+#[test]
+fn test_arrow_hash_key_local_in_grep_block() {
+    assert_clean_parse(
+        r#"return grep {
+    $_->{defined} && $_->{dynamic} && !$_->{local}
+} values %{$self->{dynsyms}};"#,
+    );
+}


### PR DESCRIPTION
Problem: #9297 promoted keyword-like hash subscript keys, but local still stayed on the expression path and kept Dpkg $_->{local} in the unexpected_rbrace_expr corpus bucket.
Fix: Include TokenKind::Local in the hash-subscript bareword-key guard and add the Dpkg grep-block regression.
Verification: focused hash-key regression test passes; parser-core check/clippy/fmt/diff/status gates pass; WSL system corpus sweep passes ratchet with 7095 files, 7017 clean, +146 clean vs baseline, unexpected_rbrace_expr=2, 0 parser-accuracy failure packets, provider rows unchanged.
Known gap: broad Windows cargo test -p perl-parser-core --profile agent --locked still fails the pre-existing safe_relative_path_resolves_under_workspace path-prefix assertion; unrelated suites completed around that failure.