### PR TITLE
test(ux): lock same-file rename edits (#9717)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -581,7 +581,7 @@
       ],
       "expected_outcomes": [
         "prepareRename and rename do not error",
-        "rename returns clean null or valid workspace edit for the opened file"
+        "same-file subroutine rename returns edits for the declaration and call sites"
       ],
       "confidence_signals": [
         "first_five_minutes_harness",

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
@@ -5,8 +5,13 @@
 //!
 //! Contract:
 //! - `prepareRename` and `rename` MUST NOT return JSON-RPC errors.
-//! - `rename` MAY return null in degraded mode, but if edits are returned they
-//!   MUST target the opened file and update multiple occurrences.
+//! - simple same-file subroutine rename MUST return a WorkspaceEdit targeting
+//!   the opened file.
+//! - rename edits MUST cover the declaration and both call sites with the
+//!   requested new name.
+
+// Tests print skip reasons when the optional perl-lsp binary is unavailable.
+#![allow(clippy::print_stderr)]
 
 use anyhow::{Context, Result};
 use perl_lsp_ux_tests::binary_available;
@@ -92,17 +97,24 @@ fn scenario_23_rename_workspace_edit_targets_file_and_multiple_occurrences() -> 
 
     assert!(rename.get("error").is_none(), "rename returned JSON-RPC error: {:?}", rename);
 
-    let Some(result) = rename.get("result") else {
-        return Ok(());
-    };
-    if result.is_null() {
-        return Ok(());
-    }
+    let result = rename.get("result").context("rename response missing result")?;
+    assert!(!result.is_null(), "same-file subroutine rename must return edits: {:?}", rename);
 
     let edit_count = workspace_edit_count_for_uri(result, &uri)?;
     assert!(
-        edit_count >= 2,
-        "rename should update at least declaration + one call-site when edits are returned; got {edit_count} edits"
+        edit_count >= 3,
+        "rename should update declaration + two call-sites; got {edit_count} edits"
+    );
+
+    let new_texts = workspace_edit_new_texts_for_uri(result, &uri)?;
+    assert_eq!(
+        new_texts.len(),
+        edit_count,
+        "every counted rename edit should include newText; got {new_texts:?}"
+    );
+    assert!(
+        new_texts.iter().all(|new_text| new_text == "welcome"),
+        "rename edits should use requested new name; got {new_texts:?}"
     );
 
     harness.assert_no_crash();
@@ -138,4 +150,41 @@ fn workspace_edit_count_for_uri(workspace_edit: &Value, uri: &str) -> Result<usi
     }
 
     Ok(0)
+}
+
+fn workspace_edit_new_texts_for_uri(workspace_edit: &Value, uri: &str) -> Result<Vec<String>> {
+    let mut new_texts = Vec::new();
+
+    if let Some(changes) = workspace_edit.get("changes").and_then(Value::as_object) {
+        if let Some(edits) = changes.get(uri).and_then(Value::as_array) {
+            new_texts.extend(edits.iter().filter_map(rename_edit_new_text));
+        }
+    }
+
+    if let Some(document_changes) = workspace_edit.get("documentChanges").and_then(Value::as_array)
+    {
+        for change in document_changes {
+            let text_document = change
+                .get("textDocument")
+                .and_then(Value::as_object)
+                .context("rename documentChanges entry missing textDocument")?;
+            let entry_uri = text_document
+                .get("uri")
+                .and_then(Value::as_str)
+                .context("rename documentChanges.textDocument.uri missing")?;
+            if entry_uri == uri {
+                let edits = change
+                    .get("edits")
+                    .and_then(Value::as_array)
+                    .context("rename documentChanges entry missing edits")?;
+                new_texts.extend(edits.iter().filter_map(rename_edit_new_text));
+            }
+        }
+    }
+
+    Ok(new_texts)
+}
+
+fn rename_edit_new_text(edit: &Value) -> Option<String> {
+    edit.get("newText").and_then(Value::as_str).map(ToOwned::to_owned)
 }


### PR DESCRIPTION
Problem: The core rename UX scenario accepted degraded null output for a simple same-file subroutine rename.
Fix: Require scenario 23 to return same-file edits for the declaration and call sites, and update the fixture matrix receipt.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_23_rename_workflow --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_23_rename_workflow --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes.