### PR TITLE
ci(gates): add conflict marker timeout headroom (#9454)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -139,10 +139,10 @@ gates:
     description: "Prevent committed merge conflict markers"
     required: true
     command: just check-conflict-markers
-    timeout_seconds: 30
+    timeout_seconds: 60
     retry_count: 0
     budgets:
-      max_duration_ms: 10000
+      max_duration_ms: 45000
     quarantine: false
     tags:
       - hygiene

--- a/xtask/tests/gate_policy_profile_tests.rs
+++ b/xtask/tests/gate_policy_profile_tests.rs
@@ -111,6 +111,34 @@ fn release_history_pr_gates_have_realistic_timeout_headroom()
 }
 
 #[test]
+fn conflict_marker_gate_has_local_runtime_headroom() -> Result<(), Box<dyn std::error::Error>> {
+    let root = project_root();
+    let policy_path = root.join(".ci/gate-policy.yaml");
+    let content = fs::read_to_string(policy_path)?;
+    let parsed: GatePolicyDoc = serde_yaml_ng::from_str(&content)?;
+
+    let gate = parsed
+        .gates
+        .into_iter()
+        .find(|gate| gate.name == "check_conflict_markers")
+        .ok_or("missing check_conflict_markers gate")?;
+
+    assert_eq!(gate.tier, "pr_fast", "conflict marker scan must stay in pr-fast");
+    assert!(gate.required, "conflict marker scan must stay PR-blocking");
+    assert!(
+        gate.timeout_seconds.unwrap_or_default() >= 60,
+        "conflict marker timeout must include Windows and mounted-worktree headroom"
+    );
+    assert!(
+        gate.budgets.as_ref().and_then(|budget| budget.max_duration_ms).unwrap_or_default()
+            >= 45_000,
+        "conflict marker budget must reflect observed local runtime"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn gate_registry_alignment_prevents_stale_parser_wiring() -> Result<(), Box<dyn std::error::Error>>
 {
     let root = project_root();


### PR DESCRIPTION
Problem: The local pr-fast checkpoint can fail from a control-plane timeout even when `just check-conflict-markers` succeeds. On this checkout the direct command passed in 27.1s, but the gate killed it at 30s.

Fix: Increase the `check_conflict_markers` pr-fast timeout to 60s, align the duration budget to 45s, and add a gate-policy regression test for that headroom.

Verification:
- `time just check-conflict-markers` passed in 27.1s before the fix.
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt` passed.
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p xtask --test gate_policy_profile_tests conflict_marker_gate_has_local_runtime_headroom --profile agent --locked -- --nocapture` passed.
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask gates --tier pr-fast` passed: 10 passed, 0 failed, `check_conflict_markers` completed in 27.4s under the new 60s timeout.
- `./scripts/storage-doctor` passed after removing the repo-local receipt `target/`.