### PR TITLE
feat(code-actions): add quick-fix handlers for PL700, PL501, PL602

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -184,6 +184,18 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         c if c == DiagnosticCode::DuplicateHashKey.as_str() => {
             actions.extend(quick_fixes::fix_duplicate_hash_keys(source, &qf_diag));
         }
+        // PL700: Unused import
+        c if c == DiagnosticCode::UnusedImport.as_str() => {
+            actions.extend(quick_fixes::fix_unused_import(source, &qf_diag));
+        }
+        // PL501: Deprecated $[ array base variable
+        c if c == DiagnosticCode::DeprecatedArrayBase.as_str() => {
+            actions.extend(quick_fixes::fix_deprecated_array_base(source, &qf_diag));
+        }
+        // PL602: Global signal handler assignment
+        c if c == DiagnosticCode::SecuritySignalHandler.as_str() => {
+            actions.extend(quick_fixes::fix_security_signal_handler(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1641,3 +1641,94 @@ fn split_two_top_level_args(input: &str) -> Option<(&str, &str)> {
 
     Some((first, second))
 }
+
+/// Remove an unused `use Module;` import statement (PL700).
+///
+/// When a module is imported but never referenced in the file, this fix
+/// deletes the entire `use Module;` line so no blank line is left behind.
+/// The module name is extracted from the diagnostic message
+/// (`"Module 'Foo::Bar' appears to be unused"`).
+pub fn fix_unused_import(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let start = diagnostic.range.0.min(source.len());
+    let end = diagnostic.range.1.min(source.len());
+
+    let line_start = source[..start].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let line_end = source[end..].find('\n').map(|p| end + p + 1).unwrap_or(source.len());
+
+    let module_name = diagnostic.message.split('\'').nth(1).unwrap_or("module");
+
+    vec![CodeAction {
+        title: format!("Remove unused 'use {};'", module_name),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::UnusedImport.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: line_start, end: line_end },
+                new_text: String::new(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Remove a deprecated `$[` array-base variable assignment (PL501).
+///
+/// `$[` was a Perl variable that changed the starting index for arrays and
+/// string operations. It has been deprecated since Perl 5.12. This fix removes
+/// the whole line containing the `$[` reference. Removing `$[ = 0;` is always
+/// safe (0 is the permanent default in modern Perl). Removing `$[ = N;` for
+/// N ≠ 0 may require renumbering array subscripts elsewhere in the file.
+pub fn fix_deprecated_array_base(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let start = diagnostic.range.0.min(source.len());
+    let end = diagnostic.range.1.min(source.len());
+
+    let line_start = source[..start].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    let line_end = source[end..].find('\n').map(|p| end + p + 1).unwrap_or(source.len());
+
+    vec![CodeAction {
+        title: "Remove deprecated '$[' array base assignment".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::DeprecatedArrayBase.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: line_start, end: line_end },
+                new_text: String::new(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Scope a global signal handler assignment with `local` (PL603).
+///
+/// A bare `$SIG{__DIE__} = ...` or `$SIG{__WARN__} = ...` at file scope
+/// changes signal handling for the whole process. Prepending `local` limits
+/// the effect to the enclosing block so the original handler is restored on
+/// scope exit, preventing the hook from leaking into unrelated call stacks.
+pub fn fix_security_signal_handler(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let insert_pos = diagnostic.range.0.min(source.len());
+
+    let at_pos = source.get(insert_pos..).unwrap_or("");
+    if !at_pos.starts_with("$SIG")
+        && !at_pos.starts_with("$main::SIG")
+        && !at_pos.starts_with("$::SIG")
+    {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: "Add 'local' to scope signal handler to the current block".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::SecuritySignalHandler.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: insert_pos, end: insert_pos },
+                new_text: "local ".to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_new_codes_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_new_codes_bdd.rs
@@ -1,0 +1,344 @@
+//! BDD tests for quick-fix handlers added in this release:
+//!   PL700 — Unused import (`fix_unused_import`)
+//!   PL501 — Deprecated `$[` array base (`fix_deprecated_array_base`)
+//!   PL602 — Global signal handler (`fix_security_signal_handler`)
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a specific anti-pattern
+//!   WHEN   diagnostics are produced and code actions are requested
+//!   THEN   exactly the expected action(s) are returned with correct edits
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply the first matching edit from an action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+/// Find the first action whose title matches the predicate.
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL700 — Unused import
+// ===========================================================================
+
+#[test]
+fn unused_import_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a file that imports a module but never uses it
+    let source = "use strict;\nuse List::Util;\nmy $x = 1;\n";
+
+    let use_start = source.find("use List::Util;").ok_or("marker not found")?;
+    let use_end = use_start + "use List::Util;".len();
+
+    let diag = make_diag(use_start, use_end, "PL700", "Module 'List::Util' appears to be unused");
+
+    // WHEN code actions are requested for the diagnostic range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering removal of the import
+    let action = find_action(&actions, |t| t.contains("List::Util"))
+        .ok_or_else(|| format!("no remove action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove unused 'use List::Util;'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the removal action should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn unused_import_edit_deletes_entire_line() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source where the unused import is sandwiched between other lines
+    let source = "use strict;\nuse POSIX;\nuse warnings;\n";
+    let use_start = source.find("use POSIX;").ok_or("marker not found")?;
+    let use_end = use_start + "use POSIX;".len();
+
+    let diag = make_diag(use_start, use_end, "PL700", "Module 'POSIX' appears to be unused");
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("POSIX"))
+        .ok_or_else(|| format!("no POSIX action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN the `use POSIX;\n` line is completely removed — no blank line left
+    assert_eq!(result, "use strict;\nuse warnings;\n");
+
+    Ok(())
+}
+
+#[test]
+fn unused_import_at_start_of_file_leaves_no_blank_line() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use LWP::UserAgent;\nuse strict;\n";
+    let use_end = "use LWP::UserAgent;".len();
+
+    let diag = make_diag(0, use_end, "PL700", "Module 'LWP::UserAgent' appears to be unused");
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("LWP::UserAgent"))
+        .ok_or_else(|| format!("no LWP::UserAgent action in: {:?}", actions))?;
+    let result = edited(source, action);
+    assert_eq!(result, "use strict;\n");
+
+    Ok(())
+}
+
+#[test]
+fn unused_import_title_uses_module_name_from_message() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "use Foo::Bar::Baz;\n";
+    let use_end = "use Foo::Bar::Baz;".len();
+    let diag = make_diag(0, use_end, "PL700", "Module 'Foo::Bar::Baz' appears to be unused");
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Foo::Bar::Baz"))
+        .ok_or_else(|| format!("no Foo::Bar::Baz action in: {:?}", actions))?;
+    assert_eq!(action.title, "Remove unused 'use Foo::Bar::Baz;'");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL501 — Deprecated `$[` array base variable
+// ===========================================================================
+
+#[test]
+fn deprecated_array_base_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN code that assigns to the deprecated $[ variable
+    let source = "use strict;\n$[ = 0;\nmy @arr = (1, 2, 3);\n";
+    let dollar_start = source.find("$[").ok_or("marker not found")?;
+    let dollar_end = dollar_start + 2; // "$[" is two bytes
+
+    let diag = make_diag(
+        dollar_start,
+        dollar_end,
+        "PL501",
+        "Use of '$[' is deprecated and will be removed",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering removal
+    let action = find_action(&actions, |t| t.contains("$['"))
+        .ok_or_else(|| format!("no '$[' action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove deprecated '$[' array base assignment");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn deprecated_array_base_edit_removes_entire_statement_line()
+-> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a standalone `$[ = 0;` line between two other statements
+    let source = "use strict;\n$[ = 0;\nmy @arr = ();\n";
+    let dollar_start = source.find("$[").ok_or("marker not found")?;
+    let dollar_end = dollar_start + 2;
+
+    let diag = make_diag(dollar_start, dollar_end, "PL501", "Use of '$[' is deprecated");
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("$['"))
+        .ok_or_else(|| format!("no '$[' action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN the `$[ = 0;\n` line is gone; surrounding code is intact
+    assert_eq!(result, "use strict;\nmy @arr = ();\n");
+
+    Ok(())
+}
+
+#[test]
+fn deprecated_array_base_nonzero_assignment_is_also_offered()
+-> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN `$[ = 1;` (non-default, requires manual renumbering)
+    let source = "use strict;\n$[ = 1;\nprint $arr[1];\n";
+    let dollar_start = source.find("$[").ok_or("marker not found")?;
+    let dollar_end = dollar_start + 2;
+
+    let diag = make_diag(dollar_start, dollar_end, "PL501", "Use of '$[' is deprecated");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN we still offer removal (caller is responsible for renumbering)
+    let action = find_action(&actions, |t| t.contains("$['"))
+        .ok_or_else(|| format!("no '$[' action in: {:?}", actions))?;
+    let result = edited(source, action);
+    assert_eq!(result, "use strict;\nprint $arr[1];\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL602 — Global signal handler assignment
+// ===========================================================================
+
+#[test]
+fn signal_handler_produces_local_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a bare global $SIG{__DIE__} assignment at file scope
+    let source = "use strict;\n$SIG{__DIE__} = sub { die @_ };\n";
+    let sig_start = source.find("$SIG{__DIE__}").ok_or("marker not found")?;
+    let stmt_end = source[sig_start..].find(";\n").ok_or("semicolon not found")? + sig_start;
+
+    let diag = make_diag(
+        sig_start,
+        stmt_end,
+        "PL602",
+        "Global assignment to $SIG{__DIE__} changes process-wide behavior.",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to add `local`
+    let action = find_action(&actions, |t| t.contains("local"))
+        .ok_or_else(|| format!("no 'local' action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Add 'local' to scope signal handler to the current block");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn signal_handler_edit_prepends_local_before_sig() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "$SIG{__WARN__} = sub { warn @_ };\n";
+    let sig_start = 0usize;
+    let stmt_end = source.find(";\n").ok_or("semicolon not found")?;
+
+    let diag = make_diag(sig_start, stmt_end, "PL602", "Global $SIG{__WARN__} assignment");
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("local"))
+        .ok_or_else(|| format!("no 'local' action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN `local ` is prepended to the $SIG reference
+    assert!(
+        result.starts_with("local $SIG{__WARN__}"),
+        "expected 'local $SIG{{__WARN__}}' prefix, got: {result:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn signal_handler_main_qualified_sig_gets_local() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "$main::SIG{__DIE__} = sub { };\n";
+    let sig_start = 0usize;
+    let stmt_end = source.find(";\n").ok_or("semicolon not found")?;
+
+    let diag = make_diag(sig_start, stmt_end, "PL602", "Global $main::SIG assignment");
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("local"))
+        .ok_or_else(|| format!("no 'local' action in: {:?}", actions))?;
+    let result = edited(source, action);
+    assert!(result.starts_with("local $main::SIG"), "expected local prefix, got: {result:?}");
+
+    Ok(())
+}
+
+#[test]
+fn signal_handler_guard_suppresses_action_for_non_sig_range()
+-> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL602 diagnostic whose range points to something that is NOT $SIG
+    // (this simulates a misrouted or synthetic diagnostic)
+    let source = "my $x = 1;\n";
+    let diag = make_diag(3, 5, "PL602", "Spurious signal handler diagnostic");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no signal-handler-specific "local" action is produced
+    let has_local_action = actions.iter().any(|a| a.title.contains("local"));
+    assert!(
+        !has_local_action,
+        "expected no 'local' action for misaligned range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Cross-cutting: dispatch-table smoke test
+// ===========================================================================
+
+#[test]
+fn all_three_new_codes_reach_their_handlers() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: each code reaches at least one action when given a trivially
+    // correct diagnostic, confirming the dispatch table is wired up correctly.
+
+    let source = "use strict;\nuse Foo;\n$[ = 0;\n$SIG{__DIE__} = sub {};\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let foo_start = source.find("use Foo;").ok_or("use Foo not found")?;
+    let dollar_start = source.find("$[").ok_or("$[ not found")?;
+    let sig_start = source.find("$SIG{__DIE__}").ok_or("$SIG not found")?;
+    let sig_stmt_end = source[sig_start..].find(";\n").ok_or("sig stmt end not found")? + sig_start;
+
+    let diags = vec![
+        // PL700 — unused import
+        make_diag(
+            foo_start,
+            foo_start + "use Foo;".len(),
+            "PL700",
+            "Module 'Foo' appears to be unused",
+        ),
+        // PL501 — deprecated $[
+        make_diag(dollar_start, dollar_start + 2, "PL501", "Use of '$[' is deprecated"),
+        // PL602 — global signal handler
+        make_diag(sig_start, sig_stmt_end, "PL602", "Global $SIG assignment"),
+    ];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_pl700 = actions.iter().any(|a| a.title.contains("use Foo"));
+    let has_pl501 = actions.iter().any(|a| a.title.contains("$['"));
+    let has_pl602 = actions.iter().any(|a| a.title.contains("local"));
+
+    assert!(has_pl700, "PL700 route not producing action; actions: {:?}", actions);
+    assert!(has_pl501, "PL501 route not producing action; actions: {:?}", actions);
+    assert!(has_pl602, "PL602 route not producing action; actions: {:?}", actions);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Three diagnostic codes that the LSP already detects had no code-action handlers in the dispatch table (`diagnostic_routes.rs`). When a user triggered `textDocument/codeAction` for these diagnostics the server returned an empty list. This PR wires them up.

### PL700 — Unused import (`fix_unused_import`)

Removes the entire `use Module;` line when a module is imported but never referenced. The edit includes the trailing newline so no blank line is left. The action title shows the exact module name extracted from the diagnostic message (`"Module 'X' appears to be unused"`).

**Before:** `use POSIX;` flagged with PL700 → no action offered  
**After:** "Remove unused 'use POSIX;'" → deletes the line

### PL501 — Deprecated `$[` array base (`fix_deprecated_array_base`)

Removes the whole line containing a `$[` variable reference. `$[` has been deprecated since Perl 5.12 (and will be removed). Removing `$[ = 0;` is always safe since 0 is the permanent default in modern Perl. A non-zero value still gets the removal action; the developer is responsible for renumbering array subscripts.

**Before:** `$[ = 0;` flagged with PL501 → no action offered  
**After:** "Remove deprecated '$[' array base assignment" → deletes the line

### PL602 — Global signal handler (`fix_security_signal_handler`)

Inserts `local ` before the `$SIG{...}` reference so the override is scoped to the enclosing block and the original handler is restored on scope exit, preventing exception/warning hooks from leaking into unrelated call stacks. A guard checks the diagnostic range actually starts with `$SIG` (or `$main::SIG` / `$::SIG`) before emitting any edit.

**Before:** `$SIG{__DIE__} = sub { ... };` flagged with PL602 → no action offered  
**After:** "Add 'local' to scope signal handler to the current block" → prepends `local `

## Files changed

| File | Change |
|------|--------|
| `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs` | +91 lines: three new `pub fn fix_*` implementations |
| `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs` | +12 lines: three new match arms routing PL700/PL501/PL602 |
| `crates/perl-lsp-rs-core/tests/quick_fix_new_codes_bdd.rs` | +344 lines: 12 new BDD tests |

## Test plan

All new tests are BDD-style in `quick_fix_new_codes_bdd.rs`:

- [x] `unused_import_produces_remove_action` — PL700 action kind, title, is_preferred
- [x] `unused_import_edit_deletes_entire_line` — edit removes `use POSIX;\n` exactly
- [x] `unused_import_at_start_of_file_leaves_no_blank_line` — BOF edge case
- [x] `unused_import_title_uses_module_name_from_message` — deeply-qualified name
- [x] `deprecated_array_base_produces_remove_action` — PL501 action kind, title, is_preferred
- [x] `deprecated_array_base_edit_removes_entire_statement_line` — correct line deletion
- [x] `deprecated_array_base_nonzero_assignment_is_also_offered` — `$[ = 1` case
- [x] `signal_handler_produces_local_action` — PL602 action kind, title, is_preferred
- [x] `signal_handler_edit_prepends_local_before_sig` — exact text `local $SIG{...}`
- [x] `signal_handler_main_qualified_sig_gets_local` — `$main::SIG` variant
- [x] `signal_handler_guard_suppresses_action_for_non_sig_range` — misaligned range guard
- [x] `all_three_new_codes_reach_their_handlers` — dispatch-table smoke test

```
test result: ok. 12 passed; 0 failed
```

All pre-existing `perl-lsp-rs-core` tests continue to pass (the one pre-existing failure `test_dap_build_includes_rs_core_catalog` is unrelated to this PR and was failing before these changes).

https://claude.ai/code/session_01GdpFGeiTmkrfXBrFXgJV4t

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdpFGeiTmkrfXBrFXgJV4t)_