### PR TITLE
test(ux): lock Mojolicious semantic-token probes non-empty (#9735)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -858,6 +858,7 @@
       ],
       "expected_outcomes": [
         "semantic-token requests return valid 5-tuple data without JSON-RPC errors",
+        "all semantic-token probes return live tokens",
         "decoded token spans do not overlap and map back to source text",
         "receipt records expected source-backed tokens, dynamic-boundary-shaped strings, and edit freshness"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_34_mojolicious_semantic_tokens_quality.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_34_mojolicious_semantic_tokens_quality.rs
@@ -1,3 +1,6 @@
+// Test receipt emits per-probe status and JSON evidence to stderr for auditability.
+#![allow(clippy::print_stderr)]
+
 //! Scenario 34 - Mojolicious semantic-token quality receipt.
 //!
 //! This receipt exercises `textDocument/semanticTokens/full` over the committed
@@ -606,6 +609,10 @@ fn scenario_34_mojolicious_semantic_tokens_quality_receipt() {
                     ]),
             )?;
             recorder.check("semantic-token probes returned live tokens", token_total > 0)?;
+            recorder.check(
+                "all semantic-token probes returned live tokens",
+                fallback_or_empty_count == 0,
+            )?;
             recorder.check(
                 "semantic-token data used valid 5-tuple encoding",
                 invalid_tuple_total == 0,


### PR DESCRIPTION
Problem: Scenario 34 only required Mojolicious semantic-token probes to return live tokens in aggregate.
Fix: Require every semantic-token probe to return live token data and update the UX fixture matrix.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_34_mojolicious_semantic_tokens_quality --profile agent --locked -- --test-threads=1` passes with `PERL_LSP_BIN`; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_34_mojolicious_semantic_tokens_quality --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G.