### PR TITLE
sync: bring swarm ripr timeout headroom to source (#8197)

### DIFF
--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -29,7 +29,7 @@ jobs:
   ripr:
     name: ripr static exposure
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 45
     continue-on-error: true
     if: github.event.pull_request.draft != true
     env:


### PR DESCRIPTION
Problem: The v0.15.0 cutover merged before the swarm ripr timeout headroom fix, leaving the publishing repo with the weaker 20-minute advisory ripr budget.\nFix: Merge current perl-lsp-swarm/main through 51143b into the publishing repo; the resulting tree matches swarm main and only changes .github/workflows/ripr.yml versus source/master.\nVerification: \git diff --check source/master..HEAD\ passes. \git diff --stat origin/main..HEAD\ is empty. Swarm PR #271 passed, including ripr static exposure.