### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label (#9612)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo LABEL references an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,38 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Drop undefined label from `next`/`last`/`redo LABEL` (PL410).
+///
+/// The only safe automated fix is to remove the label so the statement
+/// targets the innermost enclosing loop. For example, `next OUTER` becomes
+/// `next`. This is a runtime-fatal condition in Perl, so `is_preferred: true`.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(snippet) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+
+    let op = snippet.split_whitespace().next().unwrap_or("");
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Remove undefined label — write '{op}' to target innermost loop"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,258 @@
+//! BDD tests for the PL410 quick-fix handler (`fix_loop_control_undefined_label`).
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a `next`/`last`/`redo LABEL` where the label is undefined
+//!   WHEN   a PL410 diagnostic is produced and code actions are requested
+//!   THEN   exactly one action is returned that removes the label and leaves the bare op
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action (sorted descending by offset) and return the
+/// resulting source so tests can verify the exact text produced.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn pl410_next_undefined_label_produces_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source where `next OUTER` references a label that is not defined
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action that removes the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no PL410 action for `next OUTER` in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "PL410 fix should be preferred — it is the only sensible fix");
+
+    // Applying the edit rewrites `next OUTER` → `next`
+    let result = edited(source, action);
+    assert!(
+        result.contains("next;")
+            || result.contains("next ")
+            || result.contains("next\n")
+            || result.ends_with("next"),
+        "edit should replace `next OUTER` with `next`: {result:?}"
+    );
+    assert!(!result.contains("OUTER"), "label name should be removed: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn pl410_last_undefined_label_produces_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source where `last MISSING` references a label that is not defined
+    let source = "while (1) { last MISSING; }\n";
+    let stmt_start = source.find("last MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action for `last`
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no PL410 action for `last MISSING` in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // The edit removes the label name
+    let result = edited(source, action);
+    assert!(!result.contains("MISSING"), "label name should be removed: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn pl410_redo_undefined_label_produces_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source where `redo NOWHERE` references a label that is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }\n";
+    let stmt_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action for `redo`
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no PL410 action for `redo NOWHERE` in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert!(!result.contains("NOWHERE"), "label name should be removed: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Title naming convention
+// ===========================================================================
+
+#[test]
+fn pl410_action_title_names_the_op() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic on `next GHOST`
+    let source = "for my $x (1..3) { next GHOST; }\n";
+    let stmt_start = source.find("next GHOST").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next GHOST".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the title mentions both the fix concept and the operator name
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no action found, got: {actions:?}"))?;
+
+    assert!(action.title.contains("next"), "title should mention the op 'next': {}", action.title);
+    assert!(
+        action.title.to_lowercase().contains("label")
+            || action.title.to_lowercase().contains("innermost"),
+        "title should describe the fix intent: {}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Invalid range guard
+// ===========================================================================
+
+#[test]
+fn pl410_invalid_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose range is beyond the end of the source
+    let source = "for my $i (1..10) { next OUTER; }\n";
+
+    let diag = make_diag(
+        source.len() + 1,
+        source.len() + 10,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for an out-of-bounds range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL410 action is produced (range guard must reject it)
+    let has_pl410_action =
+        actions.iter().any(|a| a.title.contains("next") || a.title.contains("innermost"));
+    assert!(!has_pl410_action, "expected no PL410 action for invalid range, got: {actions:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: PL410 reaches the fix handler when given a well-formed diagnostic,
+    // confirming the dispatch table is wired correctly.
+    let source = "for my $i (1..10) { next PHANTOM; }\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let stmt_start = source.find("next PHANTOM").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next PHANTOM".len();
+
+    let diags = vec![make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next PHANTOM` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_pl410 = actions.iter().any(|a| a.title.contains("next"));
+    assert!(has_pl410, "PL410 dispatch route not producing an action; actions: {actions:?}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements whose label is not defined in the file receive a PL410 diagnostic, but clicking the lightbulb in an editor returned **no code actions** — the diagnostic route table had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so every PL410 diagnostic silently fell through to `_ => {}`.

This is a runtime-fatal condition in Perl: if the named label doesn't exist, Perl dies at runtime with `Label not found for "next LABEL"`. The only safe automated fix is to drop the label so the statement targets the innermost enclosing loop.

## Changes

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

Added `fix_loop_control_undefined_label`:

- Validates the byte range with the existing `valid_diagnostic_range` guard before touching source text
- Extracts the operator keyword from the source at the diagnostic range (first whitespace-delimited token)
- Guards that the op is exactly one of `next`, `last`, `redo` — any other value returns no actions
- Returns a single `is_preferred: true` action that replaces the entire `op LABEL` span with the bare `op`
- Title clearly names both the op and the effect: `"Remove undefined label — write '{op}' to target innermost loop"`

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

Added the PL410 routing arm just before the catch-all `_ => {}`:

```rust
// PL410: next/last/redo LABEL references an undefined label
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` (new)

6 BDD integration tests following the same GIVEN/WHEN/THEN pattern as `quick_fix_new_codes_bdd.rs`:

| Test | What it verifies |
|---|---|
| `pl410_next_undefined_label_produces_action` | `next LABEL` → action produced, `is_preferred`, label removed from result |
| `pl410_last_undefined_label_produces_action` | `last LABEL` → action produced, `is_preferred`, label removed |
| `pl410_redo_undefined_label_produces_action` | `redo LABEL` → action produced, `is_preferred`, label removed |
| `pl410_action_title_names_the_op` | Title contains the op name and describes the fix intent |
| `pl410_invalid_range_returns_no_actions` | Out-of-bounds range → zero actions (range guard) |
| `pl410_dispatch_smoke_reaches_handler` | Dispatch table wire-up confirmed end-to-end |

## Test results

```
running 6 tests
test pl410_action_title_names_the_op ... ok
test pl410_dispatch_smoke_reaches_handler ... ok
test pl410_invalid_range_returns_no_actions ... ok
test pl410_last_undefined_label_produces_action ... ok
test pl410_next_undefined_label_produces_action ... ok
test pl410_redo_undefined_label_produces_action ... ok

test result: ok. 6 passed; 0 failed; 0 ignored

running 17 tests (quick_fix_new_codes_bdd — pre-existing)
test result: ok. 17 passed; 0 failed; 0 ignored
```

`cargo clippy -p perl-lsp-rs-core --lib` — no new warnings. `cargo fmt --check` — clean.

## Non-goals (per spec)

- Does not add a "suggest defining a label" alternative fix — that would require AST-level rewrite guidance outside the quick-fix layer
- Does not affect the PL410 diagnostic emission logic in `loop_control_label.rs`
- Does not handle the `GotoUndefinedLabel` (PL409) case — separate diagnostic code, separate issue if needed

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPjGncFfN9Rhnj6p83VuVX)_