### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo targets an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1972,6 +1972,54 @@ fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, 
     Some((line_start, line_end))
 }
 
+/// Drop the undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL`
+/// statement (PL410 / `LoopControlUndefinedLabel`).
+///
+/// The only safe automated fix is to remove the label so the statement
+/// targets the innermost enclosing loop at runtime.  `is_preferred: true`
+/// because there is exactly one sensible mechanical action.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let span = &source[start..end];
+
+    // The span covers the LoopControl node: `next LABEL`, `last LABEL`, or
+    // `redo LABEL`.  Split on the first whitespace to isolate the operator.
+    let mut parts = span.splitn(2, char::is_whitespace);
+    let Some(op) = parts.next() else {
+        return Vec::new();
+    };
+
+    // Only handle the three documented loop-control operators.
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    // There must be a label part after the operator; bare forms have no label
+    // and are not flagged by PL410.
+    if parts.next().is_none() {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Remove label and use bare `{op}`"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = range;
     if start > end

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,254 @@
+//! BDD tests for the PL410 quick-fix handler:
+//!   PL410 — `next`/`last`/`redo LABEL` references an undefined label
+//!           (`fix_loop_control_undefined_label`)
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is present and code actions are requested
+//!   THEN   the handler offers exactly one preferred action that drops the label
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply the edits from an action and return the modified source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// next LABEL — PL410
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_remove_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }\n";
+
+    let ctrl_start = source.find("next OUTER").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "next OUTER".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a preferred action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no `next` action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "PL410 fix should be marked preferred");
+
+    // AND the edit replaces `next OUTER` with bare `next`
+    let result = edited(source, action);
+    assert!(
+        result.contains("next;") || result.contains("next "),
+        "expected bare `next` after edit, got: {result:?}"
+    );
+    assert!(!result.contains("OUTER"), "label should be removed after edit, got: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// last LABEL — PL410
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_remove_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `last MISSING` where MISSING is not defined
+    let source = "for my $i (1..10) { last MISSING; }\n";
+
+    let ctrl_start = source.find("last MISSING").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "last MISSING".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a preferred action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no `last` action in: {actions:?}"))?;
+
+    assert!(action.is_preferred, "PL410 fix should be marked preferred");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+
+    let result = edited(source, action);
+    assert!(!result.contains("MISSING"), "label should be removed after edit, got: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// redo LABEL — PL410
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_remove_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }\n";
+
+    let ctrl_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no `redo` action in: {actions:?}"))?;
+
+    assert!(action.is_preferred);
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+
+    let result = edited(source, action);
+    assert!(!result.contains("NOWHERE"), "label should be removed after edit, got: {result:?}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Action title includes the operator name
+// ===========================================================================
+
+#[test]
+fn pl410_action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a next statement with an undefined label
+    let source = "while (1) { next GHOST; }\n";
+
+    let ctrl_start = source.find("next GHOST").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "next GHOST".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title mentions the `next` operator by name
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no action with 'next' in title: {actions:?}"))?;
+
+    assert!(
+        action.title.contains("next"),
+        "title should name the operator 'next', got: {:?}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Invalid-range guard
+// ===========================================================================
+
+#[test]
+fn pl410_non_char_boundary_range_produces_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source with a multi-byte character and a PL410 diagnostic whose
+    // range falls inside the multi-byte sequence (not on a char boundary)
+    let source = "for my $i (1..10) { next OUTER; }\nmy $s = \"\u{e9}\";\n";
+
+    let char_pos = source.find('\u{e9}').ok_or("marker not found")?;
+    // char_pos+1 is inside the 2-byte UTF-8 sequence — not a valid char boundary
+    let diag = make_diag(char_pos + 1, char_pos + 2, "PL410", "`next OUTER` undefined label");
+
+    let actions = actions_for(source, &[diag]);
+
+    assert!(
+        !actions.iter().any(|a| a.title.contains("next") || a.title.contains("last") || a.title.contains("redo")),
+        "expected no PL410 action for invalid range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Dispatch smoke test — PL410 reaches the handler
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: a correctly positioned PL410 diagnostic produces at least
+    // one action, confirming the dispatch table routes PL410 to its handler.
+    let source = "for my $i (1..10) { next OUTER; }\n";
+
+    let ctrl_start = source.find("next OUTER").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "next OUTER".len();
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let diags = vec![make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("next")),
+        "PL410 route should produce a loop-control action; got: {actions:?}"
+    );
+
+    Ok(())
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -212,7 +212,9 @@ fn pl410_non_char_boundary_range_produces_no_action() -> Result<(), Box<dyn std:
     let actions = actions_for(source, &[diag]);
 
     assert!(
-        !actions.iter().any(|a| a.title.contains("next") || a.title.contains("last") || a.title.contains("redo")),
+        !actions.iter().any(|a| a.title.contains("next")
+            || a.title.contains("last")
+            || a.title.contains("redo")),
         "expected no PL410 action for invalid range, got: {actions:?}"
     );
 


### PR DESCRIPTION
## Summary

Closes #9612

Before this PR, clicking the lightbulb on a `next LABEL` / `last LABEL` / `redo LABEL` diagnostic (PL410 — label not defined in file) returned **no code actions**. The route table in `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so every PL410 diagnostic silently fell through to `_ => {}`.

This PR wires up the missing handler and adds 6 BDD integration tests to lock in the behavior.

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`
- Added `pub fn fix_loop_control_undefined_label(source, diagnostic) -> Vec<CodeAction>`
  - Validates the byte range with `valid_diagnostic_range` before touching source bytes
  - Extracts the operator (`next`/`last`/`redo`) from the beginning of the diagnostic span
  - Guards against unknown operators and bare forms (those are never flagged by PL410)
  - Emits a single `CodeAction` that replaces `op LABEL` with bare `op`
  - `is_preferred: true` — there is exactly one sensible mechanical fix

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`
- Added `PL410` / `LoopControlUndefinedLabel` arm after the existing PL405 arm:
  ```rust
  c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
      actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
  }
  ```

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` (new)
Six BDD tests following the same pattern as `quick_fix_new_codes_bdd.rs`:

| Test | Covers |
|------|--------|
| `next_undefined_label_produces_remove_label_action` | `next LABEL` → preferred action, label removed from edit result |
| `last_undefined_label_produces_remove_label_action` | `last LABEL` → preferred action, label removed |
| `redo_undefined_label_produces_remove_label_action` | `redo LABEL` → preferred action, label removed |
| `pl410_action_title_names_the_operator` | Title contains the operator name (`next`/`last`/`redo`) |
| `pl410_non_char_boundary_range_produces_no_action` | Range inside multi-byte UTF-8 sequence → empty result (guard) |
| `pl410_dispatch_reaches_handler` | Smoke test: PL410 diagnostic reaches the handler end-to-end |

## Why this approach

The diagnostic range set by `loop_control_label.rs` spans exactly the `LoopControl` AST node (`next LABEL` without the semicolon). Reading the operator by splitting on the first whitespace character is reliable, robust to label names containing hyphens or underscores, and requires no message parsing. The operator guard (`next | last | redo`) ensures correctness if any future variant were added to the AST.

## Verification

```
cargo test -p perl-lsp-rs-core --test quick_fix_pl410_bdd
# 6 passed; 0 failed

cargo test -p perl-lsp-rs-core --test quick_fix_new_codes_bdd
# 17 passed; 0 failed (no regressions)

cargo build -p perl-lsp-rs-core
# Finished — no errors
```

## Non-goals (per spec)
- Does not add a "suggest defining a label" alternative fix (AST rewrite, out of scope)
- Does not change the diagnostic emission logic in `loop_control_label.rs`

---
_Generated by [Claude Code](https://claude.ai/code/session_017or3pNyKvLbePLHBTmdqu3)_