### PR TITLE
fix(vscode): clarify dap reinstall guidance (#9793)

### DIFF
--- a/vscode-extension/src/debugAdapter.ts
+++ b/vscode-extension/src/debugAdapter.ts
@@ -384,7 +384,7 @@ export class PerlDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
         if (!dapPath) {
             vscode.window.showErrorMessage(
                 'Perl Debug Adapter (perl-dap) not found. Debugging requires perl-dap. ' +
-                'Use "Perl LSP: Reinstall" from the Command Palette to re-download it, ' +
+                'Use "Perl: Reinstall Server Binary" from the Command Palette to re-download it, ' +
                 'or install it manually with: cargo install perl-dap.',
                 'Reinstall',
                 'Open Debugging Guide'

--- a/vscode-extension/src/test/debugAdapter.test.ts
+++ b/vscode-extension/src/test/debugAdapter.test.ts
@@ -181,11 +181,14 @@ describe('PerlDebugAdapterDescriptorFactory', () => {
     try {
       const result = factory.createDebugAdapterDescriptor({} as any, undefined);
       expect(result).toBeUndefined();
+      const call = vscode.window.showErrorMessage.mock.calls[0];
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
         expect.stringContaining('perl-dap'),
         'Reinstall',
         'Open Debugging Guide'
       );
+      expect(call[0]).toContain('Perl: Reinstall Server Binary');
+      expect(call[0]).not.toContain('Perl LSP: Reinstall');
     } finally {
       process.env.PATH = origPath;
       process.env.HOME = origHome;


### PR DESCRIPTION
Problem: The missing perl-dap warning names a reinstall command that does not match the VS Code Command Palette label.\nFix: Point users to "Perl: Reinstall Server Binary" when the debug adapter is missing.\nVerification: `npm test -- --runInBand src/test/debugAdapter.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9793