### PR TITLE
test(ux): lock external perlcritic setup warning (#9689)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -111,6 +111,7 @@
       ],
       "expected_outcomes": [
         "diagnostics degrade gracefully",
+        "external perlcritic mode emits an actionable missing-tool warning",
         "no crash or panic-style messaging"
       ],
       "confidence_signals": [

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_04_missing_perlcritic.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_04_missing_perlcritic.rs
@@ -1,5 +1,7 @@
 // Test infrastructure — allow test-friendly patterns.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// UX receipt scenarios print skip markers during `--nocapture` runs.
+#![allow(clippy::print_stderr)]
 
 //! Scenario 04 — Missing perlcritic.
 //!
@@ -11,8 +13,11 @@
 //! - Server MUST NOT crash when it tries to run perlcritic and fails.
 //! - Server must remain responsive after the diagnostic pass.
 
+use anyhow::Result;
+use perl_lsp_ux_tests::LspEvent;
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::json;
 use std::time::Duration;
 
 fn config_without_perlcritic() -> ScenarioConfig {
@@ -26,6 +31,39 @@ fn config_without_perlcritic() -> ScenarioConfig {
         .map(String::from)
         .collect();
     ScenarioConfig { path_restriction: Some(dirs), ..Default::default() }
+}
+
+fn config_without_any_path_tools() -> ScenarioConfig {
+    ScenarioConfig { path_restriction: Some(Vec::new()), ..Default::default() }
+}
+
+fn send_external_perlcritic_config(harness: &UxHarness) -> Result<()> {
+    harness.client.notify(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "perl": {
+                    "perlcritic": {
+                        "enabled": true
+                    },
+                    "critic": {
+                        "engine": "perlcritic"
+                    }
+                }
+            }
+        }),
+    )?;
+    std::thread::sleep(Duration::from_millis(200));
+    Ok(())
+}
+
+fn message_text(event: &LspEvent) -> Option<&str> {
+    match event {
+        LspEvent::WindowMessage { message, .. } | LspEvent::LogMessage { message, .. } => {
+            Some(message.as_str())
+        }
+        _ => None,
+    }
 }
 
 #[test]
@@ -42,6 +80,46 @@ fn scenario_04_diagnostics_without_perlcritic_no_crash() {
     std::thread::sleep(Duration::from_secs(1));
 
     harness.assert_no_crash();
+}
+
+#[test]
+fn scenario_04_external_perlcritic_missing_warning_is_actionable() -> Result<()> {
+    if !binary_available() {
+        eprintln!("SKIP scenario_04: perl-lsp binary not found");
+        return Ok(());
+    }
+
+    let source = "sub foo {\n    my $unused = 1;\n    return 42;\n}\n";
+    let harness = UxHarness::new(config_without_any_path_tools())?;
+    send_external_perlcritic_config(&harness)?;
+
+    harness.open_file("external_critic_missing.pl", source)?;
+    std::thread::sleep(Duration::from_secs(1));
+
+    let events = harness.peek_notifications();
+    let warning = events
+        .iter()
+        .filter_map(message_text)
+        .find(|message| message.contains("`perlcritic` was not found"));
+    let Some(warning) = warning else {
+        anyhow::bail!("external perlcritic should emit a missing-tool warning; events={events:?}");
+    };
+
+    assert!(
+        warning.contains("cpanm Perl::Critic"),
+        "missing-tool warning should include install guidance: {warning}"
+    );
+    assert!(
+        warning.contains("disable perl.perlcritic.enabled"),
+        "missing-tool warning should include disable guidance: {warning}"
+    );
+    assert!(
+        !warning.contains("panicked at") && !warning.contains("SIGABRT"),
+        "missing-tool warning should not expose crash text: {warning}"
+    );
+
+    harness.assert_no_crash();
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
Problem: The missing-perlcritic UX scenario proved no crash, but did not prove external Perl::Critic mode surfaces actionable setup guidance when `perlcritic` is unavailable.
Fix: Add a focused UX assertion that switches diagnostics to external perlcritic mode, clears PATH tools, and checks the missing-tool warning for install guidance, disable guidance, and no panic-style text.
Verification: `just agent-pr-fast` passes.

Tracks #9689