### PR TITLE
fix(ci): satisfy Rust 1.95 clippy release gate (#9607)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -105,7 +105,7 @@ fn constrain_inline_completions_to_selected_info(
                 Some(range) if range == &selected.range => Some(item),
                 Some(_) => None,
                 None if selected.range == implicit_range => {
-                    item.range = Some(selected.range.clone());
+                    item.range = Some(selected.range);
                     Some(item)
                 }
                 None => None,

--- a/crates/perl-subprocess-runtime/src/os_runtime/mod.rs
+++ b/crates/perl-subprocess-runtime/src/os_runtime/mod.rs
@@ -6,13 +6,12 @@ mod validation;
 #[cfg(windows)]
 mod windows;
 
-#[cfg(windows)]
 pub(crate) use invocation::resolve_command_invocation;
 use process::run_os_command;
 
 use crate::{SubprocessError, SubprocessOutput, SubprocessRuntime};
 
-#[cfg(windows)]
+#[cfg(all(windows, test))]
 pub(crate) use windows::{windows_program_priority, windows_quote_for_cmd};
 
 /// Default implementation using `std::process::Command`.

--- a/crates/perl-subprocess-runtime/src/os_runtime/process.rs
+++ b/crates/perl-subprocess-runtime/src/os_runtime/process.rs
@@ -1,4 +1,4 @@
-use super::invocation::resolve_command_invocation;
+use super::resolve_command_invocation;
 use super::validation::validate_command_input;
 use crate::{SubprocessError, SubprocessOutput};
 use std::io::Write;


### PR DESCRIPTION
Problem: release orchestration refused to tag v0.15.1 because ci/merge-gate failed on clippy_full.
Fix: mirror swarm #454: remove the unnecessary clone from copied LSP Range values and route subprocess invocation through a production module-level import while keeping Windows helper re-exports test-only.
Verification:
- `rtk cargo xtask gates --gate clippy_full --receipt --receipt-path target/receipts/clippy-full-inline-range-copy.json`
- `rtk cargo test -p perl-lsp-rs --test lsp_inline_completion_registration_tests --locked`
- `rtk cargo test -p perl-subprocess-runtime --lib --locked`
- `rtk cargo build -p perl-subprocess-runtime --release --locked`
- `rtk git diff --check`