### PR TITLE
feat(receiver): infer bless field facts (#8197)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
+++ b/crates/perl-lsp-rs-core/src/providers/completion/completion/workspace.rs
@@ -19,6 +19,7 @@ use perl_semantic_analyzer::{
         ReceiverKind, receiver_fact_for_method_call,
     },
     semantic::SemanticModel,
+    type_facts::TypeEvidence,
     type_inference::{PerlType, TypeInferenceEngine},
 };
 use perl_semantic_facts::{
@@ -1012,6 +1013,15 @@ fn method_call_named<'a>(node: &'a Node, name: &str) -> Option<&'a Node> {
 }
 
 fn exact_receiver_fact_evidence(fact: &ReceiverFact) -> Option<ReceiverEvidence> {
+    if fact.confidence == Confidence::Medium
+        && fact.freshness == ReceiverFactFreshness::Fresh
+        && fact.dynamic_boundary.is_none()
+        && fact.source_range.is_some()
+        && let Some(package) = literal_bless_package_from_fact(fact)
+    {
+        return Some(ReceiverEvidence::LiteralBless(package));
+    }
+
     if fact.confidence != Confidence::High
         || fact.freshness != ReceiverFactFreshness::Fresh
         || fact.fallback_state != ReceiverFallbackState::Exact
@@ -1033,6 +1043,16 @@ fn exact_receiver_fact_evidence(fact: &ReceiverFact) -> Option<ReceiverEvidence>
         | ReceiverKind::Unknown => None,
         _ => None,
     }
+}
+
+fn literal_bless_package_from_fact(fact: &ReceiverFact) -> Option<String> {
+    let package = fact.package.as_ref()?;
+    fact.evidence.iter().find_map(|evidence| match evidence {
+        TypeEvidence::BlessLiteral { package: evidence_package } if evidence_package == package => {
+            Some(package.clone())
+        }
+        _ => None,
+    })
 }
 
 /// Type-engine arm of [`classify_receiver`]. Extracted from the legacy

--- a/crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs
@@ -387,6 +387,7 @@ fn hash_slot_type_fact(container_fact: &TypeFact, evidence: &TypeEvidence) -> Op
             .get(key)
             .cloned()
             .or_else(|| shape.fallback_value.as_ref().map(|fact| fact.as_ref().clone())),
+        Some(ShapeFact::Object(shape)) => shape.fields.get(key).cloned(),
         _ => None,
     }
 }
@@ -567,6 +568,21 @@ mod tests {
         }
     }
 
