### PR TITLE
fix(parser): parse nested bare call arguments (#9170)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/postfix.rs
@@ -1116,6 +1116,11 @@ impl<'a> Parser<'a> {
                                         args.push(self.parse_assignment_or_declaration()?);
                                     }
 
+                                    while self.should_continue_bare_call_after_qualified_arg(&args)
+                                    {
+                                        args.push(self.parse_assignment_or_declaration()?);
+                                    }
+
                                     // Special case: print/say/printf/exec/send with indirect object.
                                     // `print $fh $msg` / `send $sock $msg` — first arg is the
                                     // filehandle/socket (no comma before remaining args).

--- a/crates/perl-parser-core/src/engine/parser/helpers.rs
+++ b/crates/perl-parser-core/src/engine/parser/helpers.rs
@@ -375,6 +375,40 @@ impl<'a> Parser<'a> {
         matches!(kind, Some(TokenKind::And | TokenKind::Or | TokenKind::DefinedOr))
     }
 
+    fn is_sigil_argument_start(kind: TokenKind, text: &str) -> bool {
+        text.starts_with('$')
+            || text.starts_with('@')
+            || text.starts_with('%')
+            || matches!(
+                kind,
+                TokenKind::Backslash
+                    | TokenKind::ScalarSigil
+                    | TokenKind::ArraySigil
+                    | TokenKind::HashSigil
+                    | TokenKind::GlobSigil
+                    | TokenKind::SubSigil
+                    | TokenKind::BitwiseAnd
+                    | TokenKind::Star
+            )
+    }
+
+    fn should_continue_bare_call_after_qualified_arg(&mut self, args: &[Node]) -> bool {
+        let Some(last) = args.last() else {
+            return false;
+        };
+        let NodeKind::Identifier { name } = &last.kind else {
+            return false;
+        };
+        if !name.contains("::") || self.is_at_statement_end() {
+            return false;
+        }
+
+        self.tokens
+            .peek()
+            .ok()
+            .is_some_and(|token| Self::is_sigil_argument_start(token.kind, token.text.as_ref()))
+    }
+
     fn assignment_operator_text(kind: TokenKind) -> Option<&'static str> {
         match kind {
             TokenKind::Assign => Some("="),
@@ -1101,10 +1135,12 @@ impl<'a> Parser<'a> {
                 // Allow qualified names (e.g. `File::Spec`, `Scalar::Util`) as arguments.
                 // They start with uppercase but the `::` disambiguates them from constants.
                 if next_text.contains("::") {
-                    // Qualified name — check that the following token is `->` or `(`.
+                    // Qualified name — check that the following token is `->`, `(`,
+                    // or another explicit argument in a list-operator style call.
                     if let Ok(third) = self.tokens.peek_second() {
                         return third.kind == TokenKind::Arrow
-                            || third.kind == TokenKind::LeftParen;
+                            || third.kind == TokenKind::LeftParen
+                            || Self::is_sigil_argument_start(third.kind, third.text.as_ref());
                     }
                     return false;
                 }
@@ -1127,13 +1163,19 @@ impl<'a> Parser<'a> {
                 if Self::is_builtin_function(&next_text) {
                     if let Ok(third) = self.tokens.peek_second() {
                         let third_text: &str = &third.text;
-                        return third_text.starts_with('$')
-                            || third_text.starts_with('@')
-                            || third_text.starts_with('%')
-                            || third.kind == TokenKind::Star
-                            || third.kind == TokenKind::ScalarSigil
-                            || third.kind == TokenKind::ArraySigil
-                            || third.kind == TokenKind::HashSigil;
+                        return Self::is_sigil_argument_start(third.kind, third_text);
+                    }
+                }
+                if next_text.starts_with(|c: char| c.is_ascii_lowercase() || c == '_') {
+                    if self
+                        .tokens
+                        .peek_second()
+                        .ok()
+                        .is_some_and(|third| {
+                            Self::is_sigil_argument_start(third.kind, third.text.as_ref())
+                        })
+                    {
+                        return true;
                     }
                 }
                 // Check if the next-next token is `(` — that signals a function call

--- a/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_paren_identifier_tests.rs
@@ -133,6 +133,30 @@ fn class_accessor_style() {
 }
 
 #[test]
+fn b_deparse_nested_imported_bare_call_argument() {
+    assert_clean_parse(
+        r#"
+sub quoted_const_str {
+    my ($self, $str) = @_;
+    return single_delim("qq", '"', uninterp(escape_str unback $str), $self);
+}
+"#,
+    );
+}
+
+#[test]
+fn mime_lite_parenthesized_wrap_qualified_class_and_ref_arg() {
+    assert_clean_parse(
+        r#"
+sub as_string {
+    my $buf = "";
+    my $io = (wrap MIME::Lite::IO_Scalar \$buf);
+}
+"#,
+    );
+}
+
+#[test]
 fn test_more_subtest() {
     assert_clean_parse(r#"subtest("widget tests" => sub { ok(1); });"#);
 }


### PR DESCRIPTION
Problem: The current system-corpus pointer's largest first-error bucket was unclosed_paren_identifier, covering B::Deparse nested imported bare calls and MIME::Lite wrap CLASS REF calls.
Fix: Recognize lower-case imported bare calls followed by explicit sigil/ref arguments, and continue list-operator calls after qualified package arguments when another explicit sigil/ref argument follows.
Verification: rtk cargo test -p perl-parser-core --test unclosed_paren_identifier_tests --profile agent --locked; rtk cargo test -p perl-parser-core complex_args_tests --profile agent --locked; rtk cargo test -p perl-parser-core builtin_expansion_tests --profile agent --locked; rtk cargo check --all-targets -p perl-parser-core --profile agent --locked; rtk cargo clippy -p perl-parser-core --profile agent --locked; rtk cargo xtask fmt; rtk git diff --check; rtk cargo xtask metrics parser-accuracy --check; rtk cargo xtask metrics ratchet-check parser_accuracy; rtk cargo xtask parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt; rtk cargo xtask update-status --only parser --check; WSL targeted B::Deparse/MIME::Lite sweep; WSL full parser corpus sweep.
Deltas: system corpus moved from 7033/7095 clean, 14 dirty, 36 ERROR nodes to 7039/7095 clean, 8 dirty, 24 ERROR nodes. unclosed_paren_identifier dropped out of first-error buckets. Parser accuracy denominator stayed 50 fixtures / 29 families; failure packets stayed 0 active; provider rows unchanged; parser_accuracy ratchet passed.