### PR TITLE
fix(vscode): render labeled pod links usefully (#9805)

### DIFF
--- a/vscode-extension/src/podPreview.ts
+++ b/vscode-extension/src/podPreview.ts
@@ -299,25 +299,42 @@ function renderLinkCode(inner: string): string {
     if (pipeIdx !== -1) {
         const label = inner.slice(0, pipeIdx).trim();
         const target = inner.slice(pipeIdx + 1).trim();
-        if (/^https?:\/\//.test(target)) {
-            return `<a href="${escapeAttr(target)}">${escapeHtml(label)}</a>`;
-        }
-        return `<a href="#${escapeAttr(target.replace(/\s+/g, '-').toLowerCase())}">${escapeHtml(label)}</a>`;
+        return `<a href="${podLinkHref(target)}">${escapeHtml(label)}</a>`;
     }
 
-    if (/^https?:\/\//.test(inner)) {
-        return `<a href="${escapeAttr(inner)}">${escapeHtml(inner)}</a>`;
+    return `<a href="${podLinkHref(inner)}">${escapeHtml(inner)}</a>`;
+}
+
+function podLinkHref(target: string): string {
+    const trimmed = target.trim();
+    if (trimmed === '') {
+        return '#';
     }
 
-    // Module/manpage reference
-    const slashIdx = inner.indexOf('/');
+    if (/^https?:\/\//.test(trimmed)) {
+        return escapeAttr(trimmed);
+    }
+
+    if (trimmed.startsWith('/')) {
+        return `#${escapeAttr(sectionFragment(trimmed.slice(1)))}`;
+    }
+
+    const slashIdx = trimmed.indexOf('/');
     if (slashIdx !== -1) {
-        const mod = inner.slice(0, slashIdx);
-        const section = inner.slice(slashIdx + 1);
-        return `<a href="https://perldoc.perl.org/${escapeAttr(mod)}">${escapeHtml(mod)}/${escapeHtml(section)}</a>`;
+        const mod = trimmed.slice(0, slashIdx).trim();
+        const section = trimmed.slice(slashIdx + 1).trim();
+        if (mod === '') {
+            return `#${escapeAttr(sectionFragment(section))}`;
+        }
+        const fragment = section ? `#${escapeAttr(sectionFragment(section))}` : '';
+        return `https://perldoc.perl.org/${escapeAttr(mod)}${fragment}`;
     }
 
-    return `<a href="https://perldoc.perl.org/${escapeAttr(inner)}">${escapeHtml(inner)}</a>`;
+    return `https://perldoc.perl.org/${escapeAttr(trimmed)}`;
+}
+
+function sectionFragment(section: string): string {
+    return section.replace(/\s+/g, '-').toLowerCase();
 }
 
 function renderEscapeCode(name: string): string {

--- a/vscode-extension/src/test/podPreview.test.ts
+++ b/vscode-extension/src/test/podPreview.test.ts
@@ -134,6 +134,20 @@ describe('podToHtml', () => {
     expect(html).toContain('perldoc');
   });
 
+  test('renders labeled L<label|module> links as perldoc URLs', () => {
+    const pod = '=pod\n\nSee L<the test library|Test::More>.\n\n=cut\n';
+    const html = podToHtml(pod);
+    expect(html).toContain('href="https://perldoc.perl.org/Test::More"');
+    expect(html).toContain('>the test library</a>');
+    expect(html).not.toContain('href="#test::more"');
+  });
+
+  test('renders module section links with a perldoc fragment', () => {
+    const pod = '=pod\n\nSee L<open docs|perlfunc/open>.\n\n=cut\n';
+    const html = podToHtml(pod);
+    expect(html).toContain('href="https://perldoc.perl.org/perlfunc#open"');
+  });
+
   test('renders E<lt> as &lt;', () => {
     const pod = '=pod\n\nUse E<lt>tag E<gt> syntax.\n\n=cut\n';
     const html = podToHtml(pod);


### PR DESCRIPTION
Problem: Labeled POD links in the VS Code preview can render as dead in-page hash links instead of useful perldoc targets.\nFix: Route labeled module/manpage links through the same perldoc URL helper as unlabeled links, with section-only targets preserved as local anchors.\nVerification: `npm test -- --runInBand src/test/podPreview.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9805