### PR TITLE
feat(code-actions): add PL410 quick-fix to remove undefined loop-control label (#9612)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo targets an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1964,6 +1964,54 @@ fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
     specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
+/// Remove the undefined label from a loop-control statement (PL410).
+///
+/// `next LABEL`, `last LABEL`, and `redo LABEL` that reference a label not
+/// defined in the current file cause a fatal runtime error. The fix drops the
+/// label so the statement targets the innermost enclosing loop instead.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(range_text) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+
+    let op = if range_text.starts_with("next") {
+        "next"
+    } else if range_text.starts_with("last") {
+        "last"
+    } else if range_text.starts_with("redo") {
+        "redo"
+    } else {
+        return Vec::new();
+    };
+
+    // Operator must be followed by whitespace to rule out longer barewords.
+    if !range_text[op.len()..].starts_with(|c: char| c.is_whitespace()) {
+        return Vec::new();
+    }
+
+    // Delete the space + label name that follows the operator keyword.
+    let label_start = range_start + op.len();
+
+    vec![CodeAction {
+        title: format!("Remove undefined label from '{op}'"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: label_start, end: range_end },
+                new_text: String::new(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,250 @@
+//! BDD tests for the PL410 quick-fix: remove undefined loop-control label.
+//!
+//! `next LABEL`, `last LABEL`, and `redo LABEL` that reference a label not
+//! defined in the current file cause a fatal runtime error. The fix drops the
+//! label so the statement targets the innermost enclosing loop.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a loop-control statement targeting an undefined label
+//!   WHEN   a PL410 diagnostic is supplied and code actions are requested
+//!   THEN   exactly one action is returned that removes the label
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply every edit in the action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next with undefined label
+// ===========================================================================
+
+#[test]
+fn pl410_next_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for loop whose `next` targets a label that is never defined
+    let source = "for my $i (1..5) { next OUTER; }";
+    let stmt = "next OUTER";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+
+    let diag = make_diag(
+        start,
+        end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is exactly one action, it removes the label, and it is preferred
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the remove-label action should be preferred");
+
+    // AND the edit strips the label, leaving bare `next`
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { next; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last with undefined label
+// ===========================================================================
+
+#[test]
+fn pl410_last_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a while loop whose `last` targets an undefined label
+    let source = "while (1) { last MISSING; }";
+    let stmt = "last MISSING";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+
+    let diag = make_diag(
+        start,
+        end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action for `last` and the edit removes the label
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no 'last' action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo with undefined label
+// ===========================================================================
+
+#[test]
+fn pl410_redo_undefined_label_produces_remove_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a for loop whose `redo` targets a label that does not exist
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+    let stmt = "redo NOWHERE";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+
+    let diag = make_diag(
+        start,
+        end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action for `redo` and the edit removes the label
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no 'redo' action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { redo; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — title naming
+// ===========================================================================
+
+#[test]
+fn pl410_action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next LABEL` diagnostic
+    let source = "for my $x (1..3) { next GHOST; }";
+    let stmt = "next GHOST";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+
+    let diag = make_diag(
+        start,
+        end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the title contains the operator name so the user knows which statement is being fixed
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Remove undefined label from 'next'");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — invalid-range guard
+// ===========================================================================
+
+#[test]
+fn pl410_invalid_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source with a multibyte character
+    // WHEN the diagnostic range splits the multibyte sequence (non-char-boundary)
+    let source = "for my $i (1..5) { next OUTER; }\nmy $s = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+    let diag = make_diag(char_start + 1, char_start + 2, "PL410", "invalid range");
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL410 action is produced
+    assert!(
+        !actions.iter().any(|a| a.title.contains("undefined label")),
+        "expected no action for non-char-boundary range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — dispatch-table smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_table_route_is_wired() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: confirm the route table entry for PL410 exists and produces
+    // at least one action for a trivially valid diagnostic.
+    let source = "while (1) { next PHANTOM; }";
+    let stmt = "next PHANTOM";
+    let start = source.find(stmt).ok_or("marker not found")?;
+    let end = start + stmt.len();
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let diags = vec![make_diag(
+        start,
+        end,
+        "PL410",
+        "`next PHANTOM` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("next")),
+        "PL410 route not producing action; actions: {actions:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements targeting a label not defined in the current file cause a fatal Perl runtime error (`Label not found for "next LABEL"`). The LSP already emits a PL410 warning for this, but clicking the lightbulb returned **no code actions** — `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`.

This PR wires up the missing handler.

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

Added `fix_loop_control_undefined_label(source, diagnostic)`:

- Validates the byte range with `valid_diagnostic_range` before touching source text.
- Extracts the operator keyword (`next` / `last` / `redo`) from the start of the diagnostic range. Any other content returns no actions.
- Guards that the operator is followed by whitespace to rule out unrelated barewords that happen to start with the same letters.
- Emits a single `CodeAction` that deletes the space + label name following the operator, leaving a bare `next;` / `last;` / `redo;` that safely targets the innermost enclosing loop.
- `is_preferred: true` — there is exactly one sensible mechanical fix.

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

Added a match arm for `DiagnosticCode::LoopControlUndefinedLabel` (`"PL410"`) that calls the new handler.

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` (new)

6 BDD tests following the same GIVEN / WHEN / THEN structure as `quick_fix_new_codes_bdd.rs`:

| Test | Scenario |
|------|----------|
| `pl410_next_undefined_label_produces_remove_action` | `next OUTER` → action exists, edit leaves `next;` |
| `pl410_last_undefined_label_produces_remove_action` | `last MISSING` → action exists, edit leaves `last;` |
| `pl410_redo_undefined_label_produces_remove_action` | `redo NOWHERE` → action exists, edit leaves `redo;` |
| `pl410_action_title_names_the_operator` | Title is `"Remove undefined label from 'next'"` |
| `pl410_invalid_range_returns_no_actions` | Non-char-boundary range → no actions (safety guard) |
| `pl410_dispatch_table_route_is_wired` | Smoke test: route table entry exists and returns ≥1 action |

## Test results

```
running 6 tests
test pl410_last_undefined_label_produces_remove_action ... ok
test pl410_action_title_names_the_operator ... ok
test pl410_dispatch_table_route_is_wired ... ok
test pl410_invalid_range_returns_no_actions ... ok
test pl410_next_undefined_label_produces_remove_action ... ok
test pl410_redo_undefined_label_produces_remove_action ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

The 17 pre-existing `quick_fix_new_codes_bdd` tests all remain green. `cargo clippy -p perl-lsp-rs-core --lib` and `cargo fmt -- --check` are clean.

## Design notes

- The fix does not offer a "suggest defining a label" alternative — that would require an AST rewrite (finding the intended enclosing loop and inserting `LABEL:` before it), which is out of scope for a one-click quick-fix.
- The diagnostic range produced by `loop_control_label.rs` spans `node.location.start..node.location.end`, which covers the full `next LABEL` / `last LABEL` / `redo LABEL` expression. The handler relies on this: it checks that the range text starts with the operator keyword.
- The operator-whitespace guard (`range_text[op.len()..].starts_with(char::is_whitespace)`) prevents false matches on hypothetical barewords like `nexted`, `lastly`, or `redone`.

https://claude.ai/code/session_013EEYK6zLZnLtP7ChdV5mgL

---
_Generated by [Claude Code](https://claude.ai/code/session_013EEYK6zLZnLtP7ChdV5mgL)_