### PR TITLE
feat(diagnostics): add explain-diagnostic code action (#8197)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/code_actions.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/code_actions.rs
@@ -4,6 +4,9 @@
 //! Provides quick fixes, refactoring actions, and source actions.
 
 use super::super::*;
+use super::misc::{
+    DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION, diagnostic_explanation_payload_from_diagnostics,
+};
 use crate::protocol::{req_range, req_uri};
 use std::sync::LazyLock;
 
@@ -49,6 +52,33 @@ fn display_diagnostic_message(diagnostic: &crate::features::diagnostics::Diagnos
         Some(suggestion) => format!("{}\nSuggestion: {}", diagnostic.message, suggestion),
         None => diagnostic.message.clone(),
     }
+}
+
+fn diagnostic_severity_value(severity: crate::features::diagnostics::DiagnosticSeverity) -> u8 {
+    match severity {
+        crate::features::diagnostics::DiagnosticSeverity::Error => 1,
+        crate::features::diagnostics::DiagnosticSeverity::Warning => 2,
+        crate::features::diagnostics::DiagnosticSeverity::Information => 3,
+        crate::features::diagnostics::DiagnosticSeverity::Hint => 4,
+    }
+}
+
+fn diagnostic_range_intersects_selection(
+    diagnostic: (usize, usize),
+    selection: (usize, usize),
+) -> bool {
+    let (diag_start, diag_end) = diagnostic;
+    let (sel_start, sel_end) = selection;
+
+    if sel_start == sel_end {
+        return diag_start <= sel_start && sel_start <= diag_end;
+    }
+
+    diag_start < sel_end && sel_start < diag_end
+}
+
+fn diagnostic_code_is_explainable(code: Option<&str>) -> bool {
+    matches!(code, Some("PL701" | "PL109"))
 }
 
 /// Byte-offset-agnostic representation of an LSP range used only for
