### PR TITLE
fix(vscode): clarify missing perltidy guidance (#9791)

### DIFF
--- a/vscode-extension/src/formattingErrors.ts
+++ b/vscode-extension/src/formattingErrors.ts
@@ -39,7 +39,7 @@ export function handleFormattingError(
     const label = isNotFound ? 'Run Health Check' : 'Show Output';
     const msg = isNotFound
         ? `Perl formatting requires perltidy, which was not found on PATH. ` +
-          `Install it via: cpan Perl::Tidy  (or set perl-lsp.perltidyConfig to your config path)`
+          `Install it via: cpanm Perl::Tidy. Run "Perl: Run Health Check" if formatting is still unavailable.`
         : `Perl formatting failed: ${truncated}`;
 
     vscode.window.showErrorMessage(msg, label).then(sel => {

--- a/vscode-extension/src/test/formatting.test.ts
+++ b/vscode-extension/src/test/formatting.test.ts
@@ -47,10 +47,14 @@ describe('handleFormattingError', () => {
     test('shows Run Health Check button when perltidy is not found', () => {
         const ch = makeOutputChannel();
         handleFormattingError('perltidy not found: /usr/bin/perltidy', ch as any);
+        const call = (vscode.window.showErrorMessage as jest.Mock).mock.calls[0];
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
             expect.stringContaining('perltidy, which was not found on PATH'),
             'Run Health Check'
         );
+        expect(call[0]).toContain('cpanm Perl::Tidy');
+        expect(call[0]).toContain('Perl: Run Health Check');
+        expect(call[0]).not.toContain('perl-lsp.perltidyConfig');
     });
 
     test('does not show toast again within 30s cooldown', () => {


### PR DESCRIPTION
Problem: The missing-perltidy formatting toast suggests `perl-lsp.perltidyConfig`, which configures a .perltidyrc file and does not locate the executable.\nFix: Point users to `cpanm Perl::Tidy` and "Perl: Run Health Check" instead.\nVerification: `npm test -- --runInBand src/test/formatting.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9791