### PR TITLE
chore(perl-token): mark TokenCategory and TokenKindMetadata as #[non_exhaustive] (#8726)

### DIFF
--- a/crates/perl-token/src/lib.rs
+++ b/crates/perl-token/src/lib.rs
@@ -622,6 +622,11 @@ pub enum TokenKind {
 }
 
 /// Broad classification used for token metadata and conformance checks.
+///
+/// This enum is `#[non_exhaustive]`: external code must include a wildcard `_`
+/// arm when matching on it. This allows new categories to be added in future
+/// releases without breaking downstream crates.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenCategory {
     /// Reserved words and language keywords.
@@ -639,6 +644,12 @@ pub enum TokenCategory {
 }
 
 /// Metadata associated with each [`TokenKind`] variant.
+///
+/// This struct is `#[non_exhaustive]`: external code must not construct it
+/// using struct literal syntax. Use [`TokenKind::metadata`] to obtain
+/// instances. Additional fields may be added in future releases without
+/// constituting a breaking change.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TokenKindMetadata {
     /// Stable category used in docs/tests/gates.

--- a/crates/perl-token/tests/conformance_guards.rs
+++ b/crates/perl-token/tests/conformance_guards.rs
@@ -195,6 +195,8 @@ fn tokenkind_metadata_is_complete_and_in_sync() {
             | TokenCategory::Literal
             | TokenCategory::Identifier
             | TokenCategory::Special => {}
+            // Required by #[non_exhaustive]: catch any future category variants.
+            _ => {}
         }
     }
 }

--- a/crates/perl-token/tests/token_kind_metadata_tests.rs
+++ b/crates/perl-token/tests/token_kind_metadata_tests.rs
@@ -64,7 +64,8 @@ fn canonical_spelling_tables_cover_parser_facing_categories() {
                     "sigil {kind:?} needs canonical spelling metadata"
                 );
             }
-            TokenCategory::Identifier | TokenCategory::Literal | TokenCategory::Special => {}
+            // Required by #[non_exhaustive]: catch any future category variants.
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
Problem: perl-token exposes token category and metadata types that may need future variants or fields.
Fix: mark TokenCategory and TokenKindMetadata as #[non_exhaustive], and update external-style integration tests to use wildcard match arms.
Verification: cargo test -p perl-token passed; cargo check --all-targets -p perl-token passed; cargo clippy -p perl-token --all-targets -- -D warnings passed; cargo xtask fmt passed; git diff --check passed; parser accuracy/status/ratchet/provider matrix checks passed.