@@ -289,6 +319,13 @@ impl LspServer {
 
             // Get code actions from both providers
             let mut code_actions: Vec<Value> = Vec::new();
+            self.add_explain_diagnostic_code_actions(
+                &mut code_actions,
+                uri,
+                doc,
+                (start_offset, end_offset),
+                &diagnostics,
+            );
 
             // Add Perl::Critic quick fixes
             let builtin_analyzer = BuiltInAnalyzer::new();
@@ -770,6 +807,98 @@ impl LspServer {
 }
 
 impl LspServer {
+    fn add_explain_diagnostic_code_actions(
+        &self,
+        code_actions: &mut Vec<Value>,
+        uri: &str,
+        doc: &crate::runtime::DocumentState,
+        selection_range: (usize, usize),
+        diagnostics: &[crate::features::diagnostics::Diagnostic],
+    ) {
+        for diagnostic in diagnostics {
+            if !diagnostic_code_is_explainable(diagnostic.code.as_deref()) {
+                continue;
+            }
+            if !diagnostic_range_intersects_selection(diagnostic.range, selection_range) {
+                continue;
+            }
+
+            code_actions.push(self.explain_diagnostic_code_action(uri, doc, diagnostic));
+        }
+    }
+
+    fn explain_diagnostic_code_action(
+        &self,
+        uri: &str,
+        doc: &crate::runtime::DocumentState,
+        diagnostic: &crate::features::diagnostics::Diagnostic,
+    ) -> Value {
+        let diagnostic_value = self.lsp_diagnostic_value(doc, diagnostic);
+        let (diagnostic_payload, user_message, has_dynamic_boundary) =
+            diagnostic_explanation_payload_from_diagnostics(
+                "textDocument/codeAction",
+                std::slice::from_ref(&diagnostic_value),
+            );
+        let (line, character) = self.offset_to_pos16(doc, diagnostic.range.0);
+        let receipt = json!({
+            "provider": "diagnostics",
+            "provider_action": "textDocument/codeAction",
+            "decision": "acted",
+            "reason": "diagnostic_explanation",
+            "fact_source": "provider_runtime",
+            "confidence": "low",
+            "freshness": "fresh",
+            "source_backed": false,
+            "source_backed_state": "diagnostic_returned_by_live_provider",
+            "dynamic_boundary": has_dynamic_boundary,
+            "fallback": "none",
+            "diagnostic_explanation_schema": DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION,
+            "diagnostic_explanation": diagnostic_payload,
+            "user_message": user_message,
+            "workspace_trust_report_command": "perl.workspaceTrustReport",
+            "claim_boundary": "code action explains an existing diagnostic only; no new suppression, severity, or support-tier promotion",
+        });
+
+        json!({
+            "title": "Explain this diagnostic",
+            "kind": "quickfix",
+            "diagnostics": [diagnostic_value],
+            "command": {
+                "title": "Explain this diagnostic",
+                "command": "perl-lsp.explainDiagnostic",
+                "arguments": [{
+                    "provider": "diagnostics",
+                    "request_receipt": receipt,
+                    "request_position": {
+                        "uri_scheme": uri.split_once(':').map(|(scheme, _)| scheme).unwrap_or("file"),
+                        "line": line,
+                        "character": character,
+                    },
+                }]
+            }
+        })
+    }
+
+    fn lsp_diagnostic_value(
+        &self,
+        doc: &crate::runtime::DocumentState,
+        diagnostic: &crate::features::diagnostics::Diagnostic,
+    ) -> Value {
+        let (start_line, start_character) = self.offset_to_pos16(doc, diagnostic.range.0);
+        let (end_line, end_character) = self.offset_to_pos16(doc, diagnostic.range.1);
+
+        json!({
+            "range": {
+                "start": {"line": start_line, "character": start_character},
+                "end": {"line": end_line, "character": end_character},
+            },
+            "severity": diagnostic_severity_value(diagnostic.severity),
+            "code": diagnostic.code.clone(),
+            "source": "perl-lsp",
+            "message": display_diagnostic_message(diagnostic),
+        })
+    }
+
     fn context_diagnostics_for_code_actions(
         &self,
         params: &Value,
@@ -853,6 +982,102 @@ mod tests {
             }
         })));
         assert!(result.is_ok(), "didOpen failed: {result:?}");
