### PR TITLE
feat(semantic): infer receiver expression facts (#8197)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -1,6 +1,9 @@
-use super::type_facts::TypeFact;
+use super::type_facts::{
+    ArrayShape, DynamicBoundary, HashShape, ObjectShape, ShapeFact, TypeEvidence, TypeFact,
+};
 use crate::ast::{Node, NodeKind};
-use std::collections::HashMap;
+use perl_semantic_facts::Confidence;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::sync::Arc;
 
@@ -359,6 +362,15 @@ impl TypeInferenceEngine {
         Ok(ty)
     }
 
+    /// Infer a rich type fact for an expression using the engine's current
+    /// global environment.
+    pub fn infer_expr_fact(&mut self, expr: &Node) -> TypeFact {
+        let mut env = std::mem::take(&mut self.global_env);
+        let fact = self.infer_expr_fact_in_env(expr, &mut env);
+        self.global_env = env;
+        fact
+    }
+
     /// Infer type for a single node
     fn infer_node(
         &mut self,
@@ -471,6 +483,16 @@ impl TypeInferenceEngine {
                 Ok(Hash { key: Box::new(key_type), value: Box::new(value_type) })
             }
 
+            NodeKind::Assignment { lhs, rhs, op } => {
+                if op == "=" {
+                    let fact = self.assign_expr_fact(lhs, rhs, env);
+                    Ok(fact.erased_type())
+                } else {
+                    let rhs_ty = self.infer_node(rhs, env)?;
+                    Ok(rhs_ty)
+                }
+            }
+
             NodeKind::Binary { left, op, right } => {
                 let left_ty = self.infer_node(left, env)?;
                 let right_ty = self.infer_node(right, env)?;
@@ -499,6 +521,10 @@ impl TypeInferenceEngine {
 
                     // Assignment operators
                     "=" | "+=" | "-=" | "*=" | "/=" | ".=" => {
+                        if op == "=" {
+                            let fact = self.assign_expr_fact(left, right, env);
+                            return Ok(fact.erased_type());
+                        }
                         env.set_variable(self.extract_var_name(left), right_ty.clone());
                         Ok(right_ty)
                     }
@@ -596,65 +622,9 @@ impl TypeInferenceEngine {
                     // Strip sigil from name for storage
                     let clean_name = name.trim_start_matches(['$', '@', '%']);
 
-                    // Infer type based on sigil and initializer
-                    let inferred_type = if sigil == "@" {
-                        // Array variable - infer element type from initializer if available
-                        if let Some(init) = initializer {
-                            self.infer_node(init, env)?
-                        } else {
-                            PerlType::Array(Box::new(PerlType::Any))
-                        }
-                    } else if sigil == "%" {
-                        // Hash variable - infer key/value types from initializer if available
-                        if let Some(init) = initializer {
-                            // Check if initializer is an ArrayLiteral (which is how hash literals in parens are parsed)
-                            if let NodeKind::ArrayLiteral { elements } = &init.kind {
-                                // Convert array elements to hash type
-                                if elements.is_empty() {
-                                    PerlType::Hash {
-                                        key: Box::new(PerlType::Scalar(ScalarType::String)),
-                                        value: Box::new(PerlType::Any),
-                                    }
-                                } else if elements.len() % 2 == 0 {
-                                    // Treat as key-value pairs
-                                    let mut value_types = Vec::new();
-                                    for i in (1..elements.len()).step_by(2) {
-                                        value_types.push(self.infer_node(&elements[i], env)?);
-                                    }
-                                    let value_type = self.unify_types(&value_types);
-                                    PerlType::Hash {
-                                        key: Box::new(PerlType::Scalar(ScalarType::String)),
-                                        value: Box::new(value_type),
-                                    }
-                                } else {
-                                    // Odd number of elements - still treat as hash
-                                    PerlType::Hash {
-                                        key: Box::new(PerlType::Scalar(ScalarType::String)),
-                                        value: Box::new(PerlType::Any),
-                                    }
-                                }
-                            } else {
-                                // Normal hash literal or other expression
-                                self.infer_node(init, env)?
-                            }
-                        } else {
-                            PerlType::Hash {
-                                key: Box::new(PerlType::Scalar(ScalarType::String)),
-                                value: Box::new(PerlType::Any),
-                            }
-                        }
-                    } else {
-                        // Scalar variable - infer from initializer
-                        if let Some(init) = initializer {
-                            self.infer_node(init, env)?
-                        } else {
-                            PerlType::Scalar(ScalarType::Undef)
-                        }
-                    };
-
-                    // Store in both environments using the name WITHOUT sigil
-                    self.global_env.set_variable(clean_name.to_string(), inferred_type.clone());
-                    env.set_variable(clean_name.to_string(), inferred_type.clone());
+                    let fact = self.declared_variable_fact(sigil, clean_name, initializer, env);
+                    let inferred_type = fact.erased_type();
+                    env.set_variable_fact(clean_name.to_string(), fact);
 
                     inferred_type
                 } else {
@@ -727,6 +697,240 @@ impl TypeInferenceEngine {
         // Simplified signature parsing
         // In a full implementation, this would parse Perl 5.20+ signatures
         Ok(vec![PerlType::Any])
+    }
+
+    fn infer_expr_fact_in_env(&mut self, node: &Node, env: &mut TypeEnvironment) -> TypeFact {
+        use PerlType::*;
+        use ScalarType::*;
+
+        match &node.kind {
+            NodeKind::ExpressionStatement { expression } => {
+                self.infer_expr_fact_in_env(expression, env)
+            }
+            NodeKind::Number { value } => {
+                let ty = if value.contains('.') || value.contains('e') || value.contains('E') {
+                    Scalar(Float)
+                } else {
+                    Scalar(Integer)
+                };
+                fact_with_evidence(ty, Confidence::High, TypeEvidence::Literal)
+            }
+            NodeKind::String { .. } => {
+                fact_with_evidence(Scalar(String), Confidence::High, TypeEvidence::Literal)
+            }
+            NodeKind::Undef => {
+                fact_with_evidence(Scalar(Undef), Confidence::High, TypeEvidence::Literal)
+            }
+            NodeKind::Variable { sigil, name } => env.get_fact_at(name).unwrap_or_else(|| {
+                let ty = env.get_variable(name).cloned().unwrap_or_else(|| match sigil.as_str() {
+                    "$" => Scalar(Mixed),
+                    "@" => Array(Box::new(Any)),
+                    "%" => Hash { key: Box::new(Scalar(String)), value: Box::new(Any) },
+                    "*" => Glob,
+                    _ => Any,
+                });
+                TypeFact::new(ty, Confidence::Low)
+            }),
+            NodeKind::VariableWithAttributes { variable, .. } => {
+                self.infer_expr_fact_in_env(variable, env)
+            }
+            NodeKind::ArrayLiteral { elements } => self.array_literal_fact(elements, env),
+            NodeKind::HashLiteral { pairs } => self.hash_literal_fact(pairs, env),
+            NodeKind::MethodCall { object, method, .. } if method == "new" => {
+                static_package_node(object)
+                    .map_or_else(TypeFact::unknown, |package| constructor_fact(&package))
+            }
+            NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
+                self.assign_expr_fact(lhs, rhs, env)
+            }
+            NodeKind::Binary { left, op, right } if op == "=" => {
+                self.assign_expr_fact(left, right, env)
+            }
+            NodeKind::Binary { left, op, right } if op == "{}" || op == "->{}" => {
+                self.hash_slot_expr_fact(op, left, right, env)
+            }
+            NodeKind::Binary { left, op, right } if op == "[]" || op == "->[]" => {
+                self.array_index_expr_fact(left, right, env)
+            }
+            _ => self
+                .infer_node(node, env)
+                .map_or_else(|_| TypeFact::unknown(), |ty| TypeFact::new(ty, Confidence::Low)),
+        }
+    }
+
+    fn declared_variable_fact(
+        &mut self,
+        sigil: &str,
+        name: &str,
+        initializer: &Option<Box<Node>>,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let mut fact = match (sigil, initializer) {
+            ("%", Some(init)) => self.hash_initializer_fact(init, env),
+            ("%", None) => TypeFact::unknown_hash(),
+            ("@", Some(init)) => self.infer_expr_fact_in_env(init, env),
+            ("@", None) => TypeFact::new(PerlType::Array(Box::new(PerlType::Any)), Confidence::Low),
+            ("$", Some(init)) => self.infer_expr_fact_in_env(init, env),
+            ("$", None) => TypeFact::new(PerlType::Scalar(ScalarType::Undef), Confidence::Low),
+            _ => TypeFact::unknown(),
+        };
+        fact.evidence.push(TypeEvidence::VariableInitializer { name: name.to_string() });
+        fact
+    }
+
+    fn assign_expr_fact(&mut self, lhs: &Node, rhs: &Node, env: &mut TypeEnvironment) -> TypeFact {
+        let mut rhs_fact = self.infer_expr_fact_in_env(rhs, env);
+
+        if let Some(name) = variable_name(lhs) {
+            rhs_fact.evidence.push(TypeEvidence::Assignment { name: name.to_string() });
+            env.set_variable_fact(name.to_string(), rhs_fact.clone());
+            return rhs_fact;
+        }
+
+        if let Some((hash_name, key)) = static_hash_slot_target(lhs) {
+            rhs_fact.evidence.push(TypeEvidence::Assignment { name: hash_name.clone() });
+            rhs_fact
+                .evidence
+                .push(TypeEvidence::HashSlot { hash: format!("${hash_name}"), key: key.clone() });
+            let mut hash_fact = env.get_fact_at(&hash_name).unwrap_or_else(TypeFact::unknown_hash);
+            let mut shape = match hash_fact.shape.take() {
+                Some(ShapeFact::Hash(shape)) => shape,
+                _ => HashShape::new(BTreeMap::new(), None),
+            };
+            shape.slots.insert(key, rhs_fact.clone());
+            hash_fact.ty = hash_type_from_slot_facts(shape.slots.values());
+            hash_fact.confidence = Confidence::High;
+            hash_fact.shape = Some(ShapeFact::Hash(shape));
+            env.set_variable_fact(hash_name, hash_fact);
+            return rhs_fact;
+        }
+
+        rhs_fact
+    }
+
+    fn hash_initializer_fact(&mut self, init: &Node, env: &mut TypeEnvironment) -> TypeFact {
+        match &init.kind {
+            NodeKind::ArrayLiteral { elements } => self.hash_literal_elements_fact(elements, env),
+            NodeKind::HashLiteral { pairs } => self.hash_literal_fact(pairs, env),
+            _ => self.infer_expr_fact_in_env(init, env),
+        }
+    }
+
+    fn hash_literal_fact(&mut self, pairs: &[(Node, Node)], env: &mut TypeEnvironment) -> TypeFact {
+        let mut slots = BTreeMap::new();
+        for (key, value) in pairs {
+            if let Some(key) = static_hash_key(key) {
+                let mut value_fact = self.infer_expr_fact_in_env(value, env);
+                value_fact
+                    .evidence
+                    .push(TypeEvidence::HashSlot { hash: "literal".to_string(), key: key.clone() });
+                slots.insert(key, value_fact);
+            }
+        }
+
+        hash_shape_fact(slots, TypeEvidence::Literal)
+    }
+
+    fn hash_literal_elements_fact(
+        &mut self,
+        elements: &[Node],
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        if !elements.len().is_multiple_of(2) {
+            return hash_shape_fact(BTreeMap::new(), TypeEvidence::Literal);
+        }
+
+        let mut slots = BTreeMap::new();
+        for pair in elements.chunks(2) {
+            let [key, value] = pair else {
+                continue;
+            };
+            let Some(key) = static_hash_key(key) else {
+                return hash_shape_fact(BTreeMap::new(), TypeEvidence::Literal);
+            };
+            let mut value_fact = self.infer_expr_fact_in_env(value, env);
+            value_fact
+                .evidence
+                .push(TypeEvidence::HashSlot { hash: "literal".to_string(), key: key.clone() });
+            slots.insert(key, value_fact);
+        }
+
+        hash_shape_fact(slots, TypeEvidence::Literal)
+    }
+
+    fn array_literal_fact(&mut self, elements: &[Node], env: &mut TypeEnvironment) -> TypeFact {
+        let mut indexed = BTreeMap::new();
+        for (index, element) in elements.iter().enumerate() {
+            indexed.insert(index, self.infer_expr_fact_in_env(element, env));
+        }
+        let ty = PerlType::Array(Box::new(hash_value_type(indexed.values())));
+        let mut fact = fact_with_evidence(ty, Confidence::High, TypeEvidence::Literal);
+        fact.shape = Some(ShapeFact::Array(ArrayShape::new(indexed, None)));
+        fact
+    }
+
+    fn hash_slot_expr_fact(
+        &mut self,
+        op: &str,
+        left: &Node,
+        right: &Node,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let Some(key) = static_hash_key(right) else {
+            return TypeFact::dynamic(DynamicBoundary::DynamicHashKey);
+        };
+
+        let container_fact = self.infer_expr_fact_in_env(left, env);
+        let evidence = if op == "->{}" {
+            TypeEvidence::HashRefSlot { base: receiver_base_label(left), key: key.clone() }
+        } else {
+            TypeEvidence::HashSlot { hash: receiver_base_label(left), key: key.clone() }
+        };
+
+        match container_fact.shape {
+            Some(ShapeFact::Hash(shape)) => shape
+                .slots
+                .get(&key)
+                .cloned()
+                .or_else(|| shape.fallback_value.as_ref().map(|fact| fact.as_ref().clone()))
+                .map_or_else(
+                    || {
+                        let mut fact = TypeFact::unknown();
+                        fact.evidence.push(evidence.clone());
+                        fact
+                    },
+                    |mut fact| {
+                        fact.evidence.push(evidence.clone());
+                        fact
+                    },
+                ),
+            _ => {
+                let mut fact = TypeFact::unknown();
+                fact.evidence.push(evidence);
+                fact
+            }
+        }
+    }
+
+    fn array_index_expr_fact(
+        &mut self,
+        left: &Node,
+        right: &Node,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let Some(index) = static_array_index(right) else {
+            return TypeFact::dynamic(DynamicBoundary::UnknownReceiver);
+        };
+
+        match self.infer_expr_fact_in_env(left, env).shape {
+            Some(ShapeFact::Array(shape)) => shape
+                .indexed
+                .get(&index)
+                .cloned()
+                .or_else(|| shape.element.as_ref().map(|fact| fact.as_ref().clone()))
+                .unwrap_or_else(TypeFact::unknown),
+            _ => TypeFact::unknown(),
+        }
     }
 
     /// Extract variable name from a node
@@ -909,6 +1113,109 @@ impl TypeInferenceEngine {
             .cloned()
             .collect()
     }
+}
+
+fn fact_with_evidence(ty: PerlType, confidence: Confidence, evidence: TypeEvidence) -> TypeFact {
+    let mut fact = TypeFact::new(ty, confidence);
+    fact.evidence.push(evidence);
+    fact
+}
+
+fn constructor_fact(package: &str) -> TypeFact {
+    let mut fact = fact_with_evidence(
+        PerlType::Object(package.to_string()),
+        Confidence::High,
+        TypeEvidence::ConstructorCall { package: package.to_string() },
+    );
+    fact.shape = Some(ShapeFact::Object(ObjectShape::new(package.to_string(), BTreeMap::new())));
+    fact
+}
+
+fn hash_shape_fact(slots: BTreeMap<String, TypeFact>, evidence: TypeEvidence) -> TypeFact {
+    let confidence = if slots.is_empty() { Confidence::Low } else { Confidence::High };
+    let mut fact =
+        fact_with_evidence(hash_type_from_slot_facts(slots.values()), confidence, evidence);
+    fact.shape = Some(ShapeFact::Hash(HashShape::new(slots, None)));
+    fact
+}
+
+fn hash_type_from_slot_facts<'a, I>(facts: I) -> PerlType
+where
+    I: IntoIterator<Item = &'a TypeFact>,
+{
+    PerlType::Hash {
+        key: Box::new(PerlType::Scalar(ScalarType::String)),
+        value: Box::new(hash_value_type(facts)),
+    }
+}
+
+fn hash_value_type<'a, I>(facts: I) -> PerlType
+where
+    I: IntoIterator<Item = &'a TypeFact>,
+{
+    let mut values = facts.into_iter();
+    let Some(first) = values.next() else {
+        return PerlType::Any;
+    };
+    let first_ty = first.erased_type();
+    if values.all(|fact| fact.erased_type() == first_ty) { first_ty } else { PerlType::Any }
+}
+
+fn static_package_node(node: &Node) -> Option<String> {
+    match &node.kind {
+        NodeKind::Identifier { name } => Some(name.clone()),
+        NodeKind::String { value, .. } => normalize_literal(value),
+        _ => None,
+    }
+}
+
+fn variable_name(node: &Node) -> Option<&str> {
+    match &node.kind {
+        NodeKind::Variable { name, .. } => Some(name.as_str()),
+        NodeKind::VariableWithAttributes { variable, .. } => variable_name(variable),
+        _ => None,
+    }
+}
+
+fn static_hash_slot_target(node: &Node) -> Option<(String, String)> {
+    let NodeKind::Binary { op, left, right } = &node.kind else {
+        return None;
+    };
+    if op != "{}" {
+        return None;
+    }
+    let name = variable_name(left)?;
+    let key = static_hash_key(right)?;
+    Some((name.to_string(), key))
+}
+
+fn static_hash_key(node: &Node) -> Option<String> {
+    match &node.kind {
+        NodeKind::String { value, .. } => normalize_literal(value),
+        NodeKind::Identifier { name } => Some(name.clone()),
+        NodeKind::Number { value } => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn static_array_index(node: &Node) -> Option<usize> {
+    match &node.kind {
+        NodeKind::Number { value } => value.parse().ok(),
+        _ => None,
+    }
+}
+
+fn receiver_base_label(node: &Node) -> String {
+    match &node.kind {
+        NodeKind::Variable { sigil, name } => format!("{sigil}{name}"),
+        NodeKind::VariableWithAttributes { variable, .. } => receiver_base_label(variable),
+        _ => node.kind.kind_name().to_string(),
+    }
+}
+
+fn normalize_literal(value: &str) -> Option<String> {
+    let normalized = value.trim().trim_matches('\'').trim_matches('"').trim();
+    if normalized.is_empty() { None } else { Some(normalized.to_string()) }
 }
 
 /// Type-based code completion suggestions

--- a/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
@@ -1,0 +1,130 @@
+use perl_semantic_analyzer::analysis::type_facts::{DynamicBoundary, ShapeFact, TypeEvidence};
+use perl_semantic_analyzer::analysis::type_inference::{PerlType, TypeInferenceEngine};
+use perl_semantic_analyzer::{Node, NodeKind, Parser};
+use perl_semantic_facts::Confidence;
+
+fn parse_ast(code: &str) -> Result<Node, String> {
+    let mut parser = Parser::new(code);
+    parser.parse().map_err(|err| format!("parse failed: {err:?}"))
+}
+
+fn method_call_named<'a>(node: &'a Node, name: &str) -> Option<&'a Node> {
+    if let NodeKind::MethodCall { method, .. } = &node.kind {
+        if method == name {
+            return Some(node);
+        }
+    }
+
+    match &node.kind {
+        NodeKind::Program { statements } => {
+            statements.iter().find_map(|child| method_call_named(child, name))
+        }
+        NodeKind::ExpressionStatement { expression } => method_call_named(expression, name),
+        NodeKind::VariableDeclaration { initializer, .. } => {
+            initializer.as_deref().and_then(|child| method_call_named(child, name))
+        }
+        NodeKind::Assignment { lhs, rhs, .. } => {
+            method_call_named(lhs, name).or_else(|| method_call_named(rhs, name))
+        }
+        NodeKind::MethodCall { object, args, .. } => method_call_named(object, name)
+            .or_else(|| args.iter().find_map(|child| method_call_named(child, name))),
+        NodeKind::Binary { left, right, .. } => {
+            method_call_named(left, name).or_else(|| method_call_named(right, name))
+        }
+        NodeKind::ArrayLiteral { elements } => {
+            elements.iter().find_map(|child| method_call_named(child, name))
+        }
+        NodeKind::HashLiteral { pairs } => pairs.iter().find_map(|(key, value)| {
+            method_call_named(key, name).or_else(|| method_call_named(value, name))
+        }),
+        _ => None,
+    }
+}
+
+fn method_receiver<'a>(node: &'a Node, name: &str) -> Result<&'a Node, String> {
+    let call = method_call_named(node, name).ok_or_else(|| format!("missing {name} call"))?;
+    match &call.kind {
+        NodeKind::MethodCall { object, .. } => Ok(object),
+        _ => Err(format!("{name} is not a method call")),
+    }
+}
+
+#[test]
+fn constructor_expr_fact_records_object_package() -> Result<(), String> {
+    let ast = parse_ast("MyApp::DB->new();")?;
+    let receiver = method_call_named(&ast, "new").ok_or_else(|| "missing new call".to_string())?;
+    let mut engine = TypeInferenceEngine::new();
+
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Object("MyApp::DB".to_string()));
+    assert_eq!(fact.confidence, Confidence::High);
+    assert!(matches!(fact.shape, Some(ShapeFact::Object(_))));
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::ConstructorCall { package } if package == "MyApp::DB")
+    }));
+    Ok(())
+}
+
+#[test]
+fn plain_hash_literal_slot_resolves_source_derived_receiver_fact() -> Result<(), String> {
+    let code = "my %services = (db => MyApp::DB->new); $services{db}->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let services =
+        engine.get_fact_at("services").ok_or_else(|| "missing services fact".to_string())?;
+    assert!(matches!(services.shape, Some(ShapeFact::Hash(_))));
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Object("MyApp::DB".to_string()));
+    assert_eq!(fact.confidence, Confidence::High);
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::HashSlot { hash, key } if hash == "$services" && key == "db")
+    }));
+    Ok(())
+}
+
+#[test]
+fn plain_hash_slot_assignment_updates_later_receiver_fact() -> Result<(), String> {
+    let code = "my %services; $services{db} = MyApp::DB->new; $services{db}->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Object("MyApp::DB".to_string()));
+    assert_eq!(fact.confidence, Confidence::High);
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::Assignment { name } if name == "services")
+    }));
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::HashSlot { hash, key } if hash == "$services" && key == "db")
+    }));
+    Ok(())
+}
+
+#[test]
+fn dynamic_plain_hash_key_fails_closed() -> Result<(), String> {
+    let code = "my %services = (db => MyApp::DB->new); $services{$name}->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Any);
+    assert_eq!(fact.confidence, Confidence::Low);
+    assert_eq!(fact.dynamic_boundary, Some(DynamicBoundary::DynamicHashKey));
+    assert!(fact.evidence.is_empty());
+    Ok(())
+}

