### PR TITLE
test(lsp): isolate @INC context label receipt (#9677)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/lifecycle/inc_context/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/lifecycle/inc_context/mod.rs
@@ -213,6 +213,7 @@ mod tests {
         let mut config = perl_lsp_rs_core::config::WorkspaceConfig::default();
         config.include_paths = vec!["lib".to_string()];
         config.use_system_inc = false;
+        config.use_perl5lib = false;
         config.resolution_timeout_ms = 123;
 
         let server = LspServer::new();
@@ -232,7 +233,7 @@ mod tests {
         assert_eq!(context.folder_uri.as_deref(), Some(workspace_uri.as_str()));
         assert_eq!(context.doc_uri.as_deref(), Some(doc_uri.as_str()));
         assert!(!context.use_system_inc);
-        assert!(context.use_perl5lib);
+        assert!(!context.use_perl5lib);
         assert_eq!(context.resolution_timeout_ms, 123);
         assert_eq!(context.effective_roots.len(), 2);
         assert_eq!(context.effective_roots[0].kind, IncRootKind::FileLocalLexical);


### PR DESCRIPTION
Problem: The effective @INC context label receipt inherited ambient PERL5LIB, so its lexical/workspace root count depended on the agent shell.\nFix: Disable PERL5LIB participation in that focused receipt and assert the resulting policy explicitly.\nVerification: `just agent-pr-fast` passes.\n\nTracks #9677