+    }
+
+    #[test]
+    fn code_action_runtime_offers_explain_diagnostic_for_pl701_and_pl109()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let server = LspServer::new();
+        let uri = "file:///explain-diagnostic.pl";
+        let text = "use Missing::Payload;\nprint bareword;\n";
+        open_test_document(&server, uri, text);
+
+        let response = server.handle_code_action(Some(json!({
+            "textDocument": { "uri": uri },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 1, "character": 14 }
+            },
+            "context": {
+                "diagnostics": [
+                    {
+                        "range": {
+                            "start": { "line": 0, "character": 4 },
+                            "end": { "line": 0, "character": 20 }
+                        },
+                        "severity": 2,
+                        "code": "PL701",
+                        "source": "perl-lsp",
+                        "message": "Module 'Missing::Payload' not found in configured @INC paths.\nSearched @INC:\n- /workspace/lib (workspace includePaths)"
+                    },
+                    {
+                        "range": {
+                            "start": { "line": 1, "character": 6 },
+                            "end": { "line": 1, "character": 14 }
+                        },
+                        "severity": 1,
+                        "code": "PL109",
+                        "source": "perl-lsp",
+                        "message": "Symbol may be unresolved; dynamic boundary prevents static confirmation."
+                    }
+                ]
+            }
+        })))?;
+        let response = response.ok_or("missing code action response")?;
+        let actions = response.as_array().ok_or("code action response must be an array")?;
+        let explain_actions: Vec<&Value> = actions
+            .iter()
+            .filter(|action| {
+                action.get("title").and_then(Value::as_str) == Some("Explain this diagnostic")
+            })
+            .collect();
+
+        assert_eq!(
+            explain_actions.len(),
+            2,
+            "expected PL701 and PL109 explain actions: {actions:#?}"
+        );
+
+        for action in explain_actions {
+            assert_eq!(action.get("kind").and_then(Value::as_str), Some("quickfix"));
+            assert!(action.get("edit").is_none(), "explain action must not edit code: {action}");
+            assert_eq!(
+                action.pointer("/command/command").and_then(Value::as_str),
+                Some("perl-lsp.explainDiagnostic")
+            );
+            assert_eq!(
+                action.pointer("/command/arguments/0/provider").and_then(Value::as_str),
+                Some("diagnostics")
+            );
+            assert_eq!(
+                action
+                    .pointer(
+                        "/command/arguments/0/request_receipt/diagnostic_explanation/schema_version"
+                    )
+                    .and_then(Value::as_str),
+                Some("diagnostic_explanation.v1")
+            );
+            assert_eq!(
+                action
+                    .pointer("/command/arguments/0/request_receipt/workspace_trust_report_command")
+                    .and_then(Value::as_str),
+                Some("perl.workspaceTrustReport")
+            );
+        }
+
+        let codes: Vec<&str> = actions
+            .iter()
+            .filter(|action| action.get("title").and_then(Value::as_str) == Some("Explain this diagnostic"))
+            .filter_map(|action| {
+                action
+                    .pointer("/command/arguments/0/request_receipt/diagnostic_explanation/diagnostic_explanations/0/code")
+                    .and_then(Value::as_str)
+            })
+            .collect();
+        assert!(codes.contains(&"PL701"), "missing PL701 explain receipt: {actions:#?}");
+        assert!(codes.contains(&"PL109"), "missing PL109 explain receipt: {actions:#?}");
+
+        Ok(())
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -19,7 +19,7 @@ use std::sync::OnceLock;
 use std::time::Instant;
 
 static INLINE_VALUE_REGEX: OnceLock<Result<regex::Regex, regex::Error>> = OnceLock::new();
-const DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION: &str = "diagnostic_explanation.v1";
+pub(super) const DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION: &str = "diagnostic_explanation.v1";
 const MAX_DIAGNOSTIC_EXPLANATIONS: usize = 8;
 const MAX_REPORTED_INC_PATHS: usize = 8;
 
@@ -116,33 +116,9 @@ fn diagnostic_explanation_payload(
         return None;
     };
 
-    let diagnostics = collect_diagnostic_values(value);
-    let diagnostic_count = diagnostics.len();
-    let explanations: Vec<Value> = diagnostics
-        .iter()
-        .take(MAX_DIAGNOSTIC_EXPLANATIONS)
-        .map(|diagnostic| diagnostic_explanation(diagnostic))
-        .collect();
+    let diagnostics: Vec<Value> = collect_diagnostic_values(value).into_iter().cloned().collect();
 
