### PR TITLE
docs(spec): promote Real Perl Editor Trust specs to accepted (#8197)

### DIFF
--- a/docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md
+++ b/docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md
@@ -1,11 +1,29 @@
 # PLSP-SPEC-0001: Parser compatibility bucket closeout
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
-Linked ADRs: planned `PLSP-ADR-0001`
-Linked plan: planned `plans/real-perl-editor-trust/implementation-plan.md`
+Linked ADRs: [PLSP-ADR-0001](../adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Implemented by:
+- [parser accuracy next](../project/status/parser_accuracy_next.md)
+- [parser status](../project/status/parser.md)
+- [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+- [completed active goal manifest](../../.perl-lsp/goals/active.toml)
 Status impact: parser accuracy next, parser status, parser receipts
+
+## Current implementation status
+
+This spec is implemented as a control-plane rule. Current evidence lives in:
+
+- [parser accuracy next](../project/status/parser_accuracy_next.md)
+- [parser raw failure buckets](../project/status/parser.md#raw-failure-buckets)
+- [Real Perl Editor Trust routing dashboard](../project/status/real_perl_editor_trust_v1.md)
+- [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+- [completed active goal manifest](../../.perl-lsp/goals/active.toml)
+
+Current next work is not stored here; see the routing dashboard and generated
+parser status.
 
 ## Contract
 

--- a/docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md
+++ b/docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md
@@ -1,12 +1,34 @@
 # PLSP-SPEC-0002: Provider confidence receipts
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
-Linked ADRs: planned `PLSP-ADR-0002`
-Linked plan: planned `plans/real-perl-editor-trust/implementation-plan.md`
+Linked ADRs: [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Implemented by:
+- [provider confidence matrix](../project/status/provider_confidence_matrix.md)
+- [provider cutover](../project/status/provider_cutover.md)
+- [semantic scorecard](../project/status/semantic_scorecard.md)
+- [semantic shadow compare](../project/status/semantic_shadow_compare.md)
+- [support tiers](../project/status/SUPPORT_TIERS.md)
+- [completed active goal manifest](../../.perl-lsp/goals/active.toml)
 Status impact: provider cutover, semantic scorecard, semantic shadow compare,
 UX capability dashboard
+
+## Current implementation status
+
+This spec is implemented as a control-plane rule. Current evidence lives in:
+
+- [provider confidence matrix](../project/status/provider_confidence_matrix.md)
+- [provider cutover](../project/status/provider_cutover.md)
+- [semantic scorecard](../project/status/semantic_scorecard.md)
+- [semantic shadow compare](../project/status/semantic_shadow_compare.md)
+- [support tiers](../project/status/SUPPORT_TIERS.md)
+- [Real Perl Editor Trust routing dashboard](../project/status/real_perl_editor_trust_v1.md)
+- [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+
+Current next work is not stored here; see the routing dashboard and provider
+status surfaces.
 
 ## Contract
 

--- a/docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md
+++ b/docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md
@@ -1,13 +1,33 @@
 # PLSP-SPEC-0003: Real-workspace editor baseline
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked specs:
 - [PLSP-SPEC-0002](PLSP-SPEC-0002-provider-confidence-receipts.md)
-Linked ADRs: planned `PLSP-ADR-0002`
-Linked plan: planned `plans/real-perl-editor-trust/implementation-plan.md`
+Linked ADRs: [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Implemented by:
+- [real-workspace baseline rail](../development/REAL_WORKSPACE_BASELINE_RAIL.md)
+- [Mojolicious baseline receipt](../forensics/2026-05-13-real-workspace-baseline-mojolicious.md)
+- [Dancer2 baseline receipt](../forensics/2026-05-14-real-workspace-baseline-dancer2.md)
+- [provider confidence matrix](../project/status/provider_confidence_matrix.md)
+- [completed active goal manifest](../../.perl-lsp/goals/active.toml)
 Status impact: provider cutover, semantic dashboards, real-workspace receipts
+
+## Current implementation status
+
+This spec is implemented as a control-plane rule. Current evidence lives in:
+
+- [real-workspace baseline rail](../development/REAL_WORKSPACE_BASELINE_RAIL.md)
+- [Mojolicious baseline receipt](../forensics/2026-05-13-real-workspace-baseline-mojolicious.md)
+- [Dancer2 baseline receipt](../forensics/2026-05-14-real-workspace-baseline-dancer2.md)
+- [provider confidence matrix](../project/status/provider_confidence_matrix.md)
+- [support tiers](../project/status/SUPPORT_TIERS.md)
+- [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+
+Current next work is not stored here; see the routing dashboard and real
+workspace receipt/status surfaces.
 
 ## Contract
 

--- a/docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md
+++ b/docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md
@@ -1,13 +1,32 @@
 # PLSP-SPEC-0004: Corpus receipt freshness
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked specs:
 - [PLSP-SPEC-0001](PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md)
-Linked ADRs: planned `PLSP-ADR-0001`
-Linked plan: planned `plans/real-perl-editor-trust/implementation-plan.md`
+Linked ADRs: [PLSP-ADR-0001](../adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Implemented by:
+- [parser status](../project/status/parser.md)
+- [parser accuracy next](../project/status/parser_accuracy_next.md)
+- [Linux corpus refresh receipt](../forensics/2026-05-18-linux-system-corpus-refresh.md)
+- [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+- [completed active goal manifest](../../.perl-lsp/goals/active.toml)
 Status impact: parser status, parser raw buckets, support claims
+
+## Current implementation status
+
+This spec is implemented as a control-plane rule. Current evidence lives in:
+
+- [parser status](../project/status/parser.md)
+- [parser accuracy next](../project/status/parser_accuracy_next.md)
+- [Linux corpus refresh receipt](../forensics/2026-05-18-linux-system-corpus-refresh.md)
+- [Real Perl Editor Trust routing dashboard](../project/status/real_perl_editor_trust_v1.md)
+- [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+
+Current next work is not stored here; see the routing dashboard and generated
+parser status.
 
 ## Contract
 


### PR DESCRIPTION
Problem: The original Real Perl Editor Trust specs still read as proposed scaffolding even though the control-plane lane has landed. 
Fix: Mark PLSP-SPEC-0001 through 0004 accepted, replace planned ADR/plan pointers with live links, and add current implementation-status pointers to the evidence/status surfaces without copying dashboard rows. 
Claim boundary: Docs/spec metadata only; no generated status edits, support-tier promotion, validator change, or provider behavior change. 
Verification: tk cargo xtask check-support-claims; tk cargo xtask check-provider-confidence-matrix; tk git diff --check.