### PR TITLE
sync: mirror inline-completion release smoke lock (#9605)

### DIFF
--- a/crates/perl-lsp-rs/tests/lsp_streaming_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_streaming_completion_tests.rs
@@ -45,6 +45,28 @@ fn enable_ai_streaming(harness: &mut LspHarness) {
     std::thread::sleep(Duration::from_millis(50));
 }
 
+/// Helper: enable streaming and force the no-backend path to emit progress
+/// instead of falling back to one-shot inline completions.
+fn enable_ai_streaming_progress_contract(harness: &mut LspHarness) {
+    harness.notify(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "perl": {
+                    "aiCompletion": {
+                        "enabled": true,
+                        "fallback": false,
+                        "streaming": {
+                            "enabled": true
+                        }
+                    }
+                }
+            }
+        }),
+    );
+    std::thread::sleep(Duration::from_millis(50));
+}
+
 /// Helper: enable AI completion but disable streaming specifically.
 fn enable_ai_disable_streaming(harness: &mut LspHarness) {
     harness.notify(
@@ -72,7 +94,7 @@ fn enable_ai_disable_streaming(harness: &mut LspHarness) {
 #[test]
 fn streaming_completion_returns_null_and_emits_progress() -> TestResult {
     let mut harness = init_harness()?;
-    enable_ai_streaming(&mut harness);
+    enable_ai_streaming_progress_contract(&mut harness);
 
     let uri = "file:///streaming_test.pl";
     harness.open(uri, "use strict;\nmy $obj = Package->")?;
@@ -131,7 +153,7 @@ fn streaming_completion_returns_null_and_emits_progress() -> TestResult {
 #[test]
 fn streaming_completion_progress_has_valid_session_and_sequence() -> TestResult {
     let mut harness = init_harness()?;
-    enable_ai_streaming(&mut harness);
+    enable_ai_streaming_progress_contract(&mut harness);
 
     let uri = "file:///session_test.pl";
     harness.open(uri, "sub foo {\n    \n}")?;
@@ -291,7 +313,7 @@ fn streaming_completion_without_partial_result_token_falls_back() -> TestResult 
 #[test]
 fn streaming_completion_second_request_cancels_first_session() -> TestResult {
     let mut harness = init_harness()?;
-    enable_ai_streaming(&mut harness);
+    enable_ai_streaming_progress_contract(&mut harness);
 
     let uri = "file:///cancel_test.pl";
     harness.open(uri, "use strict;\nmy $x = ")?;
@@ -424,7 +446,7 @@ fn streaming_completion_capability_advertised() -> TestResult {
 #[test]
 fn streaming_completion_progress_schema_validation() -> TestResult {
     let mut harness = init_harness()?;
-    enable_ai_streaming(&mut harness);
+    enable_ai_streaming_progress_contract(&mut harness);
 
     let uri = "file:///schema_test.pl";
     harness.open(uri, "#!/usr/bin/perl\nuse strict;\n")?;

--- a/crates/perl-lsp-ux-tests/src/client.rs
+++ b/crates/perl-lsp-ux-tests/src/client.rs
@@ -206,6 +206,9 @@ impl UxClient {
         if !workspace_folders.is_empty() {
             params["workspaceFolders"] = Value::Array(workspace_folders);
         }
+        if !config.initialization_options.is_null() {
+            params["initializationOptions"] = config.initialization_options.clone();
+        }
 
         merge_json(&mut params["capabilities"], &config.client_capability_overrides);
 
@@ -325,6 +328,15 @@ impl UxClient {
             guard.iter().cloned().collect()
         };
         raw.into_iter().map(decode_event).collect()
+    }
+
+    /// Clone raw server-initiated messages without removing them from the queue.
+    ///
+    /// This preserves server request IDs and registration payloads for protocol
+    /// smoke checks that need to assert exact JSON-RPC shapes.
+    pub fn peek_raw_events(&self) -> Vec<Value> {
+        let guard = self.events.lock().unwrap_or_else(|e| e.into_inner());
+        guard.iter().cloned().collect()
     }
 
     /// Clone all stderr lines captured from the server process.

--- a/crates/perl-lsp-ux-tests/src/lib.rs
+++ b/crates/perl-lsp-ux-tests/src/lib.rs
@@ -126,6 +126,8 @@ pub struct ScenarioConfig {
     pub workspace_folders: Vec<(String, String)>,
     /// Extra client capabilities to merge into the initialize request.
     pub client_capability_overrides: Value,
+    /// Optional `initialize` request `initializationOptions`.
+    pub initialization_options: Value,
 }
 
 impl Default for ScenarioConfig {
@@ -143,6 +145,7 @@ impl Default for ScenarioConfig {
             workspace_files: Vec::new(),
             workspace_folders: Vec::new(),
             client_capability_overrides: Value::Object(Map::new()),
+            initialization_options: Value::Null,
         }
     }
 }

--- a/crates/perl-lsp-ux-tests/tests/ux_latency_raw_rpc.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_latency_raw_rpc.rs
@@ -84,6 +84,7 @@ fn e2e_config(timeout: Duration) -> ScenarioConfig {
                 }
             }
         }),
+        initialization_options: Value::Null,
     }
 }
 

--- a/crates/perl-lsp-ux-tests/tests/ux_neovim_lean_startup_trace.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_neovim_lean_startup_trace.rs
@@ -54,6 +54,7 @@ fn trace_config(timeout: Duration) -> ScenarioConfig {
                 }
             }
         }),