-    let truncated = diagnostic_count.saturating_sub(explanations.len());
-    let user_message = diagnostic_explanation_user_message(diagnostic_count, &explanations);
-    let has_dynamic_boundary = explanations.iter().any(|explanation| {
-        explanation.get("trust_boundary").and_then(Value::as_str) == Some("dynamic_boundary")
-    });
-
-    Some((
-        json!({
-            "schema_version": DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION,
-            "provider_action": method,
-            "diagnostic_count": diagnostic_count,
-            "diagnostic_explanations": explanations,
-            "truncated_diagnostic_explanations": truncated,
-            "dynamic_boundary_detected": has_dynamic_boundary,
-            "claim_boundary": "explains returned diagnostics only; no new suppression, severity, or support-tier promotion",
-        }),
-        user_message,
-        has_dynamic_boundary,
-    ))
+    Some(diagnostic_explanation_payload_from_diagnostics(method, &diagnostics))
 }
 
 fn collect_diagnostic_values(value: &Value) -> Vec<&Value> {
@@ -158,6 +134,35 @@ fn collect_diagnostic_values(value: &Value) -> Vec<&Value> {
     }
 
     if nested.is_empty() { items.iter().collect() } else { nested }
+}
+
+pub(super) fn diagnostic_explanation_payload_from_diagnostics(
+    method: &str,
+    diagnostics: &[Value],
+) -> (Value, String, bool) {
+    let diagnostic_count = diagnostics.len();
+    let explanations: Vec<Value> =
+        diagnostics.iter().take(MAX_DIAGNOSTIC_EXPLANATIONS).map(diagnostic_explanation).collect();
+
+    let truncated = diagnostic_count.saturating_sub(explanations.len());
+    let user_message = diagnostic_explanation_user_message(diagnostic_count, &explanations);
+    let has_dynamic_boundary = explanations.iter().any(|explanation| {
+        explanation.get("trust_boundary").and_then(Value::as_str) == Some("dynamic_boundary")
+    });
+
+    (
+        json!({
+            "schema_version": DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION,
+            "provider_action": method,
+            "diagnostic_count": diagnostic_count,
+            "diagnostic_explanations": explanations,
+            "truncated_diagnostic_explanations": truncated,
+            "dynamic_boundary_detected": has_dynamic_boundary,
+            "claim_boundary": "explains returned diagnostics only; no new suppression, severity, or support-tier promotion",
+        }),
+        user_message,
+        has_dynamic_boundary,
+    )
 }
 
 fn diagnostic_explanation(diagnostic: &Value) -> Value {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -804,6 +804,12 @@
         "icon": "$(search)"
       },
       {
+        "command": "perl-lsp.explainDiagnostic",
+        "title": "Explain This Diagnostic",
+        "category": "Perl LSP",
+        "icon": "$(comment-discussion)"
+      },
+      {
         "command": "perl-lsp.reportIssue",
         "title": "Report Issue",
         "category": "Perl",
@@ -922,6 +928,10 @@
         },
         {
           "command": "perl-lsp.explainMissingModuleLookup",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.explainDiagnostic",
           "when": "editorLangId == perl"
         },
         {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -704,6 +704,29 @@ export async function explainProviderDecisionCommand(
     }
 }
 
+export async function explainDiagnosticCommand(
+    activeClient: LspExecuteCommandClient | undefined = client,
+    request?: unknown
+): Promise<void> {
+    const requestObject = asObject(request);
+    const argument: Record<string, unknown> = requestObject
+        ? { ...requestObject }
+        : providerDecisionArgument('diagnostics');
+
+    if (typeof argument.provider !== 'string') {
+        argument.provider = 'diagnostics';
+    }
+
+    const result = await executeLspCommand(
+        activeClient,
+        'perl.explainProviderDecision',
+        argument
+    );
+    if (result !== undefined) {
+        await showProviderDecisionResult('Diagnostic explanation', result);
+    }
+}
+
 export async function previewSafeDeleteCommand(
     activeClient: LspExecuteCommandClient | undefined = client
 ): Promise<void> {
@@ -1076,6 +1099,13 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     );
 
