### PR TITLE
fix(test): make UX stderr drain clippy-clean (#9601)

### DIFF
--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -119,17 +119,12 @@ impl UxClient {
             .name("ux-lsp-stderr".into())
             .spawn(move || {
                 let reader = BufReader::new(stderr);
-                for line in reader.lines() {
-                    match line {
-                        Ok(l) => {
-                            if let Ok(mut guard) = stderr_clone.lock() {
-                                guard.push(l.clone());
-                            }
-                            if echo {
-                                eprintln!("[perl-lsp stderr] {}", l);
-                            }
-                        }
-                        Err(_) => {}
+                for l in reader.lines().map_while(Result::ok) {
+                    if let Ok(mut guard) = stderr_clone.lock() {
+                        guard.push(l.clone());
+                    }
+                    if echo {
+                        eprintln!("[perl-lsp stderr] {}", l);
                     }
                 }
             })


### PR DESCRIPTION
Problem: post-merge master CI fails the Linux clippy_full gate in the UX test harness stderr drain.

Fix: replace the single-pattern stderr line match with `reader.lines().map_while(Result::ok)`, which satisfies clippy without using `flatten()` on `Lines`.

Verification:
- `cargo clippy -p perl-lsp-ux-tests --lib --locked -- -D warnings -A missing_docs` passed on Windows.
- `cargo fmt -p perl-lsp-ux-tests -- --check` passed.
- `git diff --check` passed.
- WSL/Linux: `cargo clippy -p perl-lsp-ux-tests --lib --locked -- -D warnings -A missing_docs` passed.
- WSL/Linux: `cargo xtask gates --gate clippy_full --receipt` passed.