+        initialization_options: Value::Null,
     }
 }
 

--- a/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
+++ b/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
@@ -78,6 +78,20 @@ On Windows PowerShell:
 where perllsp
 ```
 
+Minimal descriptor/config example:
+
+```json
+{
+  "name": "Perl Language Server",
+  "languageId": "perl",
+  "fileExtensions": ["pl", "pm", "t", "psgi"],
+  "command": ["perllsp", "--stdio"]
+}
+```
+
+The same example is checked in at
+[`docs/EDITORS/lsp4ij-perl-lsp.json`](lsp4ij-perl-lsp.json).
+
 On Windows, use the full path with forward slashes or escaped backslashes:
 
 ```
@@ -152,6 +166,8 @@ Protocol notes:
 - `experimental.inlineCompletionProvider` is not used.
 - `experimental.perlInlineCompletionStream` is a custom extension for clients
   that explicitly integrate the streaming path.
+- The registration selector includes `perl` and `perl5`.
+- The server communicates UTF-16 positions.
 
 ## Verify It Is Running
 

--- a/docs/EDITORS/lsp4ij-perl-lsp.json
+++ b/docs/EDITORS/lsp4ij-perl-lsp.json
@@ -1,0 +1,6 @@
+{
+  "name": "Perl Language Server",
+  "languageId": "perl",
+  "fileExtensions": ["pl", "pm", "t", "psgi"],
+  "command": ["perllsp", "--stdio"]
+}

--- a/docs/development/INLINE_COMPLETION_RELEASE_GATE.md
+++ b/docs/development/INLINE_COMPLETION_RELEASE_GATE.md
@@ -1,0 +1,41 @@
+# Inline Completion Release Gate
+
+This gate locks the embedded `perllsp` binary as a standard LSP 3.18
+`textDocument/inlineCompletion` target for editor integration. It does not claim
+full LSP 3.18 coverage or general release readiness.
+
+Gate name:
+
+```text
+inline-completion-release-gate
+```
+
+Run the gate before release-adjacent inline-completion changes:
+
+```bash
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_inline_completion_registration_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_ai_inline_completion_tests --features expose_lsp_test_api --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs-core --lib inline_completion --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_streaming_completion_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_cap_snap --profile agent --locked
+./scripts/cargo-safe build -p perllsp --profile agent --locked
+./scripts/cargo-safe xtask inline-completion-smoke --binary target/agent/perllsp
+```
+
+On Windows, use the `.exe` binary path. If `cargo-safe` uses an external
+`CARGO_TARGET_DIR`, pass that built binary path to `inline-completion-smoke`.
+
+The stdio smoke proves:
+
+- static clients receive top-level `inlineCompletionProvider`;
+- dynamic clients omit the static provider and receive
+  `client/registerCapability` for `textDocument/inlineCompletion`;
+- the dynamic registration id is `perl-inlineCompletion`;
+- the dynamic registration selector includes `perl` and `perl5`;
+- `experimental.inlineCompletionProvider` is absent;
+- `experimental.perlInlineCompletionStream` remains a separate vendor extension
+  when inline completion is enabled;
+- `use ` returns the deterministic `strict;` item;
+- a neutral position returns an empty item list;
+- `disabledFeatures: ["lsp.inline_completion"]` removes the provider and stream
+  flag, prevents dynamic registration, and rejects runtime requests.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -155,6 +155,14 @@ enum Commands {
         command: SmokeCommand,
     },
 
