### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: loop-control statement references an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1964,6 +1964,62 @@ fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
     specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
+/// Remove the undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL`
+/// statement (PL410).
+///
+/// At runtime, Perl dies with `Label not found for "next LABEL"` when the
+/// target label does not exist. The only automatic fix is to drop the label so
+/// the statement targets the innermost enclosing loop; adding a label would
+/// require editing the surrounding loop structure and is out of scope.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(text) = source.get(start..end) else {
+        return Vec::new();
+    };
+
+    // Extract the operator (everything up to the first whitespace).
+    let ws_pos = text.find(|c: char| c.is_whitespace()).unwrap_or(text.len());
+    let op = &text[..ws_pos];
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    // Find the label — skip leading whitespace after the operator.
+    let after_op = &text[ws_pos..];
+    let label_indent = after_op.len() - after_op.trim_start().len();
+    let label_start_in_text = ws_pos + label_indent;
+    let label_text = &text[label_start_in_text..];
+    let label_len =
+        label_text.find(|c: char| c.is_whitespace() || c == ';').unwrap_or(label_text.len());
+    let label = &label_text[..label_len];
+
+    if label.is_empty() {
+        return Vec::new();
+    }
+
+    // Delete " LABEL" — from the whitespace before the label to its end.
+    let remove_start = start + ws_pos;
+    let remove_end = start + label_start_in_text + label_len;
+
+    vec![CodeAction {
+        title: format!("Remove undefined label '{label}' from '{op}'"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: remove_start, end: remove_end },
+                new_text: String::new(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,235 @@
+//! BDD tests for the PL410 quick-fix handler (`fix_loop_control_undefined_label`).
+//!
+//! PL410 fires when a `next LABEL`, `last LABEL`, or `redo LABEL` statement
+//! references a label that does not exist anywhere in the file. The only safe
+//! automatic fix is to drop the label so the statement targets the innermost
+//! enclosing loop.
+//!
+//! Scenarios
+//! ---------
+//!   1. `next LABEL`  — action is produced with correct title and kind
+//!   2. `last LABEL`  — edit removes the label, leaving bare `last`
+//!   3. `redo LABEL`  — action is produced
+//!   4. Title naming  — title contains both op and label name
+//!   5. Invalid-range guard — non-char-boundary range returns no actions
+//!   6. Dispatch smoke — PL410 code reaches its handler end-to-end
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// Scenario 1 — `next LABEL` produces a quick-fix action
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop-control statement that targets an undefined label
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("stmt not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN an action is produced that removes the label
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no OUTER action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the label-removal action should be preferred");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 2 — `last LABEL` edit removes the label, leaving bare `last`
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_edit_removes_label() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `last MISSING` inside a while loop
+    let source = "while (1) { last MISSING; }\n";
+    let stmt_start = source.find("last MISSING").ok_or("stmt not found")?;
+    let stmt_end = stmt_start + "last MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("MISSING"))
+        .ok_or_else(|| format!("no MISSING action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN the label is removed and `last;` targets the innermost loop
+    assert_eq!(result, "while (1) { last; }\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 3 — `redo LABEL` produces a quick-fix action
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `redo NOWHERE` inside a for loop
+    let source = "for my $j (1..5) { redo NOWHERE; }\n";
+    let stmt_start = source.find("redo NOWHERE").ok_or("stmt not found")?;
+    let stmt_end = stmt_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN an action is produced
+    let action = find_action(&actions, |t| t.contains("NOWHERE"))
+        .ok_or_else(|| format!("no NOWHERE action in: {:?}", actions))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 4 — Action title names both the operator and the label
+// ===========================================================================
+
+#[test]
+fn action_title_names_op_and_label() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next GHOST` diagnostic
+    let source = "for my $x (1..3) { next GHOST; }\n";
+    let stmt_start = source.find("next GHOST").ok_or("stmt not found")?;
+    let stmt_end = stmt_start + "next GHOST".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the title follows the pattern "Remove undefined label 'X' from 'op'"
+    let action = find_action(&actions, |t| t.contains("GHOST"))
+        .ok_or_else(|| format!("no GHOST action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove undefined label 'GHOST' from 'next'");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 5 — Non-char-boundary range produces no action
+// ===========================================================================
+
+#[test]
+fn non_char_boundary_range_is_ignored() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a range that falls inside a multi-byte UTF-8 character
+    let source = "for my $i (1..10) { next OUTER; }\nmy $name = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+    // Offset by 1 to land inside the two-byte sequence — not a char boundary.
+    let diag = make_diag(char_start + 1, char_start + 2, "PL410", "spurious");
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no label-removal action is produced
+    assert!(
+        !actions.iter().any(|a| a.title.contains("Remove undefined label")),
+        "expected no PL410 action for non-char-boundary range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 6 — Dispatch smoke: PL410 code is wired into the routing table
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: confirm the routing table routes PL410 to the fix handler.
+    let source = "while (1) { next PHANTOM; }\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let stmt_start = source.find("next PHANTOM").ok_or("stmt not found")?;
+    let stmt_end = stmt_start + "next PHANTOM".len();
+    let diags = vec![make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next PHANTOM` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("PHANTOM")),
+        "PL410 route should produce an action; got: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

When `next LABEL`, `last LABEL`, or `redo LABEL` references a label that does not exist in the file (PL410), the diagnostic lightbulb appeared in editors but offered **no code actions** — a dead end. This is a runtime-fatal condition in Perl (`Label not found for "next LABEL"`), so the missing quick-fix was a visible gap in the tooling.

This PR wires up the fix end-to-end: diagnostic → routing table → handler → editor lightbulb.

## What changed

### `quick_fixes.rs` — new handler `fix_loop_control_undefined_label`

The fix extracts the loop-control operator (`next`/`last`/`redo`) and undefined label name from the source text at the diagnostic byte range, then emits a single `CodeAction` that deletes the `" LABEL"` suffix, leaving a bare `next;` / `last;` / `redo;` that targets the innermost enclosing loop.

Key design decisions:
- **`is_preferred: true`**: there is exactly one sensible automatic fix — drop the label. Adding a new label on the surrounding loop would require rewriting the loop structure, which is out of scope for a quick-fix.
- **`valid_diagnostic_range` guard**: rejects malformed or non-char-boundary ranges before slicing the source, consistent with every other fix in this module.
- **Operator allowlist**: only `next`, `last`, `redo` produce actions. Any other token at the diagnostic start returns `vec[]` — consistent with the linter's own allowlist in `loop_control_label.rs`.

### `diagnostic_routes.rs` — new routing arm for PL410

```rust
// PL410: loop-control statement references an undefined label
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

Follows the same pattern as every other stable-code arm in the file.

### `tests/quick_fix_pl410_bdd.rs` — 6 new BDD integration tests

| # | Scenario | What it verifies |
|---|----------|-----------------|
| 1 | `next OUTER` | Action is produced; `kind == QuickFix`; `is_preferred` |
| 2 | `last MISSING` | Edit result is `last;` — label and preceding space removed |
| 3 | `redo NOWHERE` | Action is produced for the third operator |
| 4 | Title naming | `"Remove undefined label 'GHOST' from 'next'"` |
| 5 | Invalid range | Non-char-boundary byte range → no action (safety guard) |
| 6 | Dispatch smoke | PL410 code reaches the handler end-to-end via the routing table |

## Test results

```
running 6 tests
test last_undefined_label_edit_removes_label ... ok
test pl410_dispatch_reaches_handler ... ok
test action_title_names_op_and_label ... ok
test redo_undefined_label_produces_action ... ok
test non_char_boundary_range_is_ignored ... ok
test next_undefined_label_produces_action ... ok
test result: ok. 6 passed; 0 failed

running 17 tests   (quick_fix_new_codes_bdd — pre-existing)
test result: ok. 17 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy --lib` are clean.

## Non-goals (per issue scope)

- Does **not** add a "suggest defining a label" alternative fix — that would require AST-guided loop rewriting, which is a separate effort.
- Does **not** affect the diagnostic emission logic in `loop_control_label.rs`.

https://claude.ai/code/session_012xVr72DrJTVLqU1HXbeEbi

---
_Generated by [Claude Code](https://claude.ai/code/session_012xVr72DrJTVLqU1HXbeEbi)_