### PR TITLE
docs(lsp4ij): mirror upstream setup docs from swarm (#8197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,12 @@ hardening.
   inline completion, available. Semantic tokens advertise full-only support
   until the delta/result-id path is implemented.
 
+### Documentation
+
+- Updated JetBrains/LSP4IJ setup docs to prefer the upstream LSP4IJ `perl-lsp`
+  integration when available, with manual `perllsp --stdio` registration
+  moved to separate fallback and development guidance.
+
 ### Notes (0.15.1)
 
 - This release does not implement true incremental AST reuse. The live

--- a/docs/EDITORS/INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md
+++ b/docs/EDITORS/INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md
@@ -1,0 +1,102 @@
+# IntelliJ IDEA Legacy Raw Command Setup
+
+Use this fallback only when the upstream LSP4IJ `perl-lsp` integration is not
+available in your installed LSP4IJ build, when you are testing a local or
+unreleased `perllsp` binary, or when you need temporary custom launch flags.
+
+For normal JetBrains setup, start with
+[IntelliJ IDEA / JetBrains Setup Guide](INTELLIJ_IDEA_SETUP.md) and use the
+upstream LSP4IJ integration.
+
+## Add a Raw Command Server
+
+1. Open **File > Settings > Languages & Frameworks > Language Servers**.
+2. Click **+** to add a new server definition.
+3. Fill in the fields:
+
+   | Field | Value |
+   |-------|-------|
+   | **Name** | `perl-lsp` |
+   | **Command** | `perllsp --stdio` |
+   | **Mappings: File name patterns** | `*.pl`, `*.pm`, `*.t`, `*.psgi`, `*.cgi` |
+
+4. Click **OK** to save.
+
+## Binary Path
+
+If IntelliJ does not inherit your shell `PATH`, use an absolute binary path:
+
+| Field | Value |
+|-------|-------|
+| **Command** | `/usr/local/bin/perllsp --stdio` |
+
+Find the path with:
+
+```bash
+command -v perllsp
+```
+
+On Windows PowerShell:
+
+```powershell
+where perllsp
+```
+
+On Windows, use the full path with forward slashes or escaped backslashes:
+
+```text
+C:/path/to/perllsp.exe --stdio
+```
+
+## Descriptor Example
+
+Minimal descriptor/config example:
+
+```json
+{
+  "name": "Perl Language Server",
+  "languageId": "perl",
+  "fileExtensions": ["pl", "pm", "t", "psgi"],
+  "command": ["perllsp", "--stdio"]
+}
+```
+
+The same example is checked in at
+[`docs/EDITORS/lsp4ij-perl-lsp.json`](lsp4ij-perl-lsp.json).
+
+## Initialization Options
+
+If you need server-specific startup settings, add an `initializationOptions` JSON
+block in the LSP4IJ **Server** tab under **Initialization options**:
+
+```json
+{
+  "perl": {
+    "workspace": {
+      "includePaths": ["lib", ".", "local/lib/perl5"]
+    },
+    "inlayHints": {
+      "enabled": true
+    }
+  }
+}
+```
+
+Prefer `.perl-lsp.toml` in the project root for settings that should apply
+across all editors and teammates. Use LSP4IJ initialization options for
+IDE-specific overrides.
+
+## Verify
+
+1. Open a Perl file matching one of the configured file patterns.
+2. Confirm that the LSP4IJ status bar or LSP console shows `perllsp --stdio`
+   starting successfully.
+3. Introduce a temporary syntax error and confirm a diagnostic appears.
+4. Remove the syntax error.
+
+If the server does not start, verify the binary outside IntelliJ first:
+
+```bash
+perllsp --version
+perllsp --health
+```

--- a/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
+++ b/docs/EDITORS/INTELLIJ_IDEA_SETUP.md
@@ -1,11 +1,17 @@
-# IntelliJ IDEA Setup Guide for perl-lsp
+# IntelliJ IDEA / JetBrains Setup Guide for perl-lsp
 
 This guide covers using `perl-lsp` with IntelliJ IDEA via the
 [LSP4IJ](https://github.com/redhat-developer/lsp4ij) plugin.
 
-LSP4IJ is a community plugin maintained by Red Hat that provides a generic LSP
-client for all JetBrains IDEs. It lets you register any language server that speaks
-stdio by pointing it at a shell command.
+LSP4IJ is a community plugin maintained by Red Hat that provides LSP client
+support for JetBrains IDEs. This guide uses the upstream LSP4IJ `perl-lsp`
+integration path.
+
+Manual `perllsp --stdio` registration is still supported for older LSP4IJ
+builds, local development, and custom launch flags. Keep that path separate:
+use [Legacy Raw Command Setup](INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md) only when
+the upstream LSP4IJ entry is not available or you are testing an unreleased
+server build.
 
 > **Applies to:** IntelliJ IDEA (Community and Ultimate), as well as other
 > JetBrains IDEs (PyCharm, WebStorm, Rider, etc.) that support LSP4IJ.
@@ -41,64 +47,36 @@ Alternatively, download the plugin from the
 [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/23257-lsp4ij)
 and install it via **Plugins > Settings > Install Plugin from Disk**.
 
-## Configure the perl-lsp Server
+## Recommended: LSP4IJ Upstream Integration
 
-### Add a New Language Server
+Use this path when your installed LSP4IJ version includes a `perl-lsp` or Perl
+language-server entry.
 
-1. Open **File > Settings > Languages & Frameworks > Language Servers**.
-2. Click **+** to add a new server definition.
-3. Fill in the fields:
+1. Install or update LSP4IJ.
+2. Open a Perl file such as `lib/My/Module.pm` or `t/basic.t`.
+3. Confirm LSP4IJ offers or enables the upstream `perl-lsp` server for Perl.
+4. Set the `perllsp` binary path only if LSP4IJ asks for it or the binary is
+   not visible on the IDE `PATH`.
+5. Verify diagnostics, hover, go-to-definition, and inline completion if your
+   LSP4IJ build exposes inline completion.
 
-   | Field | Value |
-   |-------|-------|
-   | **Name** | `perl-lsp` |
-   | **Command** | `perllsp --stdio` |
-   | **Mappings: File name patterns** | `*.pl`, `*.pm`, `*.t`, `*.psgi`, `*.cgi` |
+If LSP4IJ does not show a `perl-lsp` entry yet, update LSP4IJ first. If the
+entry is still unavailable, use the
+[legacy Raw Command fallback](INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md).
 
-4. Click **OK** to save.
+## Binary Path
 
-### Example Configuration
+The upstream LSP4IJ entry should launch `perllsp` with stdio transport. If your
+IDE does not inherit your shell `PATH`, set the binary path in the LSP4IJ
+integration settings when prompted.
 
-If your IntelliJ installation does not inherit your shell `PATH`, use an absolute
-binary path:
+Find the binary path with `command -v perllsp` on Unix-like shells or
+`where perllsp` in Windows PowerShell.
 
-| Field | Value |
-|-------|-------|
-| **Command** | `/usr/local/bin/perllsp --stdio` |
+The upstream entry owns the server descriptor and file mappings. You should not
+need to create a custom descriptor for normal setup.
 
-Find the path with:
-
-```bash
-command -v perllsp
-```
-
-On Windows PowerShell:
-
-```powershell
-where perllsp
-```
-
-Minimal descriptor/config example:
-
-```json
-{
-  "name": "Perl Language Server",
-  "languageId": "perl",
-  "fileExtensions": ["pl", "pm", "t", "psgi"],
-  "command": ["perllsp", "--stdio"]
-}
-```
-
-The same example is checked in at
-[`docs/EDITORS/lsp4ij-perl-lsp.json`](lsp4ij-perl-lsp.json).
-
-On Windows, use the full path with forward slashes or escaped backslashes:
-
-```
-C:/path/to/perllsp.exe --stdio
-```
-
-### Initialization Options
+## Initialization Options
 
 To pass server-specific startup settings, add an `initializationOptions` JSON
 block in the LSP4IJ **Server** tab under **Initialization options**:
@@ -120,16 +98,17 @@ Prefer `.perl-lsp.toml` in the project root for settings that should apply acros
 all editors and teammates. Use LSP4IJ initialization options for IDE-specific
 overrides.
 
-## File Type Association
+## File Type Activation
 
 IntelliJ IDEA does not recognize Perl files by default unless the **Perl plugin**
-is also installed. LSP4IJ maps language servers by file name pattern, so even
-without the Perl plugin, LSP4IJ can activate `perllsp` for files matching
-`*.pl`, `*.pm`, and `*.t`.
+is also installed. The upstream LSP4IJ `perl-lsp` integration provides the Perl
+server mapping for common Perl extensions such as `*.pl`, `*.pm`, and `*.t`.
 
 If you have the IntelliJ Perl plugin installed, IntelliJ already knows the `Perl`
-file type. In that case, you can also map by file type instead of pattern in the
-LSP4IJ settings.
+file type. If Perl files still open as plain text, update LSP4IJ and confirm the
+upstream `perl-lsp` integration is enabled. For older LSP4IJ builds, use the
+[legacy Raw Command fallback](INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md), which covers
+manual file-pattern mapping.
 
 ## Optional: Inlay Hints
 
@@ -149,7 +128,8 @@ inlay_hints = true
 ## Optional: Inline Completion
 
 `perl-lsp` supports the standard LSP 3.18 `textDocument/inlineCompletion`
-request. LSP4IJ advertises dynamic inline-completion registration, so
+request. Static clients receive the top-level `inlineCompletionProvider`
+capability. LSP4IJ advertises dynamic inline-completion registration, so
 `perllsp` registers `textDocument/inlineCompletion` with
 `client/registerCapability` after `initialized` instead of also advertising a
 duplicate static `inlineCompletionProvider`.
@@ -169,11 +149,12 @@ Protocol notes:
 - The registration selector includes `perl` and `perl5`.
 - LSP wire positions use UTF-16 code units, per the LSP spec; `perllsp` converts client-provided positions to internal offsets before analysis.
 
-## Verify It Is Running
+## Verify Upstream LSP4IJ Behavior
 
 1. Open a Perl file such as `lib/My/Module.pm` or `t/basic.t`.
-2. Confirm that LSP4IJ activates: the status bar should show the language server
-   indicator.
+2. Confirm that LSP4IJ activates: the status bar should show the language
+   server indicator, and the LSP console should show `perllsp --stdio` starting
+   successfully.
 3. Introduce a temporary syntax error (e.g., remove a semicolon).
 4. Confirm a diagnostic appears in the editor gutter.
 5. Remove the syntax error.
@@ -184,6 +165,12 @@ Try LSP-backed navigation:
 - **Find Usages**: `Alt+F7`
 - **Hover**: mouse over a symbol or `Ctrl+Q` / `Ctrl+J`
 - **Rename**: `Shift+F6`
+
+Also confirm:
+
+- workspace symbols do not retain closed virtual documents,
+- inline completion is available if enabled by your LSP4IJ build,
+- feature availability matches your LSP4IJ and IDE versions.
 
 LSP4IJ exposes available LSP features through IntelliJ's standard action system.
 Not all IntelliJ actions have LSP equivalents, but diagnostics, hover, go-to-definition,
@@ -202,8 +189,9 @@ perllsp --version
 perllsp --health
 ```
 
-If IntelliJ does not inherit your shell `PATH`, use an absolute path in the
-**Command** field.
+If IntelliJ does not inherit your shell `PATH`, set the absolute `perllsp`
+binary path in the upstream LSP4IJ integration settings. For older LSP4IJ builds,
+use the [legacy Raw Command fallback](INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md).
 
 ### `perllsp --stdio` appears to hang when run manually
 
@@ -218,8 +206,9 @@ perllsp --check path/to/file.pl
 
 ### No diagnostics for Perl files
 
-- Confirm the file name pattern in LSP4IJ matches the file extension (e.g.,
-  `*.pm`, `*.pl`, `*.t`).
+- Confirm the upstream LSP4IJ `perl-lsp` integration is enabled.
+- Confirm IntelliJ recognizes the file as Perl or that the file extension is a
+  common Perl extension such as `*.pm`, `*.pl`, or `*.t`.
 - Check that the LSP4IJ plugin is enabled in **Plugins**.
 - Open the LSP Console to confirm the server started without error.
 
@@ -253,13 +242,14 @@ reload `perllsp` without restarting IntelliJ IDEA.
 
 - Use the full path to `perllsp.exe` if it is not on the system `PATH`.
 - IntelliJ on Windows may not inherit PowerShell `PATH` entries. Set the binary
-  path explicitly in the LSP4IJ **Command** field.
+  path explicitly in the LSP4IJ integration settings.
 - Use forward slashes in paths or double backslashes:
-  `C:/path/to/perllsp.exe --stdio`
+  `C:/path/to/perllsp.exe`
 
 ## See Also
 
 - [Editor Setup](../how-to/EDITOR_SETUP.md)
+- [Legacy Raw Command Setup](INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md)
 - [Configuration Reference](../reference/CONFIG.md)
 - [Troubleshooting Guide](../how-to/TROUBLESHOOTING.md)
 - [LSP4IJ Documentation](https://github.com/redhat-developer/lsp4ij/blob/main/docs/user-guide.md)

--- a/docs/development/LSP_INTERACTIVE_LATENCY_ROLLOUT.md
+++ b/docs/development/LSP_INTERACTIVE_LATENCY_ROLLOUT.md
@@ -25,6 +25,16 @@ completion registration, deterministic inline-completion execution, and
 semantic-token full-only capability advertisement. These receipts remain wiring
 proofs; benchmark latency claims still require dedicated hardware.
 
+The JetBrains lane now has two separate surfaces:
+
+- Runtime/server contract: advertise standard LSP capabilities correctly, keep
+  server-generated request IDs inside the LSP integer range, support inline
+  completion through standard `inlineCompletionProvider` / dynamic
+  `textDocument/inlineCompletion` registration, and keep lean startup dials
+  documented.
+- User docs: prefer the upstream LSP4IJ `perl-lsp` integration when available,
+  and keep manual Raw Command setup in separate fallback/development guidance.
+
 | Phase | Tracker | Scope | Stack on |
 |---|---|---|---|
 | 1. Scope-lock doc | this PR (umbrella [#229](https://github.com/EffortlessMetrics/perl-lsp-swarm/issues/229)) | docs only | n/a - lands first |

--- a/docs/examples/intellij/README.md
+++ b/docs/examples/intellij/README.md
@@ -2,6 +2,11 @@
 
 This directory contains importable snippets for JetBrains IDEs.
 
+For LSP setup in JetBrains IDEs, use the upstream LSP4IJ `perl-lsp`
+integration when available. See
+[`../../EDITORS/INTELLIJ_IDEA_SETUP.md`](../../EDITORS/INTELLIJ_IDEA_SETUP.md).
+The external-tool snippets here are only for test-running workflows.
+
 ## External Tool: repo test watch
 
 `external-tools.xml` defines two external tools:

--- a/docs/how-to/EDITOR_SETUP.md
+++ b/docs/how-to/EDITOR_SETUP.md
@@ -33,7 +33,7 @@ perllsp --health
 | VS Code | install the extension or point it at `perllsp --stdio` | [docs/EDITORS/VS_CODE_SETUP.md](../EDITORS/VS_CODE_SETUP.md) |
 | Cursor | install the VS Code-compatible extension and configure it with the `perl-lsp.*` settings namespace | [docs/EDITORS/CURSOR_SETUP.md](../EDITORS/CURSOR_SETUP.md) |
 | Trae (ByteDance) | install the VS Code-compatible extension or set command to `perllsp --stdio` | [docs/EDITORS/TRAE_SETUP.md](../EDITORS/TRAE_SETUP.md) |
-| IntelliJ IDEA | install the LSP4IJ plugin and register `perllsp --stdio` as a Raw Command server | [docs/EDITORS/INTELLIJ_IDEA_SETUP.md](../EDITORS/INTELLIJ_IDEA_SETUP.md) |
+| IntelliJ IDEA / JetBrains IDEs | install or update LSP4IJ and use the upstream `perl-lsp` server entry | [docs/EDITORS/INTELLIJ_IDEA_SETUP.md](../EDITORS/INTELLIJ_IDEA_SETUP.md) |
 | Neovim | define a custom `perllsp` config with `vim.lsp.config()` and enable via `vim.lsp.enable()` (legacy `nvim-lspconfig` supported for older Neovim) | [docs/EDITORS/NEOVIM_SETUP.md](../EDITORS/NEOVIM_SETUP.md) |
 | Vim | use `vim-lsp` with `perllsp --stdio` | [docs/EDITORS/VIM_SETUP.md](../EDITORS/VIM_SETUP.md) |
 | coc.nvim | configure `languageserver.perl-lsp` in `coc-settings.json` to launch `perllsp --stdio`; works in Neovim and Vim when the buffer filetype is `perl` | [docs/EDITORS/COC_NEOVIM_SETUP.md](../EDITORS/COC_NEOVIM_SETUP.md) |
@@ -244,17 +244,18 @@ and `.t`. See [docs/EDITORS/OPENCODE_SETUP.md](../EDITORS/OPENCODE_SETUP.md) for
 
 ### IntelliJ IDEA
 
-Install the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin,
-then open **File > Settings > Languages & Frameworks > Language Servers** and add:
+Install or update the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij)
+plugin and use the upstream `perl-lsp` server entry when your LSP4IJ version
+includes it. Set the `perllsp` binary path only if LSP4IJ asks for it or the
+binary is not on the IDE `PATH`.
 
-| Field | Value |
-| --- | --- |
-| Name | `perl-lsp` |
-| Command | `perllsp --stdio` |
-| File name patterns | `*.pl`, `*.pm`, `*.t`, `*.psgi`, `*.cgi` |
+Use the legacy Raw Command fallback only when your LSP4IJ build does not yet
+include the upstream entry, when you are testing a local `perllsp` build, or
+when you need temporary custom launch flags:
+[docs/EDITORS/INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md](../EDITORS/INTELLIJ_IDEA_LEGACY_RAW_COMMAND.md).
 
-See [docs/EDITORS/INTELLIJ_IDEA_SETUP.md](../EDITORS/INTELLIJ_IDEA_SETUP.md) for the full workflow,
-initialization options, and troubleshooting.
+See [docs/EDITORS/INTELLIJ_IDEA_SETUP.md](../EDITORS/INTELLIJ_IDEA_SETUP.md)
+for the full workflow, initialization options, and troubleshooting.
 
 LSP4IJ-shaped clients use standard LSP 3.18 inline completion:
 `textDocument.inlineCompletion.dynamicRegistration` selects dynamic

--- a/docs/releases/v0.15.0.md
+++ b/docs/releases/v0.15.0.md
@@ -126,6 +126,13 @@ keep this release focused on the crash fix and type-safety contract:
 The latency rail benefits both Neovim and LSP4IJ; it is a quality lift
 on top of the crash fix that ships in 0.15.0.
 
+## JetBrains / LSP4IJ follow-up
+
+Post-0.15.0 note: the setup docs now treat LSP4IJ as an upstream integration
+path. Use the upstream LSP4IJ `perl-lsp` entry when available; manual Raw
+Command setup remains documented separately for older plugin versions and local
+development.
+
 ## Claim boundary
 
 This release contains: the JSON-RPC ID type-safety migration (#221,


### PR DESCRIPTION
Problem: Swarm now documents JetBrains as an upstream LSP4IJ integration path, but the source repo still has the older manual-first docs.
Fix: Mirror the merged swarm docs update so the main IntelliJ guide uses the upstream LSP4IJ perl-lsp entry and keeps Raw Command setup in a separate legacy/dev fallback page.
Verification:
- `cargo-safe xtask ci-hygiene check-doc-paths docs/EDITORS`
- `cargo-safe xtask ci-hygiene check-doc-paths docs/how-to`
- `cargo-safe xtask ci-hygiene check-doc-paths docs/releases`
- `cargo-safe xtask check-support-claims`
- `cargo-safe xtask check-devex-docs`
- `cargo-safe xtask doc-claims`
- `git diff --check origin/master...HEAD`