### PR TITLE
chore(sync): mirror reconciled swarm latency state (#9571)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/scheduler.rs
+++ b/crates/perl-lsp-rs/src/runtime/scheduler.rs
@@ -1080,6 +1080,47 @@ mod tests {
         })
     }
 
+    fn position_params_at(uri: &str, line: u64, character: u64) -> serde_json::Value {
+        serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character }
+        })
+    }
+
+    fn queued_completion_read(
+        server: &crate::LspServer,
+        uri: &str,
+        line: u64,
+        character: u64,
+        arrival_seq: u64,
+        id: i64,
+    ) -> QueuedRead {
+        let params = position_params_at(uri, line, character);
+        let priority = request_priority("textDocument/completion");
+        let dedup_key = extract_dedup_key("textDocument/completion", Some(&params), priority);
+        let freshness = extract_freshness(server, "textDocument/completion", Some(&params), priority);
+        QueuedRead {
+            request: JsonRpcRequest {
+                _jsonrpc: "2.0".to_string(),
+                id: Some(JsonRpcId::Integer(id)),
+                method: "textDocument/completion".to_string(),
+                params: Some(params),
+            },
+            wait_for_seq: 0,
+            priority,
+            arrival_seq,
+            dedup_key,
+            freshness,
+        }
+    }
+
+    fn rapid_typing_source(suffix_len: usize) -> String {
+        format!(
+            "use strict;\nuse warnings;\n\nmy $value = 42;\nmy $other = $v{}\n",
+            "a".repeat(suffix_len)
+        )
+    }
+
     fn make_freshness(uri: &str, generation: Option<u32>, version: Option<i32>) -> ReadFreshness {
         ReadFreshness {
             uri: uri.to_string(),
@@ -1297,6 +1338,96 @@ mod tests {
         let current = server.document_generation("file:///z.pl");
         assert!(is_read_stale(&fa, current).is_some(), "a is stale");
         assert!(is_read_stale(&fb, current).is_some(), "b is stale");
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rapid_typing_stale_reads_cancel_before_worker_permit_receipt(
+    ) -> Result<(), JsonRpcError> {
+        let server = Arc::new(crate::LspServer::new());
+        let uri = "file:///typing-pressure.pl";
+        server.test_apply_did_open(uri, &rapid_typing_source(1), 1)?;
+
+        let mut stale_reads = Vec::new();
+        for i in 0..12 {
+            // Capture a read at the current document generation and then
+            // immediately simulate the next keystroke. The cursor position
+            // changes each time, so position-key dedupe alone cannot save us.
+            stale_reads.push(queued_completion_read(
+                &server,
+                uri,
+                4,
+                14 + i,
+                i,
+                10_000 + i as i64,
+            ));
+            server.test_apply_did_change(uri, &rapid_typing_source(i as usize + 2), i as i32 + 2)?;
+        }
+
+        let latest = queued_completion_read(&server, uri, 4, 30, 99, 20_000);
+        let current_generation = server.document_generation(uri);
+        assert!(
+            latest
+                .freshness
+                .as_ref()
+                .and_then(|freshness| is_read_stale(freshness, current_generation))
+                .is_none(),
+            "latest generation request must not be stale"
+        );
+
+        let zero_permits = Arc::new(Semaphore::new(0));
+        let mut in_flight = JoinSet::new();
+        let mutation_seq_done = Arc::new(AtomicU64::new(0));
+        let mutation_notify = Arc::new(Notify::new());
+        let latest_seq = HashMap::new();
+        let stale_count = stale_reads.len();
+
+        for queued in stale_reads {
+            let completed = tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                Scheduler::dispatch_one(
+                    queued,
+                    &latest_seq,
+                    &zero_permits,
+                    &mut in_flight,
+                    &server,
+                    &mutation_seq_done,
+                    &mutation_notify,
+                ),
+            )
+            .await;
+            assert!(
+                completed.is_ok(),
+                "stale reads must cancel before waiting for a worker permit"
+            );
+        }
+        assert_eq!(in_flight.len(), 0, "stale reads must not spawn worker tasks");
+
+        let one_permit = Arc::new(Semaphore::new(1));
+        Scheduler::dispatch_one(
+            latest,
+            &latest_seq,
+            &one_permit,
+            &mut in_flight,
+            &server,
+            &mutation_seq_done,
+            &mutation_notify,
+        )
+        .await;
+        assert_eq!(in_flight.len(), 1, "latest generation request must reach a worker");
+        while in_flight.join_next().await.is_some() {}
+
+        println!(
+            "{}",
+            serde_json::json!({
+                "profile": "neovim_lean",
+                "stale_reads_queued": stale_count,
+                "stale_reads_cancelled_before_worker_permit": stale_count,
+                "latest_generation_request_reached_worker": true,
+                "cursor_positions_changed": true
+            })
+        );
+
         Ok(())
     }
 }

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -49,6 +49,8 @@ pub struct UxClient {
     events: Arc<Mutex<VecDeque<Value>>>,
     /// Responses to requests (matched by id).
     responses: Arc<Mutex<VecDeque<Value>>>,
+    /// Stderr lines captured from the server process.
+    stderr_lines: Arc<Mutex<Vec<String>>>,
     _stdout_thread: std::thread::JoinHandle<()>,
     _stderr_thread: std::thread::JoinHandle<()>,
 }
@@ -85,6 +87,7 @@ impl UxClient {
 
         let events: Arc<Mutex<VecDeque<Value>>> = Arc::new(Mutex::new(VecDeque::new()));
         let responses: Arc<Mutex<VecDeque<Value>>> = Arc::new(Mutex::new(VecDeque::new()));
+        let stderr_lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
 
         // ── stdout reader thread ──────────────────────────────────────────────
         let ev_clone = events.clone();
@@ -110,14 +113,22 @@ impl UxClient {
 
         // ── stderr drain thread ───────────────────────────────────────────────
         let echo = config.echo_stderr;
+        let stderr_clone = stderr_lines.clone();
         let _stderr_thread = std::thread::Builder::new()
             .name("ux-lsp-stderr".into())
             .spawn(move || {
                 let reader = BufReader::new(stderr);
                 for line in reader.lines() {
                     match line {
-                        Ok(l) if echo => eprintln!("[perl-lsp stderr] {}", l),
-                        _ => {}
+                        Ok(l) => {
+                            if let Ok(mut guard) = stderr_clone.lock() {
+                                guard.push(l.clone());
+                            }
+                            if echo {
+                                eprintln!("[perl-lsp stderr] {}", l);
+                            }
+                        }
+                        Err(_) => {}
                     }
                 }
             })
@@ -131,6 +142,7 @@ impl UxClient {
             stdin: Mutex::new(stdin),
             events,
             responses,
+            stderr_lines,
             _stdout_thread,
             _stderr_thread,
         };
@@ -309,6 +321,11 @@ impl UxClient {
             guard.iter().cloned().collect()
         };
         raw.into_iter().map(decode_event).collect()
+    }
+
+    /// Clone all stderr lines captured from the server process.
+    pub fn peek_stderr_lines(&self) -> Vec<String> {
+        self.stderr_lines.lock().unwrap_or_else(|e| e.into_inner()).clone()
     }
 
     /// Wait up to `timeout` for any `window/showMessage` containing `needle`.

--- a/crates/perl-lsp-ux-tests/tests/ux_latency_raw_rpc.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_latency_raw_rpc.rs
@@ -1,4 +1,4 @@
-//! Raw-RPC latency receipts for the 0.15.1 Neovim latency lane (PR 5/5).
+//! Raw-RPC latency receipts for the post-cutover Neovim lean-mode lane.
 //!
 //! Five scenarios that exercise the e2e runtime path against the real LSP
 //! binary. They prove that:
@@ -21,6 +21,8 @@
 //!     PERL_LSP_E2E=1 \
 //!     PERL_LSP_DIAGNOSTIC_DEBOUNCE_MS=0 \
 //!     PERL_LSP_DIAGNOSTIC_MODE=syntax-only \
+//!     PERL_LSP_EAGER_WORKSPACE_INDEXING=false \
+//!     PERL_LSP_FILE_WATCHERS=false \
 //!     cargo test -p perl-lsp-ux-tests --test ux_latency_raw_rpc \
 //!         -- --test-threads=1 --nocapture
 
@@ -49,9 +51,9 @@ sub broken {}
 "#;
 
 /// Build an e2e harness config: syntax-only diagnostics, zero debounce, no
-/// eager workspace indexing, no file watchers. Mirrors what `perllsp
-/// --runtime-mode e2e` defaults to so the receipts measure the
-/// latency-focused runtime path.
+/// eager workspace indexing, no file watchers. These values mirror
+/// `perllsp --runtime-mode e2e`, but are set explicitly so the receipt
+/// documents the exact lean runtime path it exercises.
 fn e2e_config(timeout: Duration) -> ScenarioConfig {
     ScenarioConfig {
         timeout,
@@ -61,6 +63,8 @@ fn e2e_config(timeout: Duration) -> ScenarioConfig {
             ("PERL_LSP_E2E".to_string(), Some("1".to_string())),
             ("PERL_LSP_DIAGNOSTIC_DEBOUNCE_MS".to_string(), Some("0".to_string())),
             ("PERL_LSP_DIAGNOSTIC_MODE".to_string(), Some("syntax-only".to_string())),
+            ("PERL_LSP_EAGER_WORKSPACE_INDEXING".to_string(), Some("false".to_string())),
+            ("PERL_LSP_FILE_WATCHERS".to_string(), Some("false".to_string())),
             // Quiet the startup banner so test output is uncluttered.
             ("PERL_LSP_QUIET".to_string(), Some("1".to_string())),
         ],

--- a/crates/perl-lsp-ux-tests/tests/ux_neovim_lean_startup_trace.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_neovim_lean_startup_trace.rs
@@ -1,0 +1,136 @@
+//! Startup trace receipt for the Neovim lean profile.
+//!
+//! This is an e2e wiring receipt, not a hard latency budget. It records the
+//! observed lean startup path and asserts that the no-eager-indexing and
+//! no-file-watcher dials are active.
+
+use anyhow::Result;
+use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness, binary_available};
+use serde_json::{Value, json};
+use std::time::{Duration, Instant};
+
+const TRACE_SOURCE: &str = r#"use strict;
+use warnings;
+
+my $value = 42;
+my $other = $val
+sub broken {
+"#;
+
+fn trace_config(timeout: Duration) -> ScenarioConfig {
+    ScenarioConfig {
+        timeout,
+        path_restriction: None,
+        echo_stderr: false,
+        extra_env: vec![
+            ("PERL_LSP_E2E".to_string(), Some("1".to_string())),
+            ("PERL_LSP_DIAGNOSTIC_MODE".to_string(), Some("syntax-only".to_string())),
+            ("PERL_LSP_DIAGNOSTIC_DEBOUNCE_MS".to_string(), Some("0".to_string())),
+            ("PERL_LSP_EAGER_WORKSPACE_INDEXING".to_string(), Some("false".to_string())),
+            ("PERL_LSP_FILE_WATCHERS".to_string(), Some("false".to_string())),
+            ("PERL_LSP_QUIET".to_string(), Some("1".to_string())),
+            (
+                "RUST_LOG".to_string(),
+                Some("perl_lsp::runtime::dispatch::lifecycle=debug".to_string()),
+            ),
+        ],
+        workspace_files: Vec::new(),
+        workspace_folders: vec![("project".to_string(), "trace-project".to_string())],
+    }
+}
+
+fn record_event(events: &mut Vec<Value>, name: &str, start: Instant) {
+    events.push(json!({
+        "name": name,
+        "elapsed_ms": start.elapsed().as_secs_f64() * 1000.0,
+    }));
+}
+
+fn wait_for_stderr_line(harness: &UxHarness, needle: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if harness.client.peek_stderr_lines().iter().any(|line| line.contains(needle)) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    false
+}
+
+fn file_watcher_registered(events: &[LspEvent]) -> bool {
+    events.iter().any(|event| {
+        let LspEvent::Other { method, params } = event else {
+            return false;
+        };
+        method == "client/registerCapability"
+            && params
+                .get("registrations")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .any(|registration| {
+                    registration.get("method").and_then(Value::as_str)
+                        == Some("workspace/didChangeWatchedFiles")
+                })
+    })
+}
+
+#[test]
+fn ux_neovim_lean_startup_trace_receipt() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP ux_neovim_lean_startup_trace_receipt: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let start = Instant::now();
+    let mut events = Vec::new();
+    record_event(&mut events, "process_start_observed", start);
+
+    let harness = UxHarness::new(trace_config(Duration::from_secs(8)))?;
+    record_event(&mut events, "initialize_response_received", start);
+    record_event(&mut events, "initialized_notification_sent", start);
+
+    let indexing_skip_observed = wait_for_stderr_line(
+        &harness,
+        "Skipping eager workspace indexing on `initialized`",
+        Duration::from_secs(2),
+    );
+    assert!(
+        indexing_skip_observed,
+        "lean startup trace must observe eager workspace indexing skipped; stderr={:?}",
+        harness.client.peek_stderr_lines()
+    );
+    record_event(&mut events, "workspace_indexing_decision_observed", start);
+
+    let watcher_registered = file_watcher_registered(&harness.client.peek_events());
+    assert!(
+        !watcher_registered,
+        "lean startup trace must not register workspace file watchers"
+    );
+    record_event(&mut events, "file_watcher_registration_checked", start);
+
+    harness.open_file("project/trace.pl", TRACE_SOURCE)?;
+    record_event(&mut events, "did_open_sent", start);
+
+    let diags = harness.wait_for_diagnostics("project/trace.pl", Duration::from_secs(5));
+    assert!(!diags.is_empty(), "syntax-only lean trace must publish parser diagnostics");
+    record_event(&mut events, "first_did_open_processed", start);
+    record_event(&mut events, "first_diagnostic_published", start);
+
+    let _items = harness.completion("project/trace.pl", 4, 16)?;
+    record_event(&mut events, "first_completion_response", start);
+
+    let receipt = json!({
+        "profile": "neovim_lean",
+        "workspace_indexing_started": false,
+        "workspace_indexing_decision_observed": indexing_skip_observed,
+        "file_watchers_registered": watcher_registered,
+        "diagnostic_mode": "syntax_only",
+        "diagnostic_debounce_ms": 0,
+        "events": events,
+    });
+    println!("{}", serde_json::to_string_pretty(&receipt)?);
+
+    harness.assert_no_crash();
+    Ok(())
+}

--- a/docs/EDITORS/NEOVIM_SETUP.md
+++ b/docs/EDITORS/NEOVIM_SETUP.md
@@ -99,6 +99,41 @@ Restart Neovim, open a Perl file, and run:
 :checkhealth vim.lsp
 ```
 
+## Optional: lean latency profile
+
+Use this profile when responsiveness matters more than full semantic,
+module-resolution, native critic, and workspace dead-code diagnostics. Normal
+mode remains the richer default.
+
+```lua
+vim.lsp.config('perllsp', {
+  cmd = {
+    'perllsp',
+    '--stdio',
+    '--runtime-mode', 'e2e',
+    '--diagnostic-mode', 'syntax-only',
+    '--diagnostic-debounce-ms', '0',
+    '--eager-workspace-indexing=false',
+    '--file-watchers=false',
+  },
+  filetypes = { 'perl' },
+  root_markers = {
+    '.perl-lsp.toml',
+    'Makefile.PL',
+    'Build.PL',
+    'cpanfile',
+    'dist.ini',
+    '.git',
+  },
+})
+
+vim.lsp.enable('perllsp')
+```
+
+This profile keeps parser diagnostics but bypasses the full semantic/module
+diagnostic stack and avoids eager workspace indexing and file watcher
+registration. It does not provide incremental AST reuse.
+
 ## Optional: Define the config inline
 
 ```lua

--- a/docs/development/LSP_INTERACTIVE_LATENCY_ROLLOUT.md
+++ b/docs/development/LSP_INTERACTIVE_LATENCY_ROLLOUT.md
@@ -40,14 +40,16 @@ Phases 8 and 9 stack on [#223](https://github.com/EffortlessMetrics/perl-lsp-swa
 
 - [ ] Every phase lands or is explicitly deferred with a successor.
 - [ ] Receipt command in this doc reproduces the closeout proof.
-- [ ] A Neovim harness can run `perllsp --runtime-mode e2e --diagnostic-mode syntax-only --diagnostic-debounce-ms 0` and exercise hover/completion in isolation from background work.
+- [ ] A Neovim harness can run `perllsp --runtime-mode e2e --diagnostic-mode syntax-only --diagnostic-debounce-ms 0 --eager-workspace-indexing=false --file-watchers=false` and exercise hover/completion in isolation from background work.
 - [ ] `PERL_LSP_TIMING=1` writes per-phase latency receipts to a non-stdout sink.
 - [ ] Status doc updated (`docs/project/status/lsp.md` regenerated post-merge).
-- [ ] Quantitative targets below are met or explicitly waived with a written rationale.
+- [ ] Benchmark targets below are measured on dedicated hardware or explicitly deferred with a written rationale.
 
-## Quantitative targets
+## Benchmark-only targets
 
-These are the closeout thresholds for the rail. Phase 2 (timing probes) establishes the baseline; subsequent phases ratchet against it. All targets are p95 unless noted; measured on the Neovim harness against the checked-in medium fixture selected by the Phase 2 receipt on a release build.
+These targets are not claimed by the raw-RPC CI receipts. The checked-in tests are e2e wiring receipts: they prove the lean profile starts, answers, publishes syntax-only diagnostics, and clears diagnostics. Numeric latency targets require dedicated benchmark hardware and a release build.
+
+Phase 2 (timing probes) establishes the benchmark baseline; subsequent phases ratchet against it. All targets are p95 unless noted; measured on the Neovim harness against the checked-in medium fixture selected by the Phase 2 receipt on a release build.
 
 | Surface | Phase 2 baseline (TBD) | Post-rail target | Hard cap |
 |---|---|---|---|
@@ -58,9 +60,9 @@ These are the closeout thresholds for the rail. Phase 2 (timing probes) establis
 | Parser-error diagnostic publish after `didOpen` | record on land | <= 50 ms | 150 ms |
 | Stale-request cancel latency (Phase 9) | n/a | <= 10 ms after `didChange` | 50 ms |
 
-"Baseline (TBD)" is filled in when Phase 2 lands and the timing probes write their first receipt. Phases 3-10 must not regress any baseline beyond its hard cap; they should also drive each metric toward (or past) the post-rail target.
+"Baseline (TBD)" is filled in when the timing probes write a benchmark receipt on the selected hardware. Phases 3-10 must not regress any measured benchmark baseline beyond its hard cap; they should also drive each metric toward (or past) the post-rail target.
 
-Hard caps are absolute fail conditions for closeout: if any metric exceeds its cap, the rail does not close. Soft targets are the success criterion the user-facing experience is aimed at.
+Hard caps are benchmark closeout criteria only after a hardware-bound receipt exists. CI wiring receipts must not be described as satisfying these wall-clock targets.
 
 ## Rollback
 
@@ -148,6 +150,8 @@ vim.lsp.config('perl_lsp', {
     '--runtime-mode', 'e2e',
     '--diagnostic-mode', 'syntax-only',
     '--diagnostic-debounce-ms', '0',
+    '--eager-workspace-indexing=false',
+    '--file-watchers=false',
   },
   capabilities = caps,
   on_attach = function(client, bufnr)

--- a/docs/project/status/index.md
+++ b/docs/project/status/index.md
@@ -33,6 +33,7 @@
 | Memory plateau receipts | [memory_plateau.md](memory_plateau.md), [memory_plateau_trends.md](memory_plateau_trends.md) | Human | Memory guardrail, budget, or baseline changes |
 | Semantic capability dashboard | [semantic_capability_dashboard.md](semantic_capability_dashboard.md) | Human | Semantic release-readiness changes |
 | Semantic UX capability dashboard | [ux_capability_dashboard.md](ux_capability_dashboard.md) | Human | UX surface readiness changes |
+| Neovim lean latency profile | [neovim_latency.md](neovim_latency.md) | Human | Lean-profile receipts, smoke scripts, or benchmark evidence |
 | Native formatter/critic replacement status | [native_tooling.md](native_tooling.md) | Generator | Native formatter or critic capability changes |
 | CI hardening implementation status | [ci_hardening.md](ci_hardening.md) | Human | CI hardening state changes |
 

--- a/docs/project/status/neovim_latency.md
+++ b/docs/project/status/neovim_latency.md
@@ -1,0 +1,86 @@
+# Neovim Lean Latency Status
+
+> Human-owned. Update when the Neovim lean profile, raw-RPC receipts, smoke
+> scripts, trace receipts, or benchmark evidence changes.
+
+## Current Claim
+
+The post-cutover lean profile is present in swarm and is intended for sessions
+where responsiveness matters more than full semantic/module/critic diagnostics.
+Normal mode remains the richer default.
+
+The correct claim boundary is:
+
+- fast lean mode now
+- normal rich mode unchanged
+- incremental parsing later
+
+## Lean Profile
+
+The lean profile uses the existing runtime dials:
+
+```text
+PERL_LSP_E2E=1
+PERL_LSP_DIAGNOSTIC_MODE=syntax-only
+PERL_LSP_DIAGNOSTIC_DEBOUNCE_MS=0
+PERL_LSP_EAGER_WORKSPACE_INDEXING=false
+PERL_LSP_FILE_WATCHERS=false
+```
+
+Equivalent CLI flags are:
+
+```bash
+perllsp --stdio \
+  --runtime-mode e2e \
+  --diagnostic-mode syntax-only \
+  --diagnostic-debounce-ms 0 \
+  --eager-workspace-indexing=false \
+  --file-watchers=false
+```
+
+## Receipts
+
+Raw-RPC wiring receipts live in
+[`crates/perl-lsp-ux-tests/tests/ux_latency_raw_rpc.rs`](../../../crates/perl-lsp-ux-tests/tests/ux_latency_raw_rpc.rs).
+They exercise:
+
+- open -> completion returns cleanly
+- open -> hover returns cleanly
+- edit -> parse-error diagnostic surfaces
+- edit -> diagnostic clear publishes empty diagnostics
+- rapid typing -> latest completion still returns
+
+The manual Neovim smoke lives in
+[`scripts/ux/neovim_lean_smoke.sh`](../../../scripts/ux/neovim_lean_smoke.sh).
+
+The lean startup trace receipt lives in
+[`crates/perl-lsp-ux-tests/tests/ux_neovim_lean_startup_trace.rs`](../../../crates/perl-lsp-ux-tests/tests/ux_neovim_lean_startup_trace.rs).
+It emits JSON for the observed startup path, including initialize response,
+initialized notification, workspace-indexing decision, didOpen processing,
+first diagnostic publish, and first completion response.
+
+The rapid-typing stale-read pressure receipt lives in
+[`crates/perl-lsp-rs/src/runtime/scheduler.rs`](../../../crates/perl-lsp-rs/src/runtime/scheduler.rs)
+as `rapid_typing_stale_reads_cancel_before_worker_permit_receipt`. It proves
+that older generation reads cancel before taking a worker permit while the
+latest generation request reaches a worker. The raw-RPC receipt above covers
+the paired editor-shaped completion response after an edit burst.
+
+## What This Proves
+
+These receipts prove e2e wiring, not hard latency budgets. They show that the
+server starts in the lean profile and that core editor requests complete without
+waiting on full diagnostic or eager-indexing behavior.
+
+## What This Does Not Prove
+
+- No incremental AST reuse is provided by this profile.
+- CI wall-clock timing is not a benchmark receipt.
+- Full semantic/module/native critic/dead-code diagnostics are not enabled in
+  syntax-only mode.
+- Additional feature gating should wait for trace evidence showing the feature
+  is still on the latency path.
+
+## Next Evidence
+
+- Capture benchmark hardware timing before claiming numeric latency budgets.

--- a/scripts/ux/neovim_lean_smoke.sh
+++ b/scripts/ux/neovim_lean_smoke.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Neovim lean smoke for the 0.15.1 latency lane (PR 5/5).
+# Neovim lean smoke for the post-cutover latency lane.
 #
 # What this proves:
 #   - perllsp built from this branch starts under `--runtime-mode e2e` and
 #     accepts a real Neovim client over LSP.
 #   - Opening a small Perl file, applying a short edit burst, and
-#     requesting completion or hover returns a non-error response within
-#     a small wallclock budget.
+#     requesting completion returns a non-error response. This is a wiring
+#     smoke, not a hard latency budget.
 #
 # Why this is shell-scripted (not a Rust test):
 #   The CI Neovim environment is not stable enough to make this a green
@@ -72,6 +72,8 @@ local client_id = vim.lsp.start({
     '--runtime-mode', 'e2e',
     '--diagnostic-mode', 'syntax-only',
     '--diagnostic-debounce-ms', '0',
+    '--eager-workspace-indexing=false',
+    '--file-watchers=false',
   },
   capabilities = caps,
   root_dir = '${tmpdir}',


### PR DESCRIPTION
Problem: swarm now has the post-cutover Neovim latency cleanup receipts and docs, but source is missing the reconciled stable state.
Fix: mirror the reconciled swarm latency state into source as one sync patch: raw-RPC receipts, manual smoke flags, lean-profile docs/status, startup trace receipt, and rapid-typing stale-read pressure receipt.
Verification: ./scripts/cargo-safe test -p perl-lsp-rs-core --lib --profile agent --locked -- runtime::tuning; ./scripts/cargo-safe test -p perl-lsp-rs --test syntax_only_diagnostics_test --profile agent --locked; ./scripts/cargo-safe test -p perl-lsp-rs --test startup_indexing_gate_test --profile agent --locked; ./scripts/cargo-safe test -p perl-lsp-rs --lib --profile agent --locked -- scheduler::tests; ./scripts/cargo-safe test -p perl-lsp-ux-tests --test ux_latency_raw_rpc --profile agent --locked -- --nocapture passed on rerun after an initial no-output timeout; ./scripts/cargo-safe test -p perl-lsp-ux-tests --test ux_neovim_lean_startup_trace --profile agent --locked -- --nocapture passed on rerun after an initial no-output timeout; provider confidence matrix, provider promotion ledger, support claims, active goal manifest, xtask fmt, and git diff --check passed.