### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo with undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1964,6 +1964,50 @@ fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
     specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
+/// Remove the undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL`
+/// statement so it targets the innermost enclosing loop instead (PL410).
+///
+/// At runtime Perl dies with `Label not found for "next LABEL"` when the label
+/// is absent. The only safe automated fix is to drop the label entirely, making
+/// the statement target the innermost enclosing loop.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(text) = source.get(start..end) else {
+        return Vec::new();
+    };
+
+    let op = text.split_whitespace().next().unwrap_or("");
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    // Message form: "`next OUTER` references a label that is not defined in this file"
+    let label_name = diagnostic
+        .message
+        .split('`')
+        .nth(1)
+        .and_then(|inner| inner.split_whitespace().nth(1))
+        .unwrap_or("label");
+
+    vec![CodeAction {
+        title: format!("Remove undefined label '{label_name}': target innermost enclosing loop"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,250 @@
+//! BDD tests for the PL410 quick-fix handler: `fix_loop_control_undefined_label`.
+//!
+//! `PL410` fires when a `next LABEL`, `last LABEL`, or `redo LABEL` statement
+//! references a label that is not defined anywhere in the current file.  The
+//! quick fix drops the label so the statement targets the innermost enclosing
+//! loop, which is always semantically valid.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is supplied and code actions are requested
+//!   THEN   exactly one action is returned, dropping the label while leaving
+//!          the operator and surrounding code intact
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop that uses `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is exactly one action and it removes the label
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove undefined label 'OUTER': target innermost enclosing loop");
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the drop-label action should be preferred");
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..10) { next; }\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop that uses `last MISSING` where MISSING is not defined
+    let source = "while (1) { last MISSING; }\n";
+    let stmt_start = source.find("last MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last MISSING".len();
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the fix drops the label, leaving bare `last`
+    let action = find_action(&actions, |t| t.contains("MISSING"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove undefined label 'MISSING': target innermost enclosing loop");
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL with undefined label
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a loop that uses `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }\n";
+    let stmt_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo NOWHERE".len();
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the fix drops the label, leaving bare `redo`
+    let action = find_action(&actions, |t| t.contains("NOWHERE"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(action.title, "Remove undefined label 'NOWHERE': target innermost enclosing loop");
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { redo; }\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — title uses label name from message
+// ===========================================================================
+
+#[test]
+fn action_title_includes_label_name_from_message() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic whose message names a specific label
+    let source = "while (1) { next DEEPLY_NESTED_LABEL; }\n";
+    let stmt_start = source.find("next DEEPLY_NESTED_LABEL").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next DEEPLY_NESTED_LABEL".len();
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next DEEPLY_NESTED_LABEL` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title contains the label name extracted from the message
+    let action = find_action(&actions, |t| t.contains("DEEPLY_NESTED_LABEL"))
+        .ok_or_else(|| format!("no drop-label action in: {:?}", actions))?;
+
+    assert_eq!(
+        action.title,
+        "Remove undefined label 'DEEPLY_NESTED_LABEL': target innermost enclosing loop"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — invalid byte-range guard
+// ===========================================================================
+
+#[test]
+fn non_char_boundary_range_produces_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source with a multi-byte character
+    let source = "while (1) { next LOOP; }\nmy $name = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+
+    // A range that splits the multi-byte char is invalid
+    let diag = make_diag(
+        char_start + 1,
+        char_start + 2,
+        "PL410",
+        "`next LOOP` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no action is produced for the malformed range
+    assert!(
+        !actions.iter().any(|a| a.title.contains("LOOP")),
+        "expected no PL410 action for non-char-boundary range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Cross-cutting: dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_reaches_its_handler_in_dispatch_table() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: a well-formed PL410 diagnostic reaches the handler and
+    // produces at least one action, confirming the routing table is wired.
+    let source = "for my $i (1..3) { next GHOST; }\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let stmt_start = source.find("next GHOST").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next GHOST".len();
+
+    let diags = vec![make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("GHOST")),
+        "PL410 route not producing action; actions: {:?}",
+        actions
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label receive a `PL410` diagnostic, but clicking the lightbulb returned **no code actions**. The diagnostic routing table (`diagnostic_routes.rs`) had no arm for `DiagnosticCode::LoopControlUndefinedLabel`, so all PL410 diagnostics silently fell through to `_ => {}`.

This PR wires up the missing quick-fix: drop the label so the statement targets the innermost enclosing loop.

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`

New function `fix_loop_control_undefined_label`:
- Validates the diagnostic byte range using `valid_diagnostic_range` (guards against non-char-boundary offsets — same pattern as every recent handler).
- Extracts the loop-control operator from the leading token of the range text; rejects anything other than `next`, `last`, or `redo`.
- Extracts the label name from the diagnostic message for a user-readable title. Message format from the emitter: `` `next OUTER` references a label that is not defined in this file ``.
- Returns a single `CodeAction` that replaces `OPERATOR LABEL` with just `OPERATOR`, leaving the trailing `;` and all surrounding code unchanged.
- `is_preferred: true` — there is exactly one safe automated fix (Perl's only alternative is to define the label, which requires intent the editor cannot infer).

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`

New routing arm after the PL405 arm:
```rust
// PL410: next/last/redo with undefined label
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` (new)

6 BDD integration tests following the exact pattern established in `quick_fix_new_codes_bdd.rs`:

| # | Scenario | Verifies |
|---|----------|---------|
| 1 | `next OUTER` → action produced | operator `next`, edit leaves `next;`, `is_preferred` |
| 2 | `last MISSING` → action produced | operator `last`, edit leaves `last;` |
| 3 | `redo NOWHERE` → action produced | operator `redo`, edit leaves `redo;` |
| 4 | Title naming | label name from message appears in action title |
| 5 | Invalid range guard | non-char-boundary range → no action (no panic) |
| 6 | Dispatch smoke test | end-to-end routing through `CodeActionsProvider` |

## Test results

```
running 6 tests
test action_title_includes_label_name_from_message ... ok
test next_undefined_label_produces_drop_label_action ... ok
test last_undefined_label_produces_drop_label_action ... ok
test redo_undefined_label_produces_drop_label_action ... ok
test non_char_boundary_range_produces_no_action ... ok
test pl410_reaches_its_handler_in_dispatch_table ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Pre-existing `quick_fix_new_codes_bdd` suite: **17 passed, 0 failed** (no regressions).

`cargo clippy -p perl-lsp-rs-core --lib` — clean (one pre-existing warning in `inline_completion` unrelated to this PR).

## Non-goals (per spec)

- Does not add a "suggest defining a label" alternative fix — that would require AST rewrite guidance and is out of scope.
- Does not touch diagnostic *emission* logic in `loop_control_label.rs`.

https://claude.ai/code/session_01RQmd3KZw8owLNkkbwLmsQt

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQmd3KZw8owLNkkbwLmsQt)_