### PR TITLE
ci(docker): add builder publish timeout headroom (#224)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build builder image (${{ matrix.platform }})
     runs-on: ubuntu-24.04
     needs: init
-    timeout-minutes: 90
+    timeout-minutes: 150
     strategy:
       fail-fast: false
       matrix:
@@ -162,7 +162,7 @@ jobs:
     name: Publish to Docker Hub
     runs-on: ubuntu-24.04
     needs: init
-    timeout-minutes: 90
+    timeout-minutes: 150
     if: github.event.inputs.push != 'false'
 
     steps:


### PR DESCRIPTION
Problem: The v0.15.0 Docker publish run repeatedly reached the 90-minute timeout while compiling the builder image under buildx/QEMU for the Docker Hub builder-image job.\n\nFix: Increase timeout headroom for builder-image Docker publish jobs from 90 to 150 minutes. Runtime image job timeouts are unchanged.\n\nClaim boundary: Release workflow timeout headroom only. No Dockerfile, image tag, release artifact, provider behavior, or signing change.\n\nVerification:\n- rtk git diff --check\n- release evidence: docker-publish run 26299080028 cancelled in Publish to Docker Hub after the builder image compile exceeded 90 minutes