### PR TITLE
fix(vscode): add download serverpath shortcut (#9797)

### DIFF
--- a/vscode-extension/src/downloader.ts
+++ b/vscode-extension/src/downloader.ts
@@ -316,6 +316,8 @@ export class BinaryDownloader {
                 buttons = ['Install Manually', 'View Logs'];
             }
 
+            buttons = [...buttons, 'Open serverPath Setting'];
+
             vscode.window.showErrorMessage(message, ...buttons).then((choice: string | undefined) => {
                 if (choice === 'Install Manually') {
                     vscode.env.openExternal(vscode.Uri.parse(manualInstallUrl));
@@ -323,6 +325,8 @@ export class BinaryDownloader {
                     vscode.commands.executeCommand('workbench.action.openSettings', 'http.proxy');
                 } else if (choice === 'View Logs') {
                     this.outputChannel.show();
+                } else if (choice === 'Open serverPath Setting') {
+                    vscode.commands.executeCommand('workbench.action.openSettings', 'perl-lsp.serverPath');
                 }
             });
 

--- a/vscode-extension/src/test/downloader.test.ts
+++ b/vscode-extension/src/test/downloader.test.ts
@@ -1354,14 +1354,13 @@ describe('ensureBinary error classification', () => {
 
     await downloader.ensureBinary();
 
-    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-      expect.stringMatching(/proxy|VPN|network/i),
-      expect.anything(),
-      expect.anything()
-    );
-    // Must mention the manual install setting
     const call = vscode.window.showErrorMessage.mock.calls[0];
+    expect(call[0]).toMatch(/proxy|VPN|network/i);
+    // Must mention the manual install setting
     expect(call[0]).toMatch(/perl-lsp\.serverPath/);
+    expect(call.slice(1)).toEqual(
+      expect.arrayContaining(['Open Proxy Settings', 'Install Manually'])
+    );
   });
 
   test('ETIMEDOUT shows message containing proxy/VPN guidance and manual install path', async () => {
@@ -1512,6 +1511,18 @@ describe('ensureBinary error classification', () => {
     expect(buttons).toContain('Install Manually');
   });
 
+  test('error message always offers serverPath settings shortcut', async () => {
+    setupDownloadError('some unexpected error occurred');
+    const vscode = require('vscode');
+    vscode.window.showErrorMessage.mockResolvedValue(undefined);
+
+    await downloader.ensureBinary();
+
+    const call = vscode.window.showErrorMessage.mock.calls[0];
+    const buttons: string[] = call.slice(1);
+    expect(buttons).toContain('Open serverPath Setting');
+  });
+
   test('"Install Manually" button opens the manual install URL', async () => {
     setupDownloadError('some unexpected error occurred');
     const vscode = require('vscode');
@@ -1524,5 +1535,18 @@ describe('ensureBinary error classification', () => {
     );
     const uriArg = vscode.env.openExternal.mock.calls[0][0];
     expect(uriArg.toString()).toMatch(/github\.com.*perl-lsp/i);
+  });
+
+  test('"Open serverPath Setting" button opens the serverPath setting', async () => {
+    setupDownloadError('some unexpected error occurred');
+    const vscode = require('vscode');
+    vscode.window.showErrorMessage.mockResolvedValue('Open serverPath Setting');
+
+    await downloader.ensureBinary();
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'workbench.action.openSettings',
+      'perl-lsp.serverPath'
+    );
   });
 });


### PR DESCRIPTION
Problem: Binary download failures mention `perl-lsp.serverPath` but do not provide a direct way to open that setting.\nFix: Add an "Open serverPath Setting" action to downloader failure notifications and wire it to `workbench.action.openSettings` for `perl-lsp.serverPath`.\nVerification: `npm test -- --runInBand src/test/downloader.test.ts -t "ensureBinary error classification"` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nNote: Full `src/test/downloader.test.ts` still has unrelated platform-target failures in this shell because the environment is detected as Android/Termux.\n\nCloses #9797