### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -196,6 +196,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         c if c == DiagnosticCode::SecuritySignalHandler.as_str() => {
             actions.extend(quick_fixes::fix_security_signal_handler(source, &qf_diag));
         }
+        // PL410: Loop-control statement targets an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         // PL405: printf/sprintf format specifier count mismatch
         c if c == DiagnosticCode::PrintfFormatMismatch.as_str()
             || c == "native.common.printf_format_arity" =>

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1972,6 +1972,46 @@ fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, 
     Some((line_start, line_end))
 }
 
+/// Drop the undefined label from a `next LABEL` / `last LABEL` / `redo LABEL`
+/// statement so it targets the innermost enclosing loop instead (PL410).
+///
+/// Perl dies at runtime with `Label not found for "next LABEL"` when a
+/// loop-control statement names a label that does not exist in the file.
+/// The only mechanical safe fix is to remove the label so the statement
+/// targets the nearest enclosing loop.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(text) = source.get(start..end) else {
+        return Vec::new();
+    };
+    let mut tokens = text.trim_start().split_ascii_whitespace();
+    let op = match tokens.next() {
+        Some(kw) if matches!(kw, "next" | "last" | "redo") => kw,
+        _ => return Vec::new(),
+    };
+    let Some(label) = tokens.next() else {
+        return Vec::new();
+    };
+
+    vec![CodeAction {
+        title: format!("Drop undefined label '{label}' from '{op}'"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = range;
     if start > end

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,273 @@
+//! BDD tests for the PL410 quick-fix handler:
+//!   PL410 - `next`/`last`/`redo LABEL` targets an undefined label
+//!           (`fix_loop_control_undefined_label`)
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source code containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is raised and code actions are requested
+//!   THEN   exactly one action is returned offering to drop the undefined label
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action (reverse order to preserve offsets) and return the result.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop-control `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }";
+    let start = source.find("next OUTER").ok_or("marker not found")?;
+    let end = start + "next OUTER".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is exactly one action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no drop-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Drop undefined label 'OUTER' from 'next'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label action should be preferred");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop-control `last MISSING` where MISSING is not defined
+    let source = "while (1) { last MISSING; }";
+    let start = source.find("last MISSING").ok_or("marker not found")?;
+    let end = start + "last MISSING".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action offers to drop the label from `last`
+    let action = find_action(&actions, |t| t.contains("MISSING"))
+        .ok_or_else(|| format!("no drop-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Drop undefined label 'MISSING' from 'last'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND the edit produces `last` without the label
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop-control `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+    let start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let end = start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action offers to drop the label from `redo`
+    let action = find_action(&actions, |t| t.contains("NOWHERE"))
+        .ok_or_else(|| format!("no drop-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Drop undefined label 'NOWHERE' from 'redo'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — title includes both label name and operator
+// ===========================================================================
+
+#[test]
+fn title_names_operator_and_label() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next GHOST` statement
+    let source = "for my $x (1..3) { next GHOST; }";
+    let start = source.find("next GHOST").ok_or("marker not found")?;
+    let end = start + "next GHOST".len();
+
+    let diag = make_diag(
+        start,
+        end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("GHOST"))
+        .ok_or_else(|| format!("no GHOST action in: {actions:?}"))?;
+
+    // THEN the title contains both the label name and the operator
+    assert!(
+        action.title.contains("GHOST"),
+        "title should include the label name; got: {:?}",
+        action.title
+    );
+    assert!(
+        action.title.contains("next"),
+        "title should include the operator; got: {:?}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — invalid (non-char-boundary) range is rejected
+// ===========================================================================
+
+#[test]
+fn non_char_boundary_range_produces_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source with a multibyte character so we can manufacture an
+    // invalid range that straddles a char boundary
+    let source = "for my $i (1..3) { next LOOP; }\nmy $x = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+
+    // A range that starts inside the multibyte sequence is not a valid char boundary
+    let diag = make_diag(
+        char_start + 1,
+        char_start + 2,
+        "PL410",
+        "`next LOOP` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no drop-label action is produced
+    assert!(
+        !actions.iter().any(|a| a.title.contains("Drop undefined label")),
+        "expected no PL410 action for non-char-boundary range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Cross-cutting: dispatch-table smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: one diagnostic for each of the three operators confirms
+    // the dispatch table routes all three to the handler.
+    let source = "for my $i (1..10) { next ALPHA; }\nwhile (1) { last BETA; }\nfor my $j (1..3) { redo GAMMA; }\n";
+
+    let next_start = source.find("next ALPHA").ok_or("next ALPHA not found")?;
+    let last_start = source.find("last BETA").ok_or("last BETA not found")?;
+    let redo_start = source.find("redo GAMMA").ok_or("redo GAMMA not found")?;
+
+    let diags = vec![
+        make_diag(
+            next_start,
+            next_start + "next ALPHA".len(),
+            "PL410",
+            "`next ALPHA` references a label that is not defined in this file",
+        ),
+        make_diag(
+            last_start,
+            last_start + "last BETA".len(),
+            "PL410",
+            "`last BETA` references a label that is not defined in this file",
+        ),
+        make_diag(
+            redo_start,
+            redo_start + "redo GAMMA".len(),
+            "PL410",
+            "`redo GAMMA` references a label that is not defined in this file",
+        ),
+    ];
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_next = actions.iter().any(|a| a.title.contains("ALPHA"));
+    let has_last = actions.iter().any(|a| a.title.contains("BETA"));
+    let has_redo = actions.iter().any(|a| a.title.contains("GAMMA"));
+
+    assert!(has_next, "PL410 route not producing action for 'next ALPHA'; actions: {actions:?}");
+    assert!(has_last, "PL410 route not producing action for 'last BETA'; actions: {actions:?}");
+    assert!(has_redo, "PL410 route not producing action for 'redo GAMMA'; actions: {actions:?}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

When a `next LABEL`, `last LABEL`, or `redo LABEL` statement references a label that doesn't exist in the file, Perl will die at runtime with `Label not found for "next LABEL"`. The diagnostic system already flags this as **PL410**, but clicking the lightbulb returned no code actions — `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so every PL410 silently fell through to `_ => {}`.

This PR wires up the missing quick-fix so editors can offer a one-click repair.

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

Added `fix_loop_control_undefined_label(source, diagnostic)`:

- Calls `valid_diagnostic_range` (shared guard) to reject invalid / non-char-boundary ranges — same defensive pattern used by `fix_unused_import`, `fix_deprecated_array_base`, etc.
- Extracts the operator keyword (`next` / `last` / `redo`) and label name from the source text at the diagnostic range using `split_ascii_whitespace`.
- Returns empty `Vec` when: range is invalid, the first token isn't a recognised loop-control keyword, or the second token (label) is absent.
- Produces a single `CodeAction` that replaces `{op} LABEL` with just `{op}`, making the statement target the innermost enclosing loop.
- Sets `is_preferred: true` — there is exactly one sensible mechanical fix.
- Title format: `"Drop undefined label '{LABEL}' from '{op}'"` (includes both the label name and the operator for unambiguous identification in multi-diagnostic scenarios).

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

Added a match arm immediately after PL602:

```rust
// PL410: Loop-control statement targets an undefined label
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` *(new)*

6 BDD integration tests following the Gherkin GIVEN/WHEN/THEN pattern established by `quick_fix_new_codes_bdd.rs`:

| # | Test | What it verifies |
|---|------|-----------------|
| 1 | `next_undefined_label_produces_drop_action` | `next OUTER` → action with correct title, kind, `is_preferred` |
| 2 | `last_undefined_label_produces_drop_action` | `last MISSING` → action + edit produces `last` without the label |
| 3 | `redo_undefined_label_produces_drop_action` | `redo NOWHERE` → action with correct title, kind, `is_preferred` |
| 4 | `title_names_operator_and_label` | Title includes both operator name and label name |
| 5 | `non_char_boundary_range_produces_no_action` | Range straddling a UTF-8 boundary → no action produced |
| 6 | `pl410_dispatch_smoke_test` | All three operators (`next ALPHA`, `last BETA`, `redo GAMMA`) reach the handler via the dispatch table |

## Test results

```
running 6 tests
test last_undefined_label_produces_drop_action ... ok
test next_undefined_label_produces_drop_action ... ok
test non_char_boundary_range_produces_no_action ... ok
test pl410_dispatch_smoke_test ... ok
test redo_undefined_label_produces_drop_action ... ok
test title_names_operator_and_label ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

All 17 pre-existing `quick_fix_new_codes_bdd` tests remain green. `cargo clippy -p perl-lsp-rs-core --lib` reports zero errors. `cargo xtask fmt` clean.

## Design decisions

- **Source-text extraction over message parsing**: The operator and label are parsed from `source[range.0..range.1]` rather than the diagnostic message string. This is more robust — the message format is a display concern, while the source text at the reported range is a structural fact.
- **No "suggest adding a label" alternative**: The issue spec explicitly excludes this. Adding a label is an AST-rewrite operation requiring context the quick-fix layer doesn't have.
- **`is_preferred: true`**: There is exactly one sensible safe fix (drop the label). A second competing action would only add confusion.

## Non-goals

- Does not touch the diagnostic emission logic in `loop_control_label.rs`.
- Does not add a Perl::Critic policy alias arm (no such alias exists for PL410).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FscfksMhbmQ8qAfPzLBNKA)_