### PR TITLE
test(ux): record goto-declaration receipt (#9755)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -465,16 +465,18 @@
       "ci_tier": "pr",
       "component": "goto_definition",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "run goto-declaration inside a representative file",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records declaration request timing and result shape checks",
         "declaration request returns a location or clean empty result",
         "request does not error"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_goto_declaration.rs
@@ -9,9 +9,12 @@
 //! - When non-empty, each result MUST include URI/range shape (`targetUri` +
 //!   `targetRange` for links, or `uri` + `range` for locations).
 
-use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
+use serde_json::Value;
+
+const SCENARIO_FILE: &str = "ux_scenario_18_goto_declaration.rs";
 
 const DECLARATION_FIXTURE: &str = r#"use strict;
 use warnings;
@@ -27,52 +30,76 @@ my $result = inc($value);
 print "$result\n";
 "#;
 
-#[test]
-fn scenario_18_declaration_request_does_not_error() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_18: perl-lsp binary not found");
-        return Ok(());
-    }
-
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
-
-    harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
-    let result = harness.declaration("declaration.pl", 9, 13);
-
-    assert!(
-        result.is_ok(),
-        "textDocument/declaration must not return a JSON-RPC error — feature grid regression: {:?}",
-        result
-    );
-
-    harness.assert_no_crash();
-    Ok(())
+fn is_declaration_location_shape(entry: &Value) -> bool {
+    let is_link = entry.get("targetUri").is_some() && entry.get("targetRange").is_some();
+    let is_location = entry.get("uri").is_some() && entry.get("range").is_some();
+    is_link || is_location
 }
 
 #[test]
-fn scenario_18_declaration_result_is_location_or_empty() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_18: perl-lsp binary not found");
-        return Ok(());
-    }
+fn scenario_18_declaration_request_does_not_error() {
+    run_ux_scenario(
+        "goto_declaration_core",
+        SCENARIO_FILE,
+        "scenario_18_declaration_request_does_not_error",
+        UxCiTier::Pr,
+        Some(UxComponent::GotoDefinition),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE))?;
+            let harness = UxHarness::new(
+                ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE),
+            )?;
 
-    harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
-    let declarations = harness.declaration("declaration.pl", 9, 13)?;
+            harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
+            recorder.mark_request_start("declaration_request");
+            let result = harness.declaration("declaration.pl", 9, 13);
+            if result.is_ok() {
+                recorder.mark_first_useful_result("declaration_request");
+            }
 
-    for entry in declarations {
-        let is_link = entry.get("targetUri").is_some() && entry.get("targetRange").is_some();
-        let is_location = entry.get("uri").is_some() && entry.get("range").is_some();
-        assert!(
-            is_link || is_location,
-            "declaration result must be LocationLink or Location, got: {:?}",
-            entry
-        );
-    }
+            recorder.check(
+                "textDocument/declaration does not return a JSON-RPC error",
+                result.is_ok(),
+            )?;
 
-    harness.assert_no_crash();
-    Ok(())
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn scenario_18_declaration_result_is_location_or_empty() {
+    run_ux_scenario(
+        "goto_declaration_core",
+        SCENARIO_FILE,
+        "scenario_18_declaration_result_is_location_or_empty",
+        UxCiTier::Pr,
+        Some(UxComponent::GotoDefinition),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = UxHarness::new(
+                ScenarioConfig::default().with_file("declaration.pl", DECLARATION_FIXTURE),
+            )?;
+
+            harness.open_file("declaration.pl", DECLARATION_FIXTURE)?;
+            recorder.mark_request_start("declaration_shape");
+            let declarations = harness.declaration("declaration.pl", 9, 13)?;
+            recorder.mark_first_useful_result("declaration_shape");
+
+            recorder.check(
+                "declaration result is clean empty or valid Location/LocationLink shape",
+                declarations.iter().all(is_declaration_location_shape),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
 }


### PR DESCRIPTION
Problem: The goto-declaration UX scenario verified request and result-shape behavior but did not emit receipt or first-useful timing evidence.
Fix: Wrap Scenario 18 in the UX recorder, time declaration requests, and update the fixture matrix instrumentation.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_18_goto_declaration --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_18_goto_declaration --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs 0.0G.