### PR TITLE
fix(vscode): clarify mcp unavailable guidance (#9809)

### DIFF
--- a/vscode-extension/src/mcpSupport.ts
+++ b/vscode-extension/src/mcpSupport.ts
@@ -39,10 +39,17 @@ function toMcpDefinition(server: McpServerConfig): vscode.McpStdioServerDefiniti
     return definition;
 }
 
+export function formatMcpUnavailableMessage(configuredServerCount: number): string {
+    const configuredNote = configuredServerCount > 0
+        ? ` ${configuredServerCount} configured MCP server${configuredServerCount === 1 ? '' : 's'} will not be published.`
+        : '';
+    return `[mcp] VS Code MCP API unavailable in this editor build.${configuredNote} Update to a VS Code build with MCP support to use perl-lsp.mcp.servers.`;
+}
+
 export function registerMcpSupport(outputChannel: vscode.OutputChannel): vscode.Disposable | undefined {
     const mcpApi = (vscode as VscodeWithMcp).lm;
     if (!mcpApi?.registerMcpServerDefinitionProvider) {
-        outputChannel.appendLine('[mcp] VS Code MCP API unavailable in this editor build.');
+        outputChannel.appendLine(formatMcpUnavailableMessage(readConfiguredMcpServers().length));
         return undefined;
     }
 

--- a/vscode-extension/src/test/mcpSupport.test.ts
+++ b/vscode-extension/src/test/mcpSupport.test.ts
@@ -1,0 +1,21 @@
+import { formatMcpUnavailableMessage } from '../mcpSupport';
+
+describe('formatMcpUnavailableMessage', () => {
+  test('explains how to recover when no MCP servers are configured', () => {
+    const message = formatMcpUnavailableMessage(0);
+    expect(message).toContain('VS Code MCP API unavailable');
+    expect(message).toContain('Update to a VS Code build with MCP support');
+    expect(message).toContain('perl-lsp.mcp.servers');
+    expect(message).not.toContain('will not be published');
+  });
+
+  test('mentions one configured server that will not be published', () => {
+    const message = formatMcpUnavailableMessage(1);
+    expect(message).toContain('1 configured MCP server will not be published');
+  });
+
+  test('pluralizes multiple configured servers', () => {
+    const message = formatMcpUnavailableMessage(2);
+    expect(message).toContain('2 configured MCP servers will not be published');
+  });
+});


### PR DESCRIPTION
Problem: When the editor lacks the VS Code MCP API, configured MCP servers are silently not published beyond a terse unavailable log line.\nFix: Include the configured-server count and tell users to update to a VS Code build with MCP support.\nVerification: `npm test -- --runInBand src/test/mcpSupport.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9809