### PR TITLE
feat(code-actions): add PL410 quick-fix to drop undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo references an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,51 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Drop the undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL`
+/// statement (PL410).
+///
+/// When a loop-control operator references a label that does not exist in the
+/// file, Perl dies at runtime with `Label not found for "next LABEL"`. The
+/// mechanical fix is to drop the label so the operator targets the innermost
+/// enclosing loop instead — identical runtime semantics for the innermost loop,
+/// and safe when the label was simply a typo or dead reference.
+///
+/// The diagnostic range covers exactly the `op LABEL` text emitted by the
+/// `check_loop_control_labels` linter. This function validates the range,
+/// confirms the text starts with one of the three operators, and replaces the
+/// full `op LABEL` span with just `op`.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(text) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+    let op = if text.starts_with("next ") {
+        "next"
+    } else if text.starts_with("last ") {
+        "last"
+    } else if text.starts_with("redo ") {
+        "redo"
+    } else {
+        return Vec::new();
+    };
+
+    let display = text.trim();
+    vec![CodeAction {
+        title: format!("Drop label from '{display}' (targets innermost loop)"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,244 @@
+//! BDD tests for the PL410 quick-fix handler.
+//!
+//! PL410 fires when `next LABEL`, `last LABEL`, or `redo LABEL` references a
+//! label that is not defined anywhere in the current file.  The fix drops the
+//! label so the operator targets the innermost enclosing loop instead.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is produced and code actions are requested
+//!   THEN   exactly one action is returned that replaces `op LABEL` with `op`
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action and return the resulting source.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }";
+    let ctrl_start = source.find("next OUTER").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "next OUTER".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN one action is returned offering to drop the label
+    let action = find_action(&actions, |t| t.contains("next OUTER"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Drop label from 'next OUTER' (targets innermost loop)");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the drop-label action should be preferred");
+
+    // AND the edit replaces `next OUTER` with `next`
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..10) { next; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `last MISSING` where MISSING is not defined
+    let source = "while (1) { last MISSING; }";
+    let ctrl_start = source.find("last MISSING").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "last MISSING".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action exists and edits the source correctly
+    let action = find_action(&actions, |t| t.contains("last MISSING"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+    let ctrl_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action exists and edits the source correctly
+    let action = find_action(&actions, |t| t.contains("redo NOWHERE"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { redo; }");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — title naming
+// ===========================================================================
+
+#[test]
+fn title_names_the_op_and_label_from_source() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic whose range covers `last LOOP_TOP`
+    let source = "LOOP_TOP: while (1) { for my $x (1..3) { last PHANTOM; } }";
+    let ctrl_start = source.find("last PHANTOM").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the title embeds the exact `op LABEL` text from the source
+    let action = find_action(&actions, |t| t.contains("PHANTOM"))
+        .ok_or_else(|| format!("no PHANTOM action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Drop label from 'last PHANTOM' (targets innermost loop)");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — invalid-range guard
+// ===========================================================================
+
+#[test]
+fn invalid_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose byte range falls outside a multi-byte char boundary
+    let source = "for my $x (1..5) { next \u{e9}label; }";
+    let char_pos = source.find('\u{e9}').ok_or("marker not found")?;
+
+    // A range that starts inside the multi-byte character is invalid
+    let diag = make_diag(
+        char_pos + 1,
+        char_pos + 3,
+        "PL410",
+        "`next LABEL` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no drop-label action is produced
+    assert!(
+        !actions.iter().any(|a| a.title.contains("Drop label")),
+        "expected no drop-label action for invalid byte range, got: {:?}",
+        actions
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Cross-cutting: dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: PL410 code reaches the fix_loop_control_undefined_label handler
+    // and produces at least one action for a well-formed diagnostic.
+    let source = "for my $i (1..10) { next GHOST; }";
+    let ctrl_start = source.find("next GHOST").ok_or("marker not found")?;
+    let ctrl_end = ctrl_start + "next GHOST".len();
+
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let diags = vec![make_diag(
+        ctrl_start,
+        ctrl_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_pl410 = actions.iter().any(|a| a.title.contains("next GHOST"));
+    assert!(has_pl410, "PL410 route not reaching handler; actions: {:?}", actions);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label produce a PL410 diagnostic, but clicking the lightbulb in an editor returned **no code actions** — the diagnostic router had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics silently fell through to `_ => {}`.

This is a runtime-fatal condition in Perl: if the named label doesn't exist, Perl dies at runtime with `Label not found for "next LABEL"`. The fix is mechanical: drop the label so the operator targets the innermost enclosing loop.

## What changed

### `quick_fixes.rs` — new `fix_loop_control_undefined_label` handler

- Validates the byte range with the existing `valid_diagnostic_range` guard (rejects non-char-boundary or out-of-bounds ranges)
- Reads the source text at the diagnostic range (e.g. `next OUTER`)
- Confirms the text starts with exactly one of `next `, `last `, or `redo ` — anything else returns no actions
- Creates a single `QuickFix` edit that replaces the full `op LABEL` span with just `op`, making the statement target the innermost enclosing loop
- `is_preferred: true` — there is exactly one sensible mechanical fix

### `diagnostic_routes.rs` — PL410 arm wired in

Added one match arm after the existing PL405 arm (numeric ordering):

```rust
// PL410: next/last/redo references an undefined label
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `tests/quick_fix_pl410_bdd.rs` — 6 BDD integration tests

| # | Test name | What it verifies |
|---|-----------|-----------------|
| 1 | `next_undefined_label_produces_drop_action` | `next OUTER` → action exists, title is correct, edit produces `next` |
| 2 | `last_undefined_label_produces_drop_action` | `last MISSING` → edit produces `last` |
| 3 | `redo_undefined_label_produces_drop_action` | `redo NOWHERE` → edit produces `redo` |
| 4 | `title_names_the_op_and_label_from_source` | Title embeds exact `op LABEL` text from the source |
| 5 | `invalid_range_returns_no_actions` | Non-char-boundary range → no actions (guard fires) |
| 6 | `pl410_dispatch_reaches_handler` | PL410 code reaches the handler end-to-end (dispatch smoke) |

## Test results

```
running 6 tests
test pl410_dispatch_reaches_handler ... ok
test last_undefined_label_produces_drop_action ... ok
test invalid_range_returns_no_actions ... ok
test next_undefined_label_produces_drop_action ... ok
test redo_undefined_label_produces_drop_action ... ok
test title_names_the_op_and_label_from_source ... ok

test result: ok. 6 passed; 0 failed; 0 ignored
```

All 17 pre-existing `quick_fix_new_codes_bdd` tests remain green. `cargo fmt` and `cargo clippy` clean.

## Non-goals (per spec)

- Does **not** add a "suggest defining a label" alternative fix (would require AST rewrite guidance — deferred)
- Does **not** touch the diagnostic emission logic in `loop_control_label.rs`

## Diff size

3 files changed, 296 insertions(+) — all in `perl-lsp-rs-core`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012diA5CiMoPeNqbGQpvMW1y)_