### PR TITLE
feat(receiver): infer accessor return facts (#8197)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
@@ -180,6 +180,13 @@ pub enum TypeEvidence {
         /// Blessed package.
         package: String,
     },
+    /// Accessor return evidence, such as `$self->db` returning the `db` field.
+    AccessorReturn {
+        /// Accessor method name.
+        method: String,
+        /// Backing field or attribute name.
+        field: String,
+    },
     /// Moose/Moo `isa` evidence for an attribute.
     MooseIsa {
         /// Attribute name.

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -1,3 +1,4 @@
+use super::class_model::{AccessorType, ClassModelBuilder};
 use super::type_facts::{
     ArrayShape, DynamicBoundary, HashShape, ObjectShape, ShapeFact, TypeEvidence, TypeFact,
 };
@@ -223,6 +224,8 @@ pub struct TypeInferenceEngine {
     constraints: Vec<TypeConstraint>,
     /// Built-in function signatures
     builtins: HashMap<String, PerlType>,
+    /// Framework accessor return facts keyed by `(package, accessor)`.
+    accessor_return_facts: HashMap<(String, String), TypeFact>,
     /// Type aliases from use statements
     _type_aliases: HashMap<String, PerlType>,
 }
@@ -240,6 +243,7 @@ impl TypeInferenceEngine {
             global_env: TypeEnvironment::new(),
             constraints: Vec::new(),
             builtins: HashMap::new(),
+            accessor_return_facts: HashMap::new(),
             _type_aliases: HashMap::new(),
         };
 
@@ -316,6 +320,8 @@ impl TypeInferenceEngine {
 
     /// Infer types for an AST
     pub fn infer(&mut self, ast: &Node) -> Result<PerlType, Vec<TypeConstraint>> {
+        self.refresh_accessor_return_facts(ast);
+
         // We need to use a temporary environment that has global_env as parent,
         // or just use global_env directly if we want to persist top-level declarations?
         // Usually top-level declarations should persist.
@@ -743,6 +749,9 @@ impl TypeInferenceEngine {
                 static_package_node(object)
                     .map_or_else(TypeFact::unknown, |package| constructor_fact(&package))
             }
+            NodeKind::MethodCall { object, method, .. } => {
+                self.method_call_expr_fact(object, method, env)
+            }
             NodeKind::Assignment { lhs, rhs, op } if op == "=" => {
                 self.assign_expr_fact(lhs, rhs, env)
             }
@@ -779,6 +788,43 @@ impl TypeInferenceEngine {
         };
         fact.evidence.push(TypeEvidence::VariableInitializer { name: name.to_string() });
         fact
+    }
+
+    fn refresh_accessor_return_facts(&mut self, ast: &Node) {
+        self.accessor_return_facts.clear();
+
+        for model in ClassModelBuilder::new().build(ast) {
+            for attr in model.attributes {
+                if !attribute_generates_reader(attr.is) {
+                    continue;
+                }
+                let Some(package) = package_like_isa(attr.isa.as_deref()) else {
+                    continue;
+                };
+                let method = attr.accessor_name.clone();
+                let fact = accessor_return_fact(&method, &attr.name, &package);
+                self.accessor_return_facts.insert((model.name.clone(), method), fact);
+            }
+        }
+    }
+
+    fn method_call_expr_fact(
+        &mut self,
+        object: &Node,
+        method: &str,
+        env: &mut TypeEnvironment,
+    ) -> TypeFact {
+        let object_fact = self.infer_expr_fact_in_env(object, env);
+        let Some(package) = object_package_from_fact(&object_fact) else {
+            let mut fact = TypeFact::unknown();
+            fact.dynamic_boundary = object_fact.dynamic_boundary;
+            return fact;
+        };
+
+        self.accessor_return_facts
+            .get(&(package, method.to_string()))
+            .cloned()
+            .unwrap_or_else(TypeFact::unknown)
     }
 
     fn assign_expr_fact(&mut self, lhs: &Node, rhs: &Node, env: &mut TypeEnvironment) -> TypeFact {
@@ -1177,6 +1223,45 @@ fn constructor_fact(package: &str) -> TypeFact {
     );
     fact.shape = Some(ShapeFact::Object(ObjectShape::new(package.to_string(), BTreeMap::new())));
     fact
+}
+
+fn accessor_return_fact(method: &str, field: &str, package: &str) -> TypeFact {
+    let mut fact = fact_with_evidence(
+        PerlType::Any,
+        Confidence::Medium,
+        TypeEvidence::MooseIsa { attr: field.to_string(), isa: package.to_string() },
+    );
+    fact.evidence.push(TypeEvidence::AccessorReturn {
+        method: method.to_string(),
+        field: field.to_string(),
+    });
+    fact.shape = Some(ShapeFact::Object(ObjectShape::new(package.to_string(), BTreeMap::new())));
+    fact
+}
+
+fn attribute_generates_reader(mode: Option<AccessorType>) -> bool {
+    !matches!(mode, Some(AccessorType::Bare))
+}
+
+fn package_like_isa(isa: Option<&str>) -> Option<String> {
+    let candidate = isa?.trim();
+    if candidate.contains("::") { Some(candidate.to_string()) } else { None }
+}
+
+fn object_package_from_fact(fact: &TypeFact) -> Option<String> {
+    object_package_from_type(&fact.ty).or_else(|| match &fact.shape {
+        Some(ShapeFact::Object(shape)) => Some(shape.package.clone()),
+        _ => None,
+    })
+}
+
+fn object_package_from_type(ty: &PerlType) -> Option<String> {
+    match ty {
+        PerlType::Object(package) => Some(package.clone()),
+        PerlType::Reference(inner) => object_package_from_type(inner),
+        PerlType::Union(types) => types.iter().find_map(object_package_from_type),
+        _ => None,
+    }
 }
 
 fn object_fields_from_bless_reference(

--- a/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
@@ -49,6 +49,16 @@ fn method_receiver<'a>(node: &'a Node, name: &str) -> Result<&'a Node, String> {
     }
 }
 
+fn object_shape_package(
+    fact: &perl_semantic_analyzer::analysis::type_facts::TypeFact,
+) -> Result<&str, String> {
+    let shape = fact.shape.as_ref().ok_or_else(|| "missing object shape".to_string())?;
+    match shape {
+        ShapeFact::Object(object) => Ok(object.package.as_str()),
+        _ => Err("fact should carry object shape".to_string()),
+    }
+}
+
 #[test]
 fn constructor_expr_fact_records_object_package() -> Result<(), String> {
     let ast = parse_ast("MyApp::DB->new();")?;
@@ -222,6 +232,47 @@ fn dynamic_bless_class_does_not_expose_exact_object_field_fact() -> Result<(), S
     assert!(fact.evidence.iter().any(|evidence| {
         matches!(evidence, TypeEvidence::HashRefSlot { base, key } if base == "$self" && key == "db")
     }));
+    Ok(())
+}
+
+#[test]
+fn moo_accessor_return_records_medium_confidence_object_shape() -> Result<(), String> {
+    let code = "package MyApp::Service; use Moo; has db => (is => 'ro', isa => 'MyApp::DB'); my $service = MyApp::Service->new; $service->db->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Any);
+    assert_eq!(fact.confidence, Confidence::Medium);
+    assert_eq!(object_shape_package(&fact)?, "MyApp::DB");
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::MooseIsa { attr, isa } if attr == "db" && isa == "MyApp::DB")
+    }));
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::AccessorReturn { method, field } if method == "db" && field == "db")
+    }));
+    Ok(())
+}
+
+#[test]
+fn dynamic_moo_accessor_isa_stays_non_exact() -> Result<(), String> {
+    let code = "package MyApp::Service; use Moo; my $type = 'MyApp::DB'; has db => (is => 'ro', isa => $type); my $service = MyApp::Service->new; $service->db->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Any);
+    assert_eq!(fact.confidence, Confidence::Low);
+    assert!(fact.shape.is_none());
+    assert!(fact.evidence.is_empty());
     Ok(())
 }
 

