### PR TITLE
test(ux): lock missing Perl setup guidance (#9691)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -86,6 +86,7 @@
       ],
       "expected_outcomes": [
         "server starts in degraded mode",
+        "missing-PATH Perl setup emits actionable fallback or install guidance",
         "hover or completion remain available where possible"
       ],
       "confidence_signals": [

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_03_missing_perl.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_03_missing_perl.rs
@@ -1,5 +1,7 @@
 // Test infrastructure — allow test-friendly patterns.
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// UX receipt scenarios print skip markers during `--nocapture` runs.
+#![allow(clippy::print_stderr)]
 
 //! Scenario 03 — Missing perl interpreter.
 //!
@@ -11,12 +13,22 @@
 //! - Server MUST NOT crash during initialization.
 //! - Hover and completion may return null/empty — that is acceptable.
 
+use perl_lsp_ux_tests::LspEvent;
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
 use std::time::Duration;
 
 fn config_without_perl() -> ScenarioConfig {
     ScenarioConfig { path_restriction: Some(Vec::new()), ..Default::default() }
+}
+
+fn message_text(event: &LspEvent) -> Option<&str> {
+    match event {
+        LspEvent::WindowMessage { message, .. } | LspEvent::LogMessage { message, .. } => {
+            Some(message.as_str())
+        }
+        _ => None,
+    }
 }
 
 #[test]
@@ -92,28 +104,27 @@ fn scenario_03_warning_message_about_missing_perl() {
     std::thread::sleep(Duration::from_secs(1));
 
     let events = harness.collect_notifications();
-    let perl_messages: Vec<_> = events
-        .iter()
-        .filter(|ev| {
-            use perl_lsp_ux_tests::LspEvent;
-            match ev {
-                LspEvent::WindowMessage { message, .. } | LspEvent::LogMessage { message, .. } => {
-                    let lower = message.to_ascii_lowercase();
-                    lower.contains("perl") || lower.contains("interpreter")
-                }
-                _ => false,
-            }
-        })
-        .collect();
+    let fallback_message = events.iter().filter_map(message_text).find(|message| {
+        message.contains("Perl not found on PATH") || message.contains("Perl interpreter not found")
+    });
+    let Some(fallback_message) = fallback_message else {
+        panic!("missing-Perl startup should emit actionable setup guidance; events={events:?}");
+    };
 
-    if perl_messages.is_empty() {
-        eprintln!(
-            "INFO scenario_03: no Perl-related warning message — \
-             may be OK if server uses a different channel"
-        );
-    } else {
-        eprintln!("INFO scenario_03: server emitted Perl messages: {:?}", perl_messages);
-    }
+    assert!(
+        fallback_message.contains("Add Perl to PATH")
+            || fallback_message.contains("Install Perl")
+            || fallback_message.contains("install Perl"),
+        "missing-Perl message should include install/PATH guidance: {fallback_message}"
+    );
+    assert!(
+        fallback_message.contains("perl-lsp.perl.path"),
+        "missing-Perl message should name the explicit interpreter setting: {fallback_message}"
+    );
+    assert!(
+        !fallback_message.contains("panicked at") && !fallback_message.contains("SIGABRT"),
+        "missing-Perl message should not expose crash text: {fallback_message}"
+    );
 
     harness.assert_no_crash();
 }


### PR DESCRIPTION
Problem: The missing-Perl UX scenario logged startup messages but did not require actionable setup guidance when PATH excludes `perl`.
Fix: Assert the startup notification names the missing PATH Perl condition, includes install/PATH or fallback guidance, names `perl-lsp.perl.path`, and avoids panic-style text.
Verification: `just agent-pr-fast` passes.

Tracks #9691