### PR TITLE
fix(lexer): close word-apostrophe substitutions (#9170)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -3062,6 +3062,9 @@ impl<'a> PerlLexer<'a> {
         quote: char,
         delim: char,
     ) -> Option<(usize, bool)> {
+        if Self::is_word_apostrophe(self.input, start, quote) {
+            return None;
+        }
         // Adjacent quotes are literal replacement text (for example s/"/""/g),
         // not a string literal to skip while hunting for the replacement delimiter.
         if self.input.get(..start).and_then(|text| text.chars().next_back()) == Some(quote) {
@@ -3107,6 +3110,14 @@ impl<'a> PerlLexer<'a> {
         }
 
         None
+    }
+
+    fn is_word_apostrophe(input: &str, pos: usize, quote: char) -> bool {
+        quote == '\''
+            && input
+                .get(..pos)
+                .and_then(|text| text.chars().next_back())
+                .is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_')
     }
 
     fn parse_transliteration(&mut self, start: usize) -> Option<Token> {

--- a/crates/perl-lexer/tests/quote_like_recovery_tests.rs
+++ b/crates/perl-lexer/tests/quote_like_recovery_tests.rs
@@ -67,3 +67,30 @@ fn substitution_empty_quoted_replacement_closes_before_next_statement() -> TestR
     assert!(saw_substitution, "expected substitution token in {source}");
     Ok(())
 }
+
+#[test]
+fn substitution_apostrophe_replacement_closes_before_comment_apostrophes() -> TestResult {
+    let source = r#"$name =~ s/\bo'(\w)/O'\u$1/igo; # Irish names such as 'O'Malley, O'Reilly'
+$name =~ s/\[[^\]]*\]//g;"#;
+    let mut lexer = PerlLexer::new(source);
+    let mut substitutions = Vec::new();
+
+    while let Some(token) = lexer.next_token() {
+        if matches!(token.token_type, TokenType::Error(_)) {
+            return Err(format!("unexpected lexer error token: {token:?}").into());
+        }
+        if matches!(token.token_type, TokenType::Substitution) {
+            substitutions.push(token.text.to_string());
+        }
+        if matches!(token.token_type, TokenType::EOF) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        substitutions,
+        vec![r#"s/\bo'(\w)/O'\u$1/igo"#, r#"s/\[[^\]]*\]//g"#],
+        "expected each substitution to close before the trailing comment or next statement",
+    );
+    Ok(())
+}

--- a/crates/perl-parser-core/src/syntax/quote.rs
+++ b/crates/perl-parser-core/src/syntax/quote.rs
@@ -597,6 +597,9 @@ fn scan_inner_string(
     quote: char,
     delimiter: char,
 ) -> Option<(usize, bool)> {
+    if is_word_apostrophe(text, pos, quote) {
+        return None;
+    }
     // Adjacent quotes are literal replacement text (for example s/"/""/g),
     // not a string literal to skip while hunting for the replacement delimiter.
     if text.get(..pos).and_then(|prefix| prefix.chars().next_back()) == Some(quote) {
@@ -636,6 +639,14 @@ fn scan_inner_string(
         local_pos += ch.len_utf8();
     }
     end_of_string.map(|end| (end, contains_delim))
+}
+
+fn is_word_apostrophe(text: &str, pos: usize, quote: char) -> bool {
+    quote == '\''
+        && text
+            .get(..pos)
+            .and_then(|prefix| prefix.chars().next_back())
+            .is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 /// Like `extract_unpaired_body` but skips over string literals (`"..."` / `'...'`)

--- a/crates/perl-parser-core/tests/fix_expected_colon.rs
+++ b/crates/perl-parser-core/tests/fix_expected_colon.rs
@@ -975,6 +975,15 @@ sub merge {
     assert_clean_parse(source);
 }
 
+#[test]
+fn test_mail_address_substitution_comment_apostrophes_before_next_substitution() {
+    let source = r#"
+s/\bo'(\w)/O'\u$1/igo; # Irish names such as 'O'Malley, O'Reilly'
+s/\[[^\]]*\]//g;
+"#;
+    assert_clean_parse(source);
+}
+
 // =============================================================================
 // Full file parse tests (to detect cascading errors)
 // =============================================================================


### PR DESCRIPTION
Problem: Mail::Address-style substitutions with word apostrophes in the replacement followed by comment apostrophes could make the replacement scanner skip past the real slash delimiter, leaving an expected_colon parser bucket. Fix: Treat apostrophes after word characters as literal replacement text in both lexer substitution scanning and parser-core strict substitution splitting, with lexer and parser regression coverage. Verification: cargo test -p perl-lexer --test quote_like_recovery_tests --profile agent --locked; cargo test -p perl-parser-core --test fix_expected_colon --profile agent --locked; cargo test -p perl-parser-core --test fix_subst_squote_delimiter --profile agent --locked; cargo test -p perl-parser-core --test fix_substitution_misparse_2395 --profile agent --locked; cargo check --all-targets -p perl-lexer -p perl-parser-core --profile agent --locked; cargo clippy -p perl-lexer -p perl-parser-core --profile agent --locked; cargo xtask metrics parser-accuracy --check; cargo xtask metrics ratchet-check parser_accuracy; cargo xtask update-status --only parser --check; git diff --check; WSL system corpus sweep passes at 7041/7095 clean, 6 dirty, 22 ERROR nodes, with expected_colon removed.