### PR TITLE
test(ux): record deleted file churn receipt (#9749)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -438,17 +438,19 @@
       "ci_tier": "pr",
       "component": "workspace_symbols",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "delete a module file after indexing and verify stale symbol and definition results are evicted",
       "measures": [
         "workflow_pass_rate",
         "workflow_stability_rate",
-        "cross_file_definition_success_rate"
+        "cross_file_definition_success_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records workspace-symbol and definition timing around file deletion",
         "deleted symbols disappear from workspace/symbol",
         "definition no longer resolves to deleted targets"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_17_deleted_file_churn.rs
@@ -1,16 +1,16 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
 //! Scenario 17 — deleting a watched file evicts stale symbols and definition targets.
 //!
 //! Verifies that a real `workspace/didChangeWatchedFiles` Deleted event removes
 //! stale search results and cross-file definitions from the UX surface.
 
+use anyhow::Context;
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
 use serde_json::Value;
-use serde_json::json;
 use std::time::{Duration, Instant};
+
+const SCENARIO_FILE: &str = "ux_scenario_17_deleted_file_churn.rs";
 
 const MODULE_SOURCE: &str = "\
 package ModuleGone;\n\
@@ -32,93 +32,114 @@ my $value = ModuleGone::gone_value_4068();\n\
 print \"$value\\n\";\n\
 ";
 
-fn symbol_names(symbols: &[Value]) -> Vec<&str> {
-    symbols.iter().filter_map(|symbol| symbol["name"].as_str()).collect()
-}
-
 #[test]
 fn scenario_17_deleted_module_evicted_from_symbols_and_definition() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_17: perl-lsp binary not found");
-        return;
-    }
+    run_ux_scenario(
+        "deleted_file_churn_freshness",
+        SCENARIO_FILE,
+        "scenario_17_deleted_module_evicted_from_symbols_and_definition",
+        UxCiTier::Pr,
+        Some(UxComponent::WorkspaceSymbols),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-            .env("PERL_LSP_WORKSPACE", "1")
-            .with_file("main.pl", SCRIPT_SOURCE)
-            .with_file("lib/ModuleGone.pm", MODULE_SOURCE),
-    )
-    .expect("Failed to create UX harness");
+            let harness = UxHarness::new(
+                ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+                    .env("PERL_LSP_WORKSPACE", "1")
+                    .with_file("main.pl", SCRIPT_SOURCE)
+                    .with_file("lib/ModuleGone.pm", MODULE_SOURCE),
+            )?;
 
-    harness.open_file("main.pl", SCRIPT_SOURCE).expect("didOpen should succeed");
+            harness.open_file("main.pl", SCRIPT_SOURCE)?;
 
-    let cursor = harness.position_cursor("main.pl", 5, 25);
-    let before_deadline = Instant::now() + Duration::from_secs(10);
-    let mut symbols_before = Vec::new();
-    let mut defs_before = Vec::new();
-    while Instant::now() < before_deadline {
-        symbols_before = harness
-            .workspace_symbols("gone_value_4068")
-            .expect("workspace/symbol must not error before delete");
-        defs_before =
-            harness.definition_at(&cursor).expect("definition must not error before delete");
+            let cursor = harness.position_cursor("main.pl", 5, 25);
+            let before_deadline = Instant::now() + Duration::from_secs(10);
+            let mut symbols_before = Vec::new();
+            let mut defs_before = Vec::new();
+            let mut symbols_before_ready = false;
+            let mut definition_before_ready = false;
 
-        if !symbols_before.is_empty() && !defs_before.is_empty() {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(200));
-    }
+            recorder.mark_request_start("workspace_symbols_before_delete");
+            recorder.mark_request_start("definition_before_delete");
+            while Instant::now() < before_deadline {
+                symbols_before = harness.workspace_symbols("gone_value_4068")?;
+                if !symbols_before.is_empty() && !symbols_before_ready {
+                    recorder.mark_first_useful_result("workspace_symbols_before_delete");
+                    symbols_before_ready = true;
+                }
 
-    assert!(
-        !symbols_before.is_empty(),
-        "Expected gone_value_4068 to be searchable before delete, got names {:?}",
-        symbol_names(&symbols_before)
+                defs_before = harness.definition_at(&cursor)?;
+                if !defs_before.is_empty() && !definition_before_ready {
+                    recorder.mark_first_useful_result("definition_before_delete");
+                    definition_before_ready = true;
+                }
+
+                if symbols_before_ready && definition_before_ready {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+
+            recorder.check(
+                "deleted module symbol is searchable before delete",
+                !symbols_before.is_empty(),
+            )?;
+            recorder.check(
+                "deleted module definition resolves before delete",
+                !defs_before.is_empty(),
+            )?;
+            let first_def_before =
+                defs_before.first().context("definition result present before delete")?;
+            let normalized_def_before = harness.normalize_response(first_def_before);
+            recorder.check(
+                "definition target points at module before delete",
+                normalized_def_before.get("uri").and_then(Value::as_str)
+                    == Some("file://$WORKSPACE/lib/ModuleGone.pm"),
+            )?;
+
+            harness.workspace.delete("lib/ModuleGone.pm")?;
+            harness.notify_watched_files(&[("lib/ModuleGone.pm", 3)])?;
+
+            let after_deadline = Instant::now() + Duration::from_secs(10);
+            let mut symbols_after = Vec::new();
+            let mut defs_after = Vec::new();
+            let mut symbols_after_fresh = false;
+            let mut definition_after_fresh = false;
+
+            recorder.mark_request_start("workspace_symbols_after_delete");
+            recorder.mark_request_start("definition_after_delete");
+            while Instant::now() < after_deadline {
+                symbols_after = harness.workspace_symbols("gone_value_4068")?;
+                if symbols_after.is_empty() && !symbols_after_fresh {
+                    recorder.mark_first_useful_result("workspace_symbols_after_delete");
+                    symbols_after_fresh = true;
+                }
+
+                defs_after = harness.definition_at(&cursor)?;
+                if defs_after.is_empty() && !definition_after_fresh {
+                    recorder.mark_first_useful_result("definition_after_delete");
+                    definition_after_fresh = true;
+                }
+
+                if symbols_after_fresh && definition_after_fresh {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+
+            recorder.check(
+                "deleted symbol disappears from workspace/symbol",
+                symbols_after.is_empty(),
+            )?;
+            recorder.check(
+                "deleted module definition target disappears after delete",
+                defs_after.is_empty(),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-    assert!(
-        !defs_before.is_empty(),
-        "Expected definition to resolve before delete, got {:?}",
-        defs_before
-    );
-    harness.assert_normalized_eq(
-        &defs_before[0],
-        &json!({
-            "uri": "file://$WORKSPACE/lib/ModuleGone.pm",
-            "range": defs_before[0]["range"].clone(),
-        }),
-    );
-
-    harness.workspace.delete("lib/ModuleGone.pm").expect("module delete should succeed");
-    harness
-        .notify_watched_files(&[("lib/ModuleGone.pm", 3)])
-        .expect("didChangeWatchedFiles Deleted notification must not fail");
-
-    let after_deadline = Instant::now() + Duration::from_secs(10);
-    let mut symbols_after = Vec::new();
-    let mut defs_after = Vec::new();
-    while Instant::now() < after_deadline {
-        symbols_after = harness
-            .workspace_symbols("gone_value_4068")
-            .expect("workspace/symbol must not error after delete");
-        defs_after =
-            harness.definition_at(&cursor).expect("definition must not error after delete");
-
-        if symbols_after.is_empty() && defs_after.is_empty() {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(200));
-    }
-
-    assert!(
-        symbols_after.is_empty(),
-        "Expected deleted symbol gone_value_4068 to disappear from workspace/symbol, got names {:?}",
-        symbol_names(&symbols_after)
-    );
-    assert!(
-        defs_after.is_empty(),
-        "Expected deleted module definition target to disappear after delete, got {:?}",
-        defs_after
-    );
-
-    harness.assert_no_crash();
 }


### PR DESCRIPTION
Problem: The deleted-file churn UX scenario verified stale symbol and definition eviction but did not emit receipt or first-useful timing evidence.
Fix: Wrap Scenario 17 in the UX recorder, time symbol and definition probes before/after deletion, and update the fixture matrix instrumentation.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_17_deleted_file_churn --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_17_deleted_file_churn --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs 0.0G.