### PR TITLE
test(ux): record completion core receipt (#9761)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -656,9 +656,11 @@
       "user_journey": "request completion for builtins and in-file symbols in a representative editor session",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records completion request timing and shape checks",
         "completion request returns without JSON-RPC errors",
         "completion items include user-visible labels",
         "builtin completion includes print for pri prefix"

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_core.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_completion_core.rs
@@ -11,7 +11,11 @@
 
 use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
+use serde_json::Value;
+
+const SCENARIO_FILE: &str = "ux_scenario_19_completion_core.rs";
 
 const COMPLETION_FIXTURE: &str = r#"use strict;
 use warnings;
@@ -26,99 +30,128 @@ fn create_harness() -> Result<UxHarness> {
     UxHarness::new(ScenarioConfig::default().with_file("completion.pl", COMPLETION_FIXTURE))
 }
 
-#[test]
-fn scenario_19_completion_request_does_not_error() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_19: perl-lsp binary not found");
-        return Ok(());
-    }
+fn completion_item_has_display_shape(item: &Value) -> bool {
+    item.get("label").and_then(Value::as_str).is_some()
+        || item.get("insertText").and_then(Value::as_str).is_some()
+        || item.get("filterText").and_then(Value::as_str).is_some()
+}
 
-    // Given a file opened in the editor.
-    let harness = create_harness()?;
-    harness.open_file("completion.pl", COMPLETION_FIXTURE)?;
-
-    // When requesting completion for an in-progress builtin (`pri`).
-    let items = harness
-        .completion("completion.pl", 3, 3)
-        .map_err(|e| anyhow::anyhow!("textDocument/completion returned JSON-RPC error: {e}"))?;
-
-    // Then the request succeeds and returns a non-empty payload — `pri` is a
-    // prefix of the `print`/`printf` builtins so at least one completion item
-    // must be surfaced. An empty list here is a real regression, not a
-    // degraded-mode pass.
-    assert!(
-        !items.is_empty(),
-        "expected at least one completion item for `pri` prefix, got empty list"
-    );
-    harness.assert_no_crash();
-    Ok(())
+fn completion_items_include_label(items: &[Value], needle: &str) -> bool {
+    items
+        .iter()
+        .filter_map(|item| item.get("label").and_then(Value::as_str))
+        .any(|label| label.contains(needle))
 }
 
 #[test]
-fn scenario_19_completion_items_have_label_or_insert_text_shape() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_19: perl-lsp binary not found");
-        return Ok(());
-    }
+fn scenario_19_completion_request_does_not_error() {
+    run_ux_scenario(
+        "completion_core",
+        SCENARIO_FILE,
+        "scenario_19_completion_request_does_not_error",
+        UxCiTier::Pr,
+        Some(UxComponent::Completion),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    // Given a file opened in the editor.
-    let harness = create_harness()?;
-    harness.open_file("completion.pl", COMPLETION_FIXTURE)?;
+            let harness = create_harness()?;
+            harness.open_file("completion.pl", COMPLETION_FIXTURE)?;
 
-    // When requesting completion near a scalar variable prefix (`$val`).
-    let items = harness.completion("completion.pl", 6, 18)?;
+            recorder.mark_request_start("completion_builtin_prefix");
+            let completion_result = harness.completion("completion.pl", 3, 3);
+            recorder.check(
+                "textDocument/completion for `pri` does not return a JSON-RPC error",
+                completion_result.is_ok(),
+            )?;
+            let items = completion_result?;
+            if !items.is_empty() {
+                recorder.mark_first_useful_result("completion_builtin_prefix");
+            }
+            recorder.check(
+                "completion returns at least one item for `pri` prefix",
+                !items.is_empty(),
+            )?;
 
-    // Then the server returns at least one item — `$value` was declared on the
-    // previous line so a completion-driven editor must surface something.
-    // (Vacuously passing on an empty list defeats the purpose of the test.)
-    assert!(
-        !items.is_empty(),
-        "expected at least one completion item for `$val` prefix with `$value` in scope"
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    // And every returned item has a user-visible completion field.
-    for item in &items {
-        let has_label = item.get("label").and_then(serde_json::Value::as_str).is_some();
-        let has_insert_text = item.get("insertText").and_then(serde_json::Value::as_str).is_some();
-        let has_filter_text = item.get("filterText").and_then(serde_json::Value::as_str).is_some();
-        assert!(
-            has_label || has_insert_text || has_filter_text,
-            "completion item must include a string label, insertText, or filterText: {item:?}"
-        );
-    }
-
-    // And at least one item surfaces the `$value` identifier the user started
-    // typing — this is the behaviour the UX depends on.
-    let labels = harness.completion_labels("completion.pl", 6, 18)?;
-    assert!(
-        labels.iter().any(|label| label.contains("value")),
-        "expected completion label containing `value` for `$val` prefix, got: {labels:?}"
-    );
-
-    harness.assert_no_crash();
-    Ok(())
 }
 
 #[test]
-fn scenario_19_completion_builtin_workflow_surfaces_print() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_19: perl-lsp binary not found");
-        return Ok(());
-    }
+fn scenario_19_completion_items_have_label_or_insert_text_shape() {
+    run_ux_scenario(
+        "completion_core",
+        SCENARIO_FILE,
+        "scenario_19_completion_items_have_label_or_insert_text_shape",
+        UxCiTier::Pr,
+        Some(UxComponent::Completion),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    // Given a file opened in the editor.
-    let harness = create_harness()?;
-    harness.open_file("completion.pl", COMPLETION_FIXTURE)?;
+            let harness = create_harness()?;
+            harness.open_file("completion.pl", COMPLETION_FIXTURE)?;
 
-    // When requesting completion after typing `pri`.
-    let labels = harness.completion_labels("completion.pl", 3, 3)?;
+            recorder.mark_request_start("completion_scalar_prefix");
+            let completion_result = harness.completion("completion.pl", 6, 18);
+            recorder.check(
+                "textDocument/completion for `$val` does not return a JSON-RPC error",
+                completion_result.is_ok(),
+            )?;
+            let items = completion_result?;
+            if !items.is_empty() {
+                recorder.mark_first_useful_result("completion_scalar_prefix");
+            }
+            recorder.check(
+                "completion returns at least one item for `$val` prefix with `$value` in scope",
+                !items.is_empty(),
+            )?;
+            recorder.check(
+                "every completion item includes a user-visible string field",
+                items.iter().all(completion_item_has_display_shape),
+            )?;
+            recorder.check(
+                "completion labels include `value` for `$val` prefix",
+                completion_items_include_label(&items, "value"),
+            )?;
 
-    // Then `print` appears in suggestions, proving a practical UX path.
-    assert!(
-        labels.iter().any(|label| label == "print"),
-        "expected builtin `print` in completion suggestions, got labels: {labels:?}"
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
+}
 
-    harness.assert_no_crash();
-    Ok(())
+#[test]
+fn scenario_19_completion_builtin_workflow_surfaces_print() {
+    run_ux_scenario(
+        "completion_core",
+        SCENARIO_FILE,
+        "scenario_19_completion_builtin_workflow_surfaces_print",
+        UxCiTier::Pr,
+        Some(UxComponent::Completion),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = create_harness()?;
+            harness.open_file("completion.pl", COMPLETION_FIXTURE)?;
+
+            recorder.mark_request_start("completion_print_builtin");
+            let labels = harness.completion_labels("completion.pl", 3, 3)?;
+            let includes_print = labels.iter().any(|label| label == "print");
+            if includes_print {
+                recorder.mark_first_useful_result("completion_print_builtin");
+            }
+            recorder
+                .check("builtin completion includes `print` for `pri` prefix", includes_print)?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
 }


### PR DESCRIPTION
Problem: The completion core UX scenario advertised receipt-backed coverage but still used direct assertions without recorder timing.\nFix: Convert completion core tests to recorder-backed checks and add the first-useful-result timing metric to the matrix row.\nVerification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_19_completion_core --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_19_completion_core --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes.