### PR TITLE
fix(status): keep token health after token facade split (#8197)

### DIFF
--- a/docs/project/status/parser.md
+++ b/docs/project/status/parser.md
@@ -89,10 +89,10 @@ Receipt snapshot: profile `system`, commit `f201b498c`, generated `2026-05-18`, 
 <!-- END: PARSER_METRICS_BULLETS -->
 
 <!-- BEGIN: TOKEN_HEALTH_TABLE -->
-| **TokenKind variants** | 132 | enum size in `perl-token` | `crates/perl-token/src/lib.rs` |
-| **Token metadata coverage** | 132/132 (PASS) | `display_name()` mappings for all variants | `crates/perl-token/src/lib.rs` + `.ci/metrics/baselines/token.json` |
-| **Category partition** | PASS (132 tokens partitioned across canonical groups) | keywords/operators/delimiters/literals/identifiers/special | `crates/perl-token/src/lib.rs` |
-| **Display-name coverage** | 132/132 | user-facing token labels present | `crates/perl-token/src/lib.rs` |
+| **TokenKind variants** | 132 | enum size in `perl-token` | `crates/perl-token/src/kind.rs` |
+| **Token metadata coverage** | 132/132 (PASS) | `display_name()` mappings for all variants | `crates/perl-token/src/kind.rs` + `.ci/metrics/baselines/token.json` |
+| **Category partition** | PASS (132 tokens partitioned across canonical groups) | keywords/operators/delimiters/literals/identifiers/special | `crates/perl-token/src/kind.rs` |
+| **Display-name coverage** | 132/132 | user-facing token labels present | `crates/perl-token/src/kind.rs` |
 | **Lexer/parser conformance** | PASS (lexer + parser-core both consume shared `perl-token`) | integration through shared token crate | `crates/perl-lexer/Cargo.toml` + `crates/perl-parser-core/Cargo.toml` |
 | **Token perf (p50/p95)** | PASS (category predicates: p50 29 ns / p95 40 ns; clone: p50 47 ns / p95 59 ns; display_name: p50 29 ns / p95 40 ns; lexer->parser: p50 226 ns / p95 253 ns; new long: p50 60 ns / p95 85 ns; new short: p50 62 ns / p95 63 ns) | key token operations benchmark health | `docs/project/status/token_performance_scorecard.json` |
 | **Runtime dependencies** | 0 | non-dev deps in `perl-token` | `crates/perl-token/Cargo.toml` |

--- a/xtask/src/tasks/update_status/parser.rs
+++ b/xtask/src/tasks/update_status/parser.rs
@@ -392,10 +392,10 @@ pub(super) fn generate_parser_status(metrics: &ParserMetrics, original: &str) ->
 
     let token = &metrics.token_metrics;
     let token_table = format!(
-        "| **TokenKind variants** | {} | enum size in `perl-token` | `crates/perl-token/src/lib.rs` |\n\
-         | **Token metadata coverage** | {}/{} ({}) | `display_name()` mappings for all variants | `crates/perl-token/src/lib.rs` + `.ci/metrics/baselines/token.json` |\n\
-         | **Category partition** | {} | keywords/operators/delimiters/literals/identifiers/special | `crates/perl-token/src/lib.rs` |\n\
-         | **Display-name coverage** | {}/{} | user-facing token labels present | `crates/perl-token/src/lib.rs` |\n\
+        "| **TokenKind variants** | {} | enum size in `perl-token` | `crates/perl-token/src/kind.rs` |\n\
+         | **Token metadata coverage** | {}/{} ({}) | `display_name()` mappings for all variants | `crates/perl-token/src/kind.rs` + `.ci/metrics/baselines/token.json` |\n\
+         | **Category partition** | {} | keywords/operators/delimiters/literals/identifiers/special | `crates/perl-token/src/kind.rs` |\n\
+         | **Display-name coverage** | {}/{} | user-facing token labels present | `crates/perl-token/src/kind.rs` |\n\
          | **Lexer/parser conformance** | {} | integration through shared token crate | `crates/perl-lexer/Cargo.toml` + `crates/perl-parser-core/Cargo.toml` |\n\
          | **Token perf (p50/p95)** | {} | key token operations benchmark health | `docs/project/status/token_performance_scorecard.json` |\n\
          | **Runtime dependencies** | {} | non-dev deps in `perl-token` | `crates/perl-token/Cargo.toml` |",

--- a/xtask/src/tasks/update_status/token.rs
+++ b/xtask/src/tasks/update_status/token.rs
@@ -9,6 +9,9 @@ use std::path::Path;
 use regex::Regex;
 use serde::Deserialize;
 
+const TOKEN_KIND_SOURCE: &str = "crates/perl-token/src/kind.rs";
+const TOKEN_KIND_FALLBACK_SOURCE: &str = "crates/perl-token/src/lib.rs";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -66,8 +69,7 @@ pub struct TokenHealthMetrics {
 // ---------------------------------------------------------------------------
 
 pub fn collect_token_health_metrics(root: &Path) -> TokenHealthMetrics {
-    let token_src = root.join("crates/perl-token/src/lib.rs");
-    let token_lib = fs::read_to_string(token_src).unwrap_or_default();
+    let token_lib = read_token_kind_source(root);
     let variants = token_kind_variants(&token_lib);
     let display_name_arms = token_display_name_arms(&token_lib);
     let category_counts = token_category_counts(&token_lib);
@@ -148,6 +150,12 @@ pub fn collect_token_health_metrics(root: &Path) -> TokenHealthMetrics {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn read_token_kind_source(root: &Path) -> String {
+    fs::read_to_string(root.join(TOKEN_KIND_SOURCE))
+        .or_else(|_| fs::read_to_string(root.join(TOKEN_KIND_FALLBACK_SOURCE)))
+        .unwrap_or_default()
+}
 
 fn crate_depends_on_token(root: &Path, cargo_toml: &str) -> bool {
     fs::read_to_string(root.join(cargo_toml)).ok().is_some_and(|content| {
@@ -351,8 +359,7 @@ mod tests {
     #[test]
     fn token_kind_variants_matches_actual_enum() {
         let root = project_root().expect("project root");
-        let src = std::fs::read_to_string(root.join("crates/perl-token/src/lib.rs"))
-            .expect("perl-token/src/lib.rs must exist");
+        let src = read_token_kind_source(&root);
         let variants = token_kind_variants(&src);
         assert!(
             !variants.is_empty(),
@@ -373,7 +380,7 @@ mod tests {
         // guarantees this, but a double-check costs nothing).
         for name in &variants {
             assert!(
-                name.chars().next().map_or(false, |c| c.is_uppercase()),
+                name.chars().next().is_some_and(|c| c.is_uppercase()),
                 "extracted variant {name:?} does not start with uppercase"
             );
         }
@@ -395,8 +402,7 @@ mod tests {
     #[test]
     fn display_name_arms_match_variant_count() {
         let root = project_root().expect("project root");
-        let src = std::fs::read_to_string(root.join("crates/perl-token/src/lib.rs"))
-            .expect("perl-token/src/lib.rs must exist");
+        let src = read_token_kind_source(&root);
         let variants = token_kind_variants(&src);
         let arms = token_display_name_arms(&src);
         assert_eq!(
@@ -414,8 +420,7 @@ mod tests {
     #[test]
     fn all_variants_are_categorised() {
         let root = project_root().expect("project root");
-        let src = std::fs::read_to_string(root.join("crates/perl-token/src/lib.rs"))
-            .expect("perl-token/src/lib.rs must exist");
+        let src = read_token_kind_source(&root);
         let variants = token_kind_variants(&src);
         let counts = token_category_counts(&src);
         let total: usize = counts.values().sum();
@@ -486,5 +491,68 @@ mod tests {
                 metrics.performance_row
             );
         }
+    }
+
+    #[test]
+    fn collect_token_health_metrics_reads_split_kind_module() -> std::io::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path();
+        let token_src = root.join("crates/perl-token/src");
+        std::fs::create_dir_all(&token_src)?;
+        std::fs::create_dir_all(root.join("crates/perl-lexer"))?;
+        std::fs::create_dir_all(root.join("crates/perl-parser-core"))?;
+
+        std::fs::write(
+            token_src.join("lib.rs"),
+            "mod kind;\npub use kind::{TokenCategory, TokenKind, TokenKindMetadata};\n",
+        )?;
+        std::fs::write(
+            token_src.join("kind.rs"),
+            r#"
+pub enum TokenKind {
+    // ===== Keywords =====
+    My,
+    // ===== Operators =====
+    Plus,
+}
+
+#[non_exhaustive]
+pub enum TokenCategory {
+    Keyword,
+    Operator,
+}
+
+#[non_exhaustive]
+pub struct TokenKindMetadata {
+    pub category: TokenCategory,
+    pub display_name: &'static str,
+}
+
+impl TokenKind {
+    pub fn display_name(self) -> &'static str {
+        match self {
+            TokenKind::My => "'my'",
+            TokenKind::Plus => "'+'",
+        }
+    }
+}
+"#,
+        )?;
+        std::fs::write(root.join("crates/perl-lexer/Cargo.toml"), "perl-token = {}\n")?;
+        std::fs::write(root.join("crates/perl-parser-core/Cargo.toml"), "perl-token = {}\n")?;
+        std::fs::write(root.join("crates/perl-token/Cargo.toml"), "[dependencies]\n")?;
+
+        let metrics = collect_token_health_metrics(root);
+
+        assert_eq!(metrics.variant_count, 2);
+        assert_eq!(metrics.metadata_coverage_count, 2);
+        assert_eq!(metrics.display_name_coverage_count, 2);
+        assert_eq!(metrics.metadata_status, "PASS");
+        assert_eq!(
+            metrics.category_partition_status,
+            "PASS (2 tokens partitioned across canonical groups)"
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Problem: parser status token-health metrics zeroed after the perl-token facade split moved TokenKind out of lib.rs. 
Fix: read the canonical split kind.rs source with a lib.rs fallback, update the generated status source labels, and add a split-module regression fixture. 
Verification: tk cargo test -p xtask tasks::update_status::token::tests --profile agent --locked -- --nocapture; tk cargo check -p xtask --all-targets --profile agent --locked; tk cargo fmt -p xtask -- --check; tk cargo xtask update-status --only parser --check; tk cargo xtask metrics parser-accuracy --check; tk cargo xtask metrics ratchet-check parser_accuracy; provider/support/promotion/token/workspace-symbol checks passed. tk cargo clippy -p xtask --all-targets --profile agent --locked still fails on existing xtask-wide lint debt outside this change.