### PR TITLE
test(ux): lock Catalyst workspace-symbol probes non-empty (#9743)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -998,6 +998,7 @@
       ],
       "expected_outcomes": [
         "workspace-symbol requests return valid LSP shapes without JSON-RPC errors",
+        "all workspace-symbol probes return live symbols",
         "receipt records useful project hits, noisy hit counts, generated/dynamic candidate boundaries, and edit freshness",
         "compiler-backed workspace-symbol candidates remain shadowed without provider behavior promotion"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_41_catalyst_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_41_catalyst_workspace_symbol_noise.rs
@@ -11,6 +11,9 @@
 //! - dynamic-boundary-shaped names observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
+// Test receipt emits per-probe status and JSON evidence to stderr for auditability.
+#![allow(clippy::print_stderr)]
+
 use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::missing_binary_skip;
@@ -569,6 +572,10 @@ fn scenario_41_catalyst_workspace_symbol_noise_receipt() {
             recorder.check(
                 "all workspace-symbol probes produced reports",
                 reports.len() == probes.len(),
+            )?;
+            recorder.check(
+                "all workspace-symbol probes returned live symbols",
+                reports.iter().all(|report| report.first_count > 0),
             )?;
             recorder.check(
                 "workspace-symbol probes covered intended receipt categories",


### PR DESCRIPTION
Problem: The Catalyst workspace-symbol receipt could pass on aggregate results while one configured probe returned no symbols.
Fix: Require every Catalyst workspace-symbol probe to return live symbols and mirror that expectation in the UX fixture matrix.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_41_catalyst_workspace_symbol_noise --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_41_catalyst_workspace_symbol_noise --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs 0.0G.