### PR TITLE
test(ux): lock Dancer2 workspace-symbol probes non-empty (#9741)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -998,6 +998,7 @@
       ],
       "expected_outcomes": [
         "workspace-symbol requests return valid LSP shapes without JSON-RPC errors",
+        "all workspace-symbol probes return live symbols",
         "receipt records useful project hits, noisy hit counts, generated/dynamic candidate boundaries, and edit freshness",
         "compiler-backed workspace-symbol candidates remain shadowed without provider behavior promotion"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_39_dancer2_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_39_dancer2_workspace_symbol_noise.rs
@@ -1,3 +1,6 @@
+// Test receipt emits per-probe status and JSON evidence to stderr for auditability.
+#![allow(clippy::print_stderr)]
+
 //! Scenario 39 - Dancer2 workspace-symbol noise receipt.
 //!
 //! This receipt exercises `workspace/symbol` over the committed Dancer2
@@ -472,6 +475,10 @@ fn scenario_39_dancer2_workspace_symbol_noise_receipt() {
             recorder.check(
                 "workspace-symbol probes returned useful project hits",
                 useful_hit_total > 0,
+            )?;
+            recorder.check(
+                "all workspace-symbol probes returned live symbols",
+                reports.iter().all(|report| report.first_count > 0),
             )?;
             recorder.check(
                 "workspace-symbol entries used valid LSP shapes",


### PR DESCRIPTION
Problem: Scenario 39 checked useful workspace-symbol hits in aggregate but did not require every probe to return live symbols.
Fix: Require every Dancer2 workspace-symbol probe to return live symbols and update the UX fixture matrix.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_39_dancer2_workspace_symbol_noise --profile agent --locked -- --test-threads=1` passes with `PERL_LSP_BIN`; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_39_dancer2_workspace_symbol_noise --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check -p perl-lsp-ux-tests --all-targets --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G.