### PR TITLE
fix(vscode): clarify missing prove guidance (#9801)

### DIFF
--- a/vscode-extension/src/test/testAdapter.test.ts
+++ b/vscode-extension/src/test/testAdapter.test.ts
@@ -1,0 +1,65 @@
+import { EventEmitter } from 'events';
+import * as vscode from 'vscode';
+
+const mockSpawn = jest.fn();
+
+jest.mock('child_process', () => ({
+  spawn: mockSpawn,
+}));
+
+import { PerlTestAdapter, PROVE_UNAVAILABLE_GUIDANCE } from '../testAdapter';
+
+describe('Perl Test Explorer guidance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (vscode.workspace.findFiles as jest.Mock).mockResolvedValue([]);
+    (vscode.workspace as any).getWorkspaceFolder = jest.fn(() => undefined);
+  });
+
+  test('missing prove errors explain install and PATH recovery steps', async () => {
+    const proc = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: jest.Mock;
+    };
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = jest.fn();
+    mockSpawn.mockReturnValue(proc);
+
+    const adapter = Object.create(PerlTestAdapter.prototype);
+    const run = {
+      errored: jest.fn(),
+    };
+    const fileItem = {
+      uri: vscode.Uri.file('/tmp/example.t'),
+      label: 'example.t',
+    };
+    const subtest = {
+      uri: vscode.Uri.file('/tmp/example.t'),
+      label: 'loads',
+    };
+    const token = {
+      isCancellationRequested: false,
+      onCancellationRequested: jest.fn(() => ({ dispose: jest.fn() })),
+    };
+
+    const runPromise = (adapter as any).runProve('/tmp/example.t', fileItem, [subtest], run, token);
+    proc.emit('error', new Error('spawn prove ENOENT'));
+    await runPromise;
+
+    expect(PROVE_UNAVAILABLE_GUIDANCE).toContain('cpanm Test::Harness');
+    expect(run.errored).toHaveBeenCalledWith(
+      fileItem,
+      expect.objectContaining({
+        message: expect.stringContaining(PROVE_UNAVAILABLE_GUIDANCE),
+      })
+    );
+    expect(run.errored).toHaveBeenCalledWith(
+      subtest,
+      expect.objectContaining({
+        message: PROVE_UNAVAILABLE_GUIDANCE,
+      })
+    );
+  });
+});

--- a/vscode-extension/src/testAdapter.ts
+++ b/vscode-extension/src/testAdapter.ts
@@ -17,6 +17,8 @@ interface SubtestInfo {
 // Matches: subtest 'name' => sub {   or   subtest "name" => sub {
 // Also matches: subtest 'name', sub {
 const SUBTEST_RE = /^\s*subtest\s+(['"])(.*?)\1\s*(?:=>|,)\s*sub\s*\{/;
+export const PROVE_UNAVAILABLE_GUIDANCE =
+    'Perl test runner "prove" was not found on PATH. Install Test::Harness with cpanm Test::Harness, or add prove to PATH.';
 
 export class PerlTestAdapter implements vscode.Disposable {
     private testController: vscode.TestController;
@@ -257,10 +259,10 @@ export class PerlTestAdapter implements vscode.Disposable {
             proc.on('error', (err: Error) => {
                 killOnCancel.dispose();
                 run.errored(fileItem, new vscode.TestMessage(
-                    `Failed to run prove: ${err.message}. Is prove installed?`
+                    `Failed to run prove: ${err.message}. ${PROVE_UNAVAILABLE_GUIDANCE}`
                 ));
                 for (const st of subtests) {
-                    run.errored(st, new vscode.TestMessage('prove not available'));
+                    run.errored(st, new vscode.TestMessage(PROVE_UNAVAILABLE_GUIDANCE));
                 }
                 resolve();
             });


### PR DESCRIPTION
Problem: Test Explorer reports missing prove with terse messages that do not tell users how to recover.\nFix: Reuse actionable guidance that names prove, `cpanm Test::Harness`, and PATH recovery for file and subtest errors.\nVerification: `npm test -- --runInBand src/test/testAdapter.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9801