### PR TITLE
sync: mirror swarm LSP contract locks (#9623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added LSP 3.18 claim-boundary guards, text-document-content contract tests,
+  and the `xtask lsp-318-claims` check so unsupported protocol surfaces stay
+  explicit instead of accidentally documented as supported.
+- Added the semantic inline-completion roadmap for deterministic, parse-safe,
+  context-aware ghost text before any optional AI expansion.
+
 ### Fixed
 
 - Inline completion now treats automatic trigger requests conservatively by

--- a/crates/perl-lsp-rs/src/runtime/language/virtual_content.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/virtual_content.rs
@@ -26,6 +26,14 @@ impl LspServer {
             data: None,
         })?;
 
+        if !is_valid_virtual_content_uri(uri) {
+            return Err(JsonRpcError {
+                code: crate::protocol::INVALID_PARAMS,
+                message: "Missing or invalid URI".to_string(),
+                data: None,
+            });
+        }
+
         let workspace_config = self.workspace_config.lock().clone();
         if let Some(content) = fetch_virtual_content(uri, &workspace_config) {
             Ok(Some(json!({ "text": content })))
@@ -43,6 +51,17 @@ impl LspServer {
         self.send_request("workspace/textDocumentContent/refresh", json!({ "uri": uri }))
             .map(|_| ())
     }
+}
+
+fn is_valid_virtual_content_uri(uri: &str) -> bool {
+    let Some((scheme, rest)) = uri.split_once("://") else {
+        return false;
+    };
+
+    !scheme.is_empty()
+        && !rest.is_empty()
+        && scheme.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
+        && !uri.chars().any(char::is_whitespace)
 }
 
 /// Fetch content for a virtual URI
@@ -130,6 +149,14 @@ mod tests {
         let config = WorkspaceConfig::default();
         let content = fetch_virtual_content(uri, &config);
         assert!(content.is_none());
+    }
+
+    #[test]
+    fn parser_virtual_content_rejects_malformed_uri() {
+        assert!(!is_valid_virtual_content_uri("not a uri"));
+        assert!(!is_valid_virtual_content_uri("perldoc://"));
+        assert!(is_valid_virtual_content_uri("perldoc://strict"));
+        assert!(is_valid_virtual_content_uri("perldoc://Module::Name"));
     }
 
     #[test]

