### PR TITLE
fix(parser): keep no-arg filetest before blocks (#9170)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -1933,12 +1933,15 @@ impl<'a> PerlLexer<'a> {
                 if let Some(next) = candidate {
                     // `s => 1` should remain a fat-arrow hash key, not quote op.
                     let is_fat_arrow = next == '=' && char_after_next == Some('>');
+                    let is_filetest_s = text == "s"
+                        && self.input.get(..start).is_some_and(|prefix| prefix.ends_with('-'));
                     let is_paired_delim = matches!(next, '{' | '[' | '(' | '<');
                     let is_quote_char = matches!(next, '\'' | '"') && text != "s";
                     let transliteration_allows_whitespace = text == "tr" || text == "y";
                     let substitution_disallows_whitespace = text == "s" && has_whitespace;
                     let is_valid_delim = Self::is_quote_delim(next)
                         && !is_fat_arrow
+                        && !is_filetest_s
                         && !substitution_disallows_whitespace
                         && (!has_whitespace
                             || is_paired_delim
@@ -2023,6 +2026,10 @@ impl<'a> PerlLexer<'a> {
                             // Fat-arrow autoquoting: `s => value` — `=` followed by `>` is '=>',
                             // not a valid substitution delimiter. Treat as identifier.
                             let is_fat_arrow = next == '=' && char_after_next == Some('>');
+                            let is_filetest_s =
+                                op == "s" && self.input.get(..start).is_some_and(|prefix| {
+                                    prefix.ends_with('-')
+                                });
 
                             // When whitespace precedes the delimiter, only unambiguous
                             // delimiters are accepted:
@@ -2042,6 +2049,7 @@ impl<'a> PerlLexer<'a> {
                                 self.hash_brace_depth > 0 && matches!(next, ',' | '}');
                             let is_valid_delim = Self::is_quote_delim(next)
                                 && !is_fat_arrow
+                                && !is_filetest_s
                                 && !is_hash_subscript_bare_key_boundary
                                 && (!has_whitespace
                                     || is_paired_delim

--- a/crates/perl-lexer/tests/quote_like_recovery_tests.rs
+++ b/crates/perl-lexer/tests/quote_like_recovery_tests.rs
@@ -94,3 +94,29 @@ $name =~ s/\[[^\]]*\]//g;"#;
     );
     Ok(())
 }
+
+#[test]
+fn filetest_s_before_right_paren_is_not_substitution() -> TestResult {
+    let source = "if (-s) { unlink($target); }";
+    let mut lexer = PerlLexer::new(source);
+    let mut token_texts = Vec::new();
+
+    while let Some(token) = lexer.next_token() {
+        if matches!(token.token_type, TokenType::Substitution) {
+            return Err(format!("filetest -s was lexed as substitution: {token:?}").into());
+        }
+        if !matches!(token.token_type, TokenType::Whitespace | TokenType::EOF) {
+            token_texts.push(token.text.to_string());
+        }
+        if matches!(token.token_type, TokenType::EOF) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        token_texts,
+        vec!["if", "(", "-", "s", ")", "{", "unlink", "(", "$target", ")", ";", "}"],
+    );
+
+    Ok(())
+}

--- a/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
+++ b/crates/perl-parser-core/src/engine/parser/expressions/unary.rs
@@ -156,6 +156,9 @@ impl<'a> Parser<'a> {
                                             | TokenKind::LessEqual
                                             | TokenKind::Equal
                                             | TokenKind::NotEqual
+                                            | TokenKind::RightParen
+                                            | TokenKind::RightBrace
+                                            | TokenKind::RightBracket
                                     )
                                 )
                             {

--- a/crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_rbrace_expr_2404.rs
@@ -83,3 +83,20 @@ fn test_dbix_hash_splice_with_semicolon_terminated_deref_body() {
 }"#,
     );
 }
+
+#[test]
+fn test_file_find_wanted_sub_with_no_arg_filetest_if_else() {
+    let source = r#"
+find({
+    no_chdir => 1,
+    wanted => sub {
+        if (-s) {
+            unlink($target);
+        } else {
+            unlink($target);
+        }
+    }
+}, $patch_dir);
+"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
Problem: Dpkg::Source::Quilt uses File::Find callbacks with if (-s) blocks, and the lexer/parser treated the no-arg filetest boundary as substitution/block-consuming syntax, leaving the unexpected_rbrace_expr corpus bucket. Fix: Keep s after a filetest dash out of quote-op/substitution recognition and treat closing delimiters as no-arg filetest terminators in the parser. Verification: cargo test -p perl-lexer --test quote_like_recovery_tests --profile agent --locked; cargo test -p perl-parser-core --test fix_unexpected_rbrace_expr_2404 --profile agent --locked; cargo test -p perl-parser-core --test cpan_file_find --profile agent --locked; cargo test -p perl-parser-core --test fix_unexpected_token_in_expr_2731 --profile agent --locked; cargo test -p perl-parser-core --test fix_qw_space_delimiter --profile agent --locked; cargo test -p perl-parser-core --test fix_subst_unusual_delimiters_2732 --profile agent --locked; cargo check --all-targets -p perl-lexer -p perl-parser-core --profile agent --locked; cargo clippy -p perl-lexer -p perl-parser-core --profile agent --locked; cargo xtask metrics parser-accuracy --check; cargo xtask metrics ratchet-check parser_accuracy; cargo xtask update-status --only parser --check; git diff --check; WSL system corpus sweep passes at 7045/7095 clean, 2 dirty, 4 ERROR nodes, with unexpected_rbrace_expr removed.