### PR TITLE
fix(vscode): show health counts in tooltip (#9807)

### DIFF
--- a/vscode-extension/src/healthWidget.ts
+++ b/vscode-extension/src/healthWidget.ts
@@ -201,8 +201,9 @@ export class HealthWidget {
                 const detail = parts.length > 0 ? `: ${parts.join(' | ')}` : '';
                 this.item.text = `$(check) ${label}${detail}`;
                 const versionNote = this._version ? ` v${this._version}` : '';
+                const tooltipDetail = parts.length > 0 ? `: ${parts.join(', ')}` : '';
                 this.item.tooltip =
-                    `Perl Language Server${versionNote} is running (click for options)`;
+                    `Perl Language Server${versionNote} is running${tooltipDetail} (click for options)`;
                 this.item.backgroundColor = undefined;
                 break;
             }

--- a/vscode-extension/src/test/healthWidget.test.ts
+++ b/vscode-extension/src/test/healthWidget.test.ts
@@ -75,6 +75,15 @@ describe('HealthWidget — onStateChange', () => {
         expect(item.text).toBe('$(check) perl-lsp: 847 files | 12 errors');
     });
 
+    test('Running → tooltip includes file and error counts', () => {
+        const { item, widget } = makeWidget();
+        widget.setFileCount(847);
+        widget.setErrorCount(12);
+        widget.onStateChange(ClientState.Running);
+        expect(item.tooltip).toContain('847 files');
+        expect(item.tooltip).toContain('12 errors');
+    });
+
     test('Running → shows only error count when file count unknown', () => {
         const { item, widget } = makeWidget();
         widget.setErrorCount(3);


### PR DESCRIPTION
Problem: The VS Code health status can show file/error counts in the status bar, but hover text remains generic when the item is truncated.\nFix: Include the same running-state file/error details in the status tooltip.\nVerification: `npm test -- --runInBand src/test/healthWidget.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9807