### PR TITLE
diagnostics: syntax-only diagnostic mode

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -438,6 +438,17 @@ impl LspServer {
             return;
         }
 
+        // Syntax-only mode: report parse errors only and skip the full
+        // semantic / critic / module-resolution / dead-code stack. Latency
+        // harnesses use this so "first useful answer" measurements don't
+        // include the background analysis cost on every keystroke.
+        if self.runtime_tuning.diagnostic_mode
+            == perl_lsp_rs_core::runtime::tuning::DiagnosticMode::SyntaxOnly
+        {
+            self.publish_syntax_only_diagnostics(uri);
+            return;
+        }
+
         let normalized_uri = self.normalize_uri_key(uri);
 
         // Snapshot all fields needed from DocumentState while holding the lock briefly,
@@ -679,6 +690,118 @@ impl LspServer {
         }
     }
 
+    /// Build LSP diagnostics from a document's `parse_errors`, without the
+    /// AST-based semantic / critic / dead-code / module-resolution passes.
+    ///
+    /// Returns an empty `Vec` when the document has no parse errors —
+    /// publishing this still produces an empty `publishDiagnostics` payload,
+    /// which is how LSP signals "the parse cleared". This is what makes the
+    /// `syntax_only_clears_when_parse_errors_clear` acceptance case work.
+    fn syntax_only_lsp_diagnostics(
+        parse_errors: &[perl_parser::error::ParseError],
+        text: &str,
+        line_starts: &perl_parser::position::LineStartsCache,
+        rope: &ropey::Rope,
+    ) -> Vec<Value> {
+        let pos16 = |offset: usize| line_starts.offset_to_position_rope(rope, offset);
+        parse_errors
+            .iter()
+            .map(|e| {
+                let (location, base_message) = match e {
+                    crate::error::ParseError::UnexpectedToken { location, expected, found } => {
+                        (*location, format!("Expected {}, found {}", expected, found))
+                    }
+                    crate::error::ParseError::SyntaxError { location, message } => {
+                        (*location, message.clone())
+                    }
+                    crate::error::ParseError::UnexpectedEof => {
+                        (text.len(), "Unexpected end of input".to_string())
+                    }
+                    crate::error::ParseError::LexerError { message } => (0, message.clone()),
+                    _ => (0, e.to_string()),
+                };
+                let message =
+                    match perl_lsp_rs_core::providers::diagnostics::build_parse_error_hint(
+                        e,
+                        &base_message,
+                    ) {
+                        Some(hint) => format!("{base_message}\nSuggestion: {hint}"),
+                        None => base_message,
+                    };
+                let (line, character) = pos16(location);
+                json!({
+                    "range": {
+                        "start": {"line": line, "character": character},
+                        "end": {"line": line, "character": character + 1},
+                    },
+                    "severity": 1, // Error
+                    "code": DiagnosticCode::ParseError.as_str(),
+                    "source": "perl-parser",
+                    "message": message,
+                })
+            })
+            .collect()
+    }
+
+    /// Push-path publication restricted to parse errors. See
+    /// [`Self::publish_diagnostics`] for the full pipeline.
+    fn publish_syntax_only_diagnostics(&self, uri: &str) {
+        let normalized_uri = self.normalize_uri_key(uri);
+
+        let snapshot = {
+            let documents = self.documents.lock();
+            documents.get(&normalized_uri).or_else(|| documents.get(uri)).map(|doc| {
+                (
+                    doc.parse_errors.clone(),
+                    doc.text.clone(),
+                    doc.version,
+                    doc.line_starts.clone(),
+                    doc.rope.clone(),
+                    Arc::clone(&doc.generation),
+                    doc.generation.load(Ordering::SeqCst),
+                )
+            })
+        };
+
+        let Some((parse_errors, text, version, line_starts, rope, generation, gen_at_snapshot)) =
+            snapshot
+        else {
+            return;
+        };
+
+        let lsp_diagnostics =
+            Self::syntax_only_lsp_diagnostics(&parse_errors, &text, &line_starts, &rope);
+
+        // Generation-aware staleness guard mirrors the full path.
+        if generation.load(Ordering::SeqCst) != gen_at_snapshot {
+            tracing::debug!(
+                uri = %normalized_uri,
+                gen_at_snapshot,
+                current_gen = generation.load(Ordering::SeqCst),
+                "Skipping stale syntax-only diagnostic publish (generation advanced)"
+            );
+            return;
+        }
+
+        tracing::debug!(
+            count = lsp_diagnostics.len(),
+            uri = %normalized_uri,
+            version,
+            "Publishing syntax-only diagnostics"
+        );
+
+        if let Err(e) = self.notify(
+            "textDocument/publishDiagnostics",
+            json!({
+                "uri": uri,
+                "version": version,
+                "diagnostics": lsp_diagnostics
+            }),
+        ) {
+            tracing::error!(uri, error = %e, "Failed to publish syntax-only diagnostics");
+        }
+    }
+
     /// Publish parse-error diagnostics immediately (fast path, ~10ms).
     ///
     /// Called on `didChange` before the full debounced diagnostic cycle so that
