### PR TITLE
fix(tree-sitter-perl-c): add ParsePerlFileError with path context to parse_perl_file

### DIFF
--- a/crates/tree-sitter-perl-c/src/lib.rs
+++ b/crates/tree-sitter-perl-c/src/lib.rs
@@ -39,7 +39,7 @@
 //! [`perl-parser`]: https://docs.rs/perl-parser
 //! [`tree-sitter-perl-rs`]: https://docs.rs/tree-sitter-perl-rs
 
-use std::{fmt, path::Path};
+use std::{fmt, path::{Path, PathBuf}};
 use tree_sitter::{Language, Parser};
 
 /// Reusable Perl parser for hot parse loops.
@@ -94,6 +94,36 @@ impl From<tree_sitter::LanguageError> for ParsePerlError {
 impl From<std::io::Error> for ParsePerlError {
     fn from(value: std::io::Error) -> Self {
         Self::Io(value)
+    }
+}
+
+/// Contextual parse error produced by [`parse_perl_file`].
+///
+/// Wraps the original [`ParsePerlError`] and records the source path so
+/// callers surface actionable diagnostics without re-implementing path
+/// tracking themselves.
+#[derive(Debug)]
+pub struct ParsePerlFileError {
+    path: PathBuf,
+    source: ParsePerlError,
+}
+
+impl ParsePerlFileError {
+    /// Returns the path that triggered the error.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl fmt::Display for ParsePerlFileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "failed to parse Perl file {}: {}", self.path.display(), self.source)
+    }
+}
+
+impl std::error::Error for ParsePerlFileError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
     }
 }
 
@@ -307,12 +337,21 @@ pub fn try_parse_perl_code_with_parser(
 ///
 /// # Errors
 ///
-/// Returns an error if the file cannot be read or if parsing fails (see
-/// [`parse_perl_code`]).
+/// Returns a [`ParsePerlFileError`] (boxed) if the file cannot be read or if
+/// the parser cannot be initialised or returns no tree. The error message
+/// includes the file path to aid diagnostics.
 pub fn parse_perl_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<tree_sitter::Tree, Box<dyn std::error::Error>> {
-    try_parse_perl_file(path).map_err(Into::into)
+    let path_ref = path.as_ref();
+    let code = std::fs::read(path_ref).map_err(|e| {
+        Box::new(ParsePerlFileError { path: path_ref.to_path_buf(), source: ParsePerlError::Io(e) })
+            as Box<dyn std::error::Error>
+    })?;
+    try_parse_perl_bytes(&code).map_err(|source| {
+        Box::new(ParsePerlFileError { path: path_ref.to_path_buf(), source })
+            as Box<dyn std::error::Error>
+    })
 }
 
 /// Reads a file from `path` and parses it as Perl source.

--- a/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
+++ b/crates/tree-sitter-perl-c/tests/bdd_workflows.rs
@@ -353,3 +353,44 @@ fn bdd_scanner_configuration_is_stable() {
     scenario.then("the backend should report the C scanner");
     assert_eq!(get_scanner_config(), "c-scanner");
 }
+
+#[test]
+fn bdd_parse_perl_file_missing_path_reports_context() {
+    let scenario = Scenario::new("parse perl file missing path reports context");
+    let missing = unique_temp_file("missing_ctx");
+
+    scenario.given("a file path that does not exist on disk");
+    scenario.when("parse_perl_file is invoked");
+    let error = parse_perl_file(&missing).unwrap_err();
+    let message = error.to_string();
+
+    scenario.then("the error message should contain the file path");
+    let path_str = missing.to_string_lossy().to_string();
+    assert!(
+        message.contains(&path_str),
+        "expected error to contain path {path_str:?}, got: {message}"
+    );
+}
+
+#[test]
+fn bdd_parse_perl_file_unreadable_path_reports_context() {
+    let scenario = Scenario::new("parse perl file unreadable path reports context");
+
+    scenario.given("a directory path (fs::read on a directory fails with EISDIR)");
+    let dir_path: PathBuf = std::env::temp_dir();
+
+    scenario.when("parse_perl_file is invoked with the directory path");
+    let error = parse_perl_file(&dir_path).unwrap_err();
+    let message = error.to_string();
+
+    scenario.then("the error message should contain both the path and a failure description");
+    let path_str = dir_path.to_string_lossy().to_string();
+    assert!(
+        message.contains(&path_str),
+        "expected error to contain path {path_str:?}, got: {message}"
+    );
+    assert!(
+        message.contains("failed to parse Perl file"),
+        "expected 'failed to parse Perl file' in message, got: {message}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #7512

`parse_perl_file` previously returned an opaque `ParsePerlError::Io` message — something like `"failed to read Perl source file: No such file or directory"` — with no indication of *which path* failed. Every caller had to wrap their own path tracking to produce actionable diagnostics. This PR fixes that by introducing a dedicated `ParsePerlFileError` type that attaches the file path to both read-time and parse-time failures.

### What changed

**`crates/tree-sitter-perl-c/src/lib.rs`**

- Added `ParsePerlFileError { path: PathBuf, source: ParsePerlError }`:
  - `Display` implementation: `"failed to parse Perl file <path>: <source>"` — path is always present, readable, and testable.
  - `std::error::Error::source` delegation — the original `ParsePerlError` remains reachable via the error source chain for callers that unwrap it programmatically.
  - Public `path()` accessor so typed callers can extract the `&Path` without parsing the display string.
- Updated `parse_perl_file` to produce `ParsePerlFileError` for both `std::fs::read` failures and `try_parse_perl_bytes` failures, boxing it into the existing `Result<_, Box<dyn Error>>` return type. **The public API signature is unchanged.**
- `try_parse_perl_file` is **not changed** — it continues to return `ParsePerlError` so existing callers that pattern-match on `ParsePerlError::Io(_)` are unaffected (the existing `bdd_typed_file_parse_error_reports_io_failure_variant` test passes unchanged).

**`crates/tree-sitter-perl-c/tests/bdd_workflows.rs`**

- Added `bdd_parse_perl_file_missing_path_reports_context`: calls `parse_perl_file` on a unique temp path that does not exist; asserts the error `Display` string contains the full path.
- Added `bdd_parse_perl_file_unreadable_path_reports_context`: calls `parse_perl_file` on a directory path (which causes `fs::read` to fail with `EISDIR` on Linux); asserts the error string contains the path and the `"failed to parse Perl file"` prefix.

### Why this approach

- **Minimal API surface change**: only `parse_perl_file` (the `Box<dyn Error>` variant) gains path context. The typed `try_parse_perl_file` path is left alone — no churn for existing callers.
- **`Error::source` chain preserved**: downstream tools using `anyhow` or `thiserror` chains can still reach the original `ParsePerlError::Io` cause.
- **Zero new dependencies**: `PathBuf` is already in `std`; no external crate added.

## Test plan

- [x] `cargo test -p tree-sitter-perl-c` — all 17 BDD tests + 13 unit tests + 2 typed-API regression tests + 5 query conformance tests + 5 snapshot tests pass
- [x] `cargo clippy -p tree-sitter-perl-c` — clean, no warnings
- [x] `bdd_parse_perl_file_missing_path_reports_context` — new, green
- [x] `bdd_parse_perl_file_unreadable_path_reports_context` — new, green
- [x] `bdd_typed_file_parse_error_reports_io_failure_variant` — existing test, still green (typed API unchanged)

https://claude.ai/code/session_01Vreh6SMRicTPdpYFA7Sbnc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vreh6SMRicTPdpYFA7Sbnc)_