### PR TITLE
fix(hover): namespaced builtins (utf8::encode et al.) show correct hover docs

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -494,6 +494,21 @@ impl LspServer {
             // Defer resolution to Phase 2 via `build_module_hover` so no workspace lock
             // is held here.
             if let Some(pkg_name) = Self::get_package_name_at_position(text, offset) {
+                // Namespaced builtins (e.g. utf8::encode, utf8::decode) must take
+                // priority over module resolution: there is no utf8/encode.pm to
+                // find, and the correct response is the builtin hover card.
+                if let Some(builtin_doc) = crate::semantic::get_builtin_documentation(&pkg_name) {
+                    return HoverExtracted::Complete(json!({
+                        "contents": {
+                            "kind": "markdown",
+                            "value": format!(
+                                "**Built-in Function**\n\n```\n{}\n```\n\n{}",
+                                builtin_doc.signature,
+                                builtin_doc.description
+                            ),
+                        },
+                    }));
+                }
                 return HoverExtracted::PossiblePackage(
                     pkg_name,
                     text.to_string(),

--- a/crates/perl-lsp-rs/tests/hover_provider_coverage.rs
+++ b/crates/perl-lsp-rs/tests/hover_provider_coverage.rs
@@ -304,6 +304,86 @@ connect_db("localhost", 5432, "admin", "secret");
         Ok(())
     }
 
+    // ── 3b. Hover on namespaced builtins (utf8:: family) ────────────────
+    //
+    // These functions are looked up by the hover handler via
+    // `get_package_name_at_position` (which captures the `::` separator),
+    // then resolved against `get_builtin_documentation` before the module
+    // resolver is consulted.  Without this fix they regress to "module not
+    // found" cards because there is no utf8/encode.pm on disk.
+
+    #[test]
+    fn test_hover_utf8_encode_shows_builtin_docs() -> Result<(), Box<dyn std::error::Error>> {
+        let code = "use utf8;\nmy $s = 'hello';\nutf8::encode($s);\n";
+        let resp = hover_at(code, "file:///utf8_encode.pl", "encode", 2)?;
+
+        let content = hover_content(&resp).ok_or("expected hover content for utf8::encode")?;
+        assert!(
+            content.contains("Built-in Function"),
+            "hover on utf8::encode should show Built-in Function heading, got: {content}"
+        );
+        assert!(
+            content.contains("utf8::encode"),
+            "hover on utf8::encode should include the function name, got: {content}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_hover_utf8_decode_shows_builtin_docs() -> Result<(), Box<dyn std::error::Error>> {
+        let code = "my $bytes = \"\\xC3\\xA9\";\nutf8::decode($bytes);\n";
+        let resp = hover_at(code, "file:///utf8_decode.pl", "decode", 1)?;
+
+        let content = hover_content(&resp).ok_or("expected hover content for utf8::decode")?;
+        assert!(
+            content.contains("Built-in Function"),
+            "hover on utf8::decode should show Built-in Function heading, got: {content}"
+        );
+        assert!(
+            content.contains("utf8::decode"),
+            "hover on utf8::decode should include the function name, got: {content}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_hover_utf8_downgrade_shows_builtin_docs() -> Result<(), Box<dyn std::error::Error>> {
+        let code = "my $s = 'hello';\nutf8::downgrade($s);\n";
+        let resp = hover_at(code, "file:///utf8_downgrade.pl", "downgrade", 1)?;
+
+        let content = hover_content(&resp).ok_or("expected hover content for utf8::downgrade")?;
+        assert!(
+            content.contains("Built-in Function"),
+            "hover on utf8::downgrade should show Built-in Function heading, got: {content}"
+        );
+        assert!(
+            content.contains("utf8::downgrade"),
+            "hover on utf8::downgrade should include the function name, got: {content}"
+        );
+        assert!(
+            content.contains("FAIL_OK"),
+            "utf8::downgrade hover should document the optional FAIL_OK parameter, got: {content}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_hover_utf8_is_utf8_shows_builtin_docs() -> Result<(), Box<dyn std::error::Error>> {
+        let code = "my $s = 'café';\nif (utf8::is_utf8($s)) { print 1; }\n";
+        let resp = hover_at(code, "file:///utf8_is_utf8.pl", "is_utf8", 1)?;
+
+        let content = hover_content(&resp).ok_or("expected hover content for utf8::is_utf8")?;
+        assert!(
+            content.contains("Built-in Function"),
+            "hover on utf8::is_utf8 should show Built-in Function heading, got: {content}"
+        );
+        assert!(
+            content.contains("utf8::is_utf8"),
+            "hover on utf8::is_utf8 should include the function name, got: {content}"
+        );
+        Ok(())
+    }
+
     // ── 4. Hover on package name: shows module info ─────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a user-visible hover regression where hovering over `utf8::encode`, `utf8::decode`, and the other `utf8::*` namespaced builtin functions produced a **"module not found"** card instead of the correct **Built-in Function** hover documentation.

## Root Cause

The hover handler has two strategies for extracting the symbol under the cursor:

1. **`get_token_at_position_static`** — scans alphanumeric + sigil characters only; does **not** cross `::` separators.
2. **`get_package_name_at_position`** — scans across `::` separators and returns `Some(name)` when the token contains `::`.

For a call like `utf8::encode($s)`, strategy (2) correctly extracted `"utf8::encode"` as a qualified name. However, the code then passed the result **unconditionally to `build_module_hover`**, which tries to resolve the name as a `.pm` file on disk. No such file exists for `utf8::encode`, so the handler fell through to the "module not found / MetaCPAN link" path — completely hiding the builtin documentation that was already registered in `get_builtin_documentation`.

## Fix

Before delegating to `build_module_hover`, check `get_builtin_documentation` against the fully-qualified name. If it matches a known builtin, return the builtin hover card immediately and skip module resolution entirely.

```rust
// hover.rs — inside the `get_package_name_at_position` branch
if let Some(pkg_name) = Self::get_package_name_at_position(text, offset) {
    // Namespaced builtins (e.g. utf8::encode, utf8::decode) must take
    // priority over module resolution: there is no utf8/encode.pm to
    // find, and the correct response is the builtin hover card.
    if let Some(builtin_doc) = crate::semantic::get_builtin_documentation(&pkg_name) {
        return HoverExtracted::Complete(json!({ ... }));
    }
    return HoverExtracted::PossiblePackage(...); // unchanged path for real modules
}
```

Real module names (e.g. `File::Path`, `DBI`, `Moose`) are unaffected — they still go through `build_module_hover` as before.

## Affected Builtins

All 8 functions in the `utf8::*` namespace, all of which were broken:

| Function | Signature |
|---|---|
| `utf8::encode` | `utf8::encode(SCALAR)` |
| `utf8::decode` | `utf8::decode(SCALAR)` |
| `utf8::is_utf8` | `utf8::is_utf8(SCALAR)` |
| `utf8::valid` | `utf8::valid(SCALAR)` |
| `utf8::upgrade` | `utf8::upgrade(SCALAR)` |
| `utf8::downgrade` | `utf8::downgrade(SCALAR)` / `utf8::downgrade(SCALAR, FAIL_OK)` |
| `utf8::native_to_unicode` | `utf8::native_to_unicode(CODEPOINT)` |
| `utf8::unicode_to_native` | `utf8::unicode_to_native(CODEPOINT)` |

## Tests

4 new BDD-style integration tests in `hover_provider_coverage.rs`:

- `test_hover_utf8_encode_shows_builtin_docs` — asserts "Built-in Function" heading and `utf8::encode` in content
- `test_hover_utf8_decode_shows_builtin_docs` — asserts "Built-in Function" heading and `utf8::decode` in content
- `test_hover_utf8_downgrade_shows_builtin_docs` — asserts "Built-in Function", `utf8::downgrade`, and the optional `FAIL_OK` parameter documented
- `test_hover_utf8_is_utf8_shows_builtin_docs` — asserts "Built-in Function" and `utf8::is_utf8` in content

All 4 pass. 752 existing lib tests are unaffected. The 5 pre-existing failures in `hover_provider_coverage` (`BEGIN`/`CHECK`/`END`/`INIT`/`UNITCHECK` block hover tests) are not related to this change.

## Diff Size

- **hover.rs**: +15 lines (one `if let` guard before the existing `PossiblePackage` return)
- **hover_provider_coverage.rs**: +80 lines (4 new test functions)

## Verification

```bash
cargo test -p perl-lsp-rs --test hover_provider_coverage -- test_hover_utf8
# running 4 tests
# test hover_provider_tests::test_hover_utf8_encode_shows_builtin_docs ... ok
# test hover_provider_tests::test_hover_utf8_decode_shows_builtin_docs ... ok
# test hover_provider_tests::test_hover_utf8_downgrade_shows_builtin_docs ... ok
# test hover_provider_tests::test_hover_utf8_is_utf8_shows_builtin_docs ... ok
# test result: ok. 4 passed; 0 failed
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhWW2fDK3qMJAKbknzd9gS)_