### PR TITLE
test(ux): record hover core receipt (#9759)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -286,9 +286,11 @@
       "user_journey": "run hover over names and variables in a representative file",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records hover timing and shape checks",
         "hover request returns useful structure or clean empty result",
         "request does not error"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_11_hover.rs
@@ -1,6 +1,3 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
 //! Scenario 11 — Hover feature grid coverage.
 //!
 //! Verifies that `textDocument/hover` is wired up end-to-end for the LSP
@@ -13,9 +10,14 @@
 //! - A null/empty result is acceptable (degraded mode).
 //! - No crash signatures after the request.
 
+use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
+use serde_json::Value;
 use std::time::Duration;
+
+const SCENARIO_FILE: &str = "ux_scenario_11_hover.rs";
 
 /// Perl source with a clearly-named sub and variable for hover targets.
 const HOVER_SOURCE: &str = "\
@@ -31,182 +33,171 @@ my $result = calculate_sum(3, 7);\n\
 print $result;\n\
 ";
 
-#[test]
-fn scenario_11_hover_on_variable_does_not_error() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_11: perl-lsp binary not found");
-        return;
-    }
-
+fn create_hover_harness() -> Result<UxHarness> {
     let harness = UxHarness::new(
         ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
             .with_file("calc.pl", HOVER_SOURCE),
-    )
-    .expect("Failed to create UX harness");
-
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
-
+    )?;
+    harness.open_file("calc.pl", HOVER_SOURCE)?;
     std::thread::sleep(Duration::from_millis(300));
+    Ok(harness)
+}
 
-    // Hover on `$result` — line 8, char 3 (inside `$result`).
-    let hover_result = harness.hover("calc.pl", 8, 3);
-    assert!(
-        hover_result.is_ok(),
-        "textDocument/hover must not return a JSON-RPC error — feature grid regression: {:?}",
-        hover_result
+fn hover_contents_has_valid_shape(result: &Value) -> bool {
+    let Some(contents) = result.get("contents") else {
+        return false;
+    };
+    contents.get("value").is_some()
+        || contents.get("kind").is_some()
+        || contents.is_string()
+        || contents.is_array()
+}
+
+fn numeric_range(range: &Value) -> Option<(u64, u64, u64, u64)> {
+    Some((
+        range.pointer("/start/line")?.as_u64()?,
+        range.pointer("/start/character")?.as_u64()?,
+        range.pointer("/end/line")?.as_u64()?,
+        range.pointer("/end/character")?.as_u64()?,
+    ))
+}
+
+fn hover_range_contains_cursor_when_present(
+    result: &Value,
+    cursor_line: u64,
+    cursor_char: u64,
+) -> bool {
+    let Some(range) = result.get("range") else {
+        return true;
+    };
+    let Some((start_line, start_char, end_line, end_char)) = numeric_range(range) else {
+        return false;
+    };
+    if start_line > end_line || (start_line == end_line && start_char > end_char) {
+        return false;
+    }
+
+    let starts_before_cursor =
+        start_line < cursor_line || (start_line == cursor_line && start_char <= cursor_char);
+    let ends_after_cursor =
+        end_line > cursor_line || (end_line == cursor_line && end_char >= cursor_char);
+    starts_before_cursor && ends_after_cursor
+}
+
+#[test]
+fn scenario_11_hover_on_variable_does_not_error() {
+    run_ux_scenario(
+        "hover_core",
+        SCENARIO_FILE,
+        "scenario_11_hover_on_variable_does_not_error",
+        UxCiTier::Pr,
+        Some(UxComponent::Hover),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = create_hover_harness()?;
+            recorder.mark_request_start("hover_variable");
+            let hover_result = harness.hover("calc.pl", 8, 3);
+            if hover_result.is_ok() {
+                recorder.mark_first_useful_result("hover_variable");
+            }
+            recorder.check(
+                "textDocument/hover on variable does not return a JSON-RPC error",
+                hover_result.is_ok(),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    harness.assert_no_crash();
 }
 
 #[test]
 fn scenario_11_hover_result_has_valid_shape_when_non_null() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_11: perl-lsp binary not found");
-        return;
-    }
+    run_ux_scenario(
+        "hover_core",
+        SCENARIO_FILE,
+        "scenario_11_hover_result_has_valid_shape_when_non_null",
+        UxCiTier::Pr,
+        Some(UxComponent::Hover),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("calc.pl", HOVER_SOURCE),
-    )
-    .expect("Failed to create UX harness");
+            let harness = create_hover_harness()?;
+            recorder.mark_request_start("hover_variable_shape");
+            let hover_result = harness.hover("calc.pl", 8, 3)?;
+            recorder.mark_first_useful_result("hover_variable_shape");
+            recorder.check(
+                "hover result is clean empty or has valid contents shape",
+                hover_result.as_ref().is_none_or(hover_contents_has_valid_shape),
+            )?;
 
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
-
-    std::thread::sleep(Duration::from_millis(300));
-
-    match harness.hover("calc.pl", 8, 3) {
-        Ok(Some(result)) => {
-            // Must contain `contents` field.
-            assert!(
-                result.get("contents").is_some(),
-                "Hover result must have 'contents' field, got: {:?}",
-                result
-            );
-            let contents = &result["contents"];
-            // contents can be MarkupContent {kind, value}, MarkedString, or array.
-            let is_valid = contents.get("value").is_some()
-                || contents.get("kind").is_some()
-                || contents.is_string()
-                || contents.is_array();
-            assert!(
-                is_valid,
-                "Hover 'contents' must be MarkupContent, MarkedString, or array; got: {:?}",
-                contents
-            );
-        }
-        Ok(None) => {
-            eprintln!("INFO scenario_11: hover returned null (degraded mode acceptable)");
-        }
-        Err(e) => {
-            panic!("Hover returned a JSON-RPC error — feature grid regression: {}", e);
-        }
-    }
-
-    harness.assert_no_crash();
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
 }
 
 #[test]
 fn scenario_11_hover_on_sub_name_does_not_crash() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_11: perl-lsp binary not found");
-        return;
-    }
+    run_ux_scenario(
+        "hover_core",
+        SCENARIO_FILE,
+        "scenario_11_hover_on_sub_name_does_not_crash",
+        UxCiTier::Pr,
+        Some(UxComponent::Hover),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("calc.pl", HOVER_SOURCE),
-    )
-    .expect("Failed to create UX harness");
+            let harness = create_hover_harness()?;
+            recorder.mark_request_start("hover_sub_declaration");
+            let hover_result = harness.hover("calc.pl", 3, 4);
+            if hover_result.is_ok() {
+                recorder.mark_first_useful_result("hover_sub_declaration");
+            }
+            recorder.check(
+                "hover on sub declaration does not return a JSON-RPC error",
+                hover_result.is_ok(),
+            )?;
 
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
-
-    std::thread::sleep(Duration::from_millis(300));
-
-    // Hover on `calculate_sum` sub declaration — line 3, char 4.
-    let hover_result = harness.hover("calc.pl", 3, 4);
-    assert!(hover_result.is_ok(), "Hover on sub declaration must not error: {:?}", hover_result);
-
-    harness.assert_no_crash();
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
 }
 
 #[test]
 fn scenario_11_hover_range_contains_cursor_when_present() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_11: perl-lsp binary not found");
