### PR TITLE
test(ux): record diagnostics lifecycle receipt (#9777)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -1153,16 +1153,18 @@
       "ci_tier": "pr",
       "component": "diagnostics",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "introduce a syntax error then fix it and verify publishDiagnostics clears",
       "measures": [
         "workflow_pass_rate",
-        "workflow_stability_rate"
+        "workflow_stability_rate",
+        "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records initial diagnostics and post-fix clearing timing",
         "broken content yields diagnostics",
         "fixed content clears diagnostics for the same document"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_19_diagnostics_lifecycle.rs
@@ -1,6 +1,3 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
 //! Scenario 19 — diagnostics lifecycle during active editing.
 //!
 //! This scenario covers an editor-critical UX flow: a user introduces a parse
@@ -33,9 +30,13 @@
 //!                        fix arrived. Only then enter the clean-window check.
 
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{LspEvent, ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{
+    LspEvent, ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario,
+};
 use std::time::Duration;
 
+const SCENARIO_FILE: &str = "ux_scenario_19_diagnostics_lifecycle.rs";
 const BROKEN_SOURCE: &str = "use strict;\nuse warnings;\nmy $x = ;\n";
 const FIXED_SOURCE: &str = "use strict;\nuse warnings;\nmy $x = 1;\nprint $x;\n";
 const FIXED_VERSION: i64 = 2;
@@ -45,108 +46,113 @@ const FIXED_VERSION: i64 = 2;
 ///   2. Fixed content → diagnostics clear (either explicitly or by silence).
 #[test]
 fn scenario_19_diagnostics_clear_after_fix() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_19_diagnostics_clear_after_fix: perl-lsp binary not found");
-        return;
-    }
-
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
-            .with_file("live.pl", BROKEN_SOURCE),
-    )
-    .expect("Failed to create UX harness");
-
-    // Given: a workspace file opened with a syntax error.
-    harness.open_file("live.pl", BROKEN_SOURCE).expect("didOpen should succeed");
-
-    // When: diagnostics are first published for the broken content.
-    let diagnostics = harness.wait_for_diagnostics("live.pl", Duration::from_secs(5));
-    assert!(
-        !diagnostics.is_empty(),
-        "Expected diagnostics for broken source, but none were published."
-    );
-
-    // Phase 1 drain (pre-fix): remove events that have already arrived and any
-    // that arrive during a brief settle window. This covers the common case where
-    // the initial broken-content analysis is still delivering follow-up batches
-    // (e.g., separate perltidy and perlcritic passes).
-    harness.collect_notifications();
-    std::thread::sleep(Duration::from_millis(400));
-    harness.collect_notifications();
-
-    // When: the user fixes the file via a full-document didChange.
-    harness.change_file_full("live.pl", FIXED_SOURCE).expect("didChange should succeed");
-
-    // Phase 2 drain (post-fix): give any in-flight analysis of the BROKEN content
-    // time to complete and deliver its results, then drain those stale events.
-    // The server may have been mid-analysis when didChange arrived; those stale
-    // results can arrive up to ~500 ms after the fix is sent. Draining after this
-    // settle ensures the clean-window check below only sees events triggered by
-    // the fixed content.
-    std::thread::sleep(Duration::from_millis(600));
-    harness.collect_notifications();
-
-    // Then: diagnostics eventually clear. Two acceptable outcomes:
-    //   (a) Server sends explicit publishDiagnostics with empty array → cleared.
-    //   (b) No new non-empty notification arrives within the clean window → silence
-    //       means the server analysed the fixed content and found no errors.
-    //
-    // Diagnostics carry the text document version. If stale broken-content
-    // diagnostics still arrive in this window, they are ignored when their
-    // version proves they belong to the previous document state.
-    let uri = harness.workspace.uri("live.pl");
-    let deadline = std::time::Instant::now() + Duration::from_secs(4);
-
-    let mut post_settle_events: Vec<LspEvent> = Vec::new();
-    let mut cleared = false;
-
-    while std::time::Instant::now() < deadline {
-        post_settle_events.extend(harness.collect_notifications());
-
-        // Walk in reverse to find the latest diagnostic event for this URI.
-        for ev in post_settle_events.iter().rev() {
-            if let LspEvent::Diagnostics { uri: event_uri, version, diagnostics } = ev {
-                if event_uri == &uri {
-                    if version.is_some_and(|value| value < FIXED_VERSION) {
-                        continue;
-                    }
-                    if diagnostics.is_empty() {
-                        cleared = true;
-                    }
-                    break; // latest diagnostic state found — stop scanning
-                }
+    run_ux_scenario(
+        "diagnostics_lifecycle_editing",
+        SCENARIO_FILE,
+        "scenario_19_diagnostics_clear_after_fix",
+        UxCiTier::Pr,
+        Some(UxComponent::Diagnostics),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
             }
-        }
 
-        if cleared {
-            break;
-        }
+            let harness = UxHarness::new(
+                ScenarioConfig { timeout: Duration::from_secs(15), ..Default::default() }
+                    .with_file("live.pl", BROKEN_SOURCE),
+            )?;
 
-        std::thread::sleep(Duration::from_millis(100));
-    }
+            recorder.mark_request_start("broken_content_diagnostics");
+            harness.open_file("live.pl", BROKEN_SOURCE)?;
+            let diagnostics = harness.wait_for_diagnostics("live.pl", Duration::from_secs(5));
+            let has_broken_diagnostics = !diagnostics.is_empty();
+            if has_broken_diagnostics {
+                recorder.mark_first_useful_result("broken_content_diagnostics");
+            }
+            recorder.check("broken content yields diagnostics", has_broken_diagnostics)?;
 
-    // Accept silence: no new non-empty events arrived in the post-settle window.
-    if !cleared {
-        let has_new_errors = post_settle_events.iter().any(|ev| {
-            matches!(
-                ev,
-                LspEvent::Diagnostics {
-                    uri: event_uri,
-                    version,
-                    diagnostics,
-                } if event_uri == &uri
-                    && !diagnostics.is_empty()
-                    && !version.is_some_and(|value| value < FIXED_VERSION)
-            )
-        });
-        cleared = !has_new_errors;
-    }
+            // Phase 1 drain (pre-fix): remove events that have already arrived and any
+            // that arrive during a brief settle window. This covers the common case where
+            // the initial broken-content analysis is still delivering follow-up batches
+            // (e.g., separate perltidy and perlcritic passes).
+            harness.collect_notifications();
+            std::thread::sleep(Duration::from_millis(400));
+            harness.collect_notifications();
 
-    assert!(
-        cleared,
-        "Expected diagnostics to clear (or no new errors) after fixing the file; \
-         post-settle events: {:?}",
-        post_settle_events
+            recorder.mark_request_start("diagnostics_clear_after_fix");
+            harness.change_file_full("live.pl", FIXED_SOURCE)?;
+
+            // Phase 2 drain (post-fix): give any in-flight analysis of the BROKEN content
+            // time to complete and deliver its results, then drain those stale events.
+            // The server may have been mid-analysis when didChange arrived; those stale
+            // results can arrive up to ~500 ms after the fix is sent. Draining after this
+            // settle ensures the clean-window check below only sees events triggered by
+            // the fixed content.
+            std::thread::sleep(Duration::from_millis(600));
+            harness.collect_notifications();
+
+            // Then: diagnostics eventually clear. Two acceptable outcomes:
+            //   (a) Server sends explicit publishDiagnostics with empty array → cleared.
+            //   (b) No new non-empty notification arrives within the clean window → silence
+            //       means the server analysed the fixed content and found no errors.
+            //
+            // Diagnostics carry the text document version. If stale broken-content
+            // diagnostics still arrive in this window, they are ignored when their
+            // version proves they belong to the previous document state.
+            let uri = harness.workspace.uri("live.pl");
+            let deadline = std::time::Instant::now() + Duration::from_secs(4);
+
+            let mut post_settle_events: Vec<LspEvent> = Vec::new();
+            let mut cleared = false;
+
+            while std::time::Instant::now() < deadline {
+                post_settle_events.extend(harness.collect_notifications());
+
+                // Walk in reverse to find the latest diagnostic event for this URI.
+                for ev in post_settle_events.iter().rev() {
+                    if let LspEvent::Diagnostics { uri: event_uri, version, diagnostics } = ev {
+                        if event_uri == &uri {
+                            if version.is_some_and(|value| value < FIXED_VERSION) {
+                                continue;
+                            }
+                            if diagnostics.is_empty() {
+                                cleared = true;
+                            }
+                            break; // latest diagnostic state found — stop scanning
+                        }
+                    }
+                }
+
+                if cleared {
+                    break;
+                }
+
+                std::thread::sleep(Duration::from_millis(100));
+            }
+
+            // Accept silence: no new non-empty events arrived in the post-settle window.
+            if !cleared {
+                let has_new_errors = post_settle_events.iter().any(|ev| {
+                    matches!(
+                        ev,
+                        LspEvent::Diagnostics {
+                            uri: event_uri,
+                            version,
+                            diagnostics,
+                        } if event_uri == &uri
+                            && !diagnostics.is_empty()
+                            && !version.is_some_and(|value| value < FIXED_VERSION)
+                    )
+                });
+                cleared = !has_new_errors;
+            }
+
+            if cleared {
+                recorder.mark_first_useful_result("diagnostics_clear_after_fix");
+            }
+            recorder.check("fixed content clears diagnostics for the same document", cleared)?;
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-    harness.assert_no_crash();
 }


### PR DESCRIPTION
Problem: Diagnostics lifecycle editing lacked receipt-backed timing for initial broken diagnostics and post-fix clearing behavior.

Fix: Convert scenario 19 diagnostics lifecycle coverage to recorder-backed checks and enable receipt/timing instrumentation for diagnostics_lifecycle_editing in the fixture matrix.

Verification: Focused UX test, fixture matrix test, fmt check, clippy, package check, storage-doctor, and `just agent-pr-fast` pass.