### PR TITLE
feat(code-actions): add PL410 quick-fix for undefined loop-control label (#9612)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo with undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1964,6 +1964,39 @@ fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
     specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
+/// Drop the undefined label from a `next`/`last`/`redo LABEL` statement (PL410).
+///
+/// Replaces `next LABEL` with `next` so the statement targets the innermost
+/// enclosing loop instead of a non-existent named loop.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(span_text) = source.get(start..end) else {
+        return Vec::new();
+    };
+    let op = span_text.split_whitespace().next().unwrap_or("");
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Drop label — write `{op}` to target the innermost enclosing loop"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,216 @@
+//! BDD tests for the PL410 quick-fix: drop undefined loop-control label.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a `next/last/redo LABEL` where the label is undefined
+//!   WHEN   a PL410 diagnostic is provided and code actions are requested
+//!   THEN   exactly the expected drop-label action is returned with correct edit
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply the edits from an action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+/// Find the first action whose title matches the predicate.
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 - undefined loop-control label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while loop with `next MISSING` where MISSING is not defined
+    let source = "while(1) { next MISSING; }";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a drop-label action mentioning "next" and "innermost"
+    let action = find_action(&actions, |t| t.contains("next") && t.contains("innermost"))
+        .ok_or_else(|| format!("no drop-label action for next in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the drop action should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for loop with `last NOPE` where NOPE is not defined
+    let source = "for my $i (1..10) { last NOPE; }";
+    let stmt_start = source.find("last NOPE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last NOPE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last NOPE` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a drop-label action mentioning "last"
+    let action = find_action(&actions, |t| t.contains("last") && t.contains("innermost"))
+        .ok_or_else(|| format!("no drop-label action for last in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn redo_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a foreach loop with `redo TOP` where TOP is not defined
+    let source = "foreach my $x (@a) { redo TOP; }";
+    let stmt_start = source.find("redo TOP").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo TOP".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo TOP` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a drop-label action mentioning "redo"
+    let action = find_action(&actions, |t| t.contains("redo") && t.contains("innermost"))
+        .ok_or_else(|| format!("no drop-label action for redo in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn drop_label_edit_leaves_bare_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while loop with `next MISSING`
+    let source = "while(1) { next MISSING; }";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("next") && t.contains("innermost"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    // WHEN the edit is applied
+    let result = edited(source, action);
+
+    // THEN `next MISSING` becomes bare `next` (the `;` was already in source outside the span)
+    assert!(result.contains("next;"), "expected 'next MISSING' replaced with 'next', got: {result:?}");
+    assert!(!result.contains("MISSING"), "label should be removed from the result: {result:?}");
+
+    Ok(())
+}
+
+#[test]
+fn action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while loop with `next MISSING`
+    let source = "while(1) { next MISSING; }";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("next") && t.contains("innermost"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    // THEN the title matches the expected format exactly
+    assert_eq!(
+        action.title,
+        "Drop label \u{2014} write `next` to target the innermost enclosing loop"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_range_guard_suppresses_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic with an out-of-bounds range
+    let source = "while(1) { next MISSING; }";
+    let diag = make_diag(
+        9999,
+        10000,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL410 drop-label action is produced (guard fires)
+    let has_drop_action = actions.iter().any(|a| a.title.contains("innermost"));
+    assert!(
+        !has_drop_action,
+        "expected no drop-label action for out-of-bounds range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `fix_loop_control_undefined_label` to `quick_fixes.rs`: validates the diagnostic byte range, extracts the loop-control operator (`next`/`last`/`redo`), guards against mis-routed spans, and returns a single preferred `CodeAction` that drops the undefined label.
- Adds dispatch route in `diagnostic_routes.rs` for `DiagnosticCode::LoopControlUndefinedLabel` (PL410).
- Adds 6 BDD tests in `quick_fix_pl410_bdd.rs` covering all three operators, the exact edit result, the exact title format, and the invalid-range guard path.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive — new code action offered on PL410 diagnostics
- DAP surface: unchanged
- CLI: unchanged

## What changed

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label receive a PL410 diagnostic. Previously no code action was provided. Now editors offer a single preferred quick-fix: drop the label so the statement targets the innermost enclosing loop (the semantically safe fallback).

The fix replaces the full `next LABEL` span (as emitted by the diagnostic) with just the bare operator. The diagnostic range is byte-validated before any source access. The operator guard ensures only the three documented loop-control keywords produce an action; any other span content silently returns no actions.

## How to review

Start at `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs` — the new `fix_loop_control_undefined_label` function is placed just before the private `diagnostic_line_range` helper. Then check `diagnostic_routes.rs` for the four-line dispatch block. Test coverage is in `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs`.

## Evidence

```
running 6 tests
test action_title_names_the_operator ... ok
test drop_label_edit_leaves_bare_operator ... ok
test invalid_range_guard_suppresses_action ... ok
test last_undefined_label_produces_drop_action ... ok
test next_undefined_label_produces_drop_action ... ok
test redo_undefined_label_produces_drop_action ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 17 tests
test all_three_new_codes_reach_their_handlers ... ok
[... 16 more existing tests pass ...]

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Risk & rollback

Blast radius: new branch in the dispatch match — `_ => {}` fallthrough is untouched. A PL410 diagnostic that already had no action continues to have no action if the guard rejects the span. No existing behavior changes. Rollback: revert the three files.

## Follow-ups

None required. "Suggest defining a label" alternative was explicitly out of scope per the issue.

https://claude.ai/code/session_01ErxJUsqAXPi9hQFPPUHXqe

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErxJUsqAXPi9hQFPPUHXqe)_