### PR TITLE
feat(code-actions): quick fix for PL405 printf/sprintf format arity mismatch

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/code_actions.rs
@@ -1056,4 +1056,86 @@ mod tests {
         let rename = must_some(actions.iter().find(|a| a.title.contains("Rename")));
         assert_eq!(rename.edit.changes[0].new_text, "'key_2'");
     }
+
+    #[test]
+    fn test_native_printf_format_arity_listop_inserts_undef() {
+        // Route: native.common.printf_format_arity → fix_printf_format_arity
+        // Listop form: printf "fmt", $a — insert undef before the semicolon.
+        let source = "use strict;\nuse warnings;\nprintf \"%s %s\", $name;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let call_start = must_some(source.find("printf"));
+        // Call node range ends before the ';'
+        let call_end = call_start + "printf \"%s %s\", $name".len();
+        let diagnostics = vec![make_diagnostic(
+            call_start,
+            call_end,
+            "native.common.printf_format_arity",
+            "`printf` format string has 2 specifiers but 1 argument supplied",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        let action =
+            must_some(actions.iter().find(|a| a.title == "Add 1 missing argument as undef"));
+        let rewritten = apply_action(source, action);
+        assert!(
+            rewritten.contains("printf \"%s %s\", $name, undef;"),
+            "expected undef appended before semicolon, got: {rewritten:?}",
+        );
+    }
+
+    #[test]
+    fn test_pl405_parens_printf_inserts_multiple_undef() {
+        // Route: PL405 → fix_printf_format_arity
+        // Parens form: printf("fmt", $a) — insert undef before closing ')'.
+        let source = "use strict;\nuse warnings;\nprintf(\"%s %s %s\", $a);\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let call_start = must_some(source.find("printf("));
+        // Call node includes the closing ')'
+        let call_end = call_start + "printf(\"%s %s %s\", $a)".len();
+        let diagnostics = vec![make_diagnostic(
+            call_start,
+            call_end,
+            "PL405",
+            "`printf` format string has 3 specifiers but 1 argument supplied",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        let action =
+            must_some(actions.iter().find(|a| a.title == "Add 2 missing arguments as undef"));
+        let rewritten = apply_action(source, action);
+        assert!(
+            rewritten.contains("printf(\"%s %s %s\", $a, undef, undef);"),
+            "expected two undef args inserted before closing paren, got: {rewritten:?}",
+        );
+    }
+
+    #[test]
+    fn test_pl405_too_many_args_no_quick_fix() {
+        // When args > specifiers the fix is skipped (removing args is too destructive).
+        let source = "use strict;\nuse warnings;\nprintf \"%s\", $a, $b;\n";
+        let mut parser = Parser::new(source);
+        let ast = must(parser.parse());
+        let call_start = must_some(source.find("printf"));
+        let call_end = call_start + "printf \"%s\", $a, $b".len();
+        let diagnostics = vec![make_diagnostic(
+            call_start,
+            call_end,
+            "native.common.printf_format_arity",
+            "`printf` format string has 1 specifier but 2 arguments supplied",
+        )];
+
+        let provider = CodeActionsProvider::new(source.to_string());
+        let actions = provider.get_code_actions(&ast, (0, source.len()), &diagnostics);
+
+        assert!(
+            !actions.iter().any(|a| a.title.contains("missing argument")),
+            "should not offer undef insertion when args exceed specifiers, got: {actions:?}",
+        );
+    }
 }

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -196,6 +196,12 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         c if c == DiagnosticCode::SecuritySignalHandler.as_str() => {
             actions.extend(quick_fixes::fix_security_signal_handler(source, &qf_diag));
         }
+        // PL405: printf/sprintf format specifier count mismatch
+        c if c == DiagnosticCode::PrintfFormatMismatch.as_str()
+            || c == "native.common.printf_format_arity" =>
+        {
+            actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -345,6 +345,90 @@ mod tests {
         assert!(edit.location.end <= source.len(), "edit end must not exceed source length");
         assert_eq!(edit.new_text, "");
     }
+
+    // --- fix_printf_format_arity ---
+
+    #[test]
+    fn fix_printf_format_arity_listop_one_missing() {
+        // Listop form: no parens, call node ends before the semicolon.
+        let source = r#"printf "%s %s", $name;"#;
+        // Call range covers "printf "%s %s", $name" (everything before ;)
+        let call_end = source.len() - 1;
+        let diagnostic = diagnostic_for(
+            (0, call_end),
+            r#"`printf` format string has 2 specifiers but 1 argument supplied"#,
+        );
+
+        let actions = fix_printf_format_arity(source, &diagnostic);
+
+        assert!(!actions.is_empty(), "should offer a fix for 1 missing arg");
+        assert_eq!(actions[0].title, "Add 1 missing argument as undef");
+        let edit = &actions[0].edit.changes[0];
+        assert_eq!(edit.new_text, ", undef");
+        // Insertion is at the end of the call node (before ';')
+        assert_eq!(edit.location.start, call_end);
+        assert_eq!(edit.location.end, call_end);
+    }
+
+    #[test]
+    fn fix_printf_format_arity_parens_one_missing() {
+        // Parens form: insert before the closing ')'.
+        let source = r#"printf("%s %s", $a)"#;
+        let diagnostic = diagnostic_for(
+            (0, source.len()),
+            r#"`printf` format string has 2 specifiers but 1 argument supplied"#,
+        );
+
+        let actions = fix_printf_format_arity(source, &diagnostic);
+
+        assert!(!actions.is_empty(), "should offer a fix for parens form");
+        assert_eq!(actions[0].title, "Add 1 missing argument as undef");
+        let edit = &actions[0].edit.changes[0];
+        assert_eq!(edit.new_text, ", undef");
+        // Insertion position should be at the closing ')'
+        assert_eq!(&source[edit.location.start..edit.location.start + 1], ")");
+    }
+
+    #[test]
+    fn fix_printf_format_arity_two_missing_appends_two_undefs() {
+        let source = r#"sprintf "%s %s %s", $a"#;
+        let diagnostic = diagnostic_for(
+            (0, source.len()),
+            r#"`sprintf` format string has 3 specifiers but 1 argument supplied"#,
+        );
+
+        let actions = fix_printf_format_arity(source, &diagnostic);
+
+        assert!(!actions.is_empty(), "should offer a fix for 2 missing args");
+        assert_eq!(actions[0].title, "Add 2 missing arguments as undef");
+        assert_eq!(actions[0].edit.changes[0].new_text, ", undef, undef");
+    }
+
+    #[test]
+    fn fix_printf_format_arity_too_many_args_returns_no_fix() {
+        // When args > specifiers we don't auto-remove — too destructive.
+        let source = r#"printf "%s", $a, $b"#;
+        let diagnostic = diagnostic_for(
+            (0, source.len()),
+            r#"`printf` format string has 1 specifier but 2 arguments supplied"#,
+        );
+
+        let actions = fix_printf_format_arity(source, &diagnostic);
+
+        assert!(actions.is_empty(), "should not suggest fix when args exceed specifiers");
+    }
+
+    #[test]
+    fn fix_printf_format_arity_equal_counts_returns_no_fix() {
+        let source = r#"printf "%s", $a"#;
+        let diagnostic = diagnostic_for(
+            (0, source.len()),
+            r#"`printf` format string has 1 specifier but 1 argument supplied"#,
+        );
+        // Equal counts would not normally be flagged, but the function must handle it gracefully.
+        let actions = fix_printf_format_arity(source, &diagnostic);
+        assert!(actions.is_empty());
+    }
 }
 
 /// Fix assignment in condition
@@ -1758,6 +1842,82 @@ pub fn fix_security_signal_handler(
         },
         is_preferred: true,
     }]
+}
+
+/// Add missing arguments to a `printf`/`sprintf` call (PL405 / `native.common.printf_format_arity`).
+///
+/// When the format string has more specifiers than supplied arguments, this fix
+/// appends the required number of `undef` placeholders. When arguments exceed
+/// specifiers the fix is skipped — removing arguments is too destructive to automate.
+///
+/// Handles both listop form (`printf "%s", $a`) and parenthesised form
+/// (`printf("%s", $a)`), inserting before the closing `)` or at the end of the
+/// call node respectively.
+pub fn fix_printf_format_arity(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let Some((missing, call_name)) = parse_printf_format_mismatch(&diagnostic.message) else {
+        return Vec::new();
+    };
+    if missing == 0 {
+        return Vec::new();
+    }
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let call_text = &source[range_start..range_end];
+
+    // Skip past the function name to detect whether the call uses parens.
+    let after_name_offset = call_name.len();
+    let after_name = call_text.get(after_name_offset..).unwrap_or("").trim_start();
+    let has_parens = after_name.starts_with('(');
+
+    let insert_pos = if has_parens {
+        // printf("fmt", arg1) — insert the new args before the closing ')'
+        let paren_start_offset = call_text.len() - after_name.len();
+        find_matching_parenthesis(after_name).map(|close| range_start + paren_start_offset + close)
+    } else {
+        // printf "fmt", arg1 — call node ends before the ';', so appending at
+        // range_end places the new args correctly.
+        Some(range_end)
+    };
+
+    let Some(insert_pos) = insert_pos else {
+        return Vec::new();
+    };
+
+    let undef_args = ", undef".repeat(missing);
+    let plural = if missing == 1 { "" } else { "s" };
+
+    vec![CodeAction {
+        title: format!("Add {missing} missing argument{plural} as undef"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::PrintfFormatMismatch.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: insert_pos, end: insert_pos },
+                new_text: undef_args,
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Parse a `printf`/`sprintf` format-arity message and return `(missing_count, call_name)`.
+///
+/// Returns `None` when the message cannot be parsed or when args exceed specifiers
+/// (the caller decides not to offer a fix in the "too many args" case).
+fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
+    // Message form: "`printf` format string has N specifier(s) but M argument(s) supplied"
+    let backtick_start = message.find('`')? + 1;
+    let backtick_end = backtick_start + message[backtick_start..].find('`')?;
+    let call_name = message[backtick_start..backtick_end].to_string();
+
+    let after_has = message.split("has ").nth(1)?;
+    let specifiers: usize = after_has.split_whitespace().next()?.parse().ok()?;
+
+    let after_but = message.split("but ").nth(1)?;
+    let supplied: usize = after_but.split_whitespace().next()?.parse().ok()?;
+
+    specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {


### PR DESCRIPTION
## Summary

`native.common.printf_format_arity` (PL405) was already detected and surfaced as a
diagnostic — but when users clicked the light bulb, the code-action provider returned
nothing. This PR closes that gap by adding a quick fix that appends `undef` placeholders
for each missing format argument.

### The gap

`perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs` had no arm for either:
- The stable code `PL405` (`DiagnosticCode::PrintfFormatMismatch`)
- The native alias `native.common.printf_format_arity`

The native rule (`PrintfFormatArityRule`) and the violation bridge were complete; only the
quick-fix handler was missing.

## What changed

### `quick_fixes.rs` — `fix_printf_format_arity` (+99 lines)

New public function + private message-parsing helper.

**Algorithm** — two call forms are handled:

| Form | Example | Insertion strategy |
|------|---------|-------------------|
| Listop | `printf "%s %s", $a` | Append at `range_end` (before `;`) |
| Parens | `printf("%s %s", $a)` | Use `find_matching_parenthesis` to locate `)`, insert before it |

Both produce `", undef".repeat(missing)` at the computed position.

**"Too many args" is intentionally skipped** — removing existing arguments is too
destructive to automate without knowing which ones to drop.

`parse_printf_format_mismatch` extracts call name and counts from the stable message
format: `` `printf` format string has N specifier(s) but M argument(s) supplied ``.
Returns `None` when args ≥ specifiers (no fix offered).

### `diagnostic_routes.rs` — new routing arm (+6 lines)

```rust
// PL405: printf/sprintf format specifier count mismatch
c if c == DiagnosticCode::PrintfFormatMismatch.as_str()
    || c == "native.common.printf_format_arity" =>
{
    actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
}
```

Both the legacy stable code and the native alias route to the same fix function, matching
the established pattern used by every other diagnostic in the file.

## Tests added (8 new, all green)

### Unit tests in `quick_fixes.rs` (5)

These test the fix function in isolation, verifying edit position and content precisely:

| Test | Scenario | Assertion |
|------|----------|-----------|
| `fix_printf_format_arity_listop_one_missing` | 2 specs, 1 arg, listop | insert at `range_end`, text = `", undef"` |
| `fix_printf_format_arity_parens_one_missing` | 2 specs, 1 arg, parens | insert at `)`, text = `", undef"` |
| `fix_printf_format_arity_two_missing_appends_two_undefs` | 3 specs, 1 arg | text = `", undef, undef"` |
| `fix_printf_format_arity_too_many_args_returns_no_fix` | 1 spec, 2 args | empty Vec |
| `fix_printf_format_arity_equal_counts_returns_no_fix` | 1 spec, 1 arg | empty Vec (graceful no-op) |

### Integration tests in `code_actions.rs` (3)

These test the full routing pipeline (`get_code_actions` → `quick_fixes_for_diagnostics`
→ `diagnostic_routes` → `fix_printf_format_arity`), asserting the rewritten source string:

| Test | Route | Result |
|------|-------|--------|
| `test_native_printf_format_arity_listop_inserts_undef` | `native.common.printf_format_arity` | `printf "%s %s", $name, undef;` |
| `test_pl405_parens_printf_inserts_multiple_undef` | `PL405` | `printf("%s %s %s", $a, undef, undef);` |
| `test_pl405_too_many_args_no_quick_fix` | `native.common.printf_format_arity` | no "missing argument" action offered |

## Verification

```
cargo test -p perl-lsp-rs-core --lib "code_actions"
# test result: ok. 130 passed; 0 failed; 0 ignored
cargo clippy -p perl-lsp-rs-core --lib
# Finished dev profile — no warnings
cargo fmt --check -p perl-lsp-rs-core
# clean
```

## Scope

- **No production behaviour changes** for any existing diagnostic or quick fix — only a new
  `_ =>` arm is wired.
- **No new dependencies.**
- **No public API changes** — `fix_printf_format_arity` is `pub` within the crate but the
  crate's external API surface is unchanged.
- Follows the exact same pattern as `fix_security_signal_handler` (most recently added fix).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WWGZKunNJVDVfufCdMADkp)_