### PR TITLE
test(ux): lock shebang document symbols (#9697)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -213,7 +213,8 @@
         "workflow_stability_rate"
       ],
       "expected_outcomes": [
-        "languageId-perl files without extensions still behave like Perl"
+        "languageId-perl files without extensions still behave like Perl",
+        "shebang files without extensions expose Perl document symbols"
       ],
       "confidence_signals": [
         "first_five_minutes_harness",

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_08_shebang_detection.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_08_shebang_detection.rs
@@ -1,5 +1,7 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// Test infrastructure needs skip/status messages when the external binary is absent.
+#![allow(clippy::print_stderr)]
+// Test assertions intentionally panic with UX-specific failure messages.
+#![allow(clippy::panic)]
 
 //! Scenario 08 — Shebang detection / non-standard extensions.
 //!
@@ -7,59 +9,85 @@
 //!
 //! Acceptance criteria:
 //! - Server MUST accept `didOpen` with any URI when languageId is "perl".
-//! - Hover, completion MUST NOT crash.
-//! - Null results are acceptable.
+//! - Shebang files without extensions MUST expose Perl document symbols.
+//! - Hover and completion MUST NOT crash.
 
+use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
+use std::time::Duration;
+
+const SHEBANG_DEPLOY_SOURCE: &str = r#"#!/usr/bin/env perl
+use strict;
+use warnings;
+
+sub deploy_task {
+    return 42;
+}
+
+deploy_task();
+"#;
 
 #[test]
-fn scenario_08_shebang_file_without_pl_extension() {
+fn scenario_08_shebang_file_without_pl_extension_has_document_symbols() -> Result<()> {
     if !binary_available() {
         eprintln!("SKIP scenario_08: perl-lsp binary not found");
-        return;
+        return Ok(());
     }
 
-    let source = "#!/usr/bin/env perl\nuse strict;\nuse warnings;\n\n\
-                  my $answer = 42;\nprint \"Answer: $answer\\n\";\n";
-    let harness = UxHarness::new(ScenarioConfig::default()).expect("Failed to create UX harness");
+    let harness = UxHarness::new(
+        ScenarioConfig::default().with_file("deploy_script", SHEBANG_DEPLOY_SOURCE),
+    )?;
 
-    harness.open_file("deploy_script", source).expect("didOpen should succeed for shebang file");
+    harness.open_file("deploy_script", SHEBANG_DEPLOY_SOURCE)?;
 
-    let hover = harness.hover("deploy_script", 4, 3);
-    assert!(hover.is_ok(), "hover crashed on non-.pl file — UX regression: {:?}", hover);
+    std::thread::sleep(Duration::from_millis(300));
+
+    let symbols = harness.document_symbols("deploy_script")?;
+    assert!(
+        symbols.iter().any(|symbol| symbol_name_matches(symbol, "deploy_task")),
+        "expected no-extension shebang file to expose deploy_task document symbol, got: {symbols:?}"
+    );
+
+    harness.hover("deploy_script", 8, 0)?;
 
     harness.assert_no_crash();
+    Ok(())
 }
 
 #[test]
-fn scenario_08_no_extension_file_completion_does_not_crash() {
+fn scenario_08_no_extension_file_completion_does_not_crash() -> Result<()> {
     if !binary_available() {
         eprintln!("SKIP scenario_08: perl-lsp binary not found");
-        return;
+        return Ok(());
     }
 
     let source = "#!/usr/bin/perl\nmy $va\n";
-    let harness = UxHarness::new(ScenarioConfig::default()).expect("Failed to create UX harness");
+    let harness = UxHarness::new(ScenarioConfig::default())?;
 
-    harness.open_file("run_tests", source).expect("didOpen should succeed");
+    harness.open_file("run_tests", source)?;
 
-    let result = harness.completion("run_tests", 1, 7);
-    assert!(result.is_ok(), "completion crashed on non-.pl file — UX regression: {:?}", result);
+    harness.completion("run_tests", 1, 7)?;
+    Ok(())
 }
 
 #[test]
-fn scenario_08_test_file_t_extension() {
+fn scenario_08_test_file_t_extension() -> Result<()> {
     if !binary_available() {
         eprintln!("SKIP scenario_08: perl-lsp binary not found");
-        return;
+        return Ok(());
     }
 
     let source = "use Test::More;\nuse strict;\n\nok(1, 'basic');\ndone_testing();\n";
-    let harness = UxHarness::new(ScenarioConfig::default()).expect("Failed to create UX harness");
+    let harness = UxHarness::new(ScenarioConfig::default())?;
 
-    harness.open_file("basic.t", source).expect("didOpen should succeed for .t extension");
+    harness.open_file("basic.t", source)?;
 
-    let hover = harness.hover("basic.t", 3, 1);
-    assert!(hover.is_ok(), "hover crashed on .t test file — UX regression: {:?}", hover);
+    harness.hover("basic.t", 3, 1)?;
+    Ok(())
+}
+
+fn symbol_name_matches(symbol: &Value, expected: &str) -> bool {
+    symbol.get("name").and_then(Value::as_str) == Some(expected)
 }


### PR DESCRIPTION
Problem: Scenario 08 only proved no-extension shebang files did not crash, so missing Perl document symbols could pass.
Fix: Assert that a no-extension shebang file exposes the deploy_task document symbol while retaining hover/completion stability checks.
Verification: `just agent-pr-fast` passes.

Tracks #9697