### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -192,6 +192,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         c if c == DiagnosticCode::DeprecatedArrayBase.as_str() => {
             actions.extend(quick_fixes::fix_deprecated_array_base(source, &qf_diag));
         }
+        // PL410: Loop-control statement references an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         // PL602: Global signal handler assignment
         c if c == DiagnosticCode::SecuritySignalHandler.as_str() => {
             actions.extend(quick_fixes::fix_security_signal_handler(source, &qf_diag));

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1972,6 +1972,67 @@ fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, 
     Some((line_start, line_end))
 }
 
+/// Drop the undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL`
+/// statement (PL410).
+///
+/// The only safe mechanical transformation when the named label does not exist
+/// is to remove the label so the statement targets the innermost enclosing
+/// loop. Introducing a matching label definition requires AST rewrite guidance
+/// that this action cannot supply.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, _)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(at_pos) = source.get(range_start..) else {
+        return Vec::new();
+    };
+
+    let op = if at_pos.starts_with("next ") {
+        "next"
+    } else if at_pos.starts_with("last ") {
+        "last"
+    } else if at_pos.starts_with("redo ") {
+        "redo"
+    } else {
+        return Vec::new();
+    };
+
+    // Label identifier starts right after `{op} ` (one space).
+    let label_offset = op.len() + 1;
+    let Some(label_and_rest) = at_pos.get(label_offset..) else {
+        return Vec::new();
+    };
+    let label_len =
+        label_and_rest.bytes().take_while(|b| b.is_ascii_alphanumeric() || *b == b'_').count();
+    if label_len == 0 {
+        return Vec::new();
+    }
+    let label = &label_and_rest[..label_len];
+
+    // Remove the ` LABEL` portion that immediately follows the operator keyword.
+    let remove_start = range_start + op.len();
+    let remove_end = remove_start + 1 + label_len;
+    if remove_end > source.len() || !source.is_char_boundary(remove_end) {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Remove label '{label}' — use bare '{op}' to target innermost loop"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: remove_start, end: remove_end },
+                new_text: String::new(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = range;
     if start > end

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,265 @@
+//! BDD tests for the PL410 quick-fix handler (`fix_loop_control_undefined_label`).
+//!
+//! PL410 fires when `next LABEL`, `last LABEL`, or `redo LABEL` references a
+//! label that is not defined anywhere in the current file. The quick fix drops
+//! the label so the statement targets the innermost enclosing loop — the only
+//! safe mechanical transformation available without full AST rewrite support.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with an undefined label reference
+//!   WHEN   a PL410 diagnostic is produced and code actions are requested
+//!   THEN   exactly one preferred action is returned with the correct edit
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn next_pl410_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop body with `next MISSING` where MISSING is not defined
+    let source = "while (1) { next MISSING; }\n";
+    let next_start = source.find("next MISSING").ok_or("marker not found")?;
+    let next_end = next_start + "next MISSING".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a preferred action to drop the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "PL410 fix must be marked preferred");
+    assert!(
+        action.title.contains("MISSING"),
+        "title should name the removed label, got: {}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL edit correctness
+// ===========================================================================
+
+#[test]
+fn last_pl410_edit_removes_label_from_source() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop body with `last NOPE` where NOPE is not defined
+    let source = "for my $i (1..10) { last NOPE; }\n";
+    let last_start = source.find("last NOPE").ok_or("marker not found")?;
+    let last_end = last_start + "last NOPE".len();
+
+    let diag = make_diag(
+        last_start,
+        last_end,
+        "PL410",
+        "`last NOPE` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no 'last' action in: {actions:?}"))?;
+
+    // WHEN the edit is applied
+    let result = edited(source, action);
+
+    // THEN the label is stripped and the operator remains
+    assert!(
+        result.contains("last;"),
+        "edited source should contain 'last;' (label removed), got: {result:?}"
+    );
+    assert!(
+        !result.contains("NOPE"),
+        "edited source must not contain the removed label 'NOPE', got: {result:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL produces action
+// ===========================================================================
+
+#[test]
+fn redo_pl410_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop body with `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }\n";
+    let redo_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let redo_end = redo_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        redo_start,
+        redo_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a preferred action to drop the label
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no 'redo' action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND the edit produces `redo;`
+    let result = edited(source, action);
+    assert!(result.contains("redo;"), "edited source should contain 'redo;', got: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — action title names the operator
+// ===========================================================================
+
+#[test]
+fn pl410_action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `last DEADLABEL` statement
+    let source = "while (1) { last DEADLABEL; }\n";
+    let last_start = source.find("last DEADLABEL").ok_or("marker not found")?;
+    let last_end = last_start + "last DEADLABEL".len();
+
+    let diag = make_diag(
+        last_start,
+        last_end,
+        "PL410",
+        "`last DEADLABEL` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no 'last' action in: {actions:?}"))?;
+
+    // THEN the title contains the operator so the user understands what changes
+    assert!(
+        action.title.contains("last"),
+        "title must name the operator 'last', got: {}",
+        action.title
+    );
+    assert!(
+        action.title.contains("DEADLABEL"),
+        "title must name the removed label 'DEADLABEL', got: {}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — invalid range guard
+// ===========================================================================
+
+#[test]
+fn pl410_non_char_boundary_range_produces_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose byte range splits a multi-byte character
+    let source = "while (1) { next LABEL; }\nmy $s = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+
+    // The range intentionally splits the two-byte UTF-8 sequence for é
+    let diag = make_diag(
+        char_start + 1,
+        char_start + 2,
+        "PL410",
+        "`next LABEL` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no action is produced — the guard rejects the invalid range
+    assert!(
+        !actions.iter().any(|a| a.kind == CodeActionKind::QuickFix && a.title.contains("next")),
+        "expected no PL410 action for non-char-boundary range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: PL410 code reaches its handler and produces at least one
+    // action when given a valid diagnostic, confirming the route is wired up.
+    let source = "while (1) { next GHOST; }\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let next_start = source.find("next GHOST").ok_or("marker not found")?;
+    let next_end = next_start + "next GHOST".len();
+
+    let diags = vec![make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("next")),
+        "PL410 route must produce at least one action; actions: {actions:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label receive a PL410 diagnostic, but clicking the lightbulb in the editor returned **no code actions**. The diagnostic route table in `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics silently fell through to `_ => {}`.

This is a runtime-fatal condition in Perl — if the named label doesn't exist, Perl dies with `Label not found for "next LABEL"`. The mechanical fix is obvious: drop the label so the statement targets the innermost enclosing loop.

Closes #9612.

## Changes

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

Added `fix_loop_control_undefined_label(source, diagnostic)`:

- Validates the byte range with the existing `valid_diagnostic_range` guard (returns no actions on bad/non-char-boundary ranges rather than panicking)
- Extracts the operator (`next`, `last`, or `redo`) by prefix-matching the source text at the diagnostic start — anything else returns no actions
- Walks past the operator to find the label identifier (ASCII alphanumeric + underscore run)
- Emits a single `QuickFix` action with `is_preferred: true` that deletes ` LABEL` from the statement, leaving bare `next`/`last`/`redo`
- The action title names both the label being removed and the operator so the user understands exactly what changes: `"Remove label 'MISSING' — use bare 'next' to target innermost loop"`

The approach is intentionally conservative: introducing a matching `LABEL:` on an enclosing loop is out of scope because it requires AST rewrite guidance the code-action layer cannot supply (see spec non-goals).

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

Added one routing arm immediately before the PL602 block:

```rust
// PL410: Loop-control statement references an undefined label
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` (new)

6 BDD integration tests covering the full contract:

| Test | What it verifies |
|------|-----------------|
| `next_pl410_produces_drop_label_action` | `next MISSING` → preferred QuickFix action exists, title names the label |
| `last_pl410_edit_removes_label_from_source` | Applying the edit to `last NOPE` yields `last;` with no trace of `NOPE` |
| `redo_pl410_produces_drop_label_action` | `redo NOWHERE` → action exists, edit yields `redo;` |
| `pl410_action_title_names_the_operator` | Title contains both the operator name and the removed label |
| `pl410_non_char_boundary_range_produces_no_action` | Range splitting a multi-byte UTF-8 char is rejected gracefully |
| `pl410_dispatch_smoke_test` | End-to-end: route table is wired; at least one action produced for valid PL410 |

## Verification

```
cargo test -p perl-lsp-rs-core --test quick_fix_pl410_bdd
# running 6 tests … test result: ok. 6 passed

cargo test -p perl-lsp-rs-core --test quick_fix_new_codes_bdd
# running 17 tests … test result: ok. 17 passed

cargo test -p perl-lsp-rs-core --lib
# test result: ok. 1921 passed

cargo fmt -p perl-lsp-rs-core -- --check
# (clean, no diff)

cargo clippy -p perl-lsp-rs-core --lib
# 0 new warnings introduced (one pre-existing Clone/Copy warning in inline_completion)
```

## Design notes

- **Why only one action?** The spec says `is_preferred: true` because there is exactly one sensible mechanical fix. Offering "define the label instead" would require knowing which enclosing loop to attach it to — that's an AST rewrite the action layer can't safely synthesize.
- **Why extract from source text rather than the message?** Extracting from source at the validated range start is more robust: the message format could change, the source won't. The operator extraction uses a simple prefix match on `"next "`, `"last "`, `"redo "` which is unambiguous at a LoopControl node's start position.
- **Guard pattern** follows exactly the `fix_security_signal_handler` and `fix_printf_format_arity` precedents already established in the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQ6G1cBUfh9goNHz5yTX7j)_