### PR TITLE
feat(code-actions): add PL410 quick-fix for undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo to undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,57 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Remove the undefined label from a loop-control statement (PL410).
+///
+/// `next LABEL`, `last LABEL`, and `redo LABEL` statements that reference a
+/// label that does not exist in any enclosing loop cause a runtime-fatal
+/// "Label not found" error in Perl. The one mechanical fix is to drop the
+/// label so the statement targets the innermost enclosing loop instead.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(text) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+    let trimmed = text.trim_start();
+    let Some(op) = loop_control_op(trimmed) else {
+        return Vec::new();
+    };
+    // Verify whitespace follows the operator — guards against "nextfoo" or bare "next".
+    if !trimmed[op.len()..].starts_with(|c: char| c.is_whitespace()) {
+        return Vec::new();
+    }
+    // Preserve any leading indentation that precedes the operator in the range.
+    let leading = text.len() - trimmed.len();
+    let new_text = format!("{}{op}", &text[..leading]);
+
+    vec![CodeAction {
+        title: format!("Remove undefined label from '{op}'"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text,
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+fn loop_control_op(text: &str) -> Option<&'static str> {
+    if text.starts_with("next") {
+        Some("next")
+    } else if text.starts_with("last") {
+        Some("last")
+    } else if text.starts_with("redo") {
+        Some("redo")
+    } else {
+        None
+    }
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,215 @@
+//! BDD tests for the PL410 quick-fix handler:
+//!   PL410 — `next`/`last`/`redo LABEL` where the label is not defined
+//!            (`fix_loop_control_undefined_label`)
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   diagnostics are produced and code actions are requested
+//!   THEN   exactly the expected action(s) are returned with correct edits
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next/last/redo to undefined label
+// ===========================================================================
+
+#[test]
+fn loop_control_pl410_next_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while loop containing `next OUTER` where OUTER is not defined
+    let source = "while (1) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the diagnostic range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a drop-label action for 'next'
+    let action = find_action(&actions, |t| t.contains("'next'"))
+        .ok_or_else(|| format!("no PL410 drop action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove undefined label from 'next'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the drop-label action should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn loop_control_pl410_last_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for loop containing `last DONE` where DONE is not defined
+    let source = "for my $i (1..10) { last DONE; }\n";
+    let stmt_start = source.find("last DONE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last DONE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last DONE` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("'last'"))
+        .ok_or_else(|| format!("no PL410 drop action for 'last' in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove undefined label from 'last'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn loop_control_pl410_redo_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a foreach loop containing `redo RETRY` where RETRY is not defined
+    let source = "foreach my $x (@items) { redo RETRY; }\n";
+    let stmt_start = source.find("redo RETRY").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo RETRY".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo RETRY` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("'redo'"))
+        .ok_or_else(|| format!("no PL410 drop action for 'redo' in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove undefined label from 'redo'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn loop_control_pl410_edit_drops_the_label() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source with `next MISSING` where the label does not exist
+    let source = "while (1) { next MISSING; }\n";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("'next'"))
+        .ok_or_else(|| format!("no PL410 action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN the label is dropped; only the bare operator remains
+    assert_eq!(result, "while (1) { next; }\n");
+
+    Ok(())
+}
+
+#[test]
+fn loop_control_pl410_invalid_range_is_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose range straddles a multi-byte character boundary
+    let source = "while (1) { next OUTER; }\nmy $x = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+    // Point into the middle of the two-byte UTF-8 sequence — not a char boundary.
+    let diag = make_diag(
+        char_start + 1,
+        char_start + 2,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no drop-label action is produced for the invalid range
+    assert!(
+        !actions.iter().any(|a| a.title.contains("Remove undefined label")),
+        "expected no PL410 action for non-char-boundary range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn loop_control_pl410_dispatch_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: confirms the dispatch table in diagnostic_routes.rs routes
+    // PL410 to the handler and produces at least one action for a valid diagnostic.
+    let source = "while (1) { next NOWHERE; }\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let stmt_start = source.find("next NOWHERE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next NOWHERE".len();
+
+    let diags = vec![make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next NOWHERE` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("Remove undefined label")),
+        "PL410 dispatch route not producing an action; actions: {actions:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference a label not defined in any enclosing loop already receive a PL410 diagnostic. However, clicking the lightbulb in an editor returned **no code actions** because `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics fell through to `_ => {}`.

This is a runtime-fatal condition in Perl — Perl dies with `Label not found for "next LABEL"`. The fix is mechanical and unambiguous: drop the undefined label so the statement targets the innermost enclosing loop.

## Changes

### `quick_fixes.rs`
- Added `fix_loop_control_undefined_label(source, diagnostic)` — the handler that:
  1. Validates the byte range with `valid_diagnostic_range` (guards non-char-boundary inputs)
  2. Extracts the loop-control operator from the start of the ranged text (`next`, `last`, or `redo`)
  3. Guards against bare forms (no following whitespace means no label to drop)
  4. Guards against non-operator text (any other token returns no actions)
  5. Preserves leading indentation within the diagnostic range
  6. Replaces `next LABEL` → `next`, `last LABEL` → `last`, `redo LABEL` → `redo`
  7. Marks `is_preferred: true` since there is exactly one sensible fix
- Added `loop_control_op(text)` private helper — centralizes the three-operator match so it stays in one place

### `diagnostic_routes.rs`
- Added arm for `DiagnosticCode::LoopControlUndefinedLabel` (PL410) routing to `fix_loop_control_undefined_label`

### `tests/quick_fix_pl410_bdd.rs` (new)
Six BDD integration tests following the established pattern from `quick_fix_new_codes_bdd.rs`:

| Test | What it verifies |
|------|-----------------|
| `loop_control_pl410_next_produces_drop_action` | `next OUTER` → action titled `"Remove undefined label from 'next'"`, `is_preferred` |
| `loop_control_pl410_last_produces_drop_action` | `last DONE` → action for `last` |
| `loop_control_pl410_redo_produces_drop_action` | `redo RETRY` → action for `redo` |
| `loop_control_pl410_edit_drops_the_label` | Applying the edit transforms `next MISSING;` → `next;` |
| `loop_control_pl410_invalid_range_is_ignored` | A range straddling a UTF-8 boundary produces no action |
| `loop_control_pl410_dispatch_smoke_test` | Confirms the `diagnostic_routes.rs` wiring produces ≥1 action end-to-end |

## Test results

```
running 6 tests
test loop_control_pl410_dispatch_smoke_test ... ok
test loop_control_pl410_edit_drops_the_label ... ok
test loop_control_pl410_invalid_range_is_ignored ... ok
test loop_control_pl410_last_produces_drop_action ... ok
test loop_control_pl410_next_produces_drop_action ... ok
test loop_control_pl410_redo_produces_drop_action ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

- 17 pre-existing `quick_fix_new_codes_bdd` tests: **green**
- 12 pre-existing `loop_control_label_tests` tests: **green**
- `cargo clippy -p perl-lsp-rs-core --lib`: **clean** (one pre-existing unrelated warning in `inline_completion/mod.rs`)

## Non-goals (per spec)

- Does **not** add a "suggest defining a label" alternative fix — that would require AST rewrite guidance
- Does **not** affect the diagnostic emission logic in `loop_control_label.rs`
- Does **not** handle `PL409` (goto label) — separate diagnostic, separate handler

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dzs4ZQNNVMrCphouHu6vuN)_