### PR TITLE
ci(gates): add conflict marker timeout headroom (#8197)

### DIFF
--- a/.ci/gate-policy.yaml
+++ b/.ci/gate-policy.yaml
@@ -139,10 +139,10 @@ gates:
     description: "Prevent committed merge conflict markers"
     required: true
     command: just check-conflict-markers
-    timeout_seconds: 60
+    timeout_seconds: 180
     retry_count: 0
     budgets:
-      max_duration_ms: 45000
+      max_duration_ms: 120000
     quarantine: false
     tags:
       - hygiene

--- a/xtask/tests/gate_policy_profile_tests.rs
+++ b/xtask/tests/gate_policy_profile_tests.rs
@@ -126,12 +126,12 @@ fn conflict_marker_gate_has_local_runtime_headroom() -> Result<(), Box<dyn std::
     assert_eq!(gate.tier, "pr_fast", "conflict marker scan must stay in pr-fast");
     assert!(gate.required, "conflict marker scan must stay PR-blocking");
     assert!(
-        gate.timeout_seconds.unwrap_or_default() >= 60,
+        gate.timeout_seconds.unwrap_or_default() >= 120,
         "conflict marker timeout must include Windows and mounted-worktree headroom"
     );
     assert!(
         gate.budgets.as_ref().and_then(|budget| budget.max_duration_ms).unwrap_or_default()
-            >= 45_000,
+            >= 120_000,
         "conflict marker budget must reflect observed local runtime"
     );
 


### PR DESCRIPTION
Problem: just agent-pr-fast timed out check_conflict_markers at 60s even though direct just check-conflict-markers passed in 1m39.038s on the mounted worktree.

Fix: Raise the gate timeout to 180s and max-duration budget to 120s, then update the policy test floor so the local headroom stays encoded.

Verification:
- git diff --check
- MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe test -p xtask conflict_marker_gate_has_local_runtime_headroom --profile agent --locked -- --nocapture
- MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask gate-policy check
- MIN_FREE_GB=20 MAX_USED_PCT=95 ./scripts/cargo-safe xtask fmt --check
- ash -lc 'time just check-conflict-markers' passed in 1m39.038s
- ash -lc 'just agent-pr-fast' passed, 10/10 gates; check_conflict_markers passed with 	imeout=180; repo-local 	arget/ was removed afterward and scripts/storage-doctor was clean

Control-plane note: direct Windows just agent-pr-fast failed because just could not find its shell, so the gate was rerun through Bash.

Claim boundary: control-plane timeout/budget only; no product, runtime, provider, or parser behavior changes.