### PR TITLE
test(parser): refresh zero-error system corpus baseline (#9170)

### DIFF
--- a/.ci/parser-corpus-baseline.json
+++ b/.ci/parser-corpus-baseline.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.3.0",
-  "commit": "3c287d7db",
-  "timestamp": "2026-04-28T09:33:05.003748112+00:00",
+  "commit": "f201b498c",
+  "timestamp": "2026-05-18T20:28:21.038313964+00:00",
   "corpus_profile": "system",
   "corpus_roots": [
     "/usr/share/perl",
@@ -12,239 +12,43 @@
   "perl_version": "5.038002",
   "total_files": 7095,
   "files_unreadable": 48,
-  "clean_files": 6871,
-  "files_with_errors": 176,
-  "total_dirty_files": 176,
-  "files_with_structured_recovery_only": 36,
-  "files_with_error_nodes": 140,
+  "clean_files": 7047,
+  "files_with_errors": 0,
+  "total_dirty_files": 0,
+  "files_with_structured_recovery_only": 0,
+  "files_with_error_nodes": 0,
   "files_with_catastrophic_parse_failure": 0,
-  "total_error_nodes": 536,
-  "recovered_node_count": 94,
-  "first_unrecovered_error_node_buckets": {
-    "expected_colon": 4,
-    "expected_comma": 4,
-    "expected_left_brace": 6,
-    "substitution_misparse": 2,
-    "unclosed_brace": 10,
-    "unclosed_bracket": 2,
-    "unclosed_paren": 2,
-    "unclosed_paren_identifier": 22,
-    "unexpected_assign_expr": 12,
-    "unexpected_comma_expr": 10,
-    "unexpected_eq_expr": 10,
-    "unexpected_rbrace_expr": 6,
-    "unexpected_rparen_expr": 8,
-    "unexpected_token_in_expr": 38,
-    "unexpected_word_op_or": 4
-  },
-  "first_error_buckets": {
-    "expected_colon": 4,
-    "expected_comma": 4,
-    "expected_left_brace": 6,
-    "substitution_misparse": 2,
-    "unclosed_brace": 10,
-    "unclosed_bracket": 2,
-    "unclosed_paren": 2,
-    "unclosed_paren_identifier": 22,
-    "unexpected_assign_expr": 12,
-    "unexpected_comma_expr": 10,
-    "unexpected_eq_expr": 10,
-    "unexpected_rbrace_expr": 6,
-    "unexpected_rparen_expr": 8,
-    "unexpected_token_in_expr": 38,
-    "unexpected_word_op_or": 4
-  },
-  "files_by_bucket": {
-    "expected_colon": [
-      "/usr/share/perl5/Parse/RecDescent.pm",
-      "/usr/share/perl5/Parse/RecDescent.pm",
-      "/usr/share/perl5/Regexp/Common/SEN.pm",
-      "/usr/share/perl5/Regexp/Common/SEN.pm"
-    ],
-    "expected_comma": [
-      "/usr/share/perl/5.38/Memoize/Expire.pm",
-      "/usr/share/perl/5.38/Memoize/Expire.pm",
-      "/usr/share/perl/5.38.2/Memoize/Expire.pm",
-      "/usr/share/perl/5.38.2/Memoize/Expire.pm"
-    ],
-    "expected_left_brace": [
-      "/usr/share/perl/5.38/CPAN/Shell.pm",
-      "/usr/share/perl/5.38/CPAN/Shell.pm",
-      "/usr/share/perl/5.38.2/CPAN/Shell.pm",
-      "/usr/share/perl/5.38.2/CPAN/Shell.pm",
-      "/usr/share/perl5/Method/Generate/Accessor.pm",
-      "/usr/share/perl5/Method/Generate/Accessor.pm"
-    ],
-    "substitution_misparse": [
-      "/usr/share/perl5/Biber/Input/file/bibtex.pm",
-      "/usr/share/perl5/Biber/Input/file/bibtex.pm"
-    ],
-    "unclosed_brace": [
-      "/usr/share/perl/5.38/Test/More.pm",
-      "/usr/share/perl/5.38/Test/More.pm",
-      "/usr/share/perl/5.38/fields.pm",
-      "/usr/share/perl/5.38/fields.pm",
-      "/usr/share/perl/5.38.2/Test/More.pm",
-      "/usr/share/perl/5.38.2/Test/More.pm",
-      "/usr/share/perl/5.38.2/fields.pm",
-      "/usr/share/perl/5.38.2/fields.pm",
-      "/usr/share/perl5/Log/Log4perl/Logger.pm",
-      "/usr/share/perl5/Log/Log4perl/Logger.pm"
-    ],
-    "unclosed_bracket": [
-      "/usr/share/perl5/Regexp/Common/zip.pm",
-      "/usr/share/perl5/Regexp/Common/zip.pm"
-    ],
-    "unclosed_paren": [
-      "/usr/share/perl5/Dpkg/Source/Archive.pm",
-      "/usr/share/perl5/Dpkg/Source/Archive.pm"
-    ],
-    "unclosed_paren_identifier": [
-      "/usr/lib/x86_64-linux-gnu/perl/5.38/Unicode/Collate.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38/Unicode/Collate.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38/Unicode/Normalize.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38/Unicode/Normalize.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38.2/Unicode/Collate.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38.2/Unicode/Collate.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38.2/Unicode/Normalize.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38.2/Unicode/Normalize.pm",
-      "/usr/share/perl/5.38/Carp.pm",
-      "/usr/share/perl/5.38/Carp.pm",
-      "/usr/share/perl/5.38/ExtUtils/MM_Unix.pm",
-      "/usr/share/perl/5.38/ExtUtils/MM_Unix.pm",
-      "/usr/share/perl/5.38/Pod/Simple/XHTML.pm",
-      "/usr/share/perl/5.38/Pod/Simple/XHTML.pm",
-      "/usr/share/perl/5.38.2/Carp.pm",
-      "/usr/share/perl/5.38.2/Carp.pm",
-      "/usr/share/perl/5.38.2/ExtUtils/MM_Unix.pm",
-      "/usr/share/perl/5.38.2/ExtUtils/MM_Unix.pm",
-      "/usr/share/perl/5.38.2/Pod/Simple/XHTML.pm",
-      "/usr/share/perl/5.38.2/Pod/Simple/XHTML.pm",
-      "/usr/share/perl5/Regexp/Common/comment.pm",
-      "/usr/share/perl5/Regexp/Common/comment.pm"
-    ],
-    "unexpected_assign_expr": [
-      "/usr/lib/x86_64-linux-gnu/perl/5.38/re.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38/re.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38.2/re.pm",
-      "/usr/lib/x86_64-linux-gnu/perl/5.38.2/re.pm",
-      "/usr/share/perl/5.38/Text/Balanced.pm",
-      "/usr/share/perl/5.38/Text/Balanced.pm",
-      "/usr/share/perl/5.38/Unicode/UCD.pm",
-      "/usr/share/perl/5.38/Unicode/UCD.pm",
-      "/usr/share/perl/5.38.2/Text/Balanced.pm",
-      "/usr/share/perl/5.38.2/Text/Balanced.pm",
-      "/usr/share/perl/5.38.2/Unicode/UCD.pm",
-      "/usr/share/perl/5.38.2/Unicode/UCD.pm"
-    ],
-    "unexpected_comma_expr": [
-      "/usr/share/perl/5.38/App/Cpan.pm",
-      "/usr/share/perl/5.38/App/Cpan.pm",
-      "/usr/share/perl/5.38/unicore/Name.pm",
-      "/usr/share/perl/5.38/unicore/Name.pm",
-      "/usr/share/perl/5.38.2/App/Cpan.pm",
-      "/usr/share/perl/5.38.2/App/Cpan.pm",
-      "/usr/share/perl/5.38.2/unicore/Name.pm",
-      "/usr/share/perl/5.38.2/unicore/Name.pm",
-      "/usr/share/perl5/OLE/Storage_Lite.pm",
-      "/usr/share/perl5/OLE/Storage_Lite.pm"
-    ],
-    "unexpected_eq_expr": [
-      "/usr/share/perl/5.38/CPAN/Distribution.pm",
-      "/usr/share/perl/5.38/CPAN/Distribution.pm",
-      "/usr/share/perl/5.38/CPAN/Tarzip.pm",
-      "/usr/share/perl/5.38/CPAN/Tarzip.pm",
-      "/usr/share/perl/5.38.2/CPAN/Distribution.pm",
-      "/usr/share/perl/5.38.2/CPAN/Distribution.pm",
-      "/usr/share/perl/5.38.2/CPAN/Tarzip.pm",
-      "/usr/share/perl/5.38.2/CPAN/Tarzip.pm",
-      "/usr/share/perl5/Debian/AdduserLogging.pm",
-      "/usr/share/perl5/Debian/AdduserLogging.pm"
-    ],
-    "unexpected_rbrace_expr": [
-      "/usr/share/perl/5.38/B/Op_private.pm",
-      "/usr/share/perl/5.38/B/Op_private.pm",
-      "/usr/share/perl/5.38.2/B/Op_private.pm",
-      "/usr/share/perl/5.38.2/B/Op_private.pm",
-      "/usr/share/perl5/Dpkg/Source/Quilt.pm",
-      "/usr/share/perl5/Dpkg/Source/Quilt.pm"
-    ],
-    "unexpected_rparen_expr": [
-      "/usr/share/perl/5.38/B/Deparse.pm",
-      "/usr/share/perl/5.38/B/Deparse.pm",
-      "/usr/share/perl/5.38.2/B/Deparse.pm",
-      "/usr/share/perl/5.38.2/B/Deparse.pm",
-      "/usr/share/perl5/Data/Compare.pm",
-      "/usr/share/perl5/Data/Compare.pm",
-      "/usr/share/perl5/Date/Manip/DM5.pm",
-      "/usr/share/perl5/Date/Manip/DM5.pm"
-    ],
-    "unexpected_token_in_expr": [
-      "/usr/share/perl/5.38/English.pm",
-      "/usr/share/perl/5.38/English.pm",
-      "/usr/share/perl/5.38/File/Copy.pm",
-      "/usr/share/perl/5.38/File/Copy.pm",
-      "/usr/share/perl/5.38/IPC/Cmd.pm",
-      "/usr/share/perl/5.38/IPC/Cmd.pm",
-      "/usr/share/perl/5.38/Tie/File.pm",
-      "/usr/share/perl/5.38/Tie/File.pm",
-      "/usr/share/perl/5.38/experimental.pm",
-      "/usr/share/perl/5.38/experimental.pm",
-      "/usr/share/perl/5.38/feature.pm",
-      "/usr/share/perl/5.38/feature.pm",
-      "/usr/share/perl/5.38.2/English.pm",
-      "/usr/share/perl/5.38.2/English.pm",
-      "/usr/share/perl/5.38.2/File/Copy.pm",
-      "/usr/share/perl/5.38.2/File/Copy.pm",
-      "/usr/share/perl/5.38.2/IPC/Cmd.pm",
-      "/usr/share/perl/5.38.2/IPC/Cmd.pm",
-      "/usr/share/perl/5.38.2/Tie/File.pm",
-      "/usr/share/perl/5.38.2/Tie/File.pm",
-      "/usr/share/perl/5.38.2/experimental.pm",
-      "/usr/share/perl/5.38.2/experimental.pm",
-      "/usr/share/perl/5.38.2/feature.pm",
-      "/usr/share/perl/5.38.2/feature.pm",
-      "/usr/share/perl5/Data/Dump.pm",
-      "/usr/share/perl5/Data/Dump.pm",
-      "/usr/share/perl5/File/MimeInfo.pm",
-      "/usr/share/perl5/File/MimeInfo.pm",
-      "/usr/share/perl5/IPC/Run3.pm",
-      "/usr/share/perl5/IPC/Run3.pm",
-      "/usr/share/perl5/MIME/Lite.pm",
-      "/usr/share/perl5/MIME/Lite.pm",
-      "/usr/share/perl5/MIME/Type.pm",
-      "/usr/share/perl5/MIME/Type.pm",
-      "/usr/share/perl5/Mail/Sendmail.pm",
-      "/usr/share/perl5/Mail/Sendmail.pm",
-      "/usr/share/perl5/Ref/Util.pm",
-      "/usr/share/perl5/Ref/Util.pm"
-    ],
-    "unexpected_word_op_or": [
-      "/usr/share/perl/5.38/Pod/Perldoc.pm",
-      "/usr/share/perl/5.38/Pod/Perldoc.pm",
-      "/usr/share/perl/5.38.2/Pod/Perldoc.pm",
-      "/usr/share/perl/5.38.2/Pod/Perldoc.pm"
-    ]
-  },
-  "elapsed_secs": 4.777117897,
+  "total_error_nodes": 0,
+  "recovered_node_count": 0,
+  "first_unrecovered_error_node_buckets": {},
+  "first_error_buckets": {},
+  "elapsed_secs": 4.800157997,
   "phase_timings": {
-    "discovery_ms": 18,
-    "file_io_ms": 145,
-    "parse_ms": 4147,
-    "total_ms": 4777
+    "discovery_ms": 19,
+    "file_io_ms": 136,
+    "parse_ms": 4280,
+    "total_ms": 4800
   },
-  "median_error_density_per_1k_loc": 1.8656716417910448,
-  "recovery_salvage_rate": 0.20454545454545456,
   "slowest_files": [
-    {
-      "path": "/usr/share/perl5/Perl/Tidy/Formatter.pm",
-      "parse_duration_ms": 32,
-      "line_count": 30467
-    },
     {
       "path": "/usr/share/perl/5.38.2/Module/CoreList.pm",
       "parse_duration_ms": 31,
       "line_count": 23759
+    },
+    {
+      "path": "/usr/share/perl/5.38/Module/CoreList.pm",
+      "parse_duration_ms": 31,
+      "line_count": 23759
+    },
+    {
+      "path": "/usr/share/perl5/Perl/Tidy/Formatter.pm",
+      "parse_duration_ms": 31,
+      "line_count": 30467
+    },
+    {
+      "path": "/usr/share/perl5/Perl/Tidy/Formatter.pm",
+      "parse_duration_ms": 31,
+      "line_count": 30467
     },
     {
       "path": "/usr/share/perl/5.38.2/Module/CoreList.pm",
@@ -253,23 +57,8 @@
     },
     {
       "path": "/usr/share/perl/5.38/Module/CoreList.pm",
-      "parse_duration_ms": 29,
+      "parse_duration_ms": 30,
       "line_count": 23759
-    },
-    {
-      "path": "/usr/share/perl/5.38/Module/CoreList.pm",
-      "parse_duration_ms": 29,
-      "line_count": 23759
-    },
-    {
-      "path": "/usr/share/perl5/Perl/Tidy/Formatter.pm",
-      "parse_duration_ms": 29,
-      "line_count": 30467
-    },
-    {
-      "path": "/usr/share/perl5/XML/Twig.pm",
-      "parse_duration_ms": 19,
-      "line_count": 14361
     },
     {
       "path": "/usr/share/perl5/XML/Twig.pm",
@@ -277,19 +66,24 @@
       "line_count": 14361
     },
     {
-      "path": "/usr/share/perl/5.38/B/Deparse.pm",
+      "path": "/usr/share/perl5/XML/Twig.pm",
+      "parse_duration_ms": 17,
+      "line_count": 14361
+    },
+    {
+      "path": "/usr/share/perl5/Date/Manip/DM5.pm",
       "parse_duration_ms": 14,
+      "line_count": 7486
+    },
+    {
+      "path": "/usr/share/perl5/Date/Manip/DM5.pm",
+      "parse_duration_ms": 14,
+      "line_count": 7486
+    },
+    {
+      "path": "/usr/share/perl/5.38.2/B/Deparse.pm",
+      "parse_duration_ms": 12,
       "line_count": 7266
-    },
-    {
-      "path": "/usr/share/perl5/Date/Manip/DM5.pm",
-      "parse_duration_ms": 14,
-      "line_count": 7486
-    },
-    {
-      "path": "/usr/share/perl5/Date/Manip/DM5.pm",
-      "parse_duration_ms": 14,
-      "line_count": 7486
     },
     {
       "path": "/usr/share/perl/5.38/B/Deparse.pm",
@@ -297,9 +91,9 @@
       "line_count": 7266
     },
     {
-      "path": "/usr/share/perl/5.38.2/B/Deparse.pm",
-      "parse_duration_ms": 11,
-      "line_count": 7266
+      "path": "/usr/share/perl5/Date/Manip/TZ/euprag00.pm",
+      "parse_duration_ms": 12,
+      "line_count": 1231
     },
     {
       "path": "/usr/share/perl/5.38.2/B/Deparse.pm",
@@ -307,34 +101,34 @@
       "line_count": 7266
     },
     {
-      "path": "/usr/share/perl5/Perl/Tidy/Tokenizer.pm",
+      "path": "/usr/share/perl/5.38/B/Deparse.pm",
+      "parse_duration_ms": 11,
+      "line_count": 7266
+    },
+    {
+      "path": "/usr/lib/x86_64-linux-gnu/perl/5.38/B/Concise.pm",
       "parse_duration_ms": 10,
-      "line_count": 10661
+      "line_count": 1929
     },
     {
       "path": "/usr/share/perl/5.38.2/Math/BigFloat.pm",
-      "parse_duration_ms": 9,
+      "parse_duration_ms": 10,
       "line_count": 6838
     },
     {
-      "path": "/usr/share/perl/5.38.2/Math/BigFloat.pm",
-      "parse_duration_ms": 9,
-      "line_count": 6838
+      "path": "/usr/share/perl5/Date/Manip/TZ/amst_j00.pm",
+      "parse_duration_ms": 10,
+      "line_count": 1657
     },
     {
-      "path": "/usr/share/perl/5.38/CPAN/Distribution.pm",
-      "parse_duration_ms": 9,
-      "line_count": 4930
+      "path": "/usr/share/perl5/Date/Manip/TZ/amst_j00.pm",
+      "parse_duration_ms": 10,
+      "line_count": 1657
     },
     {
-      "path": "/usr/share/perl/5.38/CPAN/Distribution.pm",
-      "parse_duration_ms": 9,
-      "line_count": 4930
-    },
-    {
-      "path": "/usr/share/perl/5.38/Math/BigFloat.pm",
-      "parse_duration_ms": 9,
-      "line_count": 6838
+      "path": "/usr/share/perl5/Date/Manip/TZ/eudubl00.pm",
+      "parse_duration_ms": 10,
+      "line_count": 1612
     }
   ]
 }

--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -7,7 +7,7 @@
 
 | --- | --- | --- | --- |
 | <!-- BEGIN: PARSER_TRACKING_TABLE -->
-| **Ubuntu system Perl** | 96.8% clean (`6871/7095`) / 20.5% salvage | Compatibility baseline; Perl `5.038002`, `48` unreadable, `36` recovery-only, `140` ERROR-node files, `0` catastrophic, baseline `2026-04-28` | `.ci/parser-corpus-baseline.json` |
+| **Ubuntu system Perl** | 99.3% clean (`7047/7095`) / insufficient_data salvage | Compatibility baseline; Perl `5.038002`, `48` unreadable, `0` recovery-only, `0` ERROR-node files, `0` catastrophic, baseline `2026-05-18` | `.ci/parser-corpus-baseline.json` |
 | **CPAN top 1000** | 95.3% clean (`8931/9372`) / insufficient_data salvage | Ecosystem breadth baseline; `6` unreadable, `insufficient_data` recovery-only, `insufficient_data` ERROR-node files, `insufficient_data` catastrophic, cached downloads in `target/cpan-corpus/.cpanm`, baseline `2026-04-09` | `.ci/cpan-corpus-baseline.json` |
 | **Project corpus** | 100.0% clean (`96/96`) | Deterministic regression baseline; `74` `test_corpus/` + `22` `perl-corpus` files, `0` errors, `0` timeouts, `0` panics, `66/69` NodeKinds, `12/12` GA features | `test_corpus/` + `crates/perl-corpus/src/gen` |
 <!-- END: PARSER_TRACKING_TABLE -->
@@ -60,10 +60,10 @@ Failures in the system-Perl baseline grouped by cluster. Counts come from `first
 <!-- BEGIN: PARSER_FAILURE_WORKLIST -->
 | transliteration / quote parsing | 0 |
 | declaration / package parsing | 0 |
-| heredoc / delimiter handling | 56 |
-| recovery-only failures | 38 |
+| heredoc / delimiter handling | 0 |
+| recovery-only failures | 0 |
 | encoding / multibyte | 0 |
-| other | 46 |
+| other | 0 |
 <!-- END: PARSER_FAILURE_WORKLIST -->
 
 ### Raw Failure Buckets
@@ -71,27 +71,13 @@ Failures in the system-Perl baseline grouped by cluster. Counts come from `first
 Raw first-error buckets from the same system-Perl receipt, grouped by cluster so the generated worklist can be split into one parser-fix lane at a time.
 
 <!-- BEGIN: PARSER_FAILURE_RECEIPT_NOTE -->
-Receipt snapshot: profile `system`, commit `3c287d7db`, generated `2026-04-28`, Perl `5.038002`, `86` resolved roots. Raw bucket counts are point-in-time compatibility data; before starting a parser-fix lane from a bucket, rerun `cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` on Linux or add a focused fixture when system roots are unavailable.
+Receipt snapshot: profile `system`, commit `f201b498c`, generated `2026-05-18`, Perl `5.038002`, `86` resolved roots. Raw bucket counts are point-in-time compatibility data; before starting a parser-fix lane from a bucket, rerun `cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt` on Linux or add a focused fixture when system roots are unavailable.
 <!-- END: PARSER_FAILURE_RECEIPT_NOTE -->
 
 | Cluster | Bucket | Files |
 | --- | --- | --- |
 <!-- BEGIN: PARSER_FAILURE_BUCKETS -->
-| heredoc / delimiter handling | `unclosed_paren_identifier` | 22 |
-| heredoc / delimiter handling | `unclosed_brace` | 10 |
-| heredoc / delimiter handling | `unexpected_rparen_expr` | 8 |
-| heredoc / delimiter handling | `expected_left_brace` | 6 |
-| heredoc / delimiter handling | `unexpected_rbrace_expr` | 6 |
-| heredoc / delimiter handling | `unclosed_bracket` | 2 |
-| heredoc / delimiter handling | `unclosed_paren` | 2 |
-| recovery-only failures | `unexpected_token_in_expr` | 38 |
-| other | `unexpected_assign_expr` | 12 |
-| other | `unexpected_comma_expr` | 10 |
-| other | `unexpected_eq_expr` | 10 |
-| other | `expected_colon` | 4 |
-| other | `expected_comma` | 4 |
-| other | `unexpected_word_op_or` | 4 |
-| other | `substitution_misparse` | 2 |
+| none | n/a | 0 |
 <!-- END: PARSER_FAILURE_BUCKETS -->
 
 <!-- BEGIN: PARSER_METRICS_BULLETS -->


### PR DESCRIPTION
Problem: Parser status still pointed at the stale 2026-04-28 system-corpus raw failure buckets after the fresh WSL sweep proved zero dirty/error files.

Fix: Refresh .ci/parser-corpus-baseline.json and generated docs/project/status/parser.md only.

Claim boundary: Measurement-only; no parser runtime change, provider behavior change, parser status movement, corpus bucket claim expansion, or CPAN claim.

Verification:
- rtk cargo xtask update-status --only parser --check
- rtk cargo xtask metrics parser-accuracy --check
- rtk cargo xtask metrics ratchet-check parser_accuracy
- rtk cargo xtask fmt
- rtk git diff --check
- rtk wsl bash -lc 'cd /mnt/h/pacc-next-bucket && GIT_DIR=/mnt/h/Code/Rust/perl-lsp/.git/worktrees/pacc-next-bucket GIT_COMMON_DIR=/mnt/h/Code/Rust/perl-lsp/.git GIT_WORK_TREE=/mnt/h/pacc-next-bucket cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt'