### PR TITLE
fix(lsp): align inline completion capability advertisement (#6797)

### DIFF
--- a/crates/perl-lsp-rs-core/src/features/flags.rs
+++ b/crates/perl-lsp-rs-core/src/features/flags.rs
@@ -63,6 +63,8 @@ pub struct AdvertisedFeatures {
     pub document_highlight: bool,
     /// Go-to-declaration navigation
     pub declaration: bool,
+    /// Inline completion provider support.
+    pub inline_completion: bool,
 }
 
 /// Build-time feature flags for conditional LSP capability compilation
@@ -173,6 +175,7 @@ impl BuildFlags {
             signature_help: self.signature_help,
             document_highlight: self.document_highlight,
             declaration: self.declaration,
+            inline_completion: self.inline_completion,
         }
     }
 

--- a/crates/perl-lsp-rs-core/src/protocol/capabilities.rs
+++ b/crates/perl-lsp-rs-core/src/protocol/capabilities.rs
@@ -79,6 +79,11 @@ pub fn capabilities_json(build: BuildFlags) -> Value {
     if build.range_formatting {
         json["documentRangesFormattingProvider"] = serde_json::json!(true);
     }
+    // Manually add inlineCompletionProvider (LSP 3.18) because lsp-types 0.97
+    // predates this field. The handler already exists in completion.rs.
+    if build.inline_completion {
+        json["inlineCompletionProvider"] = serde_json::json!({});
+    }
 
     json
 }
