### PR TITLE
docs(spec): define module path and ambient authority (#8197)

### DIFF
--- a/docs/project/status/real_perl_editor_trust_v1.md
+++ b/docs/project/status/real_perl_editor_trust_v1.md
@@ -24,6 +24,7 @@ of current evidence.
 | Shared edit authorization states for rename and safe delete | [PLSP-SPEC-0018](../../specs/PLSP-SPEC-0018-edit-authorization-contract.md) |
 | Semantic token class promotion rules | [PLSP-SPEC-0019](../../specs/PLSP-SPEC-0019-semantic-token-class-promotion-contract.md), [semantic-token-classes.toml](../../../policy/semantic-token-classes.toml) |
 | Workspace symbol generated-label rules | [PLSP-SPEC-0020](../../specs/PLSP-SPEC-0020-workspace-symbol-generated-label-contract.md), [workspace-symbol-classes.toml](../../../policy/workspace-symbol-classes.toml) |
+| Module path authority and ambient-input boundaries | [PLSP-SPEC-0022](../../specs/PLSP-SPEC-0022-module-path-authority.md), [PLSP-SPEC-0023](../../specs/PLSP-SPEC-0023-ambient-inputs.md) |
 | User-facing support claims and known limitations | [SUPPORT_TIERS.md](SUPPORT_TIERS.md) |
 | Provider fact source, confidence, freshness, fallback, and next proof | [provider_confidence_matrix.md](provider_confidence_matrix.md) |
 | Provider promotion, fallback, blocker, and defer decisions by fact class | [provider_promotion_ledger.md](provider_promotion_ledger.md), [provider-promotion-ledger.toml](../../../policy/provider-promotion-ledger.toml) |

--- a/docs/specs/PLSP-SPEC-0009-workspace-trust-report.md
+++ b/docs/specs/PLSP-SPEC-0009-workspace-trust-report.md
@@ -6,6 +6,8 @@ Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-t
 Linked specs:
 - [PLSP-SPEC-0002](PLSP-SPEC-0002-provider-confidence-receipts.md)
 - [PLSP-SPEC-0003](PLSP-SPEC-0003-real-workspace-editor-baseline.md)
+- [PLSP-SPEC-0022](PLSP-SPEC-0022-module-path-authority.md)
+- [PLSP-SPEC-0023](PLSP-SPEC-0023-ambient-inputs.md)
 Linked ADRs:
 - [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
 Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)

--- a/docs/specs/PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md
+++ b/docs/specs/PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md
@@ -14,6 +14,8 @@ Linked specs:
 - [PLSP-SPEC-0018](PLSP-SPEC-0018-edit-authorization-contract.md)
 - [PLSP-SPEC-0019](PLSP-SPEC-0019-semantic-token-class-promotion-contract.md)
 - [PLSP-SPEC-0020](PLSP-SPEC-0020-workspace-symbol-generated-label-contract.md)
+- [PLSP-SPEC-0022](PLSP-SPEC-0022-module-path-authority.md)
+- [PLSP-SPEC-0023](PLSP-SPEC-0023-ambient-inputs.md)
 Linked ADRs:
 - [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
 - [PLSP-ADR-0003](../adr/PLSP-ADR-0003-preview-before-edit.md)

--- a/docs/specs/PLSP-SPEC-0017-fact-provenance-and-source-backing.md
+++ b/docs/specs/PLSP-SPEC-0017-fact-provenance-and-source-backing.md
@@ -10,6 +10,8 @@ Linked specs:
 - [PLSP-SPEC-0016](PLSP-SPEC-0016-provider-decision-receipt-v1.md)
 - [PLSP-SPEC-0018](PLSP-SPEC-0018-edit-authorization-contract.md)
 - [PLSP-SPEC-0020](PLSP-SPEC-0020-workspace-symbol-generated-label-contract.md)
+- [PLSP-SPEC-0022](PLSP-SPEC-0022-module-path-authority.md)
+- [PLSP-SPEC-0023](PLSP-SPEC-0023-ambient-inputs.md)
 Linked ADRs:
 - [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
 Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)

--- a/docs/specs/PLSP-SPEC-0022-module-path-authority.md
+++ b/docs/specs/PLSP-SPEC-0022-module-path-authority.md
@@ -1,0 +1,186 @@
+# PLSP-SPEC-0022: Module path authority
+
+Status: accepted
+Owner: perl-lsp maintainers
+Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked specs:
+- [PLSP-SPEC-0009](PLSP-SPEC-0009-workspace-trust-report.md)
+- [PLSP-SPEC-0015](PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md)
+- [PLSP-SPEC-0017](PLSP-SPEC-0017-fact-provenance-and-source-backing.md)
+- [PLSP-SPEC-0023](PLSP-SPEC-0023-ambient-inputs.md)
+Linked ADRs:
+- [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Status impact: module resolution status, workspace trust report, provider
+confidence matrix, support tiers, determinism planning
+
+## Current Implementation Status
+
+The current module-resolution rail is tracked in
+[module_resolution.md](../project/status/module_resolution.md). That status
+page owns current consumer conformance, include-root classification, and
+receipt history.
+
+This spec defines authority rules for module paths and `@INC` inputs. It does
+not change module resolution, DAP launch behavior, subprocess seams, or support
+tiers in the PR that adds the spec.
+
+## Contract
+
+Module-path authority is the right of an input to affect a resolver,
+subprocess, provider answer, trust report, or future determinism receipt.
+Inputs with similar path shapes do not have the same authority.
+
+Every module-path input must be classified before it can influence behavior:
+
+| Input | Authority |
+| --- | --- |
+| Workspace `perl.workspace.includePaths` | Compiler and LSP resolver input inside the workspace configuration boundary. |
+| Lexical `use lib` / `no lib` | Source-backed, position-scoped resolver input. |
+| FindBin-derived lexical paths | Source-backed, file-scoped resolver input when the pattern is modeled. |
+| `PERL5LIB` | Ambient input, visible only when the configured surface opts into it. |
+| Interpreter startup `@INC` | Ambient oracle input, visible only when the configured surface opts into it. |
+| DAP `includePaths` | DAP report/config metadata only unless a separate behavior receipt promotes native DAP module-path authority. |
+| Launch `env.PERL5LIB` | Current DAP launch/syntax-check module-path authority for launch subprocess behavior. |
+| `perldoc` | Helper/oracle boundary, not compiler truth. |
+| Real Perl subprocesses | Differential oracle boundary, not editor-runtime dependency. |
+
+No provider, report, or future compiler surface may silently treat an ambient,
+report-only, or oracle input as workspace source.
+
+## Authority Rules
+
+### Workspace Include Paths
+
+Configured include paths are explicit workspace configuration. They may
+participate in LSP resolver behavior, provider receipts, and compiler
+environment facts when the receiving surface is already allowed to consume
+workspace configuration.
+
+They must remain labeled as configured roots in receipts and reports. They are
+not source-backed declarations, and they do not prove that a symbol is defined
+in workspace source.
+
+### Lexical Module Paths
+
+Lexical `use lib`, `no lib`, and modeled FindBin-derived paths are source-backed
+resolver inputs. Their authority is position-scoped and must preserve
+`no lib` cancellation semantics.
+
+These inputs may support module-resolution providers when the resolver uses the
+current document position. They must not be cached or lifted into a
+workspace-wide truth without preserving the source anchor and scope.
+
+### PERL5LIB
+
+`PERL5LIB` is an ambient input. It may affect module resolution only for
+surfaces whose configuration explicitly opts into that authority.
+
+Receipts and reports must label `PERL5LIB` as ambient. It must not be merged
+into workspace source facts, silently used by subprocess oracles that disabled
+it, or used to promote provider support without a receipt that names the
+authority.
+
+### Interpreter Startup `@INC`
+
+Interpreter startup `@INC` is an oracle-derived ambient input. It may affect
+module resolution only when the configured surface opts into system include
+roots.
+
+Startup `@INC` probes are subprocess seams. Their failures must be explicit and
+fail closed. Startup `@INC` does not prove source-backed symbols or workspace
+ownership.
+
+### DAP Include Paths
+
+DAP `includePaths` are report/config metadata by default. They may be counted,
+classified, and displayed by the workspace trust report, but they are not
+native `@INC` authority for syntax-check or debug-launch subprocess behavior
+unless a separate DAP behavior receipt promotes that fact class.
+
+Until such a receipt exists, launch `env.PERL5LIB` remains the current
+module-path authority for DAP launch and syntax-check subprocess behavior.
+
+### Perldoc And Real Perl
+
+`perldoc` and real Perl subprocesses are helper/oracle seams. They may support
+documentation lookup, setup reporting, or differential conformance receipts
+when their specs allow it.
+
+They must not become implicit editor-runtime dependencies, source-backed facts,
+or provider cutover evidence without a separate receipt.
+
+## Valid PR Shapes
+
+Valid PRs under this spec include:
+
+- docs PRs that clarify module-path authority without behavior changes
+- receipt PRs that prove one resolver consumer respects an existing authority
+- DAP behavior PRs that explicitly promote or defer one DAP module-path fact
+  class
+- workspace trust report PRs that report sanitized path classes without
+  changing resolver behavior
+- determinism PRs that classify module roots and ambient inputs
+
+Every valid PR must say whether it changes docs, receipts, resolver behavior,
+DAP launch behavior, subprocess seams, trust-report rendering, or support
+claims.
+
+## Invalid PR Shapes
+
+Invalid PRs include:
+
+- treating DAP `includePaths` as native `@INC` authority from report metadata
+  alone
+- treating `PERL5LIB` or system `@INC` as workspace source
+- using ambient paths to authorize rename, safe-delete, exact generated
+  locations, or diagnostic suppression without provider-specific proof
+- running Perl, `perldoc`, DAP, or workspace scans from explanation-only or
+  report-only surfaces
+- promoting module-resolution support tiers from documentation alone
+- broadening provider behavior from include-root plumbing without a promotion
+  ledger row and receipt
+
+## Acceptance
+
+A PR satisfies this spec when:
+
+- every touched module-path input is classified by authority
+- ambient inputs remain labeled as ambient
+- report-only metadata does not change resolver or subprocess behavior
+- DAP launch and syntax-check authority remains explicit
+- subprocess oracle seams preserve their opt-in environment rules
+- provider decisions and trust reports expose the authority boundary when
+  module paths participate
+- support-tier wording follows receipts rather than inferred setup state
+
+## Proof Commands
+
+Docs-only PRs for this spec may use:
+
+```bash
+cargo xtask ci-hygiene check-doc-paths docs/specs
+cargo xtask check-support-claims
+cargo xtask check-provider-confidence-matrix
+git diff --check
+```
+
+Resolver, DAP, trust-report, or provider PRs must also run the focused tests
+for the touched surface and any provider-ledger checks required by the
+promotion row.
+
+## Non-goals
+
+- No module-resolution behavior change from this spec alone.
+- No DAP launch or syntax-check behavior change.
+- No workspace trust report probing.
+- No `perldoc` or real-Perl subprocess promotion.
+- No provider cutover or support-tier promotion.
+- No determinism receipt implementation.
+
+## Claim Boundaries
+
+This spec may claim that module-path inputs have explicit authority classes. It
+may not claim that all module resolution is complete, DAP `includePaths` are
+native `@INC` authority, ambient roots are workspace source, or real Perl is an
+editor-runtime dependency.

--- a/docs/specs/PLSP-SPEC-0023-ambient-inputs.md
+++ b/docs/specs/PLSP-SPEC-0023-ambient-inputs.md
@@ -1,0 +1,171 @@
+# PLSP-SPEC-0023: Ambient inputs
+
+Status: accepted
+Owner: perl-lsp maintainers
+Linked proposal: [PLSP-PROP-0001](../proposals/PLSP-PROP-0001-real-perl-editor-trust.md)
+Linked specs:
+- [PLSP-SPEC-0009](PLSP-SPEC-0009-workspace-trust-report.md)
+- [PLSP-SPEC-0015](PLSP-SPEC-0015-real-perl-editor-trust-v1-boundary.md)
+- [PLSP-SPEC-0017](PLSP-SPEC-0017-fact-provenance-and-source-backing.md)
+- [PLSP-SPEC-0022](PLSP-SPEC-0022-module-path-authority.md)
+Linked ADRs:
+- [PLSP-ADR-0002](../adr/PLSP-ADR-0002-confidence-before-cutover.md)
+Linked plan: [Real Perl Editor Trust implementation plan](../../plans/real-perl-editor-trust/implementation-plan.md)
+Status impact: workspace trust report, module resolution status, provider
+decision receipts, determinism planning, support tiers
+
+## Current Implementation Status
+
+Current ambient setup state is reported through the workspace trust report and
+module-resolution status. Existing code already distinguishes configured roots,
+`PERL5LIB`, startup `@INC`, DAP/client state, perldoc configuration, and Perl
+oracle seams in several provider and runtime paths.
+
+This spec defines the shared ambient-input contract for Real Perl Editor Trust
+and future determinism receipts. It does not introduce a new runtime registry,
+JSON schema, provider behavior, or subprocess behavior in the PR that adds the
+spec.
+
+## Contract
+
+An ambient input is any fact source that can affect Perl behavior without being
+an explicit source declaration in the analyzed workspace document.
+
+Ambient inputs may be reported, labeled, redacted, and used only by surfaces
+whose specs grant that authority. They must not be silently converted into
+source-backed facts.
+
+Ambient input classes include:
+
+| Class | Examples | Default authority |
+| --- | --- | --- |
+| WorkspaceConfig | configured include paths, configured Perl binary, configured flags | Explicit configuration input for the configured surface. |
+| SourceScopedConfig | lexical `use lib`, `no lib`, modeled FindBin paths | Source-backed resolver input with source scope. |
+| ProcessEnvironment | `PERL5LIB`, `PERL5OPT`, `HOME`, local::lib activation variables | Ambient; opt-in or denied by subprocess seam. |
+| InterpreterState | startup `@INC`, Perl version, core library roots | Oracle-derived ambient state. |
+| ClientRuntimeState | VS Code DAP/perldoc state, launch configuration counts, path classes | Report metadata only unless promoted by behavior proof. |
+| GeneratedRoots | `blib`, generated roots, build output roots | Ambient/generated; labeled and never workspace source by default. |
+| ExternalOracle | `perldoc`, real Perl, CPAN-installed modules | Helper or differential oracle boundary. |
+| UnknownAmbient | unclassified external influence | Fallback, block, or defer. |
+
+## Ambient Rules
+
+### Reporting
+
+Ambient inputs may appear in workspace trust reports, provider decision
+receipts, diagnostics explanations, module-resolution summaries, and future
+determinism receipts when they are labeled with their class and authority.
+
+Reports should prefer path classes, counts, root classes, hashes, and sanitized
+labels over raw paths when raw values are not required to explain behavior.
+
+### Provider Behavior
+
+Provider behavior may consume ambient inputs only when a spec and support row
+name that authority. If an ambient input participates in a provider decision,
+the decision receipt must show the fact source, confidence or unavailability,
+freshness when meaningful, fallback state, and blocker or claim boundary.
+
+Ambient inputs must not authorize rename, safe-delete, exact generated method
+body locations, or broad diagnostic suppression unless a provider-specific
+promotion row and receipt explicitly allow it.
+
+### Subprocess Seams
+
+Subprocess seams must state which ambient environment variables are allowed,
+denied, or explicitly supplied. Denied ambient inputs must not leak through by
+default.
+
+`PERL5LIB`, `PERL5OPT`, `HOME`, local::lib variables, and configured launch
+environment values are distinct authorities. A surface that allows one of them
+does not automatically allow the others.
+
+### Determinism
+
+Future determinism receipts must classify ambient inputs instead of hiding them
+inside deterministic claims.
+
+Suggested determinism projection:
+
+```text
+deterministic:
+  no relevant unmodeled ambient input participates
+
+bounded_dynamic:
+  ambient inputs participate but are explicitly configured, labeled, and bounded
+
+non_deterministic:
+  ambient or dynamic behavior affects compile facts without a bounded model
+
+unknown:
+  ambient input coverage is incomplete, stale, or unclassified
+```
+
+## Valid PR Shapes
+
+Valid PRs under this spec include:
+
+- docs PRs that clarify ambient-input authority without behavior changes
+- workspace trust report PRs that add sanitized ambient classes from already
+  known state
+- provider decision PRs that expose ambient blockers or fallback reasons
+- subprocess seam PRs that deny, allow, or explicitly supply one ambient input
+  class with tests
+- determinism PRs that classify ambient inputs in receipts
+
+## Invalid PR Shapes
+
+Invalid PRs include:
+
+- treating ambient inputs as workspace source
+- hiding `PERL5LIB`, startup `@INC`, DAP metadata, generated roots, perldoc, or
+  real Perl oracle output inside exact provider claims
+- probing Perl, running `perldoc`, starting DAP, inspecting debug sessions, or
+  scanning the workspace from report-only surfaces
+- exposing raw secrets, tokens, private environment values, or unnecessary raw
+  launch paths
+- promoting support tiers from ambient reporting alone
+- using unclassified ambient evidence to authorize edits
+
+## Acceptance
+
+A PR satisfies this spec when:
+
+- every touched ambient input has a class and authority
+- report-only surfaces stay read-only and sanitized
+- subprocess seams preserve explicit allow/deny behavior
+- provider receipts expose ambient fallback or blocker state when relevant
+- edit-producing providers treat ambient-only evidence as fallback, preview, or
+  blocked unless a promotion row proves otherwise
+- determinism-facing work records ambient inputs instead of erasing them
+- support claims do not outgrow receipts
+
+## Proof Commands
+
+Docs-only PRs for this spec may use:
+
+```bash
+cargo xtask ci-hygiene check-doc-paths docs/specs
+cargo xtask check-support-claims
+cargo xtask check-provider-confidence-matrix
+git diff --check
+```
+
+Runtime or provider PRs must also run the focused tests for the changed
+subprocess seam, provider, trust-report, diagnostic, module-resolution, or
+determinism surface.
+
+## Non-goals
+
+- No new ambient-input registry from this spec alone.
+- No provider behavior change.
+- No workspace trust report probing.
+- No DAP launch behavior change.
+- No determinism receipt implementation.
+- No real Perl replacement claim.
+
+## Claim Boundaries
+
+This spec may claim that ambient inputs must be labeled, bounded, and kept out
+of exact source-backed claims. It may not claim that every ambient input is
+fully modeled, deterministic, safe for edits, or available to every provider.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -41,6 +41,8 @@ generated sections.
 - [PLSP-SPEC-0019: Semantic token class promotion contract](PLSP-SPEC-0019-semantic-token-class-promotion-contract.md)
 - [PLSP-SPEC-0020: Workspace symbol generated-label contract](PLSP-SPEC-0020-workspace-symbol-generated-label-contract.md)
 - [PLSP-SPEC-0021: Diagnostic explanation v1](PLSP-SPEC-0021-diagnostic-explanation-v1.md)
+- [PLSP-SPEC-0022: Module path authority](PLSP-SPEC-0022-module-path-authority.md)
+- [PLSP-SPEC-0023: Ambient inputs](PLSP-SPEC-0023-ambient-inputs.md)
 
 ## Acceptance and Proof
 


### PR DESCRIPTION
Problem: Module-path and ambient-input authority were still routed through dashboard language instead of durable specs.
Fix: Add PLSP-SPEC-0022 and PLSP-SPEC-0023 to define module path authority, ambient input classes, invalid PR shapes, acceptance, and claim boundaries, then wire them into the spec catalog and trust dashboard links.
Verification: cargo xtask ci-hygiene check-doc-paths docs/specs passes; cargo xtask ci-hygiene check-doc-paths docs/project/status passes; cargo xtask check-support-claims passes; cargo xtask check-provider-confidence-matrix passes; cargo xtask check-provider-promotion-ledger passes; git diff --cached --check passes.