### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label (#9612)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: Loop control with undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,45 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Fix undefined loop-control label by dropping the label (PL410).
+///
+/// `next LABEL`, `last LABEL`, and `redo LABEL` statements die at runtime when
+/// the named label is not defined. The only mechanical fix is to drop the label
+/// so the statement targets the innermost enclosing loop.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let snippet = &source[start..end];
+    let Some(op) = loop_control_op(snippet) else {
+        return Vec::new();
+    };
+
+    vec![CodeAction {
+        title: format!("Remove undefined label (use bare '{op}')"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+fn loop_control_op(snippet: &str) -> Option<&'static str> {
+    for op in ["next", "last", "redo"] {
+        if let Some(rest) = snippet.strip_prefix(op) {
+            if rest.starts_with(|c: char| c.is_whitespace()) {
+                return Some(op);
+            }
+        }
+    }
+    None
+}

--- a/crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs
@@ -223,7 +223,7 @@ impl InlineCompletionProvider {
 
         for item in &mut list.items {
             if item.range.is_none() && item_matches_fragment(item, fragment.text) {
-                item.range = Some(range.clone());
+                item.range = Some(range);
             }
         }
 

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,247 @@
+//! BDD tests for PL410 quick-fix handler: `fix_loop_control_undefined_label`
+//!
+//! PL410 fires when `next LABEL`, `last LABEL`, or `redo LABEL` targets a label
+//! that is not defined in the current file. The fix drops the undefined label so
+//! the statement targets the innermost enclosing loop instead.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is produced and code actions are requested
+//!   THEN   exactly the expected action is returned with a correct edit
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from the action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by_key(|e| std::cmp::Reverse(e.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action(actions: &[CodeAction], pred: impl Fn(&str) -> bool) -> Option<&CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — `next LABEL` with undefined label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next MISSING` statement where MISSING is not defined
+    let source = "while (1) {\n    next MISSING;\n}\n";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no PL410 action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove undefined label (use bare 'next')");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label action should be is_preferred");
+
+    Ok(())
+}
+
+#[test]
+fn next_undefined_label_edit_strips_label_from_source() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN `next MISSING` in a while loop
+    let source = "while (1) {\n    next MISSING;\n}\n";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no PL410 action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN the label is stripped; the semicolon and surrounding code are intact
+    assert_eq!(result, "while (1) {\n    next;\n}\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — `last LABEL` with undefined label
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_edit_strips_label_from_source() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN `last NOPE` in a for loop
+    let source = "for my $x (1..10) {\n    last NOPE;\n}\n";
+    let stmt_start = source.find("last NOPE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last NOPE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last NOPE` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no PL410 action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN `last NOPE` is replaced with `last`
+    assert_eq!(result, "for my $x (1..10) {\n    last;\n}\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — `redo LABEL` with undefined label
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_edit_strips_label_from_source() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN `redo TOP` in a foreach loop
+    let source = "foreach my $item (@items) {\n    redo TOP;\n}\n";
+    let stmt_start = source.find("redo TOP").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo TOP".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo TOP` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no PL410 action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN `redo TOP` is replaced with `redo`
+    assert_eq!(result, "foreach my $item (@items) {\n    redo;\n}\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — guard: invalid range returns no actions
+// ===========================================================================
+
+#[test]
+fn pl410_out_of_bounds_range_produces_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic range that extends beyond the source
+    let source = "while (1) {\n    next MISSING;\n}\n";
+    let out_of_bounds_start = source.len() + 1;
+    let out_of_bounds_end = source.len() + 10;
+
+    let diag = make_diag(
+        out_of_bounds_start,
+        out_of_bounds_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no action is produced
+    assert!(
+        !actions.iter().any(|a| a.title.contains("next")),
+        "expected no PL410 action for out-of-bounds range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Cross-cutting: dispatch-table smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_test_all_three_operators() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: verify the PL410 route in diagnostic_routes.rs dispatches
+    // correctly for next, last, and redo in a single pass.
+    let source = "while (1) {\n    next MISSING;\n    last GONE;\n    redo AWAY;\n}\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let next_start = source.find("next MISSING").ok_or("next marker")?;
+    let last_start = source.find("last GONE").ok_or("last marker")?;
+    let redo_start = source.find("redo AWAY").ok_or("redo marker")?;
+
+    let diags = vec![
+        make_diag(
+            next_start,
+            next_start + "next MISSING".len(),
+            "PL410",
+            "`next MISSING` references a label that is not defined in this file",
+        ),
+        make_diag(
+            last_start,
+            last_start + "last GONE".len(),
+            "PL410",
+            "`last GONE` references a label that is not defined in this file",
+        ),
+        make_diag(
+            redo_start,
+            redo_start + "redo AWAY".len(),
+            "PL410",
+            "`redo AWAY` references a label that is not defined in this file",
+        ),
+    ];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_next = actions.iter().any(|a| a.title.contains("'next'"));
+    let has_last = actions.iter().any(|a| a.title.contains("'last'"));
+    let has_redo = actions.iter().any(|a| a.title.contains("'redo'"));
+
+    assert!(has_next, "PL410 route not producing next action; actions: {:?}", actions);
+    assert!(has_last, "PL410 route not producing last action; actions: {:?}", actions);
+    assert!(has_redo, "PL410 route not producing redo action; actions: {:?}", actions);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the PL410 quick-fix handler: when `next LABEL`, `last LABEL`, or `redo LABEL` references a label that is not defined in the file, the LSP now offers a code action to drop the undefined label, making the statement target the innermost enclosing loop instead.

The fix is purely mechanical — it replaces the `<op> LABEL` span with just `<op>`. No heuristics, no guessing at the intended label: the diagnostic already confirmed the label is undefined, so stripping it is the only safe automated repair.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive (new code action for PL410 diagnostics)
- DAP surface: unchanged
- CLI: unchanged

## What changed

**`crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`**
- Added `fix_loop_control_undefined_label(source, diagnostic)` — validates range, identifies the loop-control operator via `loop_control_op`, replaces the full `<op> LABEL` span with bare `<op>`.
- Added `loop_control_op(snippet)` — returns `Some("next")`, `Some("last")`, or `Some("redo")` when the snippet starts with the keyword followed by whitespace; `None` otherwise. Returns `&'static str` to avoid allocations.

**`crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`**
- Added PL410 arm to the `match policy_code` dispatch table, after PL405 and before `_ => {}`.

**`crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs`** (new file)
- 6 BDD tests: next/last/redo strip-label edits, `is_preferred` flag, out-of-bounds guard, and dispatch-table smoke test for all three operators.

**`crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs`**
- Fixed pre-existing `clippy::clone_on_copy` warning: `range.clone()` → `range` (Range is Copy).

## How to review

Start at `quick_fixes.rs` — the two new functions at the end. Then check `diagnostic_routes.rs` for the PL410 arm. The test file is self-contained BDD style, matching the pattern in `quick_fix_new_codes_bdd.rs`.

## Evidence

```
running 6 tests
test last_undefined_label_edit_strips_label_from_source ... ok
test next_undefined_label_produces_drop_label_action ... ok
test next_undefined_label_edit_strips_label_from_source ... ok
test pl410_dispatch_smoke_test_all_three_operators ... ok
test pl410_out_of_bounds_range_produces_no_actions ... ok
test redo_undefined_label_edit_strips_label_from_source ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

running 17 tests [existing quick_fix_new_codes_bdd]
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

## Risk & rollback

- **Blast radius**: zero — new dispatch arm only fires on `PL410` code; all other diagnostic routes are untouched.
- **Failure modes**: if `valid_diagnostic_range` rejects the range (out-of-bounds, non-char-boundary), `Vec::new()` is returned — no action surfaced.
- **Rollback**: revert the 4-line diagnostic_routes.rs hunk.

## Follow-ups

None required.

https://claude.ai/code/session_01CKbr6RsPFJAtd9RdZo8483

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKbr6RsPFJAtd9RdZo8483)_