### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo LABEL where LABEL is not defined in this file
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1964,6 +1964,64 @@ fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
     specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
+/// Drop the undefined label from a loop-control statement (PL410).
+///
+/// `next LABEL`, `last LABEL`, and `redo LABEL` where `LABEL` is not defined
+/// anywhere in the current file are runtime-fatal in Perl. The only safe
+/// mechanical fix is to drop the label so the statement targets the innermost
+/// enclosing loop instead.
+///
+/// The diagnostic range covers the full `next LABEL` token span. We replace
+/// that span with just the operator keyword.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let Some(op) = parse_loop_control_op(&diagnostic.message) else {
+        return Vec::new();
+    };
+
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    // Sanity-check: the source text at the diagnostic range must start with the operator.
+    let Some(range_text) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+    if !range_text.trim_start().starts_with(op) {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Drop undefined label: write `{op}` to target innermost loop"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
+/// Extract the loop-control operator from a PL410 diagnostic message.
+///
+/// Message format: `` `next FOO` references a label that is not defined in this file ``
+/// Returns the first word inside the backtick pair (e.g. `"next"`).
+fn parse_loop_control_op(message: &str) -> Option<&str> {
+    let backtick_start = message.find('`')? + 1;
+    let backtick_end = backtick_start + message[backtick_start..].find('`')?;
+    let inside = message.get(backtick_start..backtick_end)?;
+    inside.split_whitespace().next()
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,258 @@
+//! BDD tests for PL410 quick-fix: drop undefined loop-control label.
+//!
+//!   PL410 - `next`/`last`/`redo LABEL` where LABEL is not defined in this file
+//!
+//! Fix: drop the label so the statement targets the innermost enclosing loop.
+//!
+//! Each scenario follows:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is presented and code actions are requested
+//!   THEN   a single preferred action is returned that strips the label
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (same pattern as quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for-loop body that uses `next FOO` where FOO is not defined
+    let source = "for my $i (1..10) { next FOO; }";
+    let range_start = source.find("next FOO").ok_or("marker not found")?;
+    let range_end = range_start + "next FOO".len();
+
+    let diag = make_diag(
+        range_start,
+        range_end,
+        "PL410",
+        "`next FOO` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the diagnostic range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a preferred action that drops the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no drop-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Drop undefined label: write `next` to target innermost loop");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label action should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn next_undefined_label_edit_strips_label_from_source() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source where `next FOO` appears between other statements
+    let source = "for my $i (1..10) { next FOO; }";
+    let range_start = source.find("next FOO").ok_or("marker not found")?;
+    let range_end = range_start + "next FOO".len();
+
+    let diag = make_diag(
+        range_start,
+        range_end,
+        "PL410",
+        "`next FOO` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no drop-label action in: {actions:?}"))?;
+    let result = edited(source, action);
+
+    // THEN `next FOO` becomes `next` — the label is gone, semicolon is untouched
+    assert_eq!(result, "for my $i (1..10) { next; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while-loop with `last MISSING` where MISSING is not defined
+    let source = "while (1) { last MISSING; }";
+    let range_start = source.find("last MISSING").ok_or("marker not found")?;
+    let range_end = range_start + "last MISSING".len();
+
+    let diag = make_diag(
+        range_start,
+        range_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no drop-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Drop undefined label: write `last` to target innermost loop");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for-loop with `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+    let range_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let range_end = range_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        range_start,
+        range_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no drop-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Drop undefined label: write `redo` to target innermost loop");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { redo; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Guard: invalid diagnostic range produces no actions
+// ===========================================================================
+
+#[test]
+fn invalid_range_produces_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic with an out-of-bounds byte range
+    let source = "for my $i (1..10) { next FOO; }";
+    let beyond = source.len() + 10;
+
+    let diag = make_diag(
+        beyond,
+        beyond + 8,
+        "PL410",
+        "`next FOO` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no code action is produced (safe guard)
+    assert!(
+        !actions.iter().any(|a| a.title.contains("innermost loop")),
+        "expected no PL410 action for out-of-bounds range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Dispatch smoke test: all three ops reach their handler
+// ===========================================================================
+
+#[test]
+fn all_three_loop_ops_reach_pl410_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: next, last, and redo each produce at least one action when given
+    // a correctly-formed PL410 diagnostic, confirming the dispatch route is wired up.
+    let source = "for my $i (1..5) { next FOO; last BAR; redo BAZ; }";
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let next_start = source.find("next FOO").ok_or("next not found")?;
+    let last_start = source.find("last BAR").ok_or("last not found")?;
+    let redo_start = source.find("redo BAZ").ok_or("redo not found")?;
+
+    let diags = vec![
+        make_diag(
+            next_start,
+            next_start + "next FOO".len(),
+            "PL410",
+            "`next FOO` references a label that is not defined in this file",
+        ),
+        make_diag(
+            last_start,
+            last_start + "last BAR".len(),
+            "PL410",
+            "`last BAR` references a label that is not defined in this file",
+        ),
+        make_diag(
+            redo_start,
+            redo_start + "redo BAZ".len(),
+            "PL410",
+            "`redo BAZ` references a label that is not defined in this file",
+        ),
+    ];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_next = actions.iter().any(|a| a.title.contains("`next`"));
+    let has_last = actions.iter().any(|a| a.title.contains("`last`"));
+    let has_redo = actions.iter().any(|a| a.title.contains("`redo`"));
+
+    assert!(has_next, "PL410 route not producing action for `next`; actions: {actions:?}");
+    assert!(has_last, "PL410 route not producing action for `last`; actions: {actions:?}");
+    assert!(has_redo, "PL410 route not producing action for `redo`; actions: {actions:?}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label receive a PL410 diagnostic. Before this PR, clicking the lightbulb in an editor returned **no code actions** — the dispatch table in `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics fell through to `_ => {}`.

This PR wires up a quick-fix handler that drops the undefined label, so `next FOO` becomes `next`, targeting the innermost enclosing loop — the only safe mechanical fix (an undefined label is runtime-fatal in Perl).

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

Added `fix_loop_control_undefined_label(source, diagnostic) -> Vec<CodeAction>`:

- Calls `valid_diagnostic_range` to guard against out-of-bounds or non-char-boundary ranges (same pattern as all other handlers in this file)
- Parses the operator (`next` / `last` / `redo`) from the backtick-quoted prefix of the diagnostic message (`` `next FOO` references a label... ``)
- Whitelist-checks the operator — anything other than the three documented ops returns no actions, preventing misrouted diagnostics from producing unexpected edits
- Sanity-checks that the source text at the range actually starts with the operator
- Returns a single `is_preferred: true` action titled `"Drop undefined label: write \`{op}\` to target innermost loop"` that replaces the full `op LABEL` span with just `op`

Added private helper `parse_loop_control_op(message) -> Option<&str>` that extracts the first word from inside the backtick pair.

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

Added a new match arm for `DiagnosticCode::LoopControlUndefinedLabel` (PL410) immediately after the PL405 arm, routing to the new handler.

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` *(new)*

Six BDD integration tests following the same GIVEN/WHEN/THEN pattern as `quick_fix_new_codes_bdd.rs`:

| Test | What it covers |
|------|---------------|
| `next_undefined_label_produces_drop_action` | `next FOO` → action title, kind, `is_preferred` |
| `next_undefined_label_edit_strips_label_from_source` | Edit correctness: `next FOO` → `next` in full source context |
| `last_undefined_label_produces_drop_action` | `last MISSING` → action + edit correctness |
| `redo_undefined_label_produces_drop_action` | `redo NOWHERE` → action + edit correctness |
| `invalid_range_produces_no_action` | Out-of-bounds range yields no action (guard path) |
| `all_three_loop_ops_reach_pl410_handler` | Dispatch smoke test: all three ops routed correctly |

## Test results

```
running 6 tests
test all_three_loop_ops_reach_pl410_handler ... ok
test next_undefined_label_produces_drop_action ... ok
test next_undefined_label_edit_strips_label_from_source ... ok
test last_undefined_label_produces_drop_action ... ok
test redo_undefined_label_produces_drop_action ... ok
test invalid_range_produces_no_action ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

The 17 pre-existing `quick_fix_new_codes_bdd` tests remain green. `cargo fmt --check` and `cargo clippy --lib` (no new warnings) are clean.

## Design decisions

- **Single action, `is_preferred: true`**: The spec calls for exactly one sensible fix (drop the label). There is no "suggest defining the label" alternative because that would require AST rewrite guidance and is out of scope per #9612.
- **Message-based op extraction**: The operator is parsed from the message rather than re-scanning source, consistent with how other handlers (PL700, PL301, PL300) extract names — the diagnostic already carried this information forward.
- **Range replaces full `op LABEL` span**: The diagnostic range from `loop_control_label.rs` covers the entire node (`node.location.start..node.location.end`), which is `next FOO` without the trailing semicolon. Replacing that span with `next` leaves the semicolon untouched.

## Non-goals (per spec)

- Does not add a "suggest defining a label" alternative (requires AST rewrite guidance)
- Does not affect the diagnostic emission logic in `loop_control_label.rs`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qeorxdg2LZnFEokudkLivN)_