### PR TITLE
fix(vscode): clarify gherkin workspace guidance (#9799)

### DIFF
--- a/vscode-extension/src/gherkinStepDefinitions.ts
+++ b/vscode-extension/src/gherkinStepDefinitions.ts
@@ -259,7 +259,7 @@ async function createStepDefinitionFromFeature(args: CreateStepDefinitionArgs): 
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(featureUri);
     if (!workspaceFolder) {
         void vscode.window.showWarningMessage(
-            'Step definition generation requires an open workspace folder.'
+            'Step definition generation requires an open workspace folder. Open this .feature file from a folder or workspace, then run the action again.'
         );
         return;
     }

--- a/vscode-extension/src/test/gherkinStepDefinitions.test.ts
+++ b/vscode-extension/src/test/gherkinStepDefinitions.test.ts
@@ -25,6 +25,23 @@ describe('gherkin step definition support', () => {
     ]);
   });
 
+  test('explains how to recover when creating a step without a workspace folder', async () => {
+    registerGherkinStepDefinitionSupport();
+    (vscode.workspace.openTextDocument as jest.Mock).mockResolvedValueOnce({
+      lineAt: jest.fn(() => ({ text: 'Given a user exists' })),
+    });
+    (vscode.workspace as any).getWorkspaceFolder = jest.fn(() => undefined);
+
+    await vscode.commands.executeCommand('perl-lsp.createGherkinStepDefinition', {
+      featureUri: 'file:///tmp/checkout.feature',
+      line: 0,
+    });
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Open this .feature file from a folder or workspace')
+    );
+  });
+
   test('parses Given/When/Then step lines and skips non-step lines', () => {
     expect(parseGherkinStepLine('    Given a signed-in user', 4)).toEqual({
       keyword: 'Given',


### PR DESCRIPTION
Problem: Gherkin step-definition generation warns that a workspace is required but does not tell users how to recover.\nFix: Explain that the .feature file should be opened from a folder or workspace before rerunning the action.\nVerification: `npm test -- --runInBand src/test/gherkinStepDefinitions.test.ts -t "explains how to recover"` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nNote: Full `src/test/gherkinStepDefinitions.test.ts` still has an unrelated existing classifier expectation failure outside this warning path.\n\nCloses #9799