### PR TITLE
test(ux): lock declaration target (#9711)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -475,7 +475,7 @@
         "workflow_stability_rate"
       ],
       "expected_outcomes": [
-        "declaration request returns a location or clean empty result",
+        "declaration request points same-file subroutine calls to their declaration",
         "request does not error"
       ],
       "confidence_signals": [

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
@@ -5,13 +5,21 @@
 //!
 //! Contract:
 //! - `textDocument/declaration` MUST NOT return a JSON-RPC error.
-//! - A declaration result MAY be empty (degraded mode acceptable) but must not crash.
-//! - When non-empty, each result MUST include URI/range shape (`targetUri` +
+//! - Same-file subroutine calls MUST resolve to the source declaration.
+//! - Each result MUST include URI/range shape (`targetUri` +
 //!   `targetRange` for links, or `uri` + `range` for locations).
+
+// Binary skip messages are visible only in integration-test output.
+#![allow(clippy::print_stderr)]
 
 use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use serde_json::Value;
+
+const INC_CALL_LINE: u32 = 10;
+const INC_CALL_CHARACTER: u32 = 13;
+const INC_DECLARATION_LINE: u64 = 5;
 
 const DECLARATION_FIXTURE: &str = r#"use strict;
 use warnings;
@@ -38,7 +46,7 @@ fn scenario_18_declaration_request_does_not_error() -> Result<()> {
         UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
 
     harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
-    let result = harness.declaration("declaration.pl", 9, 13);
+    let result = harness.declaration("declaration.pl", INC_CALL_LINE, INC_CALL_CHARACTER);
 
     assert!(
         result.is_ok(),
@@ -51,7 +59,7 @@ fn scenario_18_declaration_request_does_not_error() -> Result<()> {
 }
 
 #[test]
-fn scenario_18_declaration_result_is_location_or_empty() -> Result<()> {
+fn scenario_18_declaration_result_points_to_sub_inc() -> Result<()> {
     if !binary_available() {
         eprintln!("SKIP scenario_18: perl-lsp binary not found");
         return Ok(());
@@ -61,18 +69,49 @@ fn scenario_18_declaration_result_is_location_or_empty() -> Result<()> {
         UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
 
     harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
-    let declarations = harness.declaration("declaration.pl", 9, 13)?;
+    let declarations = harness.declaration("declaration.pl", INC_CALL_LINE, INC_CALL_CHARACTER)?;
 
-    for entry in declarations {
-        let is_link = entry.get("targetUri").is_some() && entry.get("targetRange").is_some();
-        let is_location = entry.get("uri").is_some() && entry.get("range").is_some();
+    assert!(
+        !declarations.is_empty(),
+        "goto-declaration on `inc($value)` must return the `sub inc` declaration"
+    );
+
+    for entry in &declarations {
         assert!(
-            is_link || is_location,
+            is_location_shape(entry),
             "declaration result must be LocationLink or Location, got: {:?}",
             entry
         );
     }
 
+    let points_to_inc = declarations.iter().any(|entry| {
+        entry_uri(entry).is_some_and(|uri| uri.ends_with("declaration.pl"))
+            && entry_target_start_line(entry) == Some(INC_DECLARATION_LINE)
+    });
+    assert!(
+        points_to_inc,
+        "goto-declaration on `inc($value)` must point to `sub inc` on line \
+         {INC_DECLARATION_LINE}, got: {declarations:?}"
+    );
+
     harness.assert_no_crash();
     Ok(())
+}
+
+fn is_location_shape(entry: &Value) -> bool {
+    let is_link = entry.get("targetUri").is_some() && entry.get("targetRange").is_some();
+    let is_location = entry.get("uri").is_some() && entry.get("range").is_some();
+    is_link || is_location
+}
+
+fn entry_uri(entry: &Value) -> Option<&str> {
+    entry.get("targetUri").or_else(|| entry.get("uri")).and_then(Value::as_str)
+}
+
+fn entry_target_start_line(entry: &Value) -> Option<u64> {
+    entry
+        .pointer("/targetSelectionRange/start/line")
+        .or_else(|| entry.pointer("/targetRange/start/line"))
+        .or_else(|| entry.pointer("/range/start/line"))
+        .and_then(Value::as_u64)
 }


### PR DESCRIPTION
Problem: Scenario 18 allowed empty declaration results and requested a blank line before the sample call.\nFix: Request go-to-declaration on inc() and require the response to target the same-file sub inc declaration.\nVerification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_18_goto_declaration --profile agent --locked` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `just agent-pr-fast` passes.