### PR TITLE
test(ux): record diagnostics after edit receipt (#9757)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -518,16 +518,18 @@
       "ci_tier": "pr",
       "component": "diagnostics",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "open a file, edit it, and verify diagnostics republish for the updated content",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records diagnostics timing before and after full-document edit",
         "didChange full-document edit succeeds",
         "publishDiagnostics republish occurs after edit",
         "updated diagnostic payload remains valid"

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_18_diagnostics_after_edit.rs
@@ -1,14 +1,16 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
 //! Scenario 18 — diagnostics refresh after textDocument/didChange.
 //!
 //! Verifies that the UX harness can drive a real edit cycle and observe
 //! follow-up `textDocument/publishDiagnostics` updates for the edited file.
 
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{
+    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario,
+};
 use std::time::{Duration, Instant};
+
+const SCENARIO_FILE: &str = "ux_scenario_18_diagnostics_after_edit.rs";
 
 // NOTE: BROKEN_SOURCE contains a genuine Perl syntax error — the incomplete
 // expression `(1 +` triggers a parse failure under `use strict`.  A missing
@@ -39,62 +41,75 @@ sub greet {\n\
 
 #[test]
 fn scenario_18_diagnostics_republish_after_full_document_edit() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_18: perl-lsp binary not found");
-        return;
-    }
+    run_ux_scenario(
+        "diagnostics_after_edit_refresh",
+        SCENARIO_FILE,
+        "scenario_18_diagnostics_republish_after_full_document_edit",
+        UxCiTier::Pr,
+        Some(UxComponent::Diagnostics),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("edit_diag.pl", BROKEN_SOURCE),
-    )
-    .expect("Failed to create UX harness");
+            let harness = UxHarness::new(
+                ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+                    .with_file("edit_diag.pl", BROKEN_SOURCE),
+            )?;
 
-    harness.open_file("edit_diag.pl", BROKEN_SOURCE).expect("didOpen should succeed");
+            harness.open_file("edit_diag.pl", BROKEN_SOURCE)?;
 
-    // Wait for and then drain the initial diagnostics so the post-edit wait
-    // sees only new events, not the pre-edit ones still in the peek queue.
-    let initial = harness.wait_for_diagnostics("edit_diag.pl", Duration::from_secs(5));
-    assert!(
-        !initial.is_empty(),
-        "Expected at least one diagnostic for BROKEN_SOURCE (unterminated expression); \
-         got none — check the fixture content"
+            recorder.mark_request_start("initial_diagnostics");
+            let initial = harness.wait_for_diagnostics("edit_diag.pl", Duration::from_secs(5));
+            if !initial.is_empty() {
+                recorder.mark_first_useful_result("initial_diagnostics");
+            }
+            recorder.check(
+                "broken source published at least one initial diagnostic",
+                !initial.is_empty(),
+            )?;
+            harness.collect_notifications();
+
+            recorder.mark_request_start("diagnostics_after_full_document_edit");
+            let updated = harness.apply_edit_and_collect_diagnostics(
+                "edit_diag.pl",
+                FIXED_SOURCE,
+                Duration::from_secs(5),
+            )?;
+            recorder.mark_first_useful_result("diagnostics_after_full_document_edit");
+            recorder.check(
+                "updated diagnostics payload entries include range and message",
+                updated
+                    .iter()
+                    .all(|diag| diag.get("range").is_some() && diag.get("message").is_some()),
+            )?;
+
+            recorder.mark_request_start("publish_diagnostics_after_edit");
+            let uri = harness.workspace.uri("edit_diag.pl");
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut diagnostics_event_count = 0_usize;
+            while Instant::now() < deadline {
+                diagnostics_event_count = harness
+                    .peek_notifications()
+                    .iter()
+                    .filter(|event| {
+                        matches!(event, LspEvent::Diagnostics { uri: event_uri, .. } if event_uri == &uri)
+                    })
+                    .count();
+                if diagnostics_event_count >= 1 {
+                    recorder.mark_first_useful_result("publish_diagnostics_after_edit");
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+
+            recorder.check(
+                "publishDiagnostics republished after didChange edit",
+                diagnostics_event_count >= 1,
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-    // Drain so the next wait_for_diagnostics sees only the post-edit notification.
-    harness.collect_notifications();
-
-    let updated = harness
-        .apply_edit_and_collect_diagnostics("edit_diag.pl", FIXED_SOURCE, Duration::from_secs(5))
-        .expect("didChange full document should succeed");
-    for diag in &updated {
-        assert!(
-            diag.get("range").is_some() && diag.get("message").is_some(),
-            "Updated diagnostics payload must include range/message, got: {:?}",
-            diag
-        );
-    }
-
-    // After draining the open-event and sending didChange, wait for the server
-    // to republish diagnostics.  We expect at least 1 new diagnostics event.
-    let uri = harness.workspace.uri("edit_diag.pl");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let mut diagnostics_event_count = 0_usize;
-    while Instant::now() < deadline {
-        diagnostics_event_count = harness
-            .peek_notifications()
-            .iter()
-            .filter(|event| matches!(event, LspEvent::Diagnostics { uri: event_uri, .. } if event_uri == &uri))
-            .count();
-        if diagnostics_event_count >= 1 {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-
-    assert!(
-        diagnostics_event_count >= 1,
-        "Expected diagnostics to republish after didChange edit; observed {} post-edit events",
-        diagnostics_event_count
-    );
-    harness.assert_no_crash();
 }


### PR DESCRIPTION
Problem: The diagnostics-after-edit UX scenario verified edit-triggered diagnostic refresh but did not emit receipt or first-useful timing evidence.
Fix: Wrap Scenario 18 diagnostics refresh in the UX recorder, time initial diagnostics, edit-triggered diagnostics, and post-edit publishDiagnostics, and update the fixture matrix instrumentation.
Verification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_18_diagnostics_after_edit --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_18_diagnostics_after_edit --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs 0.0G.