### PR TITLE
test(ux): record document symbols receipt (#9763)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -331,16 +331,18 @@
       "ci_tier": "pr",
       "component": "workspace_symbols",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "request document symbols for parsable and empty files",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records document-symbol timing and structure checks",
         "document symbols return valid structure",
         "rich files surface known sub names"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_13_document_symbols.rs
@@ -1,6 +1,3 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
 //! Scenario 13 — Document symbols feature grid coverage.
 //!
 //! Verifies that `textDocument/documentSymbol` is wired up end-to-end for the
@@ -13,9 +10,14 @@
 //! - An empty result is acceptable for degraded-mode servers.
 //! - No crash signatures after the request.
 
+use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
+use serde_json::Value;
 use std::time::Duration;
+
+const SCENARIO_FILE: &str = "ux_scenario_13_document_symbols.rs";
 
 /// Source with two named subs and a package declaration — rich symbol table.
 const SYMBOLS_SOURCE: &str = "\
@@ -41,136 +43,155 @@ sub farewell {\n\
 1;\n\
 ";
 
-#[test]
-fn scenario_13_document_symbol_does_not_error() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_13: perl-lsp binary not found");
-        return;
-    }
-
+fn create_symbols_harness() -> Result<UxHarness> {
     let harness = UxHarness::new(
         ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
             .with_file("Greeter.pm", SYMBOLS_SOURCE),
-    )
-    .expect("Failed to create UX harness");
-
-    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
-
+    )?;
+    harness.open_file("Greeter.pm", SYMBOLS_SOURCE)?;
     std::thread::sleep(Duration::from_millis(300));
+    Ok(harness)
+}
 
-    let result = harness.document_symbols("Greeter.pm");
-    assert!(
-        result.is_ok(),
-        "textDocument/documentSymbol must not return a JSON-RPC error \
-         — feature grid regression: {:?}",
-        result
+fn create_empty_harness() -> Result<UxHarness> {
+    let source = "# empty file\n";
+    let harness = UxHarness::new(ScenarioConfig::default().with_file("empty.pl", source))?;
+    harness.open_file("empty.pl", source)?;
+    Ok(harness)
+}
+
+fn symbol_has_valid_shape(symbol: &Value) -> bool {
+    let has_name = symbol.get("name").and_then(Value::as_str).is_some();
+    let has_valid_kind =
+        symbol.get("kind").is_none_or(|kind| kind.as_u64().is_some_and(|k| (1..=26).contains(&k)));
+    let has_range_or_location = symbol.get("range").is_some() || symbol.get("location").is_some();
+    has_name && has_valid_kind && has_range_or_location
+}
+
+fn symbols_include_known_sub_name(symbols: &[Value]) -> bool {
+    symbols
+        .iter()
+        .filter_map(|symbol| symbol.get("name").and_then(Value::as_str))
+        .any(|name| ["new", "greet", "farewell"].contains(&name))
+}
+
+#[test]
+fn scenario_13_document_symbol_does_not_error() {
+    run_ux_scenario(
+        "document_symbols_core",
+        SCENARIO_FILE,
+        "scenario_13_document_symbol_does_not_error",
+        UxCiTier::Pr,
+        Some(UxComponent::WorkspaceSymbols),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = create_symbols_harness()?;
+            recorder.mark_request_start("document_symbols_rich_file");
+            let result = harness.document_symbols("Greeter.pm");
+            if result.is_ok() {
+                recorder.mark_first_useful_result("document_symbols_rich_file");
+            }
+            recorder.check(
+                "textDocument/documentSymbol does not return a JSON-RPC error",
+                result.is_ok(),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    harness.assert_no_crash();
 }
 
 #[test]
 fn scenario_13_returned_symbols_have_valid_shape() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_13: perl-lsp binary not found");
-        return;
-    }
+    run_ux_scenario(
+        "document_symbols_core",
+        SCENARIO_FILE,
+        "scenario_13_returned_symbols_have_valid_shape",
+        UxCiTier::Pr,
+        Some(UxComponent::WorkspaceSymbols),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("Greeter.pm", SYMBOLS_SOURCE),
-    )
-    .expect("Failed to create UX harness");
+            let harness = create_symbols_harness()?;
+            recorder.mark_request_start("document_symbols_shape");
+            let symbols = harness.document_symbols("Greeter.pm")?;
+            if !symbols.is_empty() {
+                recorder.mark_first_useful_result("document_symbols_shape");
+            }
+            recorder.check(
+                "returned document symbols have valid shape when present",
+                symbols.iter().all(symbol_has_valid_shape),
+            )?;
 
-    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
-
-    std::thread::sleep(Duration::from_millis(300));
-
-    let symbols = harness.document_symbols("Greeter.pm").expect("documentSymbol must not error");
-
-    for sym in &symbols {
-        assert!(sym.get("name").is_some(), "Each symbol must have a 'name' field, got: {:?}", sym);
-        // kind is required by the LSP spec (1-26 SymbolKind enum).
-        if let Some(kind) = sym.get("kind") {
-            let k = kind.as_u64().unwrap_or(0);
-            assert!((1..=26).contains(&k), "Symbol 'kind' must be 1-26, got: {}", k);
-        }
-        // DocumentSymbol has 'range'; SymbolInformation has 'location'.
-        // Either is acceptable.
-        let has_range = sym.get("range").is_some();
-        let has_location = sym.get("location").is_some();
-        assert!(
-            has_range || has_location,
-            "Symbol must have either 'range' (DocumentSymbol) or 'location' \
-             (SymbolInformation), got: {:?}",
-            sym
-        );
-    }
-
-    harness.assert_no_crash();
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
 }
 
 #[test]
 fn scenario_13_rich_file_returns_known_sub_names() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_13: perl-lsp binary not found");
-        return;
-    }
+    run_ux_scenario(
+        "document_symbols_core",
+        SCENARIO_FILE,
+        "scenario_13_rich_file_returns_known_sub_names",
+        UxCiTier::Pr,
+        Some(UxComponent::WorkspaceSymbols),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("Greeter.pm", SYMBOLS_SOURCE),
-    )
-    .expect("Failed to create UX harness");
+            let harness = create_symbols_harness()?;
+            recorder.mark_request_start("document_symbols_known_subs");
+            let symbols = harness.document_symbols("Greeter.pm")?;
+            let found_known_name = symbols_include_known_sub_name(&symbols);
+            if found_known_name {
+                recorder.mark_first_useful_result("document_symbols_known_subs");
+            }
+            recorder.check(
+                "rich file returns empty degraded result or at least one known sub name",
+                symbols.is_empty() || found_known_name,
+            )?;
 
-    harness.open_file("Greeter.pm", SYMBOLS_SOURCE).expect("didOpen should succeed");
-
-    std::thread::sleep(Duration::from_millis(300));
-
-    let symbols = harness.document_symbols("Greeter.pm").expect("documentSymbol must not error");
-
-    if symbols.is_empty() {
-        eprintln!(
-            "INFO scenario_13: documentSymbol returned empty list \
-             (degraded mode acceptable — sub-symbol extraction may not be implemented yet)"
-        );
-        harness.assert_no_crash();
-        return;
-    }
-
-    let names: Vec<&str> = symbols.iter().filter_map(|s| s["name"].as_str()).collect();
-
-    // At least one of our three subs should appear.
-    let found_any = names.iter().any(|n| ["new", "greet", "farewell"].contains(n));
-    assert!(
-        found_any,
-        "Expected at least one of [new, greet, farewell] in document symbols, \
-         got: {:?}",
-        names
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    harness.assert_no_crash();
 }
 
 #[test]
 fn scenario_13_empty_file_returns_empty_or_null() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_13: perl-lsp binary not found");
-        return;
-    }
+    run_ux_scenario(
+        "document_symbols_core",
+        SCENARIO_FILE,
+        "scenario_13_empty_file_returns_empty_or_null",
+        UxCiTier::Pr,
+        Some(UxComponent::WorkspaceSymbols),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let source = "# empty file\n";
-    let harness = UxHarness::new(ScenarioConfig::default().with_file("empty.pl", source))
-        .expect("Failed to create UX harness");
+            let harness = create_empty_harness()?;
+            recorder.mark_request_start("document_symbols_empty_file");
+            let result = harness.document_symbols("empty.pl");
+            if result.is_ok() {
+                recorder.mark_first_useful_result("document_symbols_empty_file");
+            }
+            recorder.check(
+                "documentSymbol on empty file does not return a JSON-RPC error",
+                result.is_ok(),
+            )?;
 
-    harness.open_file("empty.pl", source).expect("didOpen should succeed");
-
-    let symbols =
-        harness.document_symbols("empty.pl").expect("documentSymbol on empty file must not error");
-
-    // Empty list is the correct response for a file with no symbols.
-    // We just verify no crash.
-    let _ = symbols;
-
-    harness.assert_no_crash();
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
 }


### PR DESCRIPTION
Problem: The document symbols core UX scenario was not receipt-enabled, so timing and structure checks were missing from the receipt stream.\nFix: Convert document-symbol tests to recorder-backed checks and enable first-useful-result receipt instrumentation in the matrix row.\nVerification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_13_document_symbols --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_13_document_symbols --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes.