### PR TITLE
fix(parser): parse bare substr lvalue assignment (#9170)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1170,6 +1170,12 @@ impl<'a> Parser<'a> {
                                         self.peek_kind(),
                                         Some(TokenKind::Comma) | Some(TokenKind::FatArrow)
                                     ) {
+                                        if self
+                                            .consume_bare_lvalue_assignment_separator(bare_name)?
+                                        {
+                                            break;
+                                        }
+
                                         self.consume_token()?;
                                         if self.is_at_statement_end() {
                                             break;

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -375,6 +375,75 @@ impl<'a> Parser<'a> {
         matches!(kind, Some(TokenKind::And | TokenKind::Or | TokenKind::DefinedOr))
     }
 
+    fn assignment_operator_text(kind: TokenKind) -> Option<&'static str> {
+        match kind {
+            TokenKind::Assign => Some("="),
+            TokenKind::PlusAssign => Some("+="),
+            TokenKind::MinusAssign => Some("-="),
+            TokenKind::StarAssign => Some("*="),
+            TokenKind::SlashAssign => Some("/="),
+            TokenKind::PercentAssign => Some("%="),
+            TokenKind::DotAssign => Some(".="),
+            TokenKind::AndAssign => Some("&="),
+            TokenKind::OrAssign => Some("|="),
+            TokenKind::XorAssign => Some("^="),
+            TokenKind::PowerAssign => Some("**="),
+            TokenKind::LeftShiftAssign => Some("<<="),
+            TokenKind::RightShiftAssign => Some(">>="),
+            TokenKind::LogicalAndAssign => Some("&&="),
+            TokenKind::LogicalOrAssign => Some("||="),
+            TokenKind::DefinedOrAssign => Some("//="),
+            _ => None,
+        }
+    }
+
+    fn consume_bare_lvalue_assignment_separator(&mut self, func_name: &str) -> ParseResult<bool> {
+        if func_name != "substr" || self.peek_kind() != Some(TokenKind::Comma) {
+            return Ok(false);
+        }
+
+        if self
+            .tokens
+            .peek_second()
+            .ok()
+            .and_then(|token| Self::assignment_operator_text(token.kind))
+            .is_none()
+        {
+            return Ok(false);
+        }
+
+        self.consume_token()?;
+        Ok(true)
+    }
+
+    fn parse_lvalue_builtin_assignment_tail(
+        &mut self,
+        func_name: &str,
+        expr: Node,
+    ) -> ParseResult<Node> {
+        if func_name != "substr" {
+            return Ok(expr);
+        }
+
+        let Some(op) = self.peek_kind().and_then(Self::assignment_operator_text) else {
+            return Ok(expr);
+        };
+
+        let op_token = self.tokens.next()?;
+        let rhs = if let Some(missing) = self.recover_missing_infix_rhs(op_token.start) {
+            missing
+        } else {
+            self.parse_assignment()?
+        };
+        let start = expr.location.start;
+        let end = rhs.location.end;
+
+        Ok(Node::new(
+            NodeKind::Assignment { lhs: Box::new(expr), rhs: Box::new(rhs), op: op.to_string() },
+            SourceLocation { start, end },
+        ))
+    }
+
     fn is_explicit_sub_sigil_argument_start(&mut self) -> bool {
         matches!(self.peek_kind(), Some(TokenKind::SubSigil | TokenKind::BitwiseAnd))
             && self.tokens.peek_second().is_ok_and(|token| {

--- a/crates/perl-parser-core/src/engine/parser/statements.rs
+++ b/crates/perl-parser-core/src/engine/parser/statements.rs
@@ -1002,6 +1002,12 @@ impl<'a> Parser<'a> {
                                 // For other functions, require commas (or fat arrows) between arguments
                                 // Perl allows `push @array => $value` as well as `push @array, $value`
                                 while matches!(self.peek_kind(), Some(TokenKind::Comma) | Some(TokenKind::FatArrow)) {
+                                    if self
+                                        .consume_bare_lvalue_assignment_separator(func_name.as_ref())?
+                                    {
+                                        break;
+                                    }
+
                                     self.consume_token()?; // consume comma or fat arrow
 
                                     // Handle `, =>` (comma then fat arrow) — consume
@@ -1032,6 +1038,8 @@ impl<'a> Parser<'a> {
                                 NodeKind::FunctionCall { name: func_name.to_string(), args },
                                 SourceLocation { start, end },
                             );
+                            let call = self
+                                .parse_lvalue_builtin_assignment_tail(func_name.as_ref(), call)?;
                             self.parse_named_unary_statement_tail(call)
                         }
                     }

--- a/crates/perl-parser-core/tests/fix_unexpected_assign_expr.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_assign_expr.rs
@@ -1,0 +1,26 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn b_deparse_bare_substr_lvalue_assignment_with_trailing_comma() {
+    assert_clean_parse(
+        r#"
+sub lex_in_scope {
+    my ($self, $name, $our) = @_;
+    substr $name, 0, 0, = $our ? 'o' : 'm';
+}
+"#,
+    );
+}
+
+#[test]
+fn b_deparse_bare_substr_lvalue_assignment_after_and() {
+    assert_clean_parse(
+        r#"
+sub qualify {
+    my ($self, $kid, $fq) = @_;
+    $fq and substr $kid, 0, 0, = $self->{'curstash'} . '::';
+}
+"#,
+    );
+}


### PR DESCRIPTION
Problem: B::Deparse uses bare lvalue substr assignments like substr $name, 0, 0, = ..., and the parser consumed the comma before = as another argument separator.
Fix: Stop bare substr argument collection at comma-plus-assignment and let assignment bind to the substr call in statement and expression paths.
Verification: rtk cargo test -p perl-parser-core --test fix_unexpected_assign_expr --profile agent --locked; rtk cargo test -p perl-parser-core builtin_expansion_tests --profile agent --locked; rtk cargo check --all-targets -p perl-parser-core --profile agent --locked; rtk cargo clippy -p perl-parser-core --profile agent --locked; rtk cargo xtask fmt; rtk git diff --check; rtk cargo xtask metrics parser-accuracy --check; rtk cargo xtask metrics ratchet-check parser_accuracy; rtk cargo xtask parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt; rtk cargo xtask update-status --only parser --check; WSL targeted B::Deparse sweep; WSL full parser corpus sweep.