### PR TITLE
fix(diagnostics): expand from_message coverage for 4 common Perl compiler messages (#9553)

### DIFF
--- a/crates/perl-diagnostics/src/codes/metadata.rs
+++ b/crates/perl-diagnostics/src/codes/metadata.rs
@@ -537,6 +537,30 @@ impl DiagnosticCode {
             || contains_diagnostic_phrase(&msg_lower, "syntax error")
         {
             Some(Self::ParseError)
+        // Real Perl: "Use of uninitialized value $x in string at file.pl line N."
+        // Also: "Use of uninitialized value in concatenation (.) or string at file.pl line N."
+        } else if contains_diagnostic_phrase(&msg_lower, "uninitialized value") {
+            Some(Self::UninitializedVariable)
+        // Real Perl: "Can't locate Foo/Bar.pm in @INC (...) at file.pl line N."
+        } else if contains_diagnostic_phrase(&msg_lower, "can't locate")
+            && msg_lower.contains(".pm")
+        {
+            Some(Self::ModuleNotFound)
+        // Real Perl: `Bareword "foo" not allowed while 'strict subs' in use at file.pl line N.`
+        // Real Perl: "Unquoted string "foo" may clash with future reserved word at file.pl line N."
+        // Note: the actual bareword name is interpolated between "Bareword" and "not allowed",
+        // so we match on "strict subs" (unique to this warning) or "unquoted string".
+        } else if contains_diagnostic_phrase(&msg_lower, "strict subs")
+            || contains_diagnostic_phrase(&msg_lower, "unquoted string")
+            || contains_diagnostic_phrase(&msg_lower, "bareword not allowed")
+        {
+            Some(Self::UnquotedBareword)
+        // Real Perl: "defined(@array) is deprecated (it's always defined) at file.pl line N."
+        // Real Perl: "defined(%hash) is deprecated (it's always defined) at file.pl line N."
+        } else if msg_lower.contains("defined(")
+            && contains_diagnostic_phrase(&msg_lower, "deprecated")
+        {
+            Some(Self::DeprecatedDefined)
         } else {
             None
         }

--- a/crates/perl-diagnostics/tests/codes_comprehensive_unit_tests.rs
+++ b/crates/perl-diagnostics/tests/codes_comprehensive_unit_tests.rs
@@ -1125,6 +1125,119 @@ fn from_message_real_perl_prototype_mismatch() {
     );
 }
 
+/// Real Perl output: `Use of uninitialized value $x in string at script.pl line 5.`
+/// Also: `Use of uninitialized value in concatenation (.) or string at script.pl line 5.`
+#[test]
+fn from_message_real_perl_uninitialized_value() {
+    assert_eq!(
+        DiagnosticCode::from_message(
+            r#"Use of uninitialized value $x in string at script.pl line 5."#
+        ),
+        Some(DiagnosticCode::UninitializedVariable),
+    );
+    // Named variable omitted (common for array elements, hash values)
+    assert_eq!(
+        DiagnosticCode::from_message(
+            "Use of uninitialized value in concatenation (.) or string at script.pl line 5."
+        ),
+        Some(DiagnosticCode::UninitializedVariable),
+    );
+    // Case-insensitive
+    assert_eq!(
+        DiagnosticCode::from_message("USE OF UNINITIALIZED VALUE in numeric comparison"),
+        Some(DiagnosticCode::UninitializedVariable),
+    );
+    // Must not match messages that only say "uninitialized" without "value"
+    assert_eq!(DiagnosticCode::from_message("uninitialized pointer dereference"), None);
+}
+
+/// Real Perl output: `Can't locate Foo/Bar.pm in @INC (...) at script.pl line 3.`
+#[test]
+fn from_message_real_perl_cant_locate_module() {
+    assert_eq!(
+        DiagnosticCode::from_message(
+            "Can't locate Foo/Bar.pm in @INC (you may need to install the Foo::Bar module) (@INC contains: /usr/lib/perl5) at script.pl line 3."
+        ),
+        Some(DiagnosticCode::ModuleNotFound),
+    );
+    // Shorter form
+    assert_eq!(
+        DiagnosticCode::from_message("Can't locate Scalar/Util.pm in @INC"),
+        Some(DiagnosticCode::ModuleNotFound),
+    );
+    // Case-insensitive
+    assert_eq!(
+        DiagnosticCode::from_message("can't locate My/Module.pm in @inc"),
+        Some(DiagnosticCode::ModuleNotFound),
+    );
+    // Must not match "can't locate" without a .pm path (file I/O error, not module-not-found)
+    assert_eq!(DiagnosticCode::from_message("can't locate the configuration entry"), None,);
+}
+
+/// Real Perl output: `Bareword "foo" not allowed while 'strict subs' in use at script.pl line 7.`
+/// Also: `Unquoted string "foo" may clash with future reserved word at script.pl line 7.`
+#[test]
+fn from_message_real_perl_bareword_not_allowed() {
+    // Real Perl message has bareword name interpolated: `Bareword "foo" not allowed while 'strict subs'...`
+    // Matched via "strict subs" which is unique to this warning.
+    assert_eq!(
+        DiagnosticCode::from_message(
+            r#"Bareword "foo" not allowed while 'strict subs' in use at script.pl line 7."#
+        ),
+        Some(DiagnosticCode::UnquotedBareword),
+    );
+    // Case-insensitive: the phrase "strict subs" anchors this regardless of surrounding text
+    assert_eq!(
+        DiagnosticCode::from_message("BAREWORD NOT ALLOWED WHILE STRICT SUBS IN USE"),
+        Some(DiagnosticCode::UnquotedBareword),
+    );
+    // Compact form without surrounding context (also matched by "bareword not allowed" fallback)
+    assert_eq!(
+        DiagnosticCode::from_message("bareword not allowed"),
+        Some(DiagnosticCode::UnquotedBareword),
+    );
+    // "Unquoted string" variant
+    assert_eq!(
+        DiagnosticCode::from_message(
+            r#"Unquoted string "foo" may clash with future reserved word at script.pl line 7."#
+        ),
+        Some(DiagnosticCode::UnquotedBareword),
+    );
+    // Must not collide with BarewordFilehandle (already handled earlier in the chain)
+    assert_eq!(
+        DiagnosticCode::from_message("Bareword filehandle FOO detected"),
+        Some(DiagnosticCode::BarewordFilehandle),
+    );
+}
+
+/// Real Perl output: `defined(@array) is deprecated (it's always defined) at script.pl line 4.`
+/// Also: `defined(%hash) is deprecated (it's always defined) at script.pl line 4.`
+#[test]
+fn from_message_real_perl_defined_deprecated() {
+    assert_eq!(
+        DiagnosticCode::from_message(
+            "defined(@array) is deprecated (it's always defined) at script.pl line 4."
+        ),
+        Some(DiagnosticCode::DeprecatedDefined),
+    );
+    assert_eq!(
+        DiagnosticCode::from_message(
+            "defined(%hash) is deprecated (it's always defined) at script.pl line 4."
+        ),
+        Some(DiagnosticCode::DeprecatedDefined),
+    );
+    // Case-insensitive
+    assert_eq!(
+        DiagnosticCode::from_message("DEFINED(@ARRAY) IS DEPRECATED"),
+        Some(DiagnosticCode::DeprecatedDefined),
+    );
+    // "deprecated" alone without "defined(" must not match
+    assert_eq!(
+        DiagnosticCode::from_message("This feature is deprecated at script.pl line 4."),
+        None,
+    );
+}
+
 // --- DiagnosticCode: documentation_url coverage ---
 
 #[test]


### PR DESCRIPTION
## Summary

`DiagnosticCode::from_message` is called when `perl -c` stderr output is parsed so the LSP can attach a typed diagnostic code to a compiler message. Four very common real-world Perl messages were silently returning `None`, meaning the LSP showed them as unclassified text instead of surfacing actionable diagnostic metadata (documentation links, code action suggestions, severity).

## What changed

### `crates/perl-diagnostics/src/codes/metadata.rs` — 4 new arms in `from_message`

**`UninitializedVariable` (PL110)**
```
Use of uninitialized value $x in string at file.pl line 5.
Use of uninitialized value in concatenation (.) or string at file.pl line 5.
```
Matched via `"uninitialized value"`. This is Perl's most frequently seen runtime warning and was entirely unhandled. It fires when a variable that has never been assigned is read.

**`ModuleNotFound` (PL701)**
```
Can't locate Foo/Bar.pm in @INC (you may need to install the Foo::Bar module) at file.pl line 3.
```
Matched via `"can't locate"` + `.pm` guard (distinguishes module-load failures from unrelated I/O errors). Actionable: the editor can now suggest `cpanm Foo::Bar`.

**`UnquotedBareword` (PL109)**
```
Bareword "foo" not allowed while 'strict subs' in use at file.pl line 7.
Unquoted string "foo" may clash with future reserved word at file.pl line 7.
```
Matched via `"strict subs"` (unique to this warning) and `"unquoted string"`. The existing `"bareword filehandle"` arm fires first so there is zero collision risk. The phrase `"bareword not allowed"` cannot be used as a single phrase because Perl interpolates the bareword name in the middle: `Bareword "name" not allowed`.

**`DeprecatedDefined` (PL500)**
```
defined(@array) is deprecated (it's always defined) at file.pl line 4.
defined(%hash) is deprecated (it's always defined) at file.pl line 4.
```
Matched via `"defined("` + `"deprecated"`. The `.contains("defined(")` guard ensures only the array/hash `defined()` form fires, not unrelated deprecation notices.

### `crates/perl-diagnostics/tests/codes_comprehensive_unit_tests.rs` — 4 new test functions

Each function covers:
- The real Perl message form (exact output from `perl -c`)
- A case-insensitive variant (from_message lowercases before matching)
- At least one negative assertion that a superficially similar message does NOT trigger the wrong code

| Test function | Assertions | What's guarded |
|---|---|---|
| `from_message_real_perl_uninitialized_value` | 4 | "uninitialized pointer" must not match |
| `from_message_real_perl_cant_locate_module` | 4 | "can't locate" without `.pm` must not match |
| `from_message_real_perl_bareword_not_allowed` | 5 | `BarewordFilehandle` collision guard |
| `from_message_real_perl_defined_deprecated` | 4 | bare "deprecated" without `defined(` must not match |

## Why this matters

These four messages cover the daily workflow of any Perl developer running `perl -c` checks through the LSP:
- Strict-mode variable errors (`UninitializedVariable`)
- Missing module installs (`ModuleNotFound`)
- Strict-subs bareword errors (`UnquotedBareword`)
- Legacy deprecated-defined patterns (`DeprecatedDefined`)

Without these arms, users saw generic unclassified errors. With them, each message gets a code, a documentation link, a severity level, and (for `ModuleNotFound`) a potential code action.

## Verification

```bash
cargo test -p perl-diagnostics                  # 388 tests pass, 0 failed
cargo clippy -p perl-diagnostics --lib --tests  # clean
cargo fmt --check -p perl-diagnostics           # clean
cargo check --workspace --lib                   # workspace clean
```

All 388 `perl-diagnostics` tests pass. No new warnings. Formatted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHoV9gJvR4Q1cpAAYPYBAS)_