### PR TITLE
test(ux): lock empty folding ranges (#9715)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -1243,7 +1243,8 @@
       "expected_outcomes": [
         "foldingRange requests do not return JSON-RPC errors",
         "folding ranges include valid start and end line fields when present",
-        "multi-block files produce at least one fold"
+        "multi-block files produce at least one fold",
+        "empty and single-line files return empty folding range arrays"
       ],
       "confidence_signals": [
         "first_five_minutes_harness",

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_27_folding_range.rs
@@ -12,6 +12,9 @@
 //!   at least one range so the editor can offer at least one fold.
 //! - The server MUST remain stable after repeated fold requests.
 
+// Binary skip messages are visible only in integration-test output.
+#![allow(clippy::print_stderr)]
+
 use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
@@ -214,6 +217,11 @@ fn scenario_27_empty_file_does_not_error() -> Result<()> {
         "foldingRange on empty file MUST NOT return JSON-RPC error: {:?}",
         response
     );
+    let ranges = response
+        .get("result")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("empty file foldingRange result MUST be an array"))?;
+    assert!(ranges.is_empty(), "empty files MUST return no folding ranges, got: {ranges:?}");
 
     harness.assert_no_crash();
     Ok(())
@@ -241,6 +249,11 @@ fn scenario_27_single_line_file_does_not_error() -> Result<()> {
         "foldingRange on single-line file MUST NOT return JSON-RPC error: {:?}",
         response
     );
+    let ranges = response
+        .get("result")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("single-line foldingRange result MUST be an array"))?;
+    assert!(ranges.is_empty(), "single-line files MUST return no folding ranges, got: {ranges:?}");
 
     harness.assert_no_crash();
     Ok(())


### PR DESCRIPTION
Problem: Scenario 27 only checked that empty and single-line foldingRange requests did not error.\nFix: Require empty and single-line files to return empty folding-range arrays, matching the UX contract.\nVerification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_27_folding_range --profile agent --locked` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `just agent-pr-fast` passes.