### PR TITLE
feat(receiver): track hashref expression facts (#8197)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -787,11 +787,14 @@ impl TypeInferenceEngine {
             return rhs_fact;
         }
 
-        if let Some((hash_name, key)) = static_hash_slot_target(lhs) {
+        if let Some((hash_name, key, is_hashref_slot)) = static_hash_slot_target(lhs) {
             rhs_fact.evidence.push(TypeEvidence::Assignment { name: hash_name.clone() });
-            rhs_fact
-                .evidence
-                .push(TypeEvidence::HashSlot { hash: format!("${hash_name}"), key: key.clone() });
+            let slot_evidence = if is_hashref_slot {
+                TypeEvidence::HashRefSlot { base: format!("${hash_name}"), key: key.clone() }
+            } else {
+                TypeEvidence::HashSlot { hash: format!("${hash_name}"), key: key.clone() }
+            };
+            rhs_fact.evidence.push(slot_evidence);
             let mut hash_fact = env.get_fact_at(&hash_name).unwrap_or_else(TypeFact::unknown_hash);
             let mut shape = match hash_fact.shape.take() {
                 Some(ShapeFact::Hash(shape)) => shape,
@@ -1183,16 +1186,16 @@ fn variable_name(node: &Node) -> Option<&str> {
     }
 }
 
-fn static_hash_slot_target(node: &Node) -> Option<(String, String)> {
+fn static_hash_slot_target(node: &Node) -> Option<(String, String, bool)> {
     let NodeKind::Binary { op, left, right } = &node.kind else {
         return None;
     };
-    if op != "{}" {
+    if op != "{}" && op != "->{}" {
         return None;
     }
     let name = variable_name(left)?;
     let key = static_hash_key(right)?;
-    Some((name.to_string(), key))
+    Some((name.to_string(), key, op == "->{}"))
 }
 
 fn static_hash_key(node: &Node) -> Option<String> {

--- a/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
@@ -112,6 +112,57 @@ fn plain_hash_slot_assignment_updates_later_receiver_fact() -> Result<(), String
 }
 
 #[test]
+fn hashref_literal_slot_resolves_source_derived_receiver_fact() -> Result<(), String> {
+    let code = "my $services = { db => MyApp::DB->new }; $services->{db}->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let services =
+        engine.get_fact_at("services").ok_or_else(|| "missing services fact".to_string())?;
+    assert!(matches!(services.shape, Some(ShapeFact::Hash(_))));
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Object("MyApp::DB".to_string()));
+    assert_eq!(fact.confidence, Confidence::High);
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(
+            evidence,
+            TypeEvidence::HashRefSlot { base, key } if base == "$services" && key == "db"
+        )
+    }));
+    Ok(())
+}
+
+#[test]
+fn hashref_slot_assignment_updates_later_receiver_fact() -> Result<(), String> {
+    let code = "my $services = {}; $services->{db} = MyApp::DB->new; $services->{db}->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Object("MyApp::DB".to_string()));
+    assert_eq!(fact.confidence, Confidence::High);
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::Assignment { name } if name == "services")
+    }));
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(
+            evidence,
+            TypeEvidence::HashRefSlot { base, key } if base == "$services" && key == "db"
+        )
+    }));
+    Ok(())
+}
+
+#[test]
 fn dynamic_plain_hash_key_fails_closed() -> Result<(), String> {
     let code = "my %services = (db => MyApp::DB->new); $services{$name}->connect;";
     let ast = parse_ast(code)?;

--- a/docs/project/status/receiver_facts.md
+++ b/docs/project/status/receiver_facts.md
@@ -57,10 +57,10 @@ no support-tier promotion
 | `static_package_receiver` | `landed` | `receiver_facts` module test `static_constructor_receiver_records_package`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static package receivers can produce high-confidence constructor evidence. |
 | `object_variable_receiver` | `landed` | `receiver_facts` module tests for `$self` and `$object`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Exact package requires a supplied type-environment fact. Unknown object variables stay low confidence. |
 | `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; `receiver_expression_facts` tests for plain hash literals and slot assignment | Works when `TypeEnvironment` contains a `HashShape`; source-derived plain `%hash` literals and `$hash{key}` assignments can now populate that shape. Hashref, bless-field, and accessor-return source inference remain pending. |
-| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Works when the base fact already has a hash shape; `$hashref->{key}` fact production from source declarations is still missing. |
+| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; `receiver_expression_facts` tests for hashref literals and slot assignment | Works when the base fact already has a hash shape; source-derived `$hashref->{key}` facts are proven for hashref literals and slot assignment. Bless-field, accessor-return, and chained method-return source inference remain pending. |
 | `array_index_receiver` | `partial` | `receiver_facts` module tests for static and dynamic array indexes; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static indexes can use existing `ArrayShape` facts; dynamic indexes remain non-exact. |
 | `dynamic_key_boundary` | `landed` | `receiver_facts` module test `dynamic_hash_key_marks_dynamic_boundary`; `TypeFact::dynamic` test in `type_facts.rs`; `receiver_expression_facts` dynamic plain-hash-key test; completion provider test `dynamic_hash_key_receiver_preserves_imported_fallback` | Proven for receiver extraction, plain hash expression facts, and the first completion-provider boundary receipt. Additional provider boundary receipts remain pending for other receiver forms. |
-| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, static plain hash slot reads, and dynamic plain hash keys are facts-only substrate. Hashref slots, bless fields, accessor returns, and chained method-return facts remain pending. |
+| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, hashref literals, hashref slot assignment, static plain/hashref slot reads, and dynamic plain hash keys are facts-only substrate. Bless fields, accessor returns, and chained method-return facts remain pending. |
 | `receiver_fact_api` | `landed` | `crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | API extracts facts from existing AST and supplied environment facts; method-call chains remain unknown until explicit rules land. |
 | `completion_cutover` | `narrow-pilot` | Completion provider tests `source_backed_hash_slot_receiver_uses_exact_completion_pilot` and `dynamic_hash_key_receiver_preserves_imported_fallback`; PR [#9502](https://github.com/EffortlessMetrics/perl-lsp/pull/9502) | Only fresh high-confidence source-backed receiver facts may authorize exact receiver completion. Unknown, dynamic, generated/no-source, stale, and low-confidence receiver shapes stay fallback, shadowed, or blocked. |
 
@@ -77,10 +77,10 @@ receiver_fact_completion_cutover:
 
 ## Next Implementation Steps
 
-1. Add hashref, bless-field, accessor-return, and chained method-return
-   expression facts without changing provider output.
-2. Add facts-only fixtures that prove source-derived `$hashref`, `$self`, and
-   framework accessor receiver facts without changing provider output.
+1. Add bless-field, accessor-return, and chained method-return expression facts
+   without changing provider output.
+2. Add facts-only fixtures that prove source-derived `$self` and framework
+   accessor receiver facts without changing provider output.
 3. Add real-workspace and additional receiver-form provider confidence receipts
    for exact, fallback, and dynamic receiver cases.
 4. Broaden completion only after facts-only and provider fallback receipts pass

--- a/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
+++ b/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
@@ -17,9 +17,10 @@ completion consumer are implemented or partially implemented as tracked in
 [receiver_facts.md](../project/status/receiver_facts.md).
 
 Current implementation state and next source-shape work live in the status doc
-and receiver-facts implementation plan, not in this spec. Hashref source
-inference, bless-field facts, accessor-return facts, and chained method-return
-facts remain bounded by their own future fixtures and provider receipts.
+and receiver-facts implementation plan, not in this spec. Hashref literal and
+slot-assignment inference are fixture-backed facts-only substrate. Bless-field
+facts, accessor-return facts, and chained method-return facts remain bounded by
+their own future fixtures and provider receipts.
 
 ## Contract
 


### PR DESCRIPTION
Problem: Hashref receiver facts had a source-shape gap, and local focused validation showed slot-assignment proof was not actually implemented.\nFix: Add facts-only receiver expression tests for hashref literals and hashref slot assignment, teach static hashref slot assignment to preserve shape/evidence, and update the receiver-facts status/spec implementation note.\nVerification: cargo test -p perl-semantic-analyzer --test receiver_expression_facts --locked -- --nocapture passes; cargo check --all-targets -p perl-semantic-analyzer --locked passes; cargo xtask fmt --check passes; cargo xtask check-support-claims passes; cargo xtask check-provider-confidence-matrix passes; cargo xtask ci-hygiene check-doc-paths docs/specs passes; cargo xtask ci-hygiene check-doc-paths docs/project/status passes; git diff --check passes.\n\nClaim boundary: facts-only substrate. No completion candidate behavior change, no provider cutover, and no support-tier promotion.