+    /// Verify inline completion over stdio against a built binary.
+    #[command(name = "inline-completion-smoke")]
+    InlineCompletionSmoke {
+        /// Path to the perl-lsp binary to execute.
+        #[arg(long)]
+        binary: PathBuf,
+    },
+
     /// Regenerate public Shields endpoint JSON for README badges.
     Badges {
         /// Check committed endpoints for drift without updating badges/.
@@ -2621,6 +2629,7 @@ fn main() -> Result<()> {
         Commands::Smoke { command } => match command {
             SmokeCommand::InlineCompletion { binary } => inline_completion_smoke::run(binary),
         },
+        Commands::InlineCompletionSmoke { binary } => inline_completion_smoke::run(binary),
         Commands::Badges { check } => badges::run(check),
         Commands::RiprPr { root, base, head, check } => {
             ripr_evidence::ripr_pr(&root, &base, &head, check)

--- a/xtask/src/tasks/inline_completion_smoke.rs
+++ b/xtask/src/tasks/inline_completion_smoke.rs
@@ -1,12 +1,35 @@
 use color_eyre::eyre::{Result, bail, eyre};
-use perl_lsp_ux_tests::{FakeWorkspace, LspEvent, ScenarioConfig, UxClient};
+use perl_lsp_ux_tests::{FakeWorkspace, ScenarioConfig, UxClient};
 use serde_json::{Value, json};
 use std::path::PathBuf;
+use std::thread;
 use std::time::{Duration, Instant};
 
 pub fn run(binary: PathBuf) -> Result<()> {
     let binary = resolve_binary_path(binary)?;
 
+    run_static_client(&binary)?;
+    run_dynamic_client(&binary)?;
+    run_disabled_client(&binary)?;
+
+    println!("inline-completion stdio smoke OK: {}", binary.display());
+    Ok(())
+}
+
+fn run_static_client(binary: &PathBuf) -> Result<()> {
+    let workspace = ux(FakeWorkspace::new())?;
+    let timeout = Duration::from_secs(30);
+    let config = ScenarioConfig { timeout, ..ScenarioConfig::default() };
+    let client = spawn_client(binary, &workspace, &config)?;
+
+    let initialize = client.initialize_result();
+    ensure_static_initialize_shape(&initialize)?;
+    assert_no_inline_registration(&client, Duration::from_millis(300))?;
+    assert_inline_completion_runtime(&client, "static", timeout)?;
+    shutdown_exit(&client, timeout)
+}
+
+fn run_dynamic_client(binary: &PathBuf) -> Result<()> {
     let workspace = ux(FakeWorkspace::new())?;
     let timeout = Duration::from_secs(30);
     let config = ScenarioConfig {
@@ -20,24 +43,199 @@ pub fn run(binary: PathBuf) -> Result<()> {
         }),
         ..ScenarioConfig::default()
     };
-
-    let binary_path = binary.to_string_lossy().into_owned();
-    let client = ux(UxClient::spawn(&binary_path, &workspace, &config))?;
+    let client = spawn_client(binary, &workspace, &config)?;
 
     let initialize = client.initialize_result();
     ensure_dynamic_initialize_shape(&initialize)?;
-    ensure_inline_completion_dynamic_registration(&client, timeout)?;
+    let registration = wait_for_inline_registration(&client, timeout)?;
+    ensure_inline_registration_shape(&registration)?;
+    assert_inline_completion_runtime(&client, "dynamic", timeout)?;
+    shutdown_exit(&client, timeout)
+}
 
-    let uri = "file:///release-inline.pl";
+fn run_disabled_client(binary: &PathBuf) -> Result<()> {
+    let workspace = ux(FakeWorkspace::new())?;
+    let timeout = Duration::from_secs(30);
+    let config = ScenarioConfig {
+        timeout,
+        client_capability_overrides: json!({
+            "textDocument": {
+                "inlineCompletion": {
+                    "dynamicRegistration": true
+                }
+            }
+        }),
+        initialization_options: json!({
+            "disabledFeatures": ["lsp.inline_completion"]
+        }),
+        ..ScenarioConfig::default()
+    };
+    let client = spawn_client(binary, &workspace, &config)?;
+
+    let initialize = client.initialize_result();
+    ensure_disabled_initialize_shape(&initialize)?;
+    assert_no_inline_registration(&client, Duration::from_millis(300))?;
+
+    let uri = "file:///release-inline-disabled.pl";
     ux(client.did_open(uri, "use "))?;
-    let items = request_inline_completion_items(&client, uri, 0, 4, timeout)?;
+    let response = request_inline_completion_response(&client, uri, 0, 4, timeout)?;
+    if response.get("error").is_none() {
+        bail!("disabled inline completion unexpectedly succeeded: {}", response);
+    }
+
+    shutdown_exit(&client, timeout)
+}
+
+fn spawn_client(
+    binary: &PathBuf,
+    workspace: &FakeWorkspace,
+    config: &ScenarioConfig,
+) -> Result<UxClient> {
+    let binary_path = binary.to_string_lossy().into_owned();
+    ux(UxClient::spawn(&binary_path, workspace, config))
+}
+
+fn capabilities(initialize: &Value) -> Result<&Value> {
+    initialize
+        .pointer("/result/capabilities")
+        .or_else(|| initialize.get("capabilities"))
+        .ok_or_else(|| eyre!("initialize response missing capabilities: {}", initialize))
+}
+
+fn ensure_static_initialize_shape(initialize: &Value) -> Result<()> {
+    let caps = capabilities(initialize)?;
+    if caps.get("inlineCompletionProvider") != Some(&json!({})) {
+        bail!("static client did not receive inlineCompletionProvider: {}", initialize);
+    }
+    ensure_standard_provider_not_experimental(caps)?;
+    ensure_stream_extension_enabled(caps)
+}
+
+fn ensure_dynamic_initialize_shape(initialize: &Value) -> Result<()> {
+    let caps = capabilities(initialize)?;
+    if caps.get("inlineCompletionProvider").is_some() {
+        bail!(
+            "dynamic inline-completion client received duplicate static inlineCompletionProvider: {}",
+            initialize
+        );
+    }
+    ensure_standard_provider_not_experimental(caps)?;
+    ensure_stream_extension_enabled(caps)
+}
+
+fn ensure_disabled_initialize_shape(initialize: &Value) -> Result<()> {
+    let caps = capabilities(initialize)?;
+    if caps.get("inlineCompletionProvider").is_some() {
+        bail!("disabled inline completion still advertised inlineCompletionProvider: {initialize}");
+    }
+    ensure_standard_provider_not_experimental(caps)?;
+    if caps.pointer("/experimental/perlInlineCompletionStream").is_some() {
+        bail!(
+            "disabled inline completion still advertised perlInlineCompletionStream: {initialize}"
+        );
+    }
+    Ok(())
+}
+
+fn ensure_standard_provider_not_experimental(caps: &Value) -> Result<()> {
+    if caps.pointer("/experimental/inlineCompletionProvider").is_some() {
+        bail!("initialize response advertised experimental.inlineCompletionProvider: {caps}");
+    }
+    Ok(())
+}
+
+fn ensure_stream_extension_enabled(caps: &Value) -> Result<()> {
+    if caps.pointer("/experimental/perlInlineCompletionStream") != Some(&json!(true)) {
+        bail!("inline completion did not advertise vendor stream extension separately: {caps}");
+    }
+    Ok(())
+}
+
+fn wait_for_inline_registration(client: &UxClient, timeout: Duration) -> Result<Value> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        for event in client.peek_raw_events() {
+            if let Some(registration) = inline_registration(&event) {
+                let id = event.get("id").and_then(Value::as_i64).ok_or_else(|| {
+                    eyre!("client/registerCapability missing integer JSON-RPC id: {}", event)
+                })?;
+                if !(1..=i64::from(i32::MAX)).contains(&id) {
+                    bail!("client/registerCapability JSON-RPC id out of bounds: {id}");
+                }
+                return Ok(registration.clone());
+            }
+        }
+
+        if Instant::now() >= deadline {
+            bail!("dynamic client did not receive textDocument/inlineCompletion registration");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn assert_no_inline_registration(client: &UxClient, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        for event in client.peek_raw_events() {
+            if inline_registration(&event).is_some() {
+                bail!(
+                    "client unexpectedly received inline-completion dynamic registration: {event}"
+                );
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn inline_registration(event: &Value) -> Option<&Value> {
+    if event.get("method").and_then(Value::as_str) != Some("client/registerCapability") {
+        return None;
+    }
+    event.pointer("/params/registrations").and_then(Value::as_array)?.iter().find(|registration| {
+        registration.get("method").and_then(Value::as_str) == Some("textDocument/inlineCompletion")
+    })
+}
+
+fn ensure_inline_registration_shape(registration: &Value) -> Result<()> {
+    if registration.get("id") != Some(&json!("perl-inlineCompletion")) {
+        bail!("inline-completion registration id mismatch: {registration}");
+    }
+    if registration.get("method") != Some(&json!("textDocument/inlineCompletion")) {
+        bail!("inline-completion registration method mismatch: {registration}");
+    }
+
+    let selectors = registration
+        .pointer("/registerOptions/documentSelector")
+        .and_then(Value::as_array)
+        .ok_or_else(|| eyre!("inline-completion registration missing documentSelector"))?;
+    for language in ["perl", "perl5"] {
+        if !selectors.iter().any(|selector| selector.get("language") == Some(&json!(language))) {
+            bail!("inline-completion registration missing {language} selector: {registration}");
+        }
+    }
+
+    Ok(())
+}
+
+fn assert_inline_completion_runtime(
+    client: &UxClient,
+    label: &str,
+    timeout: Duration,
+) -> Result<()> {
+    let uri = format!("file:///release-inline-{label}.pl");
+    ux(client.did_open(&uri, "use "))?;
+    let items = request_inline_completion_items(client, &uri, 0, 4, timeout)?;
     if !items.iter().any(|item| item.get("insertText") == Some(&json!("strict;"))) {
         bail!("inline-completion smoke expected insertText strict;, got: {}", Value::Array(items));
     }
 
-    let neutral_uri = "file:///release-inline-neutral.pl";
-    ux(client.did_open(neutral_uri, "my $name = \"World\";"))?;
-    let neutral_items = request_inline_completion_items(&client, neutral_uri, 0, 11, timeout)?;
+    let neutral_uri = format!("file:///release-inline-neutral-{label}.pl");
+    ux(client.did_open(&neutral_uri, "my $name = \"World\";"))?;
+    let neutral_items = request_inline_completion_items(client, &neutral_uri, 0, 11, timeout)?;
     if !neutral_items.is_empty() {
         bail!(
             "inline-completion smoke expected empty unsupported-position result, got: {}",
@@ -45,84 +243,25 @@ pub fn run(binary: PathBuf) -> Result<()> {
         );
     }
 
-    let shutdown = ux(client.request("shutdown", json!({}), timeout))?;
-    if let Some(error) = shutdown.get("error") {
-        bail!("shutdown returned error: {}", error);
-    }
-    ux(client.notify("exit", json!({})))?;
-
-    println!("inline-completion stdio smoke OK: {}", binary.display());
     Ok(())
 }
 
-fn ensure_dynamic_initialize_shape(initialize: &Value) -> Result<()> {
-    if initialize.pointer("/result/capabilities/inlineCompletionProvider").is_some()
-        || initialize.pointer("/capabilities/inlineCompletionProvider").is_some()
-    {
-        bail!(
-            "dynamic inline-completion client received duplicate static inlineCompletionProvider: {}",
-            initialize
-        );
-    }
-
-    if initialize.pointer("/result/capabilities/experimental/inlineCompletionProvider").is_some()
-        || initialize.pointer("/capabilities/experimental/inlineCompletionProvider").is_some()
-    {
-        bail!(
-            "initialize response advertised experimental.inlineCompletionProvider: {}",
-            initialize
-        );
-    }
-
-    Ok(())
-}
-
-fn ensure_inline_completion_dynamic_registration(
+fn request_inline_completion_response(
     client: &UxClient,
+    uri: &str,
+    line: u32,
+    character: u32,
     timeout: Duration,
-) -> Result<()> {
-    let deadline = Instant::now() + timeout;
-
-    loop {
-        let events = client.peek_events();
-        if events.iter().any(is_inline_completion_registration) {
-            return Ok(());
-        }
-
-        if Instant::now() >= deadline {
-            bail!(
-                "inline-completion smoke did not observe dynamic client/registerCapability; events: {:?}",
-                events
-            );
-        }
-
-        std::thread::sleep(Duration::from_millis(20));
-    }
-}
-
-fn is_inline_completion_registration(event: &LspEvent) -> bool {
-    let LspEvent::Other { method, params } = event else {
-        return false;
-    };
-    if method != "client/registerCapability" {
-        return false;
-    }
-
-    params.get("registrations").and_then(Value::as_array).is_some_and(|registrations| {
-        registrations.iter().any(is_inline_completion_registration_entry)
-    })
-}
-
-fn is_inline_completion_registration_entry(registration: &Value) -> bool {
-    registration.get("method") == Some(&json!("textDocument/inlineCompletion"))
-        && registration.get("id") == Some(&json!("perl-inlineCompletion"))
-        && registration
-            .pointer("/registerOptions/documentSelector")
-            .and_then(Value::as_array)
-            .is_some_and(|selector| {
-                selector.contains(&json!({ "language": "perl" }))
-                    && selector.contains(&json!({ "language": "perl5" }))
-            })
+) -> Result<Value> {
+    ux(client.request(
+        "textDocument/inlineCompletion",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "context": { "triggerKind": 2 }
+        }),
+        timeout,
+    ))
 }
 
 fn request_inline_completion_items(
@@ -132,15 +271,7 @@ fn request_inline_completion_items(
     character: u32,
     timeout: Duration,
 ) -> Result<Vec<Value>> {
-    let response = ux(client.request(
-        "textDocument/inlineCompletion",
-        json!({
-            "textDocument": { "uri": uri },
-            "position": { "line": line, "character": character },
-            "context": { "triggerKind": 2 }
-        }),
-        timeout,
-    ))?;
+    let response = request_inline_completion_response(client, uri, line, character, timeout)?;
 
     if let Some(error) = response.get("error") {
         bail!("textDocument/inlineCompletion returned error: {}", error);
@@ -162,6 +293,14 @@ fn request_inline_completion_items(
     }
 }
 
+fn shutdown_exit(client: &UxClient, timeout: Duration) -> Result<()> {
+    let shutdown = ux(client.request("shutdown", json!({}), timeout))?;
+    if let Some(error) = shutdown.get("error") {
+        bail!("shutdown returned error: {}", error);
+    }
+    ux(client.notify("exit", json!({})))
+}
+
 fn ux<T>(result: anyhow::Result<T>) -> Result<T> {
     result.map_err(|error| eyre!("{error:#}"))
 }
@@ -171,10 +310,15 @@ fn resolve_binary_path(binary: PathBuf) -> Result<PathBuf> {
         return Ok(binary);
     }
 
-    if cfg!(windows) && binary.extension().is_none() {
-        let exe = binary.with_extension("exe");
-        if exe.is_file() {
-            return Ok(exe);
+    #[cfg(windows)]
+    {
+        let has_extension = binary.extension().is_some();
+        if !has_extension {
+            let mut exe = binary.clone();
+            exe.set_extension("exe");
+            if exe.is_file() {
+                return Ok(exe);
+            }
         }
     }
 


### PR DESCRIPTION
Problem: Swarm #452 added the final inline-completion release-smoke lock after the prior source mirror, leaving source without the latest process-boundary receipt and docs.
Fix: Mirror the #452 static/dynamic/disabled stdio smoke expansion, LSP4IJ descriptor/docs, UX harness support, and related inline-completion smoke assertions into the release repo. Release metadata is unchanged.
Verification:
- `cargo fmt -p xtask -p perl-lsp-ux-tests -p perl-lsp-rs -- --check`
- `cargo check -p xtask --locked`
- `cargo test -p perl-lsp-rs --test lsp_streaming_completion_tests --locked -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_inline_completion_registration_tests --locked -- --nocapture`
- `cargo test -p perl-lsp-rs-core --lib inline_completion --locked -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_ai_inline_completion_tests --features expose_lsp_test_api --locked -- --nocapture`
- `cargo test -p perl-lsp-rs --test lsp_cap_snap --locked -- --nocapture`
- `cargo xtask check-support-claims`
- `cargo xtask check-devex-docs`
- `cargo build --release -p perl-lsp-rs --bin perl-lsp --locked`
- `cargo xtask smoke inline-completion --binary target/release/perl-lsp`
- `cargo xtask inline-completion-smoke --binary target/release/perl-lsp`
- `git diff --check`

Notes:
- Existing `perl-subprocess-runtime` and `perl-lexer` unused warnings still appear in build output.