+    fn object_field_shape_fact(field: &str, field_package: &str) -> TypeFact {
+        let mut fields = BTreeMap::new();
+        fields.insert(field.to_string(), object_fact(field_package, Confidence::Medium));
+        TypeFact {
+            ty: PerlType::Object("My::Controller".to_string()),
+            confidence: Confidence::Medium,
+            evidence: vec![TypeEvidence::BlessLiteral { package: "My::Controller".to_string() }],
+            dynamic_boundary: None,
+            shape: Some(ShapeFact::Object(super::super::type_facts::ObjectShape::new(
+                "My::Controller".to_string(),
+                fields,
+            ))),
+        }
+    }
+
     fn array_shape_fact(index: usize, package: &str) -> TypeFact {
         let mut indexed = BTreeMap::new();
         indexed.insert(index, object_fact(package, Confidence::High));
@@ -708,6 +724,23 @@ mod tests {
         assert_eq!(fact.fallback_state, ReceiverFallbackState::Exact);
         assert!(fact.evidence.iter().any(|evidence| {
             matches!(evidence, TypeEvidence::HashRefSlot { base, key } if base == "$services" && key == "mailer")
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn object_field_receiver_preserves_fallback() -> Result<(), String> {
+        let mut env = TypeEnvironment::new();
+        env.set_variable_fact("self".to_string(), object_field_shape_fact("db", "My::DB"));
+
+        let fact = receiver_fact_for("$self->{db}->connect();", "connect", &env)?;
+
+        assert_eq!(fact.kind, ReceiverKind::HashRefSlot);
+        assert_eq!(fact.package.as_deref(), Some("My::DB"));
+        assert_eq!(fact.confidence, Confidence::Medium);
+        assert_eq!(fact.fallback_state, ReceiverFallbackState::Fallback);
+        assert!(fact.evidence.iter().any(|evidence| {
+            matches!(evidence, TypeEvidence::HashRefSlot { base, key } if base == "$self" && key == "db")
         }));
         Ok(())
     }

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -736,6 +736,9 @@ impl TypeInferenceEngine {
             }
             NodeKind::ArrayLiteral { elements } => self.array_literal_fact(elements, env),
             NodeKind::HashLiteral { pairs } => self.hash_literal_fact(pairs, env),
+            NodeKind::FunctionCall { name, args } if name == "bless" => {
+                self.bless_expr_fact(args, env)
+            }
             NodeKind::MethodCall { object, method, .. } if method == "new" => {
                 static_package_node(object)
                     .map_or_else(TypeFact::unknown, |package| constructor_fact(&package))
@@ -861,6 +864,28 @@ impl TypeInferenceEngine {
         hash_shape_fact(slots, TypeEvidence::Literal)
     }
 
+    fn bless_expr_fact(&mut self, args: &[Node], env: &mut TypeEnvironment) -> TypeFact {
+        let Some(reference) = args.first() else {
+            return TypeFact::unknown();
+        };
+        let Some(package_node) = args.get(1) else {
+            return TypeFact::dynamic(DynamicBoundary::DynamicBlessClass);
+        };
+        let Some(package) = static_package_node(package_node) else {
+            return TypeFact::dynamic(DynamicBoundary::DynamicBlessClass);
+        };
+
+        let reference_fact = self.infer_expr_fact_in_env(reference, env);
+        let fields = object_fields_from_bless_reference(reference_fact, &package);
+        let mut fact = fact_with_evidence(
+            PerlType::Object(package.clone()),
+            Confidence::Medium,
+            TypeEvidence::BlessLiteral { package: package.clone() },
+        );
+        fact.shape = Some(ShapeFact::Object(ObjectShape::new(package, fields)));
+        fact
+    }
+
     fn array_literal_fact(&mut self, elements: &[Node], env: &mut TypeEnvironment) -> TypeFact {
         let mut indexed = BTreeMap::new();
         for (index, element) in elements.iter().enumerate() {
@@ -907,8 +932,24 @@ impl TypeInferenceEngine {
                         fact
                     },
                 ),
+            Some(ShapeFact::Object(shape)) if op == "->{}" => shape
+                .fields
+                .get(&key)
+                .cloned()
+                .map_or_else(
+                    || {
+                        let mut fact = TypeFact::unknown();
+                        fact.evidence.push(evidence.clone());
+                        fact
+                    },
+                    |mut fact| {
+                        fact.evidence.push(evidence.clone());
+                        fact
+                    },
+                ),
             _ => {
                 let mut fact = TypeFact::unknown();
+                fact.dynamic_boundary = container_fact.dynamic_boundary;
                 fact.evidence.push(evidence);
                 fact
             }
@@ -1137,6 +1178,28 @@ fn constructor_fact(package: &str) -> TypeFact {
         TypeEvidence::ConstructorCall { package: package.to_string() },
     );
     fact.shape = Some(ShapeFact::Object(ObjectShape::new(package.to_string(), BTreeMap::new())));
+    fact
+}
+
+fn object_fields_from_bless_reference(
+    reference_fact: TypeFact,
+    package: &str,
+) -> BTreeMap<String, TypeFact> {
+    match reference_fact.shape {
+        Some(ShapeFact::Hash(shape)) => shape
+            .slots
+            .into_iter()
+            .map(|(name, fact)| (name, bless_field_fact(fact, package)))
+            .collect(),
+        _ => BTreeMap::new(),
+    }
+}
+
+fn bless_field_fact(mut fact: TypeFact, package: &str) -> TypeFact {
+    if fact.confidence == Confidence::High {
+        fact.confidence = Confidence::Medium;
+    }
+    fact.evidence.push(TypeEvidence::BlessLiteral { package: package.to_string() });
     fact
 }
 

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -932,11 +932,8 @@ impl TypeInferenceEngine {
                         fact
                     },
                 ),
-            Some(ShapeFact::Object(shape)) if op == "->{}" => shape
-                .fields
-                .get(&key)
-                .cloned()
-                .map_or_else(
+            Some(ShapeFact::Object(shape)) if op == "->{}" => {
+                shape.fields.get(&key).cloned().map_or_else(
                     || {
                         let mut fact = TypeFact::unknown();
                         fact.evidence.push(evidence.clone());
@@ -946,7 +943,8 @@ impl TypeInferenceEngine {
                         fact.evidence.push(evidence.clone());
                         fact
                     },
-                ),
+                )
+            }
             _ => {
                 let mut fact = TypeFact::unknown();
                 fact.dynamic_boundary = container_fact.dynamic_boundary;

--- a/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
@@ -163,6 +163,70 @@ fn hashref_slot_assignment_updates_later_receiver_fact() -> Result<(), String> {
 }
 
 #[test]
+fn bless_hash_field_resolves_medium_confidence_receiver_fact() -> Result<(), String> {
+    let code =
+        "my $self = bless { db => MyApp::DB->new }, 'MyApp::Service'; $self->{db}->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let self_fact = engine.get_fact_at("self").ok_or_else(|| "missing self fact".to_string())?;
+    assert_eq!(self_fact.ty, PerlType::Object("MyApp::Service".to_string()));
+    assert_eq!(self_fact.confidence, Confidence::Medium);
+    let ShapeFact::Object(shape) =
+        self_fact.shape.as_ref().ok_or_else(|| "missing object shape".to_string())?
+    else {
+        return Err("self fact should carry object shape".to_string());
+    };
+    assert!(shape.fields.contains_key("db"));
+    assert!(self_fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::BlessLiteral { package } if package == "MyApp::Service")
+    }));
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Object("MyApp::DB".to_string()));
+    assert_eq!(fact.confidence, Confidence::Medium);
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::ConstructorCall { package } if package == "MyApp::DB")
+    }));
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::BlessLiteral { package } if package == "MyApp::Service")
+    }));
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::HashRefSlot { base, key } if base == "$self" && key == "db")
+    }));
+    Ok(())
+}
+
+#[test]
+fn dynamic_bless_class_does_not_expose_exact_object_field_fact() -> Result<(), String> {
+    let code = "my $class = 'MyApp::Service'; my $self = bless { db => MyApp::DB->new }, $class; $self->{db}->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let self_fact = engine.get_fact_at("self").ok_or_else(|| "missing self fact".to_string())?;
+    assert_eq!(self_fact.ty, PerlType::Any);
+    assert_eq!(self_fact.confidence, Confidence::Low);
+    assert_eq!(self_fact.dynamic_boundary, Some(DynamicBoundary::DynamicBlessClass));
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Any);
+    assert_eq!(fact.confidence, Confidence::Low);
+    assert_eq!(fact.dynamic_boundary, Some(DynamicBoundary::DynamicBlessClass));
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::HashRefSlot { base, key } if base == "$self" && key == "db")
+    }));
+    Ok(())
+}
+
+#[test]
 fn dynamic_plain_hash_key_fails_closed() -> Result<(), String> {
     let code = "my %services = (db => MyApp::DB->new); $services{$name}->connect;";
     let ast = parse_ast(code)?;

--- a/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
@@ -164,8 +164,7 @@ fn hashref_slot_assignment_updates_later_receiver_fact() -> Result<(), String> {
 
 #[test]
 fn bless_hash_field_resolves_medium_confidence_receiver_fact() -> Result<(), String> {
-    let code =
-        "my $self = bless { db => MyApp::DB->new }, 'MyApp::Service'; $self->{db}->connect;";
+    let code = "my $self = bless { db => MyApp::DB->new }, 'MyApp::Service'; $self->{db}->connect;";
     let ast = parse_ast(code)?;
     let mut engine = TypeInferenceEngine::new();
 

--- a/docs/project/status/receiver_facts.md
+++ b/docs/project/status/receiver_facts.md
@@ -26,7 +26,8 @@ It may claim:
 
 - rich fact model and type-environment storage where tests prove it
 - receiver extraction over existing `TypeFact` and `ShapeFact` evidence
-- source-derived constructor and plain-hash slot facts where tests prove them
+- source-derived constructor, plain-hash, hashref, and static bless-field facts
+  where tests prove them
 - dynamic-key boundaries for receiver extraction
 - no completion candidate behavior change unless the PR is explicitly a
   provider cutover receipt tied to [PLSP-SPEC-0007](../../specs/PLSP-SPEC-0007-receiver-fact-completion.md)
@@ -37,8 +38,8 @@ It may not claim:
   source-backed pilot
 - hover, goto, diagnostics, or refactor behavior changes
 - support-tier promotion
-- hashref, bless-field, accessor-return, or chained method-return facts until
-  focused fixtures prove those source shapes
+- accessor-return or chained method-return facts until focused fixtures prove
+  those source shapes
 
 Facts-only PRs must keep this wording in their claim boundary:
 
@@ -56,11 +57,12 @@ no support-tier promotion
 | `type_environment_fact_map` | `landed` | `TypeEnvironment::set_variable_fact`, `get_variable_fact`, `get_fact_at`; stale fact clearing and parent lookup tests in `type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Existing `PerlType` callers keep erased compatibility while source-level expression inference stores richer facts for proven shapes. |
 | `static_package_receiver` | `landed` | `receiver_facts` module test `static_constructor_receiver_records_package`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static package receivers can produce high-confidence constructor evidence. |
 | `object_variable_receiver` | `landed` | `receiver_facts` module tests for `$self` and `$object`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Exact package requires a supplied type-environment fact. Unknown object variables stay low confidence. |
-| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; `receiver_expression_facts` tests for plain hash literals and slot assignment | Works when `TypeEnvironment` contains a `HashShape`; source-derived plain `%hash` literals and `$hash{key}` assignments can now populate that shape. Hashref, bless-field, and accessor-return source inference remain pending. |
-| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; `receiver_expression_facts` tests for hashref literals and slot assignment | Works when the base fact already has a hash shape; source-derived `$hashref->{key}` facts are proven for hashref literals and slot assignment. Bless-field, accessor-return, and chained method-return source inference remain pending. |
+| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; `receiver_expression_facts` tests for plain hash literals and slot assignment | Works when `TypeEnvironment` contains a `HashShape`; source-derived plain `%hash` literals and `$hash{key}` assignments can now populate that shape. Accessor-return source inference remains pending. |
+| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; `receiver_expression_facts` tests for hashref literals and slot assignment | Works when the base fact already has a hash shape; source-derived `$hashref->{key}` facts are proven for hashref literals and slot assignment. Accessor-return and chained method-return source inference remain pending. |
+| `bless_field_receiver` | `partial` | `receiver_expression_facts` tests for static bless fields and dynamic bless class fallback; `receiver_facts` module test `object_field_receiver_preserves_fallback` | Static `bless { field => Package->new }, 'Class'` populates medium-confidence object-field facts for `$self->{field}`. Dynamic bless class names fail closed. This is semantic substrate only and does not broaden completion. |
 | `array_index_receiver` | `partial` | `receiver_facts` module tests for static and dynamic array indexes; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static indexes can use existing `ArrayShape` facts; dynamic indexes remain non-exact. |
 | `dynamic_key_boundary` | `landed` | `receiver_facts` module test `dynamic_hash_key_marks_dynamic_boundary`; `TypeFact::dynamic` test in `type_facts.rs`; `receiver_expression_facts` dynamic plain-hash-key test; completion provider test `dynamic_hash_key_receiver_preserves_imported_fallback` | Proven for receiver extraction, plain hash expression facts, and the first completion-provider boundary receipt. Additional provider boundary receipts remain pending for other receiver forms. |
-| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, hashref literals, hashref slot assignment, static plain/hashref slot reads, and dynamic plain hash keys are facts-only substrate. Bless fields, accessor returns, and chained method-return facts remain pending. |
+| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, hashref literals, hashref slot assignment, static plain/hashref slot reads, static bless fields, dynamic plain hash keys, and dynamic bless classes are facts-only substrate. Accessor returns and chained method-return facts remain pending. |
 | `receiver_fact_api` | `landed` | `crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | API extracts facts from existing AST and supplied environment facts; method-call chains remain unknown until explicit rules land. |
 | `completion_cutover` | `narrow-pilot` | Completion provider tests `source_backed_hash_slot_receiver_uses_exact_completion_pilot` and `dynamic_hash_key_receiver_preserves_imported_fallback`; PR [#9502](https://github.com/EffortlessMetrics/perl-lsp/pull/9502) | Only fresh high-confidence source-backed receiver facts may authorize exact receiver completion. Unknown, dynamic, generated/no-source, stale, and low-confidence receiver shapes stay fallback, shadowed, or blocked. |
 
@@ -77,8 +79,8 @@ receiver_fact_completion_cutover:
 
 ## Next Implementation Steps
 
-1. Add bless-field, accessor-return, and chained method-return expression facts
-   without changing provider output.
+1. Add accessor-return and chained method-return expression facts without
+   changing provider output.
 2. Add facts-only fixtures that prove source-derived `$self` and framework
    accessor receiver facts without changing provider output.
 3. Add real-workspace and additional receiver-form provider confidence receipts

--- a/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
+++ b/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
@@ -18,9 +18,10 @@ completion consumer are implemented or partially implemented as tracked in
 
 Current implementation state and next source-shape work live in the status doc
 and receiver-facts implementation plan, not in this spec. Hashref literal and
-slot-assignment inference are fixture-backed facts-only substrate. Bless-field
-facts, accessor-return facts, and chained method-return facts remain bounded by
-their own future fixtures and provider receipts.
+slot-assignment inference are fixture-backed facts-only substrate. Static
+`bless { field => Package->new }, 'Class'` field inference is fixture-backed as
+medium-confidence substrate. Accessor-return facts and chained method-return
+facts remain bounded by their own future fixtures and provider receipts.
 
 ## Contract
 


### PR DESCRIPTION
Problem: Receiver fact substrate did not preserve source-derived bless hash fields, so \->{field} remained unmodeled before any completion cutover.\n\nFix: Infer medium-confidence object field facts from static bless { field => Package->new }, 'Class', fail closed for dynamic bless classes, preserve existing literal-bless completion provenance when those new facts reach the provider, and update receiver-fact status/spec notes as substrate-only.\n\nVerification: rtk cargo test -p perl-semantic-analyzer --test receiver_expression_facts --locked -- --nocapture; rtk cargo test -p perl-semantic-analyzer --lib receiver_facts --locked -- --nocapture; rtk cargo test --locked --lib -p perl-lsp-rs -p perl-lsp-rs-core -p perl-semantic-analyzer detail_includes_literal_bless_receiver_evidence -- --nocapture; rtk cargo test --locked --lib -p perl-lsp-rs -p perl-lsp-rs-core -p perl-semantic-analyzer; rtk cargo check --all-targets -p perl-semantic-analyzer --locked; rtk cargo xtask fmt --check; rtk cargo xtask check-support-claims; rtk cargo xtask check-provider-confidence-matrix; rtk cargo xtask ci-hygiene check-doc-paths docs/specs; rtk cargo xtask ci-hygiene check-doc-paths docs/project/status; rtk git diff --check. Local scoped clippy is blocked on pre-existing Windows-only perl-subprocess-runtime unused re-export warnings; hosted Linux scoped clippy previously passed.\n\nClaim boundary: semantic substrate only; no completion candidate behavior change; no support-tier promotion.