### PR TITLE
docs(swarm): add release-lineage sync protocol (#8197)

### DIFF
--- a/docs/swarm/sync-protocol.md
+++ b/docs/swarm/sync-protocol.md
@@ -1,0 +1,123 @@
+# perl-lsp Sync Protocol
+
+`perl-lsp-swarm` is the active development source of truth. `perl-lsp` is the
+release, history, and canonical package-lineage repo.
+
+This protocol is control-plane documentation only. It does not change branch
+protection, CI workflows, release automation, package publication, or provider
+behavior.
+
+## Source of Truth
+
+| Repo | Authority |
+|---|---|
+| `perl-lsp-swarm/main` | Active development, agent lanes, proof receipts, spec hardening, promotion-ledger work, cleanup trains, compiler substrate work |
+| `perl-lsp/master` | Release lineage, historical upstream, user-facing package lineage, emergency release fixes, curated sync target |
+
+Default routing:
+
+```text
+new development -> perl-lsp-swarm
+curated release sync -> perl-lsp
+emergency release fix -> perl-lsp, then immediate swarm mirror/sync
+```
+
+## Hard Invariant
+
+`perl-lsp/master` must not be ahead of `perl-lsp-swarm/main`.
+
+Before merging any `perl-lsp` PR, one of these must be true:
+
+1. The same change is already present in `perl-lsp-swarm/main`.
+2. A swarm sync PR that includes the change is ready to merge first.
+3. The change is an emergency release fix and a swarm mirror PR is opened before
+   the old-repo PR is treated as complete.
+
+If this invariant is uncertain, stop and sync swarm first.
+
+## Sync Directions
+
+### Swarm to perl-lsp
+
+Use for curated release syncs.
+
+Required before opening the old-repo sync PR:
+
+- list included swarm PRs
+- list excluded swarm PRs and why
+- run the relevant support/provider/status checks in swarm
+- preserve release notes and package-lineage docs
+- state whether the sync changes user-facing package behavior
+
+The old-repo PR body must link to the swarm source PRs and list verification.
+
+### perl-lsp to Swarm
+
+Use only for emergency release fixes or old-repo-only markers.
+
+Required before merging old `perl-lsp` work:
+
+- verify the same content exists in swarm, or merge a swarm mirror PR first
+- keep the old-repo PR scoped to release-lineage work
+- run the narrowest old-repo validation for the changed files
+- run the corresponding swarm validation after the mirror
+
+Source-to-swarm sync PRs should use merge commits when commit ancestry matters.
+Do not squash source-sync PRs that are meant to prove `source/master` ancestry.
+
+## Cadence
+
+Routine cadence:
+
+```text
+merge in swarm
+batch into curated release sync
+open old-repo sync PR
+verify release-lineage gates
+merge old-repo sync
+tag or publish only with explicit release approval
+```
+
+Emergency cadence:
+
+```text
+open old-repo emergency PR
+open or merge swarm mirror first
+merge old-repo emergency PR only after the invariant is preserved
+run post-merge support/provider/status checks
+```
+
+## Docs That Must Stay Aligned
+
+- `docs/swarm/operating-model.md`
+- `docs/swarm/review-rules.md`
+- `docs/swarm/sync-protocol.md`
+- `docs/project/status/development-moved-to-perl-lsp-swarm.md`
+- `docs/project/status/real_perl_editor_trust_v1.md`
+- `docs/project/status/provider_promotion_ledger.md`
+- `.perl-lsp/goals/active.toml`
+
+Do not duplicate generated status tables. Link to the status source instead.
+
+## Branch Protection Expectations
+
+This document does not configure branch protection.
+
+Expected policy:
+
+- `perl-lsp-swarm/main` remains the development integration branch.
+- `perl-lsp/master` accepts curated syncs and release-lineage work only.
+- Required checks must be green before merge unless a documented emergency
+  exception exists.
+- Branch deletion, force-push, history rewrite, tagging, package publish, and
+  GitHub release creation still require explicit approval.
+
+## Completion Criteria
+
+A sync is complete only when:
+
+- the target PR is merged
+- the source/target invariant is checked
+- required support/provider/status receipts are still valid
+- any excluded work is listed
+- release or publish claims are not made without explicit approval


### PR DESCRIPTION
Problem: the release-lineage repo needs the same sync protocol that already landed in perl-lsp-swarm.\n\nFix: add docs/swarm/sync-protocol.md matching the swarm copy, including source-of-truth roles, the old-main-not-ahead invariant, sync directions, cadence, aligned docs, and completion criteria.\n\nVerification:\n- rtk cargo xtask ci-hygiene check-doc-paths docs/swarm\n- rtk proxy git diff --cached --check\n\nNon-goals: no provider behavior, support-tier promotion, CI workflow, branch protection, package publication, release automation, or sync execution.