### PR TITLE
test(ux): record multi-root workspace symbols receipt (#9781)

### DIFF
--- a/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
+++ b/crates/perl-lsp-ux-tests/fixtures/editor_ux_fixture_matrix.json
@@ -176,8 +176,8 @@
       "ci_tier": "pr",
       "component": "workspace_symbols",
       "instrumentation": {
-        "run_receipt": false,
-        "first_useful_result": false,
+        "run_receipt": true,
+        "first_useful_result": true,
         "protocol_goldens": false
       },
       "user_journey": "open multiple files in a workspace and navigate across them",
@@ -395,6 +395,7 @@
         "p95_time_to_first_useful_result_ms"
       ],
       "expected_outcomes": [
+        "receipt records multi-root workspace/symbol timing",
         "workspace/symbol returns same-named symbols from multiple roots",
         "results include workspaceFolderUri"
       ],

--- a/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
+++ b/crates/perl-lsp-ux-tests/tests/ux_scenario_15_workspace_symbols.rs
@@ -1,6 +1,3 @@
-// Test infrastructure — allow test-friendly patterns.
-#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-
 //! Scenario 15 — workspace symbol search across multiple workspace folders.
 //!
 //! Verifies that the UX harness can drive `workspace/symbol` in a multi-root
@@ -8,10 +5,13 @@
 //! disambiguatable via `workspaceFolderUri`.
 
 use perl_lsp_ux_tests::binary_available;
-use perl_lsp_ux_tests::{ScenarioConfig, UxHarness};
+use perl_lsp_ux_tests::missing_binary_skip;
+use perl_lsp_ux_tests::{ScenarioConfig, UxCiTier, UxComponent, UxHarness, run_ux_scenario};
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
+
+const SCENARIO_FILE: &str = "ux_scenario_15_workspace_symbols.rs";
 
 const RUNNER_A: &str = "\
 package Runner;\n\
@@ -50,69 +50,72 @@ fn normalized_folder_uris(harness: &UxHarness, symbols: &[Value]) -> BTreeSet<St
 
 #[test]
 fn scenario_15_workspace_symbol_multi_root_disambiguation() {
-    if !binary_available() {
-        eprintln!("SKIP scenario_15: perl-lsp binary not found");
-        return;
-    }
+    run_ux_scenario(
+        "multi_root_workspace_symbols",
+        SCENARIO_FILE,
+        "scenario_15_workspace_symbol_multi_root_disambiguation",
+        UxCiTier::Pr,
+        Some(UxComponent::WorkspaceSymbols),
+        |recorder| {
+            if !binary_available() {
+                return Err(missing_binary_skip().into());
+            }
 
-    let harness = UxHarness::new(
-        ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
-            .env("PERL_LSP_WORKSPACE", "1")
-            .with_workspace_folder("svc-a", "svc-a")
-            .with_workspace_folder("svc-b", "svc-b")
-            .with_file("svc-a/lib/Runner.pm", RUNNER_A)
-            .with_file("svc-b/lib/Runner.pm", RUNNER_B),
-    )
-    .expect("Failed to create UX harness");
+            let harness = UxHarness::new(
+                ScenarioConfig { timeout: Duration::from_secs(20), ..Default::default() }
+                    .env("PERL_LSP_WORKSPACE", "1")
+                    .with_workspace_folder("svc-a", "svc-a")
+                    .with_workspace_folder("svc-b", "svc-b")
+                    .with_file("svc-a/lib/Runner.pm", RUNNER_A)
+                    .with_file("svc-b/lib/Runner.pm", RUNNER_B),
+            )?;
 
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let mut latest_symbols = Vec::new();
+            recorder.mark_request_start("workspace_symbol_multi_root");
 
-    while Instant::now() < deadline {
-        latest_symbols = harness
-            .workspace_symbols("run")
-            .expect("workspace/symbol must not return an error in multi-root mode");
+            let deadline = Instant::now() + Duration::from_secs(10);
+            let mut latest_symbols = Vec::new();
 
-        let run_symbols = matching_run_symbols(&latest_symbols);
-        let folder_uris = normalized_folder_uris(&harness, &run_symbols);
+            while Instant::now() < deadline {
+                latest_symbols = harness.workspace_symbols("run")?;
 
-        if run_symbols.len() >= 2
-            && folder_uris.len() >= 2
-            && folder_uris.contains("file://$WORKSPACE/svc-a")
-            && folder_uris.contains("file://$WORKSPACE/svc-b")
-        {
-            break;
-        }
+                let run_symbols = matching_run_symbols(&latest_symbols);
+                let folder_uris = normalized_folder_uris(&harness, &run_symbols);
 
-        std::thread::sleep(Duration::from_millis(200));
-    }
+                if run_symbols.len() >= 2
+                    && folder_uris.len() >= 2
+                    && folder_uris.contains("file://$WORKSPACE/svc-a")
+                    && folder_uris.contains("file://$WORKSPACE/svc-b")
+                {
+                    recorder.mark_first_useful_result("workspace_symbol_multi_root");
+                    break;
+                }
 
-    let run_symbols = matching_run_symbols(&latest_symbols);
-    assert!(
-        run_symbols.len() >= 2,
-        "Expected workspace/symbol to find same-named 'run' entries across both workspace \
-         folders, got: {:?}",
-        latest_symbols
+                std::thread::sleep(Duration::from_millis(200));
+            }
+
+            let run_symbols = matching_run_symbols(&latest_symbols);
+            recorder.check(
+                "workspace/symbol returns same-named run entries across both roots",
+                run_symbols.len() >= 2,
+            )?;
+
+            let folder_uris = normalized_folder_uris(&harness, &run_symbols);
+
+            recorder.check(
+                "workspace symbols include distinct workspaceFolderUri values",
+                folder_uris.len() >= 2,
+            )?;
+            recorder.check(
+                "one workspace symbol points at svc-a",
+                folder_uris.contains("file://$WORKSPACE/svc-a"),
+            )?;
+            recorder.check(
+                "one workspace symbol points at svc-b",
+                folder_uris.contains("file://$WORKSPACE/svc-b"),
+            )?;
+
+            harness.assert_no_crash();
+            Ok(())
+        },
     );
-
-    let folder_uris = normalized_folder_uris(&harness, &run_symbols);
-
-    assert!(
-        folder_uris.len() >= 2,
-        "Expected workspace symbols to carry distinct workspaceFolderUri values for multi-root \
-         disambiguation, got: {:?}",
-        latest_symbols
-    );
-    assert!(
-        folder_uris.contains("file://$WORKSPACE/svc-a"),
-        "Expected one workspace symbol to point at svc-a, got: {:?}",
-        folder_uris
-    );
-    assert!(
-        folder_uris.contains("file://$WORKSPACE/svc-b"),
-        "Expected one workspace symbol to point at svc-b, got: {:?}",
-        folder_uris
-    );
-
-    harness.assert_no_crash();
 }


### PR DESCRIPTION
Problem: Multi-root workspace-symbol UX coverage lacked receipt-backed timing for workspace/symbol results and workspaceFolderUri disambiguation.

Fix: Convert scenario 15 to recorder-backed checks and enable receipt/timing instrumentation for multi_root_workspace_symbols in the fixture matrix.

Verification: Focused UX test, fixture matrix test, fmt check, clippy, package check, storage-doctor, and `just agent-pr-fast` pass.