### PR TITLE
fix(vscode): include lib in new test boilerplate (#9803)

### DIFF
--- a/vscode-extension/src/fileCreation.ts
+++ b/vscode-extension/src/fileCreation.ts
@@ -61,7 +61,7 @@ export function generateBoilerplate(filePath: string): BoilerplateResult | null 
     }
 
     if (ext === '.t') {
-        const content = `use strict;\nuse warnings;\nuse Test::More;\n\n\n\ndone_testing;\n`;
+        const content = `use strict;\nuse warnings;\nuse lib 'lib';\nuse Test::More;\n\n\n\ndone_testing;\n`;
         return { kind: FileKind.Test, content };
     }
 

--- a/vscode-extension/src/test/fileCreation.test.ts
+++ b/vscode-extension/src/test/fileCreation.test.ts
@@ -120,6 +120,14 @@ describe('generateBoilerplate for .t files', () => {
         expect(result.content).toContain('use Test::More;');
     });
 
+    test('includes local lib before Test::More', () => {
+        const result = generateBoilerplate('/project/t/foo.t')!;
+        expect(result.content).toContain("use lib 'lib';");
+        expect(result.content.indexOf("use lib 'lib';")).toBeLessThan(
+            result.content.indexOf('use Test::More;')
+        );
+    });
+
     test('ends with done_testing', () => {
         const result = generateBoilerplate('/project/t/foo.t')!;
         expect(result.content.trimEnd()).toMatch(/done_testing;$/);


### PR DESCRIPTION
Problem: New .t files from the VS Code boilerplate can fail to load local modules when run through the Test Explorer until users manually add lib setup.\nFix: Add `use lib 'lib';` before `Test::More` in the generated .t starter and lock that ordering in the focused unit test.\nVerification: `npm test -- --runInBand src/test/fileCreation.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9803