### PR TITLE
docs(editors): clarify LSP4IJ UTF-16 positions (#9606)

### DIFF
--- a/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
+++ b/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
@@ -167,7 +167,7 @@ Protocol notes:
 - `experimental.perlInlineCompletionStream` is a custom extension for clients
   that explicitly integrate the streaming path.
 - The registration selector includes `perl` and `perl5`.
-- The server communicates UTF-16 positions.
+- LSP wire positions use UTF-16 code units, per the LSP spec; `perllsp` converts client-provided positions to internal offsets before analysis.
 
 ## Verify It Is Running
 


### PR DESCRIPTION
Problem: The LSP4IJ setup guide implied the server communicates UTF-16 positions, which blurs the LSP wire encoding with internal offsets.
Fix: Mirror the swarm docs correction that says LSP wire positions use UTF-16 code units and perllsp converts client-provided positions internally before analysis.
Verification: tk cargo xtask check-devex-docs; tk cargo xtask doc-claims; tk git diff --check.