### PR TITLE
feat(code-actions): add PL410 quick-fix for undefined loop-control label (#9612)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -196,6 +196,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         c if c == DiagnosticCode::SecuritySignalHandler.as_str() => {
             actions.extend(quick_fixes::fix_security_signal_handler(source, &qf_diag));
         }
+        // PL410: Loop control statement targets undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1760,6 +1760,40 @@ pub fn fix_security_signal_handler(
     }]
 }
 
+/// Drop an undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL` statement (PL410).
+///
+/// Perl dies at runtime with `Label not found for "next LABEL"` when the named label does not
+/// exist.  The only mechanical fix is to remove the label so the statement targets the innermost
+/// enclosing loop.  Suggesting "define the label" is out of scope — it would require knowing
+/// which loop the author intended.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let text = &source[start..end];
+    let op = text.split_ascii_whitespace().next().unwrap_or("");
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Remove undefined label (use bare `{op}` to target innermost loop)"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,262 @@
+//! BDD tests for the PL410 (LoopControlUndefinedLabel) quick-fix handler:
+//!   `fix_loop_control_undefined_label`
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a loop control statement targeting an undefined label
+//!   WHEN   a PL410 diagnostic is provided and code actions are requested
+//!   THEN   exactly the expected action(s) are returned with correct edits
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 - Loop control statement targets undefined label
+// ===========================================================================
+
+#[test]
+fn pl410_next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next GHOST` statement where GHOST is not defined as a label
+    let source = "for my $x (1..3) { next GHOST; }";
+    let stmt_start = source.find("next GHOST").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next GHOST".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the diagnostic
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no drop-label action for 'next' in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label action should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn pl410_next_edit_removes_label_from_statement() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next GHOST` where the label is undefined
+    let source = "for my $x (1..3) { next GHOST; }";
+    let stmt_start = source.find("next GHOST").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next GHOST".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no next action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN the label is removed; `next` becomes bare
+    assert_eq!(result, "for my $x (1..3) { next; }");
+
+    Ok(())
+}
+
+#[test]
+fn pl410_last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `last MISSING` statement
+    let source = "for my $i (1..10) { last MISSING; }";
+    let stmt_start = source.find("last MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no last action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..10) { last; }");
+
+    Ok(())
+}
+
+#[test]
+fn pl410_redo_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `redo NOWHERE` statement
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+    let stmt_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no redo action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { redo; }");
+
+    Ok(())
+}
+
+#[test]
+fn pl410_action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic for `next PHANTOM`
+    let source = "while (1) { next PHANTOM; }";
+    let stmt_start = source.find("next PHANTOM").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next PHANTOM".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next PHANTOM` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title includes the operator name
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no action naming 'next' in: {:?}", actions))?;
+
+    assert!(
+        action.title.contains("next"),
+        "title should name the operator 'next', got: {:?}",
+        action.title
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pl410_invalid_range_guard_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic with an out-of-bounds range
+    let source = "for my $x (1..3) { next GHOST; }";
+    let diag = make_diag(
+        source.len() + 1,
+        source.len() + 10,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL410 drop-label action is returned (range guard fires)
+    assert!(
+        !actions.iter().any(|a| a.title.contains("Remove undefined label")),
+        "expected no drop-label action for out-of-bounds range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Cross-cutting: dispatch-table smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_test_all_three_ops_reach_handler() -> Result<(), Box<dyn std::error::Error>>
+{
+    // Smoke test: each of the three operators produces at least one action,
+    // confirming the PL410 dispatch arm is wired up correctly.
+
+    let source = "for my $x (1..3) { next GHOST; last MISSING; redo NOWHERE; }";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let next_start = source.find("next GHOST").ok_or("next GHOST not found")?;
+    let last_start = source.find("last MISSING").ok_or("last MISSING not found")?;
+    let redo_start = source.find("redo NOWHERE").ok_or("redo NOWHERE not found")?;
+
+    let diags = vec![
+        make_diag(
+            next_start,
+            next_start + "next GHOST".len(),
+            "PL410",
+            "`next GHOST` references a label that is not defined in this file",
+        ),
+        make_diag(
+            last_start,
+            last_start + "last MISSING".len(),
+            "PL410",
+            "`last MISSING` references a label that is not defined in this file",
+        ),
+        make_diag(
+            redo_start,
+            redo_start + "redo NOWHERE".len(),
+            "PL410",
+            "`redo NOWHERE` references a label that is not defined in this file",
+        ),
+    ];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_next = actions.iter().any(|a| a.title.contains("next"));
+    let has_last = actions.iter().any(|a| a.title.contains("last"));
+    let has_redo = actions.iter().any(|a| a.title.contains("redo"));
+
+    assert!(has_next, "PL410 next route not producing action; actions: {:?}", actions);
+    assert!(has_last, "PL410 last route not producing action; actions: {:?}", actions);
+    assert!(has_redo, "PL410 redo route not producing action; actions: {:?}", actions);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a quick-fix code action for PL410 (`LoopControlUndefinedLabel`) diagnostics. When `next LABEL`, `last LABEL`, or `redo LABEL` references a label that does not exist in the file, the LSP now offers a single mechanical fix: drop the label so the statement targets the innermost enclosing loop.

The only safe automated repair is label removal — suggesting "define the label" would require knowing which loop the author intended, which static analysis cannot determine without user intent. This is consistent with how other quick-fixes in this codebase handle "remove the offending part."

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive (new code action returned for PL410 diagnostics; no existing actions removed)
- DAP surface: unchanged
- CLI: unchanged

## What changed

**`crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`**
Adds `fix_loop_control_undefined_label`: validates the diagnostic range, extracts the operator (`next`/`last`/`redo`), and returns a `QuickFix` `CodeAction` that replaces `next LABEL` with `next` (and similarly for `last`/`redo`). Uses the existing `valid_diagnostic_range` guard so out-of-bounds ranges return an empty vec.

**`crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`**
Wires the new function into the `match policy_code` dispatch table via a new PL410 arm before the `_ => {}` catch-all.

**`crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs`**
7 BDD tests covering: `next`/`last`/`redo` each produce a drop-label action and correct edit, the action title names the operator, the invalid-range guard returns no PL410 actions, and a smoke test confirming all three operators reach the dispatch arm.

## How to review

Start at `quick_fixes.rs` around the new `fix_loop_control_undefined_label` function (near the bottom of the public section, after `fix_security_signal_handler`). Then check the one-line dispatch arm in `diagnostic_routes.rs`. Tests are in `tests/quick_fix_pl410_bdd.rs`.

## Evidence

```
running 7 tests
test pl410_action_title_names_the_operator ... ok
test pl410_dispatch_smoke_test_all_three_ops_reach_handler ... ok
test pl410_last_undefined_label_produces_drop_action ... ok
test pl410_next_edit_removes_label_from_statement ... ok
test pl410_redo_undefined_label_produces_drop_action ... ok
test pl410_next_undefined_label_produces_drop_action ... ok
test pl410_invalid_range_guard_returns_no_actions ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo clippy -p perl-lsp-rs-core --lib: no warnings
cargo xtask fmt: exit 0 (no formatting changes)
existing tests (loop_control_label_tests, quick_fix_new_codes_bdd): 29 passed, 0 failed
```

## Risk & rollback

Blast radius is confined to `perl-lsp-rs-core`. The new dispatch arm only fires when a diagnostic carries the exact code string `"PL410"`; all other codes are unaffected. The `valid_diagnostic_range` guard prevents panics on malformed ranges. Rollback: revert the three-file commit.

## Follow-ups

None required. The diagnostic itself (PL410 emission) is covered by the existing `loop_control_label_tests.rs` suite; this PR only adds the repair side.

https://claude.ai/code/session_01DDeDGsqheLsbuAedqJYo6P

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDeDGsqheLsbuAedqJYo6P)_