### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: Undefined loop-control label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,36 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Drop the undefined label from a loop-control statement (PL410).
+///
+/// `next LABEL`, `last LABEL`, and `redo LABEL` with an undefined label are
+/// runtime-fatal. The only safe mechanical fix is to drop the label so the
+/// statement targets the innermost enclosing loop.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let text = &source[start..end];
+    let op = text.split_ascii_whitespace().next().unwrap_or("");
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Remove undefined label (use '{op}' without label)"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,235 @@
+//! BDD tests for the PL410 quick-fix handler (`fix_loop_control_undefined_label`).
+//!
+//! PL410 fires when `next LABEL`, `last LABEL`, or `redo LABEL` references a
+//! label that is not defined in any enclosing loop. The only safe mechanical fix
+//! is to drop the label so the statement targets the innermost enclosing loop.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is produced and code actions are requested
+//!   THEN   exactly one preferred action is returned that replaces the statement
+//!          with the bare operator
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Error,
+        code: Some("PL410".to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+// ===========================================================================
+// Scenario 1: `next LABEL` — drop label, leaving bare `next`
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop body that uses `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_diag(stmt_start, stmt_end, "Label 'OUTER' is not defined");
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is exactly one preferred action that drops the label
+    let action = actions
+        .iter()
+        .find(|a| a.title.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label action should be preferred");
+
+    let result = edited(source, action);
+    assert!(
+        result.contains("next;") || result.contains("next "),
+        "expected bare 'next', got: {result:?}"
+    );
+    assert!(!result.contains("next OUTER"), "label should be removed, got: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 2: `last LABEL` — drop label, leaving bare `last`
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop that uses `last LOOP` where LOOP is undefined
+    let source = "while (1) { last LOOP; }\n";
+    let stmt_start = source.find("last LOOP").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last LOOP".len();
+
+    let diag = make_diag(stmt_start, stmt_end, "Label 'LOOP' is not defined");
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action that removes the label from `last`
+    let action = actions
+        .iter()
+        .find(|a| a.title.contains("last"))
+        .ok_or_else(|| format!("no 'last' action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert!(!result.contains("last LOOP"), "label should be removed, got: {result:?}");
+    assert!(result.contains("last"), "bare 'last' should remain, got: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 3: `redo LABEL` — drop label, leaving bare `redo`
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop that uses `redo RETRY` where RETRY is undefined
+    let source = "for my $n (1..5) { redo RETRY; }\n";
+    let stmt_start = source.find("redo RETRY").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo RETRY".len();
+
+    let diag = make_diag(stmt_start, stmt_end, "Label 'RETRY' is not defined");
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action that removes the label from `redo`
+    let action = actions
+        .iter()
+        .find(|a| a.title.contains("redo"))
+        .ok_or_else(|| format!("no 'redo' action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert!(!result.contains("redo RETRY"), "label should be removed, got: {result:?}");
+    assert!(result.contains("redo"), "bare 'redo' should remain, got: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 4: Title naming — action title includes the operator name
+// ===========================================================================
+
+#[test]
+fn action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next MISSING` diagnostic
+    let source = "for (1..3) { next MISSING; }\n";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag = make_diag(stmt_start, stmt_end, "Label 'MISSING' is not defined");
+    let actions = actions_for(source, &[diag]);
+
+    let action = actions
+        .iter()
+        .find(|a| a.title.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {:?}", actions))?;
+
+    // THEN the title explicitly mentions removing the label and names the operator
+    assert!(
+        action.title.contains("next"),
+        "title should name the operator, got: {:?}",
+        action.title
+    );
+    assert!(
+        action.title.to_lowercase().contains("label") || action.title.contains("without"),
+        "title should mention label removal, got: {:?}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 5: Invalid-range guard — out-of-bounds range returns no actions
+// ===========================================================================
+
+#[test]
+fn invalid_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic whose range extends past the end of the source
+    let source = "for (1..3) { next OUTER; }\n";
+    let beyond_end = source.len() + 5;
+
+    let diag = make_diag(beyond_end, beyond_end + 10, "Label 'OUTER' is not defined");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL410 action is produced
+    assert!(
+        !actions.iter().any(|a| a.title.contains("without label")),
+        "expected no action for out-of-bounds range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 6: Dispatch smoke test — PL410 route reaches the handler
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source with a `last UNDEFINED` in a loop
+    let source = "while (1) { last UNDEFINED; }\n";
+    let stmt_start = source.find("last UNDEFINED").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last UNDEFINED".len();
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let diags = vec![make_diag(stmt_start, stmt_end, "Label 'UNDEFINED' is not defined")];
+
+    // WHEN code actions are requested via the provider's dispatch table
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    // THEN at least one action is produced confirming the PL410 route is wired
+    assert!(
+        actions.iter().any(|a| a.title.contains("last")),
+        "PL410 route not producing action; actions: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements referencing an undefined label trigger a PL410 diagnostic (runtime-fatal in Perl), but the diagnostic route table had no arm for `DiagnosticCode::LoopControlUndefinedLabel` — so every PL410 lightbulb click returned nothing.

This PR wires up the missing route and adds the handler.

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`
- Added `pub fn fix_loop_control_undefined_label(source, diagnostic)`:
  - Validates the byte range via the existing `valid_diagnostic_range` guard (returns empty on out-of-bounds or non-char-boundary ranges)
  - Extracts the first whitespace-delimited token from the diagnostic range
  - Accepts only `next`, `last`, or `redo` — anything else returns no actions
  - Returns a single **preferred** `CodeAction` with title `"Remove undefined label (use '{op}' without label)"` that replaces `OP LABEL` with bare `OP`

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`
- Added a new match arm for `DiagnosticCode::LoopControlUndefinedLabel` (`"PL410"`) that calls `fix_loop_control_undefined_label`

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` (new)
Six BDD integration tests following the same GIVEN/WHEN/THEN structure as `quick_fix_new_codes_bdd.rs`:

| # | Test | Verifies |
|---|------|----------|
| 1 | `next_undefined_label_produces_drop_label_action` | `next OUTER` → bare `next`; is_preferred = true |
| 2 | `last_undefined_label_produces_drop_label_action` | `last LOOP` → bare `last`; is_preferred = true |
| 3 | `redo_undefined_label_produces_drop_label_action` | `redo RETRY` → bare `redo`; is_preferred = true |
| 4 | `action_title_names_the_operator` | Title contains operator name and mentions label removal |
| 5 | `invalid_range_returns_no_actions` | Out-of-bounds range → no action (range guard) |
| 6 | `pl410_dispatch_smoke_test` | End-to-end: PL410 code through `get_code_actions` → at least one action |

## Test results

```
running 6 tests
test action_title_names_the_operator ... ok
test invalid_range_returns_no_actions ... ok
test next_undefined_label_produces_drop_label_action ... ok
test last_undefined_label_produces_drop_label_action ... ok
test pl410_dispatch_smoke_test ... ok
test redo_undefined_label_produces_drop_label_action ... ok

test result: ok. 6 passed; 0 failed
```

All 17 pre-existing `quick_fix_new_codes_bdd` tests remain green. `cargo fmt` and `cargo clippy` clean.

## Design notes

- `is_preferred: true` — there is exactly one sensible fix for a runtime-fatal undefined label reference; no alternative actions are offered
- The handler is intentionally narrow: it rejects any operator that is not one of the three Perl loop-control keywords, ensuring no accidental matches on unrelated PL410 subcodes
- No changes to diagnostic emission (`loop_control_label.rs`) — purely a code-actions layer addition

https://claude.ai/code/session_011sjCDTNsGxynWsyb4LxpPt

---
_Generated by [Claude Code](https://claude.ai/code/session_011sjCDTNsGxynWsyb4LxpPt)_