### PR TITLE
test(smoke): add inline-completion stdio binary smoke (#9602)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -149,6 +149,12 @@ enum Commands {
         coverage: bool,
     },
 
+    /// Run local smoke checks against explicit binaries.
+    Smoke {
+        #[command(subcommand)]
+        command: SmokeCommand,
+    },
+
     /// Regenerate public Shields endpoint JSON for README badges.
     Badges {
         /// Check committed endpoints for drift without updating badges/.
@@ -2482,6 +2488,17 @@ enum QueueCommand {
 }
 
 #[derive(Subcommand)]
+enum SmokeCommand {
+    /// Verify textDocument/inlineCompletion over stdio against a built binary.
+    #[command(name = "inline-completion")]
+    InlineCompletion {
+        /// Path to the perl-lsp binary to execute.
+        #[arg(long)]
+        binary: PathBuf,
+    },
+}
+
+#[derive(Subcommand)]
 enum AgentCommand {
     /// Lease lifecycle commands.
     Lease {
@@ -2601,6 +2618,9 @@ fn main() -> Result<()> {
         Commands::Test { release, suite, features, verbose, coverage } => {
             test::run(release, suite, features, verbose, coverage)
         }
+        Commands::Smoke { command } => match command {
+            SmokeCommand::InlineCompletion { binary } => inline_completion_smoke::run(binary),
+        },
         Commands::Badges { check } => badges::run(check),
         Commands::RiprPr { root, base, head, check } => {
             ripr_evidence::ripr_pr(&root, &base, &head, check)

--- a/xtask/src/tasks/inline_completion_smoke.rs
+++ b/xtask/src/tasks/inline_completion_smoke.rs
@@ -1,0 +1,120 @@
+use color_eyre::eyre::{Result, bail, eyre};
+use perl_lsp_ux_tests::{FakeWorkspace, ScenarioConfig, UxClient};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub fn run(binary: PathBuf) -> Result<()> {
+    if !binary.is_file() {
+        bail!("inline-completion smoke binary does not exist: {}", binary.display());
+    }
+
+    let workspace = ux(FakeWorkspace::new())?;
+    let timeout = Duration::from_secs(30);
+    let config = ScenarioConfig {
+        timeout,
+        client_capability_overrides: json!({
+            "textDocument": {
+                "inlineCompletion": {
+                    "dynamicRegistration": true
+                }
+            }
+        }),
+        ..ScenarioConfig::default()
+    };
+
+    let binary_path = binary.to_string_lossy().into_owned();
+    let client = ux(UxClient::spawn(&binary_path, &workspace, &config))?;
+
+    let initialize = client.initialize_result();
+    ensure_dynamic_initialize_shape(&initialize)?;
+
+    let uri = "file:///release-inline.pl";
+    ux(client.did_open(uri, "use "))?;
+    let items = request_inline_completion_items(&client, uri, 0, 4, timeout)?;
+    if !items.iter().any(|item| item.get("insertText") == Some(&json!("strict;"))) {
+        bail!("inline-completion smoke expected insertText strict;, got: {}", Value::Array(items));
+    }
+
+    let neutral_uri = "file:///release-inline-neutral.pl";
+    ux(client.did_open(neutral_uri, "my $name = \"World\";"))?;
+    let neutral_items = request_inline_completion_items(&client, neutral_uri, 0, 11, timeout)?;
+    if !neutral_items.is_empty() {
+        bail!(
+            "inline-completion smoke expected empty unsupported-position result, got: {}",
+            Value::Array(neutral_items)
+        );
+    }
+
+    let shutdown = ux(client.request("shutdown", json!({}), timeout))?;
+    if let Some(error) = shutdown.get("error") {
+        bail!("shutdown returned error: {}", error);
+    }
+    ux(client.notify("exit", json!({})))?;
+
+    println!("inline-completion stdio smoke OK: {}", binary.display());
+    Ok(())
+}
+
+fn ensure_dynamic_initialize_shape(initialize: &Value) -> Result<()> {
+    if initialize.pointer("/result/capabilities/inlineCompletionProvider").is_some()
+        || initialize.pointer("/capabilities/inlineCompletionProvider").is_some()
+    {
+        bail!(
+            "dynamic inline-completion client received duplicate static inlineCompletionProvider: {}",
+            initialize
+        );
+    }
+
+    if initialize.pointer("/result/capabilities/experimental/inlineCompletionProvider").is_some()
+        || initialize.pointer("/capabilities/experimental/inlineCompletionProvider").is_some()
+    {
+        bail!(
+            "initialize response advertised experimental.inlineCompletionProvider: {}",
+            initialize
+        );
+    }
+
+    Ok(())
+}
+
+fn request_inline_completion_items(
+    client: &UxClient,
+    uri: &str,
+    line: u32,
+    character: u32,
+    timeout: Duration,
+) -> Result<Vec<Value>> {
+    let response = ux(client.request(
+        "textDocument/inlineCompletion",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "context": { "triggerKind": 2 }
+        }),
+        timeout,
+    ))?;
+
+    if let Some(error) = response.get("error") {
+        bail!("textDocument/inlineCompletion returned error: {}", error);
+    }
+
+    let result = response
+        .get("result")
+        .ok_or_else(|| eyre!("inline-completion response missing result: {}", response))?;
+
+    match result {
+        Value::Null => Ok(Vec::new()),
+        Value::Array(items) => Ok(items.clone()),
+        Value::Object(_) => {
+            result.get("items").and_then(Value::as_array).cloned().ok_or_else(|| {
+                eyre!("inline-completion response missing result.items array: {}", response)
+            })
+        }
+        _ => bail!("inline-completion response had unexpected result shape: {}", response),
+    }
+}
+
+fn ux<T>(result: anyhow::Result<T>) -> Result<T> {
+    result.map_err(|error| eyre!("{error:#}"))
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -65,6 +65,7 @@ pub mod highlight;
 pub mod hook_checks;
 pub mod ignored_tests;
 pub mod inject_sha_assets;
+pub mod inline_completion_smoke;
 pub mod install_surface_check;
 pub mod intent_diff_gate;
 pub mod label_projector;


### PR DESCRIPTION
Problem: The inline-completion fix was covered by harness tests, but not by a release-built binary over the real stdio LSP boundary.

Fix: Add cargo xtask smoke inline-completion --binary <path>, which spawns the supplied perl-lsp binary with --stdio, initializes as a dynamic inline-completion client, opens use , verifies textDocument/inlineCompletion with context.triggerKind = 2 returns strict;, verifies an unsupported position returns empty, and shuts down cleanly.

Verification:
- cargo fmt -p xtask -- --check passed
- cargo check -p xtask --locked passed with existing unrelated subprocess-runtime warnings
- cargo build --release -p perl-lsp-rs --bin perl-lsp --locked passed with existing unrelated warnings
- cargo xtask smoke inline-completion --binary target/release/perl-lsp.exe passed
- git diff --check passed
- Windows cargo fmt --all -- --check hit known path-length os error 206; exact WSL/Linux rerun passed

No release, tag, publish, or channel update in this PR.