### PR TITLE
docs(specs): accept editor trust contracts (#8197)

### DIFF
--- a/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
+++ b/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
@@ -1,12 +1,25 @@
 # PLSP-SPEC-0005: Receiver expression facts
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked ADRs: none yet
 Linked plan: [Receiver facts implementation plan](../project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md)
 Status impact: provider cutover, semantic scorecard, semantic capability dashboard,
 UX capability dashboard
+
+## Current implementation status
+
+This spec is accepted as the receiver-fact substrate contract. The initial fact
+model, type-environment fact map, receiver fact API, static package and object
+receiver facts, plain-hash slot inference, dynamic-key boundary, and the first
+completion consumer are implemented or partially implemented as tracked in
+[receiver_facts.md](../project/status/receiver_facts.md).
+
+Current implementation state and next source-shape work live in the status doc
+and receiver-facts implementation plan, not in this spec. Hashref source
+inference, bless-field facts, accessor-return facts, and chained method-return
+facts remain bounded by their own future fixtures and provider receipts.
 
 ## Contract
 

--- a/docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md
+++ b/docs/specs/PLSP-SPEC-0007-receiver-fact-completion.md
@@ -1,12 +1,27 @@
 # PLSP-SPEC-0007: Receiver-fact completion
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked ADRs: [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
 Linked plan: [Receiver facts implementation plan](../project/RECEIVER_FACTS_IMPLEMENTATION_PLAN.md)
 Status impact: provider confidence matrix, provider cutover, semantic scorecard,
 semantic shadow compare, UX capability dashboard, support tiers
+
+## Current implementation status
+
+This spec is accepted as the receiver-aware completion cutover contract. The
+current implementation has landed a narrow source-backed receiver completion
+pilot for the proved hash-slot class, plus fallback preservation for dynamic
+hash keys. Current evidence lives in [receiver_facts.md](../project/status/receiver_facts.md),
+[provider_confidence_matrix.md](../project/status/provider_confidence_matrix.md),
+[provider_cutover.md](../project/status/provider_cutover.md), and
+[SUPPORT_TIERS.md](../project/status/SUPPORT_TIERS.md).
+
+Completion remains `partial-live-with-fallback`. Broader receiver forms,
+generated/no-source members, dynamic keys, stale facts, low-confidence facts,
+and unknown receivers remain fallback, blocked, or future receipt work until a
+separate PR satisfies this contract.
 
 ## Contract
 

--- a/docs/specs/PLSP-SPEC-0009-workspace-trust-report.md
+++ b/docs/specs/PLSP-SPEC-0009-workspace-trust-report.md
@@ -1,6 +1,6 @@
 # PLSP-SPEC-0009: Workspace trust report
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked specs:
@@ -11,6 +11,20 @@ Linked ADRs:
 Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
 Status impact: support tiers, provider confidence matrix, real editor trust
 dashboard, VS Code command documentation, setup troubleshooting docs
+
+## Current implementation status
+
+This spec is accepted as the workspace trust report contract. The current
+report and VS Code output surface are implemented as read-only views over
+existing server and client state, with schema coverage tracked from
+`lsp_execute_command_tests` and support evidence owned by
+[SUPPORT_TIERS.md](../project/status/SUPPORT_TIERS.md) and
+[real_perl_editor_trust_v1.md](../project/status/real_perl_editor_trust_v1.md).
+
+Current setup hints, perldoc/DAP state, launch-configuration classes, and
+module-path boundaries remain report-only. They do not probe Perl, run
+`perldoc`, launch DAP, scan the workspace, or promote setup-health support
+tiers.
 
 ## Contract
 

--- a/docs/specs/PLSP-SPEC-0011-trust-lane-ci-routing.md
+++ b/docs/specs/PLSP-SPEC-0011-trust-lane-ci-routing.md
@@ -1,6 +1,6 @@
 # PLSP-SPEC-0011: Trust-lane CI routing
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked ADRs: [PLSP-ADR-0001](../adr/PLSP-ADR-0001-generated-status-is-control-plane.md),
@@ -11,7 +11,8 @@ provider confidence matrix, parser status, Real Perl Editor Trust dashboard
 
 ## Current implementation status
 
-The repository already has advisory CI economics and risk-pack infrastructure:
+This spec is accepted as the trust-lane CI routing contract. The repository
+already has advisory CI economics and risk-pack infrastructure:
 
 - [PR plan](../ci/pr-plan.md)
 - [risk packs](../ci/risk-packs.md)

--- a/docs/specs/PLSP-SPEC-0012-user-facing-trust-surfaces.md
+++ b/docs/specs/PLSP-SPEC-0012-user-facing-trust-surfaces.md
@@ -1,6 +1,6 @@
 # PLSP-SPEC-0012: User-facing trust surfaces
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked specs:
@@ -13,6 +13,23 @@ Linked ADRs:
 Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
 Status impact: provider confidence matrix, provider cutover, support tiers,
 workspace trust report, diagnostic explanations, VS Code command surfaces
+
+## Current implementation status
+
+This spec is accepted as the user-facing trust surface contract. Provider
+decision explanations, copyable provider receipts, diagnostic explanations,
+explain-diagnostic actions, missing-module lookup explanations, workspace trust
+report output, and VS Code command-palette presentation now exist as bounded
+trust surfaces.
+
+Current evidence and public claim boundaries live in
+[provider_confidence_matrix.md](../project/status/provider_confidence_matrix.md),
+[provider_cutover.md](../project/status/provider_cutover.md),
+[SUPPORT_TIERS.md](../project/status/SUPPORT_TIERS.md), and
+[real_perl_editor_trust_v1.md](../project/status/real_perl_editor_trust_v1.md).
+Future explanation or command-surface PRs must preserve this spec's rule that
+presentation explains existing evidence without creating facts or broadening
+provider behavior.
 
 ## Contract
 

--- a/docs/specs/PLSP-SPEC-0013-agent-build-storage-and-gates.md
+++ b/docs/specs/PLSP-SPEC-0013-agent-build-storage-and-gates.md
@@ -1,12 +1,23 @@
 # PLSP-SPEC-0013: Agent build storage and gates
 
-Status: proposed
+Status: accepted
 Owner: perl-lsp maintainers
 Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
 Linked ADRs: [PLSP-ADR-0001](../adr/PLSP-ADR-0001-generated-status-is-control-plane.md)
 Linked plan: [0.14.0 Readiness Queue](../releases/0.14.0-readiness.md)
 Status impact: local proof commands, gate receipts, storage hygiene, CI
 hardening status, PR disposition comments
+
+## Current implementation status
+
+This spec is accepted as the agent proof and storage-hygiene contract. The
+current repo already routes agent Cargo proof through `./scripts/cargo-safe`,
+uses `./scripts/storage-doctor` as the storage receipt, and records gate timeout
+classification as control-plane evidence rather than product behavior proof.
+
+This spec governs how agents report local proof. It does not replace
+trust-lane CI routing, provider receipts, parser status, release gates, or
+support-tier evidence.
 
 ## Contract
 


### PR DESCRIPTION
Problem: Completed editor-trust contracts were still marked proposed, so active-goal artifacts depended on specs that did not reflect their current role.
Fix: Mark the implemented editor-trust contracts accepted and add short implementation-status pointers to the owning status docs without copying dashboard rows.
Verification: git diff --check passes; xtask ci-hygiene check-doc-paths docs/specs passes via the existing xtask binary; xtask check-support-claims passes; xtask check-provider-confidence-matrix passes; direct changed-file link checks pass; storage-doctor passes with explicit worktree Git env after the default Git Bash route misresolved the Windows worktree path.