### PR TITLE
policy(provider): encode promotion ledger as TOML (#8197)

### DIFF
--- a/docs/project/status/provider_promotion_ledger.md
+++ b/docs/project/status/provider_promotion_ledger.md
@@ -14,6 +14,14 @@ behavior. The source of current evidence remains the provider-specific receipt,
 [provider confidence matrix](provider_confidence_matrix.md), and
 [provider cutover](provider_cutover.md).
 
+Machine-readable policy lives in
+[policy/provider-promotion-ledger.toml](../../../policy/provider-promotion-ledger.toml).
+Validate row parity and condition shape with:
+
+```bash
+cargo xtask check-provider-promotion-ledger
+```
+
 ## Operating Rule
 
 Every row must support one of four decisions:

--- a/docs/project/status/real_perl_editor_trust_v1.md
+++ b/docs/project/status/real_perl_editor_trust_v1.md
@@ -22,7 +22,7 @@ of current evidence.
 | Provider decision receipt schema and explanation payload contract | [PLSP-SPEC-0016](../../specs/PLSP-SPEC-0016-provider-decision-receipt-v1.md), [provider_decision.v1.schema.json](../../../schemas/provider_decision.v1.schema.json) |
 | User-facing support claims and known limitations | [SUPPORT_TIERS.md](SUPPORT_TIERS.md) |
 | Provider fact source, confidence, freshness, fallback, and next proof | [provider_confidence_matrix.md](provider_confidence_matrix.md) |
-| Provider promotion, fallback, blocker, and defer decisions by fact class | [provider_promotion_ledger.md](provider_promotion_ledger.md) |
+| Provider promotion, fallback, blocker, and defer decisions by fact class | [provider_promotion_ledger.md](provider_promotion_ledger.md), [provider-promotion-ledger.toml](../../../policy/provider-promotion-ledger.toml) |
 | Provider live/shadow state and cutover rules | [provider_cutover.md](provider_cutover.md) |
 | Compiler-backed provider receipts | [semantic_shadow_compare.md](semantic_shadow_compare.md), [semantic_scorecard.md](semantic_scorecard.md) |
 | UX/provider capability context | [ux_capability_dashboard.md](ux_capability_dashboard.md) |

--- a/policy/provider-promotion-ledger.toml
+++ b/policy/provider-promotion-ledger.toml
@@ -1,0 +1,432 @@
+# Machine-readable provider promotion ledger.
+#
+# Human-readable routing remains in:
+# docs/project/status/provider_promotion_ledger.md
+#
+# This policy records one row per provider fact class. It does not broaden live
+# provider behavior, promote support tiers, or replace provider-specific
+# receipts.
+
+schema_version = 1
+policy = "provider-promotion-ledger"
+owner = "perl-lsp maintainers"
+status = "advisory"
+updated = "2026-05-20"
+spec = "docs/specs/PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md"
+human_ledger = "docs/project/status/provider_promotion_ledger.md"
+
+decision_states = [
+  "promote",
+  "fallback",
+  "block",
+  "defer",
+]
+
+blocker_registry = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "ambiguous_identity",
+  "imported_exported",
+  "typeglob_alias",
+  "autoload",
+  "symbolic_ref",
+  "dynamic_require",
+  "rollback_missing",
+  "current_source_reference",
+  "workspace_reference",
+  "unsupported_fact_class",
+  "unsafe_edit_blocked",
+  "missing_fact",
+  "fallback_policy",
+  "unknown",
+]
+
+[[provider_class]]
+surface = "Completion"
+fact_class = "Source-backed receiver fact"
+current_state = "source-backed receiver pilot"
+decision = "promote"
+next_proof = "Real-workspace receiver-quality receipts and additional receiver-form proof before broader method completion expansion"
+promotion_conditions = [
+  "fresh_high_confidence_source_backed_receiver_fact",
+  "receiver_fact_identifies_package_for_request",
+  "exact_receiver_candidates_rank_above_fallback",
+  "provider_receipts_preserved",
+]
+fallback_conditions = [
+  "unknown_receiver",
+  "unsupported_receiver",
+  "partial_receiver_evidence",
+  "dynamic_key_receiver_evidence",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "stale_fact",
+  "low_confidence",
+  "dynamic_boundary",
+  "ambiguous_identity",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/provider_confidence_matrix.md",
+  "docs/project/status/real_perl_editor_trust_v1.md",
+]
+
+[[provider_class]]
+surface = "Semantic tokens"
+fact_class = "Subroutine declaration token"
+current_state = "partial live trace slice"
+decision = "promote"
+next_proof = "Another scoped compiler-token class proof before broader compiler-token promotion"
+promotion_conditions = [
+  "fresh_source_backed_compiler_span",
+  "span_matches_exactly_one_existing_live_function_token",
+  "emits_no_new_token_output",
+]
+fallback_conditions = [
+  "compiler_identity_absent",
+  "compiler_span_unmatched",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "fallback_policy",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[provider_class]]
+surface = "Semantic tokens"
+fact_class = "Method declaration token"
+current_state = "partial live trace slice"
+decision = "promote"
+next_proof = "Another scoped compiler-token class proof before broader compiler-token promotion"
+promotion_conditions = [
+  "fresh_source_backed_method_declaration_span",
+  "span_matches_exactly_one_existing_live_method_token",
+  "did_change_freshness_proven",
+  "emits_no_new_token_output",
+]
+fallback_conditions = [
+  "unproven_method_token_shape",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[provider_class]]
+surface = "Semantic tokens"
+fact_class = "Package declaration token"
+current_state = "partial live trace slice"
+decision = "promote"
+next_proof = "Another scoped compiler-token class proof before broader compiler-token promotion"
+promotion_conditions = [
+  "fresh_source_backed_package_declaration_span",
+  "span_matches_exactly_one_existing_live_namespace_token",
+  "did_change_freshness_proven",
+  "emits_no_new_token_output",
+]
+fallback_conditions = [
+  "unproven_namespace_token_shape",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "fallback_policy",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[provider_class]]
+surface = "Semantic tokens"
+fact_class = "Field declaration token"
+current_state = "partial live trace slice"
+decision = "promote"
+next_proof = "Another scoped compiler-token class proof before broader compiler-token promotion"
+promotion_conditions = [
+  "fresh_source_backed_field_declaration_span",
+  "span_matches_exactly_one_existing_live_variable_token",
+  "did_change_freshness_proven",
+  "emits_no_new_token_output",
+]
+fallback_conditions = [
+  "unproven_variable_token_shape",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[provider_class]]
+surface = "Semantic tokens"
+fact_class = "Method call token"
+current_state = "partial live trace slice"
+decision = "promote"
+next_proof = "Another scoped compiler-token class proof before broader compiler-token promotion"
+promotion_conditions = [
+  "fresh_source_backed_method_call_span",
+  "span_matches_exactly_one_existing_live_method_token",
+  "did_change_freshness_proven",
+  "emits_no_new_token_output",
+]
+fallback_conditions = [
+  "unproven_method_call_shape",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[provider_class]]
+surface = "Semantic tokens"
+fact_class = "Self method-call token"
+current_state = "partial live trace slice"
+decision = "promote"
+next_proof = "Another scoped compiler-token class proof before broader compiler-token promotion"
+promotion_conditions = [
+  "fresh_source_backed_self_method_call_span",
+  "span_matches_exactly_one_existing_live_method_token",
+  "did_change_freshness_proven",
+  "emits_no_new_token_output",
+]
+fallback_conditions = [
+  "unproven_receiver_specific_method_call_shape",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "ambiguous_identity",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/semantic_shadow_compare.md",
+]
+
+[[provider_class]]
+surface = "Workspace symbols"
+fact_class = "Source-backed exact symbol"
+current_state = "partial live"
+decision = "promote"
+next_proof = "Project-shape quality receipts before broader expansion"
+promotion_conditions = [
+  "non_empty_query",
+  "fresh_ready_workspace_index",
+  "high_confidence_source_backed_symbol",
+]
+fallback_conditions = [
+  "empty_query",
+  "partial_index",
+  "open_document_fallback",
+  "absent_ready_index_proof",
+]
+blocker_conditions = [
+  "stale_fact",
+  "dynamic_boundary",
+  "low_confidence",
+  "ambiguous_identity",
+  "generated_no_source",
+]
+required_receipts = [
+  "docs/project/status/provider_confidence_matrix.md",
+  "docs/project/status/real_perl_editor_trust_v1.md",
+]
+
+[[provider_class]]
+surface = "Workspace symbols"
+fact_class = "Source-backed generated/framework symbol"
+current_state = "generated-label pilot"
+decision = "promote"
+next_proof = "Additional generated/no-source project variants and explicit-label rank/noise proof before broader generated-symbol expansion"
+promotion_conditions = [
+  "fresh_source_backed_generated_framework_member",
+  "explicit_generated_label",
+  "framework_declaration_anchor",
+  "bounded_confidence",
+  "generated_no_source_blocker_receipts_exist",
+]
+fallback_conditions = [
+  "source_anchor_missing",
+  "generated_label_missing",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "stale_fact",
+  "dynamic_boundary",
+  "low_confidence",
+  "ambiguous_identity",
+  "fallback_policy",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/provider_confidence_matrix.md",
+  "docs/project/status/real_perl_editor_trust_v1.md",
+]
+
+[[provider_class]]
+surface = "Rename"
+fact_class = "Same-file lexical symbol"
+current_state = "narrow live"
+decision = "promote"
+next_proof = "Keep unsafe-edit receipts fresh when rename facts change"
+promotion_conditions = [
+  "current_document_has_exactly_one_source_backed_my_or_state_declaration_edit",
+  "references_remain_in_same_file",
+]
+fallback_conditions = [
+  "scoped_lexical_proof_absent",
+]
+blocker_conditions = [
+  "generated_no_source",
+  "imported_exported",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "ambiguous_identity",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/provider_confidence_matrix.md",
+  "docs/project/status/real_perl_editor_trust_v1.md",
+]
+
+[[provider_class]]
+surface = "Rename"
+fact_class = "Package-local source-backed plan"
+current_state = "package-local pilot"
+decision = "promote"
+next_proof = "Keep project-shaped unsafe-edit and edit-freshness receipts fresh; broader promotion deferred"
+promotion_conditions = [
+  "materialized_source_backed_semantic_edit_set",
+  "semantic_edit_set_matches_workspace_source_ambiguity_guard",
+  "rollback_no_edit_proof_preserved",
+]
+fallback_conditions = [
+  "compiler_plan_partial",
+  "current_source_coverage_requires_broader_fresh_edit_set",
+]
+blocker_conditions = [
+  "imported_exported",
+  "generated_no_source",
+  "dynamic_boundary",
+  "typeglob_alias",
+  "autoload",
+  "symbolic_ref",
+  "stale_fact",
+  "low_confidence",
+  "missing_fact",
+  "ambiguous_identity",
+  "rollback_missing",
+  "unsupported_fact_class",
+]
+required_receipts = [
+  "docs/project/status/provider_confidence_matrix.md",
+  "docs/project/status/real_perl_editor_trust_v1.md",
+]
+
+[[provider_class]]
+surface = "Safe delete"
+fact_class = "Exact static source-backed subroutine"
+current_state = "source-backed pilot + current-source/workspace reference and identity guards"
+decision = "promote"
+next_proof = "Keep generated/dynamic blocker receipts fresh; broader promotion deferred"
+promotion_conditions = [
+  "compiler_plan_allowed",
+  "fresh_high_confidence_source_backed_subroutine",
+  "zero_compiler_references",
+  "zero_current_source_references",
+  "zero_workspace_index_references",
+  "workspace_identity_guard_accepts",
+  "rollback_proof_restores_original_text",
+]
+fallback_conditions = [
+  "preview_only_when_live_delete_proof_incomplete",
+]
+blocker_conditions = [
+  "imported_exported",
+  "generated_no_source",
+  "unsupported_fact_class",
+  "current_source_reference",
+  "workspace_reference",
+  "ambiguous_identity",
+  "typeglob_alias",
+  "autoload",
+  "symbolic_ref",
+  "dynamic_require",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "fallback_policy",
+  "rollback_missing",
+]
+required_receipts = [
+  "docs/project/status/provider_confidence_matrix.md",
+  "docs/project/status/real_perl_editor_trust_v1.md",
+]
+
+[[provider_class]]
+surface = "Provider explanation"
+fact_class = "Request-local provider decision"
+current_state = "partial live schema"
+decision = "promote"
+next_proof = "Keep schema stable as providers add live slices"
+promotion_conditions = [
+  "provider_request_emits_or_persists_fact_source",
+  "provider_request_emits_or_persists_confidence",
+  "provider_request_emits_or_persists_freshness",
+  "provider_request_emits_or_persists_source_backed_state",
+  "provider_request_emits_or_persists_fallback_state",
+  "provider_request_emits_or_persists_blocker",
+  "provider_request_emits_or_persists_claim_boundary",
+  "provider_request_emits_or_persists_user_message",
+]
+fallback_conditions = [
+  "latest_trace_replay",
+  "request_local_receipt_payload",
+]
+blocker_conditions = [
+  "missing_fact",
+  "unknown",
+  "unsupported_fact_class",
+  "fallback_policy",
+]
+required_receipts = [
+  "docs/specs/PLSP-SPEC-0016-provider-decision-receipt-v1.md",
+  "schemas/provider_decision.v1.schema.json",
+]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -74,6 +74,9 @@ enum Commands {
     /// Validate Real Perl Editor Trust support claim map.
     CheckSupportClaims,
 
+    /// Validate machine-readable Real Perl Editor Trust provider promotion ledger.
+    CheckProviderPromotionLedger,
+
     /// Capture a GitHub PR queue snapshot for disconnected maintainership.
     Queue {
         #[command(subcommand)]
@@ -2497,6 +2500,7 @@ fn main() -> Result<()> {
         Commands::CheckDevexDocs => devex_docs::run(),
         Commands::CheckProviderConfidenceMatrix => provider_confidence_matrix::run(),
         Commands::CheckSupportClaims => provider_confidence_matrix::run_support_claims(),
+        Commands::CheckProviderPromotionLedger => provider_promotion_ledger::run(),
         Commands::Queue { command } => match command {
             QueueCommand::Snapshot { out, fixture } => queue_snapshot::run_snapshot(out, fixture),
             QueueCommand::Health { receipt, fixture } => {

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -83,6 +83,7 @@ pub mod populate_book;
 pub mod pr;
 pub mod prep_crates_io_launch;
 pub mod provider_confidence_matrix;
+pub mod provider_promotion_ledger;
 pub mod publication_facts;
 pub mod publish;
 pub mod publish_closure;

--- a/xtask/src/tasks/provider_promotion_ledger.rs
+++ b/xtask/src/tasks/provider_promotion_ledger.rs
@@ -1,0 +1,432 @@
+//! Validate the machine-readable provider promotion ledger.
+
+use crate::utils::project_root;
+use color_eyre::eyre::{Context, Result, bail};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::Path;
+
+const POLICY_PATH: &str = "policy/provider-promotion-ledger.toml";
+const HUMAN_LEDGER: &str = "docs/project/status/provider_promotion_ledger.md";
+const POLICY_NAME: &str = "provider-promotion-ledger";
+
+const REQUIRED_DECISIONS: &[&str] = &["promote", "fallback", "block", "defer"];
+
+const REQUIRED_BLOCKERS: &[&str] = &[
+    "generated_no_source",
+    "dynamic_boundary",
+    "stale_fact",
+    "low_confidence",
+    "ambiguous_identity",
+    "imported_exported",
+    "typeglob_alias",
+    "autoload",
+    "symbolic_ref",
+    "dynamic_require",
+    "rollback_missing",
+    "current_source_reference",
+    "workspace_reference",
+    "unsupported_fact_class",
+    "unsafe_edit_blocked",
+    "missing_fact",
+    "fallback_policy",
+    "unknown",
+];
+
+#[derive(Debug, Deserialize)]
+struct ProviderPromotionLedger {
+    schema_version: u32,
+    policy: String,
+    human_ledger: String,
+    decision_states: Vec<String>,
+    blocker_registry: Vec<String>,
+    #[serde(default)]
+    provider_class: Vec<ProviderClass>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderClass {
+    surface: String,
+    fact_class: String,
+    current_state: String,
+    decision: String,
+    next_proof: String,
+    promotion_conditions: Vec<String>,
+    fallback_conditions: Vec<String>,
+    blocker_conditions: Vec<String>,
+    required_receipts: Vec<String>,
+}
+
+#[derive(Debug)]
+struct MarkdownTable {
+    header: Vec<String>,
+    rows: Vec<TableRow>,
+}
+
+#[derive(Debug)]
+struct TableRow {
+    line_number: usize,
+    cells: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ValidationStats {
+    policy_rows: usize,
+    human_rows: usize,
+    blockers: usize,
+}
+
+pub fn run() -> Result<()> {
+    let root = project_root()?;
+    let stats = validate(&root)?;
+    println!(
+        "provider promotion ledger check passed: {} policy rows, {} human rows, {} blocker registry entries",
+        stats.policy_rows, stats.human_rows, stats.blockers
+    );
+    Ok(())
+}
+
+fn validate(root: &Path) -> Result<ValidationStats> {
+    let policy = read_policy(root, POLICY_PATH)?;
+    let human_text = read_text(root, HUMAN_LEDGER)?;
+    let human_table = parse_table(&human_text, "Surface")
+        .ok_or_else(|| color_eyre::eyre::eyre!("provider promotion ledger table not found"))?;
+
+    let mut violations = Vec::new();
+    validate_policy_shape(&policy, &mut violations);
+    validate_human_table(&human_table, &mut violations);
+    validate_policy_rows(root, &policy, &mut violations);
+    validate_policy_matches_human(&policy, &human_table, &mut violations);
+
+    if !violations.is_empty() {
+        eprintln!("provider promotion ledger violations:");
+        for violation in &violations {
+            eprintln!("  - {violation}");
+        }
+        bail!("provider promotion ledger check failed with {} violation(s)", violations.len());
+    }
+
+    Ok(ValidationStats {
+        policy_rows: policy.provider_class.len(),
+        human_rows: human_table.rows.len(),
+        blockers: policy.blocker_registry.len(),
+    })
+}
+
+fn read_policy(root: &Path, rel: &str) -> Result<ProviderPromotionLedger> {
+    let text = read_text(root, rel)?;
+    toml::from_str(&text).with_context(|| format!("failed to parse {rel}"))
+}
+
+fn read_text(root: &Path, rel: &str) -> Result<String> {
+    let path = root.join(rel);
+    fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))
+}
+
+fn validate_policy_shape(policy: &ProviderPromotionLedger, violations: &mut Vec<String>) {
+    if policy.schema_version != 1 {
+        violations.push(format!(
+            "{POLICY_PATH}: schema_version is {}; expected 1",
+            policy.schema_version
+        ));
+    }
+    if policy.policy != POLICY_NAME {
+        violations.push(format!(
+            "{POLICY_PATH}: policy is {:?}; expected {:?}",
+            policy.policy, POLICY_NAME
+        ));
+    }
+    if policy.human_ledger != HUMAN_LEDGER {
+        violations.push(format!(
+            "{POLICY_PATH}: human_ledger is {:?}; expected {:?}",
+            policy.human_ledger, HUMAN_LEDGER
+        ));
+    }
+
+    require_exact_set(
+        POLICY_PATH,
+        "decision_states",
+        &policy.decision_states,
+        REQUIRED_DECISIONS,
+        violations,
+    );
+    require_exact_set(
+        POLICY_PATH,
+        "blocker_registry",
+        &policy.blocker_registry,
+        REQUIRED_BLOCKERS,
+        violations,
+    );
+    if policy.provider_class.is_empty() {
+        violations.push(format!("{POLICY_PATH}: provider_class must not be empty"));
+    }
+}
+
+fn validate_human_table(table: &MarkdownTable, violations: &mut Vec<String>) {
+    let expected = [
+        "Surface",
+        "Fact class",
+        "Current state",
+        "Next proof",
+        "Promotion condition",
+        "Fallback condition",
+        "Blocker condition",
+    ];
+    if table.header.len() != expected.len() {
+        violations.push(format!(
+            "{HUMAN_LEDGER}: header has {} columns; expected {}",
+            table.header.len(),
+            expected.len()
+        ));
+        return;
+    }
+
+    for (index, (actual, expected_cell)) in table.header.iter().zip(expected.iter()).enumerate() {
+        if actual != expected_cell {
+            violations.push(format!(
+                "{HUMAN_LEDGER}: header column {} is {:?}; expected {:?}",
+                index + 1,
+                actual,
+                expected_cell
+            ));
+        }
+    }
+}
+
+fn validate_policy_rows(
+    root: &Path,
+    policy: &ProviderPromotionLedger,
+    violations: &mut Vec<String>,
+) {
+    let decision_states =
+        policy.decision_states.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    let blocker_registry =
+        policy.blocker_registry.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    let mut seen_rows = BTreeSet::new();
+
+    for row in &policy.provider_class {
+        let key = row_key(&row.surface, &row.fact_class);
+        if !seen_rows.insert(key.clone()) {
+            violations.push(format!("{POLICY_PATH}: duplicate provider_class row {key}"));
+        }
+
+        require_non_empty(&key, "surface", &row.surface, violations);
+        require_non_empty(&key, "fact_class", &row.fact_class, violations);
+        require_non_empty(&key, "current_state", &row.current_state, violations);
+        require_non_empty(&key, "next_proof", &row.next_proof, violations);
+
+        if !decision_states.contains(row.decision.as_str()) {
+            violations.push(format!(
+                "{POLICY_PATH}: {key} decision {:?} is not listed in decision_states",
+                row.decision
+            ));
+        }
+
+        require_non_empty_list(&key, "promotion_conditions", &row.promotion_conditions, violations);
+        require_non_empty_list(&key, "fallback_conditions", &row.fallback_conditions, violations);
+        require_non_empty_list(&key, "blocker_conditions", &row.blocker_conditions, violations);
+        require_non_empty_list(&key, "required_receipts", &row.required_receipts, violations);
+
+        for blocker in &row.blocker_conditions {
+            if !blocker_registry.contains(blocker.as_str()) {
+                violations.push(format!(
+                    "{POLICY_PATH}: {key} blocker condition {:?} is missing from blocker_registry",
+                    blocker
+                ));
+            }
+        }
+
+        for receipt in &row.required_receipts {
+            if !root.join(receipt).exists() {
+                violations.push(format!(
+                    "{POLICY_PATH}: {key} required receipt does not exist: {receipt}"
+                ));
+            }
+        }
+    }
+}
+
+fn validate_policy_matches_human(
+    policy: &ProviderPromotionLedger,
+    table: &MarkdownTable,
+    violations: &mut Vec<String>,
+) {
+    let mut human_rows = BTreeSet::new();
+    for row in &table.rows {
+        if row.cells.len() != table.header.len() {
+            violations.push(format!(
+                "{HUMAN_LEDGER}:{}: row has {} columns; expected {}",
+                row.line_number,
+                row.cells.len(),
+                table.header.len()
+            ));
+            continue;
+        }
+        human_rows.insert(HumanRow {
+            key: row_key(&row.cells[0], &row.cells[1]),
+            current_state: normalize_inline_code(&row.cells[2]),
+            next_proof: row.cells[3].clone(),
+        });
+    }
+
+    let policy_rows = policy
+        .provider_class
+        .iter()
+        .map(|row| HumanRow {
+            key: row_key(&row.surface, &row.fact_class),
+            current_state: row.current_state.clone(),
+            next_proof: row.next_proof.clone(),
+        })
+        .collect::<BTreeSet<_>>();
+
+    for row in human_rows.difference(&policy_rows) {
+        violations
+            .push(format!("{POLICY_PATH}: missing TOML row matching human ledger row {}", row.key));
+    }
+    for row in policy_rows.difference(&human_rows) {
+        violations
+            .push(format!("{POLICY_PATH}: TOML row has no matching human ledger row {}", row.key));
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct HumanRow {
+    key: String,
+    current_state: String,
+    next_proof: String,
+}
+
+fn require_exact_set(
+    doc: &str,
+    field: &str,
+    actual: &[String],
+    expected: &[&str],
+    violations: &mut Vec<String>,
+) {
+    let actual_set = actual.iter().map(String::as_str).collect::<BTreeSet<_>>();
+    let expected_set = expected.iter().copied().collect::<BTreeSet<_>>();
+
+    for missing in expected_set.difference(&actual_set) {
+        violations.push(format!("{doc}: {field} missing required entry {missing:?}"));
+    }
+    for unexpected in actual_set.difference(&expected_set) {
+        violations.push(format!("{doc}: {field} contains unsupported entry {unexpected:?}"));
+    }
+}
+
+fn require_non_empty(row: &str, field: &str, value: &str, violations: &mut Vec<String>) {
+    if value.trim().is_empty() {
+        violations.push(format!("{POLICY_PATH}: {row} field {field} must not be empty"));
+    }
+}
+
+fn require_non_empty_list(row: &str, field: &str, values: &[String], violations: &mut Vec<String>) {
+    if values.is_empty() {
+        violations.push(format!("{POLICY_PATH}: {row} field {field} must not be empty"));
+        return;
+    }
+
+    for value in values {
+        if value.trim().is_empty() {
+            violations.push(format!("{POLICY_PATH}: {row} field {field} contains an empty item"));
+        }
+    }
+}
+
+fn row_key(surface: &str, fact_class: &str) -> String {
+    format!("{}::{}", surface.trim(), fact_class.trim())
+}
+
+fn normalize_inline_code(value: &str) -> String {
+    value.trim().trim_matches('`').trim().to_string()
+}
+
+fn parse_table(text: &str, first_header_cell: &str) -> Option<MarkdownTable> {
+    let lines = text.lines().collect::<Vec<_>>();
+    let header_index = lines.iter().position(|line| {
+        split_table_row(line)
+            .and_then(|cells| cells.first().cloned())
+            .is_some_and(|cell| cell == first_header_cell)
+    })?;
+    let header = split_table_row(lines[header_index])?;
+    let mut rows = Vec::new();
+
+    for (offset, line) in lines.iter().enumerate().skip(header_index + 1) {
+        let Some(cells) = split_table_row(line) else {
+            break;
+        };
+        if is_separator_row(&cells) {
+            continue;
+        }
+        rows.push(TableRow { line_number: offset + 1, cells });
+    }
+
+    Some(MarkdownTable { header, rows })
+}
+
+fn split_table_row(line: &str) -> Option<Vec<String>> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with('|') || !trimmed.ends_with('|') {
+        return None;
+    }
+    Some(trimmed.trim_matches('|').split('|').map(|cell| cell.trim().to_string()).collect())
+}
+
+fn is_separator_row(cells: &[String]) -> bool {
+    cells.iter().all(|cell| {
+        let trimmed = cell.trim();
+        !trimmed.is_empty()
+            && trimmed.chars().all(|ch| matches!(ch, '-' | ':' | ' '))
+            && trimmed.contains('-')
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult<T = ()> = Result<T>;
+
+    #[test]
+    fn parses_markdown_ledger_rows() -> TestResult {
+        let table = parse_table(
+            "\
+| Surface | Fact class | Current state | Next proof | Promotion condition | Fallback condition | Blocker condition |
+| --- | --- | --- | --- | --- | --- | --- |
+| Completion | Source-backed receiver fact | `pilot` | next | promote | fallback | block |
+",
+            "Surface",
+        )
+        .ok_or_else(|| color_eyre::eyre::eyre!("expected provider ledger table"))?;
+
+        assert_eq!(table.rows.len(), 1);
+        assert_eq!(table.rows[0].cells[0], "Completion");
+        assert_eq!(normalize_inline_code(&table.rows[0].cells[2]), "pilot");
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_policy_missing_required_blocker() -> TestResult {
+        let policy = ProviderPromotionLedger {
+            schema_version: 1,
+            policy: POLICY_NAME.to_string(),
+            human_ledger: HUMAN_LEDGER.to_string(),
+            decision_states: REQUIRED_DECISIONS.iter().map(|value| (*value).to_string()).collect(),
+            blocker_registry: REQUIRED_BLOCKERS[1..]
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+            provider_class: Vec::new(),
+        };
+        let mut violations = Vec::new();
+
+        validate_policy_shape(&policy, &mut violations);
+
+        assert!(
+            violations.iter().any(|violation| violation.contains("generated_no_source")),
+            "missing blocker should be reported: {violations:?}"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
Problem: The provider promotion ledger is the routing surface for trusted behavior, but it was only markdown and could drift from policy checks.
Fix: Add policy/provider-promotion-ledger.toml, add cargo xtask check-provider-promotion-ledger, and link the machine policy from the human ledger and trust dashboard.
Verification: cargo xtask check-provider-promotion-ledger; cargo test -p xtask provider_promotion_ledger --profile agent --locked -- --nocapture; cargo check -p xtask --all-targets --profile agent --locked; cargo fmt -p xtask -- --check; cargo xtask check-provider-confidence-matrix; cargo xtask check-support-claims; cargo xtask ci-hygiene check-doc-paths docs/project/status; git diff --check.