### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: Loop-control statement references an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,69 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Drop an undefined loop-control label (PL410 / `LoopControlUndefinedLabel`).
+///
+/// Fires for `next LABEL`, `last LABEL`, and `redo LABEL` when `LABEL` is not
+/// defined anywhere in the file.  The fix strips the label so the statement
+/// targets the innermost enclosing loop instead.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    // Message format: "`{op} {label}` references a label that is not defined in this file"
+    let Some(inner) = diagnostic.message.split('`').nth(1) else {
+        return Vec::new();
+    };
+    let parts: Vec<&str> = inner.split_whitespace().collect();
+    if parts.len() != 2 {
+        return Vec::new();
+    }
+    let (op, label) = (parts[0], parts[1]);
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let Some(slice) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+
+    // The node slice must begin with the operator keyword.
+    if !slice.starts_with(op) {
+        return Vec::new();
+    }
+
+    // Locate the label within the slice (after the op keyword).
+    let after_op = &slice[op.len()..];
+    let Some(label_rel_offset) = after_op.find(label) else {
+        return Vec::new();
+    };
+
+    // Delete from end-of-op through end-of-label (removes " LABEL" including space).
+    let delete_start = range_start + op.len();
+    let delete_end = delete_start + label_rel_offset + label.len();
+
+    if delete_end > range_end
+        || !source.is_char_boundary(delete_start)
+        || !source.is_char_boundary(delete_end)
+    {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Drop undefined label '{label}' — '{op}' targets the innermost loop"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: delete_start, end: delete_end },
+                new_text: String::new(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,272 @@
+//! BDD tests for the PL410 quick-fix handler:
+//!   `fix_loop_control_undefined_label` — drop the undefined label from a
+//!   `next`/`last`/`redo LABEL` statement so it targets the innermost loop.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a loop-control statement whose label is not defined
+//!   WHEN   a PL410 diagnostic is present and code actions are requested
+//!   THEN   exactly the expected action is returned with the correct edit
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action in reverse offset order and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 – next LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a file where `next OUTER` references a label that does not exist
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the PL410 diagnostic
+    let actions = actions_for(source, &[diag]);
+
+    // THEN exactly one action offering to drop the label is returned
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label action should be marked preferred");
+
+    // AND applying the fix converts `next OUTER` to bare `next`
+    let result = edited(source, action);
+    assert!(
+        result.contains("next;"),
+        "expected bare 'next;' after label drop, got: {result:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 – last LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a file where `last MISSING` references an undefined label
+    let source = "while (1) { last MISSING; }\n";
+    let stmt_start = source.find("last MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN a drop-label action is offered
+    let action = find_action(&actions, |t| t.contains("MISSING"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND the edit converts `last MISSING` to bare `last`
+    let result = edited(source, action);
+    assert!(
+        result.contains("last;"),
+        "expected bare 'last;' after label drop, got: {result:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 – redo LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a file where `redo NOWHERE` references an undefined label
+    let source = "for my $i (1..5) { redo NOWHERE; }\n";
+    let stmt_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN a drop-label action is offered
+    let action = find_action(&actions, |t| t.contains("NOWHERE"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND the edit converts `redo NOWHERE` to bare `redo`
+    let result = edited(source, action);
+    assert!(
+        result.contains("redo;"),
+        "expected bare 'redo;' after label drop, got: {result:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 – title naming convention
+// ===========================================================================
+
+#[test]
+fn drop_label_action_title_names_the_operator_and_label() -> Result<(), Box<dyn std::error::Error>>
+{
+    // GIVEN a `last PHANTOM` diagnostic
+    let source = "while (1) { last PHANTOM; }\n";
+    let stmt_start = source.find("last PHANTOM").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title contains both the label name and the operator keyword
+    let action = find_action(&actions, |t| t.contains("PHANTOM"))
+        .ok_or_else(|| format!("no action for PHANTOM in: {:?}", actions))?;
+
+    assert!(
+        action.title.contains("last"),
+        "title should name the operator 'last', got: {:?}",
+        action.title
+    );
+    assert!(
+        action.title.contains("PHANTOM"),
+        "title should name the label 'PHANTOM', got: {:?}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 – invalid-range guard
+// ===========================================================================
+
+#[test]
+fn drop_label_action_invalid_range_is_guarded() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose byte range falls inside a multi-byte character
+    let source = "for my $i (1..10) { next OUTER; }\nmy $s = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("UTF-8 marker not found")?;
+
+    // Range straddling a non-char-boundary (char_start + 1 is mid-codepoint)
+    let diag = make_diag(
+        char_start + 1,
+        char_start + 2,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no drop-label action is produced — the guard rejects the invalid range
+    assert!(
+        !actions.iter().any(|a| a.title.contains("OUTER")),
+        "expected no PL410 action for non-char-boundary range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Cross-cutting: dispatch-table smoke test
+// ===========================================================================
+
+#[test]
+fn dispatch_smoke_test_pl410_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: a PL410 diagnostic produces at least one action, confirming
+    // the dispatch table in diagnostic_routes.rs is wired up correctly.
+    let source = "for my $i (1..10) { next GHOST; }\n";
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let stmt_start = source.find("next GHOST").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next GHOST".len();
+
+    let diags = vec![make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("GHOST")),
+        "PL410 route not wired — no action for 'GHOST' in: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label fire the PL410 diagnostic, but clicking the lightbulb in an editor returned **no code actions**. The diagnostic route table in `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics silently fell through to `_ => {}`.

This is a runtime-fatal condition in Perl — if the named label doesn't exist, Perl dies at runtime with `Label not found for "next LABEL"`. The mechanical fix is unambiguous: drop the label so the statement targets the innermost enclosing loop.

Closes #9612.

## Changes

### `quick_fixes.rs` — new handler `fix_loop_control_undefined_label`

Parses the operator (`next`/`last`/`redo`) and label name from the backtick-quoted prefix of the PL410 message:

```
`next OUTER` references a label that is not defined in this file
```

Then:
1. Validates the byte range with `valid_diagnostic_range` (guards against non-char-boundary ranges).
2. Verifies the source slice at the range starts with the operator keyword.
3. Locates the label within the slice and emits a single `is_preferred: true` CodeAction that deletes `" LABEL"` from the node range — leaving bare `next`/`last`/`redo` to target the innermost loop.

Only the three documented Perl operators are handled; any other value in the message returns no actions.

### `diagnostic_routes.rs` — new PL410 routing arm

```rust
// PL410: Loop-control statement references an undefined label
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

Added after the PL405 arm, before the `_ => {}` fallthrough.

### `tests/quick_fix_pl410_bdd.rs` — 6 new BDD tests

| Test | Covers |
|------|--------|
| `next_undefined_label_produces_drop_label_action` | `next OUTER` → bare `next;` |
| `last_undefined_label_produces_drop_label_action` | `last MISSING` → bare `last;` |
| `redo_undefined_label_produces_drop_label_action` | `redo NOWHERE` → bare `redo;` |
| `drop_label_action_title_names_the_operator_and_label` | Title contains both op and label name |
| `drop_label_action_invalid_range_is_guarded` | Non-char-boundary range → no action |
| `dispatch_smoke_test_pl410_reaches_handler` | PL410 code reaches the handler via the route table |

## Verification

```
running 6 tests
test dispatch_smoke_test_pl410_reaches_handler ... ok
test last_undefined_label_produces_drop_label_action ... ok
test drop_label_action_invalid_range_is_guarded ... ok
test drop_label_action_title_names_the_operator_and_label ... ok
test next_undefined_label_produces_drop_label_action ... ok
test redo_undefined_label_produces_drop_label_action ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured
```

Pre-existing `quick_fix_new_codes_bdd` suite: 17/17 green. `cargo clippy` and `cargo xtask fmt` clean.

## Non-goals

- Does not add a "suggest defining a label" alternative (requires AST rewrite guidance — out of scope per #9612).
- Does not affect the diagnostic emission logic in `loop_control_label.rs`.

https://claude.ai/code/session_01KY2wdCfvC2DyKVBMTyexie

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY2wdCfvC2DyKVBMTyexie)_