### PR TITLE
docs(spec): define semantic token class promotion contract (#8197)

### DIFF
--- a/docs/project/status/real_perl_editor_trust_v1.md
+++ b/docs/project/status/real_perl_editor_trust_v1.md
@@ -22,6 +22,7 @@ of current evidence.
 | Provider decision receipt schema and explanation payload contract | [PLSP-SPEC-0016](../../specs/PLSP-SPEC-0016-provider-decision-receipt-v1.md), [provider_decision.v1.schema.json](../../../schemas/provider_decision.v1.schema.json) |
 | Shared fact provenance and source-backing semantics | [PLSP-SPEC-0017](../../specs/PLSP-SPEC-0017-fact-provenance-and-source-backing.md) |
 | Shared edit authorization states for rename and safe delete | [PLSP-SPEC-0018](../../specs/PLSP-SPEC-0018-edit-authorization-contract.md) |
+| Semantic token class promotion rules | [PLSP-SPEC-0019](../../specs/PLSP-SPEC-0019-semantic-token-class-promotion-contract.md), [semantic-token-classes.toml](../../../policy/semantic-token-classes.toml) |
 | User-facing support claims and known limitations | [SUPPORT_TIERS.md](SUPPORT_TIERS.md) |
 | Provider fact source, confidence, freshness, fallback, and next proof | [provider_confidence_matrix.md](provider_confidence_matrix.md) |
 | Provider promotion, fallback, blocker, and defer decisions by fact class | [provider_promotion_ledger.md](provider_promotion_ledger.md), [provider-promotion-ledger.toml](../../../policy/provider-promotion-ledger.toml) |

--- a/docs/specs/PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md
+++ b/docs/specs/PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md
@@ -12,6 +12,7 @@ Linked specs:
 - [PLSP-SPEC-0014](PLSP-SPEC-0014-refactor-acceptance.md)
 - [PLSP-SPEC-0017](PLSP-SPEC-0017-fact-provenance-and-source-backing.md)
 - [PLSP-SPEC-0018](PLSP-SPEC-0018-edit-authorization-contract.md)
+- [PLSP-SPEC-0019](PLSP-SPEC-0019-semantic-token-class-promotion-contract.md)
 Linked ADRs:
 - [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
 - [PLSP-ADR-0003](../adr/PLSP-ADR-0003-preview-before-edit.md)

--- a/docs/specs/PLSP-SPEC-0019-semantic-token-class-promotion-contract.md
+++ b/docs/specs/PLSP-SPEC-0019-semantic-token-class-promotion-contract.md
@@ -1,0 +1,207 @@
+# PLSP-SPEC-0019: Semantic token class promotion contract
+
+Status: accepted
+Owner: perl-lsp maintainers
+Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked specs:
+- [PLSP-SPEC-0002](PLSP-SPEC-0002-provider-confidence-receipts.md)
+- [PLSP-SPEC-0015](PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md)
+- [PLSP-SPEC-0016](PLSP-SPEC-0016-provider-decision-receipt-v1.md)
+- [PLSP-SPEC-0017](PLSP-SPEC-0017-fact-provenance-and-source-backing.md)
+Linked ADRs:
+- [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Policy: [semantic-token-classes.toml](../../policy/semantic-token-classes.toml)
+Status impact: semantic tokens, provider promotion ledger, provider
+confidence matrix, support tiers, semantic shadow compare
+
+## Current Implementation Status
+
+Semantic tokens are `partial-live-with-fallback`. The parser/HIR provider
+remains the live token source. Compiler-backed token facts may participate only
+as reviewed, source-backed, output-neutral trace slices for specific classes.
+
+The current reviewed trace classes are:
+
+```text
+subroutine_declaration
+method_declaration
+package_declaration
+field_declaration
+method_call
+self_method_call
+lexical_variable_declaration
+lexical_variable_use
+```
+
+Those classes prove identity alignment with existing live tokens. They do not
+emit new semantic tokens, broaden token classifications, or authorize generated,
+dynamic, stale, low-confidence, fallback, or unmatched compiler-token facts.
+
+## Contract
+
+Compiler-backed semantic-token classes are deny-by-default.
+
+A compiler-token class can be promoted only when all of these are true:
+
+1. the compiler span is source-backed
+2. the span matches exactly one existing live parser/HIR token
+3. live output does not gain unscoped tokens
+4. `didChange` freshness is proven for the request shape
+5. generated/no-source candidates are blocked
+6. stale, dynamic, low-confidence, fallback, and unmatched candidates are
+   blocked or shadowed
+7. support review says the proof does not imply broad compiler-token promotion
+
+The policy registry in
+[semantic-token-classes.toml](../../policy/semantic-token-classes.toml)
+records the reviewed classes. Unlisted classes are not promoted.
+
+## Class States
+
+### `partial_live_trace`
+
+The class may appear in provider decision traces when its source-backed compiler
+span exactly matches one existing live parser/HIR token. It must not add token
+output.
+
+### `shadow_proof`
+
+The class may appear in receipts or shadow comparison output. It must not affect
+live provider output.
+
+### `blocked`
+
+The class is known to be unsafe or unsupported for live output. It may appear
+only as a blocker, fallback, or explanation.
+
+### `deferred`
+
+The class has no reviewed promotion rule yet. It remains fallback-only until a
+new policy row and receipt promote one class.
+
+## Required Class Fields
+
+Each promoted or traced class must define:
+
+- class name
+- current state
+- live token kind it must match
+- whether it emits new output
+- exact live-token match requirement
+- edit-freshness requirement
+- blocker list
+- receipt sources
+- claim boundary
+
+The current registry is advisory until a dedicated validator lands, but PRs
+that touch semantic-token class behavior must keep the registry and status
+claims in agreement.
+
+## Provider Rules
+
+Semantic-token providers must preserve these rules:
+
+- existing parser/HIR token output remains the fallback and live baseline
+- source-backed compiler-token trace slices may explain why a class is trusted
+- trace slices must be output-neutral unless a later spec and support review
+  explicitly promote emitted output
+- one class receipt promotes only that class
+- broader compiler-token categories remain blocked, fallback-only, or shadowed
+- generated/no-source, stale, dynamic, low-confidence, fallback, and unmatched
+  candidates cannot become token identities
+- provider decision receipts must expose the fallback or blocker state when a
+  compiler-token fact is not used
+
+## Valid PR Shapes
+
+Valid PRs under this spec include:
+
+- adding a new class row to `semantic-token-classes.toml`
+- adding source-backed span-match proof for exactly one token class
+- adding `didChange` freshness proof for exactly one token class
+- adding blockers for generated/no-source, stale, dynamic, low-confidence,
+  fallback, or unmatched compiler-token candidates
+- adding a validator for semantic-token class policy
+- support-review PRs that keep broad compiler-token promotion deferred
+
+Every class-promotion PR must name the class, live token kind, promotion rule,
+fallback rule, blocker rule, and receipt.
+
+## Invalid PR Shapes
+
+Invalid PRs include:
+
+- broad compiler-backed semantic-token cutover from a scoped trace receipt
+- adding emitted token output without a class-specific support review
+- promoting a class whose compiler span does not exactly match one live token
+- treating generated/no-source, dynamic, stale, low-confidence, fallback, or
+  unmatched compiler facts as token identities
+- using token proof to authorize rename, safe delete, diagnostics, or broader
+  provider behavior
+- support-tier promotion without policy, receipts, and status review
+
+## Acceptance
+
+A semantic-token PR satisfies this spec when:
+
+- every touched compiler-token class has a policy row or remains explicitly
+  unlisted and blocked
+- promoted/traced classes are source-backed and fresh
+- the compiler span matches exactly one existing live token
+- live output remains unchanged unless a later policy row explicitly permits
+  output expansion
+- generated/no-source, stale, dynamic, low-confidence, fallback, and unmatched
+  candidates remain blocked or shadowed
+- provider decision receipts and support-tier wording stay bounded by the
+  reviewed class
+
+## Proof Commands
+
+Docs-only changes to this spec or policy may use:
+
+```bash
+cargo xtask check-provider-confidence-matrix
+cargo xtask check-support-claims
+cargo xtask check-provider-promotion-ledger
+cargo xtask ci-hygiene check-doc-paths docs/specs
+cargo xtask ci-hygiene check-doc-paths docs/project/status
+git diff --check
+```
+
+Class-behavior PRs must add or update focused semantic-token runtime and shadow
+receipts for the touched class.
+
+## Future Validator
+
+A future validator may be exposed as:
+
+```bash
+cargo xtask check-semantic-token-classes
+```
+
+That validator should check:
+
+- every live compiler-token class has a policy row
+- every policy row has receipt sources
+- every `partial_live_trace` class requires exact live-token match
+- every current row is output-neutral unless explicitly reviewed otherwise
+- blocker names are drawn from the provider promotion ledger blocker registry
+- status docs and policy do not disagree on promoted/traced classes
+
+## Non-goals
+
+- No provider behavior change from this spec alone.
+- No broad compiler-backed semantic-token promotion.
+- No generated/no-source token promotion.
+- No dynamic token promotion.
+- No emitted output expansion from trace-only class proof.
+- No rename, safe-delete, diagnostic, workspace-symbol, or support-tier
+  promotion from token proof alone.
+
+## Claim Boundaries
+
+This spec may claim that semantic-token class promotion is controlled by a
+class registry and output-neutral proof boundary. It may not claim that broad
+compiler-token output is live, or that a scoped class receipt proves any other
+class.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -38,6 +38,7 @@ generated sections.
 - [PLSP-SPEC-0016: Provider decision receipt v1](PLSP-SPEC-0016-provider-decision-receipt-v1.md)
 - [PLSP-SPEC-0017: Fact provenance and source backing](PLSP-SPEC-0017-fact-provenance-and-source-backing.md)
 - [PLSP-SPEC-0018: Edit authorization contract](PLSP-SPEC-0018-edit-authorization-contract.md)
+- [PLSP-SPEC-0019: Semantic token class promotion contract](PLSP-SPEC-0019-semantic-token-class-promotion-contract.md)
 
 ## Acceptance and Proof
 

--- a/policy/semantic-token-classes.toml
+++ b/policy/semantic-token-classes.toml
@@ -1,0 +1,189 @@
+# Advisory semantic-token class promotion registry.
+#
+# This policy records reviewed compiler-token classes. It does not broaden live
+# token output or replace semantic-token receipts.
+
+schema_version = 1
+policy = "semantic-token-classes"
+owner = "perl-lsp maintainers"
+status = "advisory"
+updated = "2026-05-20"
+spec = "docs/specs/PLSP-SPEC-0019-semantic-token-class-promotion-contract.md"
+support_tiers = "docs/project/status/SUPPORT_TIERS.md"
+provider_promotion_ledger = "policy/provider-promotion-ledger.toml"
+
+default_state = "blocked_unlisted"
+default_fallback = "parser_hir_semantic_tokens"
+
+required_promotion_conditions = [
+  "source_backed_compiler_span",
+  "span_matches_exactly_one_existing_live_token",
+  "emits_no_unscoped_new_output",
+  "did_change_freshness_proven",
+  "generated_no_source_blocked",
+  "stale_dynamic_low_confidence_fallback_unmatched_blocked",
+  "support_review_blocks_broad_promotion",
+]
+
+default_blockers = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "fallback_policy",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+
+receipt_sources = [
+  "docs/project/status/semantic_shadow_compare.md",
+  "docs/project/status/semantic_scorecard.md",
+  "docs/project/status/real_perl_editor_trust_v1.md",
+]
+
+[[class]]
+name = "subroutine_declaration"
+state = "partial_live_trace"
+live_token_kind = "function"
+compiler_identity_prefix = "token:function:"
+emits_new_output = false
+requires_exact_live_token_match = true
+requires_edit_freshness = true
+blocks = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "fallback_policy",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+claim_boundary = "Only source-backed compiler subroutine-declaration spans that exactly match existing live parser/HIR function tokens participate."
+
+[[class]]
+name = "method_declaration"
+state = "partial_live_trace"
+live_token_kind = "method"
+compiler_identity_prefix = "token:method_declaration:"
+emits_new_output = false
+requires_exact_live_token_match = true
+requires_edit_freshness = true
+blocks = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+claim_boundary = "Only source-backed compiler method-declaration spans that exactly match existing live parser/HIR method tokens participate."
+
+[[class]]
+name = "package_declaration"
+state = "partial_live_trace"
+live_token_kind = "namespace"
+compiler_identity_prefix = "token:package_declaration:"
+emits_new_output = false
+requires_exact_live_token_match = true
+requires_edit_freshness = true
+blocks = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "fallback_policy",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+claim_boundary = "Only source-backed compiler package-declaration spans that exactly match existing live parser/HIR namespace tokens participate."
+
+[[class]]
+name = "field_declaration"
+state = "partial_live_trace"
+live_token_kind = "variable"
+compiler_identity_prefix = "token:field_declaration:"
+emits_new_output = false
+requires_exact_live_token_match = true
+requires_edit_freshness = true
+blocks = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+claim_boundary = "Only source-backed compiler field-declaration spans that exactly match existing live parser/HIR variable tokens participate."
+
+[[class]]
+name = "method_call"
+state = "partial_live_trace"
+live_token_kind = "method"
+compiler_identity_prefix = "token:method_call:"
+emits_new_output = false
+requires_exact_live_token_match = true
+requires_edit_freshness = true
+blocks = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+claim_boundary = "Only source-backed compiler method-call spans that exactly match existing live parser/HIR method tokens participate."
+
+[[class]]
+name = "self_method_call"
+state = "partial_live_trace"
+live_token_kind = "method"
+compiler_identity_prefix = "token:self_method_call:"
+emits_new_output = false
+requires_exact_live_token_match = true
+requires_edit_freshness = true
+blocks = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "ambiguous_identity",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+claim_boundary = "Only source-backed compiler $self method-call spans that exactly match existing live parser/HIR method tokens participate."
+
+[[class]]
+name = "lexical_variable_declaration"
+state = "partial_live_trace"
+live_token_kind = "variable"
+compiler_identity_prefix = "token:lexical_variable_declaration:"
+emits_new_output = false
+requires_exact_live_token_match = true
+requires_edit_freshness = true
+blocks = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+claim_boundary = "Only source-backed compiler lexical-variable declaration spans that exactly match existing live parser/HIR variable tokens participate."
+
+[[class]]
+name = "lexical_variable_use"
+state = "partial_live_trace"
+live_token_kind = "variable"
+compiler_identity_prefix = "token:lexical_variable_use:"
+emits_new_output = false
+requires_exact_live_token_match = true
+requires_edit_freshness = true
+blocks = [
+  "generated_no_source",
+  "dynamic_boundary",
+  "stale_fact",
+  "low_confidence",
+  "unsupported_fact_class",
+  "unmatched_span",
+]
+claim_boundary = "Only source-backed compiler lexical-variable use spans that exactly match existing live parser/HIR variable tokens participate."


### PR DESCRIPTION
Problem: Scoped compiler-token traces exist, but the class-by-class promotion rules were not captured as a durable spec and policy registry. Fix: Add PLSP-SPEC-0019 plus policy/semantic-token-classes.toml, and link them from the trust v1 boundary, spec catalog, and dashboard source stack. Verification: rtk python TOML parse for policy/semantic-token-classes.toml; rtk cargo xtask check-provider-confidence-matrix; rtk cargo xtask check-support-claims; rtk cargo xtask check-provider-promotion-ledger; rtk cargo xtask ci-hygiene check-doc-paths docs/specs; rtk cargo xtask ci-hygiene check-doc-paths docs/project/status; rtk git diff --check.