### PR TITLE
docs(status): record receiver facts implementation state (#8197)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -15,8 +15,6 @@ specs = [
   "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md",
   "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md",
   "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md",
-  "docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md",
-  "docs/specs/PLSP-SPEC-0006-pr-queue-disposition.md",
 ]
 
 adrs = [
@@ -50,29 +48,10 @@ status_docs = [
   "docs/project/status/parser.md",
   "docs/project/status/provider_cutover.md",
   "docs/project/status/provider_confidence_matrix.md",
-  "docs/project/status/receiver_facts.md",
   "docs/project/status/SUPPORT_TIERS.md",
   "docs/project/status/ux_capability_dashboard.md",
   "docs/project/status/semantic_scorecard.md",
   "docs/project/status/semantic_shadow_compare.md",
-]
-
-[[work_item]]
-id = "receiver-facts-foundation"
-status = "partial"
-spec = "docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md"
-adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
-plan = "docs/project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md"
-current_pointer = "docs/project/status/receiver_facts.md"
-receipt = "https://github.com/EffortlessMetrics/perl-lsp/pull/9468"
-claim_boundary = "Semantic substrate only; no completion candidate behavior change and no support-tier promotion."
-commands = [
-  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-semantic-analyzer --test type_facts --profile agent --locked",
-  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-semantic-analyzer --lib receiver_facts --profile agent --locked -- --nocapture",
-  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe check --all-targets -p perl-semantic-analyzer --profile agent --locked",
-  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs",
-  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt",
-  "git diff --check",
 ]
 
 [[work_item]]

--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -15,6 +15,8 @@ specs = [
   "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md",
   "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md",
   "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md",
+  "docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md",
+  "docs/specs/PLSP-SPEC-0006-pr-queue-disposition.md",
 ]
 
 adrs = [
@@ -48,10 +50,29 @@ status_docs = [
   "docs/project/status/parser.md",
   "docs/project/status/provider_cutover.md",
   "docs/project/status/provider_confidence_matrix.md",
+  "docs/project/status/receiver_facts.md",
   "docs/project/status/SUPPORT_TIERS.md",
   "docs/project/status/ux_capability_dashboard.md",
   "docs/project/status/semantic_scorecard.md",
   "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[work_item]]
+id = "receiver-facts-foundation"
+status = "partial"
+spec = "docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md"
+adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
+plan = "docs/project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md"
+current_pointer = "docs/project/status/receiver_facts.md"
+receipt = "https://github.com/EffortlessMetrics/perl-lsp/pull/9468"
+claim_boundary = "Semantic substrate only; no completion candidate behavior change and no support-tier promotion."
+commands = [
+  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-semantic-analyzer --test type_facts --profile agent --locked",
+  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-semantic-analyzer --lib receiver_facts --profile agent --locked -- --nocapture",
+  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe check --all-targets -p perl-semantic-analyzer --profile agent --locked",
+  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs",
+  "MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt",
+  "git diff --check",
 ]
 
 [[work_item]]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -113,7 +113,7 @@ Decision records, project status, and planning documents.
 - [Edit-Producing Provider Safety Spec](specs/PLSP-SPEC-0008-edit-producing-provider-safety.md)
 - [Workspace Trust Report Spec](specs/PLSP-SPEC-0009-workspace-trust-report.md)
 - [Support Claim Map Spec](specs/PLSP-SPEC-0010-support-claim-map.md)
-- [Receiver Expression Facts Spec](specs/PLSP-SPEC-0005-receiver-expression-facts.md) and [Receiver Facts Implementation Plan](project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md)
+- [Receiver Expression Facts Spec](specs/PLSP-SPEC-0005-receiver-expression-facts.md), [Receiver Facts Implementation Plan](project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md), and [Receiver Facts Status](project/status/receiver_facts.md)
 - [Project Milestones](project/MILESTONES.md)
 - [Feature Governance](project/FEATURE_GOVERNANCE.md)
 - [Metric Stack](project/metrics/README.md) — contributor-facing summary of the layered scorecard model and the ratchet

--- a/docs/project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md
+++ b/docs/project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md
@@ -1,9 +1,10 @@
 # Receiver Facts Implementation Plan
 
-Status: proposed
+Status: partial substrate landed; completion cutover blocked
 Owner: perl-lsp maintainers
 Spec: [PLSP-SPEC-0005: Receiver expression facts](../specs/PLSP-SPEC-0005-receiver-expression-facts.md)
 Related proposal: [PLSP-PROP-0001: Real Perl editor trust](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Current status: [receiver facts status](status/receiver_facts.md)
 
 ## Objective
 
@@ -20,6 +21,24 @@ parse receiver expression
 The implementation should recognize the AST shapes that already exist for
 postfix access and method calls. It should add semantic facts on top of the AST,
 not a parser rewrite and not new AST node variants in the first wave.
+
+## Current Implementation Status
+
+The current foundation, merged in
+[#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468), is a
+facts-only semantic substrate. It adds the rich fact model, a parallel
+type-environment fact map, and a receiver-fact extractor over existing
+`TypeFact` and `ShapeFact` evidence.
+
+That foundation does not yet add source-level expression inference and does not
+change completion candidates. Current detailed status lives in
+[receiver_facts.md](status/receiver_facts.md). The active claim boundary remains:
+
+```text
+semantic substrate only
+no completion candidate behavior change
+no support-tier promotion
+```
 
 ## Design Choice Locked for the First Wave
 

--- a/docs/project/status/receiver_facts.md
+++ b/docs/project/status/receiver_facts.md
@@ -1,0 +1,102 @@
+# Receiver Facts Status
+
+> Human-owned. This page tracks implementation state for
+> [PLSP-SPEC-0005](../../specs/PLSP-SPEC-0005-receiver-expression-facts.md).
+> It does not generate metrics, broaden completion behavior, or replace
+> provider cutover receipts.
+
+Receiver facts are the semantic substrate for evidence-backed method receiver
+behavior. Fact availability alone is not provider cutover. Completion, hover,
+goto, diagnostics, or refactors may consume receiver facts only after their
+provider-specific fallback and confidence receipts satisfy
+[PLSP-SPEC-0002](../../specs/PLSP-SPEC-0002-provider-confidence-receipts.md).
+
+Current implementation plan:
+[RECEIVER_FACTS_IMPLEMENTATION_PLAN.md](../RECEIVER_FACTS_IMPLEMENTATION_PLAN.md).
+Current provider cutover state:
+[provider_cutover.md](provider_cutover.md).
+
+## Claim Boundary
+
+Current receiver-facts work is semantic substrate only.
+
+It may claim:
+
+- rich fact model and type-environment storage where tests prove it
+- receiver extraction over existing `TypeFact` and `ShapeFact` evidence
+- dynamic-key boundaries for receiver extraction
+- no completion candidate behavior change
+
+It may not claim:
+
+- receiver-backed completion cutover
+- hover, goto, diagnostics, or refactor behavior changes
+- support-tier promotion
+- expression-level fact inference from Perl source declarations and
+  assignments until `infer_expr_fact` or equivalent fixtures prove it
+
+Facts-only PRs must keep this wording in their claim boundary:
+
+```text
+semantic substrate only
+no completion candidate behavior change
+no support-tier promotion
+```
+
+## Status Rows
+
+| Area | Status | Current proof | Boundary / next step |
+| --- | --- | --- | --- |
+| `fact_model` | `landed` | `crates/perl-semantic-analyzer/src/analysis/type_facts.rs`; `crates/perl-semantic-analyzer/tests/type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | `TypeFact`, `ShapeFact`, `HashShape`, `ArrayShape`, `ObjectShape`, `TypeEvidence`, and `DynamicBoundary` exist as substrate. |
+| `type_environment_fact_map` | `landed` | `TypeEnvironment::set_variable_fact`, `get_variable_fact`, `get_fact_at`; stale fact clearing and parent lookup tests in `type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Existing `PerlType` callers keep erased compatibility; source-level expression inference is separate. |
+| `static_package_receiver` | `landed` | `receiver_facts` module test `static_constructor_receiver_records_package`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static package receivers can produce high-confidence constructor evidence. |
+| `object_variable_receiver` | `landed` | `receiver_facts` module tests for `$self` and `$object`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Exact package requires a supplied type-environment fact. Unknown object variables stay low confidence. |
+| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Works when `TypeEnvironment` already contains a `HashShape`; hash literal and assignment expression inference is still missing. |
+| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Works when the base fact already has a hash shape; `$hashref->{key}` fact production from source declarations is still missing. |
+| `array_index_receiver` | `partial` | `receiver_facts` module tests for static and dynamic array indexes; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static indexes can use existing `ArrayShape` facts; dynamic indexes remain non-exact. |
+| `dynamic_key_boundary` | `landed` | `receiver_facts` module test `dynamic_hash_key_marks_dynamic_boundary`; `TypeFact::dynamic` test in `type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Proven for receiver extraction. Broader expression and provider boundary receipts remain pending. |
+| `expression_inference` | `missing` | No `TypeInferenceEngine::infer_expr_fact` API on current `master` | Next semantic slice should infer facts from literals, declarations, assignments, constructor calls, and static hash/hashref slots. |
+| `receiver_fact_api` | `landed` | `crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | API extracts facts from existing AST and supplied environment facts; method-call chains remain unknown until explicit rules land. |
+| `completion_cutover` | `blocked` | No completion provider usage of `ReceiverFact` on current `master` | Blocked by facts-only fixtures, expression inference, provider fallback proof, and receiver confidence receipts. |
+
+## Provider Cutover Dashboard
+
+```text
+receiver_fact_completion_cutover:
+  facts_substrate: partial
+  completion_consumes_fact: no
+  fallback_proven: pending
+  dynamic_boundary_proven: partial receiver-extraction only
+  support_claim_allowed: no
+```
+
+## Next Implementation Steps
+
+1. Add expression-level fact inference for literals, assignments,
+   declarations, constructor calls, and hash/hashref slot reads.
+2. Add facts-only fixtures that prove source-derived `%hash` and `$hashref`
+   receiver facts without changing provider output.
+3. Add provider confidence receipts for exact, fallback, and dynamic receiver
+   cases.
+4. Cut completion over only after the facts-only and provider fallback receipts
+   pass.
+
+## Proof Commands
+
+Use these checks for semantic receiver-facts implementation PRs:
+
+```bash
+MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-semantic-analyzer --test type_facts --profile agent --locked
+MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-semantic-analyzer --lib receiver_facts --profile agent --locked -- --nocapture
+MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe check --all-targets -p perl-semantic-analyzer --profile agent --locked
+MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs
+MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt
+git diff --check
+```
+
+Docs-only status updates may run:
+
+```bash
+git diff --check
+MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask ci-hygiene check-doc-paths docs/project/status
+```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -49,6 +49,7 @@ of copying generated values:
 - [parser accuracy next](../project/status/parser_accuracy_next.md)
 - [parser status](../project/status/parser.md)
 - [provider cutover](../project/status/provider_cutover.md)
+- [receiver facts](../project/status/receiver_facts.md)
 - [semantic scorecard](../project/status/semantic_scorecard.md)
 - [semantic shadow compare](../project/status/semantic_shadow_compare.md)
 - [semantic capability dashboard](../project/status/semantic_capability_dashboard.md)


### PR DESCRIPTION
Problem: Receiver-facts implementation has started landing, but the current substrate state and cutover boundary were not visible in a dedicated status surface.

Fix: Add `docs/project/status/receiver_facts.md`, update the receiver-facts implementation plan and docs indexes, and keep the active-goal manifest unchanged. The status records the #9468-era foundation as semantic substrate only: no completion candidate behavior change and no support-tier promotion.

Verification:
- `git diff --check`
- `git diff --check origin/master...HEAD`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-semantic-analyzer --test type_facts --profile agent --locked -- --nocapture` (5 passed)
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe test -p perl-semantic-analyzer --lib receiver_fact --profile agent --locked -- --nocapture` (9 passed)
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask ci-hygiene check-doc-paths docs/specs`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask ci-hygiene check-doc-paths docs/project/status`
- `bash scripts/storage-doctor` (repo-local target dirs: none)