### PR TITLE
docs(project): mark active development moved to swarm (#8197)

### DIFF
--- a/docs/project/status/development-moved-to-perl-lsp-swarm.md
+++ b/docs/project/status/development-moved-to-perl-lsp-swarm.md
@@ -1,0 +1,30 @@
+# Development Moved to perl-lsp-swarm
+
+Active development has moved to
+[`EffortlessMetrics/perl-lsp-swarm`](https://github.com/EffortlessMetrics/perl-lsp-swarm).
+
+`perl-lsp` remains the release, history, and canonical package-lineage repo until
+curated sync or release PRs promote swarm work back here.
+
+New feature work should target `perl-lsp-swarm`.
+
+## Repository Roles
+
+| Repo | Role |
+|---|---|
+| `perl-lsp-swarm` | Active development execution repo for agent lanes, proof receipts, spec hardening, promotion-ledger work, cleanup trains, and compiler substrate work |
+| `perl-lsp` | Release lineage, historical upstream, emergency release fixes, and curated sync target |
+
+## Sync Invariant
+
+`perl-lsp` must not advance ahead of `perl-lsp-swarm`.
+
+Routine work starts in `perl-lsp-swarm`. If an emergency release fix must land in
+`perl-lsp`, mirror or sync that change through `perl-lsp-swarm` before treating
+the old repo as current.
+
+## Current Boundary
+
+This marker is documentation only. It does not change provider behavior, support
+tiers, CI workflows, branch protection, package publication, or release
+automation.


### PR DESCRIPTION
Problem: the old perl-lsp repo needs a durable marker that routine development now targets perl-lsp-swarm.\n\nFix: add a release-lineage status note that names perl-lsp-swarm as the active execution repo, keeps perl-lsp as release/history/package lineage, and records the invariant that perl-lsp must not advance ahead of swarm.\n\nVerification:\n- rtk cargo xtask ci-hygiene check-doc-paths docs/project/status\n- rtk proxy git diff --cached --check\n\nNon-goals: no provider behavior, support-tier promotion, CI workflow, branch protection, package publication, release automation, or source-sync change.\n\nMerge note: do not merge this PR unless the same marker is represented in perl-lsp-swarm or a sync PR is ready, so perl-lsp master does not advance ahead of swarm.