### PR TITLE
fix(parser): stop bare calls before short-circuit ops (#9170)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/calls.rs
@@ -304,18 +304,21 @@ impl<'a> Parser<'a> {
                         if third.kind == TokenKind::Arrow {
                             return false;
                         }
-                        // Word operators after $var means regular call with low-precedence
-                        // operator: func @list or die, func $arg and next, etc.
+                        // Short-circuit operators after $var mean a regular call with
+                        // the operator outside the argument: func $arg || die,
+                        // func @list or die, func $arg and next, etc.
                         // These are NOT indirect method calls.
-                        if matches!(
-                            third.kind,
-                            TokenKind::WordOr
-                                | TokenKind::WordAnd
-                                | TokenKind::WordXor
-                                | TokenKind::WordNot
-                                | TokenKind::Question
-                                | TokenKind::Semicolon
-                        ) {
+                        if Self::is_symbolic_short_circuit_operator(Some(third.kind))
+                            || matches!(
+                                third.kind,
+                                TokenKind::WordOr
+                                    | TokenKind::WordAnd
+                                    | TokenKind::WordXor
+                                    | TokenKind::WordNot
+                                    | TokenKind::Question
+                                    | TokenKind::Semicolon
+                            )
+                        {
                             return false;
                         }
                         return true;
@@ -380,6 +383,7 @@ impl<'a> Parser<'a> {
         // so they terminate argument collection for indirect calls.
         while !Self::is_statement_terminator(self.peek_kind())
             && !self.is_statement_modifier_keyword()
+            && !Self::is_symbolic_short_circuit_operator(self.peek_kind())
             && !matches!(
                 self.peek_kind(),
                 Some(

--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -860,9 +860,15 @@ impl<'a> Parser<'a> {
                             // Also applies to optional-arg builtins (defined, length, ord, etc.)
                             // that implicitly use $_ when no explicit argument is given, so that
                             // `defined && ...`, `length > 0`, `ord >= 32` parse correctly.
+                            let next_is_binary_operator =
+                                self.peek_kind().is_some_and(Self::is_binary_operator);
+                            let optional_arg_has_explicit_sub_arg =
+                                Self::is_optional_arg_builtin(bare_name)
+                                    && self.is_explicit_sub_sigil_argument_start();
                             let is_nullary_without_args = (Self::is_nullary_builtin(bare_name)
-                                || Self::is_optional_arg_builtin(bare_name))
-                                && self.peek_kind().is_some_and(Self::is_binary_operator);
+                                || (Self::is_optional_arg_builtin(bare_name)
+                                    && !optional_arg_has_explicit_sub_arg))
+                                && next_is_binary_operator;
 
                             // When a builtin is followed by a comma, it should be treated
                             // as having no arguments.  The comma belongs to an enclosing

--- a/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/primary.rs
@@ -794,6 +794,7 @@ impl<'a> Parser<'a> {
                             // In expression context, stop at common delimiters to avoid
                             // consuming surrounding list/argument separators.
                             while !self.tokens.is_eof()
+                                && !Self::is_symbolic_short_circuit_operator(self.peek_kind())
                                 && !matches!(
                                     self.peek_kind(),
                                     Some(

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -371,6 +371,17 @@ impl<'a> Parser<'a> {
             )
     }
 
+    fn is_symbolic_short_circuit_operator(kind: Option<TokenKind>) -> bool {
+        matches!(kind, Some(TokenKind::And | TokenKind::Or | TokenKind::DefinedOr))
+    }
+
+    fn is_explicit_sub_sigil_argument_start(&mut self) -> bool {
+        matches!(self.peek_kind(), Some(TokenKind::SubSigil | TokenKind::BitwiseAnd))
+            && self.tokens.peek_second().is_ok_and(|token| {
+                token.kind == TokenKind::LeftBrace || Self::can_be_sub_name(token.kind)
+            })
+    }
+
     /// Peek at the next token's kind
     fn peek_kind(&mut self) -> Option<TokenKind> {
         self.tokens.peek().ok().map(|t| t.kind)

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -460,9 +460,10 @@ impl<'a> Parser<'a> {
                     if self.is_indirect_call_pattern(&text) {
                         // Parse indirect call but DON'T return early - let it go through
                         // the same modifier/semicolon handling as other statements.
-                        // Word operators (or, and, xor) may follow: `print $fh "msg" or die`.
+                        // Short-circuit operators may follow: `print $fh "msg" or die`,
+                        // `close FH || croak`.
                         let call = self.parse_indirect_call()?;
-                        Ok(self.parse_word_or_expr(call)?)
+                        Ok(self.parse_named_unary_statement_tail(call)?)
                     } else {
                         self.parse_expression_statement()
                     }
@@ -623,8 +624,11 @@ impl<'a> Parser<'a> {
         func_name: &str,
         allow_no_args: bool,
     ) -> ParseResult<Node> {
+        let binary_operator_starts_missing_arg = self.peek_kind().is_some_and(Self::is_binary_operator)
+            && !(Self::is_optional_arg_builtin(func_name)
+                && self.is_explicit_sub_sigil_argument_start());
         let omit_optional_arg = allow_no_args
-            && (self.peek_kind().is_some_and(Self::is_binary_operator)
+            && (binary_operator_starts_missing_arg
                 || self.peek_kind() == Some(TokenKind::Slash)
                 // Nullary/named-unary builtins at statement start may be
                 // followed by a comma operator:

--- a/crates/perl-parser-core/tests/fix_unexpected_token_in_expr_2731.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_token_in_expr_2731.rs
@@ -66,6 +66,22 @@ fn test_umask_before_or_in_bitwise_not() {
 }
 
 #[test]
+fn test_defined_qualified_sub_before_and() {
+    // From Data::Dump: `&utf8::is_utf8` is an explicit defined() argument,
+    // not a nullary `defined` followed by a bitwise-AND expression.
+    assert_clean_parse(r#"if (defined &utf8::is_utf8 && !utf8::is_utf8($_[0])) { }"#);
+}
+
+#[test]
+fn test_indirect_call_before_symbolic_or() {
+    // From File::MimeInfo / MIME::Lite / IPC::Cmd: symbolic short-circuit
+    // operators terminate bare or indirect-call arguments.
+    assert_clean_parse(r#"close GLOB || croak "Could not open file";"#);
+    assert_clean_parse(r#"my $DATA = new FileHandle || Carp::croak "can't get filehandle";"#);
+    assert_clean_parse(r#"alarm $timeout || 0;"#);
+}
+
+#[test]
 fn test_statement_start_builtin_paren_call_comparison_or_do() {
     // From IPC::Cmd: statement-start builtin with explicit parens followed by
     // an equality comparison and a low-precedence `or do` fallback.


### PR DESCRIPTION
Problem: The current WSL corpus sweep still reported unexpected_token_in_expr for short-circuit expressions after optional builtins, indirect calls, and 
ew constructor syntax.
Fix: Preserve explicit &sub operands for optional builtins and stop bare/indirect constructor argument collection before symbolic &&, ||, and //; add corpus-shaped regressions.
Verification: cargo test -p perl-parser-core --test fix_unexpected_token_in_expr_2731 --profile agent --locked passes; cargo check --all-targets -p perl-parser-core --profile agent --locked passes; cargo clippy -p perl-parser-core --profile agent --locked passes; cargo xtask fmt --check passes; git diff --check passes; targeted WSL sweep improved 5 files from 0 clean / 15 ERROR nodes to 2 clean / 4 ERROR nodes and cleared unexpected_token_in_expr; full WSL sweep passed ratchet at 7021 clean / 7095 total (+150 vs baseline); parser metrics, ratchet-check, common corpus, and update-status checks pass.
Known gap: broad Windows cargo test -p perl-parser-core --profile agent --locked still hits the pre-existing safe_relative_path_resolves_under_workspace path-prefix assertion after the relevant parser suites pass.