### PR TITLE
feat(code-actions): add quick-fix for PL304 missing POD coverage

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL304: Exported subroutine lacks POD documentation
+        c if c == DiagnosticCode::MissingPodCoverage.as_str() => {
+            actions.extend(quick_fixes::fix_missing_pod_coverage(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1964,6 +1964,46 @@ fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
     specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
+/// Insert a POD documentation stub before an exported subroutine (PL304).
+///
+/// Extracts the subroutine name from the diagnostic message and inserts a
+/// `=head2` skeleton immediately before the line containing the `sub` keyword.
+/// The stub is minimal but valid POD:
+///
+/// ```text
+/// =head2 name
+///
+/// Description.
+///
+/// =cut
+///
+/// ```
+pub fn fix_missing_pod_coverage(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let Some(sub_name) = diagnostic.message.split('\'').nth(1) else {
+        return Vec::new();
+    };
+    let Some((range_start, _)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let insert_pos = source[..range_start].rfind('\n').map_or(0, |p| p + 1);
+
+    let pod_stub = format!("=head2 {sub_name}\n\nDescription.\n\n=cut\n\n");
+
+    vec![CodeAction {
+        title: format!("Add '=head2 {sub_name}' POD documentation stub"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::MissingPodCoverage.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: insert_pos, end: insert_pos },
+                new_text: pod_stub,
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl304_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl304_bdd.rs
@@ -1,0 +1,246 @@
+//! BDD tests for the PL304 quick-fix handler: add POD documentation stub
+//!
+//! PL304 fires when an exported subroutine has no corresponding `=head2` or
+//! `=item` POD documentation.  The quick-fix inserts a `=head2 name` skeleton
+//! immediately before the `sub` line so the developer only has to fill in the
+//! description.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with an exported sub that lacks POD documentation
+//!   WHEN   a PL304 diagnostic is produced and code actions are requested
+//!   THEN   the expected action(s) are returned with correct edits
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers  (identical structure to quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL304 — Missing POD coverage
+// ===========================================================================
+
+#[test]
+fn pl304_exported_sub_produces_add_pod_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN an exported subroutine that has no POD documentation
+    let source = "package MyMod;\nuse Exporter 'import';\nour @EXPORT = qw(frobnicate);\n\nsub frobnicate { 1 }\n";
+
+    let sub_start = source.find("sub frobnicate").ok_or("sub not found")?;
+    let sub_end = source.find('}').ok_or("closing brace not found")? + 1;
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'frobnicate' has no POD documentation",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN an action is returned that offers to add a POD stub
+    let action = find_action(&actions, |t| t.contains("frobnicate"))
+        .ok_or_else(|| format!("no PL304 action in: {:?}", actions))?;
+
+    assert!(
+        action.title.contains("=head2"),
+        "title should reference =head2, got: {}",
+        action.title
+    );
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "adding POD is the only fix, so it should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn pl304_edit_inserts_pod_stub_before_sub_line() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a module with an undocumented exported sub
+    let source =
+        "package MyMod;\nuse Exporter 'import';\nour @EXPORT = qw(run);\n\nsub run { 42 }\n";
+
+    let sub_start = source.find("sub run").ok_or("sub not found")?;
+    let sub_end = sub_start + "sub run { 42 }".len();
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'run' has no POD documentation",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("run"))
+        .ok_or_else(|| format!("no action in: {:?}", actions))?;
+
+    // WHEN the edit is applied
+    let result = edited(source, action);
+
+    // THEN =head2 appears on the line immediately before `sub run`
+    let pod_pos = result.find("=head2 run").ok_or("=head2 run not found in result")?;
+    let sub_pos = result.find("sub run").ok_or("sub run not found in result")?;
+    assert!(pod_pos < sub_pos, "=head2 should appear before sub run");
+
+    // AND the stub ends with =cut before the sub
+    let between = &result[pod_pos..sub_pos];
+    assert!(between.contains("=cut"), "stub should end with =cut before the sub");
+
+    Ok(())
+}
+
+#[test]
+fn pl304_pod_stub_format_is_correct() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a minimal source with an exported sub
+    let source = "package M;\nuse Exporter;\nour @EXPORT = qw(greet);\nsub greet { 'hello' }\n";
+
+    let sub_start = source.find("sub greet").ok_or("sub not found")?;
+    let sub_end = source.rfind('}').ok_or("} not found")? + 1;
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'greet' has no POD documentation",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("greet"))
+        .ok_or_else(|| format!("no action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN the stub has the exact expected format
+    assert!(
+        result.contains("=head2 greet\n\nDescription.\n\n=cut\n"),
+        "stub format wrong; result:\n{result}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pl304_sub_name_appears_in_action_title() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic for a sub named process_data
+    let source = "package Proc;\nuse Exporter 'import';\nour @EXPORT = qw(process_data);\nsub process_data { }\n";
+
+    let sub_start = source.find("sub process_data").ok_or("sub not found")?;
+    let sub_end = source.rfind('}').ok_or("} not found")? + 1;
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'process_data' has no POD documentation",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title contains the exact sub name
+    let action = find_action(&actions, |t| t.contains("process_data"))
+        .ok_or_else(|| format!("no action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Add '=head2 process_data' POD documentation stub");
+
+    Ok(())
+}
+
+#[test]
+fn pl304_invalid_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic with an out-of-bounds byte range
+    let source = "sub foo { }\n";
+    let oob_start = source.len() + 10;
+    let oob_end = oob_start + 5;
+
+    let diag = make_diag(
+        oob_start,
+        oob_end,
+        "PL304",
+        "Exported subroutine 'foo' has no POD documentation",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no actions are returned (range guard fires)
+    let pl304_actions: Vec<_> = actions.iter().filter(|a| a.title.contains("=head2")).collect();
+    assert!(
+        pl304_actions.is_empty(),
+        "OOB range should produce no PL304 actions, got: {:?}",
+        pl304_actions
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pl304_dispatch_smoke_test_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a valid PL304 diagnostic delivered through the full provider pipeline
+    let source =
+        "package Smoke;\nuse Exporter 'import';\nour @EXPORT = qw(smoke_fn);\nsub smoke_fn { 1 }\n";
+
+    let sub_start = source.find("sub smoke_fn").ok_or("sub not found")?;
+    let sub_end = source.rfind('}').ok_or("} not found")? + 1;
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'smoke_fn' has no POD documentation",
+    );
+
+    // WHEN code actions are collected via the full provider
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    let actions = provider.get_code_actions(&ast, (sub_start, sub_end), &[diag]);
+
+    // THEN at least one QuickFix action is returned — the routing table wires up the handler
+    let quick_fix_actions: Vec<_> =
+        actions.iter().filter(|a| a.kind == CodeActionKind::QuickFix).collect();
+    assert!(
+        !quick_fix_actions.is_empty(),
+        "PL304 dispatch must reach fix_missing_pod_coverage; got actions: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

PL304 fires when an exported subroutine has no `=head2` or `=item` POD documentation. The LSP correctly emits the diagnostic (`perl-lsp-rs-core/src/providers/diagnostics/lints/pod_coverage.rs`) but before this PR the lightbulb returned **no code actions** — `DiagnosticCode::MissingPodCoverage` had no arm in the dispatch table and silently fell through to `_ => {}`.

This PR closes that gap with a minimal, focused implementation.

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

Added `pub fn fix_missing_pod_coverage(source, diagnostic) -> Vec<CodeAction>`:

- Extracts the sub name from the diagnostic message  
  (`"Exported subroutine 'name' has no POD documentation"` → `name`)
- Validates the byte range via the existing `valid_diagnostic_range` guard  
  (returns `[]` on OOB or non-char-boundary ranges — no panic path)
- Finds the start of the line containing the `sub` keyword  
  (`rfind('\n')` on `source[..range_start]`)
- Inserts a minimal but valid POD skeleton at that line start:

```perl
=head2 name

Description.

=cut

```

- `is_preferred: true` — there is exactly one sensible automated fix for a missing POD block

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

Added one routing arm for `PL304`:

```rust
// PL304: Exported subroutine lacks POD documentation
c if c == DiagnosticCode::MissingPodCoverage.as_str() => {
    actions.extend(quick_fixes::fix_missing_pod_coverage(source, &qf_diag));
}
```

### `crates/perl-lsp-rs-core/tests/quick_fix_pl304_bdd.rs` (new)

Six BDD integration tests following the repo's established GIVEN/WHEN/THEN pattern (identical helper structure to `quick_fix_new_codes_bdd.rs`):

| # | Test | What it pins |
|---|------|-------------|
| 1 | `pl304_exported_sub_produces_add_pod_action` | Action returned, kind = QuickFix, is_preferred = true |
| 2 | `pl304_edit_inserts_pod_stub_before_sub_line` | `=head2` appears before `sub`, stub contains `=cut` |
| 3 | `pl304_pod_stub_format_is_correct` | Exact format: `=head2 name\n\nDescription.\n\n=cut\n` |
| 4 | `pl304_sub_name_appears_in_action_title` | Title is `"Add '=head2 name' POD documentation stub"` |
| 5 | `pl304_invalid_range_returns_no_actions` | OOB range → no actions (range guard) |
| 6 | `pl304_dispatch_smoke_test_reaches_handler` | End-to-end: PL304 through `get_code_actions` → QuickFix action |

## Test results

```
running 6 tests
test pl304_exported_sub_produces_add_pod_action ... ok
test pl304_dispatch_smoke_test_reaches_handler ... ok
test pl304_edit_inserts_pod_stub_before_sub_line ... ok
test pl304_invalid_range_returns_no_actions ... ok
test pl304_sub_name_appears_in_action_title ... ok
test pl304_pod_stub_format_is_correct ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

17 pre-existing `quick_fix_new_codes_bdd` tests remain green.  
`cargo clippy -p perl-lsp-rs-core --lib` clean.  
`cargo fmt -p perl-lsp-rs-core` clean.

## Why this matters

Perl module authors who export functions are strongly encouraged (and often required by CPAN policy) to document every exported symbol with POD. The `perldoc` toolchain and `Pod::Coverage` enforce this. When `perl-lsp` emits a PL304 hint the developer sees the problem, but without a code action they have to type the POD boilerplate by hand. This one-click stub insertion removes that friction — the developer fills in the description, the structure is already correct.

## Design notes

- The inserted stub uses `=head2` (not `=item`) because `=head2` is the conventional choice for module-level function documentation in Perl (CPAN style, `perldoc` convention). `=item` is valid but typically appears inside `=over`/`=back` blocks.
- The placeholder text `Description.` is intentionally generic — it signals clearly that the stub needs editing.
- The handler is intentionally narrow: it only fires on `PL304` / `MissingPodCoverage`. No other diagnostic codes are affected.
- No changes to diagnostic emission logic in `pod_coverage.rs`.

## Scope

- 3 files changed: `quick_fixes.rs` (+37 lines), `diagnostic_routes.rs` (+4 lines), new `tests/quick_fix_pl304_bdd.rs` (+249 lines)
- No new dependencies
- No production logic changed outside the code-actions module

https://claude.ai/code/session_01CR6QbZJ2znSg5BjZFadH2i

---
_Generated by [Claude Code](https://claude.ai/code/session_01CR6QbZJ2znSg5BjZFadH2i)_