### PR TITLE
docs(editors): add Cursor and IntelliJ IDEA setup guides (#7454)

### DIFF
--- a/docs/EDITORS/CURSOR_SETUP.md
+++ b/docs/EDITORS/CURSOR_SETUP.md
@@ -1,0 +1,202 @@
+# Cursor Setup Guide for perl-lsp
+
+This guide covers using `perl-lsp` with Cursor, the AI-assisted code editor.
+
+Cursor is based on the VS Code codebase and can add language support through
+extensions. Use the VS Code-compatible `perl-lsp` extension path:
+
+- **Extension (recommended)** - install the `EffortlessMetrics.perl-lsp-rs` VSIX
+  extension and let it manage `perllsp` automatically.
+
+## Prerequisites
+
+- A current Cursor build
+- `perllsp` installed and on your `PATH` (optional when using the extension with
+  auto-download enabled)
+- A Perl project opened in Cursor
+
+Verify `perllsp` before changing editor settings:
+
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+If you still need to install the binary, see
+[INSTALLATION.md](../how-to/INSTALLATION.md).
+
+## Extension Setup
+
+### Install the Extension
+
+Cursor supports VS Code extension format. Install the `EffortlessMetrics.perl-lsp-rs`
+extension using one of these methods:
+
+**From the Extensions panel:**
+1. Open the Extensions panel: `Ctrl+Shift+X` (Cmd+Shift+X on macOS).
+2. Search for `perl-lsp` or `EffortlessMetrics.perl-lsp-rs`.
+3. Click **Install**.
+
+**From the command line:**
+```bash
+cursor --install-extension EffortlessMetrics.perl-lsp-rs
+```
+
+**From a downloaded VSIX:**
+1. Download the `.vsix` from [GitHub Releases](https://github.com/EffortlessMetrics/perl-lsp/releases).
+2. Open the Extensions panel, click the `...` menu, and choose **Install from VSIX**.
+
+### Configure the Extension
+
+The extension works without configuration using its defaults. For a workspace-specific
+setup, create or edit `.vscode/settings.json` in your project root:
+
+```json
+{
+  "perl-lsp.autoDownload": true,
+  "perl-lsp.enableDiagnostics": true,
+  "perl-lsp.enableSemanticTokens": true,
+  "perl-lsp.enableFormatting": true,
+  "perl-lsp.formatOnSave": false,
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5"]
+}
+```
+
+Cursor reads `.vscode/settings.json` for workspace-scoped settings, same as VS Code.
+User-level settings are in Cursor's own settings file (accessible via
+`Ctrl+,` / Cmd+,).
+
+### Pin a Specific Release
+
+To avoid tracking the `latest` channel:
+
+```json
+{
+  "perl-lsp.channel": "tag",
+  "perl-lsp.versionTag": "v0.15.0"
+}
+```
+
+### Use a Pre-installed Binary
+
+To disable auto-download and use a binary you installed:
+
+```json
+{
+  "perl-lsp.serverPath": "/usr/local/bin/perllsp",
+  "perl-lsp.autoDownload": false
+}
+```
+
+## Optional: Server Initialization Options
+
+Prefer `.perl-lsp.toml` for settings shared across all editors. Use
+workspace settings for Cursor-specific startup settings that should not apply
+everywhere.
+
+```json
+{
+  "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"]
+}
+```
+
+## Cursor AI and LSP
+
+Cursor's AI features (tab completion, inline chat, composer) operate independently
+of the LSP layer. Both run simultaneously without conflict. If Cursor's AI suggests
+Perl completions and `perllsp` also fires, the two sources will appear in the same
+completion list. This is expected behavior.
+
+## Verify It Is Running
+
+1. Open a Perl file such as `lib/My/Module.pm` or `t/basic.t`.
+2. Confirm the language mode shows `Perl` in the status bar.
+3. Introduce a temporary syntax error (e.g., remove a semicolon).
+4. Confirm a diagnostic squiggle appears.
+5. Remove the syntax error.
+
+Try LSP-backed navigation:
+
+- **Go to Definition**: `F12` or `Ctrl+Click` (Cmd+Click on macOS)
+- **Find All References**: `Shift+F12`
+- **Hover**: mouse over a symbol or `Ctrl+K Ctrl+I`
+- **Rename Symbol**: `F2`
+- **Format Document**: `Shift+Alt+F` (Shift+Option+F on macOS)
+
+To restart the server without restarting Cursor:
+
+1. Press `Ctrl+Shift+P` (Cmd+Shift+P on macOS).
+2. Run **Perl: Restart Language Server**.
+
+## Troubleshooting
+
+### Server does not start
+
+1. Verify the binary:
+   ```bash
+   perllsp --version
+   perllsp --health
+   ```
+
+2. Open the Output panel (`Ctrl+Shift+U` / Cmd+Shift+U) and select
+   **Perl Language Server** from the dropdown. Look for error messages.
+
+3. Enable verbose tracing:
+   ```json
+   { "perl-lsp.trace.server": "verbose" }
+   ```
+
+4. Confirm Cursor was launched from a shell that has `perllsp` on its `PATH`.
+   If Cursor was opened from a GUI launcher, it may not inherit shell `PATH`.
+   Set an absolute `serverPath` in that case:
+   ```json
+   { "perl-lsp.serverPath": "/absolute/path/to/perllsp" }
+   ```
+
+### `perllsp --stdio` appears to hang
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP JSON-RPC input.
+It is not suitable for running manually without a client. Use these diagnostic
+commands instead:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+```
+
+### No diagnostics appear
+
+- Confirm the file extension is `.pl`, `.pm`, or `.t`.
+- Confirm the language mode in the status bar shows **Perl**.
+- Confirm `perl-lsp.enableDiagnostics` is `true`.
+
+### Module resolution fails
+
+Add the missing roots:
+
+```json
+{ "perl-lsp.includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"] }
+```
+
+Or set them in `.perl-lsp.toml` (applies to all editors):
+
+```toml
+[perl]
+include_paths = ["lib", "local/lib/perl5", "vendor/lib"]
+```
+
+### Duplicate diagnostics
+
+If another Perl extension is installed (e.g., a different Perl LSP extension),
+disable it. Open the Extensions panel, search for `perl`, and disable extensions
+that register a language server.
+
+## See Also
+
+- [VS Code Setup](VS_CODE_SETUP.md) - the Cursor extension is the same package
+- [Editor Setup](../how-to/EDITOR_SETUP.md)
+- [Configuration Reference](../reference/CONFIG.md)
+- [Troubleshooting Guide](../how-to/TROUBLESHOOTING.md)
+- [DAP User Guide](../tutorials/DAP_USER_GUIDE.md) - debugging support

--- a/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
+++ b/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
@@ -1,0 +1,228 @@
+# IntelliJ IDEA Setup Guide for perl-lsp
+
+This guide covers using `perl-lsp` with IntelliJ IDEA via the
+[LSP4IJ](https://github.com/redhat-developer/lsp4ij) plugin.
+
+LSP4IJ is a community plugin maintained by Red Hat that provides a generic LSP
+client for all JetBrains IDEs. It lets you register any language server that speaks
+stdio by pointing it at a shell command.
+
+> **Applies to:** IntelliJ IDEA (Community and Ultimate), as well as other
+> JetBrains IDEs (PyCharm, WebStorm, Rider, etc.) that support LSP4IJ.
+
+## Prerequisites
+
+- IntelliJ IDEA 2024.2 or later (current LSP4IJ releases target the 2024.2+
+  platform)
+- The **LSP4IJ** plugin installed (see [Install LSP4IJ](#install-lsp4ij))
+- `perllsp` installed and available on your `PATH`
+- A Perl project opened in IntelliJ IDEA
+
+Verify `perllsp` before configuring the IDE:
+
+```bash
+perllsp --version
+perllsp --health
+perllsp --info
+```
+
+If you still need to install the binary, see
+[INSTALLATION.md](../how-to/INSTALLATION.md).
+
+## Install LSP4IJ
+
+1. Open **File > Settings** (IntelliJ IDEA > Settings on macOS) >
+   **Plugins**.
+2. Switch to the **Marketplace** tab.
+3. Search for `LSP4IJ`.
+4. Click **Install** and restart IntelliJ IDEA when prompted.
+
+Alternatively, download the plugin from the
+[JetBrains Marketplace](https://plugins.jetbrains.com/plugin/23257-lsp4ij)
+and install it via **Plugins > Settings > Install Plugin from Disk**.
+
+## Configure the perl-lsp Server
+
+### Add a New Language Server
+
+1. Open **File > Settings > Languages & Frameworks > Language Servers**.
+2. Click **+** to add a new server definition.
+3. Fill in the fields:
+
+   | Field | Value |
+   |-------|-------|
+   | **Name** | `perl-lsp` |
+   | **Command** | `perllsp --stdio` |
+   | **Mappings: File name patterns** | `*.pl`, `*.pm`, `*.t`, `*.psgi`, `*.cgi` |
+
+4. Click **OK** to save.
+
+### Example Configuration
+
+If your IntelliJ installation does not inherit your shell `PATH`, use an absolute
+binary path:
+
+| Field | Value |
+|-------|-------|
+| **Command** | `/usr/local/bin/perllsp --stdio` |
+
+Find the path with:
+
+```bash
+command -v perllsp
+```
+
+On Windows PowerShell:
+
+```powershell
+where perllsp
+```
+
+On Windows, use the full path with forward slashes or escaped backslashes:
+
+```
+C:/path/to/perllsp.exe --stdio
+```
+
+### Initialization Options
+
+To pass server-specific startup settings, add an `initializationOptions` JSON
+block in the LSP4IJ **Server** tab under **Initialization options**:
+
+```json
+{
+  "perl": {
+    "workspace": {
+      "includePaths": ["lib", ".", "local/lib/perl5"]
+    },
+    "inlayHints": {
+      "enabled": true
+    }
+  }
+}
+```
+
+Prefer `.perl-lsp.toml` in the project root for settings that should apply across
+all editors and teammates. Use LSP4IJ initialization options for IDE-specific
+overrides.
+
+## File Type Association
+
+IntelliJ IDEA does not recognize Perl files by default unless the **Perl plugin**
+is also installed. LSP4IJ maps language servers by file name pattern, so even
+without the Perl plugin, LSP4IJ can activate `perllsp` for files matching
+`*.pl`, `*.pm`, and `*.t`.
+
+If you have the IntelliJ Perl plugin installed, IntelliJ already knows the `Perl`
+file type. In that case, you can also map by file type instead of pattern in the
+LSP4IJ settings.
+
+## Optional: Inlay Hints
+
+Recent LSP4IJ-supported IntelliJ builds surface LSP inlay hints. To enable them:
+
+1. Open **File > Settings > Editor > Inlay Hints**.
+2. Confirm that **LSP** hints are enabled.
+
+Then enable inlay hints on the server side via initialization options (see above)
+or in `.perl-lsp.toml`:
+
+```toml
+[features]
+inlay_hints = true
+```
+
+## Verify It Is Running
+
+1. Open a Perl file such as `lib/My/Module.pm` or `t/basic.t`.
+2. Confirm that LSP4IJ activates: the status bar should show the language server
+   indicator.
+3. Introduce a temporary syntax error (e.g., remove a semicolon).
+4. Confirm a diagnostic appears in the editor gutter.
+5. Remove the syntax error.
+
+Try LSP-backed navigation:
+
+- **Go to Declaration**: `Ctrl+B` / `Cmd+B`
+- **Find Usages**: `Alt+F7`
+- **Hover**: mouse over a symbol or `Ctrl+Q` / `Ctrl+J`
+- **Rename**: `Shift+F6`
+
+LSP4IJ exposes available LSP features through IntelliJ's standard action system.
+Not all IntelliJ actions have LSP equivalents, but diagnostics, hover, go-to-definition,
+references, and rename are supported.
+
+## Troubleshooting
+
+### Server does not start
+
+Open **View > Tool Windows > LSP** (or the LSP Console from the status bar) to
+see the LSP4IJ log. The console shows server startup commands and error output.
+
+```bash
+# Verify the binary outside IntelliJ first
+perllsp --version
+perllsp --health
+```
+
+If IntelliJ does not inherit your shell `PATH`, use an absolute path in the
+**Command** field.
+
+### `perllsp --stdio` appears to hang when run manually
+
+That is expected. In stdio mode, `perllsp` waits for framed LSP JSON-RPC input.
+It is not suitable for running interactively. Use these commands for manual checks:
+
+```bash
+perllsp --health
+perllsp --info
+perllsp --check path/to/file.pl
+```
+
+### No diagnostics for Perl files
+
+- Confirm the file name pattern in LSP4IJ matches the file extension (e.g.,
+  `*.pm`, `*.pl`, `*.t`).
+- Check that the LSP4IJ plugin is enabled in **Plugins**.
+- Open the LSP Console to confirm the server started without error.
+
+### Module resolution fails
+
+Add the missing roots via initialization options:
+
+```json
+{
+  "perl": {
+    "workspace": {
+      "includePaths": ["lib", ".", "local/lib/perl5", "vendor/lib"]
+    }
+  }
+}
+```
+
+Or use `.perl-lsp.toml`:
+
+```toml
+[perl]
+include_paths = ["lib", "local/lib/perl5", "vendor/lib"]
+```
+
+### Restart the language server
+
+From the LSP Console or status bar indicator, use the **Restart** action to
+reload `perllsp` without restarting IntelliJ IDEA.
+
+## Windows Notes
+
+- Use the full path to `perllsp.exe` if it is not on the system `PATH`.
+- IntelliJ on Windows may not inherit PowerShell `PATH` entries. Set the binary
+  path explicitly in the LSP4IJ **Command** field.
+- Use forward slashes in paths or double backslashes:
+  `C:/path/to/perllsp.exe --stdio`
+
+## See Also
+
+- [Editor Setup](../how-to/EDITOR_SETUP.md)
+- [Configuration Reference](../reference/CONFIG.md)
+- [Troubleshooting Guide](../how-to/TROUBLESHOOTING.md)
+- [LSP4IJ Documentation](https://github.com/redhat-developer/lsp4ij/blob/main/docs/user-guide.md)

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -31,7 +31,9 @@ perllsp --health
 | Editor | Fast path | Detailed guide |
 | --- | --- | --- |
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
+| Cursor | install the VS Code-compatible extension and configure it with the `perl-lsp.*` settings namespace | [docs/EDITORS/CURSOR_SETUP.md](../EDITORS/CURSOR_SETUP.md) |
 | Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
+| IntelliJ IDEA | install the LSP4IJ plugin and register `perllsp --stdio` as a Raw Command server | [docs/EDITORS/INTELLIJ_IDEA_SETUP.md](../EDITORS/INTELLIJ_IDEA_SETUP.md) |
 | Neovim | define a custom `perllsp` config with `vim.lsp.config()` and enable via `vim.lsp.enable()` (legacy `nvim-lspconfig` supported for older Neovim) | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | coc.nvim | configure `languageserver.perl-lsp` in `coc-settings.json` to launch `perllsp --stdio`; works in Neovim and Vim when the buffer filetype is `perl` | [docs/EDITORS/COC_NEOVIM_SETUP.md](../EDITORS/COC_NEOVIM_SETUP.md) |
@@ -52,6 +54,12 @@ perllsp --health
 The repo-maintained extension is the easiest route. If you prefer a manual
 configuration, set the command to `perllsp --stdio` and keep the workspace
 root pointed at the project root.
+
+### Cursor
+
+Cursor is based on the VS Code codebase. Install the `EffortlessMetrics.perl-lsp-rs`
+extension from Cursor's Extensions panel (or via VSIX). Workspace settings use
+the same `.vscode/settings.json` format as VS Code.
 
 ### Trae (ByteDance)
 
@@ -226,6 +234,20 @@ the full workflow, bridge config, and troubleshooting.
 Create or update `opencode.json` and register a custom LSP server with
 `"command": ["perllsp", "--stdio"]` and Perl extensions like `.pl`, `.pm`,
 and `.t`. See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for a full example.
+
+### IntelliJ IDEA
+
+Install the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin,
+then open **File > Settings > Languages & Frameworks > Language Servers** and add:
+
+| Field | Value |
+| --- | --- |
+| Name | `perl-lsp` |
+| Command | `perllsp --stdio` |
+| File name patterns | `*.pl`, `*.pm`, `*.t`, `*.psgi`, `*.cgi` |
+
+See [docs/EDITORS/INTELLIJ_IDEA_SETUP.md](../EDITORS/INTELLIJ_IDEA_SETUP.md) for the full workflow,
+initialization options, and troubleshooting.
 
 ## When Setup Fails
 


### PR DESCRIPTION
## Summary

Closes #7454 and #7455.

Adds first-party setup guides for Cursor and IntelliJ IDEA, then links both from the editor setup overview. This is docs-only.

## Scope

- docs/EDITORS/CURSOR_SETUP.md: VS Code-compatible extension setup, workspace settings, release pinning, server-path override, verification, and troubleshooting.
- docs/EDITORS/INTELLIJ_IDEA_SETUP.md: LSP4IJ setup for current IntelliJ builds, server command registration, file patterns, initialization options, inlay hints, Windows path notes, and troubleshooting.
- docs/how-to/EDITOR_SETUP.md: Cursor and IntelliJ IDEA rows plus minimal setup notes.

## Review notes

- Removed the unsupported claim that Cursor has a built-in generic LSP configuration path.
- Updated LSP4IJ platform wording to the current 2024.2+ requirement.
- Replaced machine-specific Windows paths with generic examples.

## Verification

- MIN_FREE_GB=20 MAX_USED_PCT=99 CARGO_LOCK_WAIT=1200 ./scripts/cargo-safe xtask ci-hygiene check-doc-paths docs/EDITORS
- MIN_FREE_GB=20 MAX_USED_PCT=99 CARGO_LOCK_WAIT=1200 ./scripts/cargo-safe xtask ci-hygiene check-doc-paths docs/how-to
- git diff --check origin/master

## Validation gap

The repo-wide docs path check is already blocked by pre-existing archived /home/steven links outside this PR. The touched docs directories pass the same checker.