### PR TITLE
test(ux): lock real-workspace module completion (#9725)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -1461,6 +1461,7 @@
       ],
       "expected_outcomes": [
         "completion, goto-definition, hover, and diagnostics all respond without crash",
+        "module-prefix completion surfaces RealBaseline::App",
         "cross-file definition requests resolve or return clean empty results",
         "real-workspace fixture exercises provider parity across module boundaries"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_20_real_workspace_providers.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_20_real_workspace_providers.rs
@@ -1,5 +1,5 @@
-// Test infrastructure — allow test-friendly patterns used throughout this module.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+// Test infrastructure allows assertion panics and status stderr throughout this module.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, clippy::print_stderr)]
 
 //! Scenario 20 — Real-workspace provider expectations (completion / goto-definition /
 //! hover / diagnostics).
@@ -207,16 +207,11 @@ fn scenario_20_completion_module_prefix_surfaces_real_baseline_app() -> anyhow::
     // We ask for completion at col 17 which is after `use RealBaseline::`.
     let labels = harness.completion_labels("script/real-baseline.pl", 3, 17)?;
 
-    if labels.iter().any(|l| l.contains("RealBaseline") || l.contains("App")) {
-        eprintln!("status: completion/module-prefix: works — RealBaseline module label found");
-    } else {
-        eprintln!(
-            "status: completion/module-prefix: known gap — no RealBaseline label; \
-             got: {labels:?}"
-        );
-    }
+    assert!(
+        labels.iter().any(|label| label == "RealBaseline::App" || label.ends_with("::App")),
+        "module-prefix completion should surface RealBaseline::App; got labels: {labels:?}"
+    );
 
-    // works: the request itself must not produce a JSON-RPC error.
     harness.assert_no_crash();
     Ok(())
 }


### PR DESCRIPTION
Problem: The real-workspace provider receipt soft-passed when module-prefix completion failed to surface the workspace module label.
Fix: Require scenario 20 completion for `use RealBaseline::` to surface `RealBaseline::App`, and update the fixture matrix receipt.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_20_real_workspace_providers --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_20_real_workspace_providers --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes.