### PR TITLE
test(ux): record incremental text sync receipt (#9773)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -1126,16 +1126,18 @@
       "ci_tier": "pr",
       "component": "infra",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "fix a parse error via didChange full-text sync and verify diagnostics recover and hover remains responsive",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records didChange recovery, diagnostics, and hover timing",
         "broken content yields at least one diagnostic",
         "fixed content clears parse-like diagnostics after didChange",
         "hover does not JSON-RPC error after didChange recovery"

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_text_sync.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_incremental_text_sync.rs
@@ -5,10 +5,15 @@
 //! - When the user fixes the document and the editor emits didChange,
 //! - Then diagnostics should recover and the server should keep serving requests.
 
-use anyhow::{Context, Result, ensure};
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{
+    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario,
+};
+use serde_json::Value;
 use std::time::{Duration, Instant};
+
+const SCENARIO_FILE: &str = "ux_scenario_19_incremental_text_sync.rs";
 
 const BROKEN_SOURCE: &str = "\
 use strict;\n\
@@ -26,13 +31,12 @@ my $value = 42;\n\
 print $value;\n\
 ";
 
-fn has_parse_like_diagnostic(diagnostics: &[serde_json::Value]) -> bool {
+fn has_parse_like_diagnostic(diagnostics: &[Value]) -> bool {
     diagnostics.iter().any(|diag| {
         let message = diag
             .get("message")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("")
-            .to_ascii_lowercase();
+            .and_then(Value::as_str)
+            .map_or_else(String::new, str::to_ascii_lowercase);
         message.contains("syntax")
             || message.contains("parse")
             || message.contains("unexpected")
@@ -40,10 +44,7 @@ fn has_parse_like_diagnostic(diagnostics: &[serde_json::Value]) -> bool {
     })
 }
 
-fn wait_for_any_diagnostics_event(
-    harness: &UxHarness,
-    timeout: Duration,
-) -> Option<Vec<serde_json::Value>> {
+fn wait_for_any_diagnostics_event(harness: &UxHarness, timeout: Duration) -> Option<Vec<Value>> {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
         for event in harness.peek_notifications() {
@@ -57,80 +58,80 @@ fn wait_for_any_diagnostics_event(
 }
 
 #[test]
-fn scenario_19_didchange_recovers_after_parse_error_fix() -> Result<()> {
-    if !binary_available() {
-        tracing::info!("SKIP scenario_19: perl-lsp binary not found");
-        return Ok(());
-    }
+fn scenario_19_didchange_recovers_after_parse_error_fix() {
+    run_ux_scenario(
+        "incremental_text_sync_recovery",
+        SCENARIO_FILE,
+        "scenario_19_didchange_recovers_after_parse_error_fix",
+        UxCiTier::Pr,
+        Some(UxComponent::Infra),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("sync.pl", BROKEN_SOURCE),
-    )
-    .context("Failed to create UX harness")?;
+            let harness = UxHarness::new(
+                ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+                    .with_file("sync.pl", BROKEN_SOURCE),
+            )?;
 
-    // Given: user opens a file that initially has parse issues.
-    harness.open_file("sync.pl", BROKEN_SOURCE).context("didOpen should succeed")?;
-    let initial_diagnostics = harness.wait_for_diagnostics("sync.pl", Duration::from_secs(5));
+            recorder.mark_request_start("initial_parse_diagnostics");
+            harness.open_file("sync.pl", BROKEN_SOURCE)?;
+            let initial_diagnostics =
+                harness.wait_for_diagnostics("sync.pl", Duration::from_secs(5));
+            let has_initial_diagnostics = !initial_diagnostics.is_empty();
+            if has_initial_diagnostics {
+                recorder.mark_first_useful_result("initial_parse_diagnostics");
+            }
+            recorder.check(
+                "broken content yields at least one diagnostic before fix",
+                has_initial_diagnostics,
+            )?;
 
-    // The GIVEN clause is load-bearing: if the server never reports a
-    // parse-like problem for `my $value = ;` the rest of the test is
-    // meaningless (we cannot prove "recovery" without a prior broken state).
-    // We require at least one diagnostic; we keep the parse-keyword check as
-    // a soft preference so wording changes in the server don't break the test,
-    // but we refuse to silently continue when the server emitted nothing.
-    ensure!(
-        !initial_diagnostics.is_empty(),
-        "GIVEN preconditions failed: expected at least one diagnostic for \
-         `my $value = ;` before the fix, got empty. Recovery assertion would \
-         otherwise pass vacuously."
+            let _ = harness.collect_notifications();
+
+            harness.change_file_full("sync.pl", FIXED_SOURCE)?;
+
+            recorder.mark_request_start("post_change_diagnostics_recovery");
+            let post_change_diagnostics =
+                harness.wait_for_diagnostics("sync.pl", Duration::from_secs(5));
+            let parse_like_cleared = !has_parse_like_diagnostic(&post_change_diagnostics);
+            let diagnostics_changed = post_change_diagnostics != initial_diagnostics;
+            if parse_like_cleared && diagnostics_changed {
+                recorder.mark_first_useful_result("post_change_diagnostics_recovery");
+            }
+            recorder.check(
+                "fixed content clears parse-like diagnostics after didChange",
+                parse_like_cleared,
+            )?;
+            recorder.check(
+                "diagnostics after fix differ from the broken-content diagnostics",
+                diagnostics_changed,
+            )?;
+
+            recorder.mark_request_start("post_change_hover");
+            let hover_result = harness.hover("sync.pl", 4, 2);
+            if hover_result.is_ok() {
+                recorder.mark_first_useful_result("post_change_hover");
+            }
+            recorder.check(
+                "hover does not JSON-RPC error after didChange recovery",
+                hover_result.is_ok(),
+            )?;
+
+            recorder.mark_request_start("post_change_publish_diagnostics_event");
+            let diagnostics_event =
+                wait_for_any_diagnostics_event(&harness, Duration::from_secs(1));
+            if diagnostics_event.is_some() {
+                recorder.mark_first_useful_result("post_change_publish_diagnostics_event");
+            }
+            recorder.check(
+                "publishDiagnostics event is observed during didChange recovery",
+                diagnostics_event.is_some(),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    // Clear previously buffered notifications so post-change assertions inspect fresh server output.
-    let _ = harness.collect_notifications();
-
-    // When: user fixes the file and the editor sends didChange full-text sync.
-    harness.change_file_full("sync.pl", FIXED_SOURCE).context("didChange should succeed")?;
-
-    // Then: diagnostics should settle without parse-like errors and server remains responsive.
-    let post_change_diagnostics = harness.wait_for_diagnostics("sync.pl", Duration::from_secs(5));
-    ensure!(
-        !has_parse_like_diagnostic(&post_change_diagnostics),
-        "expected parse-like diagnostics to clear after fixing file; got: {:?}",
-        post_change_diagnostics
-    );
-    // And the diagnostic set must have strictly shrunk or changed — if we
-    // see an identical list we didn't actually recover from anything.
-    ensure!(
-        post_change_diagnostics != initial_diagnostics,
-        "diagnostics after fix are identical to before; didChange had no effect"
-    );
-
-    // Hover must not only avoid error but also be wired up (Err, or Ok(None)
-    // when the server cannot reach the symbol index, is an observable
-    // regression for first-session UX — let the test flag it).
-    let hover_result = harness.hover("sync.pl", 4, 2);
-    ensure!(
-        hover_result.is_ok(),
-        "hover should not JSON-RPC error after didChange recovery: {:?}",
-        hover_result
-    );
-    // Note: we accept Ok(None) with a log but still require the call itself
-    // to be well-formed. Downgrading to None-only would hide a real bug where
-    // hover stops returning anything at all after a didChange.
-    if let Ok(None) = hover_result {
-        tracing::info!(
-            "INFO scenario_19: hover returned null after didChange (degraded \
-             but not a protocol error)"
-        );
-    }
-
-    let diagnostics_event = wait_for_any_diagnostics_event(&harness, Duration::from_secs(1));
-    ensure!(
-        diagnostics_event.is_some(),
-        "expected at least one publishDiagnostics event during didChange recovery"
-    );
-
-    harness.assert_no_crash();
-    Ok(())
 }


### PR DESCRIPTION
Problem: Incremental text sync recovery lacked a receipt-backed UX scenario, so didChange recovery diagnostics and post-change responsiveness were not captured in the UX receipt stream.

Fix: Convert scenario 19 to recorder-backed checks and enable receipt/timing instrumentation for incremental_text_sync_recovery in the fixture matrix.

Verification: Focused UX test, fixture matrix test, fmt check, clippy, package check, storage-doctor, and `just agent-pr-fast` pass.