### PR TITLE
test(ux): record rename workflow receipt (#9775)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -570,16 +570,18 @@
       "ci_tier": "pr",
       "component": "rename",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "rename a symbol in a representative file and validate workspace edit output",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records prepareRename, rename, and workspace edit timing",
         "prepareRename and rename do not error",
         "rename returns clean null or valid workspace edit for the opened file"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_23_rename_workflow.rs
@@ -10,10 +10,12 @@
 
 use anyhow::{Context, Result};
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
 use serde_json::{Value, json};
 use std::time::Duration;
 
+const SCENARIO_FILE: &str = "ux_scenario_23_rename_workflow.rs";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 const RENAME_FIXTURE: &str = r#"use strict;
@@ -28,85 +30,122 @@ print greet();
 "#;
 
 #[test]
-fn scenario_23_prepare_rename_and_rename_do_not_error() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_23: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("rename_flow.pl", RENAME_FIXTURE))?;
-    harness.open_file("rename_flow.pl", RENAME_FIXTURE)?;
+fn scenario_23_prepare_rename_and_rename_do_not_error() {
+    run_ux_scenario(
+        "rename_workflow_core",
+        SCENARIO_FILE,
+        "scenario_23_prepare_rename_and_rename_do_not_error",
+        UxCiTier::Pr,
+        Some(UxComponent::Rename),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let uri = harness.workspace.uri("rename_flow.pl");
+            let harness = UxHarness::new(
+                ScenarioConfig::default().with_file("rename_flow.pl", RENAME_FIXTURE),
+            )?;
+            harness.open_file("rename_flow.pl", RENAME_FIXTURE)?;
 
-    let prepare = harness.client.request(
-        "textDocument/prepareRename",
-        json!({
-            "textDocument": { "uri": uri },
-            "position": { "line": 7, "character": 12 }
-        }),
-        REQUEST_TIMEOUT,
-    )?;
-    assert!(
-        prepare.get("error").is_none(),
-        "prepareRename must not return JSON-RPC error: {:?}",
-        prepare
+            let uri = harness.workspace.uri("rename_flow.pl");
+
+            recorder.mark_request_start("prepare_rename");
+            let prepare = harness.client.request(
+                "textDocument/prepareRename",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": 7, "character": 12 }
+                }),
+                REQUEST_TIMEOUT,
+            )?;
+            let prepare_clean = prepare.get("error").is_none();
+            if prepare_clean {
+                recorder.mark_first_useful_result("prepare_rename");
+            }
+            recorder.check("prepareRename does not return a JSON-RPC error", prepare_clean)?;
+
+            recorder.mark_request_start("rename");
+            let rename = harness.client.request(
+                "textDocument/rename",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": 7, "character": 12 },
+                    "newName": "welcome"
+                }),
+                REQUEST_TIMEOUT,
+            )?;
+            let rename_clean = rename.get("error").is_none();
+            if rename_clean {
+                recorder.mark_first_useful_result("rename");
+            }
+            recorder.check("rename does not return a JSON-RPC error", rename_clean)?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    let rename = harness.client.request(
-        "textDocument/rename",
-        json!({
-            "textDocument": { "uri": uri },
-            "position": { "line": 7, "character": 12 },
-            "newName": "welcome"
-        }),
-        REQUEST_TIMEOUT,
-    )?;
-    assert!(rename.get("error").is_none(), "rename must not return JSON-RPC error: {:?}", rename);
-
-    harness.assert_no_crash();
-    Ok(())
 }
 
 #[test]
-fn scenario_23_rename_workspace_edit_targets_file_and_multiple_occurrences() -> Result<()> {
-    if !binary_available() {
-        eprintln!("SKIP scenario_23: perl-lsp binary not found");
-        return Ok(());
-    }
-    let harness =
-        UxHarness::new(ScenarioConfig::default().with_file("rename_flow.pl", RENAME_FIXTURE))?;
-    harness.open_file("rename_flow.pl", RENAME_FIXTURE)?;
+fn scenario_23_rename_workspace_edit_targets_file_and_multiple_occurrences() {
+    run_ux_scenario(
+        "rename_workflow_core",
+        SCENARIO_FILE,
+        "scenario_23_rename_workspace_edit_targets_file_and_multiple_occurrences",
+        UxCiTier::Pr,
+        Some(UxComponent::Rename),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let uri = harness.workspace.uri("rename_flow.pl");
+            let harness = UxHarness::new(
+                ScenarioConfig::default().with_file("rename_flow.pl", RENAME_FIXTURE),
+            )?;
+            harness.open_file("rename_flow.pl", RENAME_FIXTURE)?;
 
-    let rename = harness.client.request(
-        "textDocument/rename",
-        json!({
-            "textDocument": { "uri": uri },
-            "position": { "line": 7, "character": 12 },
-            "newName": "welcome"
-        }),
-        REQUEST_TIMEOUT,
-    )?;
+            let uri = harness.workspace.uri("rename_flow.pl");
 
-    assert!(rename.get("error").is_none(), "rename returned JSON-RPC error: {:?}", rename);
+            recorder.mark_request_start("rename_workspace_edit");
+            let rename = harness.client.request(
+                "textDocument/rename",
+                json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": 7, "character": 12 },
+                    "newName": "welcome"
+                }),
+                REQUEST_TIMEOUT,
+            )?;
 
-    let Some(result) = rename.get("result") else {
-        return Ok(());
-    };
-    if result.is_null() {
-        return Ok(());
-    }
+            let rename_clean = rename.get("error").is_none();
+            let rename_has_result = rename.get("result").is_some();
+            if rename_clean && rename_has_result {
+                recorder.mark_first_useful_result("rename_workspace_edit");
+            }
+            recorder.check("rename returns no JSON-RPC error", rename_clean)?;
+            recorder
+                .check("rename returns a result field when it does not error", rename_has_result)?;
 
-    let edit_count = workspace_edit_count_for_uri(result, &uri)?;
-    assert!(
-        edit_count >= 2,
-        "rename should update at least declaration + one call-site when edits are returned; got {edit_count} edits"
+            let Some(result) = rename.get("result") else {
+                harness.assert_no_crash();
+                return Ok(());
+            };
+            if result.is_null() {
+                recorder.check("rename returned clean null in degraded mode", true)?;
+                harness.assert_no_crash();
+                return Ok(());
+            }
+
+            let edit_count = workspace_edit_count_for_uri(result, &uri)?;
+            recorder.check(
+                "rename workspace edit targets opened file with multiple occurrences",
+                edit_count >= 2,
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    harness.assert_no_crash();
-    Ok(())
 }
 
 fn workspace_edit_count_for_uri(workspace_edit: &Value, uri: &str) -> Result<usize> {


### PR DESCRIPTION
Problem: Core rename workflow UX coverage lacked receipt-backed timing for prepareRename, rename, and workspace edit behavior.

Fix: Convert scenario 23 to recorder-backed checks and enable receipt/timing instrumentation for rename_workflow_core in the fixture matrix.

Verification: Focused UX test, fixture matrix test, fmt check, clippy, package check, storage-doctor, and `just agent-pr-fast` pass.