### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: Loop-control statement references undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,52 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Drop an undefined loop-control label so the statement targets the innermost loop (PL410).
+///
+/// `next FOO;` where `FOO` is not defined → replace `next FOO` with `next`.
+/// Only applied when the range text starts with `next`, `last`, or `redo`.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(range_text) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+
+    // The range text is `{op} {LABEL}`.  Extract the operator.
+    let op = if range_text.starts_with("next") {
+        "next"
+    } else if range_text.starts_with("last") {
+        "last"
+    } else if range_text.starts_with("redo") {
+        "redo"
+    } else {
+        return Vec::new();
+    };
+
+    // Extract label name from the range text after the operator.
+    let after_op = match range_text.get(op.len()..) {
+        Some(s) => s.trim_start(),
+        None => return Vec::new(),
+    };
+    let label_name = after_op.split_whitespace().next().unwrap_or("LABEL");
+
+    vec![CodeAction {
+        title: format!(
+            "Drop undefined label '{label_name}' — `{op};` will target the innermost loop"
+        ),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,212 @@
+//! BDD tests for PL410 quick-fix handler:
+//!   PL410 - Loop-control statement references undefined label (`fix_loop_control_undefined_label`)
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with `next/last/redo LABEL` where LABEL is not defined
+//!   WHEN   code actions are requested
+//!   THEN   an action is returned that drops the label, targeting the innermost loop
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply the first matching edit from an action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+/// Find the first action whose title matches the predicate.
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 - Undefined loop-control label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop body with `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }";
+    let next_start = source.find("next OUTER").ok_or("marker not found")?;
+    let next_end = next_start + "next OUTER".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is an action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(
+        action.title,
+        "Drop undefined label 'OUTER' — `next;` will target the innermost loop"
+    );
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label should be the preferred fix");
+
+    Ok(())
+}
+
+#[test]
+fn last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    let source = "while (1) { last MISSING; }";
+    let last_start = source.find("last MISSING").ok_or("marker not found")?;
+    let last_end = last_start + "last MISSING".len();
+
+    let diag = make_diag(
+        last_start,
+        last_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("MISSING"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(
+        action.title,
+        "Drop undefined label 'MISSING' — `last;` will target the innermost loop"
+    );
+    assert!(action.is_preferred);
+
+    Ok(())
+}
+
+#[test]
+fn redo_undefined_label_edit_replaces_with_bare_op() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN `redo NOWHERE` inside a loop
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+    let redo_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let redo_end = redo_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        redo_start,
+        redo_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("NOWHERE"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+    let result = edited(source, action);
+
+    // THEN `redo NOWHERE` is replaced with bare `redo`
+    assert_eq!(result, "for my $i (1..5) { redo; }");
+
+    Ok(())
+}
+
+#[test]
+fn action_title_names_the_label_from_range_text() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN next with a long multi-word-style label name
+    let source = "for my $x (1..3) { next MY_CUSTOM_LABEL; }";
+    let next_start = source.find("next MY_CUSTOM_LABEL").ok_or("marker not found")?;
+    let next_end = next_start + "next MY_CUSTOM_LABEL".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next MY_CUSTOM_LABEL` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("MY_CUSTOM_LABEL"))
+        .ok_or_else(|| format!("no action with label name in: {:?}", actions))?;
+
+    assert!(
+        action.title.contains("MY_CUSTOM_LABEL"),
+        "title should contain the label name, got: {}",
+        action.title
+    );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_range_does_not_produce_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose range points to something that is NOT a loop-control op
+    let source = "my $x = 1;\n";
+    let diag = make_diag(
+        3,
+        5,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    assert!(
+        !actions.iter().any(|a| a.title.contains("innermost")),
+        "expected no drop-label action for misaligned range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pl410_dispatch_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: PL410 reaches the handler in the routing table.
+    let source = "for my $i (1..10) { next OUTER; }";
+    let next_start = source.find("next OUTER").ok_or("marker not found")?;
+    let next_end = next_start + "next OUTER".len();
+
+    let diag = make_diag(
+        next_start,
+        next_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("OUTER")),
+        "PL410 route not producing action; actions: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

Adds a `codeAction` quick-fix for **PL410** — the diagnostic that fires when `next LABEL`, `last LABEL`, or `redo LABEL` references a label that is not defined in the file.

The fix is the single sensible mechanical repair: drop the undefined label so the statement targets the innermost enclosing loop. For example, `next OUTER` becomes `next`. This matches what Perl itself would require — if the named label doesn't exist the program dies at runtime with `Label not found for "next LABEL"`.

## What changed

Three files touched, all in `crates/perl-lsp-rs-core`:

| File | Change |
|------|--------|
| `src/providers/code_actions/quick_fixes.rs` | New `fix_loop_control_undefined_label(source, diagnostic)` function (+49 lines) |
| `src/providers/code_actions/diagnostic_routes.rs` | New routing arm for `DiagnosticCode::LoopControlUndefinedLabel` after PL405 (+4 lines) |
| `tests/quick_fix_pl410_bdd.rs` | New BDD test file — 6 tests (212 lines) |

**No other crate is touched.** The PL410 diagnostic lint itself (`loop_control_label.rs`) is unchanged.

## Implementation notes

- `fix_loop_control_undefined_label` validates the byte range with `valid_diagnostic_range` before touching the source — same guard used by `fix_security_signal_handler` and `fix_printf_format_arity`.
- The operator is extracted from the range text directly (starts-with `next` / `last` / `redo`), not from the diagnostic message. This makes the function robust to message-format changes.
- The label name for the action title is extracted from the range text after the operator — again independent of the message.
- `is_preferred: true` — there is exactly one sensible fix (drop the label).
- The edit replaces the full diagnostic range (`op LABEL`) with the bare operator; the trailing semicolon is outside the range and is preserved.

## Test coverage

6 BDD tests in `tests/quick_fix_pl410_bdd.rs` following the exact pattern of `quick_fix_new_codes_bdd.rs`:

| # | Test | What it verifies |
|---|------|-----------------|
| 1 | `next_undefined_label_produces_drop_action` | Title, kind, is_preferred for `next OUTER` |
| 2 | `last_undefined_label_produces_drop_action` | Same properties for `last MISSING` |
| 3 | `redo_undefined_label_edit_replaces_with_bare_op` | Edit correctness — `redo NOWHERE` → `redo` |
| 4 | `action_title_names_the_label_from_range_text` | Title contains the exact label name |
| 5 | `invalid_range_does_not_produce_action` | Guard: misaligned range produces no action |
| 6 | `pl410_dispatch_smoke_test` | Routing table wires PL410 to handler |

All 6 pass. All 17 pre-existing `quick_fix_new_codes_bdd` tests remain green. `cargo clippy -p perl-lsp-rs-core --lib` is clean.

## Interface & compatibility

- **LSP surface**: additive only — new `codeAction` response for PL410 diagnostics
- **perl-parser API**: unchanged
- **DAP surface**: unchanged

## Risk & rollback

Blast radius: `perl-lsp-rs-core` only. The new routing arm is additive — no existing arm is modified. Rollback: revert the 4-line routing arm and the `fix_loop_control_undefined_label` function.

## How to review

1. Read `fix_loop_control_undefined_label` in `quick_fixes.rs` — it's ~30 lines, simple and self-contained.
2. Verify the 4-line routing arm in `diagnostic_routes.rs` follows the same pattern as the surrounding arms.
3. Skim `quick_fix_pl410_bdd.rs` — it mirrors `quick_fix_new_codes_bdd.rs` structure exactly.

https://claude.ai/code/session_01S4esALubBJUCqpbpAkwkiK

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4esALubBJUCqpbpAkwkiK)_