### PR TITLE
fix(diff-auditor): replace gh pr diff with GitHub API pulls/N/files (#6876)

### DIFF
--- a/.claude/agents/diff-auditor.md
+++ b/.claude/agents/diff-auditor.md
@@ -25,7 +25,15 @@ Each agent sees its own step. Nobody has checked that:
 
 1. **Diff vs spec alignment** — does the total diff implement what the issue asked for?
    ```bash
-   gh pr diff <number> --stat
+   # Canonical PR file list — only what the PR author actually changed
+   # NEVER use gh pr diff here: it shows branch-vs-current-master and includes
+   # inherited base state from master commits after the PR branched, producing
+   # false-positive contamination claims on PRs that are >2 days old.
+   REPO="effortlessmetrics/perl-lsp"
+   gh api "repos/$REPO/pulls/<number>/files" --paginate --jq '.[].filename'
+
+   # Authored diff stat (three-dot — excludes inherited base state)
+   git diff "$(git merge-base origin/master HEAD)"..HEAD --stat
    cat .spec/*/acceptance.md 2>/dev/null
    ```
    Every acceptance criterion should be addressable from the diff.
@@ -82,7 +90,8 @@ Detection heuristic — for every file in the diff, ask: "does this file's path/
 - If the diff adds tests for crate X but the PR title is about crate Y (and those tests aren't named in the spec): flag as CONTAMINATION
 - If the diff adds ADRs whose work-id doesn't match this PR's branch work-id: flag as CONTAMINATION
 - Tell-tale: PR title claims a small change but `--stat` shows >100 lines outside the named scope. Diff bulk shouldn't be unrelated to the title.
-- Mechanical check: `gh pr diff <num> --stat` then for each crate path, ask whether the PR title/body mentions it; orphan-crate paths are contamination candidates.
+- Mechanical check: `gh api "repos/effortlessmetrics/perl-lsp/pulls/<num>/files" --paginate --jq '.[].filename'` then for each crate path, ask whether the PR title/body mentions it; orphan-crate paths are contamination candidates.
+- **Self-check before flagging**: Before writing CONTAMINATION for any file, confirm it appears in `pulls/<num>/files` (PR-authored). Files that only appear in `git diff origin/master..HEAD` (two-dot) but NOT in the API response are **inherited base state, not drift** — the PR did not author them.
 
 When found, route to `needs-diff-fix` with a `git rm` list. Don't let a 22-of-2063-line legitimate change ride a 2043-line contaminated diff into master.
 

--- a/.claude/commands/diff-audit-check.md
+++ b/.claude/commands/diff-audit-check.md
@@ -9,10 +9,18 @@ Review the cumulative diff from all agents.
 
 ## Steps
 
-1. Get the full diff stat and diff:
+1. Get the canonical PR file list and authored diff:
    ```bash
-   gh pr diff <number> --stat
-   gh pr diff <number>
+   # Authoritative file list — only files the PR author actually changed
+   # (gh pr diff shows branch-vs-current-master and includes inherited base state)
+   REPO="effortlessmetrics/perl-lsp"
+   gh api "repos/$REPO/pulls/<number>/files" --paginate --jq '.[].filename'
+
+   # Authored diff stat — three-dot excludes inherited base content
+   git diff "$(git merge-base origin/master HEAD)"..HEAD --stat
+
+   # Full authored diff for detailed inspection
+   git diff "$(git merge-base origin/master HEAD)"..HEAD
    ```
 
 2. Read the spec:


### PR DESCRIPTION
## Problem

`gh pr diff` computes a **branch-vs-current-master** diff. On any PR that is 2+ days old, master has received new commits since the PR branched, so `gh pr diff` shows those master-side commits as if they belonged to the PR. The diff-auditor agent then flags files from recent master changes as "cross-PR contamination" — even though the PR never touched those files.

**Wave B4 evidence (2026-04-26):** The diff-auditor produced **5 false-positive cross-PR contamination verdicts** on PRs EffortlessMetrics/perl-lsp#6786, EffortlessMetrics/perl-lsp#6777, EffortlessMetrics/perl-lsp#6740, EffortlessMetrics/perl-lsp#6232, and EffortlessMetrics/perl-lsp#6731. It claimed all 5 PRs modified identical `.ci/GATE_REGISTRY.toml`, `.ci/gate-policy.yaml`, `.claude/agents/`, and `.claude/commands/` paths. Independent verification via `gh api repos/.../pulls/N/files` confirmed **zero of the 5 PRs touched any of those paths**. The "contamination" was master's own fire-fix commits appearing in the two-dot diff.

This bug was filed as EffortlessMetrics/perl-lsp-swarm#2798. A prior fix attempt (closed PR EffortlessMetrics/perl-lsp#9564) was drafted but never merged into master.

## Fix

Replace `gh pr diff` with two correct tools in both the agent definition and the skill step:

| Tool | What it shows |
|---|---|
| `gh api repos/$REPO/pulls/N/files` | **Only what the PR author actually changed** — authoritative, paginated |
| `git diff $(git merge-base origin/master HEAD)..HEAD` | **Three-dot authored diff** — excludes inherited base state from master |

Add a mandatory **self-check rule** before any contamination verdict: the flagged file must appear in `pulls/N/files` (PR-authored). If a file only appears in a two-dot `git diff origin/master..HEAD` but NOT in the API response, it is inherited base state — not drift authored by the PR.

## Files changed

- **`.claude/agents/diff-auditor.md`**
  - Step 1 code block: `gh pr diff <number> --stat` → GitHub API + three-dot diff, with a prominent NEVER-USE comment explaining why `gh pr diff` is wrong
  - Mechanical-check bullet: updated to use `gh api pulls/N/files` with `--paginate --jq '.[].filename'`
  - New self-check rule added inline: "before writing CONTAMINATION for any file, confirm it appears in `pulls/<num>/files`"

- **`.claude/commands/diff-audit-check.md`**
  - Step 1: replaced `gh pr diff <number> --stat` + `gh pr diff <number>` with three commands — API file list, three-dot stat, three-dot full diff — each annotated with what it does and why

## What this prevents going forward

- No false-positive SCOPE DRIFT or CONTAMINATION verdicts caused by master-forward commits that postdate the PR's branch point
- The `pulls/N/files` API is the canonical source of truth for "what did this PR author change"
- The three-dot diff (`git diff $(git merge-base ...)..HEAD`) is the correct local authored view
- The self-check rule makes the contract explicit in the audit workflow

## What this does NOT change

- The diff-auditor's contamination detection logic (still correct — just pointed at the right data source)
- Other agents that use `gh pr diff` for non-contamination purposes (those are out of scope per EffortlessMetrics/perl-lsp-swarm#2798)
- Any production Rust code

## Verification

```bash
# gh pr diff no longer appears as an executable command in either file
grep 'gh pr diff' .claude/agents/diff-auditor.md .claude/commands/diff-audit-check.md
# Expected: only in NEVER-USE explanatory comments, not as a command to run

# The correct API pattern is present in both files
grep 'pulls.*files' .claude/agents/diff-auditor.md .claude/commands/diff-audit-check.md
# Expected: matches in both files

# Three-dot merge-base diff is present in both files  
grep 'merge-base' .claude/agents/diff-auditor.md .claude/commands/diff-audit-check.md
# Expected: matches in both files
```

## Related

- EffortlessMetrics/perl-lsp-swarm#2798 — root cause incident report
- Closed PR EffortlessMetrics/perl-lsp#9564 — prior fix attempt (not merged)
- Wave B4 false-positive session (2026-04-26) — 5 PRs incorrectly flagged

https://claude.ai/code/session_01HvJzs22ADx8FXQrz7jiPHT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvJzs22ADx8FXQrz7jiPHT)_