### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -196,6 +196,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         c if c == DiagnosticCode::SecuritySignalHandler.as_str() => {
             actions.extend(quick_fixes::fix_security_signal_handler(source, &qf_diag));
         }
+        // PL410: Loop-control targets undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         // PL405: printf/sprintf format specifier count mismatch
         c if c == DiagnosticCode::PrintfFormatMismatch.as_str()
             || c == "native.common.printf_format_arity" =>

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,104 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Drop the label from a `next LABEL`, `last LABEL`, or `redo LABEL` statement (PL410).
+///
+/// When the named label is not defined anywhere in the file, Perl dies at
+/// runtime with "Label not found". Dropping the label makes the statement
+/// target the innermost enclosing loop — the only safe automated fix.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, _range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    // Locate the operator in source at the diagnostic range.
+    let range_text = match source.get(range_start..) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    let ws_len = first_non_whitespace(range_text).unwrap_or(0);
+    let from_op = match range_text.get(ws_len..) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+
+    // Validate: must start with a recognized loop-control keyword followed by whitespace.
+    let op = ["next", "last", "redo"].iter().copied().find(|&k| {
+        from_op.starts_with(k)
+            && from_op
+                .get(k.len()..)
+                .map_or(false, |rest| rest.starts_with(|c: char| c.is_whitespace()))
+    });
+    let Some(op) = op else {
+        return Vec::new();
+    };
+
+    // Find the label name from the message to include in the title.
+    let label_name = parse_loop_control_label(&diagnostic.message).unwrap_or_default();
+
+    // Find and measure the " LABEL" span after the keyword.
+    let after_op = match from_op.get(op.len()..) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+    let span = loop_control_label_span(after_op);
+    if span == 0 {
+        return Vec::new();
+    }
+
+    let delete_start = range_start + ws_len + op.len();
+    let delete_end = delete_start + span;
+
+    if !source.is_char_boundary(delete_end) {
+        return Vec::new();
+    }
+
+    let title = if label_name.is_empty() {
+        format!("Drop undefined label and use '{op}' to target the innermost loop")
+    } else {
+        format!("Drop undefined label '{label_name}' and use '{op}' to target the innermost loop")
+    };
+
+    vec![CodeAction {
+        title,
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: delete_start, end: delete_end },
+                new_text: String::new(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Parse the label name from a PL410 message.
+///
+/// Message form: `` `{op} {label}` references a label ... ``
+fn parse_loop_control_label(message: &str) -> Option<String> {
+    let start = message.find('`')? + 1;
+    let inner = &message[start..];
+    let end = inner.find('`')?;
+    let inside = &inner[..end]; // e.g., "next OUTER"
+    inside.split_whitespace().nth(1).map(str::to_string)
+}
+
+/// Measure the " LABEL" span (whitespace + identifier) after the op keyword.
+fn loop_control_label_span(after_op: &str) -> usize {
+    let ws_len = after_op.len() - after_op.trim_start().len();
+    if ws_len == 0 {
+        return 0;
+    }
+    let label_part = &after_op[ws_len..];
+    let label_len =
+        label_part.find(|c: char| !c.is_alphanumeric() && c != '_').unwrap_or(label_part.len());
+    if label_len == 0 {
+        return 0;
+    }
+    ws_len + label_len
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,224 @@
+//! BDD tests for the PL410 quick-fix handler: drop undefined loop-control label.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is passed and code actions are requested
+//!   THEN   exactly the expected action is returned with the correct edit
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_pl410(start: usize, end: usize, op: &str, label: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some("PL410".to_string()),
+        message: format!("`{op} {label}` references a label that is not defined in this file"),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop-control statement `next OUTER` with an undefined label
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_pl410(stmt_start, stmt_end, "next", "OUTER");
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is exactly one action, offering to drop the label
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no OUTER action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the drop-label action should be preferred");
+
+    // AND the edit removes ' OUTER' leaving 'next;' intact
+    let result = edited(source, action);
+    assert!(result.contains("next;"), "expected 'next;' after label removal, got: {result:?}");
+    assert!(!result.contains("OUTER"), "label 'OUTER' should be gone, got: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop-control statement `last INNER` with an undefined label
+    let source = "while (1) { last INNER; }\n";
+    let stmt_start = source.find("last INNER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last INNER".len();
+
+    let diag = make_pl410(stmt_start, stmt_end, "last", "INNER");
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action for the `last` statement
+    let action = find_action(&actions, |t| t.contains("INNER"))
+        .ok_or_else(|| format!("no INNER action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop-control statement `redo LOOP` with an undefined label
+    let source = "for my $x (1..5) { redo LOOP; }\n";
+    let stmt_start = source.find("redo LOOP").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo LOOP".len();
+
+    let diag = make_pl410(stmt_start, stmt_end, "redo", "LOOP");
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action for the `redo` statement
+    let action = find_action(&actions, |t| t.contains("LOOP"))
+        .ok_or_else(|| format!("no LOOP action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+// ===========================================================================
+// Title contains op and label name
+// ===========================================================================
+
+#[test]
+fn title_names_the_op_and_label() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a next OUTER diagnostic
+    let source = "for my $i (1..3) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_pl410(stmt_start, stmt_end, "next", "OUTER");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title contains both the label 'OUTER' and the op 'next'
+    let action = find_action(&actions, |t| t.contains("OUTER") && t.contains("next"))
+        .ok_or_else(|| format!("expected title with OUTER+next, got: {:?}", actions))?;
+
+    // Title should NOT be generic — it should mention the actual label
+    assert!(
+        action.title.contains("OUTER"),
+        "title should name the label 'OUTER', got: {:?}",
+        action.title
+    );
+    assert!(
+        action.title.contains("next"),
+        "title should name the op 'next', got: {:?}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Invalid-range guard: no action for non-char-boundary range
+// ===========================================================================
+
+#[test]
+fn invalid_range_guard_returns_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source with a multi-byte character; a diagnostic pointing into its
+    // interior (not a char boundary) should produce no actions.
+    let source = "for my $i (1..3) { next OUTER; }\nmy $x = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+
+    // Point the diagnostic at a non-char-boundary offset (middle of 2-byte char)
+    let diag = make_pl410(char_start + 1, char_start + 2, "next", "OUTER");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL410 drop-label action is produced
+    assert!(
+        !actions.iter().any(|a| a.title.contains("OUTER")),
+        "expected no PL410 action for non-char-boundary range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Dispatch smoke test: PL410 route is wired in diagnostic_routes.rs
+// ===========================================================================
+
+#[test]
+fn dispatch_smoke_test_pl410_route_is_wired() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test confirming the dispatch table routes PL410 to the handler.
+    let source = "for my $i (1..10) { next MISSING; }\n";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let diags = vec![make_pl410(stmt_start, stmt_end, "next", "MISSING")];
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    // THEN at least one action is produced (route is live)
+    assert!(
+        !actions.is_empty(),
+        "PL410 dispatch route produced no actions; dispatch table may be unwired"
+    );
+    assert!(
+        actions.iter().any(|a| a.title.contains("MISSING")),
+        "expected an action mentioning 'MISSING', got: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements that target an undefined label are a **runtime-fatal condition in Perl** — Perl dies with `Label not found for "next LABEL"` at execution time. The PL410 diagnostic correctly flagged these, but clicking the lightbulb returned **no code actions** because `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`.

This PR wires the missing route and implements the handler.

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

Added three items:

- **`fix_loop_control_undefined_label(source, diagnostic) -> Vec<CodeAction>`** — the public handler. Extracts the operator keyword from the source text at the diagnostic range, validates it is `next`/`last`/`redo`, measures the ` LABEL` span after the keyword, and emits a `QuickFix` action that deletes that span. Result: `next OUTER` → `next` (the trailing `;` was never part of the AST node range and remains untouched). `is_preferred: true` because there is exactly one safe automated fix.
- **`parse_loop_control_label(message)`** — private; extracts the label name from the PL410 message (`` `{op} {label}` references a label ... ``) for inclusion in the action title.
- **`loop_control_label_span(after_op)`** — private; measures the whitespace + identifier span after the operator so only ` LABEL` is deleted, not any surrounding punctuation or statement terminator.

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

Added one route arm after PL602 / before PL405:

```rust
// PL410: Loop-control targets undefined label
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` (new file)

6 BDD integration tests following the exact pattern of `quick_fix_new_codes_bdd.rs`:

| Test | Covers |
|------|--------|
| `next_undefined_label_produces_drop_action` | `next LABEL` → action produced; edit verified (`next;` remains, label gone) |
| `last_undefined_label_produces_drop_action` | `last LABEL` → action produced with correct metadata |
| `redo_undefined_label_produces_drop_action` | `redo LABEL` → action produced with correct metadata |
| `title_names_the_op_and_label` | Title contains both the operator name and the specific label string |
| `invalid_range_guard_returns_no_action` | Non-char-boundary range → no action (guards against malformed diagnostics) |
| `dispatch_smoke_test_pl410_route_is_wired` | Confirms `diagnostic_routes.rs` routes PL410 to the handler end-to-end |

## Verification

```
cargo test -p perl-lsp-rs-core --test quick_fix_pl410_bdd
# → test result: ok. 6 passed; 0 failed

cargo test -p perl-lsp-rs-core --test quick_fix_new_codes_bdd
# → test result: ok. 17 passed; 0 failed   (pre-existing tests, all green)

cargo clippy -p perl-lsp-rs-core   # → clean
cargo fmt -p perl-lsp-rs-core      # → clean
```

## Design decisions

- **Drop-label only, no "suggest defining a label" alternative.** Generating a correct label insertion requires knowing which enclosing loop to annotate — that needs AST traversal beyond what the quick-fix layer does. The issue spec explicitly excludes this as out of scope.
- **Operator validated from source text, not message alone.** The source text is the ground truth; the message is used only to extract the label name for the title string.
- **`is_preferred: true`** — there is exactly one sensible automated fix for a missing label, consistent with how the other single-fix handlers (PL501, PL602) set this flag.

https://claude.ai/code/session_01M9Dh7JHLQY9edSejdWineE

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9Dh7JHLQY9edSejdWineE)_