### PR TITLE
goals: record editor trust user docs complete (#8197)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -80,10 +80,14 @@ commands = [
 
 [[work_item]]
 id = "editor-trust-user-docs"
-status = "ready"
-spec = "docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md"
+status = "completed"
+spec = "docs/specs/PLSP-SPEC-0012-user-facing-trust-surfaces.md"
 plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-editor-trust-user-docs"
 current_pointer = "docs/project/status/SUPPORT_TIERS.md"
+receipt = "docs/how-to/EDITOR_TRUST.md"
+setup_receipt = "docs/how-to/PERL_SETUP_TROUBLESHOOTING.md"
+vscode_receipt = "vscode-extension/README.md"
+commands_receipt = "docs/reference/COMMANDS_REFERENCE.md"
 claim_boundary = "Plain-language docs must link to support tiers and avoid broad CPAN/static/refactor claims."
 commands = [
   "cargo xtask check-support-claims",

--- a/plans/editor-trust-ux-closeout/implementation-plan.md
+++ b/plans/editor-trust-ux-closeout/implementation-plan.md
@@ -90,11 +90,16 @@ contract lands.
 
 ## Work item: editor-trust-user-docs
 
-Status: ready
+Status: completed
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
-Linked spec: [PLSP-SPEC-0002](../../docs/specs/PLSP-SPEC-0002-provider-confidence-receipts.md)
+Linked spec: [PLSP-SPEC-0012](../../docs/specs/PLSP-SPEC-0012-user-facing-trust-surfaces.md)
 Blocks: README claim refresh, VS Code command docs
 Blocked by: none
+Receipt: [Editor Trust](../../docs/how-to/EDITOR_TRUST.md)
+Supporting receipts:
+[Perl Setup Troubleshooting](../../docs/how-to/PERL_SETUP_TROUBLESHOOTING.md),
+[VS Code README](../../vscode-extension/README.md),
+[Commands reference](../../docs/reference/COMMANDS_REFERENCE.md)
 
 Goal
 
@@ -117,6 +122,13 @@ Docs explain partial-live-with-fallback, fallback reasons, safe-edit previews,
 dynamic Perl boundaries, `@INC`/module resolution, workspace trust report,
 provider explanations, diagnostic explanations, and copyable receipts in plain
 language while linking to status/support truth sources.
+
+Current implementation status
+
+The user-facing guide, setup troubleshooting guide, VS Code trust-claim docs,
+and command reference now cover the trust and explanation surfaces. This work
+item is documentation only; it does not promote support tiers or broaden
+provider behavior.
 
 Proof commands
 


### PR DESCRIPTION
Problem: The active editor trust UX goal still lists user-facing docs as ready even though the guide, setup troubleshooting, VS Code command docs, and command reference are already present on master.

Fix: Mark the editor-trust-user-docs work item completed, point it at the user-facing trust surfaces spec, and record the landed docs as receipts in the active goal and implementation plan.

Verification: rtk python active-goal TOML/receipt check passed; rtk cargo xtask check-support-claims passed; rtk cargo xtask check-provider-confidence-matrix passed; rtk cargo xtask fmt --check passed; rtk git diff --check passed.