--- a/docs/project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md
+++ b/docs/project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Receiver Facts Implementation Plan
 
-Status: partial substrate landed; completion cutover blocked
+Status: partial substrate plus constructor/plain-hash expression facts landed; completion cutover blocked
 Owner: perl-lsp maintainers
 Spec: [PLSP-SPEC-0005: Receiver expression facts](../specs/PLSP-SPEC-0005-receiver-expression-facts.md)
 Related proposal: [PLSP-PROP-0001: Real Perl editor trust](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
@@ -30,9 +30,11 @@ facts-only semantic substrate. It adds the rich fact model, a parallel
 type-environment fact map, and a receiver-fact extractor over existing
 `TypeFact` and `ShapeFact` evidence.
 
-That foundation does not yet add source-level expression inference and does not
-change completion candidates. Current detailed status lives in
-[receiver_facts.md](status/receiver_facts.md). The active claim boundary remains:
+That foundation has started source-level expression inference for constructor
+calls, plain hash literals, plain hash slot assignments, static plain hash slot
+reads, and dynamic plain hash keys. It still does not change completion
+candidates. Current detailed status lives in [receiver_facts.md](status/receiver_facts.md).
+The active claim boundary remains:
 
 ```text
 semantic substrate only
@@ -100,6 +102,10 @@ lookup for existing variable types.
 ```
 
 ### PR 2 — Expression fact inference for constructors and plain hashes
+
+**Status:** landed as facts-only substrate for constructor calls, plain hash
+literals, plain hash slot assignments, static plain hash slot reads, and dynamic
+plain hash keys. Provider output is unchanged.
 
 **Primary files**
 

--- a/docs/project/status/receiver_facts.md
+++ b/docs/project/status/receiver_facts.md
@@ -24,6 +24,7 @@ It may claim:
 
 - rich fact model and type-environment storage where tests prove it
 - receiver extraction over existing `TypeFact` and `ShapeFact` evidence
+- source-derived constructor and plain-hash slot facts where tests prove them
 - dynamic-key boundaries for receiver extraction
 - no completion candidate behavior change
 
@@ -32,8 +33,8 @@ It may not claim:
 - receiver-backed completion cutover
 - hover, goto, diagnostics, or refactor behavior changes
 - support-tier promotion
-- expression-level fact inference from Perl source declarations and
-  assignments until `infer_expr_fact` or equivalent fixtures prove it
+- hashref, bless-field, accessor-return, or chained method-return facts until
+  focused fixtures prove those source shapes
 
 Facts-only PRs must keep this wording in their claim boundary:
 
@@ -48,14 +49,14 @@ no support-tier promotion
 | Area | Status | Current proof | Boundary / next step |
 | --- | --- | --- | --- |
 | `fact_model` | `landed` | `crates/perl-semantic-analyzer/src/analysis/type_facts.rs`; `crates/perl-semantic-analyzer/tests/type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | `TypeFact`, `ShapeFact`, `HashShape`, `ArrayShape`, `ObjectShape`, `TypeEvidence`, and `DynamicBoundary` exist as substrate. |
-| `type_environment_fact_map` | `landed` | `TypeEnvironment::set_variable_fact`, `get_variable_fact`, `get_fact_at`; stale fact clearing and parent lookup tests in `type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Existing `PerlType` callers keep erased compatibility; source-level expression inference is separate. |
+| `type_environment_fact_map` | `landed` | `TypeEnvironment::set_variable_fact`, `get_variable_fact`, `get_fact_at`; stale fact clearing and parent lookup tests in `type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Existing `PerlType` callers keep erased compatibility while source-level expression inference stores richer facts for proven shapes. |
 | `static_package_receiver` | `landed` | `receiver_facts` module test `static_constructor_receiver_records_package`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static package receivers can produce high-confidence constructor evidence. |
 | `object_variable_receiver` | `landed` | `receiver_facts` module tests for `$self` and `$object`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Exact package requires a supplied type-environment fact. Unknown object variables stay low confidence. |
-| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Works when `TypeEnvironment` already contains a `HashShape`; hash literal and assignment expression inference is still missing. |
+| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; `receiver_expression_facts` tests for plain hash literals and slot assignment | Works when `TypeEnvironment` contains a `HashShape`; source-derived plain `%hash` literals and `$hash{key}` assignments can now populate that shape. Hashref, bless-field, and accessor-return source inference remain pending. |
 | `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Works when the base fact already has a hash shape; `$hashref->{key}` fact production from source declarations is still missing. |
 | `array_index_receiver` | `partial` | `receiver_facts` module tests for static and dynamic array indexes; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static indexes can use existing `ArrayShape` facts; dynamic indexes remain non-exact. |
-| `dynamic_key_boundary` | `landed` | `receiver_facts` module test `dynamic_hash_key_marks_dynamic_boundary`; `TypeFact::dynamic` test in `type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Proven for receiver extraction. Broader expression and provider boundary receipts remain pending. |
-| `expression_inference` | `missing` | No `TypeInferenceEngine::infer_expr_fact` API on current `master` | Next semantic slice should infer facts from literals, declarations, assignments, constructor calls, and static hash/hashref slots. |
+| `dynamic_key_boundary` | `landed` | `receiver_facts` module test `dynamic_hash_key_marks_dynamic_boundary`; `TypeFact::dynamic` test in `type_facts.rs`; `receiver_expression_facts` dynamic plain-hash-key test | Proven for receiver extraction and plain hash expression facts. Provider boundary receipts remain pending. |
+| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, static plain hash slot reads, and dynamic plain hash keys are facts-only substrate. Hashref slots, bless fields, accessor returns, and chained method-return facts remain pending. |
 | `receiver_fact_api` | `landed` | `crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | API extracts facts from existing AST and supplied environment facts; method-call chains remain unknown until explicit rules land. |
 | `completion_cutover` | `blocked` | No completion provider usage of `ReceiverFact` on current `master` | Blocked by facts-only fixtures, expression inference, provider fallback proof, and receiver confidence receipts. |
 
@@ -72,10 +73,10 @@ receiver_fact_completion_cutover:
 
 ## Next Implementation Steps
 
-1. Add expression-level fact inference for literals, assignments,
-   declarations, constructor calls, and hash/hashref slot reads.
-2. Add facts-only fixtures that prove source-derived `%hash` and `$hashref`
-   receiver facts without changing provider output.
+1. Add hashref, bless-field, accessor-return, and chained method-return
+   expression facts without changing provider output.
+2. Add facts-only fixtures that prove source-derived `$hashref`, `$self`, and
+   framework accessor receiver facts without changing provider output.
 3. Add provider confidence receipts for exact, fallback, and dynamic receiver
    cases.
 4. Cut completion over only after the facts-only and provider fallback receipts


### PR DESCRIPTION
Problem: Receiver facts could only consume manually supplied TypeEnvironment facts, so source-derived constructor and plain-hash receiver shapes could not produce facts for later completion receipts.
Fix: Add facts-only expression inference for constructor calls, plain hash literals, plain hash slot assignments/reads, and dynamic plain hash-key fallback, then record the bounded status.
Verification: `cargo test -p perl-semantic-analyzer --profile agent --locked` passes; `cargo check --all-targets -p perl-semantic-analyzer --profile agent --locked` passes; `cargo clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo xtask check-support-claims` passes; `cargo xtask check-provider-confidence-matrix` passes; `cargo xtask ci-hygiene check-doc-paths docs/project` passes; `git diff --check` passes.
Claim boundary: Facts-only semantic substrate; no completion candidate behavior change; no support-tier promotion; hashref/bless/accessor/chained method-return facts remain pending.