### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo targets a label not defined in the file
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1872,6 +1872,43 @@ pub fn fix_security_signal_handler(
     }]
 }
 
+/// Fix PL410 (`next`/`last`/`redo LABEL` with undefined label) by dropping the label.
+///
+/// At runtime, Perl dies with `Label not found for "next LABEL"` when the named
+/// label is absent. The only mechanical fix that preserves program flow is to drop
+/// the label so the statement targets the innermost enclosing loop instead.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let snippet = &source[start..end];
+    let op = if snippet.starts_with("next ") {
+        "next"
+    } else if snippet.starts_with("last ") {
+        "last"
+    } else if snippet.starts_with("redo ") {
+        "redo"
+    } else {
+        return Vec::new();
+    };
+
+    vec![CodeAction {
+        title: format!("Drop label: replace with bare `{op}`"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 /// Add missing arguments to a `printf`/`sprintf` call (PL405 / `native.common.printf_format_arity`).
 ///
 /// When the format string has more specifiers than supplied arguments, this fix

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,206 @@
+//! BDD tests for the PL410 quick-fix handler (`fix_loop_control_undefined_label`).
+//!
+//! PL410 fires when `next LABEL`, `last LABEL`, or `redo LABEL` reference a
+//! label that is not defined anywhere in the file. The only mechanical fix is
+//! to drop the label so the statement targets the innermost enclosing loop.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a loop-control statement referencing an undefined label
+//!   WHEN   a PL410 diagnostic is produced and code actions are requested
+//!   THEN   exactly one preferred action is returned that strips the label
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_pl410(start: usize, end: usize, op: &str, label: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some("PL410".to_string()),
+        message: format!("`{op} {label}` references a label that is not defined in this file"),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+fn apply_first_edit(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+// ===========================================================================
+// PL410 — next LABEL
+// ===========================================================================
+
+#[test]
+fn pl410_next_undefined_label_action_title_names_op() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop with `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let start = source.find("next OUTER").ok_or("marker not found")?;
+    let end = start + "next OUTER".len();
+    let diag = make_pl410(start, end, "next", "OUTER");
+
+    // WHEN code actions are requested for the PL410 diagnostic
+    let actions = actions_for(source, &[diag]);
+
+    // THEN exactly one action is returned and its title names the op
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no next action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "PL410 fix should be the preferred action");
+    assert!(action.title.contains("next"), "title should name the op: {}", action.title);
+
+    Ok(())
+}
+
+#[test]
+fn pl410_next_label_edit_produces_bare_next() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source with `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let start = source.find("next OUTER").ok_or("marker not found")?;
+    let end = start + "next OUTER".len();
+    let diag = make_pl410(start, end, "next", "OUTER");
+
+    // WHEN the fix is applied
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no next action in: {:?}", actions))?;
+    let result = apply_first_edit(source, action);
+
+    // THEN the label is stripped and the bare operator remains
+    assert!(result.contains("next;"), "expected bare 'next;' in result: {result:?}");
+    assert!(!result.contains("OUTER"), "label should be gone from result: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL
+// ===========================================================================
+
+#[test]
+fn pl410_last_label_edit_produces_bare_last() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source with `last INNER` where INNER is not defined
+    let source = "while (1) { last INNER; }\n";
+    let start = source.find("last INNER").ok_or("marker not found")?;
+    let end = start + "last INNER".len();
+    let diag = make_pl410(start, end, "last", "INNER");
+
+    // WHEN the fix is applied
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no last action in: {:?}", actions))?;
+    let result = apply_first_edit(source, action);
+
+    // THEN the label is stripped and the bare operator remains
+    assert!(result.contains("last;"), "expected bare 'last;' in result: {result:?}");
+    assert!(!result.contains("INNER"), "label should be gone from result: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL
+// ===========================================================================
+
+#[test]
+fn pl410_redo_label_edit_produces_bare_redo() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source with `redo CYCLE` where CYCLE is not defined
+    let source = "for my $i (1..5) { redo CYCLE; }\n";
+    let start = source.find("redo CYCLE").ok_or("marker not found")?;
+    let end = start + "redo CYCLE".len();
+    let diag = make_pl410(start, end, "redo", "CYCLE");
+
+    // WHEN the fix is applied
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no redo action in: {:?}", actions))?;
+    let result = apply_first_edit(source, action);
+
+    // THEN the label is stripped and the bare operator remains
+    assert!(result.contains("redo;"), "expected bare 'redo;' in result: {result:?}");
+    assert!(!result.contains("CYCLE"), "label should be gone from result: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — invalid-range guard
+// ===========================================================================
+
+#[test]
+fn pl410_invalid_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose byte range extends beyond the source
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let out_of_bounds_start = source.len() + 1;
+    let out_of_bounds_end = source.len() + 5;
+    let diag = make_pl410(out_of_bounds_start, out_of_bounds_end, "next", "OUTER");
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no actions are produced (range guard fires)
+    let pl410_actions: Vec<_> =
+        actions.iter().filter(|a| a.diagnostics.iter().any(|d| d == "PL410")).collect();
+    assert!(
+        pl410_actions.is_empty(),
+        "expected no PL410 action for out-of-bounds range, got: {:?}",
+        pl410_actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_test_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source with an undefined-label loop control statement
+    let source = "for my $x (1..3) { next GHOST; }\n";
+    let start = source.find("next GHOST").ok_or("marker not found")?;
+    let end = start + "next GHOST".len();
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let diag = make_pl410(start, end, "next", "GHOST");
+
+    // WHEN code actions are fetched through the full provider dispatch table
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &[diag]);
+
+    // THEN at least one PL410 quick-fix action is returned
+    let has_pl410_action = actions.iter().any(|a| a.diagnostics.iter().any(|d| d == "PL410"));
+    assert!(has_pl410_action, "PL410 route should produce at least one action; got: {:?}", actions);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

PL410 fires when `next LABEL`, `last LABEL`, or `redo LABEL` references a label not defined anywhere in the file — a runtime-fatal condition in Perl (`Label not found for "next LABEL"`). Clicking the lightbulb previously produced **no actions** because `DiagnosticCode::LoopControlUndefinedLabel` had no arm in the diagnostic route table.

This PR wires up the missing quick-fix with a focused, well-tested implementation.

## What changed

### `quick_fixes.rs` — new handler `fix_loop_control_undefined_label`

- Validates the byte range with the existing `valid_diagnostic_range` guard (shared with PL602, PL405 et al.) so out-of-bounds or non-char-boundary ranges are silently rejected.
- Extracts the operator from the snippet prefix (`"next "` / `"last "` / `"redo "`). Any other text at the range returns empty — no spurious actions on misrouted diagnostics.
- Replaces the entire `op LABEL` span with bare `op`, which is the only mechanically correct fix (Perl's bare loop-control targets the innermost enclosing loop).
- Marked `is_preferred: true` because there is exactly one sensible fix for this code.

### `diagnostic_routes.rs` — new routing arm for PL410

Added one arm to the match block:

```rust
// PL410: next/last/redo targets a label not defined in the file
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `tests/quick_fix_pl410_bdd.rs` — 6 new BDD integration tests

| Test | Covers |
|------|--------|
| `pl410_next_undefined_label_action_title_names_op` | Action title contains op name; `is_preferred` is true; kind is QuickFix |
| `pl410_next_label_edit_produces_bare_next` | Edit replaces `next OUTER` with `next`; label absent from result |
| `pl410_last_label_edit_produces_bare_last` | Same for `last INNER` |
| `pl410_redo_label_edit_produces_bare_redo` | Same for `redo CYCLE` |
| `pl410_invalid_range_returns_no_actions` | Out-of-bounds range produces zero PL410 actions |
| `pl410_dispatch_smoke_test_reaches_handler` | Full `CodeActionsProvider` dispatch reaches the handler |

## Test results

```
running 6 tests
test pl410_dispatch_smoke_test_reaches_handler ... ok
test pl410_invalid_range_returns_no_actions ... ok
test pl410_next_label_edit_produces_bare_next ... ok
test pl410_last_label_edit_produces_bare_last ... ok
test pl410_next_undefined_label_action_title_names_op ... ok
test pl410_redo_label_edit_produces_bare_redo ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

Pre-existing `quick_fix_new_codes_bdd` tests: **17 passed, 0 failed**.
Crate lib tests: **1921 passed, 0 failed**.
`cargo fmt` and `cargo clippy --lib` both clean.

## Non-goals (per spec)

- Does not add a "suggest defining a label" alternative fix — that requires AST rewrite guidance out of scope.
- Does not touch the diagnostic emission logic in `loop_control_label.rs`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PByvChfuEJjDnuezZucWeh)_