### PR TITLE
test(ux): lock core cross-file definition target (#9729)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -263,7 +263,8 @@
         "cross_file_definition_success_rate"
       ],
       "expected_outcomes": [
-        "definition request returns a location or clean empty result",
+        "same-file and cross-file definition requests resolve to source locations",
+        "definition entries use valid LSP location shapes",
         "request does not error"
       ],
       "confidence_signals": [

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_10_goto_definition.rs
@@ -1,3 +1,6 @@
+// Test infrastructure emits skip status to stderr when the local LSP binary is absent.
+#![allow(clippy::print_stderr)]
+
 //! Scenario 10 — Go-to-definition UX workflow coverage.
 //!
 //! Focus area: `textDocument/definition` behavior for first-editing-session UX.
@@ -144,9 +147,14 @@ fn scenario_10_definition_cross_file_module_symbol_points_to_module() -> Result<
     // When go-to-definition is requested on `increment` in `Counter->increment`.
     let definitions = scenario.when_requesting_definition_with_retry("main.pl", 5, 23)?;
 
-    // Then results are shape-valid. Cross-file module resolution may degrade
-    // if `use lib` handling is incomplete; keep the empty path tolerated but
-    // log it so we notice when it happens in CI.
+    // Then the cross-file definition must resolve. `Counter.pm` is opened in
+    // the same workspace and imported via `use lib`, so an empty result would
+    // be a regression in the editor navigation path.
+    assert!(
+        !definitions.is_empty(),
+        "expected cross-file definition for `Counter->increment` to resolve to Counter.pm, \
+         got empty list after retries"
+    );
     for entry in &definitions {
         assert!(
             is_lsp_location_shape(entry),
@@ -154,32 +162,24 @@ fn scenario_10_definition_cross_file_module_symbol_points_to_module() -> Result<
         );
     }
 
-    if definitions.is_empty() {
-        eprintln!(
-            "INFO scenario_10: cross-file definition returned empty — tolerated \
-             degraded path (cross-file indexing may not have settled)"
-        );
-    } else {
-        let points_to_module = definitions
-            .iter()
-            .any(|entry| entry_uri(entry).map(|uri| uri.ends_with("Counter.pm")).unwrap_or(false));
-        assert!(
-            points_to_module,
-            "non-empty cross-file definition results must include Counter.pm but did not: \
-             {definitions:?}"
-        );
-        // And they must never resolve to an unrelated file (e.g. leaking the
-        // call-site file as the definition would be a real regression).
-        let resolves_outside_workspace = definitions.iter().any(|entry| {
-            entry_uri(entry)
-                .map(|uri| !uri.ends_with("Counter.pm") && !uri.ends_with("main.pl"))
-                .unwrap_or(false)
-        });
-        assert!(
-            !resolves_outside_workspace,
-            "cross-file definition resolved to an unrelated file: {definitions:?}"
-        );
-    }
+    let points_to_module = definitions
+        .iter()
+        .any(|entry| entry_uri(entry).map(|uri| uri.ends_with("Counter.pm")).unwrap_or(false));
+    assert!(
+        points_to_module,
+        "cross-file definition results must include Counter.pm but did not: {definitions:?}"
+    );
+    // And they must never resolve to an unrelated file (e.g. leaking the
+    // call-site file as the definition would be a real regression).
+    let resolves_outside_workspace = definitions.iter().any(|entry| {
+        entry_uri(entry)
+            .map(|uri| !uri.ends_with("Counter.pm") && !uri.ends_with("main.pl"))
+            .unwrap_or(false)
+    });
+    assert!(
+        !resolves_outside_workspace,
+        "cross-file definition resolved to an unrelated file: {definitions:?}"
+    );
 
     scenario.then_no_crash_signals_exist();
     Ok(())


### PR DESCRIPTION
Problem: Scenario 10 still treated an empty cross-file definition result as acceptable for `Counter->increment`.
Fix: Require the request to return a valid definition result that includes `Counter.pm`, and update the UX fixture matrix wording.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_10_goto_definition --profile agent --locked -- --test-threads=1` passes with `PERL_LSP_BIN`; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_10_goto_definition --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G.