### PR TITLE
goals: record receiver completion pilot complete (#8197)

### DIFF
--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -113,14 +113,21 @@ commands = [
 
 [[work_item]]
 id = "receiver-fact-completion"
-status = "ready"
+status = "completed"
 spec = "docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md"
 plan = "plans/editor-trust-ux-closeout/implementation-plan.md#work-item-receiver-fact-completion"
-current_pointer = "docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md"
+current_pointer = "docs/project/status/receiver_facts.md"
+fact_receipt = "docs/project/status/receiver_facts.md"
+support_receipt = "docs/project/status/SUPPORT_TIERS.md"
+cutover_receipt = "docs/project/status/provider_cutover.md"
+confidence_receipt = "docs/project/status/provider_confidence_matrix.md"
+pilot_receipt = "crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs"
 claim_boundary = "Facts and receipts before live completion; unknown and dynamic receivers preserve legacy fallback."
 commands = [
   "cargo test -p perl-semantic-analyzer --lib receiver_fact --profile agent --locked -- --nocapture",
   "cargo test -p perl-lsp-rs-core --lib completion --profile agent --locked -- --nocapture",
+  "cargo xtask check-support-claims",
+  "cargo xtask check-provider-confidence-matrix",
   "git diff --check",
 ]
 

--- a/.perl-lsp/goals/active.toml
+++ b/.perl-lsp/goals/active.toml
@@ -122,7 +122,7 @@ support_receipt = "docs/project/status/SUPPORT_TIERS.md"
 cutover_receipt = "docs/project/status/provider_cutover.md"
 confidence_receipt = "docs/project/status/provider_confidence_matrix.md"
 pilot_receipt = "crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs"
-claim_boundary = "Facts and receipts before live completion; unknown and dynamic receivers preserve legacy fallback."
+claim_boundary = "Narrow source-backed receiver completion pilot only; unknown and dynamic receivers preserve legacy fallback."
 commands = [
   "cargo test -p perl-semantic-analyzer --lib receiver_fact --profile agent --locked -- --nocapture",
   "cargo test -p perl-lsp-rs-core --lib completion --profile agent --locked -- --nocapture",

--- a/plans/editor-trust-ux-closeout/implementation-plan.md
+++ b/plans/editor-trust-ux-closeout/implementation-plan.md
@@ -187,11 +187,17 @@ work item blocked and keep docs from promising a stable payload.
 
 ## Work item: receiver-fact-completion
 
-Status: ready
+Status: completed
 Linked proposal: [PLSP-PROP-0001](../../docs/proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked specs: [PLSP-SPEC-0005](../../docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md), [PLSP-SPEC-0007](../../docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md)
-Blocks: receiver-fact completion ranking receipt, narrow receiver completion pilot
+Blocks: broader receiver-form completion expansion
 Blocked by: none
+Receipt: [receiver facts status](../../docs/project/status/receiver_facts.md)
+Supporting receipts:
+[support tiers](../../docs/project/status/SUPPORT_TIERS.md),
+[provider cutover](../../docs/project/status/provider_cutover.md),
+[provider confidence matrix](../../docs/project/status/provider_confidence_matrix.md),
+`crates/perl-lsp-rs-core/src/providers/completion/completion/tests.rs`
 
 Goal
 
@@ -217,11 +223,23 @@ freshness, dynamic boundary, source range, and fallback state. Completion
 receipt proves source-backed `$self`/object/package/hashref known-slot ranking,
 dynamic fallback, and unknown fallback before any pilot.
 
+Current implementation status
+
+Receiver facts, expression-fact substrate, completion ranking receipts, the
+narrow source-backed receiver completion pilot, and the support review have
+landed. Completion remains partial-live-with-fallback: only fresh,
+high-confidence, source-backed receiver evidence may contribute exact method
+candidates in the narrow pilot, while unknown, dynamic, generated/no-source,
+stale, low-confidence, and broader workspace-wide method shapes remain
+fallback, shadowed, or blocked.
+
 Proof commands
 
 ```bash
 cargo test -p perl-semantic-analyzer --lib receiver_fact --profile agent --locked -- --nocapture
 cargo test -p perl-lsp-rs-core --lib completion --profile agent --locked -- --nocapture
+cargo xtask check-support-claims
+cargo xtask check-provider-confidence-matrix
 git diff --check
 ```
 


### PR DESCRIPTION
Problem: The receiver-fact completion work item still read as ready even though extraction, fallback receipts, the narrow live pilot, and the support review have landed.\n\nFix: Mark receiver-fact-completion complete in the active goal and implementation plan, and point it at the receiver facts, support tier, provider cutover, provider confidence, and pilot test receipts.\n\nClaim boundary: Goal/plan status only. Completion remains partial-live-with-fallback; this does not broaden generated, dynamic, unknown, stale, low-confidence, or workspace-wide method completion.\n\nVerification:\n- active.toml TOML parse passed\n- MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=600 ./scripts/cargo-safe xtask check-support-claims\n- MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=600 ./scripts/cargo-safe xtask check-provider-confidence-matrix\n- git diff --check