### PR TITLE
test(ux): record live edit feedback receipt (#9771)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -622,17 +622,19 @@
       "ci_tier": "pr",
       "component": "diagnostics",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "fix an undeclared variable during active editing and confirm diagnostics and navigation update",
       "measures": [
         "workflow_pass_rate",
         "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms",
         "cross_file_definition_success_rate"
       ],
       "expected_outcomes": [
+        "receipt records diagnostics refresh and navigation timing after edit",
         "undeclared variable diagnostic appears before edit",
         "go-to-definition remains responsive after didChange"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_24_live_edit_feedback.rs
@@ -9,8 +9,12 @@
 
 use anyhow::Result;
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
+use serde_json::Value;
 use std::time::Duration;
+
+const SCENARIO_FILE: &str = "ux_scenario_24_live_edit_feedback.rs";
 
 const UNDECLARED_SOURCE: &str = r#"use strict;
 use warnings;
@@ -25,66 +29,97 @@ my $name = 'world';
 print $name;
 "#;
 
-fn has_global_symbol_diagnostic(diags: &[serde_json::Value], symbol: &str) -> bool {
+fn create_live_edit_harness() -> Result<UxHarness> {
+    UxHarness::new(ScenarioConfig::default().with_file("live_edit.pl", UNDECLARED_SOURCE))
+}
+
+fn has_global_symbol_diagnostic(diags: &[Value], symbol: &str) -> bool {
     diags.iter().any(|diag| {
-        let message = diag.get("message").and_then(serde_json::Value::as_str).unwrap_or_default();
-        let code = diag.get("code").and_then(serde_json::Value::as_str).unwrap_or_default();
+        let message = diag.get("message").and_then(Value::as_str).unwrap_or_default();
+        let code = diag.get("code").and_then(Value::as_str).unwrap_or_default();
         message.contains(symbol) || (code.contains("Global symbol") && message.contains(symbol))
     })
 }
 
 #[test]
-fn given_undeclared_variable_when_opened_then_strict_diagnostic_is_published() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_24: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("live_edit.pl", UNDECLARED_SOURCE))?;
+fn given_undeclared_variable_when_opened_then_strict_diagnostic_is_published() {
+    run_ux_scenario(
+        "live_edit_feedback_loop",
+        SCENARIO_FILE,
+        "given_undeclared_variable_when_opened_then_strict_diagnostic_is_published",
+        UxCiTier::Pr,
+        Some(UxComponent::Diagnostics),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    harness.open_file("live_edit.pl", UNDECLARED_SOURCE)?;
+            let harness = create_live_edit_harness()?;
+            recorder.mark_request_start("initial_strict_diagnostics");
+            harness.open_file("live_edit.pl", UNDECLARED_SOURCE)?;
 
-    let diagnostics = harness.wait_for_diagnostics("live_edit.pl", Duration::from_secs(6));
-    assert!(
-        has_global_symbol_diagnostic(&diagnostics, "$name"),
-        "expected strict diagnostics for undeclared $name, got: {:?}",
-        diagnostics
+            let diagnostics = harness.wait_for_diagnostics("live_edit.pl", Duration::from_secs(6));
+            let has_diagnostic = has_global_symbol_diagnostic(&diagnostics, "$name");
+            if has_diagnostic {
+                recorder.mark_first_useful_result("initial_strict_diagnostics");
+            }
+            recorder
+                .check("strict diagnostics identify undeclared $name after open", has_diagnostic)?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    harness.assert_no_crash();
-    Ok(())
 }
 
 #[test]
-fn given_live_edit_when_variable_is_declared_then_navigation_remains_responsive() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_24: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("live_edit.pl", UNDECLARED_SOURCE))?;
+fn given_live_edit_when_variable_is_declared_then_navigation_remains_responsive() {
+    run_ux_scenario(
+        "live_edit_feedback_loop",
+        SCENARIO_FILE,
+        "given_live_edit_when_variable_is_declared_then_navigation_remains_responsive",
+        UxCiTier::Pr,
+        Some(UxComponent::Diagnostics),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    harness.open_file("live_edit.pl", UNDECLARED_SOURCE)?;
+            let harness = create_live_edit_harness()?;
+            recorder.mark_request_start("pre_edit_strict_diagnostics");
+            harness.open_file("live_edit.pl", UNDECLARED_SOURCE)?;
 
-    let before = harness.wait_for_diagnostics("live_edit.pl", Duration::from_secs(6));
-    assert!(
-        has_global_symbol_diagnostic(&before, "$name"),
-        "precondition failed: expected undeclared symbol diagnostic before edit, got: {:?}",
-        before
+            let before = harness.wait_for_diagnostics("live_edit.pl", Duration::from_secs(6));
+            let precondition_met = has_global_symbol_diagnostic(&before, "$name");
+            if precondition_met {
+                recorder.mark_first_useful_result("pre_edit_strict_diagnostics");
+            }
+            recorder
+                .check("pre-edit strict diagnostics identify undeclared $name", precondition_met)?;
+
+            harness.change_file_full("live_edit.pl", DECLARED_SOURCE)?;
+
+            recorder.mark_request_start("post_edit_diagnostics_refresh");
+            let post_edit_diagnostics =
+                harness.wait_for_latest_diagnostics("live_edit.pl", Duration::from_secs(6));
+            recorder.mark_first_useful_result("post_edit_diagnostics_refresh");
+            recorder.check(
+                "post-edit diagnostics refresh completes with a valid diagnostics payload",
+                post_edit_diagnostics.iter().all(|diag| diag.get("message").is_some()),
+            )?;
+
+            recorder.mark_request_start("post_edit_definition");
+            let definitions = harness.definition("live_edit.pl", 4, 7);
+            if definitions.is_ok() {
+                recorder.mark_first_useful_result("post_edit_definition");
+            }
+            recorder.check(
+                "go-to-definition remains responsive after didChange",
+                definitions.is_ok(),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    harness.change_file_full("live_edit.pl", DECLARED_SOURCE)?;
-
-    let _post_edit_diagnostics =
-        harness.wait_for_latest_diagnostics("live_edit.pl", Duration::from_secs(6));
-
-    let definitions = harness.definition("live_edit.pl", 4, 7);
-    assert!(
-        definitions.is_ok(),
-        "expected go-to-definition to stay responsive after didChange, got: {:?}",
-        definitions
-    );
-
-    harness.assert_no_crash();
-    Ok(())
 }


### PR DESCRIPTION
Problem: The live-edit feedback UX scenario was not receipt-enabled, so diagnostics refresh and post-edit navigation timing were missing from the receipt stream.\nFix: Convert live-edit feedback tests to recorder-backed checks and enable first-useful-result receipt instrumentation in the matrix row.\nVerification: `cargo test -p perl-lsp-ux-tests --test ux_scenario_24_live_edit_feedback --profile agent --locked -- --nocapture --test-threads=1` passes; `cargo test -p perl-lsp-ux-tests --test editor_ux_fixture_matrix --profile agent --locked` passes; `cargo xtask fmt --check --package perl-lsp-ux-tests` passes; `cargo clippy -p perl-lsp-ux-tests --test ux_scenario_24_live_edit_feedback --profile agent --locked -- -D warnings -A missing_docs` passes; `cargo check --all-targets -p perl-lsp-ux-tests --profile agent --locked` passes; `just agent-pr-fast` passes.