### PR TITLE
sync: mirror swarm inline-completion contract locks (#9604)

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -38,28 +38,15 @@ jobs:
             }
 
             const BOT_MARKER = '<!-- pr-title-check-bot -->';
-            const issueMatches = [...title.matchAll(/\B#(\d+)\b/g)];
-
-            if (issueMatches.length === 0) {
-              core.setFailed(
-                `PR title must reference an issue (e.g. "feat: add thing (#42)"). Got: "${title}"`
-              );
-
-              const commentBody = [
-                '## \u26a0\ufe0f PR Title Check Failed',
-                '',
-                BOT_MARKER,
-                '',
-                'This PR\'s title does not include an **issue reference** (`#<number>` outside of version strings).',
-                '',
-                '**Expected format:** `type: description (#1234)`',
-                '',
-                'Please update the title to reference the relevant issue. If this PR doesn\'t need one, add the `skip-title-check` label.',
-                '',
-                `Current title: \`${title}\``,
-              ].join('\n');
-
-              // Deduplicate: find and update existing bot comment instead of posting a new one
+            const issueGuidance = [
+              'For Codex or other agent-authored PRs: file the plan as a GitHub issue first, then update the PR title to reference that real issue.',
+              '',
+              'The issue should preserve the plan context: problem, scope, constraints, files or surfaces, validation, and explicit non-goals.',
+              '',
+              'Do not use `#0000` as a placeholder. Do not use `skip-title-check` to bypass a missing planning issue; that label is reserved for maintainer-owned exceptions.',
+            ].join('\n');
+            const upsertTitleCheckComment = async (commentBody) => {
+              // Deduplicate: find and update existing bot comment instead of posting a new one.
               const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -87,6 +74,30 @@ jobs:
                 });
                 core.info('Posted new bot comment.');
               }
+            };
+            const issueMatches = [...title.matchAll(/\B#(\d+)\b/g)];
+
+            if (issueMatches.length === 0) {
+              core.setFailed(
+                `PR title must reference an issue (e.g. "feat: add thing (#42)"). ` +
+                `Codex/agent PRs should file the plan as an issue first. Got: "${title}"`
+              );
+
+              const commentBody = [
+                '## \u26a0\ufe0f PR Title Check Failed',
+                '',
+                BOT_MARKER,
+                '',
+                'This PR\'s title does not include an **issue reference** (`#<number>` outside of version strings).',
+                '',
+                '**Expected format:** `type: description (#1234)`',
+                '',
+                issueGuidance,
+                '',
+                `Current title: \`${title}\``,
+              ].join('\n');
+
+              await upsertTitleCheckComment(commentBody);
               return;
             }
 
@@ -96,8 +107,23 @@ jobs:
             if (zeroIssueMatch) {
               core.setFailed(
                 `PR title contains zero-valued issue reference "${zeroIssueMatch[0]}", which is the Codex placeholder for an unknown issue. ` +
-                `Please replace it with the actual issue number, e.g. "(#1234)". Got: "${title}"`
+                `File the plan as an issue and replace it with the actual issue number, e.g. "(#1234)". Got: "${title}"`
               );
+              const commentBody = [
+                '## \u26a0\ufe0f PR Title Check Failed',
+                '',
+                BOT_MARKER,
+                '',
+                `This PR title uses the placeholder issue reference \`${zeroIssueMatch[0]}\`.`,
+                '',
+                '**Expected format:** `type: description (#1234)`',
+                '',
+                issueGuidance,
+                '',
+                `Current title: \`${title}\``,
+              ].join('\n');
+
+              await upsertTitleCheckComment(commentBody);
               return;
             }
 

--- a/crates/perl-lsp-rs-core/src/protocol/capabilities.rs
+++ b/crates/perl-lsp-rs-core/src/protocol/capabilities.rs
@@ -74,10 +74,13 @@ pub fn capabilities_json(build: BuildFlags) -> Value {
         });
     }
 
-    // Manually add documentRangesFormattingProvider (LSP 3.18) because lsp-types 0.97
-    // predates this field.  The handler already exists in formatting.rs.
+    // Manually add rangesSupport (LSP 3.18) because lsp-types 0.97
+    // lacks this field on DocumentRangeFormattingOptions. Multi-range formatting
+    // is advertised through the existing documentRangeFormattingProvider key.
     if build.range_formatting {
-        json["documentRangesFormattingProvider"] = serde_json::json!(true);
+        json["documentRangeFormattingProvider"] = serde_json::json!({
+            "rangesSupport": true
+        });
     }
     // Manually add inlineCompletionProvider (LSP 3.18) because lsp-types 0.97
     // predates this field. This JSON surface has no client context and
@@ -191,20 +194,25 @@ mod tests {
         assert_feature_id_alignment("all", BuildFlags::all());
     }
 
-    /// Verify that `documentRangesFormattingProvider` is present in the JSON
-    /// capabilities when `range_formatting` is enabled (LSP 3.18 gap fix).
+    /// Verify that `documentRangeFormattingProvider.rangesSupport` is present in
+    /// the JSON capabilities when `range_formatting` is enabled (LSP 3.18).
     #[test]
     fn ranges_formatting_advertised_in_json_when_enabled() {
         let flags = BuildFlags { range_formatting: true, ..BuildFlags::default() };
         let json = capabilities_json(flags);
+        assert_eq!(
+            json.pointer("/documentRangeFormattingProvider/rangesSupport"),
+            Some(&serde_json::json!(true)),
+            "documentRangeFormattingProvider.rangesSupport must be present when range_formatting \
+             is enabled"
+        );
         assert!(
-            json.get("documentRangesFormattingProvider").is_some(),
-            "documentRangesFormattingProvider must be present in capabilities JSON when \
-             range_formatting is enabled"
+            json.get("documentRangesFormattingProvider").is_none(),
+            "documentRangesFormattingProvider is not an LSP 3.18 server capability"
         );
     }
 
-    /// Verify that `documentRangesFormattingProvider` is absent when disabled.
+    /// Verify that multi-range formatting support is absent when disabled.
     #[test]
     fn ranges_formatting_absent_in_json_when_disabled() {
         let flags = BuildFlags { range_formatting: false, ..BuildFlags::default() };
@@ -212,6 +220,11 @@ mod tests {
         assert!(
             json.get("documentRangesFormattingProvider").is_none(),
             "documentRangesFormattingProvider must not be present when range_formatting is disabled"
+        );
+        assert!(
+            json.pointer("/documentRangeFormattingProvider/rangesSupport").is_none(),
+            "documentRangeFormattingProvider.rangesSupport must not be present when \
+             range_formatting is disabled"
         );
     }
 

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -44,6 +44,77 @@ fn truncate_inlay_hint_label(hint: &mut Value, max_chars: usize) {
     *label = Value::String(text.chars().take(max_chars).collect());
 }
 
+#[derive(Debug, Clone)]
+struct SelectedInlineCompletionInfo {
+    range: lsp_types::Range,
+    text: String,
+}
+
+fn selected_inline_completion_info(
+    params: &Value,
+) -> Result<Option<SelectedInlineCompletionInfo>, JsonRpcError> {
+    let Some(selected) = params.pointer("/context/selectedCompletionInfo") else {
+        return Ok(None);
+    };
+
+    let text = selected
+        .get("text")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_params("Missing selectedCompletionInfo.text"))?
+        .to_string();
+    let range = selected
+        .get("range")
+        .ok_or_else(|| invalid_params("Missing selectedCompletionInfo.range"))
+        .and_then(|range| {
+            serde_json::from_value(range.clone())
+                .map_err(|_| invalid_params("Invalid selectedCompletionInfo.range"))
+        })?;
+
+    Ok(Some(SelectedInlineCompletionInfo { range, text }))
+}
+
+fn constrain_inline_completions_to_selected_info(
+    mut list: perl_lsp_rs_core::providers::inline_completion::InlineCompletionList,
+    selected: Option<&SelectedInlineCompletionInfo>,
+    line: u32,
+    character: u32,
+) -> perl_lsp_rs_core::providers::inline_completion::InlineCompletionList {
+    let Some(selected) = selected else {
+        return list;
+    };
+
+    if selected.range.start.line != selected.range.end.line {
+        list.items.clear();
+        return list;
+    }
+
+    let implicit_range = lsp_types::Range {
+        start: lsp_types::Position::new(line, character),
+        end: lsp_types::Position::new(line, character),
+    };
+
+    list.items = list
+        .items
+        .into_iter()
+        .filter_map(|mut item| {
+            if !item.insert_text.starts_with(&selected.text) {
+                return None;
+            }
+
+            match &item.range {
+                Some(range) if range == &selected.range => Some(item),
+                Some(_) => None,
+                None if selected.range == implicit_range => {
+                    item.range = Some(selected.range.clone());
+                    Some(item)
+                }
+                None => None,
+            }
+        })
+        .collect();
+    list
+}
+
 impl LspServer {
     pub(crate) fn record_provider_decision_trace(&self, provider: &str, receipt: &Value) {
         if receipt.is_object() {
@@ -587,6 +658,7 @@ impl LspServer {
         if let Some(params) = params {
             let uri = req_uri(&params)?;
             let (line, character) = req_position(&params)?;
+            let selected_completion = selected_inline_completion_info(&params)?;
 
             // Snapshot text under document lock, then release before any slow work
             let text = {
@@ -611,12 +683,20 @@ impl LspServer {
                             let list = perl_lsp_rs_core::providers::inline_completion::InlineCompletionList {
                                 items: items.clone(),
                             };
-                            return Ok(Some(serde_json::to_value(list).map_err(|e| {
-                                crate::protocol::internal_error(&format!(
-                                    "Failed to serialize inline completions: {}",
-                                    e
-                                ))
-                            })?));
+                            let list = constrain_inline_completions_to_selected_info(
+                                list,
+                                selected_completion.as_ref(),
+                                line,
+                                character,
+                            );
+                            if !list.items.is_empty() || !ai_config.fallback {
+                                return Ok(Some(serde_json::to_value(list).map_err(|e| {
+                                    crate::protocol::internal_error(&format!(
+                                        "Failed to serialize inline completions: {}",
+                                        e
+                                    ))
+                                })?));
+                            }
                         }
                         Err(ref e) => {
                             tracing::debug!("AI inline completion failed: {}", e);
@@ -636,7 +716,12 @@ impl LspServer {
             }
 
             // Deterministic fallback
-            let completions = provider.get_inline_completions(&text, line, character);
+            let completions = constrain_inline_completions_to_selected_info(
+                provider.get_inline_completions(&text, line, character),
+                selected_completion.as_ref(),
+                line,
+                character,
+            );
             return Ok(Some(serde_json::to_value(completions).map_err(|e| {
                 crate::protocol::internal_error(&format!(
                     "Failed to serialize inline completions: {}",

--- a/crates/perl-lsp-rs/tests/lsp_caps_contract_shapes.rs
+++ b/crates/perl-lsp-rs/tests/lsp_caps_contract_shapes.rs
@@ -124,11 +124,23 @@ fn test_capability_shapes_lsp_318_contract() -> Result<(), Box<dyn std::error::E
         );
     }
 
-    // Test range formatting shape (boolean or object)
+    // Test range formatting shape. LSP 3.18 multi-range formatting is
+    // advertised through documentRangeFormattingProvider.rangesSupport, not a
+    // separate documentRangesFormattingProvider key.
     if build.range_formatting {
         assert!(
-            caps_json["documentRangeFormattingProvider"].is_boolean()
-                || caps_json["documentRangeFormattingProvider"].is_object()
+            caps_json["documentRangeFormattingProvider"].is_object(),
+            "documentRangeFormattingProvider must be an object when rangesSupport is advertised"
+        );
+        assert_eq!(
+            caps_json.pointer("/documentRangeFormattingProvider/rangesSupport"),
+            Some(&json!(true)),
+            "documentRangeFormattingProvider.rangesSupport must be true for LSP 3.18 \
+             rangesFormatting"
+        );
+        assert!(
+            caps_json.get("documentRangesFormattingProvider").is_none(),
+            "documentRangesFormattingProvider is not an LSP 3.18 server capability"
         );
     }
 

--- a/crates/perl-lsp-rs/tests/lsp_disabled_features_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_disabled_features_tests.rs
@@ -119,6 +119,29 @@ fn test_disabled_features_declaration_suppresses_json_override() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn test_disabled_features_range_formatting_suppresses_ranges_support() -> TestResult {
+    for feature_id in ["lsp.range_formatting", "lsp.ranges_formatting"] {
+        let mut harness = LspHarness::new_raw();
+        let result = harness.initialize_with_init_options(
+            Some(json!({})),
+            json!({ "disabledFeatures": [feature_id] }),
+        )?;
+        let caps = &result["capabilities"];
+
+        assert!(
+            caps.get("documentRangeFormattingProvider").is_none()
+                || caps["documentRangeFormattingProvider"].is_null(),
+            "documentRangeFormattingProvider must be absent when {feature_id} is disabled"
+        );
+        assert!(
+            caps.get("documentRangesFormattingProvider").is_none(),
+            "non-spec documentRangesFormattingProvider must never be advertised"
+        );
+    }
+    Ok(())
+}
+
 /// When `initializationOptions` is absent entirely, capabilities must be identical to
 /// a normal initialization (no regression for non-VSCode clients).
 #[test]

--- a/crates/perl-lsp-rs/tests/lsp_inline_completion_registration_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_inline_completion_registration_tests.rs
@@ -168,7 +168,7 @@ fn inline_completion_invoked_trigger_returns_deterministic_items() -> TestResult
 }
 
 #[test]
-fn inline_completion_selected_completion_info_context_is_tolerated() -> TestResult {
+fn inline_completion_selected_completion_info_matching_text_returns_same_range() -> TestResult {
     let mut harness = LspHarness::new();
     harness.initialize(Some(json!({
         "textDocument": { "inlineCompletion": { "dynamicRegistration": true } }
@@ -177,9 +177,51 @@ fn inline_completion_selected_completion_info_context_is_tolerated() -> TestResu
     let uri = "file:///inline_selected_completion_info.pl";
     harness.open(uri, "use ")?;
 
-    // This is a request-shape receipt. The deterministic provider does not
-    // implement selected-completion alignment here; it must at least tolerate
-    // the official context object without falling back to an empty/error result.
+    let selected_range = json!({
+        "start": { "line": 0, "character": 4 },
+        "end": { "line": 0, "character": 4 }
+    });
+    let result = request_inline_completion_with_context(
+        &mut harness,
+        uri,
+        0,
+        4,
+        json!({
+            "triggerKind": 1,
+            "selectedCompletionInfo": {
+                "range": selected_range.clone(),
+                "text": "strict"
+            }
+        }),
+    )?;
+    let items = result
+        .get("items")
+        .and_then(Value::as_array)
+        .ok_or("inline completion result must contain items array")?;
+
+    let strict = items
+        .iter()
+        .find(|item| item.get("insertText") == Some(&json!("strict;")))
+        .ok_or("selectedCompletionInfo text strict must return the extending strict; item")?;
+    assert_eq!(
+        strict.get("range"),
+        Some(&selected_range),
+        "matching selectedCompletionInfo items must use the selected completion range"
+    );
+    assert_eq!(strict.pointer("/range/start/line"), strict.pointer("/range/end/line"));
+    Ok(())
+}
+
+#[test]
+fn inline_completion_selected_completion_info_text_mismatch_returns_empty() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "textDocument": { "inlineCompletion": { "dynamicRegistration": true } }
+    })))?;
+
+    let uri = "file:///inline_selected_completion_text_mismatch.pl";
+    harness.open(uri, "use ")?;
+
     let result = request_inline_completion_with_context(
         &mut harness,
         uri,
@@ -192,6 +234,41 @@ fn inline_completion_selected_completion_info_context_is_tolerated() -> TestResu
                     "start": { "line": 0, "character": 4 },
                     "end": { "line": 0, "character": 4 }
                 },
+                "text": "strictlyDifferent"
+            }
+        }),
+    )?;
+    let items = result
+        .get("items")
+        .and_then(Value::as_array)
+        .ok_or("inline completion result must contain items array")?;
+
+    assert!(items.is_empty(), "non-extending selectedCompletionInfo text must return empty");
+    Ok(())
+}
+
+#[test]
+fn inline_completion_selected_completion_info_range_mismatch_returns_empty() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "textDocument": { "inlineCompletion": { "dynamicRegistration": true } }
+    })))?;
+
+    let uri = "file:///inline_selected_completion_range_mismatch.pl";
+    harness.open(uri, "use ")?;
+
+    let result = request_inline_completion_with_context(
+        &mut harness,
+        uri,
+        0,
+        4,
+        json!({
+            "triggerKind": 1,
+            "selectedCompletionInfo": {
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end": { "line": 0, "character": 3 }
+                },
                 "text": "strict"
             }
         }),
@@ -201,9 +278,65 @@ fn inline_completion_selected_completion_info_context_is_tolerated() -> TestResu
         .and_then(Value::as_array)
         .ok_or("inline completion result must contain items array")?;
 
+    assert!(items.is_empty(), "selectedCompletionInfo range mismatch must return empty");
+    Ok(())
+}
+
+#[test]
+fn inline_completion_selected_completion_info_multiline_range_returns_empty() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "textDocument": { "inlineCompletion": { "dynamicRegistration": true } }
+    })))?;
+
+    let uri = "file:///inline_selected_completion_multiline_range.pl";
+    harness.open(uri, "use \n")?;
+
+    let result = request_inline_completion_with_context(
+        &mut harness,
+        uri,
+        0,
+        4,
+        json!({
+            "triggerKind": 1,
+            "selectedCompletionInfo": {
+                "range": {
+                    "start": { "line": 0, "character": 4 },
+                    "end": { "line": 1, "character": 0 }
+                },
+                "text": "strict"
+            }
+        }),
+    )?;
+    let items = result
+        .get("items")
+        .and_then(Value::as_array)
+        .ok_or("inline completion result must contain items array")?;
+
+    assert!(items.is_empty(), "inline completion ranges must not span multiple lines");
+    Ok(())
+}
+
+#[test]
+fn inline_completion_items_use_string_insert_text() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "textDocument": { "inlineCompletion": { "dynamicRegistration": true } }
+    })))?;
+
+    let uri = "file:///inline_insert_text_shape.pl";
+    harness.open(uri, "use ")?;
+
+    let result = request_inline_completion(&mut harness, uri, 0, 4)?;
+    let items = result
+        .get("items")
+        .and_then(Value::as_array)
+        .ok_or("inline completion result must contain items array")?;
+
+    assert!(!items.is_empty(), "expected deterministic inline completion items");
     assert!(
-        items.iter().any(|item| item.get("insertText") == Some(&json!("strict;"))),
-        "selectedCompletionInfo context must be tolerated, got: {items:?}"
+        items.iter().all(|item| item.get("insertText").is_some_and(Value::is_string)),
+        "InlineCompletionItem.insertText must be a string or valid StringValue object"
     );
     Ok(())
 }

