### PR TITLE
fix(parser): accept defer as subroutine name (#9170)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -1135,6 +1135,7 @@ impl<'a> Parser<'a> {
             | TokenKind::Check
             | TokenKind::Init
             | TokenKind::Unitcheck
+            | TokenKind::Defer
             | TokenKind::Undef
             // Word-operators (also valid bareword sub names)
             | TokenKind::WordAnd    // sub and { ... }

--- a/crates/perl-parser-core/tests/fix_expected_left_brace_2399.rs
+++ b/crates/perl-parser-core/tests/fix_expected_left_brace_2399.rs
@@ -88,6 +88,20 @@ sub qux { return "hello" }
     );
 }
 
+#[test]
+fn test_sub_defer_keyword_name() {
+    // From Tie::File: `defer` is a keyword token, but remains a valid
+    // subroutine name in ordinary Perl packages.
+    assert_clean_parse(
+        r#"
+sub defer {
+    my $self = shift;
+    $self->{defer} = 1;
+}
+"#,
+    );
+}
+
 // ---- String eval (eval $expr, eval $var) ----
 
 #[test]


### PR DESCRIPTION
Problem: Tie::File uses sub defer, but defer tokenizes as a keyword and was not accepted as a subroutine name, keeping expected_left_brace dirty.

Fix: Allow TokenKind::Defer in parser sub-name keywords and add a regression for sub defer.

Verification:
- cargo test -p perl-parser-core --test fix_expected_left_brace_2399 --profile agent --locked passes
- cargo check --all-targets -p perl-parser-core --profile agent --locked passes
- cargo clippy -p perl-parser-core --profile agent --locked passes
- cargo xtask fmt --check passes
- git diff --check passes
- cargo xtask metrics parser-accuracy --check passes
- cargo xtask metrics ratchet-check parser_accuracy passes
- cargo xtask parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt passes, 10/10 strict clean
- cargo xtask update-status --only parser --check passes
- WSL targeted Tie::File sweep: 2/2 clean, 0 ERROR nodes
- WSL full corpus sweep: 7033/7095 clean, 14 dirty, 48 ERROR nodes; expected_left_brace 4 -> 0; branch delta +4 clean files and -8 ERROR nodes

Parser accuracy deltas:
- Denominator: 50 fixtures / 29 families; 139 scored lines; 117 scored symbols
- Failure packets: 0 active
- Provider rows: unchanged
- Ratchet: passed

Known gap: broad Windows cargo test -p perl-parser-core --profile agent --locked still hits the pre-existing safe_relative_path_resolves_under_workspace failure after the relevant parser suites pass.