### PR TITLE
test(parser): cover Unicode Collate map expr fixture (#9170)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -205,6 +205,13 @@ fn for_with_map_block() {
 }
 
 #[test]
+fn for_with_map_method_expr() {
+    // From Unicode::Collate: map EXPR may be a method call inside a
+    // parenthesized foreach list.
+    assert_clean_parse(r#"for my $vwt (map $self->getWt($_), @$subE) { push @wt, $vwt }"#);
+}
+
+#[test]
 fn for_with_grep_block() {
     assert_clean_parse(r#"for my $x (grep { defined $_ } @items) { print $x }"#);
 }


### PR DESCRIPTION
Problem: The generated parser status routes capability work to the unclosed_paren_identifier bucket, and Unicode::Collate is one of the source-backed files in that stale system-Perl receipt.
Fix: Add a narrow fixture for the Unicode::Collate map EXPR method-call shape inside a parenthesized foreach list.
Verification: `rtk cargo test -p perl-parser-core --test unclosed_paren_identifier_tests for_with_map_method_expr --profile agent --locked -- --nocapture --test-threads=1`; `rtk cargo check --all-targets -p perl-parser-core --profile agent --locked`; `rtk git diff --check`.
Claim boundary: fixture-only parser capability proof; no runtime parser change and no corpus bucket-count claim without a fresh Linux corpus receipt.