### PR TITLE
docs(project): align swarm migration marker (#8197)

### DIFF
--- a/docs/project/status/development-moved-to-perl-lsp-swarm.md
+++ b/docs/project/status/development-moved-to-perl-lsp-swarm.md
@@ -4,7 +4,7 @@ Active development has moved to
 [`EffortlessMetrics/perl-lsp-swarm`](https://github.com/EffortlessMetrics/perl-lsp-swarm).
 
 `perl-lsp` remains the release, history, and canonical package-lineage repo until
-curated sync or release PRs promote swarm work back here.
+curated sync or release PRs promote swarm work back there.
 
 New feature work should target `perl-lsp-swarm`.
 


### PR DESCRIPTION
Problem: the release-lineage marker merged with wording that differs from the already-merged swarm marker.\n\nFix: align the old-repo marker text to the swarm copy so perl-lsp does not carry a divergent marker.\n\nVerification:\n- rtk cargo xtask ci-hygiene check-doc-paths docs/project/status\n- rtk proxy git diff --check\n\nNon-goals: no provider behavior, support-tier promotion, CI workflow, branch protection, package publication, release automation, or source-sync change.