### PR TITLE
feat(vscode): expose package rename preview command (#8197)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -786,6 +786,12 @@
         "icon": "$(shield)"
       },
       {
+        "command": "perl-lsp.previewPackageRename",
+        "title": "Preview Package Rename",
+        "category": "Perl LSP",
+        "icon": "$(symbol-method)"
+      },
+      {
         "command": "perl-lsp.copyProviderDecisionReceipt",
         "title": "Copy Provider Decision Receipt",
         "category": "Perl LSP",
@@ -916,6 +922,10 @@
         },
         {
           "command": "perl-lsp.previewSafeDelete",
+          "when": "editorLangId == perl"
+        },
+        {
+          "command": "perl-lsp.previewPackageRename",
           "when": "editorLangId == perl"
         },
         {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -374,6 +374,47 @@ function activeSafeDeletePreviewArgument(): Record<string, unknown> | undefined 
     };
 }
 
+async function activePackageRenamePreviewArgument(): Promise<Record<string, unknown> | undefined> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'perl') {
+        return undefined;
+    }
+
+    const selectedText = editor.selection.isEmpty
+        ? ''
+        : editor.document.getText(editor.selection).trim();
+    const wordRange = editor.document.getWordRangeAtPosition(editor.selection.active);
+    const wordText = wordRange ? editor.document.getText(wordRange).trim() : '';
+    const defaultValue = selectedText || wordText;
+
+    const newName = await vscode.window.showInputBox({
+        value: defaultValue,
+        placeHolder: 'renamed_symbol',
+        prompt: 'New package or symbol name for the no-edit rename preview',
+        validateInput: value => {
+            const trimmed = value.trim();
+            if (!trimmed) {
+                return 'Enter a new Perl package or symbol name.';
+            }
+            return isPerlModuleName(trimmed)
+                ? undefined
+                : 'Use a single Perl package or symbol name.';
+        },
+    });
+    if (!newName) {
+        return undefined;
+    }
+
+    return {
+        textDocument: { uri: editor.document.uri.toString() },
+        position: {
+            line: editor.selection.active.line,
+            character: editor.selection.active.character,
+        },
+        newName: newName.trim(),
+    };
+}
+
 function isPerlModuleName(value: string): boolean {
     return /^[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*$/.test(value);
 }
@@ -956,6 +997,26 @@ export async function previewSafeDeleteCommand(
     }
 }
 
