### PR TITLE
fix(lsp): remove virtual files from workspace index on didClose (#3436)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync/lifecycle.rs
@@ -22,6 +22,26 @@ impl LspServer {
 
             self.evict_open_document_session_state(uri);
 
+            // If the closed document has no backing file on disk it existed only in
+            // the editor buffer (e.g. a new unsaved file or a test virtual document).
+            // Remove it from the workspace index so `workspace/symbol` does not
+            // return stale entries after close.
+            //
+            // For files that do exist on disk, closing the editor buffer leaves the
+            // workspace index intact: the file is still part of the project and a
+            // workspace scan would re-discover it.
+            #[cfg(feature = "workspace")]
+            {
+                let file_on_disk = source_path_from_uri(uri).map(|p| p.exists()).unwrap_or(false);
+                if !file_on_disk {
+                    if let Some(coordinator) = self.coordinator() {
+                        for key in self.uri_key_variants(uri) {
+                            coordinator.index().remove_file(&key);
+                        }
+                    }
+                }
+            }
+
             // Notify coordinator that cleanup is complete
             #[cfg(feature = "workspace")]
             if let Some(coordinator) = self.coordinator() {

--- a/crates/perl-lsp-rs/src/runtime/text_sync/tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync/tests.rs
@@ -698,10 +698,8 @@ fn test_did_close_after_change_storm_drains_background_index_tasks()
             character: 0,
         });
         server.handle_did_close(Some(json!({"textDocument": {"uri": uri}})))?;
-        #[cfg(feature = "workspace")]
-        if let Some(workspace_index) = server.workspace_index() {
-            workspace_index.remove_file(uri);
-        }
+        // handle_did_close now removes virtual files (no backing file on disk)
+        // from the workspace index automatically; no manual remove_file needed.
 
         for _ in 0..100 {
             if server.pending_index_task_count.load(Ordering::SeqCst) == 0 {
@@ -955,30 +953,81 @@ fn test_did_close_removes_document_symbols_from_index() -> Result<(), Box<dyn st
     Ok(())
 }
 
+/// A virtual document (URI with no backing file on disk) must be removed from
+/// the workspace index when closed so that `workspace/symbol` does not return
+/// stale entries for editor-only buffers.
 #[cfg(feature = "workspace")]
 #[test]
-fn test_did_close_preserves_workspace_index_for_existing_file()
+fn test_did_close_removes_virtual_file_from_workspace_index()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = LspServer::new();
-    let uri = "file:///test_close_preserves_workspace_index.pl";
-    let source = "package Close::Only;\nsub still_indexed { 1 }\n1;\n";
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("virtual_only_no_disk_backing.pl");
+    let url = url::Url::from_file_path(&path).map_err(|_| "invalid file path")?;
+    let uri = url.as_str().to_string();
+    let source = "package Virtual::Only;\nsub virtual_sym { 1 }\n1;\n";
 
     server.did_open(json!({
         "textDocument": {
-            "uri": uri,
+            "uri": &uri,
             "languageId": "perl",
             "version": 1,
             "text": source
         }
     }))?;
     if let Some(coordinator) = server.coordinator() {
-        coordinator.index().index_file(url::Url::parse(uri)?, source.to_string())?;
+        coordinator.index().index_file(url.clone(), source.to_string())?;
         assert!(
-            !coordinator.index().file_symbols(uri).is_empty(),
+            !coordinator.index().file_symbols(&uri).is_empty(),
+            "workspace index must hold symbols while virtual document is open"
+        );
+    }
+
+    server.handle_did_close(Some(json!({"textDocument": {"uri": &uri}})))?;
+
+    if let Some(coordinator) = server.coordinator() {
+        assert!(
+            coordinator.index().file_symbols(&uri).is_empty(),
+            "closing a virtual document (no backing file on disk) must remove it from workspace index"
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "workspace")]
+#[test]
+fn test_did_close_preserves_workspace_index_for_existing_file()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Use a real temporary file so that `source_path_from_uri(uri).map(|p| p.exists())`
+    // returns `true`, matching the "file exists on disk" branch in handle_did_close.
+    // A virtual URI (no backing file) would be treated as editor-only and removed
+    // from the workspace index on close, the opposite of what this test validates.
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("still_indexed.pl");
+    let source = "package Close::Only;\nsub still_indexed { 1 }\n1;\n";
+    std::fs::write(&path, source)?;
+    let url = url::Url::from_file_path(&path).map_err(|_| "invalid file path")?;
+    let uri = url.as_str().to_string();
+
+    let server = LspServer::new();
+
+    server.did_open(json!({
+        "textDocument": {
+            "uri": &uri,
+            "languageId": "perl",
+            "version": 1,
+            "text": source
+        }
+    }))?;
+    if let Some(coordinator) = server.coordinator() {
+        coordinator.index().index_file(url.clone(), source.to_string())?;
+        assert!(
+            !coordinator.index().file_symbols(&uri).is_empty(),
             "workspace index setup must hold symbols before close"
         );
         assert!(
-            coordinator.index().document_store().get(uri).is_some(),
+            coordinator.index().document_store().get(&uri).is_some(),
             "workspace document store setup must hold the file before close"
         );
     }
@@ -994,11 +1043,11 @@ fn test_did_close_preserves_workspace_index_for_existing_file()
     );
     if let Some(coordinator) = server.coordinator() {
         assert!(
-            !coordinator.index().file_symbols(uri).is_empty(),
+            !coordinator.index().file_symbols(&uri).is_empty(),
             "didClose is not file deletion; workspace-backed symbols for existing files must remain"
         );
         assert!(
-            coordinator.index().document_store().get(uri).is_some(),
+            coordinator.index().document_store().get(&uri).is_some(),
             "didClose must not remove workspace-index document store entries for existing files"
         );
     }


### PR DESCRIPTION
## Summary

Fixes an LSP lifecycle bug where workspace/symbol could return stale symbols for editor-only files after textDocument/didClose.

didClose still preserves workspace-index entries for files that exist on disk, because closing an editor buffer is not file deletion. For virtual or unsaved files with no backing path, the server now removes all URI-key variants from the workspace index so the symbol view no longer advertises closed in-memory documents.

## Scope

- runtime/text_sync/lifecycle.rs: remove virtual/no-backing files from the workspace index after open-document state is evicted.
- runtime/text_sync/tests.rs: add a virtual-file regression test, and update the existing on-disk preservation test to use a real tempfile so it exercises the intended branch.

## Verification

- MIN_FREE_GB=20 MAX_USED_PCT=99 CARGO_LOCK_WAIT=1200 ./scripts/cargo-safe xtask fmt
- MIN_FREE_GB=20 MAX_USED_PCT=99 CARGO_LOCK_WAIT=1200 ./scripts/cargo-safe test -p perl-lsp-rs --lib text_sync::tests::test_did_close --profile agent --locked -- --nocapture
- MIN_FREE_GB=20 MAX_USED_PCT=99 CARGO_LOCK_WAIT=1200 ./scripts/cargo-safe test -p perl-lsp-rs --test lsp_comprehensive_e2e_test --profile agent --locked -- --test-threads=1 --nocapture
- MIN_FREE_GB=20 MAX_USED_PCT=99 CARGO_LOCK_WAIT=1200 ./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked
- MIN_FREE_GB=20 MAX_USED_PCT=99 CARGO_LOCK_WAIT=1200 ./scripts/cargo-safe clippy -p perl-lsp-rs --lib --profile agent --locked -- -D warnings -A missing_docs
- git diff --check origin/master
- ./scripts/storage-doctor

## Claim boundary

This changes document-close lifecycle cleanup for virtual/no-backing files only. It does not change workspace-index retention for files that still exist on disk.