-        return;
-    }
-
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("calc.pl", HOVER_SOURCE),
-    )
-    .expect("Failed to create UX harness");
-
-    harness.open_file("calc.pl", HOVER_SOURCE).expect("didOpen should succeed");
-
-    std::thread::sleep(Duration::from_millis(300));
-
-    // Hover on function call site `calculate_sum` — line 8, char 14.
-    match harness.hover("calc.pl", 8, 14) {
-        Ok(Some(result)) => {
-            if let Some(range) = result.get("range") {
-                let start_line = range["start"]["line"].as_u64();
-                let start_char = range["start"]["character"].as_u64();
-                let end_line = range["end"]["line"].as_u64();
-                let end_char = range["end"]["character"].as_u64();
-
-                assert!(start_line.is_some(), "Hover range.start.line must be numeric");
-                assert!(start_char.is_some(), "Hover range.start.character must be numeric");
-                assert!(end_line.is_some(), "Hover range.end.line must be numeric");
-                assert!(end_char.is_some(), "Hover range.end.character must be numeric");
-
-                let (start_line, start_char, end_line, end_char) = (
-                    start_line.unwrap_or_default(),
-                    start_char.unwrap_or_default(),
-                    end_line.unwrap_or_default(),
-                    end_char.unwrap_or_default(),
-                );
-
-                assert!(
-                    start_line <= end_line,
-                    "Hover range start line must be <= end line: {:?}",
-                    range
-                );
-                if start_line == end_line {
-                    assert!(
-                        start_char <= end_char,
-                        "Hover range start char must be <= end char on same line: {:?}",
-                        range
-                    );
-                }
-
-                let cursor_line: u64 = 8;
-                let cursor_char: u64 = 14;
-                let starts_before_cursor = start_line < cursor_line
-                    || (start_line == cursor_line && start_char <= cursor_char);
-                let ends_after_cursor =
-                    end_line > cursor_line || (end_line == cursor_line && end_char >= cursor_char);
-                assert!(
-                    starts_before_cursor && ends_after_cursor,
-                    "Hover range should contain the cursor when provided: range={:?}, cursor=({}, {})",
-                    range,
-                    cursor_line,
-                    cursor_char
-                );
+    run_ux_scenario(
+        "hover_core",
+        SCENARIO_FILE,
+        "scenario_11_hover_range_contains_cursor_when_present",
+        UxCiTier::Pr,
+        Some(UxComponent::Hover),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
             }
-        }
-        Ok(None) => {
-            eprintln!("INFO scenario_11: hover returned null (degraded mode acceptable)");
-        }
-        Err(e) => {
-            panic!(
-                "Hover returned a JSON-RPC error at function call site — feature grid regression: {}",
-                e
-            );
-        }
-    }
 
-    harness.assert_no_crash();
+            let harness = create_hover_harness()?;
+            recorder.mark_request_start("hover_call_site_range");
+            let hover_result = harness.hover("calc.pl", 8, 14)?;
+            recorder.mark_first_useful_result("hover_call_site_range");
+            recorder.check(
+                "hover range contains cursor when present",
+                hover_result
+                    .as_ref()
+                    .is_none_or(|result| hover_range_contains_cursor_when_present(result, 8, 14)),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
 }


### PR DESCRIPTION
Problem: The hover core UX scenario advertised receipt-backed coverage but still used direct assertions without recorder timing.\nFix: Convert the hover tests to recorder-backed checks and add the first-useful-result timing metric to the matrix row.\nVerification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_11_hover --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_11_hover --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes.