### PR TITLE
test(ux): lock first-file hover contents (#9719)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -35,7 +35,7 @@
       ],
       "expected_outcomes": [
         "server starts cleanly",
-        "hover returns useful structure or empty without crashing",
+        "hover returns non-empty contents for a lexical variable",
         "completion request succeeds"
       ],
       "confidence_signals": [

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_01_simple_file.rs
@@ -9,13 +9,30 @@
 //! Acceptance criteria:
 //! - Server starts without crashing.
 //! - `textDocument/didOpen` is accepted (no error).
-//! - `textDocument/hover` on a variable returns something, or null in degraded mode.
+//! - `textDocument/hover` on a variable returns non-empty contents.
 //! - No crash signatures in the event log.
 //! - Completion request does not crash.
 
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::missing_binary_skip;
 use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
+use serde_json::Value;
+
+fn hover_contents_text(contents: &Value) -> String {
+    if let Some(value) = contents.get("value").and_then(Value::as_str) {
+        return value.to_string();
+    }
+
+    if let Some(text) = contents.as_str() {
+        return text.to_string();
+    }
+
+    if let Some(items) = contents.as_array() {
+        return items.iter().map(hover_contents_text).collect::<Vec<_>>().join("\n");
+    }
+
+    String::new()
+}
 
 #[test]
 fn scenario_01_server_starts_and_accepts_open() {
@@ -72,16 +89,19 @@ fn scenario_01_hover_on_simple_variable() {
             match hover_result {
                 Ok(Some(result)) => {
                     recorder.mark_first_useful_result("hover");
+                    let Some(contents) = result.get("contents") else {
+                        recorder.check("hover result exposes contents", false)?;
+                        anyhow::bail!("Hover returned no contents field: {result:?}");
+                    };
+                    let contents_text = hover_contents_text(contents);
                     recorder.check(
-                        "hover result is an object or string",
-                        result.is_object() || result.is_string(),
+                        "hover result exposes non-empty contents",
+                        !contents_text.trim().is_empty(),
                     )?;
                 }
                 Ok(None) => {
-                    // Degraded mode — hover returned null. Still a useful
-                    // (expected-clean) result for timing purposes.
-                    recorder.mark_first_useful_result("hover");
-                    recorder.check("hover returned null (degraded mode acceptable)", true)?;
+                    recorder.check("hover returned a useful non-null result", false)?;
+                    anyhow::bail!("Hover returned null for first-file lexical variable");
                 }
                 Err(e) => {
                     let _ = recorder.check("hover should not return a JSON-RPC error", false);


### PR DESCRIPTION
Problem: The simple first-file UX smoke accepted null hover output for a lexical variable.
Fix: Require scenario 01 to return a non-null hover result with non-empty contents and update the fixture matrix receipt.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_01_simple_file --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_01_simple_file --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes.