### PR TITLE
feat(code-actions): add quick-fix for PL410 loop-control undefined label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -196,6 +196,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         c if c == DiagnosticCode::SecuritySignalHandler.as_str() => {
             actions.extend(quick_fixes::fix_security_signal_handler(source, &qf_diag));
         }
+        // PL410: Loop control with undefined label (next/last/redo LABEL)
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1760,6 +1760,47 @@ pub fn fix_security_signal_handler(
     }]
 }
 
+/// Fix undefined loop-control label by removing the label (PL410).
+///
+/// `next LABEL`, `last LABEL`, and `redo LABEL` where the label is not defined
+/// anywhere in the file. Dropping the label converts the statement into its
+/// unlabelled form, which targets the innermost enclosing loop at runtime —
+/// usually the correct intent when the label was a typo or stale reference.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(range_text) = source.get(start..end) else {
+        return Vec::new();
+    };
+
+    // Extract just the operator (next / last / redo) — the first whitespace-delimited token.
+    let Some(op) = range_text.split_whitespace().next() else {
+        return Vec::new();
+    };
+
+    // Only act on the three expected loop-control operators for PL410.
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Remove undefined label: change to `{op}`"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,228 @@
+//! BDD tests for PL410 quick-fix: undefined loop-control label.
+//!
+//! `next LABEL`, `last LABEL`, and `redo LABEL` that reference a label not
+//! defined in the file get a single quick-fix: drop the label so the statement
+//! targets the innermost enclosing loop.
+//!
+//! Pattern for each scenario:
+//!   GIVEN  source with an undefined label in a loop-control statement
+//!   WHEN   a PL410 diagnostic is synthesised at the exact byte range and
+//!          `CodeActionsProvider::get_code_actions` is called
+//!   THEN   exactly one quick-fix action is returned, its edit replaces the
+//!          labelled form with the bare operator, and the resulting source is
+//!          syntactically correct
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (identical pattern to quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply the first matching edit and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+const PL410: &str = "PL410";
+
+// ---------------------------------------------------------------------------
+// Scenario 1: `next GHOST` inside a for loop
+// ---------------------------------------------------------------------------
+
+/// GIVEN source with `next GHOST` where GHOST is not a defined label
+/// WHEN  a PL410 diagnostic is raised at the `next GHOST` span
+/// THEN  the quick-fix drops the label, producing `next`
+#[test]
+fn pl410_next_undefined_label_drops_label() {
+    let source = "for my $x (1..3) { next GHOST; }";
+    //                                    ^^^^^^^^^  "next GHOST" = bytes 20..29
+    let start = source.find("next GHOST").expect("test source must contain 'next GHOST'");
+    let end = start + "next GHOST".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`next GHOST` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Remove undefined label"))
+        .expect("expected a 'Remove undefined label' quick-fix");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the label-removal fix should be is_preferred");
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $x (1..3) { next; }");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: `last PHANTOM` inside a while loop
+// ---------------------------------------------------------------------------
+
+/// GIVEN source with `last PHANTOM` where PHANTOM is not defined
+/// WHEN  a PL410 diagnostic is raised
+/// THEN  the quick-fix produces `last`
+#[test]
+fn pl410_last_undefined_label_drops_label() {
+    let source = "while (1) { last PHANTOM; }";
+    let start = source.find("last PHANTOM").expect("test source must contain 'last PHANTOM'");
+    let end = start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Remove undefined label"))
+        .expect("expected a 'Remove undefined label' quick-fix");
+
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: `redo WISP` inside a loop
+// ---------------------------------------------------------------------------
+
+/// GIVEN source with `redo WISP` where WISP is not defined
+/// WHEN  a PL410 diagnostic is raised
+/// THEN  the quick-fix produces `redo`
+#[test]
+fn pl410_redo_undefined_label_drops_label() {
+    let source = "for (1..5) { redo WISP; }";
+    let start = source.find("redo WISP").expect("test source must contain 'redo WISP'");
+    let end = start + "redo WISP".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`redo WISP` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Remove undefined label"))
+        .expect("expected a 'Remove undefined label' quick-fix");
+
+    let result = edited(source, action);
+    assert_eq!(result, "for (1..5) { redo; }");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4: action title names the operator
+// ---------------------------------------------------------------------------
+
+/// GIVEN a PL410 diagnostic for `last PHANTOM`
+/// WHEN  code actions are requested
+/// THEN  the title contains the operator name (`last`)
+#[test]
+fn pl410_action_title_names_operator() {
+    let source = "while (1) { last PHANTOM; }";
+    let start = source.find("last PHANTOM").expect("test source must contain 'last PHANTOM'");
+    let end = start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("Remove undefined label"))
+        .expect("expected quick-fix");
+    assert!(
+        action.title.contains("last"),
+        "title should name the operator 'last'; got: {}",
+        action.title
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5: invalid/empty range returns no actions
+// ---------------------------------------------------------------------------
+
+/// GIVEN a PL410 diagnostic with an out-of-bounds range
+/// WHEN  code actions are requested
+/// THEN  an empty Vec is returned (no panic)
+#[test]
+fn pl410_invalid_range_returns_empty() {
+    let source = "while (1) { next GHOST; }";
+    let bad_start = source.len() + 10;
+    let bad_end = bad_start + 5;
+
+    let diag = make_diag(
+        bad_start,
+        bad_end,
+        PL410,
+        "`next GHOST` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+    let pl410_actions: Vec<_> =
+        actions.iter().filter(|a| a.diagnostics.iter().any(|d| d == PL410)).collect();
+    assert!(pl410_actions.is_empty(), "should return no PL410 actions for invalid range");
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 6: dispatch smoke test — routes through the full provider
+// ---------------------------------------------------------------------------
+
+/// GIVEN a PL410 diagnostic at a valid range
+/// WHEN  CodeActionsProvider is called
+/// THEN  at least one quick-fix action with PL410 in its diagnostics vec is returned
+#[test]
+fn pl410_dispatch_smoke_test() {
+    let source = "for my $i (1..10) { next LOOP; }";
+    let start = source.find("next LOOP").expect("test source must contain 'next LOOP'");
+    let end = start + "next LOOP".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        PL410,
+        "`next LOOP` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let has_pl410_action = actions.iter().any(|a| a.diagnostics.iter().any(|d| d == PL410));
+    assert!(has_pl410_action, "expected at least one PL410 quick-fix action from the provider");
+}


### PR DESCRIPTION
## Summary

Adds a lightbulb quick-fix for PL410 (`LoopControlUndefinedLabel`) diagnostics. Previously, `next GHOST`, `last PHANTOM`, and `redo WISP` (where the label is undefined in the file) showed a warning but no code action — the routing table had no PL410 arm. Now the IDE offers a single preferred fix: drop the label, converting the statement to its bare form (`next`, `last`, `redo`) which targets the innermost enclosing loop at runtime.

This is the most common correct intent when the label is a typo or stale reference from a refactoring.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive (new code action offered for PL410 diagnostics; existing actions unchanged)
- DAP surface: unchanged
- CLI: unchanged

## What changed

Three files in `perl-lsp-rs-core`:

1. **`src/providers/code_actions/quick_fixes.rs`**: Added `pub fn fix_loop_control_undefined_label` — validates the diagnostic range, extracts the first whitespace-delimited token (the operator), guards to `next|last|redo` only, and returns a single `is_preferred` `QuickFix` action that replaces the full `"OP LABEL"` span with just `"OP"`.

2. **`src/providers/code_actions/diagnostic_routes.rs`**: Added PL410 arm before the catch-all `_ => {}`, routing to the new handler.

3. **`tests/quick_fix_pl410_bdd.rs`**: 6 BDD scenarios — `next`/`last`/`redo` drop-label, title names the operator, out-of-bounds range returns empty (no panic), and a dispatch smoke test through the full `CodeActionsProvider`.

## How to review

- Start at `quick_fixes.rs` line ~1769 — the new function is compact and follows the exact same guard-then-build pattern as its neighbours.
- Check `diagnostic_routes.rs` lines ~199-203 — the routing arm is minimal.
- Test file is self-contained BDD with clear GIVEN/WHEN/THEN comments.

## Evidence

```
running 6 tests
test pl410_invalid_range_returns_empty ... ok
test pl410_action_title_names_operator ... ok
test pl410_dispatch_smoke_test ... ok
test pl410_last_undefined_label_drops_label ... ok
test pl410_next_undefined_label_drops_label ... ok
test pl410_redo_undefined_label_drops_label ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

Clippy: no warnings
cargo check: Finished dev profile
```

## Risk & rollback

- **Blast radius**: single crate (`perl-lsp-rs-core`), additive only — no existing arms modified
- **Failure modes**: range out-of-bounds returns `Vec::new()` (graceful), non-matching operator returns `Vec::new()` (graceful)
- **Rollback**: revert the 4-line routing arm and the new function; tests will catch regression

## Follow-ups

None — the spec is fully implemented.

https://claude.ai/code/session_0121o9nXq7XkWsgpvWn9df2a

---
_Generated by [Claude Code](https://claude.ai/code/session_0121o9nXq7XkWsgpvWn9df2a)_