### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo targeting an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1914,6 +1914,47 @@ pub fn fix_printf_format_arity(source: &str, diagnostic: &QuickFixDiagnostic) ->
     }]
 }
 
+/// Fix `next LABEL`/`last LABEL`/`redo LABEL` with an undefined label (PL410).
+///
+/// The only safe mechanical fix is to drop the label so the statement targets
+/// the innermost enclosing loop instead of the nonexistent named one.
+/// `is_preferred: true` — there is exactly one sensible transformation.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let range_text = &source[range_start..range_end];
+    let op = range_text.split_whitespace().next().unwrap_or("");
+
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    // Extract label name from the message: "`op LABEL` references a label..."
+    let Some(label) =
+        diagnostic.message.split('`').nth(1).and_then(|s| s.split_whitespace().nth(1))
+    else {
+        return Vec::new();
+    };
+
+    vec![CodeAction {
+        title: format!("Remove undefined label '{label}' from '{op} {label}'"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn printf_format_insert_position(
     source: &str,
     range_start: usize,

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,242 @@
+//! BDD tests for the PL410 quick-fix handler:
+//!   PL410 — `next LABEL`/`last LABEL`/`redo LABEL` with an undefined label
+//!           (`fix_loop_control_undefined_label`)
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a loop-control statement that targets an undefined label
+//!   WHEN   a PL410 diagnostic is produced and code actions are requested
+//!   THEN   exactly one preferred action is returned that drops the label,
+//!          leaving the bare operator to target the innermost enclosing loop
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn pl410_next_with_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>>
+{
+    // GIVEN a loop body that uses `next INNER` where INNER is not defined
+    let source = "while (1) {\n    next INNER;\n}\n";
+    let next_start = source.find("next INNER").ok_or("marker not found")?;
+    let next_end = next_start + "next INNER".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next INNER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the diagnostic range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to remove the undefined label
+    let action = find_action(&actions, |t| t.contains("INNER"))
+        .ok_or_else(|| format!("no remove-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Remove undefined label 'INNER' from 'next INNER'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the remove-label action should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn pl410_last_with_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>>
+{
+    // GIVEN a loop body that uses `last OUTER` where OUTER is not defined
+    let source = "while (1) {\n    last OUTER;\n}\n";
+    let last_start = source.find("last OUTER").ok_or("marker not found")?;
+    let last_end = last_start + "last OUTER".len();
+
+    let diag = make_diag(
+        last_start,
+        last_end,
+        "PL410",
+        "`last OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to remove the label
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no remove-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Remove undefined label 'OUTER' from 'last OUTER'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn pl410_redo_with_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>>
+{
+    // GIVEN a loop body that uses `redo LOOP` where LOOP is not defined
+    let source = "for my $i (1..10) {\n    redo LOOP;\n}\n";
+    let redo_start = source.find("redo LOOP").ok_or("marker not found")?;
+    let redo_end = redo_start + "redo LOOP".len();
+
+    let diag = make_diag(
+        redo_start,
+        redo_end,
+        "PL410",
+        "`redo LOOP` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to remove the label
+    let action = find_action(&actions, |t| t.contains("LOOP"))
+        .ok_or_else(|| format!("no remove-label action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Remove undefined label 'LOOP' from 'redo LOOP'");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn pl410_edit_strips_label_leaving_bare_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source with an undefined-label next
+    let source = "while (1) {\n    next MISSING;\n}\n";
+    let next_start = source.find("next MISSING").ok_or("marker not found")?;
+    let next_end = next_start + "next MISSING".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("MISSING"))
+        .ok_or_else(|| format!("no remove-label action in: {actions:?}"))?;
+
+    // WHEN the edit is applied
+    let result = edited(source, action);
+
+    // THEN the label is stripped and the bare operator remains, leaving valid Perl
+    assert_eq!(result, "while (1) {\n    next;\n}\n");
+
+    Ok(())
+}
+
+#[test]
+fn pl410_invalid_range_produces_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose range falls inside a multi-byte character
+    // (simulates a misaligned or synthetic diagnostic)
+    let source = "while (1) {\n    next INNER;\n}\nmy $x = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+    // Deliberately point into the interior of the multi-byte UTF-8 sequence
+    let diag = make_diag(
+        char_start + 1,
+        char_start + 2,
+        "PL410",
+        "`next INNER` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no remove-label action is produced
+    assert!(
+        !actions.iter().any(|a| a.title.contains("Remove undefined label")),
+        "expected no PL410 action for non-char-boundary range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Cross-cutting: dispatch-table smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: PL410 diagnostics reach the fix_loop_control_undefined_label handler,
+    // confirming the routing in diagnostic_routes.rs is wired up correctly.
+    let source = "while (1) {\n    next FOO;\n    last BAR;\n}\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let next_start = source.find("next FOO").ok_or("next FOO not found")?;
+    let next_end = next_start + "next FOO".len();
+    let last_start = source.find("last BAR").ok_or("last BAR not found")?;
+    let last_end = last_start + "last BAR".len();
+
+    let diags = vec![
+        make_diag(
+            next_start,
+            next_end,
+            "PL410",
+            "`next FOO` references a label that is not defined in this file",
+        ),
+        make_diag(
+            last_start,
+            last_end,
+            "PL410",
+            "`last BAR` references a label that is not defined in this file",
+        ),
+    ];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_next_fix = actions.iter().any(|a| a.title.contains("'FOO'"));
+    let has_last_fix = actions.iter().any(|a| a.title.contains("'BAR'"));
+
+    assert!(has_next_fix, "PL410 route not producing action for 'next FOO'; actions: {actions:?}");
+    assert!(has_last_fix, "PL410 route not producing action for 'last BAR'; actions: {actions:?}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

PL410 diagnostics fired for `next LABEL`, `last LABEL`, and `redo LABEL` when the named label has no definition in the file produced **no code actions** — clicking the lightbulb in an editor was a dead end. The `diagnostic_routes.rs` match table had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics fell through to `_ => {}`.

This is a runtime-fatal condition: Perl dies at runtime with `Label not found for "next LABEL"`. The fix is unambiguous: drop the label so the statement targets the innermost enclosing loop.

## Changes

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

Added `pub fn fix_loop_control_undefined_label(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction>`:

- Calls `valid_diagnostic_range` to validate byte bounds before accessing source text (same guard used by every other fix in this file).
- Extracts the operator from the source text at the diagnostic range; rejects anything that isn't `next`, `last`, or `redo` to prevent misfire.
- Extracts the label name from the diagnostic message (`` `op LABEL` references... `` format from `loop_control_label.rs`).
- Returns exactly one `CodeAction` replacing `op LABEL` → `op` with `is_preferred: true`, since there is exactly one safe mechanical transformation.

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

Added a match arm for `DiagnosticCode::LoopControlUndefinedLabel` (`"PL410"`) routing to the new handler.

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` _(new file)_

6 BDD integration tests following the established pattern from `quick_fix_new_codes_bdd.rs`:

| Test | Covers |
|------|--------|
| `pl410_next_with_undefined_label_produces_remove_action` | `next LABEL` → action returned, title correct, `is_preferred` true |
| `pl410_last_with_undefined_label_produces_remove_action` | `last LABEL` — same checks |
| `pl410_redo_with_undefined_label_produces_remove_action` | `redo LABEL` — same checks |
| `pl410_edit_strips_label_leaving_bare_operator` | Applying the edit produces `next;` (valid bare-operator Perl) |
| `pl410_invalid_range_produces_no_action` | Non-char-boundary range → no action (guard fires) |
| `pl410_dispatch_smoke_test` | Confirms PL410 is wired in `diagnostic_routes.rs`; both `next FOO` and `last BAR` produce actions |

## Validation

```
running 6 tests
test pl410_dispatch_smoke_test ... ok
test pl410_edit_strips_label_leaving_bare_operator ... ok
test pl410_invalid_range_produces_no_action ... ok
test pl410_last_with_undefined_label_produces_remove_action ... ok
test pl410_next_with_undefined_label_produces_remove_action ... ok
test pl410_redo_with_undefined_label_produces_remove_action ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

All 17 pre-existing `quick_fix_new_codes_bdd` tests remain green. `cargo clippy -p perl-lsp-rs-core --lib` clean (the one pre-existing warning is in `inline_completion/mod.rs`, untouched). `cargo fmt` applied.

## Non-goals

- Does not add a "suggest defining a label" alternative fix (requires AST-guided rewrite, out of scope per #9612).
- Does not touch the diagnostic emission logic in `loop_control_label.rs`.
- Does not add a `PL409` (GotoUndefinedLabel) handler — separate issue.

https://claude.ai/code/session_01AJqB9YuVw9BUbGFnoxgdLw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJqB9YuVw9BUbGFnoxgdLw)_