### PR TITLE
goals: start editor trust UX closeout goal (#8197)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -16,6 +16,7 @@ specs = [
   "docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md",
   "docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md",
   "docs/specs/PLSP-SPEC-0009-workspace-trust-report.md",
+  "docs/specs/PLSP-SPEC-0010-support-claim-map.md",
 ]
 
 adrs = [
@@ -25,13 +26,11 @@ adrs = [
 ]
 
 in_flight_contracts = [
-  "PR #9477: support claim map contract (PLSP-SPEC-0010)",
   "PR #9478: trust-lane CI routing contract (PLSP-SPEC-0011)",
+  "PR #9481: user-facing trust surfaces contract (PLSP-SPEC-0012)",
 ]
 
-needed_contracts = [
-  "user-facing trust surfaces contract",
-]
+needed_contracts = []
 
 objective = """
 Make the existing Real Perl Editor Trust control plane visible and useful in
@@ -72,7 +71,7 @@ status_docs = [
 [[work_item]]
 id = "editor-trust-user-facing-contracts"
 status = "in_progress"
-spec = "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md"
+spec = "PR #9481: user-facing trust surfaces contract"
 plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-editor-trust-user-facing-contracts"
 current_pointer = "docs/project/status/real_perl_editor_trust_v1.md"
 claim_boundary = "Spec and docs work only; no provider behavior or support-tier promotion."

--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -17,17 +17,14 @@ specs = [
   "docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md",
   "docs/specs/PLSP-SPEC-0009-workspace-trust-report.md",
   "docs/specs/PLSP-SPEC-0010-support-claim-map.md",
+  "docs/specs/PLSP-SPEC-0011-trust-lane-ci-routing.md",
+  "docs/specs/PLSP-SPEC-0012-user-facing-trust-surfaces.md",
 ]
 
 adrs = [
   "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md",
   "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md",
   "docs/adr/PLSP-ADR-0003-preview-before-edit.md",
-]
-
-in_flight_contracts = [
-  "PR #9478: trust-lane CI routing contract (PLSP-SPEC-0011)",
-  "PR #9481: user-facing trust surfaces contract (PLSP-SPEC-0012)",
 ]
 
 needed_contracts = []
@@ -70,8 +67,8 @@ status_docs = [
 
 [[work_item]]
 id = "editor-trust-user-facing-contracts"
-status = "in_progress"
-spec = "PR #9481: user-facing trust surfaces contract"
+status = "completed"
+spec = "docs/specs/PLSP-SPEC-0012-user-facing-trust-surfaces.md"
 plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-editor-trust-user-facing-contracts"
 current_pointer = "docs/project/status/real_perl_editor_trust_v1.md"
 claim_boundary = "Spec and docs work only; no provider behavior or support-tier promotion."
@@ -100,7 +97,7 @@ status = "completed"
 spec = "docs/specs/PLSP-SPEC-0009-workspace-trust-report.md"
 plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-workspace-trust-schema-snapshots"
 current_pointer = "docs/project/status/SUPPORT_TIERS.md"
-receipt = "PR #9463: test(ux): snapshot workspace trust report schema"
+receipt = "crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs::test_execute_command_workspace_trust_report_schema_snapshot"
 claim_boundary = "Report existing state only; do not probe Perl, run perldoc, launch DAP, scan files, or promote tiers."
 commands = [
   "cargo test -p perl-lsp-rs --test lsp_execute_command_tests test_execute_command_workspace_trust_report --profile agent --locked -- --nocapture --test-threads=1",
@@ -137,8 +134,8 @@ commands = [
 
 [[work_item]]
 id = "trust-lane-ci-routing"
-status = "planned"
-spec = "PR #9478: trust-lane CI routing contract"
+status = "ready"
+spec = "docs/specs/PLSP-SPEC-0011-trust-lane-ci-routing.md"
 plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-trust-lane-ci-routing"
 current_pointer = "docs/ci/pr-plan.md"
 claim_boundary = "CI routing may classify proof cost; it does not prove provider behavior or promote support claims."

--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -14,24 +14,23 @@ specs = [
   "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md",
   "docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md",
   "docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md",
+  "docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md",
+  "docs/specs/PLSP-SPEC-0009-workspace-trust-report.md",
 ]
 
 adrs = [
   "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md",
   "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md",
+  "docs/adr/PLSP-ADR-0003-preview-before-edit.md",
 ]
 
 in_flight_contracts = [
-  "PR #9474: edit-producing provider safety",
-  "PR #9475: broad Real Perl Editor Trust v1 boundary draft; review for overlap before merge",
-  "PR #9476: workspace trust report contract",
-  "PR #9477: support claim map contract",
-  "PR #9478: trust-lane CI routing contract",
+  "PR #9477: support claim map contract (PLSP-SPEC-0010)",
+  "PR #9478: trust-lane CI routing contract (PLSP-SPEC-0011)",
 ]
 
 needed_contracts = [
   "user-facing trust surfaces contract",
-  "preview-before-edit ADR if not covered by the edit-producing provider safety PR",
 ]
 
 objective = """
@@ -98,10 +97,11 @@ commands = [
 
 [[work_item]]
 id = "workspace-trust-schema-snapshots"
-status = "ready"
-spec = "PR #9476: workspace trust report contract"
+status = "completed"
+spec = "docs/specs/PLSP-SPEC-0009-workspace-trust-report.md"
 plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-workspace-trust-schema-snapshots"
 current_pointer = "docs/project/status/SUPPORT_TIERS.md"
+receipt = "PR #9463: test(ux): snapshot workspace trust report schema"
 claim_boundary = "Report existing state only; do not probe Perl, run perldoc, launch DAP, scan files, or promote tiers."
 commands = [
   "cargo test -p perl-lsp-rs --test lsp_execute_command_tests test_execute_command_workspace_trust_report --profile agent --locked -- --nocapture --test-threads=1",
@@ -125,7 +125,7 @@ commands = [
 [[work_item]]
 id = "edit-provider-safety-refresh"
 status = "planned"
-spec = "PR #9474: edit-producing provider safety"
+spec = "docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md"
 plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-edit-provider-safety-refresh"
 current_pointer = "docs/project/status/provider_confidence_matrix.md"
 claim_boundary = "Rename and safe-delete remain narrow pilots until false-allow, freshness, blocker, and rollback proof justify more."

--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -1,20 +1,19 @@
-id = "plsp-real-perl-editor-trust"
-title = "Real Perl editor trust"
-status = "completed"
+id = "plsp-editor-trust-ux-closeout"
+title = "Editor trust UX closeout"
+status = "active"
 owner = "codex-swarm"
-created = "2026-05-13"
-completed = "2026-05-18"
+created = "2026-05-19"
 
 proposal = "docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md"
-plan = "plans/real-perl-editor-trust/implementation-plan.md"
-status_pointer = "docs/project/status/parser_accuracy_next.md"
-closeout_receipt = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
+plan = "plans/editor-trust-ux-closeout/implementation-plan.md"
+previous_goal = ".perl-lsp/goals/archive/2026-05-18-real-perl-editor-trust.toml"
+status_pointer = "docs/project/status/real_perl_editor_trust_v1.md"
 
 specs = [
-  "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md",
   "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md",
   "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md",
-  "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md",
+  "docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md",
+  "docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md",
 ]
 
 adrs = [
@@ -22,18 +21,32 @@ adrs = [
   "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md",
 ]
 
+in_flight_contracts = [
+  "PR #9474: edit-producing provider safety",
+  "PR #9475: broad Real Perl Editor Trust v1 boundary draft; review for overlap before merge",
+  "PR #9476: workspace trust report contract",
+  "PR #9477: support claim map contract",
+  "PR #9478: trust-lane CI routing contract",
+]
+
+needed_contracts = [
+  "user-facing trust surfaces contract",
+  "preview-before-edit ADR if not covered by the edit-producing provider safety PR",
+]
+
 objective = """
-Turn parser compatibility, provider confidence, and real-workspace receipts
-into an executable control plane for improving perl-lsp user trust.
+Make the existing Real Perl Editor Trust control plane visible and useful in
+normal editor workflows: explanations, receipts, workspace trust state,
+preview-first refactors, receiver-aware completion, and claim-shaped CI proof.
 """
 
 end_state = [
-  "Parser measurement queue has no active packets or gaps.",
-  "Raw parser buckets route PR-sized parser capability lanes only when generated parser status lists a nonzero raw bucket.",
-  "Corpus receipt freshness rules are encoded.",
-  "Provider confidence and freshness receipts exist before cutover.",
-  "Real-workspace baseline proves editor behavior on at least one real project.",
-  "Stable user claims link to proof commands and status docs.",
+  "User-facing trust and setup surfaces are documented, snapshotted, and supportable from receipts.",
+  "Receiver-aware completion has a narrow source-backed pilot with fallback-preserving proof.",
+  "Rename and safe-delete remain bounded by false-allow, freshness, blocker, and rollback receipts.",
+  "Workspace trust report and setup docs are the support front door.",
+  "Support claims, README claims, and VS Code command docs match proof tiers.",
+  "CI routing classifies PRs by trust lane and names required proof.",
 ]
 
 claim_boundaries = [
@@ -41,123 +54,97 @@ claim_boundaries = [
   "Do not broaden live provider behavior from receipt PRs alone.",
   "Do not hand-edit generated status sections.",
   "Do not claim all-CPAN support or full dynamic Perl inference.",
+  "Do not promote edit-producing providers without rollback, blocker, fallback, and no-edit proof.",
+  "Do not turn generated, dynamic, stale, or low-confidence facts into exact source-backed claims.",
 ]
 
 status_docs = [
-  "docs/project/status/parser_accuracy_next.md",
-  "docs/project/status/parser.md",
+  "docs/project/status/real_perl_editor_trust_v1.md",
   "docs/project/status/provider_cutover.md",
   "docs/project/status/provider_confidence_matrix.md",
   "docs/project/status/SUPPORT_TIERS.md",
   "docs/project/status/ux_capability_dashboard.md",
   "docs/project/status/semantic_scorecard.md",
   "docs/project/status/semantic_shadow_compare.md",
+  "docs/project/status/parser_accuracy_next.md",
+  "docs/project/status/parser.md",
 ]
 
 [[work_item]]
-id = "raw-bucket-fixture-lane"
-status = "deferred"
-spec = "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md"
-adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
-plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-raw-bucket-fixture-lane"
-current_pointer = "docs/project/status/parser_accuracy_next.md"
-current_status = "docs/project/status/parser.md#raw-failure-buckets"
-historical_shape_analysis = "docs/project/status/parser_unclosed_paren_identifier_shapes.md"
-boundary_receipt = "crates/perl-parser-core/tests/list_operator_boundary_receipts.rs"
-claim_boundary = "Fixture-only PRs lock source-backed shapes; bucket-count movement requires a refreshed corpus receipt."
-deferred_reason = "Generated parser status currently lists no nonzero raw bucket; do not start raw-bucket work from stale context."
-next_runtime_rule = "Resume parser runtime or fixture work only from a fresh Linux receipt, a generated nonzero raw bucket, or a focused source-backed fixture that fails against the current parser."
-commands = [
-  "cargo test -p perl-parser-core --test <bucket-test> --profile agent --locked -- --nocapture",
-  "cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture",
-  "cargo xtask metrics parser-accuracy --check",
-  "cargo xtask update-status --only parser --check",
-  "cargo xtask metrics ratchet-check parser_accuracy",
-  "cargo xtask fmt --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "linux-corpus-refresh"
-status = "deferred"
-spec = "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md"
-adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
-plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-linux-corpus-refresh"
-current_pointer = "docs/project/status/parser.md#raw-failure-buckets"
-successor_issue = "https://github.com/EffortlessMetrics/perl-lsp/issues/8863"
-deferred_reason = "Current Windows worktree lacks the Linux system Perl roots required for a system-profile corpus receipt."
-claim_boundary = "May update parser bucket counts only from refreshed generated corpus status."
-commands = [
-  "cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt",
-  "cargo xtask update-status --only parser --write",
-  "cargo xtask update-status --only parser --check",
-  "cargo xtask metrics ratchet-check parser_accuracy",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "real-workspace-baseline-run"
-status = "completed"
-spec = "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md"
-adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
-plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-real-workspace-baseline-run"
-current_pointer = "docs/development/REAL_WORKSPACE_BASELINE_RAIL.md"
-receipt = "docs/forensics/2026-05-13-real-workspace-baseline-mojolicious.md"
-claim_boundary = "A baseline proves the selected project and host receipt only; it is not all-CPAN proof or live provider cutover."
-commands = [
-  "just real-workspace-baseline mojolicious",
-  "cargo test -p perl-lsp-rs --test real_project_latency mojolicious -- --include-ignored --nocapture",
-  "cargo xtask semantic-scorecard --check",
-  "cargo xtask semantic-shadow-compare --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "provider-confidence-closeout"
-status = "completed"
+id = "editor-trust-user-facing-contracts"
+status = "in_progress"
 spec = "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md"
-adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
-plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-provider-confidence-closeout"
-current_pointer = "docs/project/status/provider_cutover.md"
-receipt = "docs/project/status/provider_confidence_matrix.md"
-claim_boundary = "Provider receipt PRs may add proof and labels; broad live cutover requires cutover proof and rollback/fallback behavior."
+plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-editor-trust-user-facing-contracts"
+current_pointer = "docs/project/status/real_perl_editor_trust_v1.md"
+claim_boundary = "Spec and docs work only; no provider behavior or support-tier promotion."
 commands = [
-  "cargo test -p perl-lsp-rs-core --lib rename_shadow safe_delete_shadow -- --nocapture",
-  "cargo test -p perl-lsp-rs --lib refactor_runtime_blocker -- --nocapture",
-  "cargo xtask semantic-scorecard --check",
-  "cargo xtask semantic-shadow-compare --check",
+  "cargo xtask check-support-claims",
+  "cargo xtask check-provider-confidence-matrix",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "support-claim-refresh"
-status = "completed"
+id = "editor-trust-user-docs"
+status = "ready"
 spec = "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md"
-adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
-plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-support-claim-refresh"
-current_pointer = "docs/project/status/ux_capability_dashboard.md"
-receipt = "docs/project/status/SUPPORT_TIERS.md"
-claim_boundary = "Support claims must link to proof commands, status docs, known limitations, and next promotion proof."
+plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-editor-trust-user-docs"
+current_pointer = "docs/project/status/SUPPORT_TIERS.md"
+claim_boundary = "Plain-language docs must link to support tiers and avoid broad CPAN/static/refactor claims."
 commands = [
-  "cargo xtask update-status --only parser --check",
-  "cargo xtask semantic-scorecard --check",
-  "cargo xtask semantic-shadow-compare --check",
+  "cargo xtask check-support-claims",
+  "cargo xtask check-provider-confidence-matrix",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "lane-closeout"
-status = "completed"
-spec = "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md"
-adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
-plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
-current_pointer = "plans/real-perl-editor-trust/implementation-plan.md"
-receipt = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
-completed = "2026-05-13"
-claim_boundary = "Close only when deferred items have explicit successors and status/support claims point to proof."
+id = "workspace-trust-schema-snapshots"
+status = "ready"
+spec = "PR #9476: workspace trust report contract"
+plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-workspace-trust-schema-snapshots"
+current_pointer = "docs/project/status/SUPPORT_TIERS.md"
+claim_boundary = "Report existing state only; do not probe Perl, run perldoc, launch DAP, scan files, or promote tiers."
 commands = [
-  "cargo xtask update-status --only parser --check",
-  "cargo xtask semantic-scorecard --check",
-  "cargo xtask semantic-shadow-compare --check",
+  "cargo test -p perl-lsp-rs --test lsp_execute_command_tests test_execute_command_workspace_trust_report --profile agent --locked -- --nocapture --test-threads=1",
+  "cargo xtask check-support-claims",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "receiver-fact-completion"
+status = "ready"
+spec = "docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md"
+plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-receiver-fact-completion"
+current_pointer = "docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md"
+claim_boundary = "Facts and receipts before live completion; unknown and dynamic receivers preserve legacy fallback."
+commands = [
+  "cargo test -p perl-semantic-analyzer --lib receiver_fact --profile agent --locked -- --nocapture",
+  "cargo test -p perl-lsp-rs-core --lib completion --profile agent --locked -- --nocapture",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "edit-provider-safety-refresh"
+status = "planned"
+spec = "PR #9474: edit-producing provider safety"
+plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-edit-provider-safety-refresh"
+current_pointer = "docs/project/status/provider_confidence_matrix.md"
+claim_boundary = "Rename and safe-delete remain narrow pilots until false-allow, freshness, blocker, and rollback proof justify more."
+commands = [
+  "cargo test -p perl-lsp-rs --lib refactor_runtime_blocker_ux_safe_delete --profile agent --locked -- --nocapture --test-threads=1",
+  "cargo test -p perl-lsp-rs-core --lib safe_delete_shadow --profile agent --locked -- --nocapture",
+  "cargo xtask check-support-claims",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "trust-lane-ci-routing"
+status = "planned"
+spec = "PR #9478: trust-lane CI routing contract"
+plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-trust-lane-ci-routing"
+current_pointer = "docs/ci/pr-plan.md"
+claim_boundary = "CI routing may classify proof cost; it does not prove provider behavior or promote support claims."
+commands = [
+  "python scripts/ci/validate_risk_packs.py --strict",
+  "cargo xtask check-support-claims",
   "git diff --check",
 ]

--- a/.perl-lsp/goals/archive/2026-05-18-real-perl-editor-trust.toml
+++ b/.perl-lsp/goals/archive/2026-05-18-real-perl-editor-trust.toml
@@ -1,0 +1,163 @@
+id = "plsp-real-perl-editor-trust"
+title = "Real Perl editor trust"
+status = "completed"
+owner = "codex-swarm"
+created = "2026-05-13"
+completed = "2026-05-18"
+
+proposal = "docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md"
+status_pointer = "docs/project/status/parser_accuracy_next.md"
+closeout_receipt = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
+
+specs = [
+  "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md",
+  "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md",
+  "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md",
+  "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md",
+]
+
+adrs = [
+  "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md",
+  "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md",
+]
+
+objective = """
+Turn parser compatibility, provider confidence, and real-workspace receipts
+into an executable control plane for improving perl-lsp user trust.
+"""
+
+end_state = [
+  "Parser measurement queue has no active packets or gaps.",
+  "Raw parser buckets route PR-sized parser capability lanes only when generated parser status lists a nonzero raw bucket.",
+  "Corpus receipt freshness rules are encoded.",
+  "Provider confidence and freshness receipts exist before cutover.",
+  "Real-workspace baseline proves editor behavior on at least one real project.",
+  "Stable user claims link to proof commands and status docs.",
+]
+
+claim_boundaries = [
+  "Do not claim parser bucket reduction without a refreshed corpus receipt.",
+  "Do not broaden live provider behavior from receipt PRs alone.",
+  "Do not hand-edit generated status sections.",
+  "Do not claim all-CPAN support or full dynamic Perl inference.",
+]
+
+status_docs = [
+  "docs/project/status/parser_accuracy_next.md",
+  "docs/project/status/parser.md",
+  "docs/project/status/provider_cutover.md",
+  "docs/project/status/provider_confidence_matrix.md",
+  "docs/project/status/SUPPORT_TIERS.md",
+  "docs/project/status/ux_capability_dashboard.md",
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[work_item]]
+id = "raw-bucket-fixture-lane"
+status = "deferred"
+spec = "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md"
+adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-raw-bucket-fixture-lane"
+current_pointer = "docs/project/status/parser_accuracy_next.md"
+current_status = "docs/project/status/parser.md#raw-failure-buckets"
+historical_shape_analysis = "docs/project/status/parser_unclosed_paren_identifier_shapes.md"
+boundary_receipt = "crates/perl-parser-core/tests/list_operator_boundary_receipts.rs"
+claim_boundary = "Fixture-only PRs lock source-backed shapes; bucket-count movement requires a refreshed corpus receipt."
+deferred_reason = "Generated parser status currently lists no nonzero raw bucket; do not start raw-bucket work from stale context."
+next_runtime_rule = "Resume parser runtime or fixture work only from a fresh Linux receipt, a generated nonzero raw bucket, or a focused source-backed fixture that fails against the current parser."
+commands = [
+  "cargo test -p perl-parser-core --test <bucket-test> --profile agent --locked -- --nocapture",
+  "cargo test -p perl-parser-core --test list_operator_boundary_receipts --profile agent --locked -- --nocapture",
+  "cargo xtask metrics parser-accuracy --check",
+  "cargo xtask update-status --only parser --check",
+  "cargo xtask metrics ratchet-check parser_accuracy",
+  "cargo xtask fmt --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "linux-corpus-refresh"
+status = "deferred"
+spec = "docs/specs/PLSP-SPEC-0004-corpus-receipt-freshness.md"
+adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-linux-corpus-refresh"
+current_pointer = "docs/project/status/parser.md#raw-failure-buckets"
+successor_issue = "https://github.com/EffortlessMetrics/perl-lsp/issues/8863"
+deferred_reason = "Current Windows worktree lacks the Linux system Perl roots required for a system-profile corpus receipt."
+claim_boundary = "May update parser bucket counts only from refreshed generated corpus status."
+commands = [
+  "cargo xtask parser-corpus-sweep --baseline .ci/parser-corpus-baseline.json --enforce --receipt",
+  "cargo xtask update-status --only parser --write",
+  "cargo xtask update-status --only parser --check",
+  "cargo xtask metrics ratchet-check parser_accuracy",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "real-workspace-baseline-run"
+status = "completed"
+spec = "docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md"
+adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-real-workspace-baseline-run"
+current_pointer = "docs/development/REAL_WORKSPACE_BASELINE_RAIL.md"
+receipt = "docs/forensics/2026-05-13-real-workspace-baseline-mojolicious.md"
+claim_boundary = "A baseline proves the selected project and host receipt only; it is not all-CPAN proof or live provider cutover."
+commands = [
+  "just real-workspace-baseline mojolicious",
+  "cargo test -p perl-lsp-rs --test real_project_latency mojolicious -- --include-ignored --nocapture",
+  "cargo xtask semantic-scorecard --check",
+  "cargo xtask semantic-shadow-compare --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "provider-confidence-closeout"
+status = "completed"
+spec = "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md"
+adr = "docs/adr/PLSP-ADR-0002-confidence-before-cutover.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-provider-confidence-closeout"
+current_pointer = "docs/project/status/provider_cutover.md"
+receipt = "docs/project/status/provider_confidence_matrix.md"
+claim_boundary = "Provider receipt PRs may add proof and labels; broad live cutover requires cutover proof and rollback/fallback behavior."
+commands = [
+  "cargo test -p perl-lsp-rs-core --lib rename_shadow safe_delete_shadow -- --nocapture",
+  "cargo test -p perl-lsp-rs --lib refactor_runtime_blocker -- --nocapture",
+  "cargo xtask semantic-scorecard --check",
+  "cargo xtask semantic-shadow-compare --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "support-claim-refresh"
+status = "completed"
+spec = "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md"
+adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-support-claim-refresh"
+current_pointer = "docs/project/status/ux_capability_dashboard.md"
+receipt = "docs/project/status/SUPPORT_TIERS.md"
+claim_boundary = "Support claims must link to proof commands, status docs, known limitations, and next promotion proof."
+commands = [
+  "cargo xtask update-status --only parser --check",
+  "cargo xtask semantic-scorecard --check",
+  "cargo xtask semantic-shadow-compare --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "lane-closeout"
+status = "completed"
+spec = "docs/specs/PLSP-SPEC-0001-parser-compatibility-bucket-closeout.md"
+adr = "docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md"
+plan = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
+current_pointer = "plans/real-perl-editor-trust/implementation-plan.md"
+receipt = "plans/real-perl-editor-trust/implementation-plan.md#work-item-lane-closeout"
+completed = "2026-05-13"
+claim_boundary = "Close only when deferred items have explicit successors and status/support claims point to proof."
+commands = [
+  "cargo xtask update-status --only parser --check",
+  "cargo xtask semantic-scorecard --check",
+  "cargo xtask semantic-shadow-compare --check",
+  "git diff --check",
+]

--- a/docs/project/status/real_perl_editor_trust_v1.md
+++ b/docs/project/status/real_perl_editor_trust_v1.md
@@ -25,7 +25,7 @@ of current evidence.
 | Compiler-backed provider receipts | [semantic_shadow_compare.md](semantic_shadow_compare.md), [semantic_scorecard.md](semantic_scorecard.md) |
 | UX/provider capability context | [ux_capability_dashboard.md](ux_capability_dashboard.md) |
 | Real-workspace baseline anchors | [2026-05-13 Mojolicious baseline](../../forensics/2026-05-13-real-workspace-baseline-mojolicious.md), [2026-05-14 Dancer2 baseline](../../forensics/2026-05-14-real-workspace-baseline-dancer2.md) |
-| Lane plan and active work | [Real Perl Editor Trust plan](../../../plans/real-perl-editor-trust/implementation-plan.md), [active goal manifest](../../../.perl-lsp/goals/active.toml) |
+| Lane plan and active work | [Real Perl Editor Trust plan](../../../plans/real-perl-editor-trust/implementation-plan.md), [Editor Trust UX closeout plan](../../../plans/editor-trust-ux-closeout/implementation-plan.md), [active goal manifest](../../../.perl-lsp/goals/active.toml) |
 
 ## Provider Trust Loop
 

--- a/plans/editor-trust-ux-closeout/implementation-plan.md
+++ b/plans/editor-trust-ux-closeout/implementation-plan.md
@@ -20,8 +20,8 @@ not promote provider behavior from docs or receipt-only PRs.
 
 Current in-flight contract PRs:
 
-- #9477: support claim map contract (`PLSP-SPEC-0010`)
 - #9478: trust-lane CI routing contract (`PLSP-SPEC-0011`)
+- #9481: user-facing trust surfaces contract (`PLSP-SPEC-0012`)
 
 Current merged contract anchors:
 
@@ -31,6 +31,7 @@ Current merged contract anchors:
 - [PLSP-SPEC-0007](../../docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md)
 - [PLSP-SPEC-0008](../../docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md)
 - [PLSP-SPEC-0009](../../docs/specs/PLSP-SPEC-0009-workspace-trust-report.md)
+- [PLSP-SPEC-0010](../../docs/specs/PLSP-SPEC-0010-support-claim-map.md)
 - [PLSP-ADR-0001](../../docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
 - [PLSP-ADR-0002](../../docs/adr/PLSP-ADR-0002-confidence-before-cutover.md)
 - [PLSP-ADR-0003](../../docs/adr/PLSP-ADR-0003-preview-before-edit.md)
@@ -50,9 +51,9 @@ Status owners:
 
 Status: in progress
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
-Linked spec: [PLSP-SPEC-0002](../../docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
+Linked spec: PR #9481 user-facing trust surfaces contract
 Blocks: user-facing trust docs, command documentation, setup troubleshooting
-Blocked by: in-flight contract PR review
+Blocked by: user-facing trust surfaces contract review
 
 Goal
 

--- a/plans/editor-trust-ux-closeout/implementation-plan.md
+++ b/plans/editor-trust-ux-closeout/implementation-plan.md
@@ -1,0 +1,308 @@
+# Editor Trust UX Closeout Implementation Plan
+
+Status: active
+Owner: perl-lsp maintainers
+Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Active goal: [active.toml](../../.perl-lsp/goals/active.toml)
+Previous goal archive: [2026-05-18-real-perl-editor-trust.toml](../../.perl-lsp/goals/archive/2026-05-18-real-perl-editor-trust.toml)
+
+## Current State
+
+The original Real Perl Editor Trust control-plane lane is archived as complete.
+Its proposal, initial specs, ADRs, generated parser status, provider confidence
+matrix, support tiers, and real-workspace receipts remain the source of truth
+for what can be claimed.
+
+This plan owns the next active lane: turning that control plane into a
+user-facing editor-trust product. It does not reopen broad parser bucket work
+while generated parser status lists no current nonzero raw bucket, and it does
+not promote provider behavior from docs or receipt-only PRs.
+
+Current in-flight contract PRs:
+
+- #9474: edit-producing provider safety
+- #9475: broad Real Perl Editor Trust v1 boundary draft; review for overlap
+  before merge
+- #9476: workspace trust report contract
+- #9477: support claim map contract
+- #9478: trust-lane CI routing contract
+
+Current merged contract anchors:
+
+- [PLSP-SPEC-0002](../../docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
+- [PLSP-SPEC-0003](../../docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md)
+- [PLSP-SPEC-0005](../../docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md)
+- [PLSP-SPEC-0007](../../docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md)
+- [PLSP-ADR-0001](../../docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
+- [PLSP-ADR-0002](../../docs/adr/PLSP-ADR-0002-confidence-before-cutover.md)
+
+Status owners:
+
+- [Real Perl Editor Trust dashboard](../../docs/project/status/real_perl_editor_trust_v1.md)
+- [support tiers](../../docs/project/status/SUPPORT_TIERS.md)
+- [provider confidence matrix](../../docs/project/status/provider_confidence_matrix.md)
+- [provider cutover](../../docs/project/status/provider_cutover.md)
+- [semantic scorecard](../../docs/project/status/semantic_scorecard.md)
+- [semantic shadow compare](../../docs/project/status/semantic_shadow_compare.md)
+- [parser accuracy next](../../docs/project/status/parser_accuracy_next.md)
+- [parser status](../../docs/project/status/parser.md)
+
+## Work item: editor-trust-user-facing-contracts
+
+Status: in progress
+Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked spec: [PLSP-SPEC-0002](../../docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
+Blocks: user-facing trust docs, command documentation, setup troubleshooting
+Blocked by: in-flight contract PR review
+
+Goal
+
+Encode the remaining user-facing trust contracts in durable specs and ADRs so
+agents do not need chat context to know what explanations, receipts, previews,
+workspace trust, support claims, and CI routing may claim.
+
+Production delta
+
+Spec and ADR changes only. No provider behavior, support-tier promotion, parser
+runtime change, workspace scan, DAP launch, perldoc execution, or CI routing
+implementation unless the PR explicitly says it is a validator/policy PR.
+
+Non-goals
+
+No broad roadmap. No generated status content. No current PR queue ordering.
+No behavior cutover from docs-only PRs.
+
+Acceptance
+
+Each spec states contract, non-goals, valid PR shapes, invalid PR shapes, proof
+commands, claim boundaries, and status docs that own current evidence.
+
+Proof commands
+
+```bash
+cargo xtask check-support-claims
+cargo xtask check-provider-confidence-matrix
+git diff --check
+```
+
+Rollback
+
+Revert the affected spec or ADR PR. If a contract is wrong, leave the active
+goal in place and mark the specific work item blocked until a replacement
+contract lands.
+
+## Work item: editor-trust-user-docs
+
+Status: ready
+Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked spec: [PLSP-SPEC-0002](../../docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
+Blocks: README claim refresh, VS Code command docs
+Blocked by: user-facing trust surface contract
+
+Goal
+
+Add user-facing docs that explain measured Perl editor trust without requiring
+users to read provider matrices or dashboards.
+
+Production delta
+
+Add or update docs for editor trust, setup troubleshooting, command discovery,
+and bug-report receipts.
+
+Non-goals
+
+No support-tier promotion. No broad CPAN/static/refactor claims. No duplicated
+support matrix.
+
+Acceptance
+
+Docs explain partial-live-with-fallback, fallback reasons, safe-edit previews,
+dynamic Perl boundaries, `@INC`/module resolution, workspace trust report,
+provider explanations, diagnostic explanations, and copyable receipts in plain
+language while linking to status/support truth sources.
+
+Proof commands
+
+```bash
+cargo xtask check-support-claims
+cargo xtask check-provider-confidence-matrix
+git diff --check
+```
+
+Rollback
+
+Revert the docs PR. If wording overclaims, narrow the docs before any support
+claim changes.
+
+## Work item: workspace-trust-schema-snapshots
+
+Status: ready
+Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked spec: PR #9476 workspace trust report contract
+Blocks: setup troubleshooting docs, support-front-door docs
+Blocked by: workspace trust report contract review
+
+Goal
+
+Lock the user-facing workspace trust report shape enough that setup support and
+bug reports do not churn.
+
+Production delta
+
+Add focused snapshots or tests for the report schema and output-channel
+presentation. The report remains read-only over existing server/client state.
+
+Non-goals
+
+No Perl probing. No perldoc execution. No DAP launch. No workspace scan. No
+support-tier promotion.
+
+Acceptance
+
+Snapshots cover workspace roots, include path state, `PERL5LIB` policy, perldoc
+contract state, DAP/perldoc runtime state when supplied, launch config
+counts/classes, provider tiers, dynamic caveats, and copyable payload fields.
+
+Proof commands
+
+```bash
+cargo test -p perl-lsp-rs --test lsp_execute_command_tests test_execute_command_workspace_trust_report --profile agent --locked -- --nocapture --test-threads=1
+cargo xtask check-support-claims
+git diff --check
+```
+
+Rollback
+
+Revert snapshots or output changes. If the report shape is unstable, mark the
+work item blocked and keep docs from promising a stable payload.
+
+## Work item: receiver-fact-completion
+
+Status: ready
+Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked specs: [PLSP-SPEC-0005](../../docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md), [PLSP-SPEC-0007](../../docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md)
+Blocks: receiver-fact completion ranking receipt, narrow receiver completion pilot
+Blocked by: none
+
+Goal
+
+Use receiver facts to make method completion useful for source-backed object and
+package shapes while preserving fallback for unknown and dynamic receivers.
+
+Production delta
+
+First add receiver fact extraction or receipts. Enable a narrow live completion
+pilot only after source-backed, fresh, high-confidence receiver facts and
+fallback preservation are proven.
+
+Non-goals
+
+No completion behavior change from facts-only PRs. No generated/no-source
+promotion. No dynamic hash key exactness. No suppression of legacy candidates
+for unknown receivers.
+
+Acceptance
+
+Facts expose receiver kind, inferred package, shape fact, confidence, evidence,
+freshness, dynamic boundary, source range, and fallback state. Completion
+receipt proves source-backed `$self`/object/package/hashref known-slot ranking,
+dynamic fallback, and unknown fallback before any pilot.
+
+Proof commands
+
+```bash
+cargo test -p perl-semantic-analyzer --lib receiver_fact --profile agent --locked -- --nocapture
+cargo test -p perl-lsp-rs-core --lib completion --profile agent --locked -- --nocapture
+git diff --check
+```
+
+Rollback
+
+Revert the facts, receipt, or pilot PR. If fallback changes unexpectedly, revert
+the pilot first and keep facts-only evidence for follow-up.
+
+## Work item: edit-provider-safety-refresh
+
+Status: planned
+Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked spec: PR #9474 edit-producing provider safety
+Blocks: rename/safe-delete support review
+Blocked by: edit-producing provider safety contract review
+
+Goal
+
+Keep rename and safe-delete false-allow, edit-freshness, blocker, and rollback
+receipts current as facts and workspace indexing evolve.
+
+Production delta
+
+Receipt/test updates only unless a separate live-cutover PR satisfies the
+edit-producing provider safety contract.
+
+Non-goals
+
+No broader package rename. No broader safe-delete. No generated, dynamic,
+imported/exported, stale, low-confidence, ambiguous, non-source-backed,
+non-subroutine, or package-wide edit authorization.
+
+Acceptance
+
+Generated/no-source, dynamic, referenced, imported/exported, stale,
+low-confidence, ambiguous, non-subroutine, and package-wide cases return no
+edit or fallback with explicit reasons and copyable receipts.
+
+Proof commands
+
+```bash
+cargo test -p perl-lsp-rs --lib refactor_runtime_blocker_ux_safe_delete --profile agent --locked -- --nocapture --test-threads=1
+cargo test -p perl-lsp-rs-core --lib safe_delete_shadow --profile agent --locked -- --nocapture
+cargo xtask check-support-claims
+cargo xtask check-provider-confidence-matrix
+git diff --check
+```
+
+Rollback
+
+Revert the receipt or behavior PR. If an edit-producing live path is unsafe,
+revert live behavior before changing docs.
+
+## Work item: trust-lane-ci-routing
+
+Status: planned
+Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked spec: PR #9478 trust-lane CI routing contract
+Blocks: cheap parser fixture lane, hosted CI exposure estimate
+Blocked by: trust-lane CI routing contract review
+
+Goal
+
+Classify PRs by trust lane so CI proof follows the claim boundary instead of
+defaulting to broad proof by habit.
+
+Production delta
+
+Add policy or PR summary support only after the routing contract lands. The
+first implementation should be advisory and receipt-producing.
+
+Non-goals
+
+No broad full-CI default. No provider behavior proof from CI routing alone. No
+support-tier promotion from routing alone.
+
+Acceptance
+
+PR summary or receipt names the trust-lane class, changed surface, required
+proof, skipped-by-policy checks, hosted-CI estimate, and widening triggers.
+
+Proof commands
+
+```bash
+python scripts/ci/validate_risk_packs.py --strict
+cargo xtask check-support-claims
+git diff --check
+```
+
+Rollback
+
+Revert the routing policy or summary PR. If classification is wrong, keep the
+spec and disable only the classifier output until fixed.

--- a/plans/editor-trust-ux-closeout/implementation-plan.md
+++ b/plans/editor-trust-ux-closeout/implementation-plan.md
@@ -20,12 +20,8 @@ not promote provider behavior from docs or receipt-only PRs.
 
 Current in-flight contract PRs:
 
-- #9474: edit-producing provider safety
-- #9475: broad Real Perl Editor Trust v1 boundary draft; review for overlap
-  before merge
-- #9476: workspace trust report contract
-- #9477: support claim map contract
-- #9478: trust-lane CI routing contract
+- #9477: support claim map contract (`PLSP-SPEC-0010`)
+- #9478: trust-lane CI routing contract (`PLSP-SPEC-0011`)
 
 Current merged contract anchors:
 
@@ -33,8 +29,11 @@ Current merged contract anchors:
 - [PLSP-SPEC-0003](../../docs/specs/PLSP-SPEC-0003-real-workspace-editor-baseline.md)
 - [PLSP-SPEC-0005](../../docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md)
 - [PLSP-SPEC-0007](../../docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md)
+- [PLSP-SPEC-0008](../../docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md)
+- [PLSP-SPEC-0009](../../docs/specs/PLSP-SPEC-0009-workspace-trust-report.md)
 - [PLSP-ADR-0001](../../docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
 - [PLSP-ADR-0002](../../docs/adr/PLSP-ADR-0002-confidence-before-cutover.md)
+- [PLSP-ADR-0003](../../docs/adr/PLSP-ADR-0003-preview-before-edit.md)
 
 Status owners:
 
@@ -136,11 +135,11 @@ claim changes.
 
 ## Work item: workspace-trust-schema-snapshots
 
-Status: ready
+Status: completed
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
-Linked spec: PR #9476 workspace trust report contract
+Linked spec: [PLSP-SPEC-0009](../../docs/specs/PLSP-SPEC-0009-workspace-trust-report.md)
 Blocks: setup troubleshooting docs, support-front-door docs
-Blocked by: workspace trust report contract review
+Receipt: PR #9463 `test(ux): snapshot workspace trust report schema`
 
 Goal
 
@@ -225,9 +224,9 @@ the pilot first and keep facts-only evidence for follow-up.
 
 Status: planned
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
-Linked spec: PR #9474 edit-producing provider safety
+Linked spec: [PLSP-SPEC-0008](../../docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md)
 Blocks: rename/safe-delete support review
-Blocked by: edit-producing provider safety contract review
+Blocked by: provider fact or workspace-index changes that require refreshed edit-safety proof
 
 Goal
 

--- a/plans/editor-trust-ux-closeout/implementation-plan.md
+++ b/plans/editor-trust-ux-closeout/implementation-plan.md
@@ -18,11 +18,6 @@ user-facing editor-trust product. It does not reopen broad parser bucket work
 while generated parser status lists no current nonzero raw bucket, and it does
 not promote provider behavior from docs or receipt-only PRs.
 
-Current in-flight contract PRs:
-
-- #9478: trust-lane CI routing contract (`PLSP-SPEC-0011`)
-- #9481: user-facing trust surfaces contract (`PLSP-SPEC-0012`)
-
 Current merged contract anchors:
 
 - [PLSP-SPEC-0002](../../docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
@@ -32,6 +27,8 @@ Current merged contract anchors:
 - [PLSP-SPEC-0008](../../docs/specs/PLSP-SPEC-0008-edit-producing-provider-safety.md)
 - [PLSP-SPEC-0009](../../docs/specs/PLSP-SPEC-0009-workspace-trust-report.md)
 - [PLSP-SPEC-0010](../../docs/specs/PLSP-SPEC-0010-support-claim-map.md)
+- [PLSP-SPEC-0011](../../docs/specs/PLSP-SPEC-0011-trust-lane-ci-routing.md)
+- [PLSP-SPEC-0012](../../docs/specs/PLSP-SPEC-0012-user-facing-trust-surfaces.md)
 - [PLSP-ADR-0001](../../docs/adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
 - [PLSP-ADR-0002](../../docs/adr/PLSP-ADR-0002-confidence-before-cutover.md)
 - [PLSP-ADR-0003](../../docs/adr/PLSP-ADR-0003-preview-before-edit.md)
@@ -49,15 +46,15 @@ Status owners:
 
 ## Work item: editor-trust-user-facing-contracts
 
-Status: in progress
+Status: completed
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
-Linked spec: PR #9481 user-facing trust surfaces contract
+Linked specs: [PLSP-SPEC-0011](../../docs/specs/PLSP-SPEC-0011-trust-lane-ci-routing.md), [PLSP-SPEC-0012](../../docs/specs/PLSP-SPEC-0012-user-facing-trust-surfaces.md)
 Blocks: user-facing trust docs, command documentation, setup troubleshooting
-Blocked by: user-facing trust surfaces contract review
+Blocked by: none
 
 Goal
 
-Encode the remaining user-facing trust contracts in durable specs and ADRs so
+Encode the remaining user-facing trust contracts in durable specs so
 agents do not need chat context to know what explanations, receipts, previews,
 workspace trust, support claims, and CI routing may claim.
 
@@ -87,7 +84,7 @@ git diff --check
 
 Rollback
 
-Revert the affected spec or ADR PR. If a contract is wrong, leave the active
+Revert the affected spec PR. If a contract is wrong, leave the active
 goal in place and mark the specific work item blocked until a replacement
 contract lands.
 
@@ -97,7 +94,7 @@ Status: ready
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked spec: [PLSP-SPEC-0002](../../docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
 Blocks: README claim refresh, VS Code command docs
-Blocked by: user-facing trust surface contract
+Blocked by: none
 
 Goal
 
@@ -140,7 +137,7 @@ Status: completed
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked spec: [PLSP-SPEC-0009](../../docs/specs/PLSP-SPEC-0009-workspace-trust-report.md)
 Blocks: setup troubleshooting docs, support-front-door docs
-Receipt: PR #9463 `test(ux): snapshot workspace trust report schema`
+Receipt: `crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs::test_execute_command_workspace_trust_report_schema_snapshot`
 
 Goal
 
@@ -268,11 +265,11 @@ revert live behavior before changing docs.
 
 ## Work item: trust-lane-ci-routing
 
-Status: planned
+Status: ready
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
-Linked spec: PR #9478 trust-lane CI routing contract
+Linked spec: [PLSP-SPEC-0011](../../docs/specs/PLSP-SPEC-0011-trust-lane-ci-routing.md)
 Blocks: cheap parser fixture lane, hosted CI exposure estimate
-Blocked by: trust-lane CI routing contract review
+Blocked by: none
 
 Goal
 


### PR DESCRIPTION
Problem: The completed Real Perl Editor Trust v1 manifest still occupied `.perl-lsp/goals/active.toml`, so agents could not read the repo and see the current UX/productization lane without chat context.
Fix: Archive the completed v1 manifest, replace `active.toml` with an active Editor Trust UX closeout goal, and add `plans/editor-trust-ux-closeout/implementation-plan.md` with current work items, claim boundaries, proof commands, status owners, and in-flight contract PRs.
Verification: TOML manifests parse with Python `tomllib`; `cargo xtask check-support-claims` passes with an explicit out-of-worktree target dir; `cargo xtask check-provider-confidence-matrix` passes with the same target dir; `git diff --check` and `git diff --cached --check` pass.