--- a/crates/perl-lsp-rs/tests/snapshots/all_capabilities.json
+++ b/crates/perl-lsp-rs/tests/snapshots/all_capabilities.json
@@ -53,8 +53,9 @@
       "\n"
     ]
   },
-  "documentRangeFormattingProvider": true,
-  "documentRangesFormattingProvider": true,
+  "documentRangeFormattingProvider": {
+    "rangesSupport": true
+  },
   "documentSymbolProvider": true,
   "executeCommandProvider": {
     "commands": [

--- a/crates/perl-lsp-rs/tests/snapshots/ga_lock_capabilities.json
+++ b/crates/perl-lsp-rs/tests/snapshots/ga_lock_capabilities.json
@@ -53,8 +53,9 @@
       "\n"
     ]
   },
-  "documentRangeFormattingProvider": true,
-  "documentRangesFormattingProvider": true,
+  "documentRangeFormattingProvider": {
+    "rangesSupport": true
+  },
   "documentSymbolProvider": true,
   "executeCommandProvider": {
     "commands": [

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_full_client.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_full_client.snap
@@ -46,8 +46,8 @@ documentOnTypeFormattingProvider:
   moreTriggerCharacter:
     - ;
     - "\n"
-documentRangeFormattingProvider: true
-documentRangesFormattingProvider: true
+documentRangeFormattingProvider:
+  rangesSupport: true
 documentSymbolProvider: true
 executeCommandProvider:
   commands:

--- a/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_minimal_client.snap
+++ b/crates/perl-lsp-rs/tests/snapshots/lsp_cap_snap__server_capabilities_minimal_client.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/perl-lsp-rs/tests/lsp_cap_snap.rs
-assertion_line: 34
 expression: caps
 ---
 callHierarchyProvider: true
@@ -47,8 +46,8 @@ documentOnTypeFormattingProvider:
   moreTriggerCharacter:
     - ;
     - "\n"
-documentRangeFormattingProvider: true
-documentRangesFormattingProvider: true
+documentRangeFormattingProvider:
+  rangesSupport: true
 documentSymbolProvider: true
 executeCommandProvider:
   commands:

--- a/crates/perl-lsp-rs/tests/snapshots/production_capabilities.json
+++ b/crates/perl-lsp-rs/tests/snapshots/production_capabilities.json
@@ -53,8 +53,9 @@
       "\n"
     ]
   },
-  "documentRangeFormattingProvider": true,
-  "documentRangesFormattingProvider": true,
+  "documentRangeFormattingProvider": {
+    "rangesSupport": true
+  },
   "documentSymbolProvider": true,
   "executeCommandProvider": {
     "commands": [

--- a/docs/adr/PLSP-ADR-0004-lsp-stack-extraction.md
+++ b/docs/adr/PLSP-ADR-0004-lsp-stack-extraction.md
@@ -1,0 +1,171 @@
+# PLSP-ADR-0004: lsp-stack extraction boundary
+
+Status: accepted
+Date: 2026-05-26
+Owner: perl-lsp maintainers
+Linked proposal: n/a
+Linked specs:
+- [PLSP-SPEC-0028](../specs/PLSP-SPEC-0028-lsp-stack-extraction.md)
+Linked plan: [lsp-stack extraction implementation plan](../../plans/lsp-stack-extraction/implementation-plan.md)
+
+## Context
+
+`perl-lsp` now has the current-app protocol and runtime hardening required
+before any reusable LSP stack extraction:
+
+- inline completion selects one registration mode for static and dynamic
+  clients
+- LSP 3.18 inline-completion parameter handling has runtime proof
+- runtime watcher registration honors lean and e2e tuning
+- semantic-token capabilities advertise full-only behavior until delta support
+  has real result-id state
+- raw RPC and lean editor receipt paths exist for the current app
+- editor docs and release notes describe the current integration behavior
+
+Those changes make the current product surface coherent enough to define a
+future extraction boundary. They do not by themselves create a reusable stack,
+prove release readiness, or authorize code movement.
+
+## Decision
+
+Future `lsp-stack` work must start from a written boundary, not from moving
+files.
+
+The reusable stack seam is the language-neutral LSP infrastructure that can be
+shared without knowing Perl. The seam may eventually include:
+
+- JSON-RPC message and request-id discipline
+- LSP message framing and transport helpers
+- server-originated request helpers
+- capability-shape and dynamic-registration primitives
+- lifecycle and runtime-tuning primitives that are not tied to Perl providers
+- cancellation and scheduling primitives that do not encode Perl semantics
+- test harness utilities for protocol contracts
+
+Perl-specific behavior stays in the current app unless a later spec proves a
+safe boundary. That includes parser, lexer, semantic analysis, workspace index,
+provider behavior, feature catalog, inline-completion behavior, editor
+receipts, DAP, packaging, and release automation.
+
+## Preconditions
+
+Extraction may begin only after current protocol, runtime, and editor-doc
+hardening is complete and proven in the app that ships today.
+
+The first extraction implementation PR must confirm that these current-app
+contracts remain true before moving code:
+
+- static inline-completion clients receive only the static provider
+- dynamic inline-completion clients receive only dynamic registration
+- disabled inline completion disables both static and dynamic registration
+- e2e and lean runtime modes do not register file watchers
+- file-watcher tuning does not suppress inline-completion registration
+- semantic tokens do not advertise delta without result-id-backed delta support
+- raw RPC and lean editor receipts continue to pass for the current app
+- docs still describe standard inline completion and the custom
+  `perlInlineCompletionStream` extension accurately
+
+## Dependency Boundary
+
+A future `lsp-stack` crate must not depend on Perl crates, Perl providers, Perl
+runtime tooling, or Perl release surfaces.
+
+Explicitly forbidden dependencies for a future `lsp-stack` include:
+
+- `perl-lsp-rs`
+- `perl-lsp-rs-core`
+- `perl-parser`
+- `perl-lexer`
+- `perl-semantic-analyzer`
+- `perl-workspace-index`
+- `perl-module-*`
+- `perl-lsp-*` feature or provider crates
+- `perl-dap-*`
+- `perl-subprocess-runtime`
+- `perl-lsp-perltidy`
+- any crate whose public contract requires Perl source, Perl workspace state,
+  Perl provider facts, Perl debugger state, or Perl release artifacts
+
+Allowed dependencies must be language-neutral infrastructure dependencies. Any
+new dependency for `lsp-stack` requires a separate dependency-boundary review.
+
+## Non-goals
+
+This ADR does not authorize:
+
+- creating `crates/lsp-stack`
+- moving protocol, transport, router, lifecycle, scheduler, or provider files
+- rewriting the router
+- introducing generic handler traits
+- extracting inline-completion types or provider logic
+- extracting capability descriptors from the Perl feature catalog
+- extracting DAP
+- implementing semantic-token delta
+- implementing true incremental parsing
+- changing release, publish, signing, marketplace, or package metadata
+- claiming release readiness
+
+## Consequences
+
+Positive consequences:
+
+- agents have a durable map before extraction starts
+- current-app behavior remains the regression baseline
+- future stack code must stay language-neutral
+- Perl-specific product behavior remains reviewable in the app until a proven
+  seam exists
+
+Tradeoffs:
+
+- extraction starts later than a direct file move
+- some infrastructure remains in `perl-lsp-rs-core` until the boundary is
+  proven by tests
+- generic handler abstractions remain out of scope until a separate design
+  proves they reduce real complexity
+
+## Alternatives Considered
+
+### Create `crates/lsp-stack` immediately
+
+Rejected. The current need is a boundary and proof map. Creating the crate
+before the current-app contracts are documented would invite broad file
+movement before the regression baseline is clear.
+
+### Extract all protocol and runtime modules at once
+
+Rejected. The protocol/runtime surface mixes language-neutral infrastructure
+with Perl-specific feature wiring and current editor receipts. A bulk move
+would obscure which behavior is reusable and which behavior is product-specific.
+
+### Extract through generic handler traits first
+
+Rejected for this tranche. Handler traits may or may not be useful after the
+language-neutral seam is identified. They are not a prerequisite for documenting
+the extraction boundary.
+
+## Follow-up Obligations
+
+- Keep [PLSP-SPEC-0028](../specs/PLSP-SPEC-0028-lsp-stack-extraction.md) as the
+  acceptance contract for extraction PRs.
+- Keep the implementation plan under
+  [plans/lsp-stack-extraction](../../plans/lsp-stack-extraction/implementation-plan.md)
+  as the PR sequence map.
+- Require future extraction PRs to state whether they move code, change runtime
+  behavior, change capability behavior, add dependencies, or alter release
+  surfaces.
+- Keep release readiness claims out of extraction PRs unless a separate release
+  lane proves them.
+
+## Status Links
+
+- [LSP interactive latency rollout](../development/LSP_INTERACTIVE_LATENCY_ROLLOUT.md)
+- [Editor setup](../how-to/EDITOR_SETUP.md)
+- [IntelliJ IDEA setup](../EDITORS/INTELLIJ_IDEA_SETUP.md)
+- [LSP capability contract ADR](0021-lsp-capability-contract.md)
+- [Custom LSP runtime ADR](0034-custom-lsp-runtime.md)
+
+## Why ADR-worthy
+
+This is an architecture boundary decision. It defines when extraction may start,
+what future reusable stack code may know, what must remain in `perl-lsp`, and
+which tempting implementation shortcuts are intentionally out of scope.

--- a/docs/specs/PLSP-SPEC-0028-lsp-stack-extraction.md
+++ b/docs/specs/PLSP-SPEC-0028-lsp-stack-extraction.md
@@ -1,0 +1,259 @@
+# PLSP-SPEC-0028: lsp-stack extraction boundary
+
+Status: accepted
+Owner: perl-lsp maintainers
+Linked proposal: n/a
+Linked ADRs:
+- [PLSP-ADR-0004](../adr/PLSP-ADR-0004-lsp-stack-extraction.md)
+Linked plan: [lsp-stack extraction implementation plan](../../plans/lsp-stack-extraction/implementation-plan.md)
+Status impact: protocol/runtime hardening, editor integration docs, future
+crate-boundary reviews
+
+## Current Implementation Status
+
+This is a docs-only boundary spec. No `lsp-stack` crate exists because this spec
+does not authorize implementation. The current app remains the source of truth
+for LSP behavior until later extraction PRs prove equivalence.
+
+The hardening prerequisite for extraction is the current-app protocol,
+runtime, and editor-doc tranche:
+
+- inline-completion registration mode is coherent for static, dynamic, and
+  disabled clients
+- LSP 3.18 inline-completion request shape has runtime coverage
+- runtime watcher registration honors lean and e2e file-watcher tuning
+- semantic-token capabilities no longer advertise delta without result-id state
+- raw RPC and lean editor receipts exist for current-app behavior
+- editor docs describe LSP4IJ, Neovim lean/e2e mode, standard inline
+  completion, and the custom `perlInlineCompletionStream` extension
+
+This spec does not claim release readiness.
+
+## Contract
+
+`lsp-stack` extraction is allowed only as a staged migration from proven
+current-app behavior to language-neutral infrastructure.
+
+The reusable seam may include only infrastructure that does not need Perl
+source, Perl facts, Perl runtime state, Perl debugging state, or Perl release
+state:
+
+- JSON-RPC request and response envelopes
+- strict request-id parsing and server-originated request-id allocation
+- LSP framing and transport helpers
+- server-originated request helper APIs
+- capability JSON shape helpers that do not encode Perl features
+- dynamic-registration helper APIs that do not encode Perl provider behavior
+- runtime tuning and scheduling primitives that are language-neutral
+- cancellation and stale-read primitives that do not inspect Perl documents
+- protocol contract test utilities
+
+The current app must retain ownership of:
+
+- Perl parser, lexer, and semantic analyzer behavior
+- workspace indexing and module resolution
+- provider implementations and provider receipts
+- `features.toml` and Perl capability catalog policy
+- inline-completion provider behavior and stream payloads
+- DAP and Perl debugger integration
+- editor-specific integration docs
+- release, publish, signing, marketplace, package, and installer surfaces
+
+## Dependency Boundary
+
+Future `lsp-stack` code must be dependency-inverted away from Perl.
+
+It must not depend on:
+
+- any crate named `perl-*`
+- `perl-lsp-rs`
+- `perl-lsp-rs-core`
+- `perllsp`
+- DAP crates from this workspace
+- parser, lexer, semantic, workspace-index, module-resolution, perltidy, or
+  subprocess-runtime crates from this workspace
+- generated feature catalogs that encode Perl provider policy
+- release or installer metadata
+
+It may depend only on language-neutral protocol, serialization, error, test, or
+runtime infrastructure after dependency review. Adding or widening dependencies
+is a separate acceptance item and cannot be hidden inside a file-move PR.
+
+## Valid PR Shapes
+
+Valid PRs under this spec include:
+
+- docs-only boundary, ADR, spec, or implementation-plan PRs
+- static analysis PRs that report candidate seams without moving code
+- test-only PRs that preserve current-app behavior before extraction
+- mechanical no-behavior-change file moves after this spec's proof commands are
+  green
+- dependency-boundary PRs that remove Perl dependencies from candidate
+  infrastructure before moving it
+- post-move parity PRs that prove the same protocol/runtime behavior from the
+  new boundary
+
+Every extraction PR must state whether it changes:
+
+- code location
+- runtime behavior
+- JSON-RPC behavior
+- capability shape
+- dynamic registration behavior
+- editor integration behavior
+- dependencies
+- release or packaging surfaces
+
+## Invalid PR Shapes
+
+Invalid PRs include:
+
+- creating `crates/lsp-stack` in the boundary-docs PR
+- moving code before the current protocol/runtime/editor-doc hardening baseline
+  is green
+- bundling extraction with inline-completion behavior changes
+- bundling extraction with DAP changes
+- bundling extraction with release, publish, signing, marketplace, or installer
+  changes
+- adding generic handler traits as part of the boundary-docs PR
+- rewriting routing as part of extraction setup
+- weakening or deleting current inline-completion, watcher, semantic-token, raw
+  RPC, or lean editor receipt tests
+- introducing Perl dependencies into a future `lsp-stack`
+- claiming release readiness from extraction docs or file movement
+
+## Future PR Sequence
+
+The intended sequence is:
+
+1. Boundary docs: add this ADR, spec, and implementation plan. No code
+   movement.
+2. Static seam audit: classify protocol/runtime files as language-neutral,
+   Perl-specific, mixed, or not extractable.
+3. Dependency audit: prove candidate language-neutral files do not require Perl
+   crates or feature-catalog policy.
+4. Test baseline: keep current-app protocol/runtime/editor receipt commands
+   green on `main`.
+5. Crate scaffold: create `crates/lsp-stack` only after the audit PRs land.
+6. First mechanical move: move one language-neutral, low-risk protocol module
+   with no behavior change.
+7. Transport/framing move: move framing helpers only after protocol parity is
+   proven.
+8. Runtime primitive move: move cancellation, request-id, or scheduling
+   primitives only when they no longer encode Perl behavior.
+9. Current-app integration: keep `perl-lsp` as the product crate and wire it to
+   the extracted infrastructure with parity tests.
+10. Post-extraction cleanup: remove duplicate wrappers only after behavior
+    parity and dependency boundaries are proven.
+
+Any step may be split smaller. No step may skip the proof commands for the
+behavior it touches.
+
+## Acceptance
+
+An extraction-boundary PR satisfies this spec when it:
+
+- adds only boundary docs, spec, and implementation-plan artifacts
+- states that no code moved
+- states that no runtime behavior changed
+- states that no extraction implementation exists yet
+- defines the reusable stack seam
+- defines the Perl-specific non-extractable surface
+- bans Perl dependencies in future `lsp-stack`
+- defines future PR order
+- defines proof commands
+- defines rollback rules
+- avoids release-readiness claims
+
+A future implementation PR satisfies this spec only when it:
+
+- starts after the current-app hardening baseline is green
+- moves or changes one bounded surface
+- proves current-app behavior still passes
+- proves the candidate code has no Perl dependencies
+- states rollback steps
+- leaves unrelated providers, DAP, release, and editor docs alone
+
+## Proof Commands
+
+Docs-only boundary PRs must run:
+
+```bash
+git diff --check
+```
+
+When stable in the checkout, also run:
+
+```bash
+cargo xtask docs-check
+```
+
+When touched docs could affect support claims, run:
+
+```bash
+cargo xtask check-support-claims
+```
+
+Future implementation PRs must also run the current-app protocol and runtime
+proof relevant to the moved surface, including targeted tests for:
+
+```bash
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_inline_completion_registration_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_registration_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_cap_snap --profile agent --locked
+./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked
+./scripts/cargo-safe check -p perl-lsp-rs-core --all-targets --profile agent --locked
+```
+
+Raw RPC and lean editor receipt commands are required for extraction PRs that
+touch runtime scheduling, watcher registration, diagnostics timing,
+initialization, request dispatch, or cancellation.
+
+Report unrelated pre-existing warnings separately from extraction failures.
+
+## Rollback Rules
+
+Boundary docs rollback:
+
+- revert the docs-only PR
+- keep current app behavior unchanged
+- do not remove current protocol/runtime tests
+
+Implementation rollback:
+
+- revert the smallest extraction PR that introduced the regression
+- restore current-app imports and module paths
+- keep the failing parity test or add a smaller regression test before retrying
+- do not repair extraction by weakening current-app behavior
+- do not remove proof commands from PR bodies to make rollback look green
+
+Dependency rollback:
+
+- remove the dependency from future `lsp-stack`
+- move any Perl-specific code back to the current app
+- document why the candidate was mixed rather than language-neutral
+
+## Non-goals
+
+This spec does not authorize:
+
+- creating `crates/lsp-stack`
+- moving code
+- rewriting routing
+- introducing generic handler traits
+- extracting inline-completion implementation
+- extracting DAP
+- changing release or publish automation
+- changing package metadata
+- claiming release readiness
+
+## Claim Boundaries
+
+This spec may claim only that the extraction boundary is documented. It must
+not claim:
+
+- an extracted reusable stack exists
+- extraction has started
+- runtime behavior changed
+- editor integrations are more ready than current receipts prove
+- release, publish, package, signing, marketplace, or installer readiness

--- a/plans/lsp-stack-extraction/implementation-plan.md
+++ b/plans/lsp-stack-extraction/implementation-plan.md
@@ -1,0 +1,319 @@
+# lsp-stack Extraction Implementation Plan
+
+Status: planned
+Owner: perl-lsp maintainers
+Linked ADR: [PLSP-ADR-0004](../../docs/adr/PLSP-ADR-0004-lsp-stack-extraction.md)
+Linked spec: [PLSP-SPEC-0028](../../docs/specs/PLSP-SPEC-0028-lsp-stack-extraction.md)
+
+## Purpose
+
+Define the PR sequence for a future `lsp-stack` extraction without starting the
+extraction in this PR.
+
+This plan exists so future agents know the boundary before they move code. The
+current app remains the shipping implementation until a later extraction PR
+proves parity.
+
+## Current-app Hardening Prerequisite
+
+Extraction starts only after current protocol, runtime, and editor-doc
+hardening is complete and green on `main`.
+
+The prerequisite baseline is:
+
+- inline-completion registration mode is correct for static, dynamic, and
+  disabled clients
+- LSP 3.18 inline-completion params coverage exists
+- watcher registration honors lean/e2e runtime tuning
+- semantic tokens advertise full-only support until delta is implemented
+- raw RPC and lean editor receipts exist for the current app
+- editor docs describe LSP4IJ, Neovim lean/e2e mode, standard inline
+  completion, and `perlInlineCompletionStream`
+
+This baseline is a regression target, not a release-readiness claim.
+
+## Boundary
+
+Future `lsp-stack` work may extract only language-neutral LSP infrastructure:
+
+- JSON-RPC envelopes and request-id handling
+- LSP framing and transport helpers
+- server-originated request helpers
+- capability-shape and dynamic-registration primitives
+- lifecycle, tuning, cancellation, and scheduling primitives that do not encode
+  Perl behavior
+- protocol contract test helpers
+
+Future `lsp-stack` work must not include:
+
+- Perl parser, lexer, semantic analysis, or workspace indexing
+- Perl module resolution or provider facts
+- inline-completion provider behavior
+- `features.toml` Perl feature policy
+- DAP or Perl debugger behavior
+- perltidy, subprocess runtime, packaging, signing, publishing, marketplace, or
+  release automation
+
+Future `lsp-stack` must have no Perl dependencies.
+
+## PR Sequence
+
+### PR 1: Boundary docs
+
+Status: this PR
+
+Goal:
+
+Add the ADR, spec, and implementation plan.
+
+Allowed files:
+
+- `docs/adr/PLSP-ADR-0004-lsp-stack-extraction.md`
+- `docs/specs/PLSP-SPEC-0028-lsp-stack-extraction.md`
+- `plans/lsp-stack-extraction/implementation-plan.md`
+
+Non-goals:
+
+- no `crates/lsp-stack`
+- no code movement
+- no generic handler traits
+- no routing rewrite
+- no inline-completion behavior change
+- no DAP change
+- no release, publish, signing, or package change
+
+Proof:
+
+```bash
+git diff --check
+cargo xtask docs-check
+cargo xtask check-support-claims
+```
+
+If an xtask command is unavailable or unstable, report that separately.
+
+Rollback:
+
+Revert the docs-only PR. No runtime rollback is needed because no code moved.
+
+### PR 2: Static seam audit
+
+Goal:
+
+Classify candidate protocol/runtime files as language-neutral, Perl-specific,
+mixed, or not extractable.
+
+Allowed changes:
+
+- docs or generated audit report only
+- no code movement
+
+Acceptance:
+
+- every candidate names its current tests
+- every mixed file names the Perl dependency that blocks extraction
+- every proposed first move is low-risk and language-neutral
+
+Proof:
+
+```bash
+git diff --check
+```
+
+Rollback:
+
+Revert the audit doc. Do not move code based on a reverted audit.
+
+### PR 3: Dependency boundary audit
+
+Goal:
+
+Prove the first candidate extraction set can compile without Perl dependencies.
+
+Allowed changes:
+
+- docs or build metadata experiments only when they do not create
+  `crates/lsp-stack`
+- no production code movement
+
+Acceptance:
+
+- no `perl-*` dependency in the candidate set
+- no provider, parser, DAP, release, or package dependency in the candidate set
+- dependency additions are documented and language-neutral
+
+Proof:
+
+```bash
+git diff --check
+./scripts/cargo-safe check -p perl-lsp-rs-core --all-targets --profile agent --locked
+```
+
+Rollback:
+
+Revert the audit. Keep candidates in the current app until the dependency
+boundary is clean.
+
+### PR 4: Crate scaffold
+
+Goal:
+
+Create `crates/lsp-stack` only after PRs 1-3 land.
+
+Allowed changes:
+
+- workspace metadata for the new crate
+- minimal crate files
+- no moved production behavior
+
+Acceptance:
+
+- the crate has no Perl dependencies
+- the crate compiles independently
+- no runtime behavior changes
+
+Proof:
+
+```bash
+git diff --check
+./scripts/cargo-safe check -p lsp-stack --all-targets --profile agent --locked
+./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked
+```
+
+Rollback:
+
+Revert the scaffold PR. Current app behavior must remain unchanged.
+
+### PR 5: First protocol primitive move
+
+Goal:
+
+Move one language-neutral protocol primitive with no behavior change.
+
+Candidate class:
+
+- JSON-RPC ID parsing or request envelope utilities
+- only if the dependency audit proves the type has no Perl dependency
+
+Acceptance:
+
+- existing current-app tests pass
+- moved tests prove the same parse/serialize behavior
+- no capability or provider behavior changes
+
+Proof:
+
+```bash
+./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_registration_tests --profile agent --locked
+./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked
+git diff --check
+```
+
+Rollback:
+
+Revert the move and restore imports. Keep any added regression test if it
+captures a real bug.
+
+### PR 6: Transport/framing move
+
+Goal:
+
+Move language-neutral message framing only after protocol primitive parity is
+proven.
+
+Acceptance:
+
+- no Perl provider imports
+- request/response framing tests pass
+- raw RPC receipt remains green
+
+Proof:
+
+```bash
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_registration_tests --profile agent --locked
+PERL_LSP_E2E=1 PERL_LSP_DIAGNOSTIC_DEBOUNCE_MS=0 PERL_LSP_DIAGNOSTIC_MODE=syntax-only cargo test -p perl-lsp-ux-tests --test ux_latency_raw_rpc -- --test-threads=1 --nocapture
+git diff --check
+```
+
+Rollback:
+
+Revert the transport move and restore current-app framing paths.
+
+### PR 7: Runtime primitive move
+
+Goal:
+
+Move cancellation, request-id allocation, or scheduling primitives only when
+they are language-neutral.
+
+Acceptance:
+
+- file-watcher tuning still gates only file watchers
+- inline-completion dynamic registration is not suppressed by watcher tuning
+- generation-aware stale-read cancellation still passes existing receipts
+
+Proof:
+
+```bash
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_registration_tests --profile agent --locked
+PERL_LSP_E2E=1 PERL_LSP_DIAGNOSTIC_DEBOUNCE_MS=0 PERL_LSP_DIAGNOSTIC_MODE=syntax-only cargo test -p perl-lsp-ux-tests --test ux_neovim_lean_startup_trace -- --test-threads=1 --nocapture
+git diff --check
+```
+
+Rollback:
+
+Revert the runtime primitive move. Do not weaken cancellation or watcher tests.
+
+### PR 8: Current-app integration cleanup
+
+Goal:
+
+Remove duplicate wrappers only after extracted primitives are proven and the
+current app has parity.
+
+Acceptance:
+
+- current app remains the product surface
+- no release, package, signing, or marketplace behavior changes
+- docs still describe current editor behavior accurately
+
+Proof:
+
+```bash
+./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_inline_completion_registration_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_registration_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_cap_snap --profile agent --locked
+git diff --check
+```
+
+Rollback:
+
+Revert cleanup only. Do not revert earlier extraction PRs unless the regression
+is in the extracted primitive.
+
+## Always Invalid In This Lane
+
+- creating `crates/lsp-stack` before the boundary and audits land
+- moving code in the boundary-docs PR
+- adding Perl dependencies to future `lsp-stack`
+- changing inline-completion behavior while extracting infrastructure
+- changing DAP while extracting LSP infrastructure
+- changing release, publish, signing, marketplace, or package behavior
+- claiming release readiness from extraction work
+- deleting current-app proof commands to make extraction pass
+
+## Reporting Requirements
+
+Every future extraction PR must say:
+
+- what moved or changed
+- what did not move
+- whether runtime behavior changed
+- whether capability JSON changed
+- whether dynamic registration changed
+- whether dependencies changed
+- whether release or package surfaces changed
+- which proof commands passed
+- which unrelated warnings were pre-existing


### PR DESCRIPTION
Problem: Swarm has the post-smoke LSP 3.18 contract locks and PR-title routing fix, while the release repo only had the earlier source-side smoke/routing work.
Fix: Mirror the swarm-only commits for the lsp-stack boundary docs, PR-title plan routing, and LSP 3.18 range-formatting / selectedCompletionInfo contract hardening into the release repo. Release metadata is unchanged.
Verification:
- `cargo check -p perl-lsp-rs --locked`
- `cargo test -p perl-lsp-rs --test lsp_inline_completion_registration_tests -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_caps_contract_shapes -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_disabled_features_tests -- --nocapture`
- `git diff --check`
