### PR TITLE
refactor(xtask): use load_publish_allowlist() in publish_closure (#4499)

### DIFF
--- a/xtask/src/tasks/publish_closure.rs
+++ b/xtask/src/tasks/publish_closure.rs
@@ -8,15 +8,15 @@
 //! ---------
 //! 1. Run `cargo metadata --format-version 1` (without `--no-deps`) so the
 //!    response includes the full `resolve` graph.
-//! 2. Read `[workspace.metadata.publish.allow]` from the root `Cargo.toml` to
-//!    get the set of crates that are published to crates.io.
+//! 2. Load `[workspace.metadata.publish.allow]` via `load_publish_allowlist()`
+//!    to get the set of crates that are published to crates.io.
 //! 3. Collect workspace members with `publish = []` (i.e. `publish = false`).
 //! 4. For every published crate (or just the one supplied via `--crate-name`),
 //!    BFS-walk the normal-dep edges in the resolve graph.  Report any visit to
 //!    a `publish = false` workspace member as a violation.
 //! 5. Exit non-zero if any violations were found.
 
-use crate::utils::{WorkspacePublishMeta, run_cargo_metadata};
+use crate::utils::{load_publish_allowlist, run_cargo_metadata};
 use color_eyre::eyre::{Result, bail, eyre};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -29,8 +29,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 struct FullMetadata {
     packages: Vec<FullPackage>,
     workspace_members: Vec<String>,
-    #[serde(rename = "metadata")]
-    workspace_metadata: Option<WorkspacePublishMeta>,
     resolve: Option<ResolveGraph>,
 }
 
@@ -80,15 +78,8 @@ struct DepKind {
 /// If `crate_filter` is `Some(name)`, only that crate is checked.  Otherwise
 /// all crates in the allowlist are checked.
 pub fn run(crate_filter: Option<String>) -> Result<()> {
+    let allowlist = load_publish_allowlist()?;
     let metadata = load_metadata()?;
-
-    // Load [workspace.metadata.publish.allow]
-    let allowlist = metadata
-        .workspace_metadata
-        .as_ref()
-        .and_then(|m| m.publish.as_ref())
-        .and_then(|p| p.allow.as_ref())
-        .ok_or_else(|| eyre!("No [workspace.metadata.publish.allow] found in Cargo.toml"))?;
 
     // Build set of workspace-member package IDs (used to restrict violations
     // to workspace-local crates only -- external registry crates are never flagged).


### PR DESCRIPTION
## Summary

Closes the last open acceptance criterion for issue #4499 (A1 offline manifest-lint).

The `cargo xtask publish-manifest-check` command (allowlist drift + LICENSE-present checks) was implemented in an earlier commit, but `publish_closure.rs` was left using inline allowlist deserialization rather than the shared `load_publish_allowlist()` helper. This PR fixes that gap.

### What changed

**`xtask/src/tasks/publish_closure.rs`** — one focused refactor:

- Remove `workspace_metadata: Option<WorkspacePublishMeta>` from `FullMetadata` (it was only used for inline allowlist extraction)
- Remove `WorkspacePublishMeta` import; add `load_publish_allowlist` import from `crate::utils`
- Call `load_publish_allowlist()?` at the top of `run()` to get the allowlist via the shared helper

The publish-closure check logic, output format, and exit codes are **unchanged**.

### Why this matters

The #4499 spec required three tasks to use the shared `load_publish_allowlist()` helper:

| Task | Status before this PR | Status after |
|------|----------------------|--------------|
| `publish_manifest_check.rs` | ✅ uses `load_publish_allowlist()` | ✅ unchanged |
| `count_ratchet.rs` | ✅ uses `load_publish_allowlist()` | ✅ unchanged |
| `publish_closure.rs` | ❌ inline deserialization via `workspace_metadata` chain | ✅ now uses `load_publish_allowlist()` |

Having all three tasks share the same helper means:
- A single code path reads `[workspace.metadata.publish.allow]` from the Cargo workspace
- Any future changes to how the allowlist is parsed only need to be made in one place
- The acceptance criterion is met: "publish_closure.rs imports load_publish_allowlist and uses it (no duplicate structs)"

### Acceptance criteria satisfied

From `.spec/4499-a1-manifest-check/acceptance.md`:

- [x] `load_publish_allowlist()` defined in `xtask/src/utils.rs`
- [x] `AllowlistMetadata`, `WorkspacePublishMeta`, `AllowList` types defined in utils.rs
- [x] `publish_closure.rs` imports `load_publish_allowlist` and uses it (no duplicate structs) ← **this PR**
- [x] `count_ratchet.rs` imports `load_publish_allowlist` and uses it
- [x] `publish_manifest_check.rs` created with `run()` and `check_metadata()` functions
- [x] Inline unit tests pass: 7 test functions in publish_manifest_check.rs
- [x] `PublishManifestCheck` variant in `Commands` enum in main.rs
- [x] Dispatch: `Commands::PublishManifestCheck => tasks::publish_manifest_check::run()`
- [x] Integration test: `publish_manifest_check_test.rs`
- [x] `.github/workflows/publish-dry-run.yml` uses `cargo xtask publish-manifest-check`
- [x] `ci-publish-manifest-check` recipe in justfile
- [x] `pr-fast` recipe includes publish-manifest-check gate
- [x] `ci-gate` recipe includes publish-manifest-check gate

### Verification

```
cargo xtask publish-manifest-check
# publish-manifest-check: OK (31 crates checked, 0 violations)

cargo xtask publish-closure
# publish-closure: OK (31 crates checked, 0 violations)

cargo test -p xtask publish_manifest_check
# running 7 tests — all pass
# running 1 test (integration) — passes
```

Clippy clean: `cargo clippy -p xtask -- -D warnings` produces no warnings.

### Code quality

- No `unwrap()`, `expect()`, `panic!()`, `todo!()`, or `dbg!()` in production code
- No new structs or types — only the import change and field removal
- `eyre!` macro still used at two call sites in `load_metadata()` and the resolve-graph guard

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvBCQEDmFqzQ6h6uvJdXn9)_