### PR TITLE
test(ux): lock live-edit definition target (#9699)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -634,7 +634,7 @@
       ],
       "expected_outcomes": [
         "undeclared variable diagnostic appears before edit",
-        "go-to-definition remains responsive after didChange"
+        "go-to-definition resolves the declared variable after didChange"
       ],
       "confidence_signals": [
         "first_five_minutes_harness",

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
@@ -1,15 +1,20 @@
+// Test infrastructure needs skip/status messages when the external binary is absent.
+#![allow(clippy::print_stderr)]
+// Test assertions intentionally panic with UX-specific failure messages.
+#![allow(clippy::panic)]
+
 //! Scenario 24 — Live-edit UX feedback loop for diagnostics + definition.
 //!
 //! BDD contract:
 //! - Given a file with an undefined variable, when it is opened, then diagnostics
 //!   should surface a strict warning/error for that variable.
 //! - Given the declaration was added, when go-to-definition runs on the use-site,
-//!   then it should stay responsive and return either locations or an empty
-//!   result (degraded mode).
+//!   then it should return a definition location in the edited file.
 
 use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
 use std::time::Duration;
 
 const UNDECLARED_SOURCE: &str = r#"use strict;
@@ -56,7 +61,7 @@ fn given_undeclared_variable_when_opened_then_strict_diagnostic_is_published() -
 }
 
 #[test]
-fn given_live_edit_when_variable_is_declared_then_navigation_remains_responsive() -> Result<()> {
+fn given_live_edit_when_variable_is_declared_then_definition_resolves_use_site() -> Result<()> {
     if !binary_available() {
         eprintln!("SKIP scenario_24: perl-lsp binary not found");
         return Ok(());
@@ -78,13 +83,36 @@ fn given_live_edit_when_variable_is_declared_then_navigation_remains_responsive(
     let _post_edit_diagnostics =
         harness.wait_for_latest_diagnostics("live_edit.pl", Duration::from_secs(6));
 
-    let definitions = harness.definition("live_edit.pl", 4, 7);
+    let definitions =
+        harness.definition_with_retry("live_edit.pl", 4, 7, 5, Duration::from_millis(200))?;
     assert!(
-        definitions.is_ok(),
-        "expected go-to-definition to stay responsive after didChange, got: {:?}",
+        !definitions.is_empty(),
+        "expected go-to-definition to resolve declared $name after didChange, got empty result"
+    );
+    assert!(
+        definitions.iter().all(is_lsp_location_shape),
+        "definition entries must be Location or LocationLink values: {definitions:?}"
+    );
+    assert!(
+        definitions.iter().any(|entry| entry_uri_ends_with(entry, "live_edit.pl")),
+        "expected go-to-definition after didChange to point at live_edit.pl, got: {:?}",
         definitions
     );
 
     harness.assert_no_crash();
     Ok(())
+}
+
+fn is_lsp_location_shape(entry: &Value) -> bool {
+    let is_location = entry.get("uri").is_some() && entry.get("range").is_some();
+    let is_location_link = entry.get("targetUri").is_some() && entry.get("targetRange").is_some();
+    is_location || is_location_link
+}
+
+fn entry_uri_ends_with(entry: &Value, suffix: &str) -> bool {
+    entry
+        .get("uri")
+        .or_else(|| entry.get("targetUri"))
+        .and_then(Value::as_str)
+        .is_some_and(|uri| uri.replace('\\', "/").ends_with(suffix))
 }


### PR DESCRIPTION
Problem: Scenario 24 accepted empty go-to-definition results after didChange added a missing variable declaration.
Fix: Retry the definition request and assert it returns valid LSP locations pointing at live_edit.pl.
Verification: `just agent-pr-fast` passes.

Tracks #9699