### PR TITLE
feat(ux): add workspace trust copyable payload (#8197)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/workspace_trust_report.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/workspace_trust_report.rs
@@ -9,6 +9,10 @@ use perl_lsp_rs_core::config::{Perl5LibPrecedence, WorkspaceConfig};
 use std::sync::atomic::Ordering;
 
 const WORKSPACE_TRUST_REPORT_SCHEMA_VERSION: &str = "workspace_trust_report.v1";
+const WORKSPACE_TRUST_REPORT_COPYABLE_PAYLOAD_SCHEMA_VERSION: &str =
+    "workspace_trust_report_copyable.v1";
+const SUPPORT_TIER_LINK: &str = "docs/project/status/SUPPORT_TIERS.md#claim-rows";
+const DYNAMIC_BOUNDARY_POLICY: &str = "Generated, dynamic, stale, low-confidence, ambiguous, and fallback facts remain labeled, gated, or blocked according to each provider support tier.";
 
 fn perl5lib_precedence_label(precedence: &Perl5LibPrecedence) -> &'static str {
     match precedence {
@@ -271,6 +275,77 @@ fn support_tiers_summary() -> Value {
     })
 }
 
+fn workspace_root_class(workspace_roots: &[String]) -> &'static str {
+    match workspace_roots.len() {
+        0 => "none",
+        1 => "single_root",
+        _ => "multi_root",
+    }
+}
+
+fn workspace_root_hash(workspace_roots: &[String]) -> Option<String> {
+    if workspace_roots.is_empty() {
+        return None;
+    }
+
+    let mut roots = workspace_roots.iter().map(|root| root.replace('\\', "/")).collect::<Vec<_>>();
+    roots.sort();
+    Some(format!("{:x}", md5::compute(roots.join("\n"))))
+}
+
+fn workspace_trust_copyable_payload(
+    workspace_roots: &[String],
+    workspace_folder_count: usize,
+    open_document_count: usize,
+    global_config: &WorkspaceConfig,
+    setup_hints: &Value,
+    client_runtime_state: &Value,
+    provider_trace_count: usize,
+) -> Value {
+    let perl5lib_paths = perl5lib_paths(global_config);
+    json!({
+        "schema_version": WORKSPACE_TRUST_REPORT_COPYABLE_PAYLOAD_SCHEMA_VERSION,
+        "perl_lsp_version": env!("CARGO_PKG_VERSION"),
+        "provider": "workspace_trust_report",
+        "command": "perl.workspaceTrustReport",
+        "workspace_root_class": workspace_root_class(workspace_roots),
+        "workspace_root_hash": workspace_root_hash(workspace_roots),
+        "workspace_folder_count": workspace_folder_count,
+        "open_document_count": open_document_count,
+        "configured_include_path_count": global_config.include_paths.len(),
+        "effective_include_path_count": global_config.effective_include_paths(&perl5lib_paths).len(),
+        "use_system_inc": global_config.use_system_inc,
+        "system_inc_status": if global_config.use_system_inc {
+            "configured_not_probed_by_report"
+        } else {
+            "disabled"
+        },
+        "use_perl5lib": global_config.use_perl5lib,
+        "perl5lib_entry_count": perl5lib_paths.len(),
+        "perl5lib_precedence": perl5lib_precedence_label(&global_config.perl5lib_precedence),
+        "perl_binary_resolution_status": setup_hints
+            .pointer("/perl_binary/resolution_status")
+            .and_then(Value::as_str),
+        "perldoc_status": setup_hints.pointer("/perldoc/status").and_then(Value::as_str),
+        "perldoc_run_status": setup_hints
+            .pointer("/perldoc/run_status")
+            .and_then(Value::as_str),
+        "dap_status": setup_hints.pointer("/dap/status").and_then(Value::as_str),
+        "client_runtime_schema_version": client_runtime_state
+            .get("schema_version")
+            .and_then(Value::as_str),
+        "client_runtime_source": client_runtime_state.get("source").and_then(Value::as_str),
+        "launch_configuration_status": client_runtime_state
+            .pointer("/dap/launch_configuration/status")
+            .and_then(Value::as_str),
+        "provider_support_tiers": support_tiers_summary(),
+        "decision_trace_count": provider_trace_count,
+        "dynamic_boundary_policy": DYNAMIC_BOUNDARY_POLICY,
+        "support_tier_link": SUPPORT_TIER_LINK,
+        "claim_boundary": "Copyable workspace trust payload summarizes existing server/client state only. It does not scan files, probe Perl, run perldoc, launch DAP, change provider behavior, upload telemetry, or promote support tiers.",
+    })
+}
+
 #[cfg(feature = "workspace")]
 fn index_report(server: &LspServer) -> Value {
     let Some(coordinator) = server.coordinator() else {
@@ -376,6 +451,27 @@ impl LspServer {
             })
             .collect();
 
+        let mut workspace_roots = folders
+            .iter()
+            .filter_map(|folder| folder.path.as_ref().map(|path| path.display().to_string()))
+            .collect::<Vec<_>>();
+        if workspace_roots.is_empty() {
+            if let Some(root_path) = root_path.as_ref() {
+                workspace_roots.push(root_path.display().to_string());
+            }
+        }
+        let setup_hints = setup_hints_summary(&global_config);
+        let client_runtime_state = client_runtime_state_summary(argument);
+        let copyable_payload = workspace_trust_copyable_payload(
+            &workspace_roots,
+            folders.len(),
+            open_document_count,
+            &global_config,
+            &setup_hints,
+            &client_runtime_state,
+            provider_trace_keys.len(),
+        );
+
         Ok(Some(json!({
             "schema_version": WORKSPACE_TRUST_REPORT_SCHEMA_VERSION,
             "command": "perl.workspaceTrustReport",
@@ -391,8 +487,8 @@ impl LspServer {
                 "global_workspace_config": workspace_config_summary(&global_config),
                 "policy": "Configured include paths and optional PERL5LIB participation are reported without probing interpreter startup @INC.",
             },
-            "setup_hints": setup_hints_summary(&global_config),
-            "client_runtime_state": client_runtime_state_summary(argument),
+            "setup_hints": setup_hints,
+            "client_runtime_state": client_runtime_state,
             "index": index_report(self),
             "providers": {
                 "support_tiers": support_tiers_summary(),
@@ -400,8 +496,9 @@ impl LspServer {
                 "decision_trace_keys": provider_trace_keys,
             },
             "dynamic_boundaries": {
-                "policy": "Generated, dynamic, stale, low-confidence, ambiguous, and fallback facts remain labeled, gated, or blocked according to each provider support tier."
+                "policy": DYNAMIC_BOUNDARY_POLICY
             },
+            "copyable_payload": copyable_payload,
         })))
     }
 }

--- a/crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs
@@ -447,7 +447,7 @@ fn test_execute_command_workspace_trust_report_schema_snapshot()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
     let root_path = temp_dir.path().to_string_lossy().to_string();
-    let server = setup_server(Some(root_path));
+    let server = setup_server(Some(root_path.clone()));
 
     let execute_request = JsonRpcRequest {
         _jsonrpc: "2.0".to_string(),
@@ -519,6 +519,7 @@ fn test_execute_command_workspace_trust_report_schema_snapshot()
             "claim_boundary",
             "client_runtime_state",
             "command",
+            "copyable_payload",
             "dynamic_boundaries",
             "index",
             "module_resolution",
@@ -649,8 +650,44 @@ fn test_execute_command_workspace_trust_report_schema_snapshot()
         sorted_object_keys_at(&result, "/providers")?,
         expected_keys(&["decision_trace_count", "decision_trace_keys", "support_tiers"])
     );
-
     let support_tier_keys = sorted_object_keys_at(&result, "/providers/support_tiers")?;
+    assert_eq!(
+        sorted_object_keys_at(&result, "/copyable_payload")?,
+        expected_keys(&[
+            "claim_boundary",
+            "client_runtime_schema_version",
+            "client_runtime_source",
+            "command",
+            "configured_include_path_count",
+            "dap_status",
+            "decision_trace_count",
+            "dynamic_boundary_policy",
+            "effective_include_path_count",
+            "launch_configuration_status",
+            "open_document_count",
+            "perl5lib_entry_count",
+            "perl5lib_precedence",
+            "perl_binary_resolution_status",
+            "perl_lsp_version",
+            "perldoc_run_status",
+            "perldoc_status",
+            "provider",
+            "provider_support_tiers",
+            "schema_version",
+            "support_tier_link",
+            "system_inc_status",
+            "use_perl5lib",
+            "use_system_inc",
+            "workspace_folder_count",
+            "workspace_root_class",
+            "workspace_root_hash",
+        ])
+    );
+    assert_eq!(
+        sorted_object_keys_at(&result, "/copyable_payload/provider_support_tiers")?,
+        support_tier_keys
+    );
+
     for required_tier in [
         "completion",
         "diagnostics",
@@ -675,6 +712,62 @@ fn test_execute_command_workspace_trust_report_schema_snapshot()
     assert_eq!(
         result.pointer("/client_runtime_state/schema_version").and_then(Value::as_str),
         Some("workspace_trust_client_runtime.v1")
+    );
+    assert_eq!(
+        result.pointer("/copyable_payload/schema_version").and_then(Value::as_str),
+        Some("workspace_trust_report_copyable.v1")
+    );
+    assert_eq!(
+        result.pointer("/copyable_payload/provider").and_then(Value::as_str),
+        Some("workspace_trust_report")
+    );
+    assert_eq!(
+        result.pointer("/copyable_payload/command").and_then(Value::as_str),
+        Some("perl.workspaceTrustReport")
+    );
+    assert_eq!(
+        result.pointer("/copyable_payload/workspace_root_class").and_then(Value::as_str),
+        Some("single_root")
+    );
+    assert!(
+        result.pointer("/copyable_payload/workspace_root_hash").and_then(Value::as_str).is_some(),
+        "copyable payload should use a workspace root hash instead of relying on raw paths"
+    );
+    let copyable_payload_text =
+        serde_json::to_string(result.get("copyable_payload").ok_or("missing copyable_payload")?)?;
+    assert!(
+        !copyable_payload_text.contains(&root_path),
+        "copyable payload must not include the raw workspace root"
+    );
+    assert_eq!(
+        result.pointer("/copyable_payload/client_runtime_source").and_then(Value::as_str),
+        Some("vscode-extension")
+    );
+    assert_eq!(
+        result.pointer("/copyable_payload/client_runtime_schema_version").and_then(Value::as_str),
+        Some("workspace_trust_client_runtime.v1")
+    );
+    assert_eq!(
+        result.pointer("/copyable_payload/launch_configuration_status").and_then(Value::as_str),
+        Some("client_launch_config_reported")
+    );
+    assert_eq!(
+        result
+            .pointer("/copyable_payload/provider_support_tiers/workspace_trust_report")
+            .and_then(Value::as_str),
+        Some("partial-live-with-fallback")
+    );
+    assert_eq!(
+        result.pointer("/copyable_payload/support_tier_link").and_then(Value::as_str),
+        Some("docs/project/status/SUPPORT_TIERS.md#claim-rows")
+    );
+    assert!(
+        result.pointer("/copyable_payload/claim_boundary").and_then(Value::as_str).is_some_and(
+            |claim| claim.contains("does not scan files")
+                && claim.contains("probe Perl")
+                && claim.contains("promote support tiers")
+        ),
+        "copyable payload must preserve the report-only claim boundary"
     );
     assert!(
         result.get("claim_boundary").and_then(Value::as_str).is_some_and(|claim| claim

--- a/docs/how-to/PERL_SETUP_TROUBLESHOOTING.md
+++ b/docs/how-to/PERL_SETUP_TROUBLESHOOTING.md
@@ -225,6 +225,8 @@ and confirm the root and include paths match the project you intended to edit.
 For setup-related reports, include:
 
 - output from **Perl LSP: Show Workspace Trust Report**
+- the `copyable_payload` object from the workspace trust report when you need
+  structured setup evidence without raw local paths
 - output from **Perl LSP: Explain Missing Module Lookup**, when PL701 or module
   lookup is involved
 - the relevant `includePaths`, `.perl-lsp.toml`, or `launch.json` snippet with


### PR DESCRIPTION
Problem: The accepted workspace trust report contract requires a copyable payload, but perl.workspaceTrustReport only returned the full report shape.
Fix: Add an additive sanitized copyable_payload summary to the workspace trust report, lock it in the existing schema snapshot test, and document it for setup-related issue reports.
Verification: `cargo test -p perl-lsp-rs --test lsp_execute_command_tests test_execute_command_workspace_trust_report --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-rs --test lsp_execute_command_tests test_execute_command_workspace_trust_report_schema_snapshot --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `cargo clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo xtask fmt` passes; `cargo xtask check-support-claims` passes; `cargo xtask check-provider-confidence-matrix` passes; `cargo xtask ci-hygiene check-doc-paths docs/how-to` passes; `git diff --check` passes.
Claim boundary: Additive report/schema field only; no workspace scan, Perl probe, perldoc run, DAP launch, provider behavior change, telemetry, or support-tier promotion.