### PR TITLE
test(ux): lock Mojolicious workspace-symbol probes non-empty (#9739)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -830,6 +830,7 @@
       ],
       "expected_outcomes": [
         "workspace-symbol probes return without JSON-RPC errors",
+        "all workspace-symbol probes return live symbols",
         "returned symbols use valid LSP WorkspaceSymbol shapes",
         "receipt records useful hits, unrelated/noisy hits, generated candidate gating, dynamic-boundary-shaped names, and edit freshness"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_33_mojolicious_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_33_mojolicious_workspace_symbol_noise.rs
@@ -1,3 +1,6 @@
+// Test receipt emits per-probe status and JSON evidence to stderr for auditability.
+#![allow(clippy::print_stderr)]
+
 //! Scenario 33 - Mojolicious workspace-symbol noise receipt.
 //!
 //! This receipt exercises `workspace/symbol` over the committed Mojolicious
@@ -475,6 +478,10 @@ fn scenario_33_mojolicious_workspace_symbol_noise_receipt() {
             )?;
             recorder
                 .check("workspace-symbol probes returned live symbols", live_symbol_total > 0)?;
+            recorder.check(
+                "all workspace-symbol probes returned live symbols",
+                reports.iter().all(|report| report.first_count > 0),
+            )?;
             recorder.check(
                 "workspace-symbol probes returned useful project hits",
                 useful_hit_total > 0,


### PR DESCRIPTION
Problem: Scenario 33 only required Mojolicious workspace-symbol probes to return live symbols in aggregate.
Fix: Require every workspace-symbol probe to return live symbols and update the UX fixture matrix.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_33_mojolicious_workspace_symbol_noise --profile agent --locked -- --test-threads=1` passes with `PERL_LSP_BIN`; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_33_mojolicious_workspace_symbol_noise --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G.