### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label (#9612)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: Loop-control statement references undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,52 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Drop an undefined loop-control label so the statement targets the innermost loop (PL410).
+///
+/// `next FOO;` where `FOO` is not defined → replace `next FOO` with `next`.
+/// Only applied when the range text starts with `next`, `last`, or `redo`.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(range_text) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+
+    // The range text is `{op} {LABEL}`.  Extract the operator.
+    let op = if range_text.starts_with("next") {
+        "next"
+    } else if range_text.starts_with("last") {
+        "last"
+    } else if range_text.starts_with("redo") {
+        "redo"
+    } else {
+        return Vec::new();
+    };
+
+    // Extract label name from the range text after the operator.
+    let after_op = match range_text.get(op.len()..) {
+        Some(s) => s.trim_start(),
+        None => return Vec::new(),
+    };
+    let label_name = after_op.split_whitespace().next().unwrap_or("LABEL");
+
+    vec![CodeAction {
+        title: format!(
+            "Drop undefined label '{label_name}' — `{op};` will target the innermost loop"
+        ),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,212 @@
+//! BDD tests for PL410 quick-fix handler:
+//!   PL410 - Loop-control statement references undefined label (`fix_loop_control_undefined_label`)
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with `next/last/redo LABEL` where LABEL is not defined
+//!   WHEN   code actions are requested
+//!   THEN   an action is returned that drops the label, targeting the innermost loop
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply the first matching edit from an action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+/// Find the first action whose title matches the predicate.
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 - Undefined loop-control label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop body with `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }";
+    let next_start = source.find("next OUTER").ok_or("marker not found")?;
+    let next_end = next_start + "next OUTER".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(
+        action.title,
+        "Drop undefined label 'OUTER' — `next;` will target the innermost loop"
+    );
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label should be the preferred fix");
+
+    Ok(())
+}
+
+#[test]
+fn last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "while (1) { last MISSING; }";
+    let last_start = source.find("last MISSING").ok_or("marker not found")?;
+    let last_end = last_start + "last MISSING".len();
+
+    let diag = make_diag(
+        last_start,
+        last_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("MISSING"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(
+        action.title,
+        "Drop undefined label 'MISSING' — `last;` will target the innermost loop"
+    );
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn redo_undefined_label_edit_replaces_with_bare_op() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN `redo NOWHERE` inside a loop
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+    let redo_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let redo_end = redo_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        redo_start,
+        redo_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("NOWHERE"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN `redo NOWHERE` is replaced with bare `redo`
+    assert_eq!(result, "for my $i (1..5) { redo; }");
+
+    Ok(())
+}
+
+#[test]
+fn action_title_names_the_label_from_range_text() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN next with a long multi-word-style label name
+    let source = "for my $x (1..3) { next MY_CUSTOM_LABEL; }";
+    let next_start = source.find("next MY_CUSTOM_LABEL").ok_or("marker not found")?;
+    let next_end = next_start + "next MY_CUSTOM_LABEL".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next MY_CUSTOM_LABEL` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("MY_CUSTOM_LABEL"))
+        .ok_or_else(|| format!("no action with label name in: {:?}", actions))?;
+
+    assert!(
+        action.title.contains("MY_CUSTOM_LABEL"),
+        "title should contain the label name, got: {}",
+        action.title
+    );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_range_does_not_produce_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose range points to something that is NOT a loop-control op
+    let source = "my $x = 1;\n";
+    let diag = make_diag(
+        3,
+        5,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    assert!(
+        !actions.iter().any(|a| a.title.contains("innermost")),
+        "expected no drop-label action for misaligned range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pl410_dispatch_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: PL410 reaches the handler in the routing table.
+    let source = "for my $i (1..10) { next OUTER; }";
+    let next_start = source.find("next OUTER").ok_or("marker not found")?;
+    let next_end = next_start + "next OUTER".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("OUTER")),
+        "PL410 route not producing action; actions: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a `codeAction` quick-fix for the PL410 diagnostic (loop-control statement references an undefined label). When `next OUTER`, `last MISSING`, or `redo NOWHERE` references a label that is not defined in the file, the fix drops the label so the statement targets the innermost enclosing loop instead. For example, `next OUTER` becomes `next`.

The fix is minimal and safe: it only fires when the diagnostic range text starts with a recognized loop-control keyword (`next`, `last`, or `redo`) and always replaces exactly the range the diagnostic spans — no trailing semicolon, no surrounding whitespace.

## Interface & compatibility

- perl-parser API: unchanged
- LSP surface: additive — new `codeAction` response for PL410 diagnostics only
- DAP surface: unchanged
- CLI: unchanged

## What changed

- **`quick_fixes.rs`**: Added `fix_loop_control_undefined_label(source, diagnostic)` — extracts the operator from the range text, extracts the label name for the action title, and returns a single preferred `QuickFix` `CodeAction` that replaces `op LABEL` with bare `op`.
- **`diagnostic_routes.rs`**: Added routing arm `c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str()` after the existing PL405 arm.
- **`tests/quick_fix_pl410_bdd.rs`**: New BDD test file with 6 tests covering `next`, `last`, `redo`, custom label names, misaligned-range guard, and a dispatch smoke test.

## How to review

Start with the new function at the end of `quick_fixes.rs`. Then check the single routing arm added to `diagnostic_routes.rs`. The test file mirrors the exact pattern of `quick_fix_new_codes_bdd.rs`.

## Evidence

```
test invalid_range_does_not_produce_action ... ok
test action_title_names_the_label_from_range_text ... ok
test last_undefined_label_produces_drop_action ... ok
test next_undefined_label_produces_drop_action ... ok
test pl410_dispatch_smoke_test ... ok
test redo_undefined_label_edit_replaces_with_bare_op ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

quick_fix_new_codes_bdd: 17 passed; 0 failed (pre-existing tests unaffected)
clippy -p perl-lsp-rs-core --lib: clean (pre-existing clone_on_copy warning in inline_completion/mod.rs is out of scope)
```

## Risk & rollback

Blast radius: `perl-lsp-rs-core` only. New routing arm is additive — no existing arm is touched. If the fix produces a wrong edit, the user can undo it; the PL410 diagnostic itself is unaffected.

Rollback: revert the 4-line routing arm and the `fix_loop_control_undefined_label` function.

## Follow-ups

None required. The PL410 diagnostic lint itself (`loop_control_label.rs`) was pre-existing and is unchanged.

https://claude.ai/code/session_01S4esALubBJUCqpbpAkwkiK

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4esALubBJUCqpbpAkwkiK)_