### PR TITLE
chore(release): prepare v0.15.1 release metadata (#9600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- Documented the Rust 1.95 / 0.14.0 rollout sequence before implementation: compatibility spike first, then MSRV/toolchain, lint, no-panic, file-policy, CI routing, and release-prep lanes.
+- Added the proactive CI integrity guards rail ([`docs/development/RUST_1_95_PROACTIVE_GUARDS.md`](docs/development/RUST_1_95_PROACTIVE_GUARDS.md)) as a sibling rollout. Six guard PRs (PG-1 through PG-6) covering label enforcement, risk-pack referential integrity, lane mapping with matrix expansion, net-new workflow-allowlist ledger, CI Actuals emitter + subscription coverage check, and broad-glob justification tightening. Each row mirrors a sibling-repo proven shape.
+- Consolidated the remaining Rust 1.95 → 0.14.0 work into a single canonical roadmap: rewrote [`docs/development/RUST_1_95_ROLLOUT.md`](docs/development/RUST_1_95_ROLLOUT.md) into a post-landing source of truth (already landed / remaining implementation ladder / per-rail acceptance contracts / Claude-Codex operating contract); slimmed [`docs/ci/perl-lsp-rust-1.95-rollout.md`](docs/ci/perl-lsp-rust-1.95-rollout.md) to a historical pointer; added [`docs/ci/test-evidence-lanes.md`](docs/ci/test-evidence-lanes.md) defining the five evidence-lane shapes (PR-fast required / PR-targeted / nightly cron / release-only / advisory) with risk-pack auto-routing, skipped-by-policy receipts, and LEM cost framing. Umbrella tracking: **#8663**.
+
+## [0.15.1] - 2026-05-26
+
+Release notes: [v0.15.1](docs/releases/v0.15.1.md)
+
+Patch release focused on LSP4IJ inline completion and lean editor-mode
+hardening.
+
 ### Added
 
 - 0.15.1 Neovim latency lane:
@@ -66,12 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   --diagnostic-debounce-ms 0`, disable file watchers, and disable
   semantic tokens at the client unless you are explicitly testing
   semantic highlighting.
-
-### Planned
-
-- Documented the Rust 1.95 / 0.14.0 rollout sequence before implementation: compatibility spike first, then MSRV/toolchain, lint, no-panic, file-policy, CI routing, and release-prep lanes.
-- Added the proactive CI integrity guards rail ([`docs/development/RUST_1_95_PROACTIVE_GUARDS.md`](docs/development/RUST_1_95_PROACTIVE_GUARDS.md)) as a sibling rollout. Six guard PRs (PG-1 through PG-6) covering label enforcement, risk-pack referential integrity, lane mapping with matrix expansion, net-new workflow-allowlist ledger, CI Actuals emitter + subscription coverage check, and broad-glob justification tightening. Each row mirrors a sibling-repo proven shape.
-- Consolidated the remaining Rust 1.95 → 0.14.0 work into a single canonical roadmap: rewrote [`docs/development/RUST_1_95_ROLLOUT.md`](docs/development/RUST_1_95_ROLLOUT.md) into a post-landing source of truth (already landed / remaining implementation ladder / per-rail acceptance contracts / Claude-Codex operating contract); slimmed [`docs/ci/perl-lsp-rust-1.95-rollout.md`](docs/ci/perl-lsp-rust-1.95-rollout.md) to a historical pointer; added [`docs/ci/test-evidence-lanes.md`](docs/ci/test-evidence-lanes.md) defining the five evidence-lane shapes (PR-fast required / PR-targeted / nightly cron / release-only / advisory) with risk-pack auto-routing, skipped-by-policy receipts, and LEM cost framing. Umbrella tracking: **#8663**.
 
 ## [0.15.0] - 2026-05-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1471,14 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "chrono",
  "clap",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "perl-corpus"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-uri",
  "perl-workspace",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-test-must",
  "serde",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lexer"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "criterion",
  "memchr",
@@ -1590,14 +1590,14 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-parser-core",
  "perl-subprocess-runtime",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ux-tests"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-parser-core",
  "perl-tdd-support",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-bench"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-parser",
  "walkdir",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-comparison"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-ast",
  "perl-parser-core",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -1808,14 +1808,14 @@ dependencies = [
 
 [[package]]
 name = "perl-pod"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "criterion",
  "perl-ast",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "proptest",
  "thiserror",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-facts"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "proptest",
  "serde",
@@ -1885,14 +1885,14 @@ dependencies = [
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "lsp-types",
  "perl-parser-core",
@@ -1919,18 +1919,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.15.0"
+version = "0.15.1"
 
 [[package]]
 name = "perl-token"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "criterion",
  "perl-lexer",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "perllsp"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -3168,7 +3168,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl-c"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "cc",
  "insta",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-perl-rs"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "insta",
  "perl-ast",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -214,26 +214,26 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.15.0" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.15.1" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.15.0" }
-perl-regex = { path = "crates/perl-regex", version = "0.15.0" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.15.0" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.15.0" }
-perl-ast = { path = "crates/perl-ast", version = "0.15.0" }
+perl-token = { path = "crates/perl-token", version = "0.15.1" }
+perl-regex = { path = "crates/perl-regex", version = "0.15.1" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.15.1" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.15.1" }
+perl-ast = { path = "crates/perl-ast", version = "0.15.1" }
 # Wave D absorbed (internal modules in perl-parser/src/):
 #   perl-heredoc-anti-patterns → perl-parser::heredoc_anti_patterns
 # Wave D absorbed (internal modules in perl-parser-core/src/syntax/):
 #   perl-quote, perl-heredoc, perl-error, perl-edit
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.15.0" }
-perl-symbol = { path = "crates/perl-symbol", version = "0.15.0" }
-perl-module = { path = 'crates/perl-module', version = "0.15.0" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.15.1" }
+perl-symbol = { path = "crates/perl-symbol", version = "0.15.1" }
+perl-module = { path = 'crates/perl-module', version = "0.15.1" }
 # Wave D absorbed: perl-qualified-name → perl-parser::qualified_name
-perl-line-index = { path = "crates/perl-line-index", version = "0.15.0" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.15.1" }
 # Wave D absorbed: perl-source-file → perl-parser::source_file
 # Wave D absorbed: perl-text-line → perl-parser-core::text_line
 # (perl-content-length-framing absorbed into perl-lsp-rs-core::transport::framing — Wave Final PR B)
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.15.0" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.15.1" }
 # (perl-lsp-document-highlight absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-document-links absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-performance absorbed into perl-lsp-rs-core::tooling::performance — Wave G3 step 5)
@@ -241,31 +241,31 @@ perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "
 # Wave D absorbed: perl-ast-utils → perl-parser::ast_utils
 # (perl-lsp-input-validation absorbed into perl-lsp-rs-core::runtime::input_validation — Wave G2)
 # (perl-lsp-text-utils absorbed into perl-lsp-rs-core::runtime::text_utils — Wave G2)
-perl-uri = { path = "crates/perl-uri", version = "0.15.0" }
+perl-uri = { path = "crates/perl-uri", version = "0.15.1" }
 # Wave D absorbed: perl-percentile → perl-parser::percentile
 # (perl-lsp-import-management absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-critic-parser absorbed into perl-lsp-rs-core::critic_parser — Wave G3 step 7)
 # (perl-lsp-protocol absorbed into perl-lsp-rs-core::protocol — Wave G3 step 2)
 # Wave D absorbed: perl-path-normalize → perl-parser-core::path_normalize
 # Wave D absorbed: perl-path-security → perl-parser-core::path_security
-perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.15.0" }
-perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.15.0" }
-perl-pod = { path = "crates/perl-pod", version = "0.15.0" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.15.0" }
-perl-dap = { path = "crates/perl-dap", version = "0.15.0" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.15.0" }
+perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.15.1" }
+perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.15.1" }
+perl-pod = { path = "crates/perl-pod", version = "0.15.1" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.15.1" }
+perl-dap = { path = "crates/perl-dap", version = "0.15.1" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.15.1" }
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.15.0" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.15.1" }
 # (perl-lsp-transport absorbed into perl-lsp-rs-core::transport — Wave G3 step 4)
 # (perl-lsp-tooling absorbed into perl-lsp-rs-core::tooling — Wave G3 step 6)
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.15.0" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.15.1" }
 # (perl-lsp-on-type-formatting absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting-types absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting absorbed into perl-lsp-rs-core::providers::formatting — Wave G1b)
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.15.0" }
-perl-test-must = { path = "crates/perl-test-must", version = "0.15.0" }
-perl-test-generators = { path = "crates/perl-test-generators", version = "0.15.0" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.15.1" }
+perl-test-must = { path = "crates/perl-test-must", version = "0.15.1" }
+perl-test-generators = { path = "crates/perl-test-generators", version = "0.15.1" }
 # (perl-lsp-diagnostics absorbed into perl-lsp-rs-core::providers::diagnostics — Wave G1b)
 # (perl-lsp-semantic-tokens absorbed into perl-lsp-rs-core::providers::semantic_tokens — Wave G1b)
 # (perl-lsp-inlay-hints absorbed into perl-lsp-rs-core::providers — Wave G1a)
@@ -289,28 +289,28 @@ perl-test-generators = { path = "crates/perl-test-generators", version = "0.15.0
 # (perl-lsp-code-actions absorbed into perl-lsp-rs-core::providers::code_actions — Wave G1b)
 # (perl-lsp-folding absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-selection-range absorbed into perl-lsp-rs-core::providers — Wave G1a)
-perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.15.0" }
+perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.15.1" }
 # Tier 3: Two-level dependencies
-perl-workspace = { path = "crates/perl-workspace", version = "0.15.0" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.15.0" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.15.0" }
+perl-workspace = { path = "crates/perl-workspace", version = "0.15.1" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.15.1" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.15.1" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.15.0" }
-perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.15.0" }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.15.1" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.15.1" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.15.0" }
-perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.15.0" }
-perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.15.0" }
+perl-parser = { path = "crates/perl-parser", version = "0.15.1" }
+perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.15.1" }
+perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.15.1" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.15.0" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.15.1" }
 
 # External dependencies
-tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.15.0" }
-tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.15.0" }
+tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.15.1" }
+tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.15.1" }
 tree-sitter = "0.26.9"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -14,6 +14,7 @@ Tag commit timestamps may differ from release dates.
 
 | Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
 |---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
+| [0.15.1] | `v0.15.1` | pending | pending | `pending` | [v0.15.0...v0.15.1] | pending | pending | pending | [v0.15.1][n-0.15.1] |
 | [0.15.0] | `v0.15.0` | pending | pending | `pending` | [v0.14.0...v0.15.0] | pending | pending | pending | [v0.15.0][n-0.15.0] |
 | [0.14.0] | `v0.14.0` | [yes][gh-0.14.0] | 2026-05-12 | `82e64200` | [v0.13.4...v0.14.0] | 1 VSIX | 0.14.0 primary packages visible; full receipt pending | pending | [v0.14.0][n-0.14.0] |
 | [0.13.4] | `v0.13.4` | pending | pending | `pending` | [v0.13.3...v0.13.4] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | pending | pending | [v0.13.4][n-0.13.4] |
@@ -61,6 +62,7 @@ Tag commit timestamps may differ from release dates.
 ## Links
 
 <!-- Notes files -->
+[n-0.15.1]: docs/releases/v0.15.1.md
 [n-0.15.0]: docs/releases/v0.15.0.md
 [n-0.14.0]: docs/releases/v0.14.0.md
 [n-0.13.4]: docs/releases/v0.13.4.md
@@ -81,6 +83,7 @@ Tag commit timestamps may differ from release dates.
 [n-0.8.3]: docs/releases/v0.8.3.md
 
 <!-- Version links (to notes files) -->
+[0.15.1]: docs/releases/v0.15.1.md
 [0.15.0]: docs/releases/v0.15.0.md
 [0.14.0]: docs/releases/v0.14.0.md
 [0.13.4]: docs/releases/v0.13.4.md
@@ -101,6 +104,7 @@ Tag commit timestamps may differ from release dates.
 [0.8.3]: docs/releases/v0.8.3.md
 
 <!-- GitHub Releases -->
+[gh-0.15.1]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.15.1
 [gh-0.15.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.15.0
 [gh-0.14.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.14.0
 [gh-0.13.4]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.4
@@ -117,6 +121,7 @@ Tag commit timestamps may differ from release dates.
 [gh-0.8.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3
 
 <!-- Compare ranges -->
+[v0.15.0...v0.15.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.0...v0.15.1
 [v0.14.0...v0.15.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.14.0...v0.15.0
 [v0.13.4...v0.14.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.4...v0.14.0
 [v0.13.3...v0.13.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.3...v0.13.4

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-module"
-version = "0.15.0"
+version = "0.15.1"
 publish = true
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.17",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
Problem: v0.15.1 needs to package the mirrored LSP4IJ inline-completion and lean editor hardening work into release metadata.

Fix: bump workspace and VS Code extension versions to 0.15.1, refresh Cargo.lock, and add 0.15.1 changelog/history entries pointing at the release notes.

Verification:
- `cargo fmt --all -- --check` attempted, but Windows hit `The filename or extension is too long. (os error 206)`.
- `cargo fmt -p perl-lsp-rs -p perl-lsp-rs-core -p perl-lsp-ux-tests -- --check` passed.
- `cargo check --workspace --all-targets --locked` passed with existing warnings in `perl-subprocess-runtime` and DAP test helpers.
- `cargo test -p perl-lsp-rs --test lsp_inline_completion_registration_tests -- --nocapture` passed.
- `cargo test -p perl-lsp-rs --test lsp_registration_tests -- --nocapture` passed.
- `cargo test -p perl-lsp-rs --test lsp_cap_snap -- --nocapture` passed.
- `cargo test -p perl-lsp-rs --test lsp_ai_inline_completion_tests --features expose_lsp_test_api -- --nocapture` passed.
- `cargo test -p perl-lsp-rs-core --lib inline_completion -- --nocapture` passed.
- `cargo test -p perl-lsp-ux-tests --test ux_latency_raw_rpc -- --test-threads=1 --nocapture` passed.
- `cargo xtask gates --tier pr-fast --receipt` attempted, but Windows shell recipes failed on missing `cygpath` / shell lookup; WSL equivalents for release history, conflict markers, and README heading checks passed.
- `git diff --check` passed.