### PR TITLE
docs(release): close v0.15.2 channel ledger (#9616)

### DIFF
--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -14,8 +14,8 @@ Tag commit timestamps may differ from release dates.
 
 | Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
 |---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
-| [0.15.2] | `v0.15.2` | pending | pending | `pending` | [v0.15.1...v0.15.2] | pending | pending | pending | [v0.15.2][n-0.15.2] |
-| [0.15.1] | `v0.15.1` | pending | pending | `pending` | [v0.15.0...v0.15.1] | pending | pending | pending | [v0.15.1][n-0.15.1] |
+| [0.15.2] | `v0.15.2` | [yes][gh-0.15.2] | 2026-05-26 | `746edcb7` | [v0.15.1...v0.15.2] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | 0.15.2 install smoke passed for `perllsp` and `perl-dap` | [perl-lsp-rs][vsce] 0.15.2 | [v0.15.2][n-0.15.2] |
+| [0.15.1] | `v0.15.1` | pending | pending | `pending` | [v0.15.0...v0.15.1] | pending | superseded by 0.15.2 for cargo install users | pending | [v0.15.1][n-0.15.1] |
 | [0.15.0] | `v0.15.0` | pending | pending | `pending` | [v0.14.0...v0.15.0] | pending | pending | pending | [v0.15.0][n-0.15.0] |
 | [0.14.0] | `v0.14.0` | [yes][gh-0.14.0] | 2026-05-12 | `82e64200` | [v0.13.4...v0.14.0] | 1 VSIX | 0.14.0 primary packages visible; full receipt pending | pending | [v0.14.0][n-0.14.0] |
 | [0.13.4] | `v0.13.4` | pending | pending | `pending` | [v0.13.3...v0.13.4] | 10 (7 binaries, VSIX, SHA256SUMS, SBOM) | pending | pending | [v0.13.4][n-0.13.4] |

--- a/docs/releases/0.15.2-closeout-audit.md
+++ b/docs/releases/0.15.2-closeout-audit.md
@@ -1,0 +1,74 @@
+# 0.15.2 Closeout Audit
+
+Release closeout verification for `v0.15.2`, the crates.io package-content
+hotfix that supersedes `v0.15.1` for `cargo install` users.
+
+## Summary
+
+`v0.15.2` is published as a hotfix for the `perl-lsp-rs-core` crate package.
+The published `0.15.1` core crate omitted `build_catalog.rs`, which broke
+`cargo install perllsp --version 0.15.1` and
+`cargo install perl-dap --version 0.15.1`. `v0.15.2` includes the missing file,
+adds package-content validation, and leaves inline-completion behavior
+unchanged from `v0.15.1`.
+
+`v0.15.1` GitHub Release binaries remain usable. No yank was performed.
+
+## Workflow Results
+
+| Workflow | Run | Result | Notes |
+|---|---:|---|---|
+| Release Orchestration | `26476027413` | success | Created `v0.15.2` and dispatched downstream publish jobs. |
+| Release | `26476070832` | success | Built release binaries and published GitHub Release assets. |
+| Publish to crates.io | `26476071731` | success | Includes `perl-lsp-rs-core` package-content gate. |
+| Publish VSCode Extension | `26477379103` | success | Rerun after GitHub Release existed; attached VSIX and passed Marketplace/Open VSX smokes. |
+| Publish Docker Images | `26476073842` | success | Docker Hub and GHCR publish workflow completed. |
+
+The first `0.15.2` release orchestration attempt (`26475634964`) failed because
+the workflow checks the legacy combined-status endpoint. A narrow success status
+was added after PR checks and the local release gate passed, then orchestration
+was rerun successfully.
+
+## Public Channel Checks
+
+| Channel | Result | Evidence |
+|---|---|---|
+| GitHub Release | verified | `gh release view v0.15.2` showed published non-draft release with 10 assets. |
+| crates.io | verified | crates.io API returned `newest_version = 0.15.2` for `perllsp`, `perl-dap`, and `perl-lsp-rs-core`. |
+| docs.rs | verified | `https://docs.rs/crate/{perllsp,perl-dap,perl-lsp-rs-core}/0.15.2` returned HTTP 200. |
+| VS Code Marketplace | verified | Marketplace gallery API returned `EffortlessMetrics.perl-lsp-rs` version `0.15.2`; published smoke passed. |
+| Open VSX | verified | Open VSX API returned `EffortlessMetrics/perl-lsp-rs` version `0.15.2`; published smoke passed. |
+| Docker Hub | verified | `docker manifest inspect` succeeded for `effortlessmetrics/perl-lsp:0.15.2` and `effortlessmetrics/perl-lsp:0.15.2-perl`. |
+| GHCR | workflow-succeeded, public check blocked | Docker workflow succeeded, but `docker manifest inspect ghcr.io/effortlessmetrics/perl-lsp:0.15.2` and `ghcr.io/effortlessmetrics/perl-lsp-perl:0.15.2` returned `denied` with the available token. |
+
+Local `docker pull` verification was not run because the Docker Desktop Linux
+engine was unavailable on this machine.
+
+## Install Smokes
+
+Fresh crates.io install smokes passed:
+
+```powershell
+cargo install perllsp --version 0.15.2 --locked --force --root target/cargo-install-smoke
+target/cargo-install-smoke/bin/perllsp.exe --version
+cargo xtask smoke inline-completion --binary target/cargo-install-smoke/bin/perllsp.exe
+
+cargo install perl-dap --version 0.15.2 --locked --force --root target/cargo-install-smoke
+target/cargo-install-smoke/bin/perl-dap.exe --version
+```
+
+Observed versions:
+
+```text
+perllsp 0.15.2
+perl-dap 0.15.2
+```
+
+The installed `perllsp.exe` also passed the inline-completion stdio smoke.
+
+## Channel State
+
+`v0.15.2` is the recommended version for `cargo install` users. Docker Hub,
+GitHub Release, crates.io, VS Code Marketplace, and Open VSX are verified.
+GHCR publish completed in CI, but public/local manifest verification was not
+confirmed from this machine.

--- a/docs/releases/v0.15.1.md
+++ b/docs/releases/v0.15.1.md
@@ -22,6 +22,11 @@ channels:
 Patch release focused on LSP4IJ inline completion and lean editor-mode
 hardening.
 
+`v0.15.2` supersedes `v0.15.1` for `cargo install` users. The `v0.15.1`
+GitHub Release binaries remain usable, but the published `perl-lsp-rs-core`
+crate package missed `build_catalog.rs`, which broke fresh installs of
+`perllsp` and `perl-dap` from crates.io. No yank was performed.
+
 ## Highlights
 
 ### For users

--- a/docs/releases/v0.15.2.md
+++ b/docs/releases/v0.15.2.md
@@ -4,15 +4,15 @@ tag: "v0.15.2"
 release_date_utc: "2026-05-26"
 previous_tag: "v0.15.1"
 compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.1...v0.15.2"
-notes_status: draft
+notes_status: canonical
 release_track: public-alpha
 release_kind: patch
 channels:
-  github_release: pending
-  crates_io: pending
-  vscode_marketplace: pending
-  open_vsx: pending
-  docker: pending
+  github_release: "published 2026-05-26; 10 assets"
+  crates_io: "0.15.2 packages visible; cargo install perllsp/perl-dap smoke passed"
+  vscode_marketplace: "0.15.2 verified"
+  open_vsx: "0.15.2 verified"
+  docker: "Docker Hub manifests verified; GHCR publish workflow succeeded but public manifest verification returned denied"
 ---
 
 # v0.15.2
@@ -35,6 +35,22 @@ Crates.io packaging hotfix for the `cargo install` path.
   file list, extracts the `.crate` archive outside the workspace, and runs
   `cargo check --locked` against the unpacked package manifest.
 
+## Release verification
+
+- GitHub Release `v0.15.2` is published with platform binaries, checksums,
+  SBOM, and VSIX asset.
+- crates.io reports `perllsp`, `perl-dap`, and `perl-lsp-rs-core` at `0.15.2`;
+  fresh `cargo install` smokes for `perllsp` and `perl-dap` passed, and the
+  installed `perllsp` binary passed the inline-completion stdio smoke.
+- VS Code Marketplace and Open VSX report extension version `0.15.2`; both
+  published-extension smokes passed after the GitHub Release asset was
+  available.
+- Docker publish workflow completed successfully. Docker Hub manifests for
+  `effortlessmetrics/perl-lsp:0.15.2` and
+  `effortlessmetrics/perl-lsp:0.15.2-perl` were verified. Local `docker pull`
+  could not run because the Docker daemon was unavailable, and GHCR manifest
+  verification returned `denied` with the available token.
+
 ## Claim boundary
 
 This hotfix changes package contents and release validation only. It does not
@@ -44,3 +60,4 @@ provider logic from `v0.15.1`.
 ## Related
 
 - Previous release: [v0.15.1](v0.15.1.md)
+- Closeout receipt: [0.15.2 closeout audit](0.15.2-closeout-audit.md)


### PR DESCRIPTION
Problem: v0.15.2 was published and verified, but the release notes/history still showed draft/pending channel state.\n\nFix: Record the v0.15.2 channel closeout evidence, add a closeout audit receipt, and note that v0.15.2 supersedes v0.15.1 for cargo install users while leaving v0.15.1 GitHub binaries usable.\n\nVerification:\n- \cargo xtask check-devex-docs\\n- \cargo xtask doc-claims\\n- \cargo xtask check-support-claims\\n- \git diff --check\\n\nChannel evidence:\n- GitHub Release v0.15.2 published with 10 assets.\n- crates.io reports perllsp, perl-dap, and perl-lsp-rs-core at 0.15.2; fresh cargo install smokes passed earlier in the release run.\n- VS Code Marketplace and Open VSX report perl-lsp-rs 0.15.2; published-extension smokes passed in run 26477379103.\n- Docker publish workflow passed in run 26476073842; Docker Hub manifests verified for 0.15.2 and 0.15.2-perl. GHCR public manifest inspection returned denied with the available token, so the docs keep that caveat explicit.