### PR TITLE
feat(code-actions): add quick fix for PL408 duplicate hash keys (#9517)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -1164,12 +1164,12 @@ mod tests {
 
     #[test]
     fn test_pl408_duplicate_hash_key_rename_action() {
-        // PL408: duplicate hash key 'host' on a multiline hash — offers rename and delete
+        // PL408: duplicate hash key 'host' on a multiline hash offers rename and delete.
         let source = "my %cfg = (\n    host => 'db1',\n    host => 'db2',\n);\n";
         let mut parser = Parser::new(source);
         let ast = must(parser.parse());
-        // Second 'host' key
-        let dup_start = source.rfind("host").unwrap();
+        // Second 'host' key.
+        let dup_start = must_some(source.rfind("host"));
         let dup_end = dup_start + "host".len();
         let diagnostics = vec![make_diagnostic(
             dup_start,
@@ -1181,11 +1181,9 @@ mod tests {
         let provider = CodeActionsProvider::new(source.to_string());
         let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
 
-        // Must offer a rename action
-        let rename = actions
-            .iter()
-            .find(|a| a.title.contains("Rename") && a.title.contains("host"))
-            .expect("PL408 should produce a rename action for duplicate key");
+        let rename = must_some(
+            actions.iter().find(|a| a.title.contains("Rename") && a.title.contains("host")),
+        );
         assert_eq!(rename.edit.changes[0].new_text, "host_2");
         assert_eq!(rename.edit.changes[0].location.start, dup_start);
         assert_eq!(rename.edit.changes[0].location.end, dup_end);
@@ -1193,11 +1191,11 @@ mod tests {
 
     #[test]
     fn test_pl408_duplicate_hash_key_delete_preferred_for_multiline() {
-        // PL408: delete action is preferred and removes only the duplicate line
+        // PL408: delete action is preferred and removes only the duplicate line.
         let source = "my %cfg = (\n    host => 'db1',\n    host => 'db2',\n);\n";
         let mut parser = Parser::new(source);
         let ast = must(parser.parse());
-        let dup_start = source.rfind("host").unwrap();
+        let dup_start = must_some(source.rfind("host"));
         let dup_end = dup_start + "host".len();
         let diagnostics = vec![make_diagnostic(
             dup_start,
@@ -1209,10 +1207,9 @@ mod tests {
         let provider = CodeActionsProvider::new(source.to_string());
         let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
 
-        let delete = actions
-            .iter()
-            .find(|a| a.title.contains("Remove") && a.title.contains("host"))
-            .expect("PL408 should produce a remove action for multiline duplicate key");
+        let delete = must_some(
+            actions.iter().find(|a| a.title.contains("Remove") && a.title.contains("host")),
+        );
         assert!(delete.is_preferred, "remove action should be preferred");
 
         let rewritten = apply_action(source, delete);
@@ -1221,11 +1218,11 @@ mod tests {
 
     #[test]
     fn test_pl408_inline_hash_only_rename_no_delete() {
-        // PL408: inline hash — delete is suppressed; only rename is offered
+        // PL408: inline hash suppresses delete; only rename is offered.
         let source = "my %h = (foo => 1, foo => 2);\n";
         let mut parser = Parser::new(source);
         let ast = must(parser.parse());
-        let dup_start = source.rfind("foo").unwrap();
+        let dup_start = must_some(source.rfind("foo"));
         let dup_end = dup_start + "foo".len();
         let diagnostics = vec![make_diagnostic(
             dup_start,
@@ -1252,7 +1249,7 @@ mod tests {
         let source = "my %h = (\n    'key' => 1,\n    'key' => 2,\n);\n";
         let mut parser = Parser::new(source);
         let ast = must(parser.parse());
-        let dup_start = source.rfind("'key'").unwrap();
+        let dup_start = must_some(source.rfind("'key'"));
         let dup_end = dup_start + "'key'".len();
         let diagnostics = vec![make_diagnostic(
             dup_start,

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -277,6 +277,11 @@ impl CodeActionsProvider {
                     c if c == DiagnosticCode::MissingReturn.as_str() => {
                         actions.extend(quick_fixes::fix_missing_return(&self.source, &qf_diag));
                     }
+                    // PL408: Duplicate hash key
+                    c if c == DiagnosticCode::DuplicateHashKey.as_str() => {
+                        actions
+                            .extend(quick_fixes::fix_duplicate_hash_keys(&self.source, &qf_diag));
+                    }
                     _ => {}
                 }
             }
@@ -1155,5 +1160,111 @@ mod tests {
                 "Expected parse error code {code} to produce at least one quick fix"
             );
         }
+    }
+
+    #[test]
+    fn test_pl408_duplicate_hash_key_rename_action() {
+        // PL408: duplicate hash key 'host' on a multiline hash — offers rename and delete
+        let source = "my %cfg = (\n    host => 'db1',\n    host => 'db2',\n);\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        // Second 'host' key
+        let dup_start = source.rfind("host").unwrap();
+        let dup_end = dup_start + "host".len();
+        let diagnostics = vec![make_diagnostic(
+            dup_start,
+            dup_end,
+            "PL408",
+            "Duplicate hash key 'host' -- only the last value will be used",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        // Must offer a rename action
+        let rename = actions
+            .iter()
+            .find(|a| a.title.contains("Rename") && a.title.contains("host"))
+            .expect("PL408 should produce a rename action for duplicate key");
+        assert_eq!(rename.edit.changes[0].new_text, "host_2");
+        assert_eq!(rename.edit.changes[0].location.start, dup_start);
+        assert_eq!(rename.edit.changes[0].location.end, dup_end);
+    }
+
+    #[test]
+    fn test_pl408_duplicate_hash_key_delete_preferred_for_multiline() {
+        // PL408: delete action is preferred and removes only the duplicate line
+        let source = "my %cfg = (\n    host => 'db1',\n    host => 'db2',\n);\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let dup_start = source.rfind("host").unwrap();
+        let dup_end = dup_start + "host".len();
+        let diagnostics = vec![make_diagnostic(
+            dup_start,
+            dup_end,
+            "PL408",
+            "Duplicate hash key 'host' -- only the last value will be used",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        let delete = actions
+            .iter()
+            .find(|a| a.title.contains("Remove") && a.title.contains("host"))
+            .expect("PL408 should produce a remove action for multiline duplicate key");
+        assert!(delete.is_preferred, "remove action should be preferred");
+
+        let rewritten = apply_action(source, delete);
+        assert_eq!(rewritten, "my %cfg = (\n    host => 'db1',\n);\n");
+    }
+
+    #[test]
+    fn test_pl408_inline_hash_only_rename_no_delete() {
+        // PL408: inline hash — delete is suppressed; only rename is offered
+        let source = "my %h = (foo => 1, foo => 2);\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let dup_start = source.rfind("foo").unwrap();
+        let dup_end = dup_start + "foo".len();
+        let diagnostics = vec![make_diagnostic(
+            dup_start,
+            dup_end,
+            "PL408",
+            "Duplicate hash key 'foo' -- only the last value will be used",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(
+            !actions.iter().any(|a| a.title.contains("Remove")),
+            "should not offer delete for inline hash"
+        );
+        assert!(
+            actions.iter().any(|a| a.title.contains("Rename") && a.title.contains("foo")),
+            "should still offer rename for inline hash"
+        );
+    }
+
+    #[test]
+    fn test_pl408_single_quoted_key_rename_preserves_quotes() {
+        let source = "my %h = (\n    'key' => 1,\n    'key' => 2,\n);\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let dup_start = source.rfind("'key'").unwrap();
+        let dup_end = dup_start + "'key'".len();
+        let diagnostics = vec![make_diagnostic(
+            dup_start,
+            dup_end,
+            "PL408",
+            "Duplicate hash key 'key' -- only the last value will be used",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        let rename = must_some(actions.iter().find(|a| a.title.contains("Rename")));
+        assert_eq!(rename.edit.changes[0].new_text, "'key_2'");
     }
 }

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -223,6 +223,31 @@ mod tests {
     }
 
     #[test]
+    fn fix_duplicate_hash_keys_empty_on_invalid_range() {
+        let source = "my %h = (foo => 1, foo => 2);\n";
+        let diagnostic = diagnostic_for(
+            (source.len() + 1, source.len() + 4),
+            "Duplicate hash key 'foo' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn fix_duplicate_hash_keys_empty_on_non_char_boundary_range() {
+        let source = "my %h = (\"\u{e9}\" => 1, \"\u{e9}\" => 2);\n";
+        let char_start = must_some(source.find('\u{e9}'));
+        let diagnostic = diagnostic_for(
+            (char_start + 1, char_start + 2),
+            "Duplicate hash key 'e' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
     fn fix_duplicate_hash_keys_no_delete_for_multiline_value() {
         let source = "my %h = (\n    foo => 1,\n    foo => {\n        nested => 1,\n    },\n);\n";
         let key_start = must_some(source.rfind("foo => {"));

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -120,6 +120,108 @@ mod tests {
     }
 
     #[test]
+    fn fix_duplicate_hash_keys_rename_bareword_key() {
+        let source = "my %h = (\n    foo => 1,\n    foo => 2,\n);\n";
+        let key_start = source.rfind("foo").unwrap();
+        let key_end = key_start + "foo".len();
+        let diagnostic = diagnostic_for(
+            (key_start, key_end),
+            "Duplicate hash key 'foo' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+
+        let rename = actions.iter().find(|a| a.title.contains("Rename")).unwrap();
+        assert_eq!(rename.edit.changes[0].new_text, "foo_2");
+        assert_eq!(rename.edit.changes[0].location.start, key_start);
+        assert_eq!(rename.edit.changes[0].location.end, key_end);
+    }
+
+    #[test]
+    fn fix_duplicate_hash_keys_delete_removes_correct_line() {
+        let source = "my %h = (\n    foo => 1,\n    foo => 2,\n);\n";
+        let key_start = source.rfind("foo").unwrap();
+        let key_end = key_start + "foo".len();
+        let diagnostic = diagnostic_for(
+            (key_start, key_end),
+            "Duplicate hash key 'foo' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+
+        let delete = actions.iter().find(|a| a.title.contains("Remove")).unwrap();
+        assert!(delete.is_preferred);
+        assert_eq!(delete.edit.changes[0].new_text, "");
+
+        // Applying the delete should remove only the duplicate line
+        let edit = &delete.edit.changes[0];
+        let remaining =
+            format!("{}{}", &source[..edit.location.start], &source[edit.location.end..]);
+        assert_eq!(remaining, "my %h = (\n    foo => 1,\n);\n");
+    }
+
+    #[test]
+    fn fix_duplicate_hash_keys_no_delete_for_inline_hash() {
+        // All pairs on one line — delete action is suppressed to avoid corrupting inline hash
+        let source = "my %h = (foo => 1, foo => 2);\n";
+        let key_start = source.rfind("foo").unwrap();
+        let key_end = key_start + "foo".len();
+        let diagnostic = diagnostic_for(
+            (key_start, key_end),
+            "Duplicate hash key 'foo' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+
+        assert!(
+            !actions.iter().any(|a| a.title.contains("Remove")),
+            "should not offer delete for inline hash"
+        );
+        assert!(actions.iter().any(|a| a.title.contains("Rename")));
+    }
+
+    #[test]
+    fn fix_duplicate_hash_keys_preserves_single_quote_style() {
+        let source = "my %h = (\n    'foo' => 1,\n    'foo' => 2,\n);\n";
+        let key_start = source.rfind("'foo'").unwrap();
+        let key_end = key_start + "'foo'".len();
+        let diagnostic = diagnostic_for(
+            (key_start, key_end),
+            "Duplicate hash key 'foo' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+
+        let rename = actions.iter().find(|a| a.title.contains("Rename")).unwrap();
+        assert_eq!(rename.edit.changes[0].new_text, "'foo_2'");
+    }
+
+    #[test]
+    fn fix_duplicate_hash_keys_preserves_double_quote_style() {
+        let source = "my %h = (\n    \"foo\" => 1,\n    \"foo\" => 2,\n);\n";
+        let key_start = source.rfind("\"foo\"").unwrap();
+        let key_end = key_start + "\"foo\"".len();
+        let diagnostic = diagnostic_for(
+            (key_start, key_end),
+            "Duplicate hash key 'foo' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+
+        let rename = actions.iter().find(|a| a.title.contains("Rename")).unwrap();
+        assert_eq!(rename.edit.changes[0].new_text, "\"foo_2\"");
+    }
+
+    #[test]
+    fn fix_duplicate_hash_keys_empty_on_unparseable_message() {
+        let source = "my %h = (foo => 1, foo => 2);\n";
+        let diagnostic = diagnostic_for((19, 22), "No key name here");
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
     fn fix_unused_variable_removal_does_not_overrun_end_of_file() {
         // Source has no trailing newline — delete_end must clamp to source.len().
         let source = "my $unused = 1;";
@@ -1064,6 +1166,82 @@ pub fn fix_duplicate_subroutine(diagnostic: &QuickFixDiagnostic) -> Vec<CodeActi
             }],
         },
         is_preferred: true,
+    });
+
+    actions
+}
+
+/// Fix duplicate hash key by renaming or removing the duplicate entry (PL408).
+///
+/// Offers two actions when the same static key appears more than once in a hash literal:
+///
+/// 1. **Remove duplicate entry** — deletes the entire line containing the duplicate key,
+///    keeping the *first* value. Offered only when the duplicate pair is on its own line
+///    (exactly one `=>` on the line) so we don't corrupt inline hashes.
+/// 2. **Rename duplicate key** — appends `_2` to the key name so both entries are kept
+///    under distinct names. The original quote style (single-quoted, double-quoted, or
+///    bareword) is preserved.
+///
+/// The diagnostic range covers the duplicate key token (second occurrence).
+/// The first occurrence location is available in `related_information` on the full
+/// `Diagnostic`, but is not needed here — we fix the duplicate in-place.
+pub fn fix_duplicate_hash_keys(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    // Message format: "Duplicate hash key 'key_name' -- only the last value will be used"
+    let Some(key_name) = diagnostic.message.split('\'').nth(1) else {
+        return Vec::new();
+    };
+
+    let mut actions = Vec::new();
+
+    // Determine the key's source representation to preserve quote style.
+    // key_source may be: bareword `foo`, single-quoted `'foo'`, double-quoted `"foo"`,
+    // or a numeric literal `42`.  Renaming appends `_2` inside the same delimiters.
+    let key_source = source.get(diagnostic.range.0..diagnostic.range.1).unwrap_or(key_name);
+    let new_key = if key_source.starts_with('\'') && key_source.ends_with('\'') {
+        format!("'{key_name}_2'")
+    } else if key_source.starts_with('"') && key_source.ends_with('"') {
+        format!("\"{key_name}_2\"")
+    } else {
+        format!("{key_name}_2")
+    };
+
+    // Offer line deletion only when the duplicate pair occupies its own line.
+    // "Its own line" heuristic: exactly one `=>` on the line (avoids corrupting
+    // inline hashes like `(foo => 1, foo => 2)`).
+    let line_start = source[..diagnostic.range.0].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let line_end = source[diagnostic.range.1..]
+        .find('\n')
+        .map(|p| diagnostic.range.1 + p)
+        .unwrap_or(source.len());
+    let delete_end = if line_end < source.len() { line_end + 1 } else { line_end };
+    let line_content = &source[line_start..line_end];
+    if line_content.matches("=>").count() == 1 {
+        actions.push(CodeAction {
+            title: format!("Remove duplicate entry '{key_name}' (keep first value)"),
+            kind: CodeActionKind::QuickFix,
+            diagnostics: vec![DiagnosticCode::DuplicateHashKey.as_str().to_string()],
+            edit: CodeActionEdit {
+                changes: vec![TextEdit {
+                    location: SourceLocation { start: line_start, end: delete_end },
+                    new_text: String::new(),
+                }],
+            },
+            is_preferred: true,
+        });
+    }
+
+    // Rename action — always safe; keeps both entries under distinct names.
+    actions.push(CodeAction {
+        title: format!("Rename duplicate key to '{new_key}'"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::DuplicateHashKey.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: diagnostic.range.0, end: diagnostic.range.1 },
+                new_text: new_key,
+            }],
+        },
+        is_preferred: false,
     });
 
     actions

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -114,6 +114,7 @@ fn split_sigil(name: &str) -> (&str, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use perl_tdd_support::must_some;
 
     fn diagnostic_for(range: (usize, usize), message: &str) -> QuickFixDiagnostic {
         QuickFixDiagnostic { range, message: message.to_string(), code: None }
@@ -122,7 +123,7 @@ mod tests {
     #[test]
     fn fix_duplicate_hash_keys_rename_bareword_key() {
         let source = "my %h = (\n    foo => 1,\n    foo => 2,\n);\n";
-        let key_start = source.rfind("foo").unwrap();
+        let key_start = must_some(source.rfind("foo"));
         let key_end = key_start + "foo".len();
         let diagnostic = diagnostic_for(
             (key_start, key_end),
@@ -131,7 +132,7 @@ mod tests {
 
         let actions = fix_duplicate_hash_keys(source, &diagnostic);
 
-        let rename = actions.iter().find(|a| a.title.contains("Rename")).unwrap();
+        let rename = must_some(actions.iter().find(|a| a.title.contains("Rename")));
         assert_eq!(rename.edit.changes[0].new_text, "foo_2");
         assert_eq!(rename.edit.changes[0].location.start, key_start);
         assert_eq!(rename.edit.changes[0].location.end, key_end);
@@ -140,7 +141,7 @@ mod tests {
     #[test]
     fn fix_duplicate_hash_keys_delete_removes_correct_line() {
         let source = "my %h = (\n    foo => 1,\n    foo => 2,\n);\n";
-        let key_start = source.rfind("foo").unwrap();
+        let key_start = must_some(source.rfind("foo"));
         let key_end = key_start + "foo".len();
         let diagnostic = diagnostic_for(
             (key_start, key_end),
@@ -149,11 +150,11 @@ mod tests {
 
         let actions = fix_duplicate_hash_keys(source, &diagnostic);
 
-        let delete = actions.iter().find(|a| a.title.contains("Remove")).unwrap();
+        let delete = must_some(actions.iter().find(|a| a.title.contains("Remove")));
         assert!(delete.is_preferred);
         assert_eq!(delete.edit.changes[0].new_text, "");
 
-        // Applying the delete should remove only the duplicate line
+        // Applying the delete should remove only the duplicate line.
         let edit = &delete.edit.changes[0];
         let remaining =
             format!("{}{}", &source[..edit.location.start], &source[edit.location.end..]);
@@ -162,9 +163,9 @@ mod tests {
 
     #[test]
     fn fix_duplicate_hash_keys_no_delete_for_inline_hash() {
-        // All pairs on one line — delete action is suppressed to avoid corrupting inline hash
+        // All pairs on one line: delete action is suppressed to avoid corrupting inline hash.
         let source = "my %h = (foo => 1, foo => 2);\n";
-        let key_start = source.rfind("foo").unwrap();
+        let key_start = must_some(source.rfind("foo"));
         let key_end = key_start + "foo".len();
         let diagnostic = diagnostic_for(
             (key_start, key_end),
@@ -183,7 +184,7 @@ mod tests {
     #[test]
     fn fix_duplicate_hash_keys_preserves_single_quote_style() {
         let source = "my %h = (\n    'foo' => 1,\n    'foo' => 2,\n);\n";
-        let key_start = source.rfind("'foo'").unwrap();
+        let key_start = must_some(source.rfind("'foo'"));
         let key_end = key_start + "'foo'".len();
         let diagnostic = diagnostic_for(
             (key_start, key_end),
@@ -192,14 +193,14 @@ mod tests {
 
         let actions = fix_duplicate_hash_keys(source, &diagnostic);
 
-        let rename = actions.iter().find(|a| a.title.contains("Rename")).unwrap();
+        let rename = must_some(actions.iter().find(|a| a.title.contains("Rename")));
         assert_eq!(rename.edit.changes[0].new_text, "'foo_2'");
     }
 
     #[test]
     fn fix_duplicate_hash_keys_preserves_double_quote_style() {
         let source = "my %h = (\n    \"foo\" => 1,\n    \"foo\" => 2,\n);\n";
-        let key_start = source.rfind("\"foo\"").unwrap();
+        let key_start = must_some(source.rfind("\"foo\""));
         let key_end = key_start + "\"foo\"".len();
         let diagnostic = diagnostic_for(
             (key_start, key_end),
@@ -208,7 +209,7 @@ mod tests {
 
         let actions = fix_duplicate_hash_keys(source, &diagnostic);
 
-        let rename = actions.iter().find(|a| a.title.contains("Rename")).unwrap();
+        let rename = must_some(actions.iter().find(|a| a.title.contains("Rename")));
         assert_eq!(rename.edit.changes[0].new_text, "\"foo_2\"");
     }
 
@@ -219,6 +220,41 @@ mod tests {
 
         let actions = fix_duplicate_hash_keys(source, &diagnostic);
         assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn fix_duplicate_hash_keys_no_delete_for_multiline_value() {
+        let source = "my %h = (\n    foo => 1,\n    foo => {\n        nested => 1,\n    },\n);\n";
+        let key_start = must_some(source.rfind("foo => {"));
+        let key_end = key_start + "foo".len();
+        let diagnostic = diagnostic_for(
+            (key_start, key_end),
+            "Duplicate hash key 'foo' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+
+        assert!(
+            !actions.iter().any(|a| a.title.contains("Remove")),
+            "should not offer line delete for multiline duplicate values"
+        );
+        assert!(actions.iter().any(|a| a.title.contains("Rename")));
+    }
+
+    #[test]
+    fn fix_duplicate_hash_keys_quotes_numeric_rename_candidate() {
+        let source = "my %h = (\n    42 => 1,\n    42 => 2,\n);\n";
+        let key_start = must_some(source.rfind("42"));
+        let key_end = key_start + "42".len();
+        let diagnostic = diagnostic_for(
+            (key_start, key_end),
+            "Duplicate hash key '42' -- only the last value will be used",
+        );
+
+        let actions = fix_duplicate_hash_keys(source, &diagnostic);
+
+        let rename = must_some(actions.iter().find(|a| a.title.contains("Rename")));
+        assert_eq!(rename.edit.changes[0].new_text, "'42_2'");
     }
 
     #[test]
@@ -1175,47 +1211,31 @@ pub fn fix_duplicate_subroutine(diagnostic: &QuickFixDiagnostic) -> Vec<CodeActi
 ///
 /// Offers two actions when the same static key appears more than once in a hash literal:
 ///
-/// 1. **Remove duplicate entry** — deletes the entire line containing the duplicate key,
-///    keeping the *first* value. Offered only when the duplicate pair is on its own line
-///    (exactly one `=>` on the line) so we don't corrupt inline hashes.
-/// 2. **Rename duplicate key** — appends `_2` to the key name so both entries are kept
+/// 1. **Remove duplicate entry** - deletes the entire line containing the duplicate key,
+///    keeping the *first* value. Offered only for simple one-line entries
+///    so we don't corrupt inline hashes or multiline values.
+/// 2. **Rename duplicate key** - appends `_2` to the key name so both entries are kept
 ///    under distinct names. The original quote style (single-quoted, double-quoted, or
 ///    bareword) is preserved.
 ///
 /// The diagnostic range covers the duplicate key token (second occurrence).
 /// The first occurrence location is available in `related_information` on the full
-/// `Diagnostic`, but is not needed here — we fix the duplicate in-place.
+/// `Diagnostic`, but is not needed here - we fix the duplicate in-place.
 pub fn fix_duplicate_hash_keys(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
-    // Message format: "Duplicate hash key 'key_name' -- only the last value will be used"
-    let Some(key_name) = diagnostic.message.split('\'').nth(1) else {
+    let Some(key_name) = duplicate_hash_key_name(&diagnostic.message) else {
         return Vec::new();
     };
 
     let mut actions = Vec::new();
 
     // Determine the key's source representation to preserve quote style.
-    // key_source may be: bareword `foo`, single-quoted `'foo'`, double-quoted `"foo"`,
-    // or a numeric literal `42`.  Renaming appends `_2` inside the same delimiters.
-    let key_source = source.get(diagnostic.range.0..diagnostic.range.1).unwrap_or(key_name);
-    let new_key = if key_source.starts_with('\'') && key_source.ends_with('\'') {
-        format!("'{key_name}_2'")
-    } else if key_source.starts_with('"') && key_source.ends_with('"') {
-        format!("\"{key_name}_2\"")
-    } else {
-        format!("{key_name}_2")
+    let Some(key_source) = source.get(diagnostic.range.0..diagnostic.range.1) else {
+        return Vec::new();
     };
+    let new_key = duplicate_hash_key_rename_text(key_source, key_name);
 
     // Offer line deletion only when the duplicate pair occupies its own line.
-    // "Its own line" heuristic: exactly one `=>` on the line (avoids corrupting
-    // inline hashes like `(foo => 1, foo => 2)`).
-    let line_start = source[..diagnostic.range.0].rfind('\n').map(|p| p + 1).unwrap_or(0);
-    let line_end = source[diagnostic.range.1..]
-        .find('\n')
-        .map(|p| diagnostic.range.1 + p)
-        .unwrap_or(source.len());
-    let delete_end = if line_end < source.len() { line_end + 1 } else { line_end };
-    let line_content = &source[line_start..line_end];
-    if line_content.matches("=>").count() == 1 {
+    if let Some((line_start, delete_end)) = duplicate_hash_key_delete_range(source, diagnostic) {
         actions.push(CodeAction {
             title: format!("Remove duplicate entry '{key_name}' (keep first value)"),
             kind: CodeActionKind::QuickFix,
@@ -1230,7 +1250,7 @@ pub fn fix_duplicate_hash_keys(source: &str, diagnostic: &QuickFixDiagnostic) ->
         });
     }
 
-    // Rename action — always safe; keeps both entries under distinct names.
+    // Rename action keeps the duplicate entry and edits only the key token.
     actions.push(CodeAction {
         title: format!("Rename duplicate key to '{new_key}'"),
         kind: CodeActionKind::QuickFix,
@@ -1245,6 +1265,74 @@ pub fn fix_duplicate_hash_keys(source: &str, diagnostic: &QuickFixDiagnostic) ->
     });
 
     actions
+}
+
+fn duplicate_hash_key_name(message: &str) -> Option<&str> {
+    const PREFIX: &str = "Duplicate hash key '";
+    const SUFFIX: &str = "' -- only the last value will be used";
+
+    message.strip_prefix(PREFIX)?.strip_suffix(SUFFIX)
+}
+
+fn duplicate_hash_key_rename_text(key_source: &str, key_name: &str) -> String {
+    if is_quoted_with(key_source, '\'') || is_quoted_with(key_source, '"') {
+        let insert_at = key_source.len().saturating_sub(1);
+        let mut renamed = String::with_capacity(key_source.len() + 2);
+        renamed.push_str(&key_source[..insert_at]);
+        renamed.push_str("_2");
+        renamed.push_str(&key_source[insert_at..]);
+        return renamed;
+    }
+
+    if is_bareword_hash_key(key_source) {
+        format!("{key_source}_2")
+    } else {
+        format!("'{}_2'", escape_single_quoted_perl(key_name))
+    }
+}
+
+fn is_quoted_with(value: &str, quote: char) -> bool {
+    value.len() >= 2 && value.starts_with(quote) && value.ends_with(quote)
+}
+
+fn is_bareword_hash_key(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn escape_single_quoted_perl(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+fn duplicate_hash_key_delete_range(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Option<(usize, usize)> {
+    let before_key = source.get(..diagnostic.range.0)?;
+    let after_key = source.get(diagnostic.range.1..)?;
+    let line_start = before_key.rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let line_end = after_key.find('\n').map(|p| diagnostic.range.1 + p).unwrap_or(source.len());
+    let delete_end = if line_end < source.len() { line_end + 1 } else { line_end };
+    let line_content = source.get(line_start..line_end)?;
+
+    if is_simple_duplicate_hash_entry_line(line_content) {
+        Some((line_start, delete_end))
+    } else {
+        None
+    }
+}
+
+fn is_simple_duplicate_hash_entry_line(line_content: &str) -> bool {
+    let trimmed = line_content.trim_end();
+
+    line_content.matches("=>").count() == 1
+        && trimmed.ends_with(',')
+        && !line_content.contains(['(', ')', '[', ']', '{', '}'])
 }
 
 /// Fix missing return statement by adding an explicit `return` before the closing brace


### PR DESCRIPTION
Problem: PL408 duplicate-hash-key diagnostics had no scoped quick fix. Fix: route PL408 to bounded code actions that rename the duplicate key, and only delete simple one-line comma-terminated duplicate entries while blocking inline, multiline-value, invalid-range, and non-char-boundary deletes. Verification: cargo xtask fmt passed; cargo test -p perl-lsp-rs-core --lib providers::code_actions passed locally; cargo check --all-targets -p perl-lsp-rs-core passed with only pre-existing perl-subprocess-runtime unused-import warnings; cargo clippy -p perl-lsp-rs-core --lib passed with the same pre-existing warnings; hosted CI Gate (Merge-Blocking), UX Regression Gate, PR Smoke, Compile All Targets, and LSP shard passed on ea1cfbe3.