### PR TITLE
test(trust-report): lock workspace trust report schema (#8197)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs
@@ -57,6 +57,63 @@ fn expected_keys(keys: &[&str]) -> Vec<String> {
     expected
 }
 
+fn workspace_trust_report_schema() -> Result<Value, Box<dyn std::error::Error>> {
+    let schema_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("schemas")
+        .join("workspace_trust_report.v1.schema.json");
+    let schema_text = std::fs::read_to_string(&schema_path).map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("failed to read {}: {error}", schema_path.display()),
+        )
+    })?;
+    Ok(serde_json::from_str(&schema_text)?)
+}
+
+fn schema_required_fields(
+    schema: &Value,
+    pointer: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let fields = schema.pointer(pointer).and_then(Value::as_array).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("schema missing required array at {pointer}"),
+        )
+    })?;
+    let mut required = Vec::with_capacity(fields.len());
+    for field in fields {
+        let Some(name) = field.as_str() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("schema required array at {pointer} contains non-string item: {field}"),
+            )
+            .into());
+        };
+        required.push(name.to_string());
+    }
+    Ok(required)
+}
+
+fn assert_schema_required_fields_present(
+    value: &Value,
+    schema: &Value,
+    required_pointer: &str,
+    context: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for field in schema_required_fields(schema, required_pointer)? {
+        if value.get(&field).is_none() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("{context} missing schema-required field {field}: {value}"),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
 #[test]
 fn test_execute_command_run_file() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
@@ -512,6 +569,97 @@ fn test_execute_command_workspace_trust_report_schema_snapshot()
         .handle_request(execute_request)
         .ok_or("No response from workspace-trust-report command")?;
     let result = response.result.ok_or("No result in workspace-trust-report response")?;
+    let schema = workspace_trust_report_schema()?;
+
+    assert_schema_required_fields_present(&result, &schema, "/required", "workspace trust report")?;
+    assert_schema_required_fields_present(
+        result.get("workspace").ok_or("missing workspace report")?,
+        &schema,
+        "/$defs/workspace/required",
+        "workspace report",
+    )?;
+    assert_schema_required_fields_present(
+        result.get("module_resolution").ok_or("missing module_resolution report")?,
+        &schema,
+        "/$defs/module_resolution/required",
+        "module-resolution report",
+    )?;
+    assert_schema_required_fields_present(
+        result
+            .pointer("/module_resolution/global_workspace_config")
+            .ok_or("missing global_workspace_config")?,
+        &schema,
+        "/$defs/workspace_config/required",
+        "global workspace config report",
+    )?;
+    assert_schema_required_fields_present(
+        result.get("setup_hints").ok_or("missing setup_hints report")?,
+        &schema,
+        "/$defs/setup_hints/required",
+        "setup hints report",
+    )?;
+    assert_schema_required_fields_present(
+        result.pointer("/setup_hints/perl_binary").ok_or("missing setup_hints perl_binary")?,
+        &schema,
+        "/$defs/setup_hints_perl_binary/required",
+        "setup hints perl binary report",
+    )?;
+    assert_schema_required_fields_present(
+        result.pointer("/setup_hints/perldoc").ok_or("missing setup_hints perldoc")?,
+        &schema,
+        "/$defs/setup_hints_perldoc/required",
+        "setup hints perldoc report",
+    )?;
+    assert_schema_required_fields_present(
+        result.pointer("/setup_hints/dap").ok_or("missing setup_hints dap")?,
+        &schema,
+        "/$defs/setup_hints_dap/required",
+        "setup hints DAP report",
+    )?;
+    assert_schema_required_fields_present(
+        result.get("client_runtime_state").ok_or("missing client_runtime_state")?,
+        &schema,
+        "/$defs/client_runtime_state/required",
+        "client runtime state report",
+    )?;
+    assert_schema_required_fields_present(
+        result.pointer("/client_runtime_state/dap").ok_or("missing client runtime DAP")?,
+        &schema,
+        "/$defs/client_runtime_dap/required",
+        "client runtime DAP report",
+    )?;
+    assert_schema_required_fields_present(
+        result
+            .pointer("/client_runtime_state/dap/launch_configuration")
+            .ok_or("missing launch configuration report")?,
+        &schema,
+        "/$defs/launch_configuration/required",
+        "launch configuration report",
+    )?;
+    assert_schema_required_fields_present(
+        result.get("index").ok_or("missing index report")?,
+        &schema,
+        "/$defs/index/required",
+        "index report",
+    )?;
+    assert_schema_required_fields_present(
+        result.get("providers").ok_or("missing providers report")?,
+        &schema,
+        "/$defs/providers/required",
+        "providers report",
+    )?;
+    assert_schema_required_fields_present(
+        result.get("dynamic_boundaries").ok_or("missing dynamic_boundaries report")?,
+        &schema,
+        "/$defs/dynamic_boundaries/required",
+        "dynamic boundaries report",
+    )?;
+    assert_schema_required_fields_present(
+        result.get("copyable_payload").ok_or("missing copyable_payload")?,
+        &schema,
+        "/$defs/copyable_payload/required",
+        "copyable workspace trust payload",
+    )?;
 
     assert_eq!(
         sorted_object_keys_at(&result, "")?,

--- a/docs/specs/PLSP-SPEC-0009-workspace-trust-report.md
+++ b/docs/specs/PLSP-SPEC-0009-workspace-trust-report.md
@@ -11,6 +11,7 @@ Linked ADRs:
 Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
 Status impact: support tiers, provider confidence matrix, real editor trust
 dashboard, VS Code command documentation, setup troubleshooting docs
+Schema: [workspace_trust_report.v1.schema.json](../../schemas/workspace_trust_report.v1.schema.json)
 
 ## Current implementation status
 
@@ -22,8 +23,9 @@ existing server and client state, with schema coverage tracked from
 [real_perl_editor_trust_v1.md](../project/status/real_perl_editor_trust_v1.md).
 
 Current setup hints, perldoc/DAP state, launch-configuration classes, and
-module-path boundaries remain report-only. They do not probe Perl, run
-`perldoc`, launch DAP, scan the workspace, or promote setup-health support
+module-path boundaries remain report-only. The payload shape is locked by
+`workspace_trust_report.v1`; neither the report nor the schema may probe Perl,
+run `perldoc`, launch DAP, scan the workspace, or promote setup-health support
 tiers.
 
 ## Contract

--- a/schemas/workspace_trust_report.v1.schema.json
+++ b/schemas/workspace_trust_report.v1.schema.json
@@ -1,0 +1,797 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://effortlessmetrics.dev/perl-lsp/schemas/workspace_trust_report.v1.schema.json",
+  "title": "Workspace trust report v1",
+  "description": "Additive schema for the read-only perl-lsp workspace trust report payload.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "command",
+    "user_message",
+    "claim_boundary",
+    "workspace",
+    "module_resolution",
+    "setup_hints",
+    "client_runtime_state",
+    "index",
+    "providers",
+    "dynamic_boundaries",
+    "copyable_payload"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "workspace_trust_report.v1"
+    },
+    "command": {
+      "const": "perl.workspaceTrustReport"
+    },
+    "user_message": {
+      "type": "string"
+    },
+    "claim_boundary": {
+      "type": "string"
+    },
+    "workspace": {
+      "$ref": "#/$defs/workspace"
+    },
+    "module_resolution": {
+      "$ref": "#/$defs/module_resolution"
+    },
+    "setup_hints": {
+      "$ref": "#/$defs/setup_hints"
+    },
+    "client_runtime_state": {
+      "$ref": "#/$defs/client_runtime_state"
+    },
+    "index": {
+      "$ref": "#/$defs/index"
+    },
+    "providers": {
+      "$ref": "#/$defs/providers"
+    },
+    "dynamic_boundaries": {
+      "$ref": "#/$defs/dynamic_boundaries"
+    },
+    "copyable_payload": {
+      "$ref": "#/$defs/copyable_payload"
+    }
+  },
+  "$defs": {
+    "string_or_null": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "nonnegative_integer_or_null": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "root_path",
+        "workspace_folder_count",
+        "open_document_count",
+        "folders"
+      ],
+      "properties": {
+        "root_path": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "workspace_folder_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "open_document_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "folders": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/workspace_folder"
+          }
+        }
+      }
+    },
+    "workspace_folder": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "uri",
+        "name",
+        "path",
+        "project_config_present",
+        "effective_workspace_config"
+      ],
+      "properties": {
+        "uri": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "project_config_present": {
+          "type": "boolean"
+        },
+        "effective_workspace_config": {
+          "$ref": "#/$defs/workspace_config"
+        }
+      }
+    },
+    "module_resolution": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "global_workspace_config",
+        "policy"
+      ],
+      "properties": {
+        "global_workspace_config": {
+          "$ref": "#/$defs/workspace_config"
+        },
+        "policy": {
+          "type": "string"
+        }
+      }
+    },
+    "workspace_config": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "include_paths",
+        "effective_include_paths",
+        "use_system_inc",
+        "system_inc_status",
+        "use_perl5lib",
+        "perl5lib_entry_count",
+        "perl5lib_precedence",
+        "perl_path",
+        "perl_args_count",
+        "resolution_timeout_ms"
+      ],
+      "properties": {
+        "include_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "effective_include_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "use_system_inc": {
+          "type": "boolean"
+        },
+        "system_inc_status": {
+          "type": "string",
+          "enum": [
+            "configured_not_probed_by_report",
+            "disabled"
+          ]
+        },
+        "use_perl5lib": {
+          "type": "boolean"
+        },
+        "perl5lib_entry_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "perl5lib_precedence": {
+          "type": "string",
+          "enum": [
+            "prepend",
+            "append"
+          ]
+        },
+        "perl_path": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "perl_args_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resolution_timeout_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "setup_hints": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "status",
+        "hint_count",
+        "hints",
+        "perl_binary",
+        "perldoc",
+        "dap",
+        "claim_boundary"
+      ],
+      "properties": {
+        "status": {
+          "const": "advisory"
+        },
+        "hint_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/setup_hint"
+          }
+        },
+        "perl_binary": {
+          "$ref": "#/$defs/setup_hints_perl_binary"
+        },
+        "perldoc": {
+          "$ref": "#/$defs/setup_hints_perldoc"
+        },
+        "dap": {
+          "$ref": "#/$defs/setup_hints_dap"
+        },
+        "claim_boundary": {
+          "type": "string"
+        }
+      }
+    },
+    "setup_hint": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "code",
+        "severity",
+        "message",
+        "action"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "info",
+            "warning",
+            "error"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "action": {
+          "type": "string"
+        }
+      }
+    },
+    "setup_hints_perl_binary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "configured_path",
+        "resolution_status",
+        "version_status",
+        "args_count"
+      ],
+      "properties": {
+        "configured_path": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "resolution_status": {
+          "type": "string"
+        },
+        "version_status": {
+          "const": "not_probed_by_report"
+        },
+        "args_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "setup_hints_perldoc": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "status",
+        "run_status",
+        "binary_source",
+        "timeout_ms",
+        "allow_perl5lib",
+        "allow_perl5opt",
+        "allow_local_lib",
+        "lc_all",
+        "argv_policy",
+        "policy"
+      ],
+      "properties": {
+        "status": {
+          "const": "oracle_contract_reported_not_run"
+        },
+        "run_status": {
+          "const": "not_run_by_report"
+        },
+        "binary_source": {
+          "type": "string"
+        },
+        "timeout_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "allow_perl5lib": {
+          "type": "boolean"
+        },
+        "allow_perl5opt": {
+          "type": "boolean"
+        },
+        "allow_local_lib": {
+          "type": "boolean"
+        },
+        "lc_all": {
+          "type": "string"
+        },
+        "argv_policy": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        }
+      }
+    },
+    "setup_hints_dap": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "status",
+        "policy"
+      ],
+      "properties": {
+        "status": {
+          "const": "not_probed_by_lsp_workspace_report"
+        },
+        "policy": {
+          "type": "string"
+        }
+      }
+    },
+    "client_runtime_state": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "schema_version",
+        "source",
+        "perldoc",
+        "dap",
+        "claim_boundary"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "workspace_trust_client_runtime.v1"
+        },
+        "source": {
+          "type": "string"
+        },
+        "perldoc": {
+          "$ref": "#/$defs/client_runtime_perldoc"
+        },
+        "dap": {
+          "$ref": "#/$defs/client_runtime_dap"
+        },
+        "claim_boundary": {
+          "type": "string"
+        }
+      }
+    },
+    "client_runtime_perldoc": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "status",
+        "uri_scheme",
+        "client_surface"
+      ],
+      "properties": {
+        "status": {
+          "type": "string"
+        },
+        "uri_scheme": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "client_surface": {
+          "$ref": "#/$defs/string_or_null"
+        }
+      }
+    },
+    "client_runtime_dap": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "status",
+        "adapter_registered",
+        "active_perl_debug_session",
+        "managed_adapter_exists",
+        "launch_json_workspace_count",
+        "workspace_folder_count",
+        "launch_configuration"
+      ],
+      "properties": {
+        "status": {
+          "type": "string"
+        },
+        "adapter_registered": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "active_perl_debug_session": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "managed_adapter_exists": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "launch_json_workspace_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "workspace_folder_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "launch_configuration": {
+          "$ref": "#/$defs/launch_configuration"
+        }
+      }
+    },
+    "launch_configuration": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "status",
+        "configuration_count",
+        "perl_configuration_count",
+        "launch_request_count",
+        "attach_request_count",
+        "perl_path_configured_count",
+        "include_paths_configured_count",
+        "include_path_entry_count",
+        "non_string_include_path_count",
+        "program_configured_count",
+        "cwd_configured_count",
+        "include_path_kind_counts",
+        "perl_path_kind_counts",
+        "program_path_kind_counts",
+        "cwd_path_kind_counts",
+        "claim_boundary"
+      ],
+      "properties": {
+        "status": {
+          "type": "string"
+        },
+        "configuration_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "perl_configuration_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "launch_request_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "attach_request_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "perl_path_configured_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "include_paths_configured_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "include_path_entry_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "non_string_include_path_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "program_configured_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "cwd_configured_count": {
+          "$ref": "#/$defs/nonnegative_integer_or_null"
+        },
+        "include_path_kind_counts": {
+          "$ref": "#/$defs/path_class_counts"
+        },
+        "perl_path_kind_counts": {
+          "$ref": "#/$defs/path_class_counts"
+        },
+        "program_path_kind_counts": {
+          "$ref": "#/$defs/path_class_counts"
+        },
+        "cwd_path_kind_counts": {
+          "$ref": "#/$defs/path_class_counts"
+        },
+        "claim_boundary": {
+          "type": "string"
+        }
+      }
+    },
+    "path_class_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "absolute": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "relative": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "workspace_variable": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "file_variable": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "other_variable": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "home_relative": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "command": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "empty": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unknown": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "index": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "availability",
+        "state",
+        "reason",
+        "file_count",
+        "symbol_count",
+        "indexed_file_count",
+        "indexed_symbol_count",
+        "pending_index_tasks",
+        "indexing_in_progress"
+      ],
+      "properties": {
+        "availability": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "file_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "symbol_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indexed_file_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indexed_symbol_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pending_index_tasks": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "indexing_in_progress": {
+          "type": "boolean"
+        }
+      }
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "support_tiers",
+        "decision_trace_count",
+        "decision_trace_keys"
+      ],
+      "properties": {
+        "support_tiers": {
+          "$ref": "#/$defs/support_tiers"
+        },
+        "decision_trace_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "decision_trace_keys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "support_tiers": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "dynamic_boundaries": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "policy"
+      ],
+      "properties": {
+        "policy": {
+          "type": "string"
+        }
+      }
+    },
+    "copyable_payload": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "schema_version",
+        "perl_lsp_version",
+        "provider",
+        "command",
+        "workspace_root_class",
+        "workspace_root_hash",
+        "workspace_folder_count",
+        "open_document_count",
+        "configured_include_path_count",
+        "effective_include_path_count",
+        "use_system_inc",
+        "system_inc_status",
+        "use_perl5lib",
+        "perl5lib_entry_count",
+        "perl5lib_precedence",
+        "perl_binary_resolution_status",
+        "perldoc_status",
+        "perldoc_run_status",
+        "dap_status",
+        "client_runtime_schema_version",
+        "client_runtime_source",
+        "launch_configuration_status",
+        "provider_support_tiers",
+        "decision_trace_count",
+        "dynamic_boundary_policy",
+        "support_tier_link",
+        "claim_boundary"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "workspace_trust_report_copyable.v1"
+        },
+        "perl_lsp_version": {
+          "type": "string"
+        },
+        "provider": {
+          "const": "workspace_trust_report"
+        },
+        "command": {
+          "const": "perl.workspaceTrustReport"
+        },
+        "workspace_root_class": {
+          "type": "string",
+          "enum": [
+            "none",
+            "single_root",
+            "multi_root"
+          ]
+        },
+        "workspace_root_hash": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "workspace_folder_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "open_document_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "configured_include_path_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "effective_include_path_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "use_system_inc": {
+          "type": "boolean"
+        },
+        "system_inc_status": {
+          "type": "string"
+        },
+        "use_perl5lib": {
+          "type": "boolean"
+        },
+        "perl5lib_entry_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "perl5lib_precedence": {
+          "type": "string"
+        },
+        "perl_binary_resolution_status": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "perldoc_status": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "perldoc_run_status": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "dap_status": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "client_runtime_schema_version": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "client_runtime_source": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "launch_configuration_status": {
+          "$ref": "#/$defs/string_or_null"
+        },
+        "provider_support_tiers": {
+          "$ref": "#/$defs/support_tiers"
+        },
+        "decision_trace_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "dynamic_boundary_policy": {
+          "type": "string"
+        },
+        "support_tier_link": {
+          "type": "string"
+        },
+        "claim_boundary": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Problem: the workspace trust report is a user-facing trust surface, but its v1 payload shape was locked only by snapshot assertions and not by a shared schema artifact.
Fix: add workspace_trust_report.v1.schema.json, link it from the accepted workspace-trust spec, and make the existing trust-report schema snapshot assert schema-required fields across the live report, setup hints, client runtime state, launch config, index, providers, dynamic boundaries, and copyable payload.
Verification: rtk powershell -NoProfile -Command "Get-Content schemas\\workspace_trust_report.v1.schema.json -Raw | ConvertFrom-Json | Out-Null"; rtk cargo test -p perl-lsp-rs --test lsp_execute_command_tests test_execute_command_workspace_trust_report_schema_snapshot --profile agent --locked -- --nocapture --test-threads=1; rtk cargo test -p perl-lsp-rs --test lsp_execute_command_tests test_execute_command_workspace_trust_report --profile agent --locked -- --nocapture --test-threads=1; rtk cargo check -p perl-lsp-rs --all-targets --profile agent --locked; rtk cargo fmt -p perl-lsp-rs -- --check; rtk cargo xtask ci-hygiene check-doc-paths docs/specs; provider/support/promotion/token/workspace-symbol checks passed; parser accuracy remains 50 fixtures / 29 families with 0 active packets and ratchet floors passing.