### PR TITLE
docs(status): close real Perl editor trust goal (#8197)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -1,12 +1,14 @@
 id = "plsp-real-perl-editor-trust"
 title = "Real Perl editor trust"
-status = "active"
+status = "completed"
 owner = "codex-swarm"
 created = "2026-05-13"
+completed = "2026-05-18"
 
 proposal = "docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md"
 plan = "plans/real-perl-editor-trust/implementation-plan.md"
 status_pointer = "docs/project/status/parser_accuracy_next.md"
+closeout_receipt = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
 
 specs = [
   "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md",

--- a/plans/real-perl-editor-trust/implementation-plan.md
+++ b/plans/real-perl-editor-trust/implementation-plan.md
@@ -1,6 +1,6 @@
 # Real Perl Editor Trust Implementation Plan
 
-Status: active
+Status: completed
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked specs:
@@ -11,7 +11,7 @@ Linked specs:
 Linked ADRs:
 - [PLSP-ADR-0001](../../docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
 - [PLSP-ADR-0002](../../docs/adr/PLSP-ADR-0002-confidence-before-cutover.md)
-Active goal: [active.toml](../../.perl-lsp/goals/active.toml)
+Goal manifest: [active.toml](../../.perl-lsp/goals/active.toml)
 
 ## Current State
 
@@ -647,14 +647,17 @@ Completion audit
 - Provider confidence: `provider_confidence_matrix.md` maps provider source,
   confidence, freshness, fallback, runtime comparison, real-workspace links,
   live state, and next proof.
-- Real-workspace proof: the 2026-05-13 Mojolicious Windows receipt records the
-  covered editor-latency surfaces and explicit deferrals.
+- Real-workspace proof: the Mojolicious and Dancer2 Windows receipts record the
+  covered editor-latency surfaces and explicit deferrals; the real-project
+  resource receipt records fixture file, line, and byte shape while leaving RSS
+  and heap ceilings to memory plateau receipts.
 - Support claims: `SUPPORT_TIERS.md` maps user-facing claims to proof commands,
   status docs, known limitations, and next promotion proof.
 
 Proof commands
 
 ```bash
+cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt
 cargo xtask update-status --only parser --check
 cargo xtask semantic-scorecard --check
 cargo xtask semantic-shadow-compare --check


### PR DESCRIPTION
Problem: The Real Perl Editor Trust work items are completed or explicitly deferred, but the machine-readable goal manifest and plan header still say the lane is active.

Fix: Mark the goal manifest and implementation plan completed, point the manifest at the closeout receipt, refresh the plan's real-workspace audit wording for the Dancer2/resource receipts, and include the common-corpus receipt prerequisite before parser status checking.

Claim boundary:
- Bookkeeping/status closeout only.
- No provider behavior change, parser behavior change, generated status edit, support-tier promotion, or corpus bucket movement claim.
- Deferred parser/Linux-corpus work remains routed to fresh evidence or its successor lane.

Verification:
- `cargo run -p xtask -- parser-corpus-sweep --manifest .ci/common-corpus-manifest.txt --enforce --receipt`
- `cargo xtask update-status --only parser --check`
- `cargo xtask semantic-scorecard --check`
- `cargo xtask semantic-shadow-compare --check`
- `cargo xtask check-support-claims`
- `cargo xtask check-provider-confidence-matrix`
- `cargo xtask fmt --check`
- `git diff --check`