### PR TITLE
release: prepare v0.15.2 crates install hotfix (#9613)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -280,6 +280,9 @@ jobs:
           print("All publishable crates match target version {}".format(target))
           '
 
+      - name: Check perl-lsp-rs-core packaged build inputs
+        run: python3 scripts/ci/check_perl_lsp_rs_core_package.py
+
       - name: Publish all crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -21,6 +21,7 @@ on:
       - '.github/workflows/publish-crates.yml'
       - '.github/workflows/publish-dry-run.yml'
       - 'scripts/cargo-package-workspace-dry-run.sh'
+      - 'scripts/ci/check_perl_lsp_rs_core_package.py'
       - 'scripts/publish-topo.py'
       - 'xtask/src/tasks/publish_manifest_check.rs'
   workflow_dispatch: {}
@@ -62,6 +63,9 @@ jobs:
 
       - name: Check allowlist drift (manifest check)
         run: cargo xtask publish-manifest-check
+
+      - name: Check perl-lsp-rs-core packaged build inputs
+        run: python3 scripts/ci/check_perl_lsp_rs_core_package.py
 
       - name: Compute topological publish order
         id: topo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the proactive CI integrity guards rail ([`docs/development/RUST_1_95_PROACTIVE_GUARDS.md`](docs/development/RUST_1_95_PROACTIVE_GUARDS.md)) as a sibling rollout. Six guard PRs (PG-1 through PG-6) covering label enforcement, risk-pack referential integrity, lane mapping with matrix expansion, net-new workflow-allowlist ledger, CI Actuals emitter + subscription coverage check, and broad-glob justification tightening. Each row mirrors a sibling-repo proven shape.
 - Consolidated the remaining Rust 1.95 → 0.14.0 work into a single canonical roadmap: rewrote [`docs/development/RUST_1_95_ROLLOUT.md`](docs/development/RUST_1_95_ROLLOUT.md) into a post-landing source of truth (already landed / remaining implementation ladder / per-rail acceptance contracts / Claude-Codex operating contract); slimmed [`docs/ci/perl-lsp-rust-1.95-rollout.md`](docs/ci/perl-lsp-rust-1.95-rollout.md) to a historical pointer; added [`docs/ci/test-evidence-lanes.md`](docs/ci/test-evidence-lanes.md) defining the five evidence-lane shapes (PR-fast required / PR-targeted / nightly cron / release-only / advisory) with risk-pack auto-routing, skipped-by-policy receipts, and LEM cost framing. Umbrella tracking: **#8663**.
 
+## [0.15.2] - 2026-05-26
+
+Release notes: [v0.15.2](docs/releases/v0.15.2.md)
+
+Crates.io packaging hotfix for the `cargo install` path.
+
+### Fixed
+
+- Included `build_catalog.rs` in the published `perl-lsp-rs-core` crate
+  package so the crate is self-contained after extraction. This fixes the
+  `0.15.1` crates.io install failure for `perllsp` and `perl-dap`.
+
+### Added
+
+- Added a package-content gate for `perl-lsp-rs-core` that checks the `.crate`
+  file list, extracts the archive, and verifies the unpacked crate with
+  `cargo check --locked`.
+
 ## [0.15.1] - 2026-05-26
 
 Release notes: [v0.15.1](docs/releases/v0.15.1.md)
@@ -1577,5 +1595,7 @@ For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HIS
 [0.9.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.9.0
 [0.8.8]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.8.5...v0.8.8
 [0.13.0-rc1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.4...v0.13.0-rc1
-[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.2...HEAD
+[Unreleased]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.2...HEAD
+[0.15.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.1...v0.15.2
+[0.15.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.14.0...v0.15.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1471,14 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "chrono",
  "clap",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "perl-corpus"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-uri",
  "perl-workspace",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-test-must",
  "serde",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lexer"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "criterion",
  "memchr",
@@ -1590,14 +1590,14 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-parser-core",
  "perl-subprocess-runtime",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs-core"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ux-tests"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-parser-core",
  "perl-tdd-support",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-bench"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-parser",
  "walkdir",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-comparison"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-ast",
  "perl-parser-core",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -1808,14 +1808,14 @@ dependencies = [
 
 [[package]]
 name = "perl-pod"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "criterion",
  "perl-ast",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "proptest",
  "thiserror",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-facts"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "proptest",
  "serde",
@@ -1885,14 +1885,14 @@ dependencies = [
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "lsp-types",
  "perl-parser-core",
@@ -1919,18 +1919,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.15.1"
+version = "0.15.2"
 
 [[package]]
 name = "perl-token"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "criterion",
  "perl-lexer",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "perllsp"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -3168,7 +3168,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl-c"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "cc",
  "insta",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-perl-rs"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "insta",
  "perl-ast",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -214,26 +214,26 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.15.1" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.15.2" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.15.1" }
-perl-regex = { path = "crates/perl-regex", version = "0.15.1" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.15.1" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.15.1" }
-perl-ast = { path = "crates/perl-ast", version = "0.15.1" }
+perl-token = { path = "crates/perl-token", version = "0.15.2" }
+perl-regex = { path = "crates/perl-regex", version = "0.15.2" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.15.2" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.15.2" }
+perl-ast = { path = "crates/perl-ast", version = "0.15.2" }
 # Wave D absorbed (internal modules in perl-parser/src/):
 #   perl-heredoc-anti-patterns → perl-parser::heredoc_anti_patterns
 # Wave D absorbed (internal modules in perl-parser-core/src/syntax/):
 #   perl-quote, perl-heredoc, perl-error, perl-edit
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.15.1" }
-perl-symbol = { path = "crates/perl-symbol", version = "0.15.1" }
-perl-module = { path = 'crates/perl-module', version = "0.15.1" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.15.2" }
+perl-symbol = { path = "crates/perl-symbol", version = "0.15.2" }
+perl-module = { path = 'crates/perl-module', version = "0.15.2" }
 # Wave D absorbed: perl-qualified-name → perl-parser::qualified_name
-perl-line-index = { path = "crates/perl-line-index", version = "0.15.1" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.15.2" }
 # Wave D absorbed: perl-source-file → perl-parser::source_file
 # Wave D absorbed: perl-text-line → perl-parser-core::text_line
 # (perl-content-length-framing absorbed into perl-lsp-rs-core::transport::framing — Wave Final PR B)
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.15.1" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.15.2" }
 # (perl-lsp-document-highlight absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-document-links absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-performance absorbed into perl-lsp-rs-core::tooling::performance — Wave G3 step 5)
@@ -241,31 +241,31 @@ perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "
 # Wave D absorbed: perl-ast-utils → perl-parser::ast_utils
 # (perl-lsp-input-validation absorbed into perl-lsp-rs-core::runtime::input_validation — Wave G2)
 # (perl-lsp-text-utils absorbed into perl-lsp-rs-core::runtime::text_utils — Wave G2)
-perl-uri = { path = "crates/perl-uri", version = "0.15.1" }
+perl-uri = { path = "crates/perl-uri", version = "0.15.2" }
 # Wave D absorbed: perl-percentile → perl-parser::percentile
 # (perl-lsp-import-management absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-critic-parser absorbed into perl-lsp-rs-core::critic_parser — Wave G3 step 7)
 # (perl-lsp-protocol absorbed into perl-lsp-rs-core::protocol — Wave G3 step 2)
 # Wave D absorbed: perl-path-normalize → perl-parser-core::path_normalize
 # Wave D absorbed: perl-path-security → perl-parser-core::path_security
-perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.15.1" }
-perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.15.1" }
-perl-pod = { path = "crates/perl-pod", version = "0.15.1" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.15.1" }
-perl-dap = { path = "crates/perl-dap", version = "0.15.1" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.15.1" }
+perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.15.2" }
+perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.15.2" }
+perl-pod = { path = "crates/perl-pod", version = "0.15.2" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.15.2" }
+perl-dap = { path = "crates/perl-dap", version = "0.15.2" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.15.2" }
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.15.1" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.15.2" }
 # (perl-lsp-transport absorbed into perl-lsp-rs-core::transport — Wave G3 step 4)
 # (perl-lsp-tooling absorbed into perl-lsp-rs-core::tooling — Wave G3 step 6)
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.15.1" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.15.2" }
 # (perl-lsp-on-type-formatting absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting-types absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting absorbed into perl-lsp-rs-core::providers::formatting — Wave G1b)
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.15.1" }
-perl-test-must = { path = "crates/perl-test-must", version = "0.15.1" }
-perl-test-generators = { path = "crates/perl-test-generators", version = "0.15.1" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.15.2" }
+perl-test-must = { path = "crates/perl-test-must", version = "0.15.2" }
+perl-test-generators = { path = "crates/perl-test-generators", version = "0.15.2" }
 # (perl-lsp-diagnostics absorbed into perl-lsp-rs-core::providers::diagnostics — Wave G1b)
 # (perl-lsp-semantic-tokens absorbed into perl-lsp-rs-core::providers::semantic_tokens — Wave G1b)
 # (perl-lsp-inlay-hints absorbed into perl-lsp-rs-core::providers — Wave G1a)
@@ -289,28 +289,28 @@ perl-test-generators = { path = "crates/perl-test-generators", version = "0.15.1
 # (perl-lsp-code-actions absorbed into perl-lsp-rs-core::providers::code_actions — Wave G1b)
 # (perl-lsp-folding absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-selection-range absorbed into perl-lsp-rs-core::providers — Wave G1a)
-perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.15.1" }
+perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.15.2" }
 # Tier 3: Two-level dependencies
-perl-workspace = { path = "crates/perl-workspace", version = "0.15.1" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.15.1" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.15.1" }
+perl-workspace = { path = "crates/perl-workspace", version = "0.15.2" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.15.2" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.15.2" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.15.1" }
-perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.15.1" }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.15.2" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.15.2" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.15.1" }
-perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.15.1" }
-perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.15.1" }
+perl-parser = { path = "crates/perl-parser", version = "0.15.2" }
+perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.15.2" }
+perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.15.2" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.15.1" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.15.2" }
 
 # External dependencies
-tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.15.1" }
-tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.15.1" }
+tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.15.2" }
+tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.15.2" }
 tree-sitter = "0.26.9"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -14,6 +14,7 @@ Tag commit timestamps may differ from release dates.
 
 | Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
 |---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
+| [0.15.2] | `v0.15.2` | pending | pending | `pending` | [v0.15.1...v0.15.2] | pending | pending | pending | [v0.15.2][n-0.15.2] |
 | [0.15.1] | `v0.15.1` | pending | pending | `pending` | [v0.15.0...v0.15.1] | pending | pending | pending | [v0.15.1][n-0.15.1] |
 | [0.15.0] | `v0.15.0` | pending | pending | `pending` | [v0.14.0...v0.15.0] | pending | pending | pending | [v0.15.0][n-0.15.0] |
 | [0.14.0] | `v0.14.0` | [yes][gh-0.14.0] | 2026-05-12 | `82e64200` | [v0.13.4...v0.14.0] | 1 VSIX | 0.14.0 primary packages visible; full receipt pending | pending | [v0.14.0][n-0.14.0] |
@@ -62,6 +63,7 @@ Tag commit timestamps may differ from release dates.
 ## Links
 
 <!-- Notes files -->
+[n-0.15.2]: docs/releases/v0.15.2.md
 [n-0.15.1]: docs/releases/v0.15.1.md
 [n-0.15.0]: docs/releases/v0.15.0.md
 [n-0.14.0]: docs/releases/v0.14.0.md
@@ -83,6 +85,7 @@ Tag commit timestamps may differ from release dates.
 [n-0.8.3]: docs/releases/v0.8.3.md
 
 <!-- Version links (to notes files) -->
+[0.15.2]: docs/releases/v0.15.2.md
 [0.15.1]: docs/releases/v0.15.1.md
 [0.15.0]: docs/releases/v0.15.0.md
 [0.14.0]: docs/releases/v0.14.0.md
@@ -104,6 +107,7 @@ Tag commit timestamps may differ from release dates.
 [0.8.3]: docs/releases/v0.8.3.md
 
 <!-- GitHub Releases -->
+[gh-0.15.2]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.15.2
 [gh-0.15.1]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.15.1
 [gh-0.15.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.15.0
 [gh-0.14.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.14.0
@@ -121,6 +125,7 @@ Tag commit timestamps may differ from release dates.
 [gh-0.8.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3
 
 <!-- Compare ranges -->
+[v0.15.1...v0.15.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.1...v0.15.2
 [v0.15.0...v0.15.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.0...v0.15.1
 [v0.14.0...v0.15.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.14.0...v0.15.0
 [v0.13.4...v0.14.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.4...v0.14.0

--- a/crates/perl-lsp-rs-core/Cargo.toml
+++ b/crates/perl-lsp-rs-core/Cargo.toml
@@ -12,7 +12,14 @@ documentation = "https://docs.rs/perl-lsp-rs-core"
 readme = "README.md"
 keywords = ["perl", "lsp", "features", "contracts", "capabilities"]
 categories = ["development-tools", "development-tools::testing"]
-include = ["src/**", "build.rs", "features_sot.toml", "Cargo.toml", "README.md"]
+include = [
+    "src/**",
+    "build.rs",
+    "build_catalog.rs",
+    "features_sot.toml",
+    "Cargo.toml",
+    "README.md",
+]
 
 [lib]
 doctest = false

--- a/crates/perl-lsp-rs-core/tests/wave_final_absorption_tests.rs
+++ b/crates/perl-lsp-rs-core/tests/wave_final_absorption_tests.rs
@@ -363,18 +363,23 @@ fn test_platform_functions_are_public_and_callable() {
     // (the use statement above confirms this at compile time)
 }
 
-/// Test 21: REGRESSION: feature_catalog build module is correctly used by both perl-dap and perl-lsp-rs-core
-/// If the include!() pattern in perl-dap/build.rs fails, this would catch it.
+/// Test 21: REGRESSION: perl-dap build catalog logic is package-local.
+/// If perl-dap/build.rs starts depending on repo-local files again, this would catch it.
 #[test]
-fn test_dap_build_includes_rs_core_catalog() {
+fn test_dap_build_uses_package_local_catalog() {
     let root = workspace_root();
     let dap_build = root.join("crates/perl-dap/build.rs");
     let content = fs::read_to_string(&dap_build).expect("perl-dap/build.rs should be readable");
 
-    // The build.rs should include the shared catalog from rs-core, not reference perl-feature-catalog crate
+    // The build.rs should keep catalog loading package-local, not reference absorbed crates or repo paths.
     assert!(
-        content.contains("perl-lsp-rs-core/build_catalog.rs"),
-        "perl-dap/build.rs must include catalog from perl-lsp-rs-core (not standalone perl-feature-catalog)"
+        content.contains("fn load_catalog_for_build"),
+        "perl-dap/build.rs must keep package-local catalog loading"
+    );
+
+    assert!(
+        !content.contains("perl-lsp-rs-core/build_catalog.rs"),
+        "perl-dap/build.rs should not depend on repo-local perl-lsp-rs-core/build_catalog.rs"
     );
 
     assert!(

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-module"
-version = "0.15.1"
+version = "0.15.2"
 publish = true
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/docs/releases/v0.15.2.md
+++ b/docs/releases/v0.15.2.md
@@ -1,0 +1,46 @@
+---
+version: "0.15.2"
+tag: "v0.15.2"
+release_date_utc: "2026-05-26"
+previous_tag: "v0.15.1"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.1...v0.15.2"
+notes_status: draft
+release_track: public-alpha
+release_kind: patch
+channels:
+  github_release: pending
+  crates_io: pending
+  vscode_marketplace: pending
+  open_vsx: pending
+  docker: pending
+---
+
+# v0.15.2
+
+## Summary
+
+Crates.io packaging hotfix for the `cargo install` path.
+
+## Fixed
+
+- Included `build_catalog.rs` in the published `perl-lsp-rs-core` crate
+  package so the crate is self-contained after extraction. The missing file in
+  `0.15.1` caused `cargo install perllsp --version 0.15.1` and
+  `cargo install perl-dap --version 0.15.1` to fail while verifying
+  dependencies from crates.io.
+
+## Added
+
+- Added a package-content gate for `perl-lsp-rs-core` that checks the packaged
+  file list, extracts the `.crate` archive outside the workspace, and runs
+  `cargo check --locked` against the unpacked package manifest.
+
+## Claim boundary
+
+This hotfix changes package contents and release validation only. It does not
+change inline-completion behavior, LSP capability negotiation, AI completion, or
+provider logic from `v0.15.1`.
+
+## Related
+
+- Previous release: [v0.15.1](v0.15.1.md)

--- a/scripts/ci/check_perl_lsp_rs_core_package.py
+++ b/scripts/ci/check_perl_lsp_rs_core_package.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Validate that perl-lsp-rs-core is self-contained when packaged."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CRATE = "perl-lsp-rs-core"
+REQUIRED_PACKAGE_FILE = "build_catalog.rs"
+
+
+def run(args: list[str], *, capture: bool = False) -> str:
+    print("+ " + " ".join(args), flush=True)
+    if capture:
+        completed = subprocess.run(
+            args,
+            cwd=ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        return completed.stdout
+    subprocess.run(args, cwd=ROOT, check=True)
+    return ""
+
+
+def workspace_package_version(crate: str) -> str:
+    metadata = json.loads(run(["cargo", "metadata", "--format-version=1", "--no-deps"], capture=True))
+    workspace_members = set(metadata["workspace_members"])
+    for package in metadata["packages"]:
+        if package["id"] in workspace_members and package["name"] == crate:
+            return package["version"]
+    raise SystemExit(f"workspace package not found: {crate}")
+
+
+def workspace_patch_args(crate: str, *, include_dev_deps: bool) -> list[str]:
+    metadata = json.loads(run(["cargo", "metadata", "--format-version=1", "--no-deps"], capture=True))
+    workspace_members = set(metadata["workspace_members"])
+    packages = {
+        package["name"]: package for package in metadata["packages"] if package["id"] in workspace_members
+    }
+    if include_dev_deps:
+        selected = {name for name in packages if name != crate}
+    else:
+        selected: set[str] = set()
+        stack = [crate]
+        while stack:
+            package = packages[stack.pop()]
+            for dependency in package["dependencies"]:
+                if dependency.get("kind") == "dev":
+                    continue
+                dependency_name = dependency["name"]
+                if dependency_name == crate or dependency_name not in packages:
+                    continue
+                if dependency_name in selected:
+                    continue
+                selected.add(dependency_name)
+                stack.append(dependency_name)
+
+    args: list[str] = []
+    for name in sorted(selected):
+        package = packages[name]
+        package_dir = Path(package["manifest_path"]).parent.resolve().as_posix()
+        args.append(f'--config=patch.crates-io.{package["name"]}.path="{package_dir}"')
+    return args
+
+
+def safe_extract(archive: Path, destination: Path) -> None:
+    destination_resolved = destination.resolve()
+    with tarfile.open(archive, "r:*") as tar:
+        for member in tar.getmembers():
+            target = (destination / member.name).resolve()
+            try:
+                target.relative_to(destination_resolved)
+            except ValueError as error:
+                raise SystemExit(f"refusing to extract path outside destination: {member.name}") from error
+        tar.extractall(destination)
+
+
+def strip_dev_dependencies(manifest: Path) -> None:
+    text = manifest.read_text(encoding="utf-8")
+    stripped = re.sub(
+        r"^\[dev-dependencies[^\]]*\].*?(?=^\[(?!dev-dependencies)|\Z)",
+        "",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    manifest.write_text(stripped, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate that perl-lsp-rs-core is self-contained when packaged.",
+    )
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="pass --allow-dirty to cargo package for local pre-commit validation",
+    )
+    return parser.parse_args()
+
+
+def package_args(
+    *extra: str,
+    allow_dirty: bool,
+    patch_args: list[str] | None = None,
+    no_verify: bool = False,
+) -> list[str]:
+    patch_args = patch_args or []
+    args = ["cargo", "package", "-p", CRATE, "--locked", *patch_args, *extra]
+    if no_verify:
+        args.append("--no-verify")
+    if allow_dirty:
+        args.append("--allow-dirty")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    version = workspace_package_version(CRATE)
+    package_patch_args = workspace_patch_args(CRATE, include_dev_deps=True)
+    check_patch_args = workspace_patch_args(CRATE, include_dev_deps=False)
+
+    package_listing = run(package_args("--list", allow_dirty=args.allow_dirty), capture=True)
+    package_files = {line.strip().replace("\\", "/") for line in package_listing.splitlines()}
+    if REQUIRED_PACKAGE_FILE not in package_files:
+        print(
+            f"ERROR: {CRATE} package is missing {REQUIRED_PACKAGE_FILE}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: package list includes {REQUIRED_PACKAGE_FILE}")
+
+    run(package_args(allow_dirty=args.allow_dirty, patch_args=package_patch_args, no_verify=True))
+
+    crate_archive = ROOT / "target" / "package" / f"{CRATE}-{version}.crate"
+    if not crate_archive.exists():
+        print(f"ERROR: expected packaged crate not found: {crate_archive}", file=sys.stderr)
+        return 1
+
+    smoke_root = Path(tempfile.mkdtemp(prefix=f"{CRATE}-package-smoke-"))
+    print(f"package smoke root: {smoke_root}")
+    safe_extract(crate_archive, smoke_root)
+
+    extracted = smoke_root / f"{CRATE}-{version}"
+    if not (extracted / REQUIRED_PACKAGE_FILE).exists():
+        print(
+            f"ERROR: unpacked {CRATE} package is missing {REQUIRED_PACKAGE_FILE}",
+            file=sys.stderr,
+        )
+        return 1
+
+    strip_dev_dependencies(extracted / "Cargo.toml")
+    run(
+        [
+            "cargo",
+            "generate-lockfile",
+            "--manifest-path",
+            str(extracted / "Cargo.toml"),
+            *check_patch_args,
+        ],
+    )
+    run(
+        [
+            "cargo",
+            "check",
+            "--manifest-path",
+            str(extracted / "Cargo.toml"),
+            "--lib",
+            "--locked",
+            *check_patch_args,
+        ],
+    )
+
+    print(f"OK: {CRATE}-{version}.crate is self-contained")
+    shutil.rmtree(smoke_root, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.17",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
Problem: v0.15.1 GitHub release binaries are usable, but the crates.io install path can fail because `perl-lsp-rs-core` omitted `build_catalog.rs` from its published package.

Fix: mirror the swarm package-content fix, add a package/unpack guard to publish workflows, and prepare v0.15.2 as a full crates-install hotfix release.

Verification:
- `cargo fmt -p perl-lsp-rs-core -p xtask -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo test -p perl-lsp-rs-core --locked`
- `cargo test -p perl-lsp-rs --test lsp_inline_completion_registration_tests --locked`
- `python scripts/ci/check_perl_lsp_rs_core_package.py`
- local package checks for `perllsp` and `perl-dap` with workspace patch config and `--no-verify`
- `cargo xtask check-support-claims`
- `cargo xtask check-devex-docs`
- `cargo xtask doc-claims`
- `cargo build --release -p perl-lsp-rs --bin perl-lsp --locked`
- `cargo xtask smoke inline-completion --binary target/release/perl-lsp`
- `git diff --check`

Notes:
- No yanking is included.
- No inline-completion behavior changed.
- No tag or publish is included in this PR.