### PR TITLE
fix(vscode): clarify crash healthcheck guidance (#9795)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2912,7 +2912,9 @@ function bindClientState(languageClient: LanguageClient) {
             lastStartupDiagnosis = {
                 kind: StartupErrorKind.Unknown,
                 hint: 'The Perl Language Server stopped unexpectedly. Check the Output panel for details.',
-                remediation: 'Try restarting the server (Command Palette: "Perl: Restart Server") or run the Health Check.',
+                remediation:
+                    'Try restarting the server (Command Palette: "Perl: Restart Server") ' +
+                    'or run "Perl: Run Health Check".',
             };
         }
     });

--- a/vscode-extension/src/test/startupError.test.ts
+++ b/vscode-extension/src/test/startupError.test.ts
@@ -348,11 +348,14 @@ describe('serverNotRunningMessage diagnosis cache (#4193)', () => {
     _setLastStartupDiagnosisForTest({
       kind: StartupErrorKind.Unknown,
       hint: 'The Perl Language Server stopped unexpectedly. Check the Output panel for details.',
-      remediation: 'Try restarting the server (Command Palette: "Perl: Restart Server") or run the Health Check.',
+      remediation:
+        'Try restarting the server (Command Palette: "Perl: Restart Server") ' +
+        'or run "Perl: Run Health Check".',
     });
 
     const msg = serverNotRunningMessage();
     expect(msg).toContain('stopped unexpectedly');
     expect(msg).toContain('Restart Server');
+    expect(msg).toContain('Perl: Run Health Check');
   });
 });


### PR DESCRIPTION
Problem: Mid-session crash remediation says to run the Health Check without naming the actual Command Palette entry.\nFix: Use the exact "Perl: Run Health Check" label alongside the existing restart guidance.\nVerification: `npm test -- --runInBand src/test/startupError.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9795