### PR TITLE
test(inline): mirror trigger-kind protocol policy (#9621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Inline completion now treats automatic trigger requests conservatively by
+  returning only the top deterministic candidate, while explicit invoked
+  requests keep the richer deterministic candidate set.
+
 ### Planned
 
 - Documented the Rust 1.95 / 0.14.0 rollout sequence before implementation: compatibility spike first, then MSRV/toolchain, lint, no-panic, file-policy, CI routing, and release-prep lanes.

--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -50,6 +50,24 @@ struct SelectedInlineCompletionInfo {
     text: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InlineCompletionTriggerKind {
+    Invoked,
+    Automatic,
+    LegacyNoContext,
+}
+
+fn inline_completion_trigger_kind(
+    params: &Value,
+) -> Result<InlineCompletionTriggerKind, JsonRpcError> {
+    match params.pointer("/context/triggerKind").and_then(Value::as_u64) {
+        Some(1) => Ok(InlineCompletionTriggerKind::Invoked),
+        Some(2) => Ok(InlineCompletionTriggerKind::Automatic),
+        Some(_) => Err(invalid_params("Invalid inlineCompletion.context.triggerKind")),
+        None => Ok(InlineCompletionTriggerKind::LegacyNoContext),
+    }
+}
+
 fn selected_inline_completion_info(
     params: &Value,
 ) -> Result<Option<SelectedInlineCompletionInfo>, JsonRpcError> {
@@ -112,6 +130,17 @@ fn constrain_inline_completions_to_selected_info(
             }
         })
         .collect();
+    list
+}
+
+fn apply_inline_completion_trigger_policy(
+    mut list: perl_lsp_rs_core::providers::inline_completion::InlineCompletionList,
+    trigger_kind: InlineCompletionTriggerKind,
+) -> perl_lsp_rs_core::providers::inline_completion::InlineCompletionList {
+    if trigger_kind == InlineCompletionTriggerKind::Automatic {
+        list.items.truncate(1);
+    }
+
     list
 }
 
@@ -658,6 +687,7 @@ impl LspServer {
         if let Some(params) = params {
             let uri = req_uri(&params)?;
             let (line, character) = req_position(&params)?;
+            let trigger_kind = inline_completion_trigger_kind(&params)?;
             let selected_completion = selected_inline_completion_info(&params)?;
 
             // Snapshot text under document lock, then release before any slow work
@@ -689,6 +719,7 @@ impl LspServer {
                                 line,
                                 character,
                             );
+                            let list = apply_inline_completion_trigger_policy(list, trigger_kind);
                             if !list.items.is_empty() || !ai_config.fallback {
                                 return Ok(Some(serde_json::to_value(list).map_err(|e| {
                                     crate::protocol::internal_error(&format!(
@@ -722,6 +753,7 @@ impl LspServer {
                 line,
                 character,
             );
+            let completions = apply_inline_completion_trigger_policy(completions, trigger_kind);
             return Ok(Some(serde_json::to_value(completions).map_err(|e| {
                 crate::protocol::internal_error(&format!(
                     "Failed to serialize inline completions: {}",

--- a/crates/perl-lsp-rs/tests/lsp_inline_completion_registration_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_inline_completion_registration_tests.rs
@@ -144,6 +144,31 @@ fn lsp4ij_dynamic_inline_completion_with_trigger_context_returns_deterministic_i
 }
 
 #[test]
+fn inline_completion_automatic_trigger_returns_one_conservative_item() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "textDocument": { "inlineCompletion": { "dynamicRegistration": true } }
+    })))?;
+
+    let uri = "file:///inline_automatic_trigger.pl";
+    harness.open(uri, "use ")?;
+
+    let result = request_inline_completion_with_trigger_kind(&mut harness, uri, 0, 4, 2)?;
+    let items = result
+        .get("items")
+        .and_then(Value::as_array)
+        .ok_or("inline completion result must contain items array")?;
+
+    assert_eq!(
+        items.len(),
+        1,
+        "automatic inline completion must show only the top conservative item"
+    );
+    assert_eq!(items[0].get("insertText"), Some(&json!("strict;")));
+    Ok(())
+}
+
+#[test]
 fn inline_completion_invoked_trigger_returns_deterministic_items() -> TestResult {
     let mut harness = LspHarness::new();
     harness.initialize(Some(json!({
@@ -160,9 +185,12 @@ fn inline_completion_invoked_trigger_returns_deterministic_items() -> TestResult
         .ok_or("inline completion result must contain items array")?;
 
     assert!(!items.is_empty(), "invoked trigger must return deterministic items");
+    let insert_texts = item_insert_texts(items);
+    assert!(insert_texts.contains(&"strict;"), "expected strict; item, got: {items:?}");
+    assert!(insert_texts.contains(&"warnings;"), "expected warnings; item, got: {items:?}");
     assert!(
-        items.iter().any(|item| item.get("insertText") == Some(&json!("strict;"))),
-        "expected deterministic strict; suggestion for invoked trigger, got: {items:?}"
+        insert_texts.contains(&"feature ':5.36';"),
+        "expected feature pragma item, got: {items:?}"
     );
     Ok(())
 }
@@ -361,6 +389,8 @@ fn inline_completion_without_context_remains_permissive() -> TestResult {
         items.iter().any(|item| item.get("insertText") == Some(&json!("strict;"))),
         "legacy no-context request remains permissive behavior, got: {items:?}"
     );
+    let insert_texts = item_insert_texts(items);
+    assert!(insert_texts.contains(&"warnings;"), "legacy no-context request should stay rich");
     Ok(())
 }
 
@@ -405,6 +435,34 @@ fn inline_completion_unsupported_position_returns_empty_items() -> TestResult {
         .ok_or("inline completion result must contain items array")?;
 
     assert!(items.is_empty(), "unsupported position must not emit noisy suggestions");
+    Ok(())
+}
+
+#[test]
+fn inline_completion_invalid_trigger_kind_is_rejected() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(Some(json!({
+        "textDocument": { "inlineCompletion": { "dynamicRegistration": true } }
+    })))?;
+
+    let uri = "file:///inline_invalid_trigger_kind.pl";
+    harness.open(uri, "use ")?;
+    let response = harness.request_raw(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "textDocument/inlineCompletion",
+        "params": {
+            "textDocument": { "uri": uri },
+            "position": { "line": 0, "character": 4 },
+            "context": { "triggerKind": 99 }
+        }
+    }));
+
+    assert_eq!(response.pointer("/error/code"), Some(&json!(-32602)));
+    assert_eq!(
+        response.pointer("/error/message"),
+        Some(&json!("Invalid inlineCompletion.context.triggerKind"))
+    );
     Ok(())
 }
 
@@ -601,4 +659,8 @@ fn request_inline_completion_without_context(
             "position": { "line": line, "character": character }
         }),
     )
+}
+
+fn item_insert_texts(items: &[Value]) -> Vec<&str> {
+    items.iter().filter_map(|item| item.get("insertText").and_then(Value::as_str)).collect()
 }


### PR DESCRIPTION
Problem: swarm now locks inline-completion trigger policy so automatic requests are conservative and invoked requests keep richer deterministic candidates. The release repo needs the curated mirror.\n\nFix: mirror perl-lsp-swarm#469 runtime triggerKind policy, protocol tests, and the source-side changelog note.\n\nVerification:\n- \cargo fmt -p perl-lsp-rs -- --check\\n- \cargo test -p perl-lsp-rs --test lsp_inline_completion_registration_tests --locked\\n- \cargo test -p perl-lsp-rs --test lsp_ai_inline_completion_tests --features expose_lsp_test_api --locked\\n- \cargo test -p perl-lsp-rs-core --lib inline_completion --locked\\n- \cargo check -p perl-lsp-rs --locked\\n- \cargo build --release -p perl-lsp-rs --bin perl-lsp --locked\\n- \cargo xtask smoke inline-completion --binary target/release/perl-lsp\\n- \cargo xtask inline-completion-smoke --binary target/release/perl-lsp\\n- \git diff --check\\n\nNotes: source checkout at H:\\Code\\Rust3\\perl-lsp has unrelated local release-doc edits, so this PR was prepared in a clean temporary worktree.