### PR TITLE
fix(vscode): pin vscode types for 0.15.0 publish (#224)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -19,7 +19,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.x",
         "@types/tar": "^7.0.87",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "1.118.0",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
         "@typescript-eslint/parser": "^8.59.4",
         "@vscode/test-electron": "^2.5.2",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.120.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
-      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
+      "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
       "dev": true,
       "license": "MIT"
     },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1163,7 +1163,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.x",
     "@types/tar": "^7.0.87",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "1.118.0",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.59.4",
     "@vscode/test-electron": "^2.5.2",


### PR DESCRIPTION
Problem: The v0.15.0 publish-extension workflow failed in Prepare VSIX because @types/vscode 1.120.0 is greater than engines.vscode ^1.118.0.\n\nFix: Pin @types/vscode to 1.118.0 in the extension manifest and lockfile.\n\nClaim boundary: Release-channel metadata fix only. No runtime code change, provider behavior change, source/swarmsync change, or signing change.\n\nVerification:\n- rtk npm --prefix vscode-extension install --package-lock-only --save-dev --save-exact @types/vscode@1.118.0\n- rtk npm --prefix vscode-extension ci\n- rtk npm --prefix vscode-extension run verify:marketplace\n- rtk git diff --check