### PR TITLE
fix(parser): parse braced qualified scalar derefs (#9170)

### DIFF
--- a/crates/perl-parser-core/src/engine/parser/variables.rs
+++ b/crates/perl-parser-core/src/engine/parser/variables.rs
@@ -286,7 +286,14 @@ impl<'a> Parser<'a> {
             let start = token.start;
 
             // Parse the expression inside the braces
-            let expr = self.parse_expression()?;
+            let expr = if sigil == "$" {
+                match self.try_parse_braced_qualified_scalar()? {
+                    Some(expr) => expr,
+                    None => self.parse_expression()?,
+                }
+            } else {
+                self.parse_expression()?
+            };
 
             self.consume_deref_body_terminators()?;
             self.expect(TokenKind::RightBrace)?;
@@ -332,14 +339,18 @@ impl<'a> Parser<'a> {
             let inner_start = token.start + sigil.len() + 1; // after sigil and {
             let inner_end = token.end;
 
-            // Create an identifier node for the captured name
-            let mut inner = Node::new(
-                NodeKind::Identifier { name: inner_name.to_string() },
-                SourceLocation { start: inner_start, end: inner_end },
-            );
+            let mut inner = if sigil == "$" && self.peek_kind() == Some(TokenKind::DoubleColon) {
+                self.parse_qualified_scalar_tail(inner_name.to_string(), inner_start, inner_end)?
+            } else {
+                // Create an identifier node for the captured name
+                let inner = Node::new(
+                    NodeKind::Identifier { name: inner_name.to_string() },
+                    SourceLocation { start: inner_start, end: inner_end },
+                );
 
-            // Parse postfix chain (handles function call parens, method calls, etc.)
-            inner = self.parse_postfix_chain(inner)?;
+                // Parse postfix chain (handles function call parens, method calls, etc.)
+                self.parse_postfix_chain(inner)?
+            };
             if self.peek_kind() == Some(TokenKind::Question) {
                 // `${ref($x) ? $x : fallback($x)}` may enter this partial-deref
                 // path when the lexer greedily captures `${ref` as one token.
@@ -438,6 +449,50 @@ impl<'a> Parser<'a> {
                 SourceLocation { start: token.start, end },
             ))
         }
+    }
+
+    fn try_parse_braced_qualified_scalar(&mut self) -> ParseResult<Option<Node>> {
+        if self.peek_kind() != Some(TokenKind::Identifier) {
+            return Ok(None);
+        }
+
+        if self.tokens.peek_second()?.kind != TokenKind::DoubleColon {
+            return Ok(None);
+        }
+
+        let first = self.tokens.next()?;
+        self.parse_qualified_scalar_tail(first.text.to_string(), first.start, first.end)
+            .map(Some)
+    }
+
+    fn parse_qualified_scalar_tail(
+        &mut self,
+        mut full_name: String,
+        start: usize,
+        mut end: usize,
+    ) -> ParseResult<Node> {
+        while self.peek_kind() == Some(TokenKind::DoubleColon) {
+            self.tokens.next()?;
+            full_name.push_str("::");
+
+            if self.peek_kind() == Some(TokenKind::Identifier) {
+                let name_token = self.tokens.next()?;
+                full_name.push_str(&name_token.text);
+                end = name_token.end;
+            } else {
+                return Err(ParseError::syntax(
+                    "Expected identifier after :: in package-qualified variable",
+                    self.current_position(),
+                ));
+            }
+        }
+
+        let variable = Node::new(
+            NodeKind::Variable { sigil: "$".to_string(), name: full_name },
+            SourceLocation { start, end },
+        );
+
+        self.parse_postfix_chain(variable)
     }
 
     fn consume_deref_body_terminators(&mut self) -> ParseResult<()> {

--- a/crates/perl-parser-core/tests/unclosed_brace_tests.rs
+++ b/crates/perl-parser-core/tests/unclosed_brace_tests.rs
@@ -22,6 +22,12 @@ fn test_hash_deref_package_name() {
 }
 
 #[test]
+fn test_scalar_deref_qualified_hash_element() {
+    let source = r#"die "duplicate" if (${Log::Log4perl::Level::LEVELS{$cust_prio}});"#;
+    assert_clean_parse(source);
+}
+
+#[test]
 fn test_array_deref_function_call() {
     let source = r#"my @r = @{get_items()};"#;
     assert_clean_parse(source);


### PR DESCRIPTION
Problem: Log4perl uses braced scalar dereferences of package-qualified hash elements, and the parser stopped at the first double-colon inside the braces, leaving the unclosed_brace corpus bucket. Fix: Parse package-qualified scalar names inside braced scalar dereferences through the existing postfix chain, including hash subscripts, while preserving the existing expression fallback. Verification: cargo test -p perl-parser-core --test unclosed_brace_tests --profile agent --locked; cargo test -p perl-parser-core --test wave2a_qualified_subscripts_tests --profile agent --locked; cargo test -p perl-parser-core --test fix_main_stash_access --profile agent --locked; cargo test -p perl-parser-core --test fix_typeglob_punct_vars --profile agent --locked; cargo check --all-targets -p perl-parser-core --profile agent --locked; cargo clippy -p perl-parser-core --profile agent --locked; cargo xtask metrics parser-accuracy --check; cargo xtask metrics ratchet-check parser_accuracy; cargo xtask update-status --only parser --check; WSL system corpus sweep passes at 7043/7095 clean, 4 dirty, 8 ERROR nodes, with unclosed_brace removed.