### PR TITLE
fix(diff-auditor): replace gh pr diff with GitHub API pulls/N/files (#6876)

### DIFF
--- a/.claude/agents/diff-auditor.md
+++ b/.claude/agents/diff-auditor.md
@@ -25,7 +25,17 @@ Each agent sees its own step. Nobody has checked that:
 
 1. **Diff vs spec alignment** — does the total diff implement what the issue asked for?
    ```bash
-   gh pr diff <number> --stat
+   # ALWAYS use the GitHub API for the authoritative PR file list.
+   # NEVER use `gh pr diff` — it shows branch-vs-current-master, not PR-authored changes,
+   # and produces false cross-PR contamination claims on PRs older than 2-3 days.
+   # See #6876 for the incident where this caused 5 false-positive audit verdicts.
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   gh api repos/$REPO/pulls/<number>/files --jq '.[].filename'
+   gh api repos/$REPO/pulls/<number>/files --jq '.[] | {filename, patch: (.patch // "(binary)")}'
+
+   # For the authored diff (three-dot base — only what the PR added, not inherited state):
+   git diff $(git merge-base origin/master HEAD)..HEAD
+
    cat .spec/*/acceptance.md 2>/dev/null
    ```
    Every acceptance criterion should be addressable from the diff.
@@ -82,7 +92,8 @@ Detection heuristic — for every file in the diff, ask: "does this file's path/
 - If the diff adds tests for crate X but the PR title is about crate Y (and those tests aren't named in the spec): flag as CONTAMINATION
 - If the diff adds ADRs whose work-id doesn't match this PR's branch work-id: flag as CONTAMINATION
 - Tell-tale: PR title claims a small change but `--stat` shows >100 lines outside the named scope. Diff bulk shouldn't be unrelated to the title.
-- Mechanical check: `gh pr diff <num> --stat` then for each crate path, ask whether the PR title/body mentions it; orphan-crate paths are contamination candidates.
+- Mechanical check: use the GitHub API file list (NOT `gh pr diff` — it shows branch-vs-current-master, creating false contamination claims): `REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner) && gh api repos/$REPO/pulls/<num>/files --jq '.[].filename'` — then for each crate path, ask whether the PR title/body mentions it; orphan-crate paths are contamination candidates.
+- Self-check: before flagging any file as cross-PR contamination, confirm it appears in `pulls/N/files` (PR-authored). If it only appears in `gh pr diff` (branch-vs-master), it is inherited base state — NOT drift. This check is mandatory.
 
 When found, route to `needs-diff-fix` with a `git rm` list. Don't let a 22-of-2063-line legitimate change ride a 2043-line contaminated diff into master.
 

--- a/.claude/commands/diff-audit-check.md
+++ b/.claude/commands/diff-audit-check.md
@@ -9,11 +9,22 @@ Review the cumulative diff from all agents.
 
 ## Steps
 
-1. Get the full diff stat and diff:
+1. Get the PR file list and diff using the GitHub API (NEVER use `gh pr diff` — it shows
+   branch-vs-current-master and produces false contamination claims on stale-base PRs):
    ```bash
-   gh pr diff <number> --stat
-   gh pr diff <number>
+   # Authoritative PR file list (PR-authored only):
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   gh api repos/$REPO/pulls/<number>/files --jq '.[].filename'
+   gh api repos/$REPO/pulls/<number>/files --jq '.[] | {filename, patch: (.patch // "(binary)")}'
+
+   # Full authored diff (three-dot — only what the PR added, not inherited state):
+   git diff $(git merge-base origin/master HEAD)..HEAD --stat
+   git diff $(git merge-base origin/master HEAD)..HEAD
    ```
+   Before flagging any file as cross-PR contamination: confirm it appears in the `pulls/N/files`
+   API response (PR-authored). If it only appears in a `gh pr diff` (branch-vs-master snapshot)
+   it is inherited base state — NOT scope drift. This self-check is mandatory before any
+   SCOPE DRIFT or CONTAMINATION verdict.
 
 2. Read the spec:
    ```bash


### PR DESCRIPTION
## Summary

Fixes EffortlessMetrics/perl-lsp-swarm#2798 — the diff-auditor agent and `diff-audit-check` skill were using `gh pr diff` to enumerate files changed by a PR, which caused **5 false-positive cross-PR contamination verdicts** in Wave B4 (PRs EffortlessMetrics/perl-lsp#6786, EffortlessMetrics/perl-lsp#6777, EffortlessMetrics/perl-lsp#6740, EffortlessMetrics/perl-lsp#6232, EffortlessMetrics/perl-lsp#6731).

### Root cause

`gh pr diff` computes a **branch-vs-current-master** diff. On any PR that is 2-3+ days old, master has received new commits since the PR branched, so `gh pr diff` shows those master changes as if they were part of the PR. The auditor then flags every file touched by recent master commits as "cross-PR contamination" — even though the PR never authored those files.

In Wave B4 this led to claims that all 5 PRs contained identical `.ci/GATE_REGISTRY.toml`, `.ci/gate-policy.yaml`, `.claude/agents/`, and `.claude/commands/` modifications. Independent verification via `gh api repos/.../pulls/N/files` confirmed: **zero of the 5 PRs touch any of those paths**.

### Fix

Replace `gh pr diff` in both the agent definition and the skill step with:

| Tool | Purpose |
|---|---|
| `gh api repos/$REPO/pulls/N/files` | **Authoritative PR file list** — only files the PR author actually changed |
| `git diff $(git merge-base origin/master HEAD)..HEAD` | **Authored diff** — three-dot diff showing only what the PR added, excluding inherited base state |

Add a mandatory self-check rule: before flagging any file as cross-PR contamination, the agent must confirm the file appears in `pulls/N/files` (PR-authored). Files that only appear in `gh pr diff` are **inherited base state, not drift**.

## Files changed

- `.claude/agents/diff-auditor.md` — updated step 1 code block; updated mechanical check bullet; added mandatory self-check rule
- `.claude/commands/diff-audit-check.md` — updated step 1 with API commands and three-dot diff; added pre-verdict self-check instruction

## What this prevents

Going forward:
- No false-positive SCOPE DRIFT or CONTAMINATION verdicts caused by master-forward commits that postdate the PR's branch point
- The `pulls/N/files` API becomes the canonical source of truth for "what did this PR author change"
- The three-dot diff (`git diff $(git merge-base origin/master HEAD)..HEAD`) is the correct local view

## What this does NOT change

- The diff-auditor's contamination detection logic itself (still correct)
- Other agents that use `gh pr diff` for non-contamination purposes (e.g., `reviewer.md` for file-path triage, `maintainer-pr-read.md` for code reading) — those are in scope for follow-up issues if needed
- Any production Rust code

## Test plan

- [ ] Read updated `.claude/agents/diff-auditor.md` — step 1 no longer references `gh pr diff`; mechanical check uses API
- [ ] Read updated `.claude/commands/diff-audit-check.md` — step 1 uses API calls and three-dot diff
- [ ] Grep confirms no remaining `gh pr diff` in the diff-auditor files:
  ```bash
  grep 'gh pr diff' .claude/agents/diff-auditor.md .claude/commands/diff-audit-check.md
  # Expected: only appears in "NEVER use..." explanatory text, not as an executable command
  ```
- [ ] No Rust code changes; cargo test not required

## Related

- EffortlessMetrics/perl-lsp-swarm#2798 — incident report and fix request
- Wave B4 false-positive session (2026-04-26) — 5 PRs incorrectly flagged
- `docs/articles/FIRE_FIX_CASCADE_METHODOLOGY.md` — stale-base disambiguation

---
_Generated by [Claude Code](https://claude.ai/code/session_0159kpWxnxmHe6pQ5M7UNpiv)_