### PR TITLE
fix(vscode): honor test cursor boundaries (#9811)

### DIFF
--- a/vscode-extension/src/runTestAtCursor.ts
+++ b/vscode-extension/src/runTestAtCursor.ts
@@ -27,13 +27,20 @@ function positionBeforeOrEqual(left: PositionLike, right: PositionLike): boolean
         || (left.line === right.line && left.character <= right.character);
 }
 
-function positionAfterOrEqual(left: PositionLike, right: PositionLike): boolean {
-    return left.line > right.line
-        || (left.line === right.line && left.character >= right.character);
+function positionBefore(left: PositionLike, right: PositionLike): boolean {
+    return left.line < right.line
+        || (left.line === right.line && left.character < right.character);
+}
+
+function positionEqual(left: PositionLike, right: PositionLike): boolean {
+    return left.line === right.line && left.character === right.character;
 }
 
 function rangeContains(range: RangeLike, position: PositionLike): boolean {
-    return positionBeforeOrEqual(range.start, position) && positionAfterOrEqual(range.end, position);
+    if (positionEqual(range.start, range.end)) {
+        return positionEqual(position, range.start);
+    }
+    return positionBeforeOrEqual(range.start, position) && positionBefore(position, range.end);
 }
 
 function rangeSpan(range: RangeLike): number {

--- a/vscode-extension/src/test/runTestAtCursor.test.ts
+++ b/vscode-extension/src/test/runTestAtCursor.test.ts
@@ -84,6 +84,74 @@ describe('selectTestCommandAtPosition', () => {
     expect(command?.command).toBe('perl.runTestFile');
   });
 
+  test('matches empty runTestFile ranges only at the exact position', () => {
+    const command = selectTestCommandAtPosition(
+      [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          command: {
+            command: 'perl.runTestFile',
+            arguments: ['/tmp/example.t'],
+          },
+        },
+      ],
+      { line: 0, character: 0 } as vscode.Position,
+    );
+
+    expect(command?.command).toBe('perl.runTestFile');
+
+    const outside = selectTestCommandAtPosition(
+      [
+        {
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          },
+          command: {
+            command: 'perl.runTestFile',
+            arguments: ['/tmp/example.t'],
+          },
+        },
+      ],
+      { line: 0, character: 1 } as vscode.Position,
+    );
+
+    expect(outside).toBeUndefined();
+  });
+
+  test('does not include the exclusive end of a test range', () => {
+    const command = selectTestCommandAtPosition(
+      [
+        {
+          range: {
+            start: { line: 3, character: 0 },
+            end: { line: 8, character: 0 },
+          },
+          command: {
+            command: 'perl.runTest',
+            arguments: ['file:///tmp/example.t::test_first'],
+          },
+        },
+        {
+          range: {
+            start: { line: 8, character: 0 },
+            end: { line: 12, character: 0 },
+          },
+          command: {
+            command: 'perl.runTest',
+            arguments: ['file:///tmp/example.t::test_second'],
+          },
+        },
+      ],
+      { line: 8, character: 0 } as vscode.Position,
+    );
+
+    expect(command?.arguments).toEqual(['file:///tmp/example.t::test_second']);
+  });
+
   test('returns undefined when no runnable lens contains the cursor', () => {
     const command = selectTestCommandAtPosition(
       [


### PR DESCRIPTION
Problem: Run Test at Cursor treats non-empty code-lens ranges as end-inclusive, so a cursor at the start of the next adjacent test can still match the previous test.\nFix: Use LSP-style end-exclusive containment for non-empty ranges while keeping exact-position matching for empty file-level lenses.\nVerification: `npm test -- --runInBand src/test/runTestAtCursor.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses #9811