@@ -826,6 +949,31 @@ impl LspServer {
                     })));
                 }
             };
+
+            // Syntax-only short-circuit for pull diagnostics. Mirrors the
+            // push-path gate in `publish_diagnostics`.
+            if self.runtime_tuning.diagnostic_mode
+                == perl_lsp_rs_core::runtime::tuning::DiagnosticMode::SyntaxOnly
+            {
+                let doc_snapshot = {
+                    let documents = self.documents.lock();
+                    self.get_document(&documents, uri_str).cloned()
+                };
+                if let Some(doc) = doc_snapshot {
+                    let items = Self::syntax_only_lsp_diagnostics(
+                        &doc.parse_errors,
+                        &doc.text,
+                        &doc.line_starts,
+                        &doc.rope,
+                    );
+                    return Ok(Some(json!({
+                        "kind": "full",
+                        "items": items,
+                    })));
+                }
+                let _ = previous_result_id;
+                return Ok(Some(json!({ "kind": "full", "items": [] })));
+            }
 
             // Snapshot the document
             let doc_snapshot = {

--- a/crates/perl-lsp-rs/tests/syntax_only_diagnostics_test.rs
+++ b/crates/perl-lsp-rs/tests/syntax_only_diagnostics_test.rs
@@ -26,8 +26,7 @@ use serde_json::json;
 
 fn syntax_only_server() -> LspServer {
     let mut tuning = RuntimeTuning::normal_defaults();
-    tuning.diagnostic_mode =
-        perl_lsp_rs_core::runtime::tuning::DiagnosticMode::SyntaxOnly;
+    tuning.diagnostic_mode = perl_lsp_rs_core::runtime::tuning::DiagnosticMode::SyntaxOnly;
     LspServer::new_with_tuning(tuning)
 }
 
@@ -61,7 +60,10 @@ fn syntax_only_reports_parse_errors() {
     assert!(!items.is_empty(), "syntax-only mode must report parse errors; got {items:?}");
     for item in &items {
         let source = item.get("source").and_then(|v| v.as_str()).unwrap_or("");
-        assert_eq!(source, "perl-parser", "syntax-only must only emit parse errors; saw source={source}");
+        assert_eq!(
+            source, "perl-parser",
+            "syntax-only must only emit parse errors; saw source={source}"
+        );
         let code = item.get("code").and_then(|v| v.as_str()).unwrap_or("");
         assert!(
             code.starts_with("PL") || code == "parse-error",

--- a/crates/perl-lsp-rs/tests/syntax_only_diagnostics_test.rs
+++ b/crates/perl-lsp-rs/tests/syntax_only_diagnostics_test.rs
@@ -1,0 +1,173 @@
+//! Syntax-only diagnostic mode tests (PR 2 of the 0.15.1 Neovim latency lane).
+//!
+//! These tests pin the four claims from the spec:
+//!
+//! 1. `syntax_only_reports_parse_errors` — parse errors still surface.
+//! 2. `syntax_only_clears_when_parse_errors_clear` — fixing the syntax
+//!    clears diagnostics (empty publishDiagnostics or empty pull report).
+//! 3. `syntax_only_skips_critic_dead_code_and_module_resolution` — the
+//!    full pipeline's dead-code / native-critic / use-Module-not-found
+//!    diagnostics are suppressed.
+//! 4. `pull_diagnostics_respect_syntax_only_mode` — `textDocument/diagnostic`
+//!    honours the same gate.
+//!
+//! Run with:
+//!
+//!     RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs \
+//!         --features expose_lsp_test_api \
+//!         --test syntax_only_diagnostics_test -- --test-threads=2
+
+#![cfg(feature = "expose_lsp_test_api")]
+
+use perl_lsp::LspServer;
+use perl_lsp_rs_core::runtime::tuning::RuntimeTuning;
+use serde_json::Value;
+use serde_json::json;
+
+fn syntax_only_server() -> LspServer {
+    let mut tuning = RuntimeTuning::normal_defaults();
+    tuning.diagnostic_mode =
+        perl_lsp_rs_core::runtime::tuning::DiagnosticMode::SyntaxOnly;
+    LspServer::new_with_tuning(tuning)
+}
+
+fn pull_request_for(uri: &str) -> Option<Value> {
+    Some(json!({
+        "textDocument": { "uri": uri },
+    }))
+}
+
+fn pull_items(result: Option<Value>) -> Vec<Value> {
+    let report = result.expect("pull diagnostic must return a result");
+    report
+        .get("items")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .expect("pull diagnostic result must include an items array")
+}
+
+#[test]
+fn syntax_only_reports_parse_errors() {
+    let server = syntax_only_server();
+    // Missing closing `}` is a clear parse error.
+    let bad = "sub broken {\n";
+    server.test_apply_did_open("file:///broken.pl", bad, 1);
+
+    let report = server
+        .test_handle_document_diagnostic(pull_request_for("file:///broken.pl"))
+        .expect("pull diagnostic must succeed");
+    let items = pull_items(report);
+
+    assert!(!items.is_empty(), "syntax-only mode must report parse errors; got {items:?}");
+    for item in &items {
+        let source = item.get("source").and_then(|v| v.as_str()).unwrap_or("");
+        assert_eq!(source, "perl-parser", "syntax-only must only emit parse errors; saw source={source}");
+        let code = item.get("code").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            code.starts_with("PL") || code == "parse-error",
+            "syntax-only diagnostic must use parse-error code; got {code}"
+        );
+    }
+}
+
+#[test]
+fn syntax_only_clears_when_parse_errors_clear() {
+    let server = syntax_only_server();
+    server.test_apply_did_open("file:///c.pl", "sub broken {\n", 1);
+    let bad = pull_items(
+        server.test_handle_document_diagnostic(pull_request_for("file:///c.pl")).unwrap(),
+    );
+    assert!(!bad.is_empty(), "broken parse must report errors");
+
+    // Now fix the file: parse succeeds, parse_errors should be empty.
+    server.test_apply_did_change("file:///c.pl", "sub broken {}\n", 2);
+    let cleared = pull_items(
+        server.test_handle_document_diagnostic(pull_request_for("file:///c.pl")).unwrap(),
+    );
+    assert!(
+        cleared.is_empty(),
+        "syntax-only mode must publish an empty diagnostic list after a clean parse; got {cleared:?}"
+    );
+}
+
+#[test]
+fn syntax_only_skips_critic_dead_code_and_module_resolution() {
+    // This buffer normally produces:
+    //   - native critic (no `use strict`/`use warnings`)
+    //   - dead-code (unused $x)
+    //   - module-resolution (cannot resolve `NoSuchModule`)
+    // Under syntax-only mode every one of those must be suppressed.
+    let server = syntax_only_server();
+    let src = "use NoSuchModule::Definitely::Missing;\nmy $x = 1;\n";
+    server.test_apply_did_open("file:///clean.pl", src, 1);
+
+    let items = pull_items(
+        server.test_handle_document_diagnostic(pull_request_for("file:///clean.pl")).unwrap(),
+    );
+
+    for item in &items {
+        let source = item.get("source").and_then(|v| v.as_str()).unwrap_or("");
+        let code = item.get("code").and_then(|v| v.as_str()).unwrap_or("");
+        assert_ne!(
+            source, "perl-lsp-critic",
+            "syntax-only must suppress critic diagnostics; got {code}: {item:?}"
+        );
+        assert!(
+            !code.starts_with("dead-code"),
+            "syntax-only must suppress dead-code diagnostics; got {code}"
+        );
+        assert!(
+            !code.contains("module") && !code.contains("Module"),
+            "syntax-only must suppress module-resolution diagnostics; got {code}"
+        );
+    }
+
+    // Same source under the default (Normal) diagnostic mode produces a
+    // non-empty diagnostic list (sanity check that the test source actually
+    // triggers the full pipeline).
+    let full = LspServer::new_with_tuning(RuntimeTuning::normal_defaults());
+    full.test_apply_did_open("file:///clean.pl", src, 1);
+    let full_items = pull_items(
+        full.test_handle_document_diagnostic(pull_request_for("file:///clean.pl")).unwrap(),
+    );
+    assert!(
+        full_items.len() > items.len(),
+        "Normal mode must produce strictly more diagnostics than syntax-only on the same source.\n\
+         syntax-only: {items:?}\nnormal: {full_items:?}"
+    );
+}
+
+#[test]
+fn pull_diagnostics_respect_syntax_only_mode() {
+    // textDocument/diagnostic for a syntactically clean buffer with critic-
+    // worthy code must return an empty items list under syntax-only mode.
+    let server = syntax_only_server();
+    let src = "my $unused_var = 1;\n";
+    server.test_apply_did_open("file:///pull.pl", src, 1);
+
+    let report = server
+        .test_handle_document_diagnostic(pull_request_for("file:///pull.pl"))
+        .expect("pull diagnostic must succeed");
+    assert_eq!(report.as_ref().and_then(|v| v.get("kind")).and_then(|k| k.as_str()), Some("full"));
+    let items = pull_items(report);
+    assert!(
+        items.is_empty(),
+        "syntax-only pull diagnostic must produce an empty items list for a syntactically clean source; got {items:?}"
+    );
+}
+
+#[test]
+fn syntax_only_normal_mode_unchanged() {
+    // Regression guard: default Normal mode still produces non-empty
+    // diagnostics for the same critic-heavy source.
+    let server = LspServer::new_with_tuning(RuntimeTuning::normal_defaults());
+    let src = "my $unused = 1;\n";
+    server.test_apply_did_open("file:///n.pl", src, 1);
+    let items = pull_items(
+        server.test_handle_document_diagnostic(pull_request_for("file:///n.pl")).unwrap(),
+    );
+    assert!(
+        !items.is_empty(),
+        "Normal mode must continue to produce diagnostics for unused vars / missing strict"
+    );
+}


### PR DESCRIPTION
## Summary

PR 2 of the 0.15.1 Neovim latency lane. **Stacks on PR #9567 (PR 1)** — the diff currently shows PR 1's commits too; GitHub will narrow once PR 1 merges. Wait for PR 1, rebase, then merge.

When `RuntimeTuning.diagnostic_mode == SyntaxOnly` (set via `--diagnostic-mode syntax-only`, `PERL_LSP_DIAGNOSTIC_MODE=syntax-only`, or implied by `--runtime-mode e2e`), the diagnostic pipeline reports **parse errors only** and bypasses:

- semantic diagnostics (PL702/PL703 etc.)
- module-resolution diagnostics (PL701 — `use NoSuchModule` not found)
- native critic policy diagnostics (`source: "perl-lsp-critic"`)
- external Perl::Critic
- workspace dead-code diagnostics (`code: "dead-code-*"`)

Both push (`textDocument/publishDiagnostics`) and pull (`textDocument/diagnostic`) paths honour the gate via one shared helper (`syntax_only_lsp_diagnostics`) so push and pull cannot drift. Publishing an empty diagnostic list (parse cleared) still works because the path returns an empty `Vec` rather than skipping the notification.

**Behaviour for `diagnostic_mode == Normal` (the default for editor sessions) is unchanged.**

## Acceptance tests (`tests/syntax_only_diagnostics_test.rs`)

- `syntax_only_reports_parse_errors`
- `syntax_only_clears_when_parse_errors_clear`
- `syntax_only_skips_critic_dead_code_and_module_resolution`
- `pull_diagnostics_respect_syntax_only_mode`
- `syntax_only_normal_mode_unchanged` (regression guard — Normal mode still produces the full pipeline output)

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo check --workspace --all-targets --locked` clean
- [ ] CI Gate (Merge-Blocking) green
- [ ] After PR #9567 merges: rebase onto master, confirm green, merge

## Dependencies

- Requires PR #9567 (RuntimeTuning substrate) to land first — the gate predicate reads `RuntimeTuning.diagnostic_mode`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPvQdSUh1vnUy4HFYXhQts)_