+    const explainDiagnosticCommandDisposable = vscode.commands.registerCommand(
+        'perl-lsp.explainDiagnostic',
+        async (request?: unknown) => {
+            await explainDiagnosticCommand(client, request);
+        }
+    );
+
     const whatsNewManager = new WhatsNewManager(context, outputChannel);
     const showWhatsNewCommand = vscode.commands.registerCommand('perl-lsp.showWhatsNew', async () => {
         await whatsNewManager.showWhatsNew();
@@ -1386,6 +1416,7 @@ export async function activate(context: vscode.ExtensionContext) {
         copyProviderDecisionReceiptCommandDisposable,
         showWorkspaceTrustReportCommandDisposable,
         explainMissingModuleLookupCommandDisposable,
+        explainDiagnosticCommandDisposable,
         showVersionCommand,
         statusMenuCommand,
         reinstallCommand,

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -373,6 +373,7 @@ describe('perl-lsp trust explanation commands', () => {
     ['perl-lsp.copyProviderDecisionReceipt', 'Copy Provider Decision Receipt'],
     ['perl-lsp.showWorkspaceTrustReport', 'Show Workspace Trust Report'],
     ['perl-lsp.explainMissingModuleLookup', 'Explain Missing Module Lookup'],
+    ['perl-lsp.explainDiagnostic', 'Explain This Diagnostic'],
   ])('%s is declared as a Perl LSP command', (id, title) => {
     const cmd = pkg.contributes.commands.find((c: any) => c.command === id);
     expect(commandIds).toContain(id);
@@ -386,6 +387,7 @@ describe('perl-lsp trust explanation commands', () => {
     'perl-lsp.previewSafeDelete',
     'perl-lsp.copyProviderDecisionReceipt',
     'perl-lsp.explainMissingModuleLookup',
+    'perl-lsp.explainDiagnostic',
   ])('%s is available from the Perl command palette', (id) => {
     const entry = paletteEntries.find((e: any) => e.command === id);
     expect(entry).toBeDefined();

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -19,6 +19,7 @@ jest.mock('vscode-languageclient/node', () => ({
 }));
 import {
   copyProviderDecisionReceiptCommand,
+  explainDiagnosticCommand,
   explainMissingModuleLookupCommand,
   explainProviderDecisionCommand,
   previewSafeDeleteCommand,
@@ -541,6 +542,52 @@ describe('extension UX warnings', () => {
     );
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
       'Goto definition used fallback.',
+      'Show Output'
+    );
+  });
+
+  test('explains a diagnostic through the provider decision command', async () => {
+    const requestReceipt = {
+      provider: 'diagnostics',
+      decision: 'acted',
+      diagnostic_explanation: {
+        schema_version: 'diagnostic_explanation.v1',
+        diagnostic_explanations: [
+          {
+            code: 'PL701',
+            trust_boundary: 'module_resolution',
+          },
+        ],
+      },
+    };
+    const sendRequest = jest.fn(async () => ({
+      provider: 'diagnostics',
+      decision: 'acted',
+      user_message: 'Diagnostic explanation is available.',
+    }));
+
+    await explainDiagnosticCommand(
+      { sendRequest } as any,
+      {
+        provider: 'diagnostics',
+        request_receipt: requestReceipt,
+      }
+    );
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'workspace/executeCommand',
+      {
+        command: 'perl.explainProviderDecision',
+        arguments: [
+          {
+            provider: 'diagnostics',
+            request_receipt: requestReceipt,
+          },
+        ],
+      }
+    );
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Diagnostic explanation is available.',
       'Show Output'
     );
   });


### PR DESCRIPTION
Problem: Diagnostic explanation receipts existed, but users could not open them directly from a diagnostic code action.
Fix: Add a command-only Explain this diagnostic quickfix for PL701/PL109 that routes a request-local diagnostic receipt through perl.explainProviderDecision, plus VS Code command wiring.
Verification: cargo test -p perl-lsp-rs --lib code_action_runtime --profile agent --locked -- --nocapture --test-threads=1; cargo test -p perl-lsp-rs --lib provider_decision_live_trace_tests::live_diagnostic_request_attaches_explainable_payload --profile agent --locked -- --nocapture --test-threads=1; cargo check -p perl-lsp-rs --lib --all-targets --profile agent --locked; npm --prefix vscode-extension test -- --runTestsByPath src/test/commands.test.ts src/test/extensionUx.test.ts; npm --prefix vscode-extension run compile; cargo xtask fmt --check; cargo xtask check-support-claims; git diff --check.
Claim boundary: code-action UX only; no diagnostic suppression, severity, provider behavior, or support-tier promotion.