### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo LABEL references an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1972,6 +1972,41 @@ fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, 
     Some((line_start, line_end))
 }
 
+/// Fix `next LABEL` / `last LABEL` / `redo LABEL` when the label is undefined (PL410).
+///
+/// The only safe mechanical fix is to drop the label so the statement targets
+/// the innermost enclosing loop, matching Perl's bare-form semantics. The range
+/// covers the entire LoopControl node (e.g. `next FOO`); the fix replaces it
+/// with the bare operator (`next`).
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let text = &source[range_start..range_end];
+    let op = text.split_whitespace().next().unwrap_or("");
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!(
+            "Remove undefined label (use bare '{op}' to target innermost loop)"
+        ),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = range;
     if start > end

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,287 @@
+//! BDD tests for the PL410 quick-fix handler: `fix_loop_control_undefined_label`.
+//!
+//! PL410 fires when `next LABEL`, `last LABEL`, or `redo LABEL` targets a
+//! label that is not defined anywhere in the current file. The only safe
+//! mechanical fix is to drop the label, turning the statement into its bare
+//! form so it targets the innermost enclosing loop at runtime.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a loop-control statement referencing an undefined label
+//!   WHEN   a PL410 diagnostic is supplied and code actions are requested
+//!   THEN   exactly one "remove label" action is returned with the correct edit
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action (sorted descending by start to avoid offset shift)
+/// and return the modified source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// Scenario 1 — `next LABEL` with undefined label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while loop that uses `next MISSING` where MISSING is not defined
+    let source = "while (1) {\n    next MISSING;\n}\n";
+
+    let node_start = source.find("next MISSING").ok_or("marker not found")?;
+    let node_end = node_start + "next MISSING".len();
+
+    let diag = make_diag(
+        node_start,
+        node_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the PL410 diagnostic
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is exactly one action, offering to remove the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the label-removal action must be preferred");
+
+    // AND the edit replaces the full `next MISSING` span with just `next`
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) {\n    next;\n}\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 2 — `last LABEL` with undefined label
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for loop that uses `last NOPE` where NOPE is not defined
+    let source = "for my $i (1..10) {\n    last NOPE;\n}\n";
+
+    let node_start = source.find("last NOPE").ok_or("marker not found")?;
+    let node_end = node_start + "last NOPE".len();
+
+    let diag = make_diag(
+        node_start,
+        node_end,
+        "PL410",
+        "`last NOPE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a fix action for `last`
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no 'last' action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND applying the edit produces bare `last`
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..10) {\n    last;\n}\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 3 — `redo LABEL` with undefined label
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while loop that uses `redo OUTER` where OUTER is not defined
+    let source = "while (1) {\n    redo OUTER;\n}\n";
+
+    let node_start = source.find("redo OUTER").ok_or("marker not found")?;
+    let node_end = node_start + "redo OUTER".len();
+
+    let diag = make_diag(
+        node_start,
+        node_end,
+        "PL410",
+        "`redo OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a fix action for `redo`
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no 'redo' action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND applying the edit produces bare `redo`
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) {\n    redo;\n}\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 4 — Title naming: exact title format
+// ===========================================================================
+
+#[test]
+fn action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next GHOST` statement where GHOST is undefined
+    let source = "while (1) { next GHOST; }\n";
+
+    let node_start = source.find("next GHOST").ok_or("marker not found")?;
+    let node_end = node_start + "next GHOST".len();
+
+    let diag = make_diag(
+        node_start,
+        node_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title names the bare operator
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {:?}", actions))?;
+
+    assert_eq!(
+        action.title,
+        "Remove undefined label (use bare 'next' to target innermost loop)"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 5 — Invalid-range guard: out-of-bounds range → no actions
+// ===========================================================================
+
+#[test]
+fn invalid_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source and a PL410 diagnostic whose byte range is past the end of source
+    let source = "while (1) { next FOO; }\n";
+    let out_of_bounds_start = source.len() + 1;
+    let out_of_bounds_end = source.len() + 10;
+
+    let diag = make_diag(
+        out_of_bounds_start,
+        out_of_bounds_end,
+        "PL410",
+        "`next FOO` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested with the bad range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL410 action is produced — the guard prevents a panic
+    let has_pl410_action = actions.iter().any(|a| {
+        a.title.contains("innermost loop") || a.title.contains("next") && a.title.contains("label")
+    });
+    assert!(
+        !has_pl410_action,
+        "expected no PL410 action for out-of-bounds range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 6 — Dispatch smoke test: PL410 code reaches the handler
+// ===========================================================================
+
+#[test]
+fn dispatch_smoke_pl410_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: confirms the PL410 code is wired into the dispatch table and
+    // reaches fix_loop_control_undefined_label for each supported operator.
+    let source =
+        "while (1) {\n    next ALPHA;\n    last BETA;\n    redo GAMMA;\n}\n";
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let next_start = source.find("next ALPHA").ok_or("next ALPHA not found")?;
+    let last_start = source.find("last BETA").ok_or("last BETA not found")?;
+    let redo_start = source.find("redo GAMMA").ok_or("redo GAMMA not found")?;
+
+    let diags = vec![
+        make_diag(
+            next_start,
+            next_start + "next ALPHA".len(),
+            "PL410",
+            "`next ALPHA` references a label that is not defined in this file",
+        ),
+        make_diag(
+            last_start,
+            last_start + "last BETA".len(),
+            "PL410",
+            "`last BETA` references a label that is not defined in this file",
+        ),
+        make_diag(
+            redo_start,
+            redo_start + "redo GAMMA".len(),
+            "PL410",
+            "`redo GAMMA` references a label that is not defined in this file",
+        ),
+    ];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_next = actions.iter().any(|a| a.title.contains("'next'"));
+    let has_last = actions.iter().any(|a| a.title.contains("'last'"));
+    let has_redo = actions.iter().any(|a| a.title.contains("'redo'"));
+
+    assert!(has_next, "PL410 next route not producing action; actions: {:?}", actions);
+    assert!(has_last, "PL410 last route not producing action; actions: {:?}", actions);
+    assert!(has_redo, "PL410 redo route not producing action; actions: {:?}", actions);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements referencing an undefined label (PL410) previously showed a lightbulb in editors but returned **no code actions** — the diagnostic route table in `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics silently fell through to `_ => {}`.

This PR fills that gap with a single, focused change set:

- **`quick_fixes.rs`** — adds `fix_loop_control_undefined_label`, which:
  1. Validates the byte range via the existing `valid_diagnostic_range` guard (prevents panics on malformed diagnostics)
  2. Extracts the first word from the source span (`next`, `last`, or `redo`)
  3. Guards against unknown operators — anything else returns no actions
  4. Produces one preferred `CodeAction` that replaces `next FOO` → `next` (bare form, targeting the innermost enclosing loop)

- **`diagnostic_routes.rs`** — wires the PL410/`LoopControlUndefinedLabel` code to the new handler, following the exact same pattern as every other code in the match arm

- **`tests/quick_fix_pl410_bdd.rs`** (new) — 6 BDD integration tests:

| # | Scenario | Verifies |
|---|----------|----------|
| 1 | `next LABEL` with undefined label | action produced, edit replaces `next FOO` → `next` |
| 2 | `last LABEL` with undefined label | action produced, edit replaces `last NOPE` → `last` |
| 3 | `redo LABEL` with undefined label | action produced, edit replaces `redo OUTER` → `redo` |
| 4 | Title naming | exact title string `"Remove undefined label (use bare 'next' to target innermost loop)"` |
| 5 | Invalid-range guard | out-of-bounds byte range → no actions (no panic) |
| 6 | Dispatch smoke test | all three operators reach their handler via the route table |

## Why this fix is safe

The only correct mechanical fix for a `next LABEL` that references a nonexistent label is to drop the label. Perl would otherwise die at runtime with `Label not found for "next LABEL"`. The bare form (`next`) is unambiguous and always valid inside any loop.

No alternative fix ("suggest defining a label") is offered — that would require AST rewrite guidance and is explicitly out of scope per the issue.

## Test results

```
running 6 tests
test last_undefined_label_produces_remove_action ... ok
test action_title_names_the_operator ... ok
test dispatch_smoke_pl410_reaches_handler ... ok
test next_undefined_label_produces_remove_action ... ok
test redo_undefined_label_produces_remove_action ... ok
test invalid_range_returns_no_actions ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

running 17 tests
[all 17 quick_fix_new_codes_bdd tests pass]

test result: ok. 17 passed; 0 failed; 0 ignored
```

## Files changed

| File | Change |
|------|--------|
| `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs` | +35 lines: new `fix_loop_control_undefined_label` function |
| `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs` | +4 lines: PL410 arm in the match |
| `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` | +287 lines: new BDD test file (6 tests) |

## Non-goals

- Does not change the diagnostic emission logic in `loop_control_label.rs`
- Does not add a "suggest defining a label" alternative fix
- Does not affect any other diagnostic code


---
_Generated by [Claude Code](https://claude.ai/code/session_01Da11StSdbL3ukBux3vBLyy)_