### PR TITLE
test(diagnostics): lock diagnostic explanation schema (#8197)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -167,7 +167,12 @@ pub(super) fn diagnostic_explanation_payload_from_diagnostics(
     (
         json!({
             "schema_version": DIAGNOSTIC_EXPLANATION_SCHEMA_VERSION,
+            "surface": "diagnostics",
+            "decision": "explanation_only",
             "provider_action": method,
+            "fact_source": "provider_runtime",
+            "confidence": "low",
+            "freshness": "fresh",
             "diagnostic_count": diagnostic_count,
             "diagnostic_explanations": explanations,
             "truncated_diagnostic_explanations": truncated,
@@ -192,6 +197,12 @@ fn diagnostic_explanation(diagnostic: &Value) -> Value {
     explanation.insert("severity".to_string(), json!(diagnostic_severity_label(diagnostic)));
     explanation.insert("summary".to_string(), json!(diagnostic_summary(message)));
     explanation.insert("reason".to_string(), json!(diagnostic_trust_reason(trust_boundary)));
+    explanation
+        .insert("why_diagnostic_fired".to_string(), json!(diagnostic_fired_reason(trust_boundary)));
+    explanation.insert(
+        "why_diagnostic_was_not_suppressed".to_string(),
+        json!(diagnostic_not_suppressed_reason(trust_boundary)),
+    );
 
     if trust_boundary == "module_resolution" {
         explanation.insert("module_resolution".to_string(), pl701_module_resolution(message));
@@ -256,6 +267,50 @@ fn diagnostic_trust_reason(trust_boundary: &str) -> &'static str {
         _ => {
             "Diagnostic was returned by the live provider; no stronger trust boundary was inferred."
         }
+    }
+}
+
+fn diagnostic_fired_reason(trust_boundary: &str) -> &'static str {
+    match trust_boundary {
+        "module_resolution" => {
+            "The diagnostic provider returned missing-module evidence from the current module-resolution context."
+        }
+        "dynamic_boundary" => {
+            "The diagnostic provider returned a finding at a dynamic Perl boundary."
+        }
+        "low_confidence" => {
+            "The diagnostic provider returned a finding with low-confidence evidence."
+        }
+        "ambiguous_evidence" => {
+            "The diagnostic provider returned a finding where evidence remained ambiguous."
+        }
+        "stale_fact" => "The diagnostic provider returned a finding with stale fact context.",
+        "generated_or_not_source_backed" => {
+            "The diagnostic provider returned a finding involving generated or non-source-backed evidence."
+        }
+        _ => "The diagnostic provider returned the finding for the current request.",
+    }
+}
+
+fn diagnostic_not_suppressed_reason(trust_boundary: &str) -> &'static str {
+    match trust_boundary {
+        "module_resolution" => {
+            "No trusted source-backed module fact suppressed the missing-module diagnostic."
+        }
+        "dynamic_boundary" => {
+            "Dynamic evidence is labeled and does not suppress conservative diagnostics."
+        }
+        "low_confidence" => {
+            "Low-confidence evidence is visible and does not silently suppress diagnostics."
+        }
+        "ambiguous_evidence" => {
+            "Ambiguous evidence is visible and does not silently suppress diagnostics."
+        }
+        "stale_fact" => "Stale facts are not trusted to suppress diagnostics.",
+        "generated_or_not_source_backed" => {
+            "Generated or non-source-backed evidence is not trusted as an exact suppression fact."
+        }
+        _ => "No stronger trusted fact was available to suppress the returned diagnostic.",
     }
 }
 

--- a/crates/perl-lsp-rs/src/runtime/language/provider_decision_live_trace_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/provider_decision_live_trace_tests.rs
@@ -3,6 +3,7 @@ use crate::runtime::LspServer;
 use parking_lot::Mutex;
 use serde_json::{Value, json};
 use std::io::Cursor;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 const TRACE_URI: &str = "file:///workspace/lib/Trace/Live.pm";
@@ -419,6 +420,64 @@ fn request_receipt<'a>(
         .ok_or_else(|| format!("missing {provider} request_receipt").into())
 }
 
+fn diagnostic_explanation_schema() -> Result<Value, Box<dyn std::error::Error>> {
+    let schema_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("schemas")
+        .join("diagnostic_explanation.v1.schema.json");
+    let schema_text = std::fs::read_to_string(&schema_path).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("failed to read {}: {error}", schema_path.display()),
+        )
+    })?;
+    let schema = serde_json::from_str(&schema_text)?;
+    Ok(schema)
+}
+
+fn schema_required_fields(
+    schema: &Value,
+    pointer: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let fields = schema.pointer(pointer).and_then(Value::as_array).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("schema missing required array at {pointer}"),
+        )
+    })?;
+    let mut required = Vec::with_capacity(fields.len());
+    for field in fields {
+        let Some(name) = field.as_str() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("schema required array at {pointer} contains non-string item: {field}"),
+            )
+            .into());
+        };
+        required.push(name.to_string());
+    }
+    Ok(required)
+}
+
+fn assert_schema_required_fields_present(
+    value: &Value,
+    schema: &Value,
+    required_pointer: &str,
+    context: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for field in schema_required_fields(schema, required_pointer)? {
+        if value.get(&field).is_none() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{context} missing schema-required field {field}: {value}"),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
 fn generated_workspace_symbol_pilot_receipt(
     server: &LspServer,
 ) -> Result<Value, Box<dyn std::error::Error>> {
@@ -610,21 +669,67 @@ fn live_diagnostic_request_attaches_explainable_payload() -> Result<(), Box<dyn 
     );
     let diagnostic_explanation =
         receipt.get("diagnostic_explanation").ok_or("missing diagnostic explanation payload")?;
+    let diagnostic_schema = diagnostic_explanation_schema()?;
+    assert_schema_required_fields_present(
+        diagnostic_explanation,
+        &diagnostic_schema,
+        "/required",
+        "diagnostic explanation payload",
+    )?;
     assert_eq!(
         diagnostic_explanation.get("schema_version").and_then(Value::as_str),
         Some("diagnostic_explanation.v1")
     );
+    assert_eq!(diagnostic_explanation.get("surface").and_then(Value::as_str), Some("diagnostics"));
+    assert_eq!(
+        diagnostic_explanation.get("decision").and_then(Value::as_str),
+        Some("explanation_only")
+    );
+    assert_eq!(
+        diagnostic_explanation.get("fact_source").and_then(Value::as_str),
+        Some("provider_runtime")
+    );
+    assert_eq!(diagnostic_explanation.get("confidence").and_then(Value::as_str), Some("low"));
+    assert_eq!(diagnostic_explanation.get("freshness").and_then(Value::as_str), Some("fresh"));
     let explanations = diagnostic_explanation
         .get("diagnostic_explanations")
         .and_then(Value::as_array)
         .ok_or("missing diagnostic explanation items")?;
+    for explanation in explanations {
+        assert_schema_required_fields_present(
+            explanation,
+            &diagnostic_schema,
+            "/$defs/diagnostic_explanation_item/required",
+            "diagnostic explanation item",
+        )?;
+    }
     let pl701 = explanations
         .iter()
         .find(|item| item.get("code").and_then(Value::as_str) == Some("PL701"))
         .ok_or("missing PL701 diagnostic explanation")?;
     assert_eq!(pl701.get("trust_boundary").and_then(Value::as_str), Some("module_resolution"));
+    assert!(
+        pl701
+            .get("why_diagnostic_fired")
+            .and_then(Value::as_str)
+            .is_some_and(|reason| reason.contains("module-resolution")),
+        "PL701 explanation should explain why the diagnostic fired: {pl701}"
+    );
+    assert!(
+        pl701
+            .get("why_diagnostic_was_not_suppressed")
+            .and_then(Value::as_str)
+            .is_some_and(|reason| reason.contains("module fact")),
+        "PL701 explanation should explain why it was not suppressed: {pl701}"
+    );
     let module_resolution =
         pl701.get("module_resolution").ok_or("missing PL701 module-resolution explanation")?;
+    assert_schema_required_fields_present(
+        module_resolution,
+        &diagnostic_schema,
+        "/$defs/module_resolution/required",
+        "PL701 module-resolution explanation",
+    )?;
     assert_eq!(
         module_resolution.get("requested_module").and_then(Value::as_str),
         Some("Missing::Payload")

--- a/docs/specs/PLSP-SPEC-0021-diagnostic-explanation-v1.md
+++ b/docs/specs/PLSP-SPEC-0021-diagnostic-explanation-v1.md
@@ -1,0 +1,120 @@
+# PLSP-SPEC-0021: Diagnostic explanation v1
+
+Status: accepted
+Owner: perl-lsp maintainers
+Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked specs:
+- [PLSP-SPEC-0012](PLSP-SPEC-0012-user-facing-trust-surfaces.md)
+- [PLSP-SPEC-0015](PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md)
+- [PLSP-SPEC-0016](PLSP-SPEC-0016-provider-decision-receipt-v1.md)
+- [PLSP-SPEC-0017](PLSP-SPEC-0017-fact-provenance-and-source-backing.md)
+Linked ADRs:
+- [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Status impact: diagnostics, provider decision explanations, support tiers,
+Real Perl Editor Trust dashboard
+Schema: [diagnostic_explanation.v1.schema.json](../../schemas/diagnostic_explanation.v1.schema.json)
+
+## Current Implementation Status
+
+Diagnostic explanation payloads are attached to provider decision receipts for
+`textDocument/diagnostic` and `workspace/diagnostic`. The payload is
+explanation-only: it describes returned diagnostics, trust boundaries, and
+module-resolution context without changing suppression, severity, resolver
+behavior, workspace scanning, support tiers, or provider promotion state.
+
+## Contract
+
+Every `diagnostic_explanation.v1` payload must include:
+
+- `schema_version = "diagnostic_explanation.v1"`
+- `surface = "diagnostics"`
+- `decision = "explanation_only"`
+- `provider_action`
+- `fact_source`
+- `confidence`
+- `freshness`
+- diagnostic counts and truncation state
+- a list of diagnostic explanation items
+- dynamic-boundary summary state
+- a claim boundary that keeps the payload explanation-only
+
+Each diagnostic explanation item must include:
+
+- trust boundary
+- severity label
+- summary
+- reason
+- why the diagnostic fired
+- why the diagnostic was not suppressed
+
+PL701 missing-module explanations must preserve module-resolution context:
+
+- requested module
+- expected relative module path
+- reported `@INC` path classes
+- whether effective include paths were reported
+- whether workspace include paths were labeled
+- PERL5LIB policy label
+- whether searched `@INC` context was reported
+
+## Valid PR Shapes
+
+Valid PRs under this spec include:
+
+- adding fields to `diagnostic_explanation.v1` without removing existing fields
+- adding focused explanation tests for one diagnostic code or trust boundary
+- adding schema snapshots or validators
+- improving user text while preserving canonical fields
+- adding redaction or path-classification proof for diagnostic explanation
+  payloads
+
+## Invalid PR Shapes
+
+Invalid PRs include:
+
+- changing diagnostic suppression from an explanation-only PR
+- changing diagnostic severity from an explanation-only PR
+- changing module resolution or workspace scanning from an explanation-only PR
+- probing Perl, running `perldoc`, or launching DAP to enrich an explanation
+- promoting diagnostic support tiers from explanation presentation alone
+- treating low-confidence, stale, generated/no-source, dynamic, or ambiguous
+  evidence as exact suppression proof
+
+## Acceptance
+
+A diagnostic explanation PR satisfies this spec when:
+
+- live diagnostic explanation payloads conform to the v1 schema-required fields
+- provider decision copyable receipts preserve the diagnostic explanation payload
+- PL701 explanations expose missing-module lookup context
+- claim boundaries explicitly state no suppression, severity, or support-tier
+  promotion
+- diagnostics support remains `partial-live-with-fallback`
+
+## Proof Commands
+
+```bash
+cargo test -p perl-lsp-rs live_diagnostic_request_attaches_explainable_payload --lib --profile agent --locked -- --nocapture --test-threads=1
+cargo xtask check-provider-confidence-matrix
+cargo xtask check-support-claims
+cargo xtask ci-hygiene check-doc-paths docs/specs
+powershell -NoProfile -Command "Get-Content schemas/diagnostic_explanation.v1.schema.json -Raw | ConvertFrom-Json | Out-Null"
+git diff --check
+```
+
+## Non-goals
+
+- No diagnostic suppression change.
+- No diagnostic severity change.
+- No resolver behavior change.
+- No workspace scanning change.
+- No Perl, `perldoc`, DAP, or subprocess probing.
+- No provider promotion or support-tier promotion.
+- No rename or safe-delete authorization.
+
+## Claim Boundaries
+
+This spec may claim that `perl-lsp` can explain returned diagnostics and their
+trust boundaries through a versioned payload. It may not claim broad diagnostic
+correctness, new suppression authority, or compiler-backed diagnostic cutover.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -40,6 +40,7 @@ generated sections.
 - [PLSP-SPEC-0018: Edit authorization contract](PLSP-SPEC-0018-edit-authorization-contract.md)
 - [PLSP-SPEC-0019: Semantic token class promotion contract](PLSP-SPEC-0019-semantic-token-class-promotion-contract.md)
 - [PLSP-SPEC-0020: Workspace symbol generated-label contract](PLSP-SPEC-0020-workspace-symbol-generated-label-contract.md)
+- [PLSP-SPEC-0021: Diagnostic explanation v1](PLSP-SPEC-0021-diagnostic-explanation-v1.md)
 
 ## Acceptance and Proof
 

--- a/schemas/diagnostic_explanation.v1.schema.json
+++ b/schemas/diagnostic_explanation.v1.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/schemas/diagnostic_explanation.v1.schema.json",
+  "title": "Diagnostic explanation v1",
+  "description": "Additive schema for perl-lsp diagnostic explanation payloads attached to provider decision receipts.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "surface",
+    "decision",
+    "provider_action",
+    "fact_source",
+    "confidence",
+    "freshness",
+    "diagnostic_count",
+    "diagnostic_explanations",
+    "truncated_diagnostic_explanations",
+    "dynamic_boundary_detected",
+    "claim_boundary"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "diagnostic_explanation.v1"
+    },
+    "surface": {
+      "const": "diagnostics"
+    },
+    "decision": {
+      "const": "explanation_only"
+    },
+    "provider_action": {
+      "type": "string",
+      "enum": [
+        "textDocument/diagnostic",
+        "workspace/diagnostic"
+      ]
+    },
+    "fact_source": {
+      "const": "provider_runtime"
+    },
+    "confidence": {
+      "enum": [
+        "low"
+      ]
+    },
+    "freshness": {
+      "enum": [
+        "fresh"
+      ]
+    },
+    "diagnostic_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "diagnostic_explanations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic_explanation_item"
+      }
+    },
+    "truncated_diagnostic_explanations": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "dynamic_boundary_detected": {
+      "type": "boolean"
+    },
+    "claim_boundary": {
+      "const": "explains returned diagnostics only; no new suppression, severity, or support-tier promotion"
+    }
+  },
+  "$defs": {
+    "diagnostic_explanation_item": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "trust_boundary",
+        "severity",
+        "summary",
+        "reason",
+        "why_diagnostic_fired",
+        "why_diagnostic_was_not_suppressed"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "trust_boundary": {
+          "type": "string",
+          "enum": [
+            "module_resolution",
+            "dynamic_boundary",
+            "low_confidence",
+            "ambiguous_evidence",
+            "stale_fact",
+            "generated_or_not_source_backed",
+            "conservative_diagnostic"
+          ]
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "information",
+            "hint",
+            "unknown"
+          ]
+        },
+        "summary": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "why_diagnostic_fired": {
+          "type": "string"
+        },
+        "why_diagnostic_was_not_suppressed": {
+          "type": "string"
+        },
+        "module_resolution": {
+          "$ref": "#/$defs/module_resolution"
+        }
+      }
+    },
+    "module_resolution": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "requested_module",
+        "expected_relative_path",
+        "reported_inc_paths",
+        "effective_include_paths_reported",
+        "workspace_include_paths_labeled",
+        "perl5lib_policy",
+        "searched_inc_reported"
+      ],
+      "properties": {
+        "requested_module": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expected_relative_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reported_inc_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "effective_include_paths_reported": {
+          "type": "boolean"
+        },
+        "workspace_include_paths_labeled": {
+          "type": "boolean"
+        },
+        "perl5lib_policy": {
+          "type": "string",
+          "enum": [
+            "reported_in_effective_search_context",
+            "not_reported_in_diagnostic_search_context"
+          ]
+        },
+        "searched_inc_reported": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Problem: Diagnostic explanations are live in provider receipts, but the payload shape was not locked as its own versioned schema/spec. 
Fix: Add diagnostic_explanation.v1 schema/spec, add explanation-only provenance fields to the payload, and make the live PL701 diagnostic explanation test verify schema-required fields. 
Verification: cargo test -p perl-lsp-rs live_diagnostic_request_attaches_explainable_payload --lib --profile agent --locked -- --nocapture --test-threads=1 passes; cargo test -p perl-lsp-rs code_action_runtime_offers_explain_diagnostic_for_pl701_and_pl109 --lib --profile agent --locked -- --nocapture --test-threads=1 passes; schema parses with PowerShell ConvertFrom-Json; cargo fmt -p perl-lsp-rs -- --check passes; cargo check -p perl-lsp-rs --all-targets --profile agent --locked passes with pre-existing perl-subprocess-runtime unused re-export warnings; provider/parser control-plane checks pass. 
Note: cargo clippy -p perl-lsp-rs --lib --profile agent --locked passes with the same pre-existing subprocess warnings. cargo clippy -p perl-lsp-rs --all-targets --profile agent --locked is blocked by existing test/lint debt outside this change.