### PR TITLE
feat(code-actions): add PL410 quick-fix — remove undefined loop-control label (#9612)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: loop-control statement references an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,46 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Remove the undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL`
+/// statement (PL410).
+///
+/// The fix strips the label so the statement targets the innermost enclosing
+/// loop — the only safe mechanical transform when the named label does not exist.
+/// The diagnostic range must point at the `op LABEL` node produced by the parser;
+/// this is verified before any edit is emitted.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(text) = source.get(start..end) else {
+        return Vec::new();
+    };
+
+    // Determine which operator is present and validate the range starts there.
+    let op = if text.starts_with("next") && text[4..].starts_with(|c: char| c.is_whitespace()) {
+        "next"
+    } else if text.starts_with("last") && text[4..].starts_with(|c: char| c.is_whitespace()) {
+        "last"
+    } else if text.starts_with("redo") && text[4..].starts_with(|c: char| c.is_whitespace()) {
+        "redo"
+    } else {
+        return Vec::new();
+    };
+
+    vec![CodeAction {
+        title: format!("Remove undefined label (use `{op}` to target innermost loop)"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,246 @@
+//! BDD tests for PL410 quick-fix: remove undefined loop-control label.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a `next`/`last`/`redo LABEL` where LABEL is undefined
+//!   WHEN   a PL410 diagnostic is passed to the code-actions provider
+//!   THEN   exactly one preferred action is returned that strips the label
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror the pattern from quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_pl410(start: usize, end: usize, op: &str, label: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some("PL410".to_string()),
+        message: format!("`{op} {label}` references a label that is not defined in this file"),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action in reverse-offset order and return the result.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop that uses `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }";
+
+    let stmt = "next OUTER";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+    let diag = make_pl410(start, end, "next", "OUTER");
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a preferred action to remove the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no PL410 action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "PL410 fix should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn next_edit_drops_label_and_leaves_semicolon() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN the diagnostic range covers `next OUTER` (not the semicolon)
+    let source = "for my $i (1..10) { next OUTER; }";
+
+    let stmt = "next OUTER";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+    let diag = make_pl410(start, end, "next", "OUTER");
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no PL410 action in: {actions:?}"))?;
+
+    let result = edited(source, action);
+
+    // THEN the label is removed; the loop keyword and semicolon are preserved
+    assert_eq!(result, "for my $i (1..10) { next; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop that uses `last MISSING` where MISSING is not defined
+    let source = "while (1) { last MISSING; }";
+
+    let stmt = "last MISSING";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+    let diag = make_pl410(start, end, "last", "MISSING");
+
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no PL410 action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop that uses `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+
+    let stmt = "redo NOWHERE";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+    let diag = make_pl410(start, end, "redo", "NOWHERE");
+
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no PL410 action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { redo; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — title naming
+// ===========================================================================
+
+#[test]
+fn action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `last GHOST` diagnostic
+    let source = "while (1) { last GHOST; }";
+
+    let stmt = "last GHOST";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+    let diag = make_pl410(start, end, "last", "GHOST");
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no PL410 action in: {actions:?}"))?;
+
+    // THEN the title includes the operator name so the user knows what will change
+    assert!(
+        action.title.contains("last"),
+        "title should mention the loop-control operator; got: {:?}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — invalid-range guard
+// ===========================================================================
+
+#[test]
+fn invalid_range_produces_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose byte range exceeds the source length
+    let source = "for my $i (1..3) { next FOO; }";
+    let out_of_bounds_start = source.len() + 1;
+    let out_of_bounds_end = source.len() + 10;
+
+    let diag = Diagnostic {
+        range: (out_of_bounds_start, out_of_bounds_end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some("PL410".to_string()),
+        message: "`next FOO` references a label that is not defined in this file".to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    };
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no action is produced — the guard rejects the bad range
+    assert!(
+        !actions.iter().any(|a| a.title.contains("innermost")),
+        "expected no PL410 action for out-of-bounds range; got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Confirm the PL410 code is wired in diagnostic_routes and produces at
+    // least one action for a well-formed diagnostic.
+    let source = "for my $x (1..3) { next PHANTOM; }";
+
+    let stmt = "next PHANTOM";
+    let start = source.find(stmt).ok_or("stmt not found")?;
+    let end = start + stmt.len();
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let diags = vec![make_pl410(start, end, "next", "PHANTOM")];
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("next")),
+        "PL410 route not producing action; actions: {actions:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements where the named label is not defined anywhere in the file trigger a PL410 diagnostic, but clicking the lightbulb returned **no code actions**. The dispatch table in `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics silently fell through to `_ => {}`.

This PR wires up the missing handler end-to-end.

## What changed

### `quick_fixes.rs` — new `fix_loop_control_undefined_label`

The fix is mechanical and unambiguous: strip the label so the statement targets the innermost enclosing loop. This is the only safe automated transform when the label cannot be found — it matches Perl's own semantics for the bare forms (`next`, `last`, `redo` without a label).

- Validates the byte range with the shared `valid_diagnostic_range` guard before touching source text (same pattern as `fix_security_signal_handler`, `fix_deprecated_array_base`, etc.).
- Confirms the text at the range starts with `next`, `last`, or `redo` followed by whitespace — anything else returns no actions, so a misrouted diagnostic produces no edit.
- Replaces the entire `op LABEL` span with just the bare operator. The semicolon lives outside the node span and is preserved automatically.
- `is_preferred: true` — there is exactly one sensible automated fix.

### `diagnostic_routes.rs` — new dispatch arm

```rust
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

Placed after PL405 following the existing numeric ordering of PL codes.

### `tests/quick_fix_pl410_bdd.rs` — 7 BDD tests (new file)

| Test | What it verifies |
|------|-----------------|
| `next_undefined_label_produces_remove_action` | `next` produces a preferred QuickFix action |
| `next_edit_drops_label_and_leaves_semicolon` | Applying the edit yields `next;` with the semicolon intact |
| `last_undefined_label_produces_remove_action` | `last` produces action; edit yields `last;` |
| `redo_undefined_label_produces_remove_action` | `redo` produces action; edit yields `redo;` |
| `action_title_names_the_operator` | Title includes the operator so the user knows what changes |
| `invalid_range_produces_no_action` | Out-of-bounds range is rejected; no action emitted |
| `pl410_dispatch_reaches_handler` | Smoke test confirming end-to-end routing through `diagnostic_routes` |

## Test results

```
running 7 tests
test next_edit_drops_label_and_leaves_semicolon ... ok
test last_undefined_label_produces_remove_action ... ok
test action_title_names_the_operator ... ok
test invalid_range_produces_no_action ... ok
test next_undefined_label_produces_remove_action ... ok
test pl410_dispatch_reaches_handler ... ok
test redo_undefined_label_produces_remove_action ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured
```

All 17 pre-existing `quick_fix_new_codes_bdd` tests remain green. All 1921 lib unit tests pass. `cargo fmt --check` and `cargo clippy --lib` are clean (the one pre-existing clippy warning in `inline_completion/mod.rs` is unrelated to this change).

## Non-goals (per spec)

- Does not add a "suggest defining a label" fix — would require AST rewrite guidance.
- Does not affect the PL410 diagnostic emission logic in `loop_control_label.rs`.

https://claude.ai/code/session_01L9542A3xmo9jLr3Pa76zpm

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9542A3xmo9jLr3Pa76zpm)_