### PR TITLE
fix(vscode): improve binary startup guidance (#9787)

### DIFF
--- a/vscode-extension/src/onboarding.ts
+++ b/vscode-extension/src/onboarding.ts
@@ -73,7 +73,8 @@ export function classifyStartupFailure(results: HealthCheckResult[]): string {
     return (
       'Perl Language Server binary (perllsp) not found. ' +
       detailWithPeriod +
-      ' Check the Output panel for download details or reinstall the extension.'
+      ' Run "Perl: Run Health Check" from the Command Palette, set `perl-lsp.serverPath` to a local perllsp binary, ' +
+      'or run "Perl: Reinstall Server Binary" to download the managed binary again.'
     );
   }
 

--- a/vscode-extension/src/test/onboarding.test.ts
+++ b/vscode-extension/src/test/onboarding.test.ts
@@ -517,6 +517,9 @@ describe('classifyStartupFailure', () => {
     const msg = classifyStartupFailure(results);
     expect(msg).not.toContain('Install Perl');
     expect(msg).toMatch(/binary|perllsp/i);
+    expect(msg).toContain('Perl: Run Health Check');
+    expect(msg).toContain('perl-lsp.serverPath');
+    expect(msg).toContain('Perl: Reinstall Server Binary');
   });
 
   test('returns generic message when all checks pass (unknown crash)', () => {


### PR DESCRIPTION
Problem: When the managed perllsp binary is missing, the startup diagnostic does not name the exact command or setting users need.\nFix: Mention "Perl: Run Health Check", `perl-lsp.serverPath`, and "Perl: Reinstall Server Binary" in the binary-missing startup message.\nVerification: `npm test -- --runInBand src/test/onboarding.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9787