### PR TITLE
fix(status): avoid stale parser bucket handoff (#8197)

### DIFF
--- a/docs/project/status/parser_accuracy_next.md
+++ b/docs/project/status/parser_accuracy_next.md
@@ -18,4 +18,4 @@ Use the measurement gap table only when there are no active failure packets. Kee
 
 ## Capability Handoff
 
-Measurement wiring is clear. Follow [`parser.md`](parser.md#raw-failure-buckets) for capability work; take the largest raw bucket inside the largest nonzero parser failure cluster as the next parser lane and keep it separate from measurement-only work.
+Measurement wiring is clear. Follow [`parser.md`](parser.md#raw-failure-buckets) for capability work only when the generated parser status lists a nonzero raw failure bucket. If parser status lists `none`, do not start parser bucket work from stale context; refresh the Linux corpus receipt or move to the next provider or real-workspace trust lane.

--- a/xtask/src/tasks/metrics/parser_accuracy.rs
+++ b/xtask/src/tasks/metrics/parser_accuracy.rs
@@ -6335,7 +6335,7 @@ fn render_next_pointer_status_receipt(artifact: &ParserAccuracyArtifact) -> Stri
         if has_no_gaps {
             output.push_str("\n## Capability Handoff\n\n");
             output.push_str(
-                "Measurement wiring is clear. Follow [`parser.md`](parser.md#raw-failure-buckets) for capability work; take the largest raw bucket inside the largest nonzero parser failure cluster as the next parser lane and keep it separate from measurement-only work.\n",
+                "Measurement wiring is clear. Follow [`parser.md`](parser.md#raw-failure-buckets) for capability work only when the generated parser status lists a nonzero raw failure bucket. If parser status lists `none`, do not start parser bucket work from stale context; refresh the Linux corpus receipt or move to the next provider or real-workspace trust lane.\n",
             );
         }
     }
@@ -8545,9 +8545,11 @@ sub dynamic_boundary_case {
         assert!(pointer.contains("## Capability Handoff"));
         assert!(pointer.contains("parser.md#raw-failure-buckets"));
         assert!(
-            pointer
-                .contains("largest raw bucket inside the largest nonzero parser failure cluster")
+            pointer.contains(
+                "only when the generated parser status lists a nonzero raw failure bucket"
+            )
         );
+        assert!(pointer.contains("do not start parser bucket work from stale context"));
         assert!(matches!(
             (
                 pointer.find("Use the measurement gap table only"),


### PR DESCRIPTION
Problem: parser_accuracy_next.md could still route agents to raw parser bucket work when generated parser.md lists no nonzero raw failure buckets.

Fix: update the generated next-pointer wording and snapshot test so zero-bucket status tells agents to refresh the Linux corpus receipt or move to the next provider/real-workspace trust lane.

Claim boundary: status/control-plane wording only; no parser behavior change; no support-tier promotion; no parser bucket movement claim.

Verification:
- rtk cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt
- rtk cargo xtask update-status --write --only parser
- rtk cargo test -p xtask next_pointer_hands_off_when_measurement_queue_is_empty --profile agent --locked -- --nocapture
- rtk cargo test -p xtask status_receipts_export_failure_packets_inventory_worklist_and_pointer --profile agent --locked -- --nocapture
- rtk cargo test -p xtask parser_failure_worklist_handles_empty_buckets --profile agent --locked -- --nocapture
- rtk cargo xtask update-status --only parser --check
- rtk cargo xtask fmt --check
- rtk git diff --check