### PR TITLE
test(ux): lock Mojolicious navigation probes non-empty (#9731)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -745,6 +745,7 @@
       ],
       "expected_outcomes": [
         "definition and references probes return without JSON-RPC errors",
+        "all navigation probes return at least one result",
         "non-empty navigation results use valid LSP Location or LocationLink shapes",
         "receipt records exact, imported, module-resolution, dynamic-shaped, and declaration-including fallback surfaces"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_30_mojolicious_navigation_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_30_mojolicious_navigation_quality.rs
@@ -1,3 +1,6 @@
+// Test receipt emits per-probe status and JSON evidence to stderr for auditability.
+#![allow(clippy::print_stderr)]
+
 //! Scenario 30 - Mojolicious navigation quality receipt.
 //!
 //! This receipt exercises the committed Mojolicious skeleton workspace and
@@ -354,6 +357,10 @@ fn scenario_30_mojolicious_navigation_quality_receipt() {
             recorder.check(
                 "all non-empty navigation results used valid LSP shapes",
                 invalid_shape_total == 0,
+            )?;
+            recorder.check(
+                "all navigation probes returned at least one result",
+                fallback_or_empty_count == 0,
             )?;
             recorder.check(
                 "navigation receipt recorded at least one expected workspace target",


### PR DESCRIPTION
Problem: Scenario 30 recorded empty/fallback navigation probes but only required one expected target overall.
Fix: Require every Mojolicious definition/references probe to return at least one result and update the UX fixture matrix.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_30_mojolicious_navigation_quality --profile agent --locked -- --test-threads=1` passes with `PERL_LSP_BIN`; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_30_mojolicious_navigation_quality --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G.