--- a/docs/project/status/receiver_facts.md
+++ b/docs/project/status/receiver_facts.md
@@ -28,6 +28,8 @@ It may claim:
 - receiver extraction over existing `TypeFact` and `ShapeFact` evidence
 - source-derived constructor, plain-hash, hashref, and static bless-field facts
   where tests prove them
+- source-derived framework accessor-return facts where tests prove package-like
+  `isa` declarations
 - dynamic-key boundaries for receiver extraction
 - no completion candidate behavior change unless the PR is explicitly a
   provider cutover receipt tied to [PLSP-SPEC-0007](../../specs/PLSP-SPEC-0007-receiver-fact-completion.md)
@@ -38,8 +40,7 @@ It may not claim:
   source-backed pilot
 - hover, goto, diagnostics, or refactor behavior changes
 - support-tier promotion
-- accessor-return or chained method-return facts until focused fixtures prove
-  those source shapes
+- chained method-return facts until focused fixtures prove those source shapes
 
 Facts-only PRs must keep this wording in their claim boundary:
 
@@ -57,12 +58,13 @@ no support-tier promotion
 | `type_environment_fact_map` | `landed` | `TypeEnvironment::set_variable_fact`, `get_variable_fact`, `get_fact_at`; stale fact clearing and parent lookup tests in `type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Existing `PerlType` callers keep erased compatibility while source-level expression inference stores richer facts for proven shapes. |
 | `static_package_receiver` | `landed` | `receiver_facts` module test `static_constructor_receiver_records_package`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static package receivers can produce high-confidence constructor evidence. |
 | `object_variable_receiver` | `landed` | `receiver_facts` module tests for `$self` and `$object`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Exact package requires a supplied type-environment fact. Unknown object variables stay low confidence. |
-| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; `receiver_expression_facts` tests for plain hash literals and slot assignment | Works when `TypeEnvironment` contains a `HashShape`; source-derived plain `%hash` literals and `$hash{key}` assignments can now populate that shape. Accessor-return source inference remains pending. |
-| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; `receiver_expression_facts` tests for hashref literals and slot assignment | Works when the base fact already has a hash shape; source-derived `$hashref->{key}` facts are proven for hashref literals and slot assignment. Accessor-return and chained method-return source inference remain pending. |
+| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; `receiver_expression_facts` tests for plain hash literals and slot assignment | Works when `TypeEnvironment` contains a `HashShape`; source-derived plain `%hash` literals and `$hash{key}` assignments can now populate that shape. Chained method-return source inference remains pending. |
+| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; `receiver_expression_facts` tests for hashref literals and slot assignment | Works when the base fact already has a hash shape; source-derived `$hashref->{key}` facts are proven for hashref literals and slot assignment. Chained method-return source inference remains pending. |
 | `bless_field_receiver` | `partial` | `receiver_expression_facts` tests for static bless fields and dynamic bless class fallback; `receiver_facts` module test `object_field_receiver_preserves_fallback` | Static `bless { field => Package->new }, 'Class'` populates medium-confidence object-field facts for `$self->{field}`. Dynamic bless class names fail closed. This is semantic substrate only and does not broaden completion. |
+| `accessor_return_receiver` | `partial` | `receiver_expression_facts` tests for Moo/Moose package-like `isa` accessor returns and dynamic `isa` fallback | Static framework declarations such as `has db => (isa => 'MyApp::DB')` populate medium-confidence object-shape facts for `$service->db`. The erased type remains `Any`, dynamic/non-package `isa` values fail closed, and this is semantic substrate only with no completion cutover. |
 | `array_index_receiver` | `partial` | `receiver_facts` module tests for static and dynamic array indexes; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static indexes can use existing `ArrayShape` facts; dynamic indexes remain non-exact. |
 | `dynamic_key_boundary` | `landed` | `receiver_facts` module test `dynamic_hash_key_marks_dynamic_boundary`; `TypeFact::dynamic` test in `type_facts.rs`; `receiver_expression_facts` dynamic plain-hash-key test; completion provider test `dynamic_hash_key_receiver_preserves_imported_fallback` | Proven for receiver extraction, plain hash expression facts, and the first completion-provider boundary receipt. Additional provider boundary receipts remain pending for other receiver forms. |
-| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, hashref literals, hashref slot assignment, static plain/hashref slot reads, static bless fields, dynamic plain hash keys, and dynamic bless classes are facts-only substrate. Accessor returns and chained method-return facts remain pending. |
+| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, hashref literals, hashref slot assignment, static plain/hashref slot reads, static bless fields, framework accessor returns, dynamic plain hash keys, dynamic bless classes, and dynamic/non-package accessor `isa` values are facts-only substrate. Chained method-return facts remain pending. |
 | `receiver_fact_api` | `landed` | `crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | API extracts facts from existing AST and supplied environment facts; method-call chains remain unknown until explicit rules land. |
 | `completion_cutover` | `narrow-pilot` | Completion provider tests `source_backed_hash_slot_receiver_uses_exact_completion_pilot` and `dynamic_hash_key_receiver_preserves_imported_fallback`; PR [#9502](https://github.com/EffortlessMetrics/perl-lsp/pull/9502) | Only fresh high-confidence source-backed receiver facts may authorize exact receiver completion. Unknown, dynamic, generated/no-source, stale, and low-confidence receiver shapes stay fallback, shadowed, or blocked. |
 
@@ -79,8 +81,7 @@ receiver_fact_completion_cutover:
 
 ## Next Implementation Steps
 
-1. Add accessor-return and chained method-return expression facts without
-   changing provider output.
+1. Add chained method-return expression facts without changing provider output.
 2. Add facts-only fixtures that prove source-derived `$self` and framework
    accessor receiver facts without changing provider output.
 3. Add real-workspace and additional receiver-form provider confidence receipts

--- a/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
+++ b/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
@@ -20,8 +20,10 @@ Current implementation state and next source-shape work live in the status doc
 and receiver-facts implementation plan, not in this spec. Hashref literal and
 slot-assignment inference are fixture-backed facts-only substrate. Static
 `bless { field => Package->new }, 'Class'` field inference is fixture-backed as
-medium-confidence substrate. Accessor-return facts and chained method-return
-facts remain bounded by their own future fixtures and provider receipts.
+medium-confidence substrate. Framework accessor-return facts for package-like
+`isa` declarations are fixture-backed as medium-confidence substrate with erased
+type compatibility preserved. Chained method-return facts remain bounded by
+their own future fixtures and provider receipts.
 
 ## Contract
 
@@ -84,6 +86,7 @@ The initial evidence vocabulary must cover:
 - Moo/Moose `isa`
 - Object::Pad fields
 - workspace-symbol evidence
+- accessor-return evidence
 - heuristic evidence
 
 The initial dynamic-boundary vocabulary must cover:
@@ -292,7 +295,7 @@ analyzer test surface should cover these scenarios:
 | hashref literal slot | `$services->{db}` resolves to `MyApp::DB` |
 | dynamic key | package is `None`; dynamic boundary is `DynamicHashKey` |
 | bless object field | `$self->{db}` resolves to `MyApp::DB`, medium confidence after bless-field slice |
-| Moo/Moose accessor | `$self->db` resolves to `MyApp::DB` after framework-accessor slice |
+| Moo/Moose accessor | `$self->db` or another source-backed object accessor resolves to `MyApp::DB` after framework-accessor slice, as medium-confidence substrate until provider receipts promote it |
 
 After facts-only tests pass, LSP completion tests must prove:
 


### PR DESCRIPTION
Problem: Receiver expression facts did not preserve Moo/Moose package-like accessor return evidence, leaving object accessor source shapes unmodeled before any broader completion work.

Fix: Infer medium-confidence accessor-return object-shape facts from framework has ... isa => 'Package::Name' declarations, keep parametrized or dynamic isa values fail-closed, keep erased type compatibility as Any, and update receiver-fact status/spec notes as substrate-only.

Verification: rtk cargo test -p perl-semantic-analyzer --test receiver_expression_facts --locked -- --nocapture --test-threads=1; rtk cargo test -p perl-semantic-analyzer --lib receiver_facts --locked -- --nocapture --test-threads=1; rtk cargo check --all-targets -p perl-semantic-analyzer --locked; rtk cargo clippy -p perl-semantic-analyzer --locked -- -D warnings -A missing_docs; rtk cargo xtask fmt --check; rtk cargo xtask check-support-claims; rtk cargo xtask check-provider-confidence-matrix; rtk cargo xtask ci-hygiene check-doc-paths docs/project/status; rtk cargo xtask ci-hygiene check-doc-paths docs/specs; rtk git diff --check.

Claim boundary: semantic substrate only; no completion candidate behavior change; no support-tier promotion. Accessor facts remain medium-confidence and erased as Any so they cannot authorize the current exact receiver completion pilot.