@@ -136,7 +141,7 @@ mod tests {
     /// `feature_ids_from_caps()` cannot detect because lsp-types 0.97
     /// lacks the corresponding `ServerCapabilities` field.
     ///
-    /// - `inline_completion`: advertised via `experimental` JSON, no typed field
+    /// - `inline_completion`: injected in `capabilities_json()` (LSP 3.18, not in lsp-types 0.97)
     /// - `notebook_cell_execution`: sub-feature of notebook sync, no own field
     /// - `ranges_formatting`: injected in `capabilities_json()` (LSP 3.18, not in lsp-types 0.97)
     ///
@@ -205,6 +210,37 @@ mod tests {
         assert!(
             json.get("documentRangesFormattingProvider").is_none(),
             "documentRangesFormattingProvider must not be present when range_formatting is disabled"
+        );
+    }
+
+    #[test]
+    fn inline_completion_advertised_as_top_level_json_when_enabled() {
+        let flags = BuildFlags { inline_completion: true, ..BuildFlags::default() };
+        let json = capabilities_json(flags);
+        assert_eq!(
+            json.get("inlineCompletionProvider"),
+            Some(&serde_json::json!({})),
+            "inlineCompletionProvider must be advertised as an empty top-level object when enabled"
+        );
+    }
+
+    #[test]
+    fn inline_completion_absent_when_disabled() {
+        let flags = BuildFlags { inline_completion: false, ..BuildFlags::default() };
+        let json = capabilities_json(flags);
+        assert!(
+            json.get("inlineCompletionProvider").is_none(),
+            "inlineCompletionProvider must be absent when inline completion is disabled"
+        );
+    }
+
+    #[test]
+    fn inline_completion_not_advertised_under_experimental() {
+        let flags = BuildFlags { inline_completion: true, ..BuildFlags::default() };
+        let json = capabilities_json(flags);
+        assert!(
+            json.pointer("/experimental/inlineCompletionProvider").is_none(),
+            "inlineCompletionProvider must not be advertised under capabilities.experimental"
         );
     }
 

--- a/crates/perl-lsp-rs-core/src/protocol/capabilities/experimental.rs
+++ b/crates/perl-lsp-rs-core/src/protocol/capabilities/experimental.rs
@@ -2,11 +2,6 @@ use super::BuildFlags;
 use lsp_types::ServerCapabilities;
 
 pub(super) fn apply_experimental_features(caps: &mut ServerCapabilities, build: &BuildFlags) {
-    // Inline completion via experimental until lsp-types has the field.
-    if build.inline_completion {
-        insert_experimental_capability(caps, "inlineCompletionProvider", serde_json::json!({}));
-    }
-
     // Type hierarchy via experimental: lsp-types 0.97 lacks a `type_hierarchy_provider`
     // field on `ServerCapabilities`. We advertise it via `experimental` so that
     // `capabilities_for()` users and `feature_ids_from_caps` can detect the capability.

--- a/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/lifecycle.rs
@@ -33,6 +33,7 @@ impl LspServer {
         if self.client_capabilities.lock().dynamic_registration_support {
             self.register_file_watchers_async();
         }
+        self.register_inline_completion_if_needed();
 
         // Start workspace indexing in the background (if workspace folders
         // exist and the eager-indexing gate allows it). The gate defaults to

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -32,10 +32,9 @@ fn merge_experimental_capability(capabilities: &mut Value, key: &str, value: Val
         capabilities["experimental"] = json!({});
     }
 
-    capabilities["experimental"]
-        .as_object_mut()
-        .expect("experimental must be object")
-        .insert(key.to_string(), value);
+    if let Some(experimental) = capabilities["experimental"].as_object_mut() {
+        experimental.insert(key.to_string(), value);
+    }
 }
 
 impl LspServer {

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs
@@ -27,6 +27,17 @@ fn is_jetbrains_client(params: &Value) -> bool {
         .unwrap_or(false)
 }
 
+fn merge_experimental_capability(capabilities: &mut Value, key: &str, value: Value) {
+    if !capabilities.get("experimental").is_some_and(Value::is_object) {
+        capabilities["experimental"] = json!({});
+    }
+
+    capabilities["experimental"]
+        .as_object_mut()
+        .expect("experimental must be object")
+        .insert(key.to_string(), value);
+}
+
 impl LspServer {
     /// Handle initialize request
     pub(crate) fn handle_initialize(
@@ -190,6 +201,14 @@ impl LspServer {
                     caps.inline_value_refresh_support = cap_val
                         .pointer("/workspace/inlineValue/refreshSupport")
                         .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+
+                    caps.inline_completion_support =
+                        cap_val.pointer("/textDocument/inlineCompletion").is_some();
+
+                    caps.inline_completion_dynamic_registration_support = cap_val
+                        .pointer("/textDocument/inlineCompletion/dynamicRegistration")
+                        .and_then(Value::as_bool)
                         .unwrap_or(false);
 
                     // workspace/diagnostic/refresh
@@ -415,21 +434,13 @@ impl LspServer {
         *self.advertised_features.lock() = features.clone();
 
         // Generate capabilities from build flags
-        let server_caps = crate::protocol::capabilities::capabilities_for(build_flags);
-        let mut capabilities = serde_json::to_value(&server_caps).map_err(|e| {
-            crate::protocol::internal_error(&format!(
-                "Failed to serialize server capabilities: {}",
-                e
-            ))
-        })?;
+        let mut capabilities =
+            crate::protocol::capabilities::capabilities_json(build_flags.clone());
 
         // Add fields not yet in lsp-types 0.97
         capabilities["positionEncoding"] = json!("utf-16");
         if features.declaration {
             capabilities["declarationProvider"] = json!(true);
-        }
-        if features.type_hierarchy {
-            capabilities["typeHierarchyProvider"] = json!(true);
         }
 
         // Override text document sync with more detailed options
@@ -491,10 +502,13 @@ impl LspServer {
             }
         });
 
-        // Advertise experimental custom requests
-        capabilities["experimental"] = json!({
-            "perlInlineCompletionStream": true
-        });
+        if features.inline_completion {
+            merge_experimental_capability(
+                &mut capabilities,
+                "perlInlineCompletionStream",
+                json!(true),
+            );
+        }
 
         Ok(Some(json!({
             "capabilities": capabilities,
@@ -796,6 +810,25 @@ mod tests {
         let caps = server.client_capabilities.lock();
         assert!(caps.snippet_support);
         assert!(caps.completion_commit_characters_support);
+    }
+
+    #[test]
+    fn lsp4ij_inline_completion_dynamic_registration_shape_is_parsed() {
+        let server = LspServer::new();
+        let params = json!({
+            "capabilities": {
+                "textDocument": {
+                    "inlineCompletion": {
+                        "dynamicRegistration": true
+                    }
+                }
+            }
+        });
+
+        let _ = server.handle_initialize(Some(params));
+        let caps = server.client_capabilities.lock();
+        assert!(caps.inline_completion_support);
+        assert!(caps.inline_completion_dynamic_registration_support);
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/lifecycle/watchers.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/watchers.rs
@@ -61,4 +61,33 @@ impl LspServer {
             tracing::error!(%error, "Failed to send file watcher registration request");
         }
     }
+
+    pub(crate) fn register_inline_completion_if_needed(&self) {
+        let should_register = {
+            let caps = self.client_capabilities.lock();
+            caps.inline_completion_dynamic_registration_support
+                && self.advertised_features.lock().inline_completion
+        };
+
+        if !should_register {
+            return;
+        }
+
+        let params = serde_json::json!({
+            "registrations": [{
+                "id": "perl-inlineCompletion",
+                "method": "textDocument/inlineCompletion",
+                "registerOptions": {
+                    "documentSelector": [
+                        { "language": "perl" },
+                        { "language": "perl5" }
+                    ]
+                }
+            }]
+        });
+
+        if let Err(error) = self.send_request("client/registerCapability", params) {
+            tracing::warn!(%error, "Failed to register inline completion capability");
+        }
+    }
 }

--- a/crates/perl-lsp-rs/src/state/document.rs
+++ b/crates/perl-lsp-rs/src/state/document.rs
@@ -290,6 +290,10 @@ pub struct ClientCapabilities {
     pub snippet_support: bool,
     /// Supports `completionItem.commitCharacters` in completion results
     pub completion_commit_characters_support: bool,
+    /// Client declared textDocument/inlineCompletion capability.
+    pub inline_completion_support: bool,
+    /// Supports dynamic registration for textDocument/inlineCompletion.
+    pub inline_completion_dynamic_registration_support: bool,
     /// Supports markdown message content in diagnostics (LSP 3.18)
     ///
     /// When true, the server can provide rich markdown formatting in diagnostic

--- a/crates/perl-lsp-rs/tests/lsp_inline_completion_registration_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_inline_completion_registration_tests.rs
@@ -1,0 +1,93 @@
+mod support;
+
+use serde_json::json;
+use support::lsp_harness::LspHarness;
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+#[test]
+fn initialize_advertises_standard_inline_completion_provider() -> TestResult {
+    let mut harness = LspHarness::new();
+    let init_result = harness.initialize(Some(json!({
+        "textDocument": {"inlineCompletion": {"dynamicRegistration": true}}
+    })))?;
+
+    assert_eq!(init_result.pointer("/capabilities/inlineCompletionProvider"), Some(&json!({})));
+    Ok(())
+}
+
+#[test]
+fn initialize_does_not_put_inline_completion_provider_under_experimental() -> TestResult {
+    let mut harness = LspHarness::new();
+    let init_result = harness.initialize(Some(json!({
+        "textDocument": {"inlineCompletion": {"dynamicRegistration": true}}
+    })))?;
+
+    assert!(init_result.pointer("/capabilities/experimental/inlineCompletionProvider").is_none());
+    Ok(())
+}
+
+#[test]
+fn initialize_preserves_perl_inline_completion_stream_flag() -> TestResult {
+    let mut harness = LspHarness::new();
+    let init_result = harness.initialize(Some(json!({
+        "textDocument": {"inlineCompletion": {"dynamicRegistration": true}}
+    })))?;
+
+    assert_eq!(
+        init_result.pointer("/capabilities/experimental/perlInlineCompletionStream"),
+        Some(&json!(true))
+    );
+    Ok(())
+}
+
+#[test]
+fn initialized_registers_inline_completion_when_dynamic_registration_supported() -> TestResult {
+    let mut harness = LspHarness::new();
+    let _ = harness.initialize(Some(json!({
+        "textDocument": {"inlineCompletion": {"dynamicRegistration": true}}
+    })))?;
+
+    let requests = harness.drain_server_requests(500);
+    let request = requests
+        .into_iter()
+        .find(|req| {
+            req.get("method") == Some(&json!("client/registerCapability"))
+                && req.pointer("/params/registrations/0/method")
+                    == Some(&json!("textDocument/inlineCompletion"))
+        })
+        .ok_or("missing inline completion dynamic registration")?;
+
+    assert_eq!(
+        request.pointer("/params/registrations/0/id"),
+        Some(&json!("perl-inlineCompletion"))
+    );
+
+    let id = request.get("id").and_then(|v| v.as_i64()).ok_or("request id must be integer")?;
+    assert!((1..=i64::from(i32::MAX)).contains(&id));
+    Ok(())
+}
+
+#[test]
+fn disabled_inline_completion_removes_static_and_experimental_capabilities() -> TestResult {
+    let mut harness = LspHarness::new();
+    let init_result = harness.initialize_with_init_options(
+        Some(json!({
+            "textDocument": {"inlineCompletion": {"dynamicRegistration": true}}
+        })),
+        json!({"disabledFeatures": ["lsp.inline_completion"]}),
+    )?;
+
+    assert!(init_result.pointer("/capabilities/inlineCompletionProvider").is_none());
+    assert!(init_result.pointer("/capabilities/experimental/perlInlineCompletionStream").is_none());
+
+    let requests = harness.drain_server_requests(500);
+    let has_inline_registration = requests.iter().any(|req| {
+        req.get("method") == Some(&json!("client/registerCapability"))
+            && req.pointer("/params/registrations/0/method")
+                == Some(&json!("textDocument/inlineCompletion"))
+    });
+    assert!(!has_inline_registration);
+
+    Ok(())
+}

--- a/crates/perl-lsp-rs/tests/lsp_registration_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_registration_tests.rs
@@ -230,3 +230,22 @@ fn test_file_watcher_glob_pattern_variants() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn guardrail_inline_completion_registration_and_capability_wiring() {
+    let lifecycle_caps = include_str!("../src/runtime/lifecycle/capabilities.rs");
+    assert!(
+        !lifecycle_caps.contains("capabilities[\"experimental\"] = json!({\n            \"perlInlineCompletionStream\": true\n        });"),
+        "initialize must not overwrite capabilities.experimental with only perlInlineCompletionStream"
+    );
+
+    let watchers = include_str!("../src/runtime/lifecycle/watchers.rs");
+    assert!(
+        !watchers.contains("self.outbound.send_request"),
+        "inline-completion dynamic registration must use self.send_request"
+    );
+    assert!(
+        !watchers.contains("dynamic_registration_support &&"),
+        "inline-completion dynamic registration must not be gated on watcher dynamic registration"
+    );
+}

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_full_client.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_full_client.snap
@@ -48,6 +48,7 @@ documentOnTypeFormattingProvider:
     - ;
     - "\n"
 documentRangeFormattingProvider: true
+documentRangesFormattingProvider: true
 documentSymbolProvider: true
 executeCommandProvider:
   commands:
@@ -70,11 +71,13 @@ executeCommandProvider:
     - perl.explainMissingModuleLookup
 experimental:
   perlInlineCompletionStream: true
+  typeHierarchyProvider: true
 foldingRangeProvider: true
 hoverProvider: true
 implementationProvider: true
 inlayHintProvider:
   resolveProvider: true
+inlineCompletionProvider: {}
 inlineValueProvider: true
 linkedEditingRangeProvider: true
 monikerProvider: true
@@ -150,7 +153,8 @@ textDocumentSync:
   willSave: true
   willSaveWaitUntil: true
 typeDefinitionProvider: true
-typeHierarchyProvider: true
+typeHierarchyProvider:
+  workDoneProgressOptions: {}
 workspace:
   fileOperations:
     didCreate:

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_minimal_client.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_minimal_client.snap
@@ -48,6 +48,7 @@ documentOnTypeFormattingProvider:
     - ;
     - "\n"
 documentRangeFormattingProvider: true
+documentRangesFormattingProvider: true
 documentSymbolProvider: true
 executeCommandProvider:
   commands:
@@ -70,11 +71,13 @@ executeCommandProvider:
     - perl.explainMissingModuleLookup
 experimental:
   perlInlineCompletionStream: true
+  typeHierarchyProvider: true
 foldingRangeProvider: true
 hoverProvider: true
 implementationProvider: true
 inlayHintProvider:
   resolveProvider: true
+inlineCompletionProvider: {}
 inlineValueProvider: true
 linkedEditingRangeProvider: true
 monikerProvider: true
@@ -150,7 +153,8 @@ textDocumentSync:
   willSave: true
   willSaveWaitUntil: true
 typeDefinitionProvider: true
-typeHierarchyProvider: true
+typeHierarchyProvider:
+  workDoneProgressOptions: {}
 workspace:
   fileOperations:
     didCreate:

--- a/crates/perl-lsp-rs/tests/support/client_caps.rs
+++ b/crates/perl-lsp-rs/tests/support/client_caps.rs
@@ -75,6 +75,9 @@ pub fn full() -> Value {
             "inlayHint": {
                 "dynamicRegistration": false
             },
+            "inlineCompletion": {
+                "dynamicRegistration": true
+            },
             "diagnostic": {
                 "dynamicRegistration": false,
                 "relatedDocumentSupport": false


### PR DESCRIPTION
### Motivation

- The server was advertising inline completion inconsistently (placed under `experimental`, then clobbered at runtime) and lacked client-capability parsing for the LSP4IJ `textDocument.inlineCompletion` shape, risking regressions.
- `lsp-types` 0.97 does not expose `inlineCompletionProvider`, so an explicit JSON injection is required to advertise the standard LSP 3.18 field.

### Description

- Inject top-level `capabilities.inlineCompletionProvider = {}` in `capabilities_json()` when inline completion is enabled, and update the KNOWN_STRUCTURAL_GAPS comment accordingly. (crates/perl-lsp-rs-core/src/protocol/capabilities.rs)
- Remove the experimental insertion of `inlineCompletionProvider`, keeping only `typeHierarchyProvider` in the experimental wiring. (crates/perl-lsp-rs-core/src/protocol/capabilities/experimental.rs)
- Make `handle_initialize` build its serialized capabilities using `capabilities_json(...)`, add a merge helper to avoid overwriting `capabilities.experimental`, and preserve `perlInlineCompletionStream` under `experimental` via a merge instead of assignment. (crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs)
- Add explicit client capability fields for inline completion support and dynamic registration, and parse the LSP4IJ shape `textDocument.inlineCompletion` and its `dynamicRegistration` boolean during initialize. (crates/perl-lsp-rs/src/state/document.rs and capabilities parsing)
- Add a dedicated `register_inline_completion_if_needed()` dynamic-registration helper that uses `self.send_request(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a146677336c8333ba5ae28f94ab4d22)