### PR TITLE
test(ux): record template language-mode receipt (#9753)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -491,17 +491,19 @@
       "ci_tier": "pr",
       "component": "goto_definition",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "open a template file in html mode and continue navigating in neighboring Perl files",
       "measures": [
         "workflow_pass_rate",
         "workflow_stability_rate",
-        "cross_file_definition_success_rate"
+        "cross_file_definition_success_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records template diagnostics and neighboring Perl navigation timing",
         "template-like html mode file does not emit Perl parse diagnostics",
         "goto-definition in adjacent Perl files remains functional"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_22_template_language_mode.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_22_template_language_mode.rs
@@ -11,9 +11,12 @@
 //! - Template diagnostics in this mode SHOULD stay empty (parse intentionally skipped).
 //! - Core navigation in normal Perl files in the same workspace MUST still work.
 
-use anyhow::Result;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::binary_available;
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
 use std::time::Duration;
+
+const SCENARIO_FILE: &str = "ux_scenario_22_template_language_mode.rs";
 
 const APP_SOURCE: &str = r#"use strict;
 use warnings;
@@ -37,32 +40,54 @@ const TEMPLATE_SOURCE: &str = r#"% my $user = shift;
 "#;
 
 #[test]
-fn scenario_22_template_in_html_mode_preserves_neighboring_perl_navigation() -> Result<()> {
-    let harness = UxHarness::new(
-        ScenarioConfig::default()
-            .with_file("app.pl", APP_SOURCE)
-            .with_file("templates/index.html.ep", TEMPLATE_SOURCE),
-    )?;
+fn scenario_22_template_in_html_mode_preserves_neighboring_perl_navigation() {
+    run_ux_scenario(
+        "template_language_mode_resilience",
+        SCENARIO_FILE,
+        "scenario_22_template_in_html_mode_preserves_neighboring_perl_navigation",
+        UxCiTier::Pr,
+        Some(UxComponent::GotoDefinition),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    harness.open_file_with_language_id("templates/index.html.ep", TEMPLATE_SOURCE, "html")?;
-    harness.open_file("app.pl", APP_SOURCE)?;
+            let harness = UxHarness::new(
+                ScenarioConfig::default()
+                    .with_file("app.pl", APP_SOURCE)
+                    .with_file("templates/index.html.ep", TEMPLATE_SOURCE),
+            )?;
 
-    std::thread::sleep(Duration::from_millis(500));
+            harness.open_file_with_language_id(
+                "templates/index.html.ep",
+                TEMPLATE_SOURCE,
+                "html",
+            )?;
+            harness.open_file("app.pl", APP_SOURCE)?;
 
-    let template_diags =
-        harness.wait_for_diagnostics("templates/index.html.ep", Duration::from_millis(1200));
-    assert!(
-        template_diags.is_empty(),
-        "template opened as html should skip Perl parse diagnostics, got: {template_diags:?}"
+            std::thread::sleep(Duration::from_millis(500));
+
+            recorder.mark_request_start("template_diagnostics");
+            let template_diags = harness
+                .wait_for_diagnostics("templates/index.html.ep", Duration::from_millis(1200));
+            recorder.mark_first_useful_result("template_diagnostics");
+            recorder.check(
+                "template opened as html skipped Perl parse diagnostics",
+                template_diags.is_empty(),
+            )?;
+
+            recorder.mark_request_start("neighboring_perl_definition");
+            let defs = harness.definition("app.pl", 4, 11)?;
+            if !defs.is_empty() {
+                recorder.mark_first_useful_result("neighboring_perl_definition");
+            }
+            recorder.check(
+                "goto-definition in neighboring Perl file stayed functional",
+                !defs.is_empty(),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    // `helper` call in `return helper();` (line 4, character 11).
-    let defs = harness.definition("app.pl", 4, 11)?;
-    assert!(
-        !defs.is_empty(),
-        "expected goto-definition in neighboring Perl file to keep working after template open"
-    );
-
-    harness.assert_no_crash();
-    Ok(())
 }


### PR DESCRIPTION
Problem: The template language-mode UX scenario verified diagnostics and neighboring navigation behavior but did not emit receipt or first-useful timing evidence.
Fix: Wrap Scenario 22 in the UX recorder, time template diagnostics and neighboring Perl goto-definition, and update the fixture matrix instrumentation.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_22_template_language_mode --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_22_template_language_mode --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs 0.0G.