### PR TITLE
fix(code-actions): route PL003 (UnexpectedEof) to quick-fix handlers + correct comment numbers (#9609)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -88,8 +88,12 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         }
         // PL001: General parse error (stable code)
         // PL002: Syntax error — same quick-fix routing as PL001
+        // PL003: Unexpected end-of-file — routes through the same handler which
+        //        offers "Add missing semicolon" or "Add closing brace" based on
+        //        the diagnostic message text.
         c if c == DiagnosticCode::ParseError.as_str()
-            || c == DiagnosticCode::SyntaxError.as_str() =>
+            || c == DiagnosticCode::SyntaxError.as_str()
+            || c == DiagnosticCode::UnexpectedEof.as_str() =>
         {
             actions.extend(quick_fixes::fix_parse_error(source, &qf_diag, c));
         }
@@ -103,13 +107,13 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_unused_parameter(&qf_diag));
         }
-        // PL107: Duplicate parameter
+        // PL106: Duplicate parameter
         c if c == DiagnosticCode::DuplicateParameter.as_str()
             || c == "native.variables.duplicate_parameter" =>
         {
             actions.extend(quick_fixes::fix_duplicate_parameter(&qf_diag));
         }
-        // PL110: Parameter shadows outer/global variable
+        // PL107: Parameter shadows outer/global variable
         c if c == DiagnosticCode::ParameterShadowsGlobal.as_str()
             || c == "native.variables.parameter_shadows_global" =>
         {

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -857,10 +857,10 @@ pub fn fix_parse_error(
                 is_preferred: true,
             });
         }
-        "PL001" | "PL002"
+        "PL001" | "PL002" | "PL003"
             if diagnostic.message.to_ascii_lowercase().contains("missing semicolon") =>
         {
-            // PL001/PL002 are general parse error codes. When the message indicates a missing
+            // PL001/PL002/PL003 parse error codes: when the message indicates a missing
             // semicolon, apply the same fix — but skip heredoc contexts where insertion is wrong.
             let at_heredoc = source[diagnostic.range.0..].get(..2).is_some_and(|s| s == "<<");
             if !at_heredoc {
@@ -955,6 +955,25 @@ pub fn fix_parse_error(
                             end: diagnostic.range.1,
                         },
                         new_text: "}".to_string(),
+                    }],
+                },
+                is_preferred: true,
+            });
+        }
+        // PL003: Unexpected end of file — the most common cause is a missing `}`.
+        // We offer to append a newline + `}` at the end of the source as a
+        // best-effort recovery; when the message already hints at a missing
+        // semicolon the earlier arm fires instead.
+        "PL003" => {
+            let insert_at = source.len();
+            actions.push(CodeAction {
+                title: "Add missing closing brace '}'".to_string(),
+                kind: CodeActionKind::QuickFix,
+                diagnostics: vec![code.to_string()],
+                edit: CodeActionEdit {
+                    changes: vec![TextEdit {
+                        location: SourceLocation { start: insert_at, end: insert_at },
+                        new_text: "\n}".to_string(),
                     }],
                 },
                 is_preferred: true,

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl003_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl003_bdd.rs
@@ -1,0 +1,183 @@
+//! BDD tests for PL003 (UnexpectedEof) quick-fix routing.
+//!
+//! PL003 is emitted when the parser reaches end-of-file without completing a
+//! syntactic unit.  Before this change there was no quick-fix handler for it,
+//! so the dispatch table silently dropped the code.
+//!
+//! After this change:
+//!
+//!   1. `pl003_missing_semicolon_message_adds_semicolon` — when the diagnostic
+//!      message mentions "missing semicolon", the fix inserts `;` at the end of
+//!      the offending line (shared arm with PL001/PL002).
+//!
+//!   2. `pl003_generic_eof_offers_closing_brace` — for any other PL003 message
+//!      (the typical "Unexpected end of file" case), the fix appends `\n}` at
+//!      the end of the source.
+//!
+//!   3. `pl003_dispatch_smoke_test` — verifies that PL003 reaches a handler
+//!      and produces at least one action (regression guard for the routing
+//!      table entry).
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Error,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    // Parse regardless of errors — code action provider works on best-effort ASTs.
+    let ast = parser.parse().unwrap_or_else(|_| {
+        let mut p = Parser::new("");
+        must(p.parse())
+    });
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn apply_edits(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL003 — missing-semicolon message path
+// ===========================================================================
+
+#[test]
+fn pl003_missing_semicolon_message_adds_semicolon() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source that ends without a semicolon
+    let source = "my $x = 1\n";
+
+    // WHEN a PL003 diagnostic is raised with a "missing semicolon" message
+    let diag = make_diag(0, source.len(), "PL003", "Unexpected end of file - missing semicolon");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the fix offers to add a semicolon
+    let action = find_action(&actions, |t| t.contains("semicolon"))
+        .ok_or_else(|| format!("no semicolon action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "semicolon fix should be preferred");
+
+    let result = apply_edits(source, action);
+    assert!(result.contains(';'), "semicolon must appear in result: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL003 — generic unexpected-EOF path
+// ===========================================================================
+
+#[test]
+fn pl003_generic_eof_offers_closing_brace() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN an unclosed subroutine
+    let source = "sub greet {\n    print \"hello\";\n";
+
+    // WHEN a PL003 diagnostic fires with the standard "Unexpected end of file" message
+    let diag =
+        make_diag(source.len().saturating_sub(1), source.len(), "PL003", "Unexpected end of file");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the fix offers to append a closing brace
+    let action = find_action(&actions, |t| t.contains("closing brace"))
+        .ok_or_else(|| format!("no closing-brace action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Add missing closing brace '}'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = apply_edits(source, action);
+    assert!(result.ends_with("\n}"), "result must end with newline + '}}'; got: {result:?}");
+
+    Ok(())
+}
+
+#[test]
+fn pl003_closing_brace_appended_at_eof() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source with no trailing newline
+    let source = "sub foo { my $x = 1;";
+    let diag =
+        make_diag(source.len().saturating_sub(1), source.len(), "PL003", "Unexpected end of file");
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("closing brace"))
+        .ok_or_else(|| format!("no closing-brace action in: {actions:?}"))?;
+
+    let result = apply_edits(source, action);
+    assert_eq!(result, "sub foo { my $x = 1;\n}", "brace must be appended at EOF");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl003_dispatch_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN any PL003 diagnostic
+    let source = "sub broken {\n";
+    let diag =
+        make_diag(source.len().saturating_sub(1), source.len(), "PL003", "Unexpected end of file");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN at least one QuickFix action is produced for PL003 — confirming the
+    // routing table entry exists and the handler fires.  (Other action kinds,
+    // such as SourceModernize, may also be present and are not checked here.)
+    let has_quick_fix = actions.iter().any(|a| a.kind == CodeActionKind::QuickFix);
+    assert!(
+        has_quick_fix,
+        "PL003 must produce at least one QuickFix action; routing table may be missing the entry. Got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Comment-correctness regression guards
+// ===========================================================================
+//
+// These tests encode the correct PL-code → DiagnosticCode mapping so that
+// a future renumbering which breaks a comment will also break a test.
+
+#[test]
+fn diagnostic_code_numbers_match_enum_strings() {
+    use perl_diagnostics::codes::DiagnosticCode;
+
+    // Previously the comments in diagnostic_routes.rs had these wrong:
+    //   "PL107: Duplicate parameter"  (should be PL106)
+    //   "PL110: Parameter shadows..."  (should be PL107)
+    assert_eq!(DiagnosticCode::DuplicateParameter.as_str(), "PL106");
+    assert_eq!(DiagnosticCode::ParameterShadowsGlobal.as_str(), "PL107");
+    assert_eq!(DiagnosticCode::UninitializedVariable.as_str(), "PL110");
+    assert_eq!(DiagnosticCode::UnexpectedEof.as_str(), "PL003");
+}


### PR DESCRIPTION
## Summary

Before this PR, `PL003` (`UnexpectedEof`) diagnostics silently produced no
quick-fix actions. The dispatch table in `diagnostic_routes.rs` only wired up
`PL001`/`PL002`; the `UnexpectedEof` code fell through to the `_ => {}` arm
and was dropped. Two comments in the same file also carried wrong PL-code numbers.

### Changes

**`crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`**

- Route `DiagnosticCode::UnexpectedEof` (PL003) through the existing
  `fix_parse_error` handler, alongside `ParseError` (PL001) and `SyntaxError`
  (PL002). The handler already contains message-text branching, so it handles
  PL003 with no behavioural change to the PL001/PL002 paths.
- Fix comment `// PL107: Duplicate parameter` → `// PL106: Duplicate parameter`
  (`DuplicateParameter.as_str()` returns `"PL106"`, not `"PL107"`).
- Fix comment `// PL110: Parameter shadows outer/global variable` →
  `// PL107: Parameter shadows outer/global variable`
  (`ParameterShadowsGlobal.as_str()` returns `"PL107"`, not `"PL110"`).

**`crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`**

- Extend the "missing semicolon" guard arm from `"PL001" | "PL002"` to
  `"PL001" | "PL002" | "PL003"` so that PL003 diagnostics whose message text
  hints at a missing semicolon get the same insert-`;` fix.
- Add a new `"PL003"` arm (fires when the message does **not** contain
  "missing semicolon") that appends `\n}` at the end of the source — the most
  common recovery for an unclosed `sub` or block.

**`crates/perl-lsp-rs-core/tests/quick_fix_pl003_bdd.rs`** *(new file)*

Five BDD tests:

| Test | What it pins |
|------|-------------|
| `pl003_missing_semicolon_message_adds_semicolon` | Message "…missing semicolon" → `;` inserted |
| `pl003_generic_eof_offers_closing_brace` | Generic EOF message → `\n}` appended |
| `pl003_closing_brace_appended_at_eof` | Exact result string when no trailing newline |
| `pl003_dispatch_smoke_test` | Routing table entry exists; at least one QuickFix emitted |
| `diagnostic_code_numbers_match_enum_strings` | Regression guard: PL106/PL107/PL110/PL003 match the enum `.as_str()` values, so a future renumbering that breaks a comment also breaks a test |

## Why this matters

Perl developers encountering "Unexpected end of file" — typically from a
missing `}` after a subroutine — currently see the diagnostic but no lightbulb
action. After this change, the LSP offers a one-click fix to append the missing
brace, and for the rarer "missing semicolon at EOF" variant it offers the same
semicolon insertion already in place for PL001/PL002.

The comment-number bugs, while not causing runtime failures (the routing code
uses enum methods rather than hardcoded strings), would mislead anyone reading
the file or adding coverage for those codes.

## Test plan

```bash
# New BDD tests
cargo test -p perl-lsp-rs-core --test quick_fix_pl003_bdd
# 5 passed, 0 failed

# Existing quick-fix tests — no regression
cargo test -p perl-lsp-rs-core --test quick_fix_new_codes_bdd
# 17 passed, 0 failed

# Full crate suite (one pre-existing failure in wave_final_absorption_tests
# unrelated to this PR — perl-dap/build.rs catalog sourcing check that
# was already failing on master before these changes)
cargo test -p perl-lsp-rs-core
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01DaihfX7rqctHL7atMH7Dzx)_