### PR TITLE
test(ux): lock multi-file definition target (#9695)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -189,6 +189,7 @@
       ],
       "expected_outcomes": [
         "cross-file definition request completes without error",
+        "cross-file definition resolves the configured workspace module target",
         "workspace interactions remain stable"
       ],
       "confidence_signals": [

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_07_multi_file_workspace.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_07_multi_file_workspace.rs
@@ -1,5 +1,7 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// Test infrastructure needs skip/status messages when the external binary is absent.
+#![allow(clippy::print_stderr)]
+// Test assertions intentionally panic with UX-specific failure messages.
+#![allow(clippy::panic)]
 
 //! Scenario 07 — Multi-file workspace / cross-file navigation.
 //!
@@ -8,18 +10,20 @@
 //!
 //! Acceptance criteria:
 //! - All files open without crashing.
-//! - `textDocument/definition` MUST NOT crash (empty result is acceptable).
+//! - `textDocument/definition` MUST resolve the configured workspace module.
 //! - Server remains responsive after workspace indexing.
 
+use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::{Value, json};
 use std::time::Duration;
 
 #[test]
-fn scenario_07_multi_file_workspace_opens_without_crash() {
+fn scenario_07_multi_file_workspace_opens_without_crash() -> Result<()> {
     if !binary_available() {
         eprintln!("SKIP scenario_07: perl-lsp binary not found");
-        return;
+        return Ok(());
     }
 
     let module_a = "package MyProject::Utils;\nuse strict;\nuse warnings;\n\n\
@@ -36,21 +40,21 @@ fn scenario_07_multi_file_workspace_opens_without_crash() {
             .with_file("lib/MyProject/Config.pm", module_b)
             .with_file("script.pl", script)
             .with_file("cpanfile", "requires 'Moo', '2.0';\n"),
-    )
-    .expect("Failed to create multi-file harness");
+    )?;
 
-    harness.open_file("lib/MyProject/Utils.pm", module_a).expect("Utils.pm should open");
-    harness.open_file("lib/MyProject/Config.pm", module_b).expect("Config.pm should open");
-    harness.open_file("script.pl", script).expect("script.pl should open");
+    harness.open_file("lib/MyProject/Utils.pm", module_a)?;
+    harness.open_file("lib/MyProject/Config.pm", module_b)?;
+    harness.open_file("script.pl", script)?;
 
     harness.assert_no_crash();
+    Ok(())
 }
 
 #[test]
-fn scenario_07_definition_request_does_not_crash() {
+fn scenario_07_definition_request_resolves_workspace_module() -> Result<()> {
     if !binary_available() {
         eprintln!("SKIP scenario_07: perl-lsp binary not found");
-        return;
+        return Ok(());
     }
 
     let module = "package Counter;\nuse strict;\nuse warnings;\n\n\
@@ -64,17 +68,60 @@ fn scenario_07_definition_request_does_not_crash() {
         ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
             .with_file("lib/Counter.pm", module)
             .with_file("main.pl", script),
-    )
-    .expect("Failed to create harness");
+    )?;
 
-    harness.open_file("lib/Counter.pm", module).expect("Counter.pm should open");
-    harness.open_file("main.pl", script).expect("main.pl should open");
+    send_include_paths(&harness, &["lib"])?;
 
-    // Allow workspace index to build.
-    std::thread::sleep(Duration::from_secs(2));
+    harness.open_file("lib/Counter.pm", module)?;
+    harness.open_file("main.pl", script)?;
 
-    let defs = harness.definition("main.pl", 3, 4);
-    assert!(defs.is_ok(), "definition request crashed server — UX regression: {:?}", defs);
+    let defs = harness.definition_with_retry("main.pl", 3, 4, 5, Duration::from_millis(250))?;
+    assert!(
+        !defs.is_empty(),
+        "expected go-to-definition on `use Counter` to resolve lib/Counter.pm, got empty result"
+    );
+    assert!(
+        defs.iter().all(is_lsp_location_shape),
+        "definition entries must be Location or LocationLink values: {defs:?}"
+    );
+    assert!(
+        defs.iter().any(|entry| entry_uri_ends_with(entry, "lib/Counter.pm")),
+        "expected at least one definition result to point at lib/Counter.pm, got: {defs:?}"
+    );
 
     harness.assert_no_crash();
+    Ok(())
+}
+
+fn send_include_paths(harness: &UxHarness, paths: &[&str]) -> Result<()> {
+    let paths_json: Vec<Value> = paths.iter().map(|path| json!(*path)).collect();
+    harness.client.notify(
+        "workspace/didChangeConfiguration",
+        json!({
+            "settings": {
+                "perl": {
+                    "workspace": {
+                        "includePaths": paths_json,
+                        "useSystemInc": false
+                    }
+                }
+            }
+        }),
+    )?;
+    std::thread::sleep(Duration::from_millis(200));
+    Ok(())
+}
+
+fn is_lsp_location_shape(entry: &Value) -> bool {
+    let is_location = entry.get("uri").is_some() && entry.get("range").is_some();
+    let is_location_link = entry.get("targetUri").is_some() && entry.get("targetRange").is_some();
+    is_location || is_location_link
+}
+
+fn entry_uri_ends_with(entry: &Value, suffix: &str) -> bool {
+    entry
+        .get("uri")
+        .or_else(|| entry.get("targetUri"))
+        .and_then(Value::as_str)
+        .is_some_and(|uri| uri.replace('\\', "/").ends_with(suffix))
 }


### PR DESCRIPTION
Problem: Scenario 07 only proved cross-file go-to-definition did not crash, so empty or wrong-target responses could pass.
Fix: Configure the workspace include path and assert the definition response resolves to lib/Counter.pm with valid LSP location shape.
Verification: `just agent-pr-fast` passes.

Tracks #9695