+export async function previewPackageRenameCommand(
+    activeClient: LspExecuteCommandClient | undefined = client
+): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'perl') {
+        vscode.window.showErrorMessage('Preview Package Rename requires an active Perl file.');
+        return;
+    }
+
+    const argument = await activePackageRenamePreviewArgument();
+    if (!argument) {
+        return;
+    }
+
+    const result = await executeLspCommand(activeClient, 'perl.previewPackageRename', argument);
+    if (result !== undefined) {
+        await showProviderDecisionResult('Package rename preview', result);
+    }
+}
+
 export async function copyProviderDecisionReceiptCommand(
     activeClient: LspExecuteCommandClient | undefined = client,
     providerOverride?: string
@@ -1286,6 +1347,13 @@ export async function activate(context: vscode.ExtensionContext) {
         'perl-lsp.previewSafeDelete',
         async () => {
             await previewSafeDeleteCommand(client);
+        }
+    );
+
+    const previewPackageRenameCommandDisposable = vscode.commands.registerCommand(
+        'perl-lsp.previewPackageRename',
+        async () => {
+            await previewPackageRenameCommand(client);
         }
     );
 
@@ -1627,6 +1695,7 @@ export async function activate(context: vscode.ExtensionContext) {
         showParserAstCommand,
         explainProviderDecisionCommandDisposable,
         previewSafeDeleteCommandDisposable,
+        previewPackageRenameCommandDisposable,
         copyProviderDecisionReceiptCommandDisposable,
         showWorkspaceTrustReportCommandDisposable,
         explainMissingModuleLookupCommandDisposable,

--- a/vscode-extension/src/test/commands.test.ts
+++ b/vscode-extension/src/test/commands.test.ts
@@ -370,6 +370,7 @@ describe('perl-lsp trust explanation commands', () => {
   test.each([
     ['perl-lsp.explainProviderDecision', 'Explain Provider Decision'],
     ['perl-lsp.previewSafeDelete', 'Preview Safe Delete'],
+    ['perl-lsp.previewPackageRename', 'Preview Package Rename'],
     ['perl-lsp.copyProviderDecisionReceipt', 'Copy Provider Decision Receipt'],
     ['perl-lsp.showWorkspaceTrustReport', 'Show Workspace Trust Report'],
     ['perl-lsp.explainMissingModuleLookup', 'Explain Missing Module Lookup'],
@@ -385,6 +386,7 @@ describe('perl-lsp trust explanation commands', () => {
   test.each([
     'perl-lsp.explainProviderDecision',
     'perl-lsp.previewSafeDelete',
+    'perl-lsp.previewPackageRename',
     'perl-lsp.copyProviderDecisionReceipt',
     'perl-lsp.explainMissingModuleLookup',
     'perl-lsp.explainDiagnostic',

--- a/vscode-extension/src/test/extensionUx.test.ts
+++ b/vscode-extension/src/test/extensionUx.test.ts
@@ -22,6 +22,7 @@ import {
   explainDiagnosticCommand,
   explainMissingModuleLookupCommand,
   explainProviderDecisionCommand,
+  previewPackageRenameCommand,
   previewSafeDeleteCommand,
   showWorkspaceTrustReportCommand,
   validateIncludePaths,
@@ -625,6 +626,53 @@ describe('extension UX warnings', () => {
     );
     expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
       'Safe delete refused. No edits were applied.',
+      'Show Output'
+    );
+  });
+
+  test('previews package rename through the no-edit LSP command', async () => {
+    const sendRequest = jest.fn(async () => ({
+      provider: 'rename',
+      decision: 'allowed',
+      user_message: 'Package rename preview is available. No edits were applied.',
+    }));
+    (vscode.window.showInputBox as jest.Mock).mockResolvedValue('renamed_shared');
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        languageId: 'perl',
+        uri: vscode.Uri.file('/workspace/lib/Foo.pm'),
+        getText: jest.fn(() => 'shared'),
+        getWordRangeAtPosition: jest.fn(() => ({ start: { line: 12, character: 4 }, end: { line: 12, character: 10 } })),
+      },
+      selection: {
+        active: { line: 12, character: 4 },
+        isEmpty: true,
+      },
+    };
+
+    await previewPackageRenameCommand({ sendRequest } as any);
+
+    expect(vscode.window.showInputBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: 'shared',
+        placeHolder: 'renamed_symbol',
+      })
+    );
+    expect(sendRequest).toHaveBeenCalledWith(
+      'workspace/executeCommand',
+      {
+        command: 'perl.previewPackageRename',
+        arguments: [
+          {
+            textDocument: { uri: 'file:///workspace/lib/Foo.pm' },
+            position: { line: 12, character: 4 },
+            newName: 'renamed_shared',
+          },
+        ],
+      }
+    );
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      'Package rename preview is available. No edits were applied.',
       'Show Output'
     );
   });


### PR DESCRIPTION
Problem: Package rename preview was available as the server-side perl.previewPackageRename command, but VS Code users did not have a command-palette wrapper for the no-edit preview flow.

Fix: Add Perl LSP: Preview Package Rename, prompt for the replacement name, call perl.previewPackageRename with the active Perl document position, and render the existing provider-decision output-channel result.

Claim boundary: VS Code presentation only. No rename provider behavior change, no edit authorization change, no support-tier promotion.

Verification:
- npm --prefix vscode-extension run compile
- npm --prefix vscode-extension test -- --runTestsByPath src/test/commands.test.ts src/test/extensionUx.test.ts
- npm --prefix vscode-extension run lint
- cargo xtask check-support-claims
- cargo xtask check-provider-confidence-matrix
- git diff --check