### PR TITLE
test(ux): lock Modern OO workspace-symbol probes non-empty (#9745)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -1054,6 +1054,7 @@
       ],
       "expected_outcomes": [
         "workspace-symbol requests return valid LSP shapes without JSON-RPC errors",
+        "all workspace-symbol probes return live symbols",
         "receipt records useful Modern OO hits, labeled generated symbols, generated exact-name gating, and edit freshness",
         "broader generated/dynamic workspace-symbol candidates remain bounded without provider behavior promotion"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_43_modern_oo_workspace_symbol_noise.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_43_modern_oo_workspace_symbol_noise.rs
@@ -13,6 +13,9 @@
 //! - role/delegation/modifier boundary shapes observed separately from exact symbols
 //! - stale/fresh query behavior after editing an open document
 
+// Test receipt emits per-probe status and JSON evidence to stderr for auditability.
+#![allow(clippy::print_stderr)]
+
 use anyhow::{Context, Result};
 use perl_lsp_ux_tests::binary_available;
 use perl_lsp_ux_tests::missing_binary_skip;
@@ -661,6 +664,10 @@ fn scenario_43_modern_oo_workspace_symbol_noise_receipt() {
             recorder.check(
                 "all workspace-symbol probes produced reports",
                 reports.len() == probes.len(),
+            )?;
+            recorder.check(
+                "all workspace-symbol probes returned live symbols",
+                reports.iter().all(|report| report.first_count > 0),
             )?;
             recorder.check(
                 "workspace-symbol probes covered intended Modern OO receipt categories",


### PR DESCRIPTION
Problem: The Modern OO workspace-symbol receipt could pass on aggregate results while one configured probe returned no symbols.
Fix: Require every Modern OO workspace-symbol probe to return live symbols and mirror that expectation in the UX fixture matrix.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_43_modern_oo_workspace_symbol_noise --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_43_modern_oo_workspace_symbol_noise --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs 0.0G.