### PR TITLE
feat(receiver): infer method return facts (#8197)

### DIFF
--- a/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_facts.rs
@@ -187,6 +187,13 @@ pub enum TypeEvidence {
         /// Backing field or attribute name.
         field: String,
     },
+    /// Method-return evidence, such as `$self->db` returning a constructed package.
+    MethodReturn {
+        /// Method name.
+        method: String,
+        /// Returned package shape.
+        package: String,
+    },
     /// Moose/Moo `isa` evidence for an attribute.
     MooseIsa {
         /// Attribute name.

--- a/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
+++ b/crates/perl-semantic-analyzer/src/analysis/type_inference.rs
@@ -226,6 +226,8 @@ pub struct TypeInferenceEngine {
     builtins: HashMap<String, PerlType>,
     /// Framework accessor return facts keyed by `(package, accessor)`.
     accessor_return_facts: HashMap<(String, String), TypeFact>,
+    /// Narrow source-backed method return facts keyed by `(package, method)`.
+    method_return_facts: HashMap<(String, String), TypeFact>,
     /// Type aliases from use statements
     _type_aliases: HashMap<String, PerlType>,
 }
@@ -244,6 +246,7 @@ impl TypeInferenceEngine {
             constraints: Vec::new(),
             builtins: HashMap::new(),
             accessor_return_facts: HashMap::new(),
+            method_return_facts: HashMap::new(),
             _type_aliases: HashMap::new(),
         };
 
@@ -321,6 +324,7 @@ impl TypeInferenceEngine {
     /// Infer types for an AST
     pub fn infer(&mut self, ast: &Node) -> Result<PerlType, Vec<TypeConstraint>> {
         self.refresh_accessor_return_facts(ast);
+        self.refresh_method_return_facts(ast);
 
         // We need to use a temporary environment that has global_env as parent,
         // or just use global_env directly if we want to persist top-level declarations?
@@ -808,6 +812,11 @@ impl TypeInferenceEngine {
         }
     }
 
+    fn refresh_method_return_facts(&mut self, ast: &Node) {
+        self.method_return_facts.clear();
+        collect_method_return_facts(ast, None, &mut self.method_return_facts);
+    }
+
     fn method_call_expr_fact(
         &mut self,
         object: &Node,
@@ -821,9 +830,11 @@ impl TypeInferenceEngine {
             return fact;
         };
 
+        let key = (package, method.to_string());
         self.accessor_return_facts
-            .get(&(package, method.to_string()))
+            .get(&key)
             .cloned()
+            .or_else(|| self.method_return_facts.get(&key).cloned())
             .unwrap_or_else(TypeFact::unknown)
     }
 
@@ -1237,6 +1248,95 @@ fn accessor_return_fact(method: &str, field: &str, package: &str) -> TypeFact {
     });
     fact.shape = Some(ShapeFact::Object(ObjectShape::new(package.to_string(), BTreeMap::new())));
     fact
+}
+
+fn method_return_fact(method: &str, package: &str) -> TypeFact {
+    let mut fact = fact_with_evidence(
+        PerlType::Any,
+        Confidence::Medium,
+        TypeEvidence::MethodReturn { method: method.to_string(), package: package.to_string() },
+    );
+    fact.evidence.push(TypeEvidence::ConstructorCall { package: package.to_string() });
+    fact.shape = Some(ShapeFact::Object(ObjectShape::new(package.to_string(), BTreeMap::new())));
+    fact
+}
+
+fn collect_method_return_facts(
+    node: &Node,
+    package: Option<&str>,
+    out: &mut HashMap<(String, String), TypeFact>,
+) {
+    match &node.kind {
+        NodeKind::Program { statements } | NodeKind::Block { statements } => {
+            collect_method_return_facts_from_statements(statements, package, out);
+        }
+        NodeKind::Package { name, block: Some(block), .. } => {
+            collect_method_return_facts(block, Some(name.as_str()), out);
+        }
+        NodeKind::Subroutine { name: Some(method), body, .. } => {
+            if let (Some(package), Some(fact)) =
+                (package, static_method_body_return_fact(method, body))
+            {
+                out.insert((package.to_string(), method.clone()), fact);
+            }
+        }
+        NodeKind::Method { name, body, .. } => {
+            if let (Some(package), Some(fact)) =
+                (package, static_method_body_return_fact(name, body))
+            {
+                out.insert((package.to_string(), name.clone()), fact);
+            }
+        }
+        _ => {
+            for child in node.children() {
+                collect_method_return_facts(child, package, out);
+            }
+        }
+    }
+}
+
+fn collect_method_return_facts_from_statements(
+    statements: &[Node],
+    package: Option<&str>,
+    out: &mut HashMap<(String, String), TypeFact>,
+) {
+    let mut current_package = package.map(ToOwned::to_owned);
+    for statement in statements {
+        match &statement.kind {
+            NodeKind::Package { name, block: None, .. } => {
+                current_package = Some(name.clone());
+            }
+            NodeKind::Package { name, block: Some(block), .. } => {
+                collect_method_return_facts(block, Some(name.as_str()), out);
+            }
+            _ => {
+                collect_method_return_facts(statement, current_package.as_deref(), out);
+            }
+        }
+    }
+}
+
+fn static_method_body_return_fact(method: &str, body: &Node) -> Option<TypeFact> {
+    let NodeKind::Block { statements } = &body.kind else {
+        return None;
+    };
+    let [statement] = statements.as_slice() else {
+        return None;
+    };
+    static_method_return_expr_fact(method, statement)
+}
+
+fn static_method_return_expr_fact(method: &str, node: &Node) -> Option<TypeFact> {
+    match &node.kind {
+        NodeKind::ExpressionStatement { expression } => {
+            static_method_return_expr_fact(method, expression)
+        }
+        NodeKind::Return { value: Some(value) } => static_method_return_expr_fact(method, value),
+        NodeKind::MethodCall { object, method: called_method, .. } if called_method == "new" => {
+            static_package_node(object).map(|package| method_return_fact(method, &package))
+        }
+        _ => None,
+    }
 }
 
 fn attribute_generates_reader(mode: Option<AccessorType>) -> bool {

--- a/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
+++ b/crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs
@@ -277,6 +277,67 @@ fn dynamic_moo_accessor_isa_stays_non_exact() -> Result<(), String> {
 }
 
 #[test]
+fn method_return_constructor_records_medium_confidence_object_shape() -> Result<(), String> {
+    let code = "package MyApp::Service; sub db { return MyApp::DB->new; } my $service = MyApp::Service->new; $service->db->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Any);
+    assert_eq!(fact.confidence, Confidence::Medium);
+    assert_eq!(object_shape_package(&fact)?, "MyApp::DB");
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::MethodReturn { method, package } if method == "db" && package == "MyApp::DB")
+    }));
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::ConstructorCall { package } if package == "MyApp::DB")
+    }));
+    Ok(())
+}
+
+#[test]
+fn implicit_method_return_constructor_records_object_shape() -> Result<(), String> {
+    let code = "package MyApp::Service; sub cache { MyApp::Cache->new; } my $service = MyApp::Service->new; $service->cache->get;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let receiver = method_receiver(&ast, "get")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Any);
+    assert_eq!(fact.confidence, Confidence::Medium);
+    assert_eq!(object_shape_package(&fact)?, "MyApp::Cache");
+    assert!(fact.evidence.iter().any(|evidence| {
+        matches!(evidence, TypeEvidence::MethodReturn { method, package } if method == "cache" && package == "MyApp::Cache")
+    }));
+    Ok(())
+}
+
+#[test]
+fn dynamic_method_return_constructor_stays_non_exact() -> Result<(), String> {
+    let code = "package MyApp::Service; sub db { return $class->new; } my $service = MyApp::Service->new; $service->db->connect;";
+    let ast = parse_ast(code)?;
+    let mut engine = TypeInferenceEngine::new();
+
+    engine.infer(&ast).map_err(|err| format!("inference failed: {err:?}"))?;
+
+    let receiver = method_receiver(&ast, "connect")?;
+    let fact = engine.infer_expr_fact(receiver);
+
+    assert_eq!(fact.ty, PerlType::Any);
+    assert_eq!(fact.confidence, Confidence::Low);
+    assert!(fact.shape.is_none());
+    assert!(fact.evidence.is_empty());
+    Ok(())
+}
+
+#[test]
 fn dynamic_plain_hash_key_fails_closed() -> Result<(), String> {
     let code = "my %services = (db => MyApp::DB->new); $services{$name}->connect;";
     let ast = parse_ast(code)?;

--- a/docs/project/status/receiver_facts.md
+++ b/docs/project/status/receiver_facts.md
@@ -30,6 +30,8 @@ It may claim:
   where tests prove them
 - source-derived framework accessor-return facts where tests prove package-like
   `isa` declarations
+- source-derived direct method-return facts where tests prove a static
+  constructor return
 - dynamic-key boundaries for receiver extraction
 - no completion candidate behavior change unless the PR is explicitly a
   provider cutover receipt tied to [PLSP-SPEC-0007](../../specs/PLSP-SPEC-0007-receiver-fact-completion.md)
@@ -40,7 +42,8 @@ It may not claim:
   source-backed pilot
 - hover, goto, diagnostics, or refactor behavior changes
 - support-tier promotion
-- chained method-return facts until focused fixtures prove those source shapes
+- broader chained method-return facts until focused fixtures prove those source
+  shapes
 
 Facts-only PRs must keep this wording in their claim boundary:
 
@@ -58,14 +61,15 @@ no support-tier promotion
 | `type_environment_fact_map` | `landed` | `TypeEnvironment::set_variable_fact`, `get_variable_fact`, `get_fact_at`; stale fact clearing and parent lookup tests in `type_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Existing `PerlType` callers keep erased compatibility while source-level expression inference stores richer facts for proven shapes. |
 | `static_package_receiver` | `landed` | `receiver_facts` module test `static_constructor_receiver_records_package`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static package receivers can produce high-confidence constructor evidence. |
 | `object_variable_receiver` | `landed` | `receiver_facts` module tests for `$self` and `$object`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Exact package requires a supplied type-environment fact. Unknown object variables stay low confidence. |
-| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; `receiver_expression_facts` tests for plain hash literals and slot assignment | Works when `TypeEnvironment` contains a `HashShape`; source-derived plain `%hash` literals and `$hash{key}` assignments can now populate that shape. Chained method-return source inference remains pending. |
-| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; `receiver_expression_facts` tests for hashref literals and slot assignment | Works when the base fact already has a hash shape; source-derived `$hashref->{key}` facts are proven for hashref literals and slot assignment. Chained method-return source inference remains pending. |
+| `hash_slot_receiver` | `partial` | `receiver_facts` module test `hash_slot_receiver_uses_known_slot_fact`; `receiver_expression_facts` tests for plain hash literals and slot assignment | Works when `TypeEnvironment` contains a `HashShape`; source-derived plain `%hash` literals and `$hash{key}` assignments can now populate that shape. Broader chained method-return source inference remains pending. |
+| `hashref_slot_receiver` | `partial` | `receiver_facts` module test `hashref_slot_receiver_preserves_hashref_kind`; `receiver_expression_facts` tests for hashref literals and slot assignment | Works when the base fact already has a hash shape; source-derived `$hashref->{key}` facts are proven for hashref literals and slot assignment. Broader chained method-return source inference remains pending. |
 | `bless_field_receiver` | `partial` | `receiver_expression_facts` tests for static bless fields and dynamic bless class fallback; `receiver_facts` module test `object_field_receiver_preserves_fallback` | Static `bless { field => Package->new }, 'Class'` populates medium-confidence object-field facts for `$self->{field}`. Dynamic bless class names fail closed. This is semantic substrate only and does not broaden completion. |
 | `accessor_return_receiver` | `partial` | `receiver_expression_facts` tests for Moo/Moose package-like `isa` accessor returns and dynamic `isa` fallback | Static framework declarations such as `has db => (isa => 'MyApp::DB')` populate medium-confidence object-shape facts for `$service->db`. The erased type remains `Any`, dynamic/non-package `isa` values fail closed, and this is semantic substrate only with no completion cutover. |
+| `method_return_receiver` | `partial` | `receiver_expression_facts` tests for direct static constructor method returns and dynamic constructor fallback | A method body with a single `return MyApp::DB->new` or implicit `MyApp::DB->new` expression can populate a medium-confidence object-shape fact for `$service->db`. The erased type remains `Any`, dynamic constructor receivers fail closed, and this is semantic substrate only with no completion cutover. |
 | `array_index_receiver` | `partial` | `receiver_facts` module tests for static and dynamic array indexes; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | Static indexes can use existing `ArrayShape` facts; dynamic indexes remain non-exact. |
 | `dynamic_key_boundary` | `landed` | `receiver_facts` module test `dynamic_hash_key_marks_dynamic_boundary`; `TypeFact::dynamic` test in `type_facts.rs`; `receiver_expression_facts` dynamic plain-hash-key test; completion provider test `dynamic_hash_key_receiver_preserves_imported_fallback` | Proven for receiver extraction, plain hash expression facts, and the first completion-provider boundary receipt. Additional provider boundary receipts remain pending for other receiver forms. |
-| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, hashref literals, hashref slot assignment, static plain/hashref slot reads, static bless fields, framework accessor returns, dynamic plain hash keys, dynamic bless classes, and dynamic/non-package accessor `isa` values are facts-only substrate. Chained method-return facts remain pending. |
-| `receiver_fact_api` | `landed` | `crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | API extracts facts from existing AST and supplied environment facts; method-call chains remain unknown until explicit rules land. |
+| `expression_inference` | `partial` | `crates/perl-semantic-analyzer/tests/receiver_expression_facts.rs`; `TypeInferenceEngine::infer_expr_fact` | Constructor calls, plain hash literals, plain hash slot assignment, hashref literals, hashref slot assignment, static plain/hashref slot reads, static bless fields, framework accessor returns, direct static constructor method returns, dynamic plain hash keys, dynamic bless classes, dynamic/non-package accessor `isa` values, and dynamic method-return constructors are facts-only substrate. Broader chained method-return facts remain pending. |
+| `receiver_fact_api` | `landed` | `crates/perl-semantic-analyzer/src/analysis/receiver_facts.rs`; PR [#9468](https://github.com/EffortlessMetrics/perl-lsp/pull/9468) | API extracts facts from existing AST and supplied environment facts; broader method-call chains remain unknown until explicit rules land. |
 | `completion_cutover` | `narrow-pilot` | Completion provider tests `source_backed_hash_slot_receiver_uses_exact_completion_pilot` and `dynamic_hash_key_receiver_preserves_imported_fallback`; PR [#9502](https://github.com/EffortlessMetrics/perl-lsp/pull/9502) | Only fresh high-confidence source-backed receiver facts may authorize exact receiver completion. Unknown, dynamic, generated/no-source, stale, and low-confidence receiver shapes stay fallback, shadowed, or blocked. |
 
 ## Provider Cutover Dashboard
@@ -81,9 +85,10 @@ receiver_fact_completion_cutover:
 
 ## Next Implementation Steps
 
-1. Add chained method-return expression facts without changing provider output.
-2. Add facts-only fixtures that prove source-derived `$self` and framework
+1. Add facts-only fixtures that prove source-derived `$self` and framework
    accessor receiver facts without changing provider output.
+2. Extend method-return expression facts beyond direct static constructor
+   returns without changing provider output.
 3. Add real-workspace and additional receiver-form provider confidence receipts
    for exact, fallback, and dynamic receiver cases.
 4. Broaden completion only after facts-only and provider fallback receipts pass

--- a/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
+++ b/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
@@ -22,8 +22,10 @@ slot-assignment inference are fixture-backed facts-only substrate. Static
 `bless { field => Package->new }, 'Class'` field inference is fixture-backed as
 medium-confidence substrate. Framework accessor-return facts for package-like
 `isa` declarations are fixture-backed as medium-confidence substrate with erased
-type compatibility preserved. Chained method-return facts remain bounded by
-their own future fixtures and provider receipts.
+type compatibility preserved. Direct static-constructor method-return facts are
+fixture-backed as medium-confidence substrate with erased type compatibility
+preserved. Broader chained method-return facts remain bounded by their own
+future fixtures and provider receipts.
 
 ## Contract
 
@@ -87,6 +89,7 @@ The initial evidence vocabulary must cover:
 - Object::Pad fields
 - workspace-symbol evidence
 - accessor-return evidence
+- method-return evidence
 - heuristic evidence
 
 The initial dynamic-boundary vocabulary must cover:
@@ -226,6 +229,7 @@ and constructor-call evidence.
 Later method-return rules may extend the same fact path for:
 
 - Moo/Moose accessors from `has ... isa => 'Package'`
+- direct method bodies that return a static constructor
 - Object::Pad reader/accessor field methods
 - `DBI->connect(...)` returning `DBI::db`
 - `$dbh->prepare(...)` returning `DBI::st`
@@ -296,6 +300,7 @@ analyzer test surface should cover these scenarios:
 | dynamic key | package is `None`; dynamic boundary is `DynamicHashKey` |
 | bless object field | `$self->{db}` resolves to `MyApp::DB`, medium confidence after bless-field slice |
 | Moo/Moose accessor | `$self->db` or another source-backed object accessor resolves to `MyApp::DB` after framework-accessor slice, as medium-confidence substrate until provider receipts promote it |
+| direct method return | `$self->db` or another source-backed object method resolves to `MyApp::DB` after a direct `return MyApp::DB->new` slice, as medium-confidence substrate until provider receipts promote it |
 
 After facts-only tests pass, LSP completion tests must prove:
 


### PR DESCRIPTION
Problem: Receiver expression facts could not preserve a source-backed method return shape for simple object methods without turning it into live completion behavior.

Fix: Add a facts-only method-return map for package methods that directly return a static constructor, keeping the fact medium-confidence with an erased Any type plus object-shape evidence. Dynamic constructor receivers fail closed, and receiver status/spec docs record the substrate-only boundary.

Verification: ./scripts/cargo-safe test -p perl-semantic-analyzer --test receiver_expression_facts --profile agent --locked -- --nocapture --test-threads=1; ./scripts/cargo-safe test -p perl-semantic-analyzer --lib receiver_facts --profile agent --locked -- --nocapture --test-threads=1; ./scripts/cargo-safe check --all-targets -p perl-semantic-analyzer --profile agent --locked; ./scripts/cargo-safe clippy -p perl-semantic-analyzer --profile agent --locked -- -D warnings -A missing_docs; cargo xtask check-support-claims; cargo xtask check-provider-confidence-matrix; cargo xtask ci-hygiene check-doc-paths docs/project/status; cargo xtask ci-hygiene check-doc-paths docs/specs; git diff --check.

Claim boundary: semantic substrate only; no completion candidate behavior change; no support-tier promotion; broader chained method-return inference remains pending.