### PR TITLE
docs(spec): define edit-producing provider safety (#8197)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -107,7 +107,10 @@ Decision records, project status, and planning documents.
 - [0.14.0 Readiness Queue](releases/0.14.0-readiness.md) — current-release meta-roadmap: drain queue + implementation phase + release lock
 - [Project Roadmap](project/ROADMAP.md)
 - [Compiler-Backed LSP Roadmap](project/COMPILER_BACKED_LSP_ROADMAP.md)
+- [Preview Before Edit ADR](adr/PLSP-ADR-0003-preview-before-edit.md)
 - [PR Queue Disposition Spec](specs/PLSP-SPEC-0006-pr-queue-disposition.md)
+- [Receiver-Fact Completion Spec](specs/PLSP-SPEC-0007-receiver-fact-completion.md)
+- [Edit-Producing Provider Safety Spec](specs/PLSP-SPEC-0008-edit-producing-provider-safety.md)
 - [Receiver Expression Facts Spec](specs/PLSP-SPEC-0005-receiver-expression-facts.md) and [Receiver Facts Implementation Plan](project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md)
 - [Project Milestones](project/MILESTONES.md)
 - [Feature Governance](project/FEATURE_GOVERNANCE.md)

--- a/docs/adr/PLSP-ADR-0003-preview-before-edit.md
+++ b/docs/adr/PLSP-ADR-0003-preview-before-edit.md
@@ -1,0 +1,115 @@
+# PLSP-ADR-0003: Preview before edit
+
+Status: accepted
+Date: 2026-05-19
+Owner: perl-lsp maintainers
+Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked specs:
+- [PLSP-SPEC-0002](../specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
+- [PLSP-SPEC-0006](../specs/PLSP-SPEC-0006-edit-producing-provider-safety.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+
+## Context
+
+Edit-producing providers are not ordinary query providers. A wrong completion,
+hover, symbol, or navigation result is visible noise. A wrong rename or safe
+delete can damage source.
+
+`perl-lsp` supports increasingly precise compiler-backed and semantic facts,
+but Perl remains dynamic. Generated members, runtime imports, typeglobs,
+symbolic references, stale compiler facts, and ambiguous workspace identity can
+all make an edit look safe when it is not.
+
+The repo already uses previews, provider receipts, blocker reasons, rollback
+proof, and narrow live pilots for rename and safe delete. This ADR makes that
+architecture decision durable.
+
+## Decision
+
+Edit-producing providers must pass through preview/no-edit, receipt, rollback,
+and blocker proof before narrow live cutover.
+
+Rename and safe delete may be conservative by design. They must refuse,
+preview, or fall back when proof is missing instead of returning speculative
+edits.
+
+Preview commands are product surfaces. They allow users and support workflows to
+inspect planned edits, blockers, fallback reasons, and copyable receipts before
+any live edit class is broadened.
+
+## Rules
+
+1. Preview comes before live edit expansion.
+2. Receipt-only PRs cannot broaden live edit behavior.
+3. Rollback proof is required before a new live edit class is promoted.
+4. Fresh source-backed identity is required before edits are returned.
+5. Generated, dynamic, stale, low-confidence, ambiguous, fallback, and no-source
+   facts cannot authorize edits.
+6. The server may return `WorkspaceEdit` values to the client, but it must not
+   apply those edits itself.
+7. Support-tier promotion requires proof commands and explicit status review.
+8. PR bodies must state whether the change is preview-only, receipt-only,
+   rollback proof, or live cutover.
+
+## Consequences
+
+Positive consequences:
+
+- Rename and safe delete can ship useful narrow slices without pretending broad
+  static certainty exists.
+- Users get a safer preview path for destructive actions.
+- Bug reports can include structured blocker and rollback receipts.
+- Future agents have a durable rule that prevents treating edit-producing
+  providers like completion or hover.
+
+Tradeoffs:
+
+- Some edits remain unavailable even when facts look promising.
+- Live refactor behavior grows more slowly than read-only provider behavior.
+- More tests and status review are required before edit cutover.
+- Preview commands must be maintained as stable UX, not removed after pilots.
+
+## Alternatives Considered
+
+### Treat rename and safe delete like ordinary providers
+
+Rejected. Query providers can fall back visibly when confidence is low. Edit
+providers need a fail-closed path because mistakes change source.
+
+### Allow compiler-backed edits whenever facts are high confidence
+
+Rejected. High confidence alone is not enough for edits. Freshness, source
+backing, identity guards, current-source reference checks, workspace-reference
+checks, and rollback proof are also required for the relevant edit class.
+
+### Keep previews as temporary scaffolding
+
+Rejected. Preview commands are the user-facing way to understand planned edits
+and blockers. They remain useful even after a narrow live pilot exists because
+broader edit classes must still be explainable without returning edits.
+
+## Follow-up Obligations
+
+- Keep [PLSP-SPEC-0006](../specs/PLSP-SPEC-0006-edit-producing-provider-safety.md)
+  linked from rename and safe-delete cutover work.
+- Keep preview commands documented as user-facing product surfaces.
+- Keep support tiers explicit that rename and safe delete are
+  `partial-live-with-fallback` unless proof promotes a scoped claim.
+- Keep generated, dynamic, stale, low-confidence, ambiguous, imported/exported,
+  referenced, no-source, non-subroutine, and package-wide boundaries visible in
+  provider receipts.
+
+## Status Links
+
+- [Provider confidence matrix](../project/status/provider_confidence_matrix.md)
+- [Provider cutover](../project/status/provider_cutover.md)
+- [Provider promotion ledger](../project/status/provider_promotion_ledger.md)
+- [Support tiers](../project/status/SUPPORT_TIERS.md)
+- [UX capability dashboard](../project/status/ux_capability_dashboard.md)
+- [Editor trust user guide](../how-to/EDITOR_TRUST.md)
+
+## Why ADR-worthy
+
+Preview-before-edit is an architecture decision, not only a test policy. It
+defines how destructive provider behavior becomes live and why conservative
+no-edit behavior is correct when proof is incomplete.

--- a/docs/adr/PLSP-ADR-0003-preview-before-edit.md
+++ b/docs/adr/PLSP-ADR-0003-preview-before-edit.md
@@ -6,7 +6,7 @@ Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked specs:
 - [PLSP-SPEC-0002](../specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
-- [PLSP-SPEC-0006](../specs/PLSP-SPEC-0006-edit-producing-provider-safety.md)
+- [PLSP-SPEC-0008](../specs/PLSP-SPEC-0008-edit-producing-provider-safety.md)
 Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
 
 ## Context
@@ -90,7 +90,7 @@ broader edit classes must still be explainable without returning edits.
 
 ## Follow-up Obligations
 
-- Keep [PLSP-SPEC-0006](../specs/PLSP-SPEC-0006-edit-producing-provider-safety.md)
+- Keep [PLSP-SPEC-0008](../specs/PLSP-SPEC-0008-edit-producing-provider-safety.md)
   linked from rename and safe-delete cutover work.
 - Keep preview commands documented as user-facing product surfaces.
 - Keep support tiers explicit that rename and safe delete are

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ Current generated and human-owned status sources include:
 |-----|--------|------|-------|-------------|
 | [PLSP-ADR-0001](PLSP-ADR-0001-generated-status-is-control-plane.md) | Accepted | 2026-05-13 | Generated Status Is Control Plane | Generated status routes parser and editor-trust work, while specs and plans interpret it without duplicating generated content |
 | [PLSP-ADR-0002](PLSP-ADR-0002-confidence-before-cutover.md) | Accepted | 2026-05-13 | Confidence Before Provider Cutover | Compiler-backed provider behavior requires confidence, freshness, fallback, blocker, and live-comparison receipts before broader cutover |
+| [PLSP-ADR-0003](PLSP-ADR-0003-preview-before-edit.md) | Accepted | 2026-05-19 | Preview Before Edit | Edit-producing providers require preview/no-edit, receipt, rollback, and blocker proof before broader live cutover |
 
 ### Legacy Series (0001–0002)
 

--- a/docs/specs/PLSP-SPEC-0006-edit-producing-provider-safety.md
+++ b/docs/specs/PLSP-SPEC-0006-edit-producing-provider-safety.md
@@ -1,0 +1,213 @@
+# PLSP-SPEC-0006: Edit-producing provider safety
+
+Status: accepted
+Owner: perl-lsp maintainers
+Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked ADRs:
+- [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
+- [PLSP-ADR-0003](../adr/PLSP-ADR-0003-preview-before-edit.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Status impact: provider confidence matrix, provider cutover, support tiers,
+semantic shadow compare, UX capability dashboard
+
+## Contract
+
+Any provider that returns a `WorkspaceEdit` must prove safety before producing
+edits.
+
+Edit-producing providers are stricter than read-only providers. Completion,
+hover, symbols, diagnostics, and navigation can be wrong in visible ways;
+rename and safe delete can damage source. They must fail closed when proof is
+missing.
+
+This spec sharpens [PLSP-SPEC-0002](PLSP-SPEC-0002-provider-confidence-receipts.md)
+for providers that can return edits. It does not replace the provider receipt
+contract; it defines the additional safety bar for edit output.
+
+## Shared Safety Rules
+
+Edit-producing providers must satisfy these rules before returning non-empty
+edits:
+
+- preview before edit
+- rollback before promotion
+- source-backed proof before live edits
+- freshness proof before edit
+- identity guard before edit
+- fallback or no-edit behavior when proof is missing
+- generated, dynamic, stale, low-confidence, ambiguous, fallback, and no-source
+  facts cannot authorize edits
+- the server returns `WorkspaceEdit` values to the client but does not apply
+  them itself
+
+Preview commands are product surfaces. They are not temporary scaffolding and
+must remain available for broader request shapes that are not live edit classes.
+
+## Rename Requirements
+
+Rename may return edits only for scoped classes that have explicit proof.
+
+Same-file lexical rename is scoped to current-document source proof. It may
+return edits only when the current source proves exactly one `my` or `state`
+declaration identity and all returned edits remain inside the proven scope.
+
+The package-local pilot may return edits only when all of these hold:
+
+- the request targets a fresh source-backed semantic edit set
+- the materialized semantic edit set exactly matches the workspace
+  source/ambiguity guard
+- the current-source and workspace-index evidence agree on identity
+- rollback or no-edit behavior is proven
+- imported, exported, ambiguous, generated, dynamic, stale, low-confidence,
+  package-wide, missing-proof, and partial unsafe plans return no edits or
+  fall back to the existing safe path
+- `didChange` freshness has been proven for the request shape before edits are
+  returned
+
+Partial semantic plans may fall back only to an already-safe legacy or
+workspace-index path. They must not become broader compiler-backed rename.
+
+## Safe-Delete Requirements
+
+Safe delete may return edits only for exact unreferenced source-backed
+subroutine deletion.
+
+The live pilot may return a delete `WorkspaceEdit` only when all of these hold:
+
+- compiler allow proof is fresh and high-confidence
+- the source guard resolves an exact source-backed subroutine definition
+- current-source references are zero
+- workspace-index references are zero
+- workspace identity guard accepts the target
+- rollback proof restores the original text
+
+These request classes must return no edit:
+
+- non-subroutine target
+- package-wide target
+- generated or no-source symbol
+- dynamic-boundary symbol
+- stale fact
+- low-confidence fact
+- imported or exported symbol
+- referenced symbol
+- current-source referenced target
+- workspace-index referenced target
+- ambiguous identity
+- fallback/no-source candidate
+- rollback failure
+
+`workspace/willDeleteFiles` warning behavior is separate from symbol safe delete
+and does not authorize symbol deletion.
+
+## Valid PR Shapes
+
+Valid PRs under this spec include:
+
+- preview-only PRs that expose planned edits, blockers, and no-edit decisions
+- receipt PRs that prove stale, generated, dynamic, low-confidence, referenced,
+  imported/exported, or ambiguous cases return no edit
+- rollback PRs that prove a returned `WorkspaceEdit` can be inverted
+- narrow live pilot PRs that return edits only for one source-backed class with
+  fallback and blocker proof
+- status PRs that review support claims after proof already landed
+
+Every PR must state whether it is preview-only, receipt-only, rollback proof,
+or live cutover.
+
+## Invalid PR Shapes
+
+Invalid PRs include:
+
+- broad live rename or safe-delete cutover from receipt-only proof
+- edits authorized by stale, generated, dynamic, low-confidence, fallback, or
+  no-source facts
+- package-wide rename or deletion without an explicit safety spec and proof
+- imported/exported or ambiguous package-local rename returning edits
+- referenced, generated/no-source, non-subroutine, or package-wide safe delete
+  returning edits
+- server-side edit application
+- support-tier promotion without proof commands and status review
+- docs/status changes that imply broader edit behavior without provider proof
+
+## Acceptance
+
+An edit-producing provider PR satisfies this spec when:
+
+- returned edits are limited to the scoped live class named by the PR
+- no-edit and fallback paths are tested for near-miss cases
+- blocker reasons are user-visible through provider receipts or preview output
+- rollback proof exists before a live edit class is promoted
+- current-source freshness is proven for request shapes affected by edits
+- dynamic, generated, stale, low-confidence, ambiguous, imported/exported, and
+  no-source cases cannot authorize edits
+- the PR body states claim boundary, fallback/no-edit behavior, and validation
+- support-tier rows are updated only when the proof covers the claim
+
+## Proof Commands
+
+Focused edit-provider proof uses provider-specific tests plus the support gates:
+
+```bash
+cargo test -p perl-lsp-rs-core --lib rename_shadow --profile agent --locked -- --nocapture
+cargo test -p perl-lsp-rs-core --lib safe_delete_shadow --profile agent --locked -- --nocapture
+cargo test -p perl-lsp-rs-core --lib rename_package_pilot --profile agent --locked -- --nocapture
+cargo test -p perl-lsp-rs --lib refactor_runtime_blocker --profile agent --locked -- --nocapture
+cargo xtask semantic-shadow-compare --check
+cargo xtask check-provider-confidence-matrix
+cargo xtask check-support-claims
+git diff --check
+```
+
+Live cutover PRs must add narrower runtime receipt commands for the specific
+rename or safe-delete class being promoted.
+
+Docs-only PRs for this spec may use:
+
+```bash
+cargo xtask check-provider-confidence-matrix
+cargo xtask check-support-claims
+git diff --check
+```
+
+## Non-goals
+
+- No broad compiler-backed rename cutover.
+- No broad symbol deletion.
+- No package-wide rename or package-wide deletion.
+- No generated/no-source edit authorization.
+- No dynamic Perl edit authorization.
+- No server-side application of workspace edits.
+- No support-tier promotion from this spec alone.
+
+## Claim Boundaries
+
+Rename remains `partial-live-with-fallback` unless support tiers, provider
+confidence, and runtime receipts prove a narrower or broader claim. Same-file
+lexical rename and the package-local pilot are distinct live classes; proof for
+one does not promote the other.
+
+Safe delete remains `partial-live-with-fallback` for exact unreferenced
+source-backed subroutine deletion. Proof for a source-backed subroutine does
+not promote generated, dynamic, non-subroutine, package-wide, imported/exported,
+referenced, fallback, or no-source deletion.
+
+Preview and receipt PRs may claim explainable no-edit behavior. They may not
+claim live edit behavior unless they also prove rollback, freshness, identity,
+and fallback boundaries.
+
+## Current Evidence Owners
+
+Current state and evidence live outside this spec:
+
+- [Provider confidence matrix](../project/status/provider_confidence_matrix.md)
+- [Provider cutover](../project/status/provider_cutover.md)
+- [Provider promotion ledger](../project/status/provider_promotion_ledger.md)
+- [Support tiers](../project/status/SUPPORT_TIERS.md)
+- [Semantic shadow compare](../project/status/semantic_shadow_compare.md)
+- [Semantic scorecard](../project/status/semantic_scorecard.md)
+- [UX capability dashboard](../project/status/ux_capability_dashboard.md)
+- [Editor trust user guide](../how-to/EDITOR_TRUST.md)
+
+Do not copy current receipt rows, generated parser state, active PR order, or
+one-off CI failures into this spec.

--- a/docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md
+++ b/docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md
@@ -1,4 +1,4 @@
-# PLSP-SPEC-0006: Edit-producing provider safety
+# PLSP-SPEC-0008: Edit-producing provider safety
 
 Status: accepted
 Owner: perl-lsp maintainers

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -26,6 +26,8 @@ generated sections.
 - [PLSP-SPEC-0004: Corpus receipt freshness](PLSP-SPEC-0004-corpus-receipt-freshness.md)
 - [PLSP-SPEC-0005: Receiver expression facts](PLSP-SPEC-0005-receiver-expression-facts.md)
 - [PLSP-SPEC-0006: PR queue disposition](PLSP-SPEC-0006-pr-queue-disposition.md)
+- [PLSP-SPEC-0007: Receiver-fact completion](PLSP-SPEC-0007-receiver-fact-completion.md)
+- [PLSP-SPEC-0008: Edit-producing provider safety](PLSP-SPEC-0008-edit-producing-provider-safety.md)
 
 ## Acceptance and Proof
 


### PR DESCRIPTION
Problem: Rename and safe-delete safety rules were encoded mainly in status rows and receipts.\nFix: Add PLSP-SPEC-0006 for WorkspaceEdit provider safety and PLSP-ADR-0003 to make preview-before-edit a durable architecture decision.\nVerification: \cargo xtask check-provider-confidence-matrix\ passes with an explicit out-of-worktree target dir; \cargo xtask check-support-claims\ passes with the same target dir; \git diff --cached --check\ passes.