### PR TITLE
fix(lexer): close quote replacement substitutions (#9170)

### DIFF
--- a/crates/perl-lexer/src/lib.rs
+++ b/crates/perl-lexer/src/lib.rs
@@ -3079,6 +3079,9 @@ impl<'a> PerlLexer<'a> {
             return None;
         }
         let mut pos = start.checked_add(quote.len_utf8())?;
+        if self.input.get(pos..).is_some_and(|text| text.starts_with(delim)) {
+            return None;
+        }
         if self.input.get(pos..).is_some_and(|text| text.starts_with(quote)) {
             return None;
         }

--- a/crates/perl-lexer/tests/quote_like_recovery_tests.rs
+++ b/crates/perl-lexer/tests/quote_like_recovery_tests.rs
@@ -96,6 +96,37 @@ $name =~ s/\[[^\]]*\]//g;"#;
 }
 
 #[test]
+fn substitution_quote_replacement_closes_before_comment_quote() -> TestResult {
+    let source = r#"for (@tokens) {
+    s/^"//;     #"
+    s/"$//;     #"
+    s/""/"/g;   #"
+}
+if ($conditional =~ /^(and|&&)$/) { }"#;
+    let mut lexer = PerlLexer::new(source);
+    let mut substitutions = Vec::new();
+
+    while let Some(token) = lexer.next_token() {
+        if matches!(token.token_type, TokenType::Error(_)) {
+            return Err(format!("unexpected lexer error token: {token:?}").into());
+        }
+        if matches!(token.token_type, TokenType::Substitution) {
+            substitutions.push(token.text.to_string());
+        }
+        if matches!(token.token_type, TokenType::EOF) {
+            break;
+        }
+    }
+
+    assert_eq!(
+        substitutions,
+        vec![r#"s/^"//"#, r#"s/"$//"#, r#"s/""/"/g"#],
+        "expected quote replacement to close before the trailing comment quote",
+    );
+    Ok(())
+}
+
+#[test]
 fn filetest_s_before_right_paren_is_not_substitution() -> TestResult {
     let source = "if (-s) { unlink($target); }";
     let mut lexer = PerlLexer::new(source);

--- a/crates/perl-parser-core/tests/fix_unexpected_word_op_and_writeexcel.rs
+++ b/crates/perl-parser-core/tests/fix_unexpected_word_op_and_writeexcel.rs
@@ -1,0 +1,32 @@
+mod cpan_test_helpers;
+use cpan_test_helpers::*;
+
+#[test]
+fn test_writeexcel_filter_expression_after_quote_replacement_substitution() {
+    let source = r#"
+sub _extract_filter_tokens {
+    my $expression = $_[0];
+    my @tokens = ($expression =~ /"(?:[^"]|"")*"|\S+/g); #"
+
+    for (@tokens) {
+        s/^"//;     #"
+        s/"$//;     #"
+        s/""/"/g;   #"
+    }
+
+    return @tokens;
+}
+
+sub _parse_filter_expression {
+    my $conditional = $tokens[3];
+
+    if ($conditional =~ /^(and|&&)$/) {
+        $conditional = 0;
+    }
+    elsif ($conditional =~ /^(or|\|\|)$/) {
+        $conditional = 1;
+    }
+}
+"#;
+    assert_clean_parse(source);
+}


### PR DESCRIPTION
Problem: WriteExcel quote replacement substitutions could skip the real closing delimiter and later surface unexpected_word_op_and. Fix: add a delimiter guard plus lexer and parser regressions for the corpus shape. Verification: focused lexer and parser tests passed; cargo check and clippy passed for touched crates; parser accuracy, ratchet, and parser status checks passed; full WSL corpus sweep passed with 7047 clean, 0 dirty, 0 ERROR nodes.