### PR TITLE
fix(vscode): clarify unknown startup remediation (#9789)

### DIFF
--- a/vscode-extension/src/startupDiagnosis.ts
+++ b/vscode-extension/src/startupDiagnosis.ts
@@ -103,7 +103,9 @@ export function classifyStartupError(output: string): StartupErrorDiagnosis {
     return {
         kind: StartupErrorKind.Unknown,
         hint: 'The LSP binary failed to start. Check the Output panel for details.',
-        remediation: 'Try "Run Health Check" to diagnose, or "Reinstall" to fetch a fresh binary.',
+        remediation:
+            'Run "Perl: Run Health Check" from the Command Palette to diagnose the environment, ' +
+            'or run "Perl: Reinstall Server Binary" to fetch a fresh managed binary.',
     };
 }
 

--- a/vscode-extension/src/test/startupError.test.ts
+++ b/vscode-extension/src/test/startupError.test.ts
@@ -92,6 +92,8 @@ describe('classifyStartupError', () => {
     expect(result.kind).toBe(StartupErrorKind.Unknown);
     expect(result.hint).toBeTruthy();
     expect(result.remediation).toBeTruthy();
+    expect(result.remediation).toContain('Perl: Run Health Check');
+    expect(result.remediation).toContain('Perl: Reinstall Server Binary');
   });
 
   test('returns Unknown for empty stderr', () => {


### PR DESCRIPTION
Problem: The unknown LSP binary startup fallback uses generic action names instead of the actual VS Code Command Palette labels.\nFix: Use "Perl: Run Health Check" and "Perl: Reinstall Server Binary" in the Unknown startup remediation.\nVerification: `npm test -- --runInBand src/test/startupError.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9789