### PR TITLE
fix(inline): remove clone-on-copy range assignment (#9680)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs
@@ -223,7 +223,7 @@ impl InlineCompletionProvider {
 
         for item in &mut list.items {
             if item.range.is_none() && item_matches_fragment(item, fragment.text) {
-                item.range = Some(range.clone());
+                item.range = Some(range);
             }
         }
 


### PR DESCRIPTION
Problem: Rust 1.95 clippy reports clone_on_copy in inline completion replacement-range assignment.\nFix: Assign the Copy Range value directly instead of cloning it.\nVerification: `just agent-pr-fast` passes.\n\nTracks #9680