--- a/crates/perl-lsp-rs/tests/lsp_318_negative_claims.rs
+++ b/crates/perl-lsp-rs/tests/lsp_318_negative_claims.rs
@@ -1,0 +1,375 @@
+//! Negative claim tests for optional LSP 3.18 surfaces.
+//!
+//! These tests do not implement new protocol features. They lock the current
+//! support boundary: optional 3.18 structures must be absent unless the server
+//! has explicit capability handling and wire tests for them.
+
+mod support;
+
+use parking_lot::Mutex;
+use perl_lsp::LspServer;
+use perl_lsp::protocol::METHOD_NOT_FOUND;
+use perl_lsp::server::MessageType;
+use perl_lsp_rs_core::runtime::tuning::RuntimeTuning;
+use perl_lsp_rs_core::transport::framing::ContentLengthFramer;
+use serde_json::{Value, json};
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Duration;
+use support::lsp_harness::LspHarness;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Clone, Default)]
+struct OutputCapture {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl OutputCapture {
+    fn messages(&self) -> TestResult<Vec<Value>> {
+        let bytes = self.buffer.lock().clone();
+        let mut framer = ContentLengthFramer::new();
+        framer.push(&bytes);
+
+        let mut messages = Vec::new();
+        while let Some(body) = framer.try_next()? {
+            messages.push(serde_json::from_slice::<Value>(&body)?);
+        }
+        Ok(messages)
+    }
+}
+
+impl Write for OutputCapture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer.lock().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn initialize_does_not_advertise_unimplemented_318_capabilities() -> TestResult {
+    let mut harness = LspHarness::new_raw();
+    let init = harness.initialize_ready("file:///workspace", Some(json!({})))?;
+    let caps = init
+        .get("capabilities")
+        .ok_or_else(|| format!("initialize response missing capabilities: {init}"))?;
+
+    assert_absent(caps, "/semanticTokensProvider/full/delta")?;
+    assert_absent(caps, "/documentRangesFormattingProvider")?;
+    assert_absent(caps, "/experimental/inlineCompletionProvider")?;
+    assert_absent(caps, "/codeActionProvider/documentation")?;
+    assert_absent(caps, "/completionProvider/applyKind")?;
+    assert_absent(caps, "/workspace/foldingRange")?;
+
+    Ok(())
+}
+
+#[test]
+fn semantic_tokens_delta_request_returns_method_not_found() -> TestResult {
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_ready("file:///workspace", Some(json!({})))?;
+    harness.open("file:///test.pl", "use strict;\n")?;
+
+    let response = harness.request_raw(json!({
+        "jsonrpc": "2.0",
+        "id": 318,
+        "method": "textDocument/semanticTokens/full/delta",
+        "params": {
+            "textDocument": { "uri": "file:///test.pl" },
+            "previousResultId": "stale-result"
+        }
+    }));
+
+    assert_error_code(&response, METHOD_NOT_FOUND)
+}
+
+#[test]
+fn completion_response_does_not_emit_apply_kind_without_client_support() -> TestResult {
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_ready("file:///workspace", Some(json!({})))?;
+    harness.open("file:///test.pl", "sub alpha {}\nal")?;
+
+    let completion = harness.request(
+        "textDocument/completion",
+        json!({
+            "textDocument": { "uri": "file:///test.pl" },
+            "position": { "line": 1, "character": 2 },
+            "context": { "triggerKind": 1 }
+        }),
+    )?;
+
+    assert_no_key(&completion, "applyKind")?;
+    if let Some(item_defaults) = completion.get("itemDefaults") {
+        assert!(
+            item_defaults.get("data").is_none(),
+            "CompletionList.itemDefaults.data is not claimed without explicit support: {completion}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn code_action_and_workspace_edit_responses_do_not_emit_optional_318_shapes() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+    harness.open("file:///test.pl", "$undefined")?;
+
+    let actions = harness.request(
+        "textDocument/codeAction",
+        json!({
+            "textDocument": { "uri": "file:///test.pl" },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 10 }
+            },
+            "context": {
+                "diagnostics": [],
+                "only": ["quickfix", "refactor"],
+                "triggerKind": 1
+            }
+        }),
+    )?;
+
+    assert_no_key(&actions, "documentation")?;
+    assert_no_key(&actions, "tags")?;
+    assert_no_key(&actions, "metadata")?;
+    assert_no_key(&actions, "snippet")?;
+    assert_no_command_tooltip(&actions)?;
+
+    let mut rename_harness = LspHarness::new();
+    rename_harness.initialize(None)?;
+    rename_harness.open("file:///rename.pl", "my $old = 1;\n$old++;")?;
+
+    let rename = rename_harness.request(
+        "textDocument/rename",
+        json!({
+            "textDocument": { "uri": "file:///rename.pl" },
+            "position": { "line": 0, "character": 4 },
+            "newName": "new"
+        }),
+    )?;
+
+    assert_no_key(&rename, "metadata")?;
+    assert_no_key(&rename, "snippet")?;
+    Ok(())
+}
+
+#[test]
+fn diagnostics_keep_plain_string_messages_without_markup_support() -> TestResult {
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_ready("file:///workspace", Some(json!({})))?;
+    harness.open("file:///test.pl", "use strict\nmy $x = ;\n")?;
+
+    let report = harness.request(
+        "textDocument/diagnostic",
+        json!({
+            "textDocument": { "uri": "file:///test.pl" },
+            "identifier": "perl-lsp",
+            "previousResultId": null
+        }),
+    )?;
+
+    assert_plain_message_values(&report)?;
+    Ok(())
+}
+
+#[test]
+fn dynamic_file_watcher_registration_uses_string_globs_not_relative_patterns() -> TestResult {
+    let mut harness = LspHarness::new_with_tuning(RuntimeTuning::normal_defaults());
+    harness.initialize(Some(json!({
+        "workspace": {
+            "didChangeWatchedFiles": {
+                "dynamicRegistration": true
+            }
+        }
+    })))?;
+
+    let requests = harness.drain_server_requests(250);
+    let registration = registration_for_method(&requests, "workspace/didChangeWatchedFiles")
+        .ok_or("expected file watcher registration")?;
+    let watchers = registration
+        .pointer("/registerOptions/watchers")
+        .and_then(Value::as_array)
+        .ok_or("watcher registration missing watchers")?;
+
+    for watcher in watchers {
+        let glob_pattern = watcher
+            .get("globPattern")
+            .ok_or_else(|| format!("watcher missing globPattern: {watcher}"))?;
+        assert!(
+            glob_pattern.is_string(),
+            "relative-pattern objects are not claimed for file watchers: {watcher}"
+        );
+        assert!(
+            glob_pattern.get("baseUri").is_none(),
+            "relative-pattern baseUri must be absent unless relativePatternSupport is handled: {watcher}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn folding_range_refresh_is_not_sent_without_client_support() -> TestResult {
+    let output = OutputCapture::default();
+    let server = LspServer::with_output(Arc::new(Mutex::new(
+        Box::new(output.clone()) as Box<dyn Write + Send>
+    )));
+
+    server.request_folding_range_refresh()?;
+    std::thread::sleep(Duration::from_millis(50));
+
+    let messages = output.messages()?;
+    assert!(
+        messages.is_empty(),
+        "workspace/foldingRange/refresh must not be sent without refreshSupport: {messages:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn window_message_type_does_not_emit_debug_level() -> TestResult {
+    let output = OutputCapture::default();
+    let server = LspServer::with_output(Arc::new(Mutex::new(
+        Box::new(output.clone()) as Box<dyn Write + Send>
+    )));
+
+    server.log_message(MessageType::Info, "info")?;
+    server.show_message(MessageType::Warning, "warning")?;
+    std::thread::sleep(Duration::from_millis(50));
+
+    for message in output.messages()? {
+        if matches!(
+            message.get("method").and_then(Value::as_str),
+            Some("window/logMessage" | "window/showMessage")
+        ) {
+            let typ = message
+                .pointer("/params/type")
+                .and_then(Value::as_i64)
+                .ok_or_else(|| format!("window message missing numeric type: {message}"))?;
+            assert_ne!(typ, 5, "MessageType.Debug is not claimed: {message}");
+        }
+    }
+    Ok(())
+}
+
+fn assert_absent(value: &Value, pointer: &str) -> TestResult {
+    assert!(value.pointer(pointer).is_none(), "{pointer} must be absent from {value}");
+    Ok(())
+}
+
+fn assert_error_code(response: &Value, expected_code: i32) -> TestResult {
+    let code = response
+        .pointer("/error/code")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| format!("expected JSON-RPC error code in response: {response}"))?;
+    assert_eq!(code, i64::from(expected_code), "response: {response}");
+    Ok(())
+}
+
+fn assert_no_key(value: &Value, key: &str) -> TestResult {
+    let mut paths = Vec::new();
+    collect_key_paths(value, key, "$", &mut paths);
+    assert!(paths.is_empty(), "key '{key}' must be absent; found at {}", paths.join(", "));
+    Ok(())
+}
+
+fn collect_key_paths(value: &Value, key: &str, path: &str, paths: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (name, child) in map {
+                let child_path = format!("{path}.{name}");
+                if name == key {
+                    paths.push(child_path.clone());
+                }
+                collect_key_paths(child, key, &child_path, paths);
+            }
+        }
+        Value::Array(items) => {
+            for (idx, child) in items.iter().enumerate() {
+                collect_key_paths(child, key, &format!("{path}[{idx}]"), paths);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_no_command_tooltip(value: &Value) -> TestResult {
+    let mut paths = Vec::new();
+    collect_command_tooltip_paths(value, "$", &mut paths);
+    assert!(
+        paths.is_empty(),
+        "Command.tooltip is not claimed; found command objects with tooltip at {}",
+        paths.join(", ")
+    );
+    Ok(())
+}
+
+fn collect_command_tooltip_paths(value: &Value, path: &str, paths: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            if map.get("command").is_some() && map.get("tooltip").is_some() {
+                paths.push(path.to_string());
+            }
+            for (name, child) in map {
+                collect_command_tooltip_paths(child, &format!("{path}.{name}"), paths);
+            }
+        }
+        Value::Array(items) => {
+            for (idx, child) in items.iter().enumerate() {
+                collect_command_tooltip_paths(child, &format!("{path}[{idx}]"), paths);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_plain_message_values(value: &Value) -> TestResult {
+    let mut non_string_paths = Vec::new();
+    collect_non_string_message_paths(value, "$", &mut non_string_paths);
+    assert!(
+        non_string_paths.is_empty(),
+        "Diagnostic.message MarkupContent is not claimed; non-string message values at {}",
+        non_string_paths.join(", ")
+    );
+    Ok(())
+}
+
+fn collect_non_string_message_paths(value: &Value, path: &str, paths: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (name, child) in map {
+                let child_path = format!("{path}.{name}");
+                if name == "message" && !child.is_string() {
+                    paths.push(child_path.clone());
+                }
+                collect_non_string_message_paths(child, &child_path, paths);
+            }
+        }
+        Value::Array(items) => {
+            for (idx, child) in items.iter().enumerate() {
+                collect_non_string_message_paths(child, &format!("{path}[{idx}]"), paths);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn registration_for_method<'a>(requests: &'a [Value], method: &str) -> Option<&'a Value> {
+    requests.iter().find_map(|request| {
+        if request.get("method").and_then(Value::as_str) != Some("client/registerCapability") {
+            return None;
+        }
+
+        request.pointer("/params/registrations").and_then(Value::as_array).and_then(
+            |registrations| {
+                registrations
+                    .iter()
+                    .find(|entry| entry.get("method").and_then(Value::as_str) == Some(method))
+            },
+        )
+    })
+}

--- a/crates/perl-lsp-rs/tests/lsp_text_document_content_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_text_document_content_tests.rs
@@ -1,0 +1,186 @@
+//! Wire-contract tests for LSP 3.18 `workspace/textDocumentContent`.
+
+mod support;
+
+use parking_lot::Mutex;
+use perl_lsp::LspServer;
+use perl_lsp::protocol::{INVALID_PARAMS, INVALID_REQUEST};
+use perl_lsp_rs_core::transport::framing::ContentLengthFramer;
+use serde_json::{Value, json};
+use std::io::Write;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use support::lsp_harness::LspHarness;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Clone, Default)]
+struct OutputCapture {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl OutputCapture {
+    fn messages(&self) -> TestResult<Vec<Value>> {
+        let bytes = self.buffer.lock().clone();
+        let mut framer = ContentLengthFramer::new();
+        framer.push(&bytes);
+
+        let mut messages = Vec::new();
+        while let Some(body) = framer.try_next()? {
+            messages.push(serde_json::from_slice::<Value>(&body)?);
+        }
+        Ok(messages)
+    }
+}
+
+impl Write for OutputCapture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer.lock().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn initialized_harness() -> Result<LspHarness, String> {
+    let mut harness = LspHarness::new_raw();
+    harness.initialize_ready("file:///workspace", Some(json!({})))?;
+    Ok(harness)
+}
+
+fn text_document_content_response(params: Option<Value>) -> Result<Value, String> {
+    let mut harness = initialized_harness()?;
+    let mut request = json!({
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "workspace/textDocumentContent"
+    });
+    if let Some(params) = params {
+        request["params"] = params;
+    }
+    Ok(harness.request_raw(request))
+}
+
+fn assert_error_code(response: &Value, expected_code: i32) -> TestResult {
+    let code = response
+        .pointer("/error/code")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| format!("expected JSON-RPC error code in response: {response}"))?;
+    assert_eq!(code, i64::from(expected_code), "response: {response}");
+    Ok(())
+}
+
+fn wait_for_method(output: &OutputCapture, method: &str) -> TestResult<Value> {
+    let deadline = Instant::now() + Duration::from_millis(250);
+    loop {
+        let messages = output.messages()?;
+        if let Some(message) = messages
+            .into_iter()
+            .find(|message| message.get("method").and_then(Value::as_str) == Some(method))
+        {
+            return Ok(message);
+        }
+
+        if Instant::now() >= deadline {
+            return Err(format!("method {method} was not emitted").into());
+        }
+
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[test]
+fn initialize_advertises_perldoc_text_document_content_scheme() -> TestResult {
+    let mut harness = LspHarness::new_raw();
+    let init = harness.initialize_ready("file:///workspace", Some(json!({})))?;
+    let schemes = init
+        .pointer("/capabilities/workspace/textDocumentContent/schemes")
+        .and_then(Value::as_array)
+        .ok_or_else(|| format!("missing workspace.textDocumentContent.schemes: {init}"))?;
+    let names: Vec<&str> = schemes.iter().filter_map(Value::as_str).collect();
+
+    assert_eq!(names, vec!["perldoc"]);
+    Ok(())
+}
+
+#[test]
+fn text_document_content_missing_params_returns_invalid_params() -> TestResult {
+    let response = text_document_content_response(None)?;
+    assert_error_code(&response, INVALID_PARAMS)
+}
+
+#[test]
+fn text_document_content_missing_uri_returns_invalid_params() -> TestResult {
+    let response = text_document_content_response(Some(json!({})))?;
+    assert_error_code(&response, INVALID_PARAMS)
+}
+
+#[test]
+fn text_document_content_invalid_uri_returns_invalid_params() -> TestResult {
+    let response = text_document_content_response(Some(json!({ "uri": "not a uri" })))?;
+    assert_error_code(&response, INVALID_PARAMS)
+}
+
+#[test]
+fn text_document_content_unsupported_scheme_returns_deterministic_error() -> TestResult {
+    let response =
+        text_document_content_response(Some(json!({ "uri": "unsupported://some/path" })))?;
+    assert_error_code(&response, INVALID_REQUEST)?;
+    let message = response
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("missing error message in response: {response}"))?;
+    assert!(
+        message.contains("Unsupported URI scheme or content not found"),
+        "unexpected unsupported-scheme error: {message}"
+    );
+    Ok(())
+}
+
+#[test]
+fn text_document_content_perldoc_strict_returns_text_or_explicit_unavailable_error() -> TestResult {
+    let response = text_document_content_response(Some(json!({ "uri": "perldoc://strict" })))?;
+
+    if response.get("error").is_some() {
+        assert_error_code(&response, INVALID_REQUEST)?;
+        let message = response
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("missing error message in response: {response}"))?;
+        assert!(
+            message.contains("Unsupported URI scheme or content not found"),
+            "perldoc unavailable path should be explicit, got: {message}"
+        );
+        return Ok(());
+    }
+
+    let text = response
+        .pointer("/result/text")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("workspace/textDocumentContent missing result.text: {response}"))?;
+    assert!(!text.trim().is_empty(), "perldoc text must not be empty");
+    assert!(text.to_ascii_lowercase().contains("strict"), "strict perldoc should mention strict");
+    Ok(())
+}
+
+#[test]
+fn text_document_content_refresh_uses_bounded_server_request_id() -> TestResult {
+    let output = OutputCapture::default();
+    let server = LspServer::with_output(Arc::new(Mutex::new(
+        Box::new(output.clone()) as Box<dyn Write + Send>
+    )));
+
+    server.request_text_document_content_refresh("perldoc://strict")?;
+
+    let request = wait_for_method(&output, "workspace/textDocumentContent/refresh")?;
+
+    let id = request
+        .get("id")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| format!("refresh request missing integer id: {request}"))?;
+    assert!((1..=i64::from(i32::MAX)).contains(&id), "request id out of bounds: {id}");
+    assert_eq!(request.pointer("/params/uri"), Some(&json!("perldoc://strict")));
+    Ok(())
+}

--- a/docs/development/INLINE_COMPLETION_ROADMAP.md
+++ b/docs/development/INLINE_COMPLETION_ROADMAP.md
@@ -1,0 +1,354 @@
+# Semantic Inline Completion Roadmap
+
+Status: planning
+Owner: perl-lsp maintainers
+Related:
+- [Inline Completion Release Gate](INLINE_COMPLETION_RELEASE_GATE.md)
+- [LSP 3.18 conformance boundary](../specs/PLSP-SPEC-0029-lsp-318-conformance-boundary.md)
+- [LSP implementation guide](../reference/LSP_IMPLEMENTATION_GUIDE.md)
+
+## Purpose
+
+This roadmap defines the lane that moves inline completion from "the method
+exists" to a trusted Perl editing primitive.
+
+The end state is:
+
+```text
+perl-lsp understands the Perl already on screen well enough to offer quiet,
+correct, context-aware next text.
+```
+
+Inline completion must not become a snippet engine, an AI demo, or a fragile
+LSP novelty. The useful version is narrower and harder: when a user is in a Perl
+file, in their project, with their imports, lexicals, test framework, object
+style, and editor, ghost text is rarely wrong, rarely annoying, and often the
+next thing they were about to type.
+
+Every suggestion must pass three product tests:
+
+- it is syntactically safe at the cursor;
+- it uses symbols, imports, and style already present or proven reachable;
+- it would not be annoying if shown automatically.
+
+## Current Boundary
+
+The release gate already proves the embedded `perllsp` binary can act as a
+standard LSP 3.18 `textDocument/inlineCompletion` target:
+
+- static clients receive top-level `inlineCompletionProvider`;
+- LSP4IJ-style dynamic clients receive `client/registerCapability` for
+  `textDocument/inlineCompletion`;
+- disabled `lsp.inline_completion` suppresses advertisement, registration, and
+  runtime execution;
+- a simple `use ` fixture returns deterministic `strict;`;
+- neutral positions return empty.
+
+Those receipts are protocol and process-boundary proof. They are not a claim
+that inline completion is semantically rich, project-aware, or ready to expand
+into AI-first behavior.
+
+## Non-Goals
+
+This lane must not become:
+
+- AI-first completion;
+- broad snippet expansion;
+- a large provider rewrite without preserving behavior;
+- broad LSP 3.18 conformance work;
+- release plumbing;
+- editor setup docs churn;
+- general code-action work.
+
+Optional AI belongs after deterministic candidates are parse-safe, ranked,
+tested, and measured. AI candidates must remain off by default, explicitly
+configured, cancellation-aware, timeout-bounded, and subject to the same range
+and parse-safety filters as deterministic candidates.
+
+## Product Contract
+
+Inline completion should be conservative by default:
+
+- automatic trigger: one high-confidence result or empty;
+- invoked trigger: richer candidate set is allowed;
+- selected completion popup: ghost text must extend the selected completion item
+  or stay silent;
+- unsupported zones: comments, strings, heredocs, POD, and unsupported ambiguous
+  syntax should return empty;
+- uncertain context: return empty instead of guessing.
+
+Silence is a feature when the context is unsafe.
+
+## Target Pipeline
+
+The long-term deterministic pipeline is:
+
+```text
+request
+  -> protocol and feature guard
+  -> SemanticInlineContext
+  -> candidate sources
+  -> ranking
+  -> parse-safety filter
+  -> editor-safe response
+  -> local/dev receipt counters
+```
+
+The pipeline must keep protocol concerns separate from candidate quality:
+
+- protocol gates decide whether the request is legal and enabled;
+- context extraction decides what Perl facts are visible;
+- candidate sources propose possible next text;
+- ranking decides what is worth showing;
+- parse-safety and editor-safety filters decide what must be suppressed.
+
+## Editor-Safety Contracts
+
+### Replacement Ranges
+
+Returned ranges must be editor-safe:
+
+- start at the current token or partial expression;
+- stay single-line unless a later explicit multiline contract is added;
+- replace the typed prefix rather than duplicating it;
+- use LSP UTF-16 positions on the wire;
+- avoid fighting text typed after the request started.
+
+Bad ranges make ghost text feel like an editor bug. Range correctness should
+land before semantic expansion.
+
+### `selectedCompletionInfo`
+
+When `selectedCompletionInfo` is present, an inline item is valid only when it
+uses a compatible range and extends the selected completion item. Conflicting
+items must be suppressed.
+
+This contract keeps ghost text from fighting an open completion popup.
+
+### Hard Reject Zones
+
+The provider must stay silent in zones where code ghost text is likely wrong:
+
+- comments;
+- string literals;
+- heredoc bodies;
+- POD;
+- regex bodies unless a future PR adds explicit regex-context support.
+
+## Semantic Context Target
+
+`SemanticInlineContext` is the bridge from line scanning to project-aware Perl
+suggestions. The initial shape should be internal and narrow:
+
+```rust
+pub struct SemanticInlineContext {
+    pub lexical_scope: ScopeId,
+    pub package: Option<PackageId>,
+    pub enclosing_sub: Option<SubId>,
+    pub expected_syntax: ExpectedSyntax,
+    pub visible_lexicals: Vec<VariableFact>,
+    pub receiver_type_hint: Option<ReceiverHint>,
+    pub imported_modules: Vec<ModuleFact>,
+    pub file_role: FileRole,
+}
+```
+
+The first implementation may use placeholders or best-effort facts when a field
+is not yet available. The important contract is the direction: candidate sources
+should consume semantic context instead of scraping only the current line.
+
+## Candidate Sources
+
+The deterministic engine should split candidate generation into sources:
+
+```rust
+trait InlineCandidateSource {
+    fn candidates(&self, ctx: &SemanticInlineContext) -> Vec<InlineCandidate>;
+}
+```
+
+Initial sources:
+
+- `SyntaxSource`: safe Perl continuations such as `use`, `return`, and control
+  flow scaffolding;
+- `LexicalSource`: visible lexical variables and nearby symbols;
+- `ImportSource`: workspace modules from effective include context;
+- `TestSource`: Test::More and Test2-aware assertions in `.t` files;
+- `ReceiverSource`: current package methods for `$self->` and narrow receiver
+  hints such as DBI handles;
+- `StyleSource`: constructor idioms, signature style, indentation, and local
+  assertion style.
+
+Adding sources should not mean adding noisy suggestions. Each source must have
+negative fixtures proving where it stays silent.
+
+## Ranking
+
+Candidate ordering should move from fixed rule order to scored confidence.
+
+Useful score components:
+
+- context match;
+- semantic confidence;
+- project style match;
+- recent symbol bonus;
+- file role bonus;
+- edit-distance or prefix-continuation bonus;
+- risk penalty;
+- annoyance penalty.
+
+Ranking should favor visible lexicals, project modules, local idiom, and
+parse-safe continuations. It should penalize placeholders, risky multiline text,
+and suggestions that are valid Perl but unlikely to be welcome as automatic
+ghost text.
+
+## Parse-Safety Filter
+
+Parse safety does not mean the whole document must become valid Perl after every
+candidate. It means the candidate must not make the local edit state worse.
+
+The filter should:
+
+- splice the candidate into the current buffer;
+- parse the affected region or document using the available parser path;
+- reject candidates that increase local error score;
+- allow candidates that improve an incomplete construct;
+- record parse-safe rejections in local/dev receipts.
+
+This is the core trust mechanism for automatic suggestions.
+
+## Fixture UX Corpus
+
+Inline completion should be tested as editor UX, not only as provider units.
+Fixture tests should encode expected and forbidden ghost text:
+
+```yaml
+source: |
+  use Test::More;
+
+  my $got = compute();
+  <CURSOR>
+expected:
+  - "is($got, $expected, '...');"
+not_expected:
+  - "done_testing();"
+  - "return $got;"
+```
+
+Seed fixtures:
+
+- `replacement_range_partial_token.yml`
+- `replacement_range_method_arrow.yml`
+- `replacement_range_use_prefix.yml`
+- `utf16_partial_token.yml`
+- `selected_completion_info_extends.yml`
+- `selected_completion_info_conflict.yml`
+- `comment_no_completion.yml`
+- `string_no_completion.yml`
+- `heredoc_no_completion.yml`
+- `pod_no_completion.yml`
+- `module_import_workspace.yml`
+- `test_more_assertion.yml`
+- `test2_assertion.yml`
+- `constructor_shift_style.yml`
+- `constructor_signature_style.yml`
+- `self_method_current_package.yml`
+- `dbi_receiver_hint.yml`
+
+Fixtures should cover both expected text and suppression. Suppression fixtures
+are as important as positive fixtures.
+
+## Local Measurement
+
+Quality counters may be added for local/dev receipts. They must not upload
+telemetry.
+
+Useful counters:
+
+- shown;
+- accepted;
+- partially accepted;
+- dismissed;
+- superseded by typing;
+- parse-safe rejected;
+- rejected by selected completion;
+- rejected by hard zone.
+
+Counters should be keyed by candidate source and rejection reason, not user
+code.
+
+## PR Ladder
+
+Build the rails before expanding intelligence.
+
+| Phase | PR shape | Scope |
+| --- | --- | --- |
+| 0 | `docs(inline): define semantic inline-completion roadmap` | This document and related docs pointers. |
+| 1 | `test(inline): lock LSP inline-completion protocol contracts` | Static, dynamic, disabled, automatic/invoked, shutdown, empty/null behavior. |
+| 2 | `fix(inline): return editor-safe replacement ranges` | Prefix replacement, UTF-16 positions, single-line range safety. |
+| 3 | `fix(inline): suppress ghost text that conflicts with selected completions` | `selectedCompletionInfo` extension/range contract. |
+| 4 | `fix(inline): suppress code ghost text in comments strings heredocs and POD` | Hard reject zones and negative fixtures. |
+| 5 | `feat(inline): build semantic context for inline candidates` | Internal `SemanticInlineContext` scaffold. |
+| 6 | `feat(inline): detect file role and local Perl style` | Module/script/test role and style facts. |
+| 7 | `feat(inline): use visible lexicals in deterministic suggestions` | Visible lexical facts and negative out-of-scope tests. |
+| 8 | `refactor(inline): split deterministic candidates into sources` | Candidate source trait with behavior-preserving split. |
+| 9 | `feat(inline): suggest workspace modules for use completions` | Effective include context and project module suggestions. |
+| 10 | `feat(inline): suggest Perl test assertions from file context` | Test::More and Test2 assertion source. |
+| 11 | `feat(inline): suggest current package methods for self receiver` | `$self->` current package method suggestions. |
+| 12 | `feat(inline): rank candidates with semantic confidence` | Scored ranking and fixture snapshots. |
+| 13 | `feat(inline): reject candidates that worsen local parse state` | Parse-safety filter. |
+| 14 | `test(inline): add fixture-based UX tests for ghost text` | YAML or equivalent editor UX corpus. |
+| 15 | `feat(inline): suggest constructor bodies matching local style` | Constructor idiom source. |
+| 16 | `feat(inline): infer basic DBI receiver methods` | Narrow DBI receiver hints. |
+| 17 | `feat(inline): suggest guard and loop continuations from visible context` | Control-flow continuations using visible facts. |
+| 18 | `feat(inline): add local dev counters for inline completion quality` | Local-only counters. |
+| 19 | `ci(inline): emit inline completion quality receipts` | Fixture totals, source counters, latency, parse regressions. |
+| 20 | `feat(inline): add gated next-edit suggestion scaffold` | Feature-gated scaffold only. |
+| 21 | `feat(inline): add guarded AI candidate source boundary` | Optional AI boundary after deterministic path is trusted. |
+
+## High-Value Perl Wins
+
+The first semantic wins should be Perl-specific and narrow:
+
+- after `use My::`, suggest reachable workspace modules from effective include
+  context;
+- after `$self->`, suggest methods from the current package first;
+- in `.t` files, suggest assertion forms that match Test::More or Test2 style;
+- inside `sub new`, follow the constructor idiom already used in the file;
+- inside unsupported zones, stay silent.
+
+These are more valuable than broad generic completions because they prove the
+server understands the user's Perl project.
+
+## Validation
+
+For docs-only roadmap changes:
+
+```bash
+cargo xtask check-devex-docs
+cargo xtask doc-claims
+cargo xtask check-support-claims
+git diff --check
+```
+
+For behavior changes, use the release gate plus the narrow provider/core tests
+listed in the relevant PR.
+
+## Claim Boundary
+
+This document is a roadmap and lane contract. It does not change runtime
+behavior, advertised capabilities, release state, support tier, or editor setup.
+
+It may claim:
+
+- the intended semantic inline-completion direction;
+- the order in which the lane should build protocol safety, context, sources,
+  ranking, parse safety, local receipts, next-edit scaffolding, and optional AI.
+
+It may not claim:
+
+- that semantic candidate sources are implemented;
+- that AI is enabled or planned as default behavior;
+- that inline completion is generally perfect or production-complete;
+- complete LSP 3.18 conformance;
+- release readiness.

--- a/docs/development/LSP_INTERACTIVE_LATENCY_ROLLOUT.md
+++ b/docs/development/LSP_INTERACTIVE_LATENCY_ROLLOUT.md
@@ -35,6 +35,13 @@ The JetBrains lane now has two separate surfaces:
 - User docs: prefer the upstream LSP4IJ `perl-lsp` integration when available,
   and keep manual Raw Command setup in separate fallback/development guidance.
 
+Inline-completion quality work is a separate semantic editing rail. This
+latency rollout keeps the editor loop responsive; it does not add candidate
+sources, ranking, parse-safety filters, or AI behavior. See
+[Semantic Inline Completion Roadmap](INLINE_COMPLETION_ROADMAP.md) for the lane
+that turns the existing LSP 3.18 inline-completion surface into project-aware,
+parse-safe ghost text.
+
 | Phase | Tracker | Scope | Stack on |
 |---|---|---|---|
 | 1. Scope-lock doc | this PR (umbrella [#229](https://github.com/EffortlessMetrics/perl-lsp-swarm/issues/229)) | docs only | n/a - lands first |

--- a/docs/specs/PLSP-SPEC-0029-lsp-318-conformance-boundary.md
+++ b/docs/specs/PLSP-SPEC-0029-lsp-318-conformance-boundary.md
@@ -1,0 +1,228 @@
+# PLSP-SPEC-0029: LSP 3.18 conformance boundary
+
+Status: accepted
+Owner: perl-lsp maintainers
+Linked proposal: n/a
+Linked ADRs:
+- [PLSP-ADR-0004](../adr/PLSP-ADR-0004-lsp-stack-extraction.md)
+Linked plan: n/a
+Status impact: LSP capability claims, editor integration receipts, protocol
+contract tests, future extraction parity reviews
+
+## Current Implementation Status
+
+This spec records the current claim boundary for selected LSP 3.18 surfaces in
+`perl-lsp`. It is a support-boundary document, not a release approval and not a
+claim of complete LSP 3.18 implementation.
+
+The upstream LSP 3.18 specification is still marked upcoming and under
+development. The project treats 3.18 support as capability-negotiated claim
+honesty: every advertised 3.18 behavior must be shaped correctly, routed
+correctly, tested over JSON-RPC, and documented; every unsupported 3.18 behavior
+must stay absent from capabilities or return the standard unsupported or invalid
+params error.
+
+Spec source: [Language Server Protocol Specification - 3.18](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/).
+
+Current lock points:
+
+- inline completion uses standard `textDocument/inlineCompletion`
+- static clients receive top-level `inlineCompletionProvider`
+- dynamic-capable clients receive `client/registerCapability` for
+  `textDocument/inlineCompletion` after `initialized`
+- `experimental.inlineCompletionProvider` is not used
+- `experimental.perlInlineCompletionStream` remains a custom extension
+- multi-range formatting is advertised through
+  `documentRangeFormattingProvider.rangesSupport`
+- `documentRangesFormattingProvider` is not advertised
+- semantic tokens advertise full/range support without delta
+- `workspace/textDocumentContent` is wired for the `perldoc` scheme
+- lean/e2e runtime mode suppresses file watcher registration without suppressing
+  unrelated inline-completion dynamic registration
+
+## Contract
+
+`perl-lsp` may claim selected LSP 3.18 support only for surfaces with:
+
+- a capability JSON path
+- a routed method or dynamic registration path
+- disabled-feature behavior when the feature is feature-gated
+- a wire-level JSON-RPC test
+- a capability snapshot or shape assertion
+- negative unsupported behavior for adjacent unimplemented 3.18 surfaces
+- editor receipt coverage when the feature affects real editor startup or use
+
+The project must not use "LSP 3.18 compliant" as a blanket claim. The supported
+claim is narrower:
+
+```text
+perl-lsp supports selected LSP 3.18 surfaces with capability-honest contracts.
+```
+
+## Supported And Locked Surfaces
+
+| Surface | Capability or method | Current contract | Proof |
+| --- | --- | --- | --- |
+| Inline completion | `inlineCompletionProvider`, `textDocument/inlineCompletion`, `client/registerCapability` | Static and dynamic modes are mutually exclusive; disabled inline completion removes provider, stream flag, dynamic registration, and runtime handling. | `lsp_inline_completion_registration_tests`, `lsp_ai_inline_completion_tests`, `lsp_streaming_completion_tests`, `lsp_cap_snap` |
+| Inline completion selected context | `selectedCompletionInfo` | Returned items must use the same range and extend selected text, or return empty. | `lsp_inline_completion_registration_tests`, `lsp_inline_completion_tests` |
+| Multi-range formatting | `documentRangeFormattingProvider.rangesSupport`, `textDocument/rangesFormatting` | Multi-range formatting uses the spec capability shape and routed method; the non-spec plural capability is absent. | `lsp_caps_contract_shapes`, `lsp_disabled_features_tests`, `lsp_formatting_e2e`, `lsp_capabilities_snapshot`, `lsp_cap_snap` |
+| Dynamic text document content | `workspace.textDocumentContent.schemes`, `workspace/textDocumentContent` | `perldoc` scheme is advertised; invalid params and malformed URIs return `InvalidParams`; unsupported schemes return deterministic unavailable errors. | `lsp_text_document_content_tests`, `lsp_cap_snap` |
+| Text document content refresh | `workspace/textDocumentContent/refresh` | Server-originated request IDs are bounded and emitted through the standard server request path. | `lsp_text_document_content_tests` |
+| Semantic tokens | `semanticTokensProvider.full`, `semanticTokensProvider.range` | Full and range are advertised; delta is not advertised without result-id state. | `lsp_caps_contract_shapes`, `lsp_semantic_legend_contract_tests`, `lsp_cap_snap` |
+| Lean/e2e watcher behavior | `workspace/didChangeWatchedFiles` dynamic registration | Runtime tuning can suppress file watchers without suppressing inline-completion dynamic registration. | `lsp_registration_tests`, lean UX receipts |
+
+## Explicitly Unclaimed Surfaces
+
+These surfaces are not part of the current claim unless a later PR adds behavior,
+capability parsing, wire tests, docs, and negative gates:
+
+- complete LSP 3.18 implementation
+- `textDocument/semanticTokens/full/delta`
+- semantic-token delta `resultId` state
+- `WorkspaceEdit` `SnippetTextEdit`
+- `WorkspaceEdit` metadata
+- `ApplyWorkspaceEditParams.metadata`
+- `CompletionList.applyKind`
+- `CompletionList.itemDefaults.data`
+- `CodeAction.documentation`
+- `CodeAction.tags`
+- `CodeActionTag.LLMGenerated`
+- `MessageType.Debug`
+- `Command.tooltip`
+- `RelativePattern` document selectors and watcher glob patterns
+- `workspace/foldingRange/refresh` without `workspace.foldingRange.refreshSupport`
+- trusted markdown command execution or theme-icon markdown behavior
+- notebook-specific 3.18 additions beyond existing notebook sync claims
+
+Unsupported or unclaimed surfaces must be absent from capabilities and from
+representative responses unless the client capability and server behavior are
+both implemented and tested.
+
+## Negative Claim Gates
+
+The `lsp_318_negative_claims` test suite is the current guardrail for optional
+3.18 surfaces. It must fail if the server accidentally:
+
+- advertises semantic-token delta
+- accepts `textDocument/semanticTokens/full/delta` as implemented
+- reintroduces `experimental.inlineCompletionProvider`
+- reintroduces `documentRangesFormattingProvider`
+- emits `CompletionList.applyKind` without explicit support
+- emits `CompletionList.itemDefaults.data` without explicit support
+- emits `CodeAction.documentation` or `CodeAction.tags`
+- emits workspace-edit metadata or snippet edits in representative edit
+  responses
+- emits diagnostic `message` as `MarkupContent` without markup support
+- registers file watchers with relative-pattern objects instead of string globs
+- sends `workspace/foldingRange/refresh` without client refresh support
+- emits `MessageType.Debug`
+
+The suite is intentionally absence-first. It does not implement the optional
+features and must not be treated as proof that those features work.
+
+## Valid PR Shapes
+
+Valid PRs under this spec include:
+
+- adding or tightening wire tests for an already advertised 3.18 surface
+- adding negative gates for unimplemented 3.18 structures
+- correcting capability JSON shape to match the upstream specification
+- documenting the current support boundary
+- adding a claim-checking `xtask` that enforces this spec
+- adding one optional 3.18 feature only when the PR includes capability parsing,
+  capability advertisement, request or response behavior, disabled-feature
+  behavior when applicable, wire tests, docs, and negative tests for disabled or
+  unsupported clients
+
+Every PR must state whether it changes capability shape, dynamic registration,
+runtime behavior, response shape, docs, editor receipts, extraction boundaries,
+or release surfaces.
+
+## Invalid PR Shapes
+
+Invalid PRs include:
+
+- claiming full LSP 3.18 implementation from selected-surface receipts
+- advertising a 3.18 capability before the routed behavior and wire tests exist
+- emitting client-gated response fields before the client capability is parsed
+- implementing semantic-token delta without result-id state
+- bundling 3.18 optional feature work with `lsp-stack` extraction
+- creating `crates/lsp-stack`
+- moving protocol or routing code as part of this spec
+- touching DAP
+- touching release, publish, signing, package, marketplace, or installer
+  behavior
+- weakening inline-completion, range-formatting, text-document-content,
+  semantic-token, watcher, or editor receipt tests
+- claiming release readiness from this spec
+
+## Acceptance
+
+This spec is satisfied when:
+
+- supported 3.18 surfaces have capability-shape and wire-contract tests
+- unimplemented optional surfaces have negative gates
+- docs name selected support rather than blanket conformance
+- extraction remains downstream of current-app behavior parity
+- every later 3.18 PR updates this spec or its proof references when it changes
+  the support boundary
+
+## Proof Commands
+
+For this docs-only boundary:
+
+```bash
+git diff --check
+cargo xtask check-support-claims
+cargo xtask check-lsp-318-claims
+cargo xtask docs-check
+```
+
+If a command is unstable in the checkout, the PR must report that separately.
+
+For behavior or test PRs touching this boundary, run the relevant subset:
+
+```bash
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_inline_completion_registration_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_ai_inline_completion_tests --features expose_lsp_test_api --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_caps_contract_shapes --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_capabilities_snapshot --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_cap_snap --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_registration_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_text_document_content_tests --profile agent --locked
+./scripts/cargo-safe test -p perl-lsp-rs --test lsp_318_negative_claims --profile agent --locked
+cargo xtask check-lsp-318-claims
+./scripts/cargo-safe check -p perl-lsp-rs --all-targets --profile agent --locked
+git diff --check
+./scripts/storage-doctor
+```
+
+Editor receipt refresh PRs must additionally run the raw RPC, lean Neovim, and
+inline-completion binary smoke commands relevant to the touched editor surface.
+
+## Non-goals
+
+- No full LSP 3.18 implementation claim.
+- No broad optional 3.18 feature implementation.
+- No semantic-token delta implementation.
+- No `lsp-stack` extraction.
+- No routing rewrite.
+- No generic handler trait introduction.
+- No DAP changes.
+- No release, publish, signing, package, marketplace, or installer changes.
+- No release-readiness claim.
+
+## Claim Boundaries
+
+This spec may claim that `perl-lsp` has a documented LSP 3.18 selected-surface
+support boundary and negative gates for unimplemented optional surfaces.
+
+It may not claim:
+
+- complete LSP 3.18 conformance
+- release readiness
+- extraction readiness beyond the separate extraction boundary spec
+- editor support beyond current receipts
+- semantic-token delta support
+- workspace-edit snippet or metadata support
+- optional 3.18 response-shape support without client capability handling

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -47,6 +47,8 @@ generated sections.
 - [PLSP-SPEC-0025: PIR v0 contract](PLSP-SPEC-0025-pir-v0.md)
 - [PLSP-SPEC-0026: Determinism receipt v1](PLSP-SPEC-0026-determinism-receipt-v1.md)
 - [PLSP-SPEC-0027: Differential real-Perl oracle contract](PLSP-SPEC-0027-differential-real-perl-oracle.md)
+- [PLSP-SPEC-0028: lsp-stack extraction boundary](PLSP-SPEC-0028-lsp-stack-extraction.md)
+- [PLSP-SPEC-0029: LSP 3.18 conformance boundary](PLSP-SPEC-0029-lsp-318-conformance-boundary.md)
 
 ## Acceptance and Proof
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -92,6 +92,10 @@ enum Commands {
     /// Validate semantic-token class promotion registry.
     CheckSemanticTokenClasses,
 
+    /// Validate selected LSP 3.18 claim-boundary guardrails.
+    #[command(name = "check-lsp-318-claims")]
+    CheckLsp318Claims,
+
     /// Validate workspace-symbol class promotion registry.
     CheckWorkspaceSymbolClasses,
 
@@ -2594,6 +2598,7 @@ fn main() -> Result<()> {
         Commands::CheckOracleFixtureManifest => oracle_fixture_manifest::run(),
         Commands::CheckOracleReceiptSchema => oracle_receipt_schema::run(),
         Commands::CheckSemanticTokenClasses => semantic_token_classes::run(),
+        Commands::CheckLsp318Claims => lsp_318_claims::run(),
         Commands::CheckWorkspaceSymbolClasses => workspace_symbol_classes::run(),
         Commands::Queue { command } => match command {
             QueueCommand::Snapshot { out, fixture } => queue_snapshot::run_snapshot(out, fixture),

--- a/xtask/src/tasks/lsp_318_claims.rs
+++ b/xtask/src/tasks/lsp_318_claims.rs
@@ -1,0 +1,440 @@
+//! Validate the selected LSP 3.18 claim boundary.
+
+use crate::utils::project_root;
+use color_eyre::eyre::{Context, Result, bail};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+const SPEC_PATH: &str = "docs/specs/PLSP-SPEC-0029-lsp-318-conformance-boundary.md";
+const NEGATIVE_CLAIMS_TEST: &str = "crates/perl-lsp-rs/tests/lsp_318_negative_claims.rs";
+const CLIENT_REQUESTS: &str = "crates/perl-lsp-rs/src/runtime/client_requests.rs";
+const LIFECYCLE_CAPABILITIES: &str = "crates/perl-lsp-rs/src/runtime/lifecycle/capabilities.rs";
+const RUNTIME_REFRESH: &str = "crates/perl-lsp-rs/src/runtime/refresh.rs";
+const FEATURE_CATALOG: &str = "features.toml";
+
+const CAPABILITY_SNAPSHOTS: &[&str] = &[
+    "crates/perl-lsp-rs/tests/snapshots/all_capabilities.json",
+    "crates/perl-lsp-rs/tests/snapshots/ga_lock_capabilities.json",
+    "crates/perl-lsp-rs/tests/snapshots/production_capabilities.json",
+];
+
+const SPEC_MARKERS: &[RequiredMarker] = &[
+    RequiredMarker { label: "claim guard command", marker: "check-lsp-318-claims" },
+    RequiredMarker { label: "negative claim gates section", marker: "## Negative Claim Gates" },
+    RequiredMarker {
+        label: "selected-surface claim boundary",
+        marker: "This spec may claim that `perl-lsp` has a documented LSP 3.18 selected-surface",
+    },
+];
+
+const NEGATIVE_TEST_MARKERS: &[RequiredMarker] = &[
+    RequiredMarker {
+        label: "unsupported capability snapshot assertions",
+        marker: "initialize_does_not_advertise_unimplemented_318_capabilities",
+    },
+    RequiredMarker {
+        label: "semantic token delta negative route",
+        marker: "semantic_tokens_delta_request_returns_method_not_found",
+    },
+    RequiredMarker {
+        label: "CompletionList.applyKind gate",
+        marker: "completion_response_does_not_emit_apply_kind_without_client_support",
+    },
+    RequiredMarker { label: "CompletionList.itemDefaults.data gate", marker: "itemDefaults" },
+    RequiredMarker {
+        label: "CodeAction documentation and tag gates",
+        marker: "code_action_and_workspace_edit_responses_do_not_emit_optional_318_shapes",
+    },
+    RequiredMarker { label: "WorkspaceEdit metadata gate", marker: "metadata" },
+    RequiredMarker { label: "SnippetTextEdit gate", marker: "snippet" },
+    RequiredMarker {
+        label: "Diagnostic MarkupContent gate",
+        marker: "diagnostics_keep_plain_string_messages_without_markup_support",
+    },
+    RequiredMarker {
+        label: "RelativePattern/baseUri gate",
+        marker: "dynamic_file_watcher_registration_uses_string_globs_not_relative_patterns",
+    },
+    RequiredMarker {
+        label: "workspace/foldingRange/refresh gate",
+        marker: "folding_range_refresh_is_not_sent_without_client_support",
+    },
+    RequiredMarker {
+        label: "MessageType.Debug gate",
+        marker: "window_message_type_does_not_emit_debug_level",
+    },
+    RequiredMarker { label: "Command.tooltip gate", marker: "assert_no_command_tooltip" },
+    RequiredMarker {
+        label: "experimental inline-completion provider gate",
+        marker: "/experimental/inlineCompletionProvider",
+    },
+    RequiredMarker {
+        label: "non-spec ranges-formatting provider gate",
+        marker: "/documentRangesFormattingProvider",
+    },
+];
+
+const FEATURE_CATALOG_MARKERS: &[RequiredMarker] = &[
+    RequiredMarker {
+        label: "inline completion feature catalog row",
+        marker: "id = \"lsp.inline_completion\"",
+    },
+    RequiredMarker {
+        label: "multi-range formatting feature catalog row",
+        marker: "id = \"lsp.ranges_formatting\"",
+    },
+    RequiredMarker {
+        label: "diagnostic markup support feature catalog row",
+        marker: "id = \"lsp.diagnostic.markup_message_support\"",
+    },
+    RequiredMarker {
+        label: "textDocumentContent feature catalog row",
+        marker: "id = \"lsp.text_document_content\"",
+    },
+    RequiredMarker {
+        label: "textDocumentContent refresh feature catalog row",
+        marker: "id = \"lsp.text_document_content_refresh\"",
+    },
+    RequiredMarker {
+        label: "folding range refresh feature catalog row",
+        marker: "id = \"lsp.folding_range_refresh\"",
+    },
+];
+
+const CAPABILITY_ABSENCE_CHECKS: &[JsonAbsenceCheck] = &[
+    JsonAbsenceCheck {
+        pointer: "/documentRangesFormattingProvider",
+        label: "non-spec multi-range formatting capability",
+        reason: "multi-range formatting must be advertised through documentRangeFormattingProvider.rangesSupport",
+    },
+    JsonAbsenceCheck {
+        pointer: "/experimental/inlineCompletionProvider",
+        label: "experimental inline completion provider",
+        reason: "inline completion is a standard top-level LSP 3.18 capability",
+    },
+    JsonAbsenceCheck {
+        pointer: "/semanticTokensProvider/full/delta",
+        label: "semantic-token delta",
+        reason: "delta requires resultId state and real delta responses",
+    },
+    JsonAbsenceCheck {
+        pointer: "/completionProvider/applyKind",
+        label: "CompletionList.applyKind",
+        reason: "applyKind must stay absent until applyKindSupport is parsed and tested",
+    },
+    JsonAbsenceCheck {
+        pointer: "/completionProvider/itemDefaults/data",
+        label: "CompletionList.itemDefaults.data",
+        reason: "default data must stay absent until explicitly supported and tested",
+    },
+    JsonAbsenceCheck {
+        pointer: "/codeActionProvider/documentation",
+        label: "CodeAction.documentation",
+        reason: "code action documentation must be client-capability gated before advertisement",
+    },
+    JsonAbsenceCheck {
+        pointer: "/workspace/foldingRange",
+        label: "workspace/foldingRange server capability",
+        reason: "folding refresh is client-capability gated and must not be advertised as a server capability",
+    },
+];
+
+const RAW_SNAPSHOT_PATTERNS: &[RawPatternCheck] = &[
+    RawPatternCheck {
+        needle: "documentRangesFormattingProvider",
+        label: "non-spec documentRangesFormattingProvider snapshot",
+    },
+    RawPatternCheck {
+        needle: "experimental.inlineCompletionProvider",
+        label: "experimental inline-completion provider snapshot",
+    },
+    RawPatternCheck { needle: "\"delta\": true", label: "semantic-token delta snapshot" },
+    RawPatternCheck { needle: "applyKind:", label: "CompletionList.applyKind snapshot" },
+    RawPatternCheck { needle: "\"applyKind\"", label: "CompletionList.applyKind JSON snapshot" },
+];
+
+const FEATURE_CATALOG_FORBIDDEN_PATTERNS: &[RawPatternCheck] = &[
+    RawPatternCheck {
+        needle: "documentRangesFormattingProvider",
+        label: "non-spec documentRangesFormattingProvider feature claim",
+    },
+    RawPatternCheck {
+        needle: "experimental.inlineCompletionProvider",
+        label: "experimental inline-completion provider feature claim",
+    },
+    RawPatternCheck {
+        needle: "semanticTokens/full/delta",
+        label: "semantic-token delta feature claim",
+    },
+    RawPatternCheck { needle: "SnippetTextEdit", label: "SnippetTextEdit feature claim" },
+    RawPatternCheck {
+        needle: "CompletionList.applyKind",
+        label: "CompletionList.applyKind feature claim",
+    },
+    RawPatternCheck {
+        needle: "CompletionList.itemDefaults.data",
+        label: "CompletionList.itemDefaults.data feature claim",
+    },
+    RawPatternCheck {
+        needle: "CodeAction.documentation",
+        label: "CodeAction.documentation feature claim",
+    },
+    RawPatternCheck { needle: "CodeAction.tags", label: "CodeAction.tags feature claim" },
+    RawPatternCheck { needle: "MessageType.Debug", label: "MessageType.Debug feature claim" },
+    RawPatternCheck { needle: "Command.tooltip", label: "Command.tooltip feature claim" },
+    RawPatternCheck { needle: "RelativePattern", label: "RelativePattern feature claim" },
+];
+
+#[derive(Clone, Copy)]
+struct RequiredMarker {
+    label: &'static str,
+    marker: &'static str,
+}
+
+#[derive(Clone, Copy)]
+struct JsonAbsenceCheck {
+    pointer: &'static str,
+    label: &'static str,
+    reason: &'static str,
+}
+
+#[derive(Clone, Copy)]
+struct RawPatternCheck {
+    needle: &'static str,
+    label: &'static str,
+}
+
+#[derive(Debug)]
+struct Violation {
+    rel_path: String,
+    line: usize,
+    label: &'static str,
+    detail: String,
+}
+
+pub fn run() -> Result<()> {
+    let root = project_root()?;
+    let mut violations = Vec::new();
+
+    check_required_markers(&root, SPEC_PATH, SPEC_MARKERS, &mut violations)?;
+    check_required_markers(&root, NEGATIVE_CLAIMS_TEST, NEGATIVE_TEST_MARKERS, &mut violations)?;
+    check_feature_catalog(&root, &mut violations)?;
+    check_capability_snapshots(&root, &mut violations)?;
+    check_folding_range_refresh_guard(&root, &mut violations)?;
+    check_forbidden_source_claims(&root, &mut violations)?;
+
+    if violations.is_empty() {
+        println!(
+            "LSP 3.18 claim guard OK: {} capability snapshots, {} feature markers, {} negative-test markers, {} spec markers checked",
+            CAPABILITY_SNAPSHOTS.len(),
+            FEATURE_CATALOG_MARKERS.len(),
+            NEGATIVE_TEST_MARKERS.len(),
+            SPEC_MARKERS.len()
+        );
+        return Ok(());
+    }
+
+    eprintln!("LSP 3.18 CLAIM GUARD VIOLATIONS:");
+    eprintln!("{}", "=".repeat(72));
+    for violation in &violations {
+        eprintln!("  {}:{}: {}", violation.rel_path, violation.line, violation.label);
+        eprintln!("    {}", violation.detail);
+    }
+    eprintln!("{}", "=".repeat(72));
+    bail!("LSP 3.18 claim guard failed with {} violation(s)", violations.len());
+}
+
+fn check_required_markers(
+    root: &Path,
+    rel_path: &str,
+    markers: &[RequiredMarker],
+    violations: &mut Vec<Violation>,
+) -> Result<()> {
+    let text = read_required(root, rel_path)?;
+    for marker in markers {
+        if !text.contains(marker.marker) {
+            violations.push(Violation {
+                rel_path: rel_path.to_string(),
+                line: 1,
+                label: marker.label,
+                detail: format!("missing required marker {:?}", marker.marker),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn check_feature_catalog(root: &Path, violations: &mut Vec<Violation>) -> Result<()> {
+    let text = read_required(root, FEATURE_CATALOG)?;
+    for marker in FEATURE_CATALOG_MARKERS {
+        if !text.contains(marker.marker) {
+            violations.push(Violation {
+                rel_path: FEATURE_CATALOG.to_string(),
+                line: 1,
+                label: marker.label,
+                detail: format!("missing required LSP 3.18 catalog marker {:?}", marker.marker),
+            });
+        }
+    }
+    for pattern in FEATURE_CATALOG_FORBIDDEN_PATTERNS {
+        if text.contains(pattern.needle) {
+            violations.push(Violation {
+                rel_path: FEATURE_CATALOG.to_string(),
+                line: line_number_for(&text, pattern.needle),
+                label: pattern.label,
+                detail: format!(
+                    "unsupported 3.18 surface must stay out of the advertised feature catalog: {:?}",
+                    pattern.needle
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn check_capability_snapshots(root: &Path, violations: &mut Vec<Violation>) -> Result<()> {
+    for rel_path in CAPABILITY_SNAPSHOTS {
+        let text = read_required(root, rel_path)?;
+        for pattern in RAW_SNAPSHOT_PATTERNS {
+            if text.contains(pattern.needle) {
+                violations.push(Violation {
+                    rel_path: (*rel_path).to_string(),
+                    line: line_number_for(&text, pattern.needle),
+                    label: pattern.label,
+                    detail: format!("forbidden snapshot text {:?}", pattern.needle),
+                });
+            }
+        }
+
+        let json: Value = serde_json::from_str(&text)
+            .with_context(|| format!("failed to parse capability snapshot {rel_path}"))?;
+        for check in CAPABILITY_ABSENCE_CHECKS {
+            if json.pointer(check.pointer).is_some() {
+                violations.push(Violation {
+                    rel_path: (*rel_path).to_string(),
+                    line: line_number_for_pointer(&text, check.pointer),
+                    label: check.label,
+                    detail: check.reason.to_string(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_folding_range_refresh_guard(root: &Path, violations: &mut Vec<Violation>) -> Result<()> {
+    let client_requests = read_required(root, CLIENT_REQUESTS)?;
+    let lifecycle_capabilities = read_required(root, LIFECYCLE_CAPABILITIES)?;
+    let runtime_refresh = read_required(root, RUNTIME_REFRESH)?;
+
+    require_all(
+        CLIENT_REQUESTS,
+        &client_requests,
+        &[
+            "request_folding_range_refresh",
+            "folding_range_refresh_support",
+            "workspace/foldingRange/refresh",
+            "self.send_request(",
+        ],
+        "workspace/foldingRange/refresh send path",
+        violations,
+    );
+    require_all(
+        LIFECYCLE_CAPABILITIES,
+        &lifecycle_capabilities,
+        &["/workspace/foldingRange/refreshSupport", "folding_range_refresh_support"],
+        "workspace/foldingRange/refresh capability parser",
+        violations,
+    );
+    require_all(
+        RUNTIME_REFRESH,
+        &runtime_refresh,
+        &[
+            "refresh_folding_ranges",
+            "folding_range_refresh_support",
+            "request_folding_range_refresh",
+        ],
+        "workspace/foldingRange/refresh debounce path",
+        violations,
+    );
+
+    Ok(())
+}
+
+fn check_forbidden_source_claims(root: &Path, violations: &mut Vec<Violation>) -> Result<()> {
+    let window = read_required(root, "crates/perl-lsp-rs/src/runtime/window.rs")?;
+    for (idx, line) in window.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.contains("MessageType::Debug")
+            || trimmed == "Debug,"
+            || trimmed.starts_with("Debug =")
+        {
+            violations.push(Violation {
+                rel_path: "crates/perl-lsp-rs/src/runtime/window.rs".to_string(),
+                line: idx + 1,
+                label: "MessageType.Debug",
+                detail: "MessageType.Debug is not part of the current selected 3.18 claim"
+                    .to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn require_all(
+    rel_path: &str,
+    text: &str,
+    needles: &[&'static str],
+    label: &'static str,
+    violations: &mut Vec<Violation>,
+) {
+    for needle in needles {
+        if !text.contains(needle) {
+            violations.push(Violation {
+                rel_path: rel_path.to_string(),
+                line: 1,
+                label,
+                detail: format!("missing required guard marker {:?}", needle),
+            });
+        }
+    }
+}
+
+fn read_required(root: &Path, rel_path: &str) -> Result<String> {
+    fs::read_to_string(root.join(rel_path))
+        .with_context(|| format!("failed to read required guard input {rel_path}"))
+}
+
+fn line_number_for(text: &str, needle: &str) -> usize {
+    text.lines().position(|line| line.contains(needle)).map_or(1, |idx| idx + 1)
+}
+
+fn line_number_for_pointer(text: &str, pointer: &str) -> usize {
+    pointer
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .map_or(1, |key| line_number_for(text, key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_number_for_reports_first_matching_line() {
+        let text = "one\ntwo marker\nthree marker\n";
+        assert_eq!(line_number_for(text, "marker"), 2);
+    }
+
+    #[test]
+    fn line_number_for_missing_marker_falls_back_to_one() {
+        assert_eq!(line_number_for("one\ntwo\n", "missing"), 1);
+    }
+
+    #[test]
+    fn pointer_line_uses_last_path_segment() {
+        let text = "{\n  \"semanticTokensProvider\": {\n    \"delta\": true\n  }\n}\n";
+        assert_eq!(line_number_for_pointer(text, "/semanticTokensProvider/full/delta"), 3);
+    }
+}

--- a/xtask/src/tasks/mod.rs
+++ b/xtask/src/tasks/mod.rs
@@ -70,6 +70,7 @@ pub mod install_surface_check;
 pub mod intent_diff_gate;
 pub mod label_projector;
 pub mod layer_check;
+pub mod lsp_318_claims;
 pub mod memory_trends;
 pub mod merge_ready;
 pub mod methodology_gate;

--- a/xtask/tests/list_commands_cli.rs
+++ b/xtask/tests/list_commands_cli.rs
@@ -13,6 +13,7 @@ fn list_commands_emits_sorted_top_level_names() -> Result<()> {
     assert!(lines.contains(&"check-active-goal-manifest"));
     assert!(lines.contains(&"ci"));
     assert!(lines.contains(&"check-active-goal-manifest"));
+    assert!(lines.contains(&"check-lsp-318-claims"));
     assert!(lines.contains(&"check-only"));
     assert!(lines.contains(&"check-test-wiring"));
     assert!(lines.contains(&"layer-check"));


### PR DESCRIPTION
Problem: Swarm had LSP 3.18 claim-boundary guards, textDocument/content tests, and the semantic inline-completion roadmap that were not yet mirrored into source. Fix: Mirror the swarm contract-lock files into source while leaving release metadata alone, and add a source changelog note for the new guard/docs surfaces. Verification: cargo fmt -p xtask -p perl-lsp-rs -- --check; cargo check -p xtask --locked; cargo test -p perl-lsp-rs --test lsp_text_document_content_tests --locked; cargo test -p perl-lsp-rs --test lsp_318_negative_claims --locked; cargo xtask check-lsp-318-claims; cargo xtask check-devex-docs; cargo xtask doc-claims; cargo test -p xtask --test list_commands_cli --locked; git diff --check.