### PR TITLE
docs(spec): align receiver fallback cutover wording (#8197)

### DIFF
--- a/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
+++ b/docs/specs/PLSP-SPEC-0005-receiver-expression-facts.md
@@ -329,10 +329,13 @@ The handoff shape is:
    arrow context.
 2. Workspace method completion receives the optional receiver fact.
 3. Receiver evidence is derived from the fact when present.
-4. Legacy text-pattern classification runs only when no semantic receiver fact
-   is available.
-5. Exact package completion uses `ReceiverFact.package`.
-6. Unknown or dynamic receivers fall back according to provider confidence rules
+4. Exact receiver behavior may use `ReceiverFact.package` only when
+   `fallback_state == Exact` and provider-specific confidence guards pass.
+5. Legacy text-pattern classification remains available when no semantic
+   receiver fact is available or when the semantic receiver fact is `Fallback`.
+6. `Blocked` receiver facts must not authorize completion, navigation, or
+   edit-producing behavior.
+7. Unknown or dynamic receivers fall back according to provider confidence rules
    and must not be labeled as exact semantic receivers.
 
 Completion details for exact receiver facts should include receiver kind,


### PR DESCRIPTION
Problem: #9542 added `ReceiverFallbackState`, but the provider handoff text still said legacy text-pattern classification runs only when no semantic receiver fact exists. That contradicts the new `Fallback` contract and the current completion implementation.

Fix: Tighten the provider cutover steps so exact behavior requires `fallback_state == Exact`, fallback facts preserve legacy classification, and blocked facts cannot authorize completion/navigation/edit-producing behavior.

Verification:
- `MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe test -p perl-semantic-analyzer --lib receiver_facts --profile agent --locked -- --nocapture`
- `MIN_FREE_GB=20 MAX_USED_PCT=95 CARGO_LOCK_WAIT=900 ./scripts/cargo-safe xtask ci-hygiene check-doc-paths docs/specs`
- `git diff --check`
- `./scripts/storage-doctor`

Claim boundary: docs/spec wording only. No runtime behavior change and no provider support-tier promotion.