### PR TITLE
test(ux): lock Mojolicious hover probes content (#9733)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -716,6 +716,7 @@
       ],
       "expected_outcomes": [
         "hover probes return without JSON-RPC errors",
+        "all hover probes return content",
         "receipt records exact, imported, generated, dynamic-shaped, and fallback/module-resolution surfaces",
         "receipt records source, provenance, confidence, freshness, generated, dynamic, and fallback labels when exposed"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_29_mojolicious_hover_provenance.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_29_mojolicious_hover_provenance.rs
@@ -1,3 +1,6 @@
+// Test receipt emits per-probe status and JSON evidence to stderr for auditability.
+#![allow(clippy::print_stderr)]
+
 //! Scenario 29 - Mojolicious hover provenance receipt.
 //!
 //! This receipt exercises hover over the committed Mojolicious skeleton
@@ -352,7 +355,7 @@ fn scenario_29_mojolicious_hover_provenance_receipt() {
                         "module_resolution",
                     ]),
             )?;
-            recorder.check("at least one hover probe returned content", content_count > 0)?;
+            recorder.check("all hover probes returned content", content_count == probes.len())?;
             recorder.check(
                 "hover receipt recorded at least one expected text hit",
                 expected_hit_total > 0,


### PR DESCRIPTION
Problem: Scenario 29 only required one Mojolicious hover probe to return content.
Fix: Require all hover probes to return content and update the UX fixture matrix.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_29_mojolicious_hover_provenance --profile agent --locked -- --test-threads=1` passes with `PERL_LSP_BIN`; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_29_mojolicious_hover_provenance --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G.