### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label (#9612)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: Loop control with undefined label (next/last/redo LABEL)
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1972,6 +1972,45 @@ fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, 
     Some((line_start, line_end))
 }
 
+/// Fix undefined loop-control label by removing the label (PL410).
+///
+/// `next LABEL`, `last LABEL`, and `redo LABEL` where the label is not defined
+/// anywhere in the file. Dropping the label converts the statement into its
+/// unlabelled form, which targets the innermost enclosing loop at runtime —
+/// usually the correct intent when the label was a typo or stale reference.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(range_text) = source.get(start..end) else {
+        return Vec::new();
+    };
+
+    // Extract just the operator (next / last / redo) — the first whitespace-delimited token.
+    let op = range_text.split_whitespace().next().unwrap_or("next");
+
+    // Only act on the three expected loop-control operators for PL410.
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Remove undefined label: change to `{op}`"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = range;
     if start > end

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,228 @@
+//! BDD tests for PL410 quick-fix: undefined loop-control label.
+//!
+//! `next LABEL`, `last LABEL`, and `redo LABEL` that reference a label not
+//! defined in the file get a single quick-fix: drop the label so the statement
+//! targets the innermost enclosing loop.
+//!
+//! Pattern for each scenario:
+//!   GIVEN  source with an undefined label in a loop-control statement
+//!   WHEN   a PL410 diagnostic is synthesised at the exact byte range and
+//!          `CodeActionsProvider::get_code_actions` is called
+//!   THEN   exactly one quick-fix action is returned, its edit replaces the
+//!          labelled form with the bare operator, and the resulting source is
+//!          syntactically correct
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (identical pattern to quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply the first matching edit and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+const PL410: &str = "PL410";
+
+// ---------------------------------------------------------------------------
+// Scenario 1: `next GHOST` inside a for loop
+// ---------------------------------------------------------------------------
+
+/// GIVEN source with `next GHOST` where GHOST is not a defined label
+/// WHEN  a PL410 diagnostic is raised at the `next GHOST` span
+/// THEN  the quick-fix drops the label, producing `next`
+#[test]
+fn pl410_next_undefined_label_drops_label() {
+    let source = "for my $x (1..3) { next GHOST; }";
+    //                                    ^^^^^^^^^  "next GHOST" = bytes 20..29
+    let start = source.find("next GHOST").expect("test source must contain 'next GHOST'");
+    let end = start + "next GHOST".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`next GHOST` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Remove undefined label"))
+        .expect("expected a 'Remove undefined label' quick-fix");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the label-removal fix should be is_preferred");
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $x (1..3) { next; }");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: `last PHANTOM` inside a while loop
+// ---------------------------------------------------------------------------
+
+/// GIVEN source with `last PHANTOM` where PHANTOM is not defined
+/// WHEN  a PL410 diagnostic is raised
+/// THEN  the quick-fix produces `last`
+#[test]
+fn pl410_last_undefined_label_drops_label() {
+    let source = "while (1) { last PHANTOM; }";
+    let start = source.find("last PHANTOM").expect("test source must contain 'last PHANTOM'");
+    let end = start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Remove undefined label"))
+        .expect("expected a 'Remove undefined label' quick-fix");
+
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: `redo WISP` inside a loop
+// ---------------------------------------------------------------------------
+
+/// GIVEN source with `redo WISP` where WISP is not defined
+/// WHEN  a PL410 diagnostic is raised
+/// THEN  the quick-fix produces `redo`
+#[test]
+fn pl410_redo_undefined_label_drops_label() {
+    let source = "for (1..5) { redo WISP; }";
+    let start = source.find("redo WISP").expect("test source must contain 'redo WISP'");
+    let end = start + "redo WISP".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`redo WISP` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Remove undefined label"))
+        .expect("expected a 'Remove undefined label' quick-fix");
+
+    let result = edited(source, action);
+    assert_eq!(result, "for (1..5) { redo; }");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: action title names the operator
+// ---------------------------------------------------------------------------
+
+/// GIVEN a PL410 diagnostic for `last PHANTOM`
+/// WHEN  code actions are requested
+/// THEN  the title contains the operator name (`last`)
+#[test]
+fn pl410_action_title_names_operator() {
+    let source = "while (1) { last PHANTOM; }";
+    let start = source.find("last PHANTOM").unwrap();
+    let end = start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Remove undefined label"))
+        .expect("expected quick-fix");
+    assert!(
+        action.title.contains("last"),
+        "title should name the operator 'last'; got: {}",
+        action.title
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5: invalid/empty range returns no actions
+// ---------------------------------------------------------------------------
+
+/// GIVEN a PL410 diagnostic with an out-of-bounds range
+/// WHEN  code actions are requested
+/// THEN  an empty Vec is returned (no panic)
+#[test]
+fn pl410_invalid_range_returns_empty() {
+    let source = "while (1) { next GHOST; }";
+    let bad_start = source.len() + 10;
+    let bad_end = bad_start + 5;
+
+    let diag = make_diag(
+        bad_start,
+        bad_end,
+        PL410,
+        "`next GHOST` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+    let pl410_actions: Vec<_> =
+        actions.iter().filter(|a| a.diagnostics.iter().any(|d| d == PL410)).collect();
+    assert!(pl410_actions.is_empty(), "should return no PL410 actions for invalid range");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 6: dispatch smoke test — routes through the full provider
+// ---------------------------------------------------------------------------
+
+/// GIVEN a PL410 diagnostic at a valid range
+/// WHEN  CodeActionsProvider is called
+/// THEN  at least one quick-fix action with PL410 in its diagnostics vec is returned
+#[test]
+fn pl410_dispatch_smoke_test() {
+    let source = "for my $i (1..10) { next LOOP; }";
+    let start = source.find("next LOOP").expect("test source must contain 'next LOOP'");
+    let end = start + "next LOOP".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`next LOOP` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let has_pl410_action = actions.iter().any(|a| a.diagnostics.iter().any(|d| d == PL410));
+    assert!(has_pl410_action, "expected at least one PL410 quick-fix action from the provider");
+}


### PR DESCRIPTION
## Summary

PL410 (`LoopControlUndefinedLabel`) fires when `next LABEL`, `last LABEL`, or `redo LABEL` references a label that is not defined anywhere in the file. Before this PR, the LSP emitted the diagnostic correctly but the lightbulb offered **no code actions** — the code fell through the `_ => {}` arm in `diagnostic_routes.rs`.

This PR adds the missing handler and BDD test suite.

## What changed

### `quick_fixes.rs` — new handler `fix_loop_control_undefined_label`

Strips the undefined label from the loop-control statement:
- `next GHOST;` → `next;`
- `last PHANTOM;` → `last;`
- `redo WISP;` → `redo;`

The bare form targets the innermost enclosing loop at runtime, which is the correct fix when the label was a typo or stale reference. Safety guards:
- Validates the diagnostic byte range via `valid_diagnostic_range` before accessing source text (returns empty Vec on invalid range, no panic).
- Verifies the extracted token is one of `next`/`last`/`redo` before acting.
- Marks the action `is_preferred: true` (standard for single-fix quick actions).

### `diagnostic_routes.rs` — new routing arm for PL410

```rust
// PL410: Loop control with undefined label (next/last/redo LABEL)
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `tests/quick_fix_pl410_bdd.rs` — 6 BDD scenarios

| Test | What it pins |
|---|---|
| `pl410_next_undefined_label_drops_label` | `next GHOST` → `next` with exact result string |
| `pl410_last_undefined_label_drops_label` | `last PHANTOM` → `last` with exact result string |
| `pl410_redo_undefined_label_drops_label` | `redo WISP` → `redo` with exact result string |
| `pl410_action_title_names_operator` | Title contains the operator name (`last`) |
| `pl410_invalid_range_returns_empty` | Out-of-bounds range → empty Vec, no panic |
| `pl410_dispatch_smoke_test` | Full `CodeActionsProvider` pipeline routes to PL410 handler |

## Test results

```
running 6 tests
test pl410_last_undefined_label_drops_label ... ok
test pl410_next_undefined_label_drops_label ... ok
test pl410_invalid_range_returns_empty ... ok
test pl410_redo_undefined_label_drops_label ... ok
test pl410_dispatch_smoke_test ... ok
test pl410_action_title_names_operator ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

17 existing `quick_fix_new_codes_bdd` tests pass with no regression. Clippy clean on `perl-lsp-rs-core --lib`.

## Why this matters

PL410 is a **runtime-fatal** condition in Perl — `Label not found for "next LABEL"` terminates the program. The LSP already detects it statically; this change closes the loop by also offering a one-click fix. The fix is unambiguous (drop the label, target innermost loop) and safe to apply automatically.

## Scope

- 3 files changed: `quick_fixes.rs`, `diagnostic_routes.rs`, new `tests/quick_fix_pl410_bdd.rs`
- No production logic changed outside the code-actions module
- No new dependencies

https://claude.ai/code/session_0121o9nXq7XkWsgpvWn9df2a

---
_Generated by [Claude Code](https://claude.ai/code/session_0121o9nXq7XkWsgpvWn9df2a)_