### PR TITLE
feat(code-actions): add PL410 quick-fix to drop undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: loop-control statement references undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,38 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Fix `next LABEL`, `last LABEL`, or `redo LABEL` with undefined label (PL410).
+///
+/// When the target label does not exist, Perl dies at runtime. The one mechanical
+/// fix is to drop the label so the statement targets the innermost enclosing loop.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let text = &source[start..end];
+
+    let op = ["next", "last", "redo"].iter().copied().find(|&op| {
+        text.starts_with(op) && text[op.len()..].starts_with(|c: char| c.is_ascii_whitespace())
+    });
+
+    let Some(op) = op else {
+        return Vec::new();
+    };
+
+    vec![CodeAction {
+        title: format!("Drop label: use bare '{op}'"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,263 @@
+//! BDD tests for the PL410 quick-fix handler (`fix_loop_control_undefined_label`).
+//!
+//! PL410 fires when `next LABEL`, `last LABEL`, or `redo LABEL` references a label
+//! that is not defined anywhere in the file. The fix drops the label so the statement
+//! targets the innermost enclosing loop instead.
+//!
+//! Scenarios
+//! ---------
+//! 1. `next LABEL` diagnostic produces a drop-label action
+//! 2. `last LABEL` diagnostic produces a drop-label action
+//! 3. `redo LABEL` diagnostic produces a drop-label action
+//! 4. Action title names the operator correctly
+//! 5. Out-of-bounds range returns no actions (guard)
+//! 6. PL410 code reaches the handler via the dispatch table (smoke)
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// Scenario 1 — next LABEL
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for-loop body with `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }";
+
+    let ctrl_start = source.find("next OUTER").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "next OUTER".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the diagnostic range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is exactly one action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no drop-label action for 'next' in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the drop-label action should be preferred");
+
+    // AND applying the edit replaces 'next OUTER' with 'next'
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..10) { next; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 2 — last LABEL
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while-loop body with `last MISSING` where MISSING is not defined
+    let source = "while (1) { last MISSING; }";
+
+    let ctrl_start = source.find("last MISSING").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "last MISSING".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no drop-label action for 'last' in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND the edit replaces 'last MISSING' with 'last'
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 3 — redo LABEL
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for-loop body with `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+
+    let ctrl_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no drop-label action for 'redo' in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND the edit replaces 'redo NOWHERE' with 'redo'
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { redo; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 4 — Title names the operator
+// ===========================================================================
+
+#[test]
+fn action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic for `next GHOST`
+    let source = "for my $x (1..3) { next GHOST; }";
+    let ctrl_start = source.find("next GHOST").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "next GHOST".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title mentions both the fix operation and the operator
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no action for 'next GHOST' in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Drop label: use bare 'next'");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 5 — Invalid-range guard
+// ===========================================================================
+
+#[test]
+fn out_of_bounds_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic whose range extends beyond the end of the source
+    let source = "for my $i (1..5) { next OUTER; }";
+    let out_of_bounds_end = source.len() + 5;
+
+    let diag = make_diag(
+        source.len(),
+        out_of_bounds_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the invalid range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no drop-label action is produced
+    let has_pl410_action = actions.iter().any(|a| a.title.contains("Drop label"));
+    assert!(
+        !has_pl410_action,
+        "expected no PL410 action for out-of-bounds range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 6 — Dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_code_reaches_handler_via_dispatch_table() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: a PL410 diagnostic given to the provider produces at least
+    // one code action, confirming the dispatch table is wired correctly.
+    let source = "while (1) { next PHANTOM; }";
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let ctrl_start = source.find("next PHANTOM").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "next PHANTOM".len();
+
+    let diags = vec![make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`next PHANTOM` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("Drop label")),
+        "PL410 dispatch route did not produce a drop-label action; actions: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

When `next LABEL`, `last LABEL`, or `redo LABEL` references a label that is not defined anywhere in the file (PL410), clicking the lightbulb in an editor previously returned **no code actions**. The dispatch table in `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics silently fell through to `_ => {}`.

This PR wires up the missing handler end-to-end.

## What changed

### `quick_fixes.rs` — new handler `fix_loop_control_undefined_label`

- Validates the diagnostic byte range with the shared `valid_diagnostic_range` guard (returns empty on out-of-bounds or non-char-boundary input)
- Reads the source text at the range and checks it starts with exactly `next`, `last`, or `redo` followed by ASCII whitespace — anything else returns no actions
- Returns one `CodeAction` with `is_preferred: true` that replaces the full `{op} LABEL` span with the bare operator, leaving the semicolon and surrounding code untouched
- Title format: `"Drop label: use bare '{op}'"` — consistent with the existing title style

### `diagnostic_routes.rs` — new dispatch arm

```rust
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

Placed alongside the other PL4xx arms just after PL405.

### `tests/quick_fix_pl410_bdd.rs` — 6 BDD integration tests (new file)

| # | Scenario | What it verifies |
|---|----------|-----------------|
| 1 | `next OUTER` with undefined label | Action produced; edit replaces `next OUTER` → `next` |
| 2 | `last MISSING` with undefined label | Action produced; edit replaces `last MISSING` → `last` |
| 3 | `redo NOWHERE` with undefined label | Action produced; edit replaces `redo NOWHERE` → `redo` |
| 4 | Title naming | Exact title is `"Drop label: use bare 'next'"` |
| 5 | Out-of-bounds range guard | No action returned when `end > source.len()` |
| 6 | Dispatch smoke | `CodeActionsProvider::get_code_actions` returns a drop-label action for a PL410-coded diagnostic, confirming the route table is wired |

## Test results

```
running 6 tests
test last_undefined_label_produces_drop_label_action ... ok
test next_undefined_label_produces_drop_label_action ... ok
test action_title_names_the_operator ... ok
test out_of_bounds_range_returns_no_actions ... ok
test pl410_code_reaches_handler_via_dispatch_table ... ok
test redo_undefined_label_produces_drop_label_action ... ok

test result: ok. 6 passed; 0 failed
```

Pre-existing `quick_fix_new_codes_bdd` suite: **17 passed, 0 failed** (unchanged).

`cargo fmt --check` and `cargo clippy -p perl-lsp-rs-core` clean (the one pre-existing clippy warning in `inline_completion/mod.rs:226` is unrelated to this PR).

## Why this is the right fix

At runtime, Perl dies with `Label not found for "next LABEL"` when the named label does not exist. The only safe mechanical fix without AST-rewriting support is to drop the label and fall through to the innermost enclosing loop — exactly what `next;` / `last;` / `redo;` do. A "define the label" alternative would require inserting a `LABEL:` on an enclosing loop construct, which is out of scope per the issue spec.

## Non-goals

- Does not add a "suggest defining a label" alternative fix
- Does not modify the diagnostic emission logic in `loop_control_label.rs`
- Does not affect bare `next;` / `last;` / `redo;` (no label) — those are already valid

https://claude.ai/code/session_01SRQg4mvQT9GkagRx8iq4ia

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRQg4mvQT9GkagRx8iq4ia)_