### PR TITLE
test(ux): record code lens receipt (#9767)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -1205,16 +1205,18 @@
       "ci_tier": "pr",
       "component": "code_lens",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "request and resolve code lenses for Perl modules and test files",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records code-lens request and resolve timing",
         "codeLens requests return arrays or null without JSON-RPC errors",
         "returned lenses contain valid ranges",
         "codeLens resolve requests do not crash the server"

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_26_code_lens.rs
@@ -13,10 +13,12 @@
 
 use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
 use serde_json::{Value, json};
 use std::time::Duration;
 
+const SCENARIO_FILE: &str = "ux_scenario_26_code_lens.rs";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A realistic OO-style Perl module with package, several subs, and a call
@@ -69,201 +71,239 @@ test_subtraction();
 done_testing();
 "#;
 
-#[test]
-fn scenario_26_code_lens_does_not_error() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_26: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
-    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
-    let uri = harness.workspace.uri("mycalc.pl");
+fn open_fixture(file: &str, source: &str) -> Result<UxHarness> {
+    let harness = UxHarness::new(ScenarioConfig::default().with_file(file, source))?;
+    harness.open_file(file, source)?;
+    Ok(harness)
+}
 
-    let response = harness.client.request(
+fn request_code_lens(harness: &UxHarness, file: &str) -> Result<Value> {
+    let uri = harness.workspace.uri(file);
+    harness.client.request(
         "textDocument/codeLens",
         json!({ "textDocument": { "uri": uri } }),
         REQUEST_TIMEOUT,
-    )?;
+    )
+}
 
-    assert!(
-        response.get("error").is_none(),
-        "codeLens MUST NOT return a JSON-RPC error, got: {:?}",
-        response
-    );
+fn response_has_no_error(response: &Value) -> bool {
+    response.get("error").is_none()
+}
 
-    harness.assert_no_crash();
-    Ok(())
+fn code_lens_result_is_array_or_null(response: &Value) -> bool {
+    response.get("result").is_none_or(|result| result.is_array() || result.is_null())
+}
+
+fn lens_has_valid_range(lens: &Value) -> bool {
+    lens.get("range")
+        .is_some_and(|range| range.get("start").is_some() && range.get("end").is_some())
+}
+
+fn code_lens_ranges_are_valid(response: &Value) -> bool {
+    response.get("result").is_none_or(|result| {
+        result.is_null()
+            || result.as_array().is_some_and(|lenses| lenses.iter().all(lens_has_valid_range))
+    })
 }
 
 #[test]
-fn scenario_26_code_lens_result_is_array() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_26: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
-    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
-    let uri = harness.workspace.uri("mycalc.pl");
+fn scenario_26_code_lens_does_not_error() {
+    run_ux_scenario(
+        "code_lens_core",
+        SCENARIO_FILE,
+        "scenario_26_code_lens_does_not_error",
+        UxCiTier::Pr,
+        Some(UxComponent::CodeLens),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let response = harness.client.request(
-        "textDocument/codeLens",
-        json!({ "textDocument": { "uri": uri } }),
-        REQUEST_TIMEOUT,
-    )?;
+            let harness = open_fixture("mycalc.pl", CODELENS_FIXTURE)?;
+            recorder.mark_request_start("code_lens_module");
+            let response = request_code_lens(&harness, "mycalc.pl")?;
+            let no_error = response_has_no_error(&response);
+            if no_error {
+                recorder.mark_first_useful_result("code_lens_module");
+            }
+            recorder.check("codeLens does not return a JSON-RPC error", no_error)?;
 
-    assert!(response.get("error").is_none(), "codeLens returned error: {:?}", response);
-
-    let result = response.get("result").unwrap_or(&Value::Null);
-    assert!(
-        result.is_array() || result.is_null(),
-        "codeLens result MUST be an array (or null for no lenses), got: {result:?}"
-    );
-
-    harness.assert_no_crash();
-    Ok(())
-}
-
-#[test]
-fn scenario_26_code_lens_items_have_valid_ranges() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_26: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
-    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
-    let uri = harness.workspace.uri("mycalc.pl");
-
-    let response = harness.client.request(
-        "textDocument/codeLens",
-        json!({ "textDocument": { "uri": uri } }),
-        REQUEST_TIMEOUT,
-    )?;
-
-    assert!(response.get("error").is_none(), "codeLens returned error: {:?}", response);
-
-    let result = response.get("result").unwrap_or(&Value::Null);
-    if let Some(lenses) = result.as_array() {
-        for (i, lens) in lenses.iter().enumerate() {
-            assert!(
-                lens.get("range").is_some(),
-                "CodeLens[{i}] MUST have a 'range' field, got: {lens:?}"
-            );
-            let Some(range) = lens.get("range") else { continue };
-            assert!(
-                range.get("start").is_some(),
-                "CodeLens[{i}].range MUST have 'start', got: {range:?}"
-            );
-            assert!(
-                range.get("end").is_some(),
-                "CodeLens[{i}].range MUST have 'end', got: {range:?}"
-            );
-        }
-    }
-
-    harness.assert_no_crash();
-    Ok(())
-}
-
-#[test]
-fn scenario_26_code_lens_is_idempotent() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_26: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
-    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
-    let uri = harness.workspace.uri("mycalc.pl");
-
-    // Two identical requests in sequence must succeed without crash.
-    for round in 1u8..=2 {
-        let response = harness.client.request(
-            "textDocument/codeLens",
-            json!({ "textDocument": { "uri": uri } }),
-            REQUEST_TIMEOUT,
-        )?;
-        assert!(
-            response.get("error").is_none(),
-            "codeLens round {round} MUST NOT return error: {:?}",
-            response
-        );
-    }
-
-    harness.assert_no_crash();
-    Ok(())
-}
-
-#[test]
-fn scenario_26_code_lens_on_test_file_does_not_error() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_26: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness = UxHarness::new(ScenarioConfig::default().with_file("mytest.t", TEST_FIXTURE))?;
-    harness.open_file("mytest.t", TEST_FIXTURE)?;
-    let uri = harness.workspace.uri("mytest.t");
-
-    let response = harness.client.request(
-        "textDocument/codeLens",
-        json!({ "textDocument": { "uri": uri } }),
-        REQUEST_TIMEOUT,
-    )?;
-
-    assert!(
-        response.get("error").is_none(),
-        "codeLens on .t test file MUST NOT return JSON-RPC error: {:?}",
-        response
-    );
-
-    harness.assert_no_crash();
-    Ok(())
-}
-
-#[test]
-fn scenario_26_code_lens_resolve_does_not_error() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_26: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("mycalc.pl", CODELENS_FIXTURE))?;
-    harness.open_file("mycalc.pl", CODELENS_FIXTURE)?;
-    let uri = harness.workspace.uri("mycalc.pl");
-
-    // Fetch lenses first so we can resolve the first one (if any exist).
-    let lens_response = harness.client.request(
-        "textDocument/codeLens",
-        json!({ "textDocument": { "uri": uri } }),
-        REQUEST_TIMEOUT,
-    )?;
-    assert!(
-        lens_response.get("error").is_none(),
-        "codeLens initial fetch returned error: {:?}",
-        lens_response
-    );
-
-    let lenses = match lens_response.get("result").and_then(Value::as_array) {
-        Some(arr) if !arr.is_empty() => arr.clone(),
-        // No lenses returned; skip resolve check (not an error).
-        _ => {
             harness.assert_no_crash();
-            return Ok(());
-        }
-    };
-
-    let first_lens = &lenses[0];
-    let resolve_response =
-        harness.client.request("codeLens/resolve", first_lens.clone(), REQUEST_TIMEOUT)?;
-
-    assert!(
-        resolve_response.get("error").is_none(),
-        "codeLens/resolve MUST NOT return JSON-RPC error: {:?}",
-        resolve_response
+            Ok(())
+        },
     );
+}
 
-    harness.assert_no_crash();
-    Ok(())
+#[test]
+fn scenario_26_code_lens_result_is_array() {
+    run_ux_scenario(
+        "code_lens_core",
+        SCENARIO_FILE,
+        "scenario_26_code_lens_result_is_array",
+        UxCiTier::Pr,
+        Some(UxComponent::CodeLens),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = open_fixture("mycalc.pl", CODELENS_FIXTURE)?;
+            recorder.mark_request_start("code_lens_result_shape");
+            let response = request_code_lens(&harness, "mycalc.pl")?;
+            let no_error = response_has_no_error(&response);
+            if no_error && code_lens_result_is_array_or_null(&response) {
+                recorder.mark_first_useful_result("code_lens_result_shape");
+            }
+            recorder.check("codeLens does not return a JSON-RPC error", no_error)?;
+            recorder.check(
+                "codeLens result is an array or null",
+                code_lens_result_is_array_or_null(&response),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn scenario_26_code_lens_items_have_valid_ranges() {
+    run_ux_scenario(
+        "code_lens_core",
+        SCENARIO_FILE,
+        "scenario_26_code_lens_items_have_valid_ranges",
+        UxCiTier::Pr,
+        Some(UxComponent::CodeLens),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = open_fixture("mycalc.pl", CODELENS_FIXTURE)?;
+            recorder.mark_request_start("code_lens_ranges");
+            let response = request_code_lens(&harness, "mycalc.pl")?;
+            let no_error = response_has_no_error(&response);
+            if no_error && code_lens_ranges_are_valid(&response) {
+                recorder.mark_first_useful_result("code_lens_ranges");
+            }
+            recorder.check("codeLens does not return a JSON-RPC error", no_error)?;
+            recorder.check(
+                "returned codeLens items have range start and end when present",
+                code_lens_ranges_are_valid(&response),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn scenario_26_code_lens_is_idempotent() {
+    run_ux_scenario(
+        "code_lens_core",
+        SCENARIO_FILE,
+        "scenario_26_code_lens_is_idempotent",
+        UxCiTier::Pr,
+        Some(UxComponent::CodeLens),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = open_fixture("mycalc.pl", CODELENS_FIXTURE)?;
+            for round in 1u8..=2 {
+                let request_name = format!("code_lens_module_round_{round}");
+                recorder.mark_request_start(&request_name);
+                let response = request_code_lens(&harness, "mycalc.pl")?;
+                let no_error = response_has_no_error(&response);
+                if no_error {
+                    recorder.mark_first_useful_result(&request_name);
+                }
+                recorder.check(
+                    &format!("codeLens repeated request round {round} does not return an error"),
+                    no_error,
+                )?;
+            }
+
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn scenario_26_code_lens_on_test_file_does_not_error() {
+    run_ux_scenario(
+        "code_lens_core",
+        SCENARIO_FILE,
+        "scenario_26_code_lens_on_test_file_does_not_error",
+        UxCiTier::Pr,
+        Some(UxComponent::CodeLens),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = open_fixture("mytest.t", TEST_FIXTURE)?;
+            recorder.mark_request_start("code_lens_test_file");
+            let response = request_code_lens(&harness, "mytest.t")?;
+            let no_error = response_has_no_error(&response);
+            if no_error {
+                recorder.mark_first_useful_result("code_lens_test_file");
+            }
+            recorder
+                .check("codeLens on .t test file does not return a JSON-RPC error", no_error)?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
+}
+
+#[test]
+fn scenario_26_code_lens_resolve_does_not_error() {
+    run_ux_scenario(
+        "code_lens_core",
+        SCENARIO_FILE,
+        "scenario_26_code_lens_resolve_does_not_error",
+        UxCiTier::Pr,
+        Some(UxComponent::CodeLens),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
+
+            let harness = open_fixture("mycalc.pl", CODELENS_FIXTURE)?;
+            recorder.mark_request_start("code_lens_resolve_fetch");
+            let lens_response = request_code_lens(&harness, "mycalc.pl")?;
+            let fetch_no_error = response_has_no_error(&lens_response);
+            if fetch_no_error {
+                recorder.mark_first_useful_result("code_lens_resolve_fetch");
+            }
+            recorder.check("codeLens initial fetch does not return an error", fetch_no_error)?;
+
+            let Some(first_lens) = lens_response
+                .get("result")
+                .and_then(Value::as_array)
+                .and_then(|lenses| lenses.first())
+            else {
+                harness.assert_no_crash();
+                return Ok(());
+            };
+
+            recorder.mark_request_start("code_lens_resolve");
+            let resolve_response =
+                harness.client.request("codeLens/resolve", first_lens.clone(), REQUEST_TIMEOUT)?;
+            let resolve_no_error = response_has_no_error(&resolve_response);
+            if resolve_no_error {
+                recorder.mark_first_useful_result("code_lens_resolve");
+            }
+            recorder
+                .check("codeLens/resolve does not return a JSON-RPC error", resolve_no_error)?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
+    );
 }


### PR DESCRIPTION
Problem: The code lens core UX scenario was not receipt-enabled, so codeLens request, range, idempotency, and resolve timing were missing from the receipt stream.\nFix: Convert code-lens tests to recorder-backed checks and enable first-useful-result receipt instrumentation in the matrix row.\nVerification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_26_code_lens --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_26_code_lens --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes.