### PR TITLE
test(parser): cover Unicode Normalize caller fixture (#9170)

### DIFF
--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -913,6 +913,13 @@ fn caller_one() {
 }
 
 #[test]
+fn caller_paren_list_assignment() {
+    // From Unicode::Normalize: caller(N) may appear on the RHS of a lexical
+    // list assignment in this bucket's source-backed corpus files.
+    assert_clean_parse(r#"my (undef, $file, $line) = caller(1);"#);
+}
+
+#[test]
 fn caller_with_parens() {
     // caller(0) — explicit parens, should still work
     assert_clean_parse(r#"my @c = caller(0);"#);


### PR DESCRIPTION
Problem: The generated parser status still routes capability work to the stale unclosed_paren_identifier bucket, and Unicode::Normalize is one of the source-backed files listed in that system-Perl receipt.
Fix: Add a narrow fixture for the Unicode::Normalize caller(1) lexical list-assignment shape.
Verification: `rtk cargo test -p perl-parser-core --test unclosed_paren_identifier_tests caller_paren_list_assignment --profile agent --locked -- --nocapture --test-threads=1`; `rtk cargo check --all-targets -p perl-parser-core --profile agent --locked`; `rtk git diff --check`.
Claim boundary: fixture-only parser capability proof; no parser runtime change and no corpus bucket-count claim without a fresh Linux corpus receipt.