### PR TITLE
chore(clippy): activate manual_ilog2 lint (#8604)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,6 +376,7 @@ collapsible_match = { level = "allow", priority = 1 }
 decimal_bitwise_operands = "warn"
 duration_suboptimal_units = "warn"
 needless_type_cast = "warn"
+manual_ilog2 = "warn"
 unnecessary_trailing_comma = "warn"
 
 [workspace.lints.rust]

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -725,10 +725,11 @@ level = "deny"
 activate_when_msrv = "1.94"
 reason = "Catch raw-parts reconstruction mistakes."
 
-[[planned]]
+[[lint]]
 name = "clippy::manual_ilog2"
 level = "warn"
-activate_when_msrv = "1.94"
+status = "active"
+class = "numeric"
 reason = "Prefer the standard integer log helper."
 
 [[lint]]


### PR DESCRIPTION
## Summary

Activates `clippy::manual_ilog2` as part of the strong-clippy-lints rollout tracked in EffortlessMetrics/perl-lsp-swarm#1796.

- The workspace MSRV is **1.95** (set in EffortlessMetrics/perl-lsp#8509), which exceeds the `1.94` activation threshold listed in `policy/clippy-lints.toml`.
- Verified **0 existing call sites** across all `crates/` and `xtask/` source before activating — no production code changes are required.
- `cargo clippy --workspace --lib` passes clean with the lint active.

## Changes

| File | Change |
|---|---|
| `Cargo.toml` | Add `manual_ilog2 = "warn"` to `[workspace.lints.clippy]` |
| `policy/clippy-lints.toml` | Promote `clippy::manual_ilog2` from `[[planned]]` → `[[lint]]` with `status = "active"`, `class = "numeric"` |

## Scope

Mechanical lint activation only — one PR per lint per EffortlessMetrics/perl-lsp-swarm#1796 policy. No production code changes, no test changes.

## Verification

```bash
# Zero violations — lint activates with no warnings raised
cargo clippy --workspace --lib --message-format=short
# → Finished `dev` profile target(s) in 4.20s  (clean)

# Policy file consistency
cargo xtask check-lint-policy
```

## Closes

Closes EffortlessMetrics/perl-lsp#8604. Part of EffortlessMetrics/perl-lsp-swarm#1796 (strong-clippy-lints rollout).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMeVaK88w1oTKa8FcNto4z)_