### PR TITLE
fix(dead-code): correct is_always_false docstring and rename postfix modifier constant (#9009)

### DIFF
--- a/crates/perl-parser/src/dead_code/mod.rs
+++ b/crates/perl-parser/src/dead_code/mod.rs
@@ -239,16 +239,17 @@ fn detect_unconditional_terminator(trimmed: &str) -> Option<&str> {
         None => after_terminator,
     }
     .trim_start();
-    if contains_postfix_condition(remainder) {
+    if contains_postfix_modifier(remainder) {
         return None;
     }
 
     Some(first)
 }
 
-fn contains_postfix_condition(remainder: &str) -> bool {
-    const CONDITIONS: [&str; 7] = ["if", "unless", "when", "while", "until", "for", "foreach"];
-    CONDITIONS.iter().any(|keyword| contains_keyword(remainder, keyword))
+fn contains_postfix_modifier(remainder: &str) -> bool {
+    const POSTFIX_MODIFIERS: [&str; 7] =
+        ["if", "unless", "when", "while", "until", "for", "foreach"];
+    POSTFIX_MODIFIERS.iter().any(|keyword| contains_keyword(remainder, keyword))
 }
 
 fn contains_keyword(text: &str, keyword: &str) -> bool {
@@ -266,7 +267,11 @@ fn is_keyword_boundary(ch: Option<char>) -> bool {
 /// Returns `true` if `condition` is a trivially-false constant expression.
 ///
 /// Matches: `0`, `""`, `''`, `undef`, `(0)`, `( 0 )` — the standard Perl idioms
-/// used to write permanently-dead `if`/`while`/`for` blocks.
+/// used to write permanently-dead `if`/`while`/`elsif` blocks.
+///
+/// Note: `for`/`foreach` are intentionally **not** guarded by this function.
+/// `for (0) {}` iterates once with `$_ = 0`; it is a list iterator, not a
+/// boolean guard, so it is never dead code.
 fn is_always_false(condition: &str) -> bool {
     let c = condition.trim();
     matches!(c, "0" | "\"\"" | "''" | "undef")

--- a/crates/perl-parser/tests/dead_code_detector.rs
+++ b/crates/perl-parser/tests/dead_code_detector.rs
@@ -214,3 +214,63 @@ fn for_loop_with_undef_is_not_dead_branch() -> TestResult {
     );
     Ok(())
 }
+
+#[test]
+fn for_loop_with_explicit_variable_is_not_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "for my $x (0) {\n    say $x;\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "for my $x (0) iterates once with $x = 0; it is not dead code"
+    );
+    Ok(())
+}
+
+#[test]
+fn foreach_loop_with_explicit_variable_is_not_dead_branch() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "foreach my $x (0) {\n    say $x;\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        !dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "foreach my $x (0) iterates once with $x = 0; it is not dead code"
+    );
+    Ok(())
+}
+
+#[test]
+fn unless_with_always_true_condition_is_flagged() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "unless (1) {\n    say 'never runs';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "unless (1) body is never executed; should be flagged as a dead branch"
+    );
+    Ok(())
+}
+
+#[test]
+fn until_with_always_true_condition_is_flagged() -> TestResult {
+    let index = WorkspaceIndex::new();
+    index_file_str(&index, "file:///script.pl", "until (1) {\n    say 'never runs';\n}\n")?;
+
+    let detector = DeadCodeDetector::new(index);
+    let dead = detector.analyze_file(&PathBuf::from("/script.pl"))?;
+
+    assert!(
+        dead.iter().any(|d| d.code_type == DeadCodeType::DeadBranch),
+        "until (1) body is never executed; should be flagged as a dead branch"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9009. Three focused correctness improvements to the dead-code detector in `crates/perl-parser/src/dead_code/mod.rs`, plus four new regression tests.

## What changed

### 1. Rename `contains_postfix_condition` → `contains_postfix_modifier`

The function detects Perl **postfix statement modifiers** (`if`, `unless`, `when`, `while`, `until`, `for`, `foreach`) on a `return`/`die` line that make the terminator conditional. The old name `contains_postfix_condition` was misleading because `for`/`foreach` are list iterators, not boolean conditions — yet they are correctly included here (a postfix `die ... for @list` is conditional, not unconditional). Renamed to `contains_postfix_modifier` to match what the function actually does.

### 2. Rename constant `CONDITIONS` → `POSTFIX_MODIFIERS`

Same reasoning. The array holds postfix modifiers; calling it `CONDITIONS` made readers wonder why `for`/`foreach` — which don't evaluate boolean conditions — were in a list named `CONDITIONS`.

### 3. Fix `is_always_false` docstring

The doc comment previously said:

> `0`, `""`, `''`, `undef`, `(0)`, `( 0 )` — the standard Perl idioms used to write permanently-dead **`if`/`while`/`for` blocks**.

This is factually wrong: `for (0) {}` iterates **once** with `$_ = 0`. It is not dead code. The corrected comment says `if`/`while`/`elsif` and adds an explicit note explaining why `for`/`foreach` are intentionally excluded from the dead-branch detector. Without this note, a future developer reading `is_always_false` would reasonably believe calling it on a `for` condition is valid — and could re-introduce the false-positive that issue #9009 describes.

### 4. Add four new tests (12 → 16)

| Test | Assertion |
|------|-----------|
| `for_loop_with_explicit_variable_is_not_dead_branch` | `for my $x (0) {}` is **not** flagged — iterates once with `$x = 0` |
| `foreach_loop_with_explicit_variable_is_not_dead_branch` | `foreach my $x (0) {}` is **not** flagged — same semantics |
| `unless_with_always_true_condition_is_flagged` | `unless (1) {}` **is** flagged — body never executes |
| `until_with_always_true_condition_is_flagged` | `until (1) {}` **is** flagged — body never executes |

The first two guard the explicit-loop-variable syntax (`for my $x ...`) that the prior tests didn't cover. The last two prove the symmetric `unless`/`until` detection (implemented but previously untested).

## Why this matters

A misleading docstring on `is_always_false` is a maintenance hazard: it would lead any developer extending the dead-code detector to call `is_always_false` on `for` conditions, silently re-introducing the `for (0)` false-positive. Correcting it (plus the misnamed constant and function) closes the gap permanently.

## Test plan

```bash
# All 16 tests pass
cargo test -p perl-parser --test dead_code_detector

# No new clippy warnings
cargo clippy -p perl-parser --lib -- -D warnings -A missing_docs

# Format clean
cargo fmt -p perl-parser -- --check
```

## Files changed

| File | Change |
|------|--------|
| `crates/perl-parser/src/dead_code/mod.rs` | Rename function + constant; fix docstring (+7 lines) |
| `crates/perl-parser/tests/dead_code_detector.rs` | Four new test functions (+60 lines) |

https://claude.ai/code/session_017EpTa6pbxAnTyNT3WfFGRe

---
_Generated by [Claude Code](https://claude.ai/code/session_017EpTa6pbxAnTyNT3WfFGRe)_