### PR TITLE
fix(vscode): scope streaming cache to document (#9813)

### DIFF
--- a/vscode-extension/src/streamingCompletion.ts
+++ b/vscode-extension/src/streamingCompletion.ts
@@ -33,6 +33,14 @@ interface CachedCandidate {
     isFinal: boolean;
 }
 
+/** Document position that owns the active stream request. */
+interface ActiveStreamContext {
+    uri: string;
+    version: number;
+    line: number;
+    character: number;
+}
+
 /**
  * Progress type marker used with `LanguageClient.onProgress`.
  *
@@ -56,6 +64,7 @@ export class StreamingCompletionController implements vscode.Disposable {
     private cachedCandidate: CachedCandidate | null = null;
     private activeTokenSource: vscode.CancellationTokenSource | null = null;
     private activeProgressToken: string | null = null;
+    private activeStreamContext: ActiveStreamContext | null = null;
     private activeProgressDisposable: vscode.Disposable | null = null;
     private disposables: vscode.Disposable[] = [];
 
@@ -122,6 +131,10 @@ export class StreamingCompletionController implements vscode.Disposable {
             return;
         }
 
+        if (!this.activeStreamContext) {
+            return;
+        }
+
         // Update cached candidate if it's newer
         if (
             this.cachedCandidate &&
@@ -132,10 +145,10 @@ export class StreamingCompletionController implements vscode.Disposable {
         }
 
         this.cachedCandidate = {
-            uri: '',
-            version: 0,
-            line: item.range?.start.line ?? 0,
-            character: item.range?.start.character ?? 0,
+            uri: this.activeStreamContext.uri,
+            version: this.activeStreamContext.version,
+            line: item.range?.start.line ?? this.activeStreamContext.line,
+            character: item.range?.start.character ?? this.activeStreamContext.character,
             text: item.insertText,
             sessionId: value.sessionId,
             sequence: value.sequence,
@@ -164,6 +177,8 @@ export class StreamingCompletionController implements vscode.Disposable {
         // If we have a cached candidate for this position, return it
         if (
             this.cachedCandidate &&
+            this.cachedCandidate.uri === document.uri.toString() &&
+            this.cachedCandidate.version === document.version &&
             this.cachedCandidate.line === position.line &&
             this.cachedCandidate.character === position.character
         ) {
@@ -197,6 +212,12 @@ export class StreamingCompletionController implements vscode.Disposable {
 
         const partialResultToken = `stream-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
         this.activeProgressToken = partialResultToken;
+        this.activeStreamContext = {
+            uri: document.uri.toString(),
+            version: document.version,
+            line: position.line,
+            character: position.character,
+        };
 
         // Register progress handler for this specific token
         this.activeProgressDisposable = this.client.onProgress(
@@ -246,6 +267,7 @@ export class StreamingCompletionController implements vscode.Disposable {
             this.activeProgressDisposable = null;
         }
         this.activeProgressToken = null;
+        this.activeStreamContext = null;
         if (this.activeTokenSource) {
             this.activeTokenSource.cancel();
             this.activeTokenSource.dispose();

--- a/vscode-extension/src/test/streamingCompletion.test.ts
+++ b/vscode-extension/src/test/streamingCompletion.test.ts
@@ -21,26 +21,60 @@ import { StreamingCompletionController } from '../streamingCompletion';
 import { LanguageClient } from 'vscode-languageclient/node';
 
 /** Create a mock LanguageClient with the methods needed by StreamingCompletionController. */
-function createMockClient(): LanguageClient {
+function createMockClient(captureProgress?: (handler: (value: unknown) => void) => void): LanguageClient {
     return {
-        onProgress: jest.fn(() => ({ dispose: jest.fn() })),
+        onProgress: jest.fn((_type, _token, handler: (value: unknown) => void) => {
+            captureProgress?.(handler);
+            return { dispose: jest.fn() };
+        }),
         sendRequest: jest.fn(async () => ({})),
         sendNotification: jest.fn(),
     } as unknown as LanguageClient;
 }
 
+function makeDocument(uri: string, version: number): vscode.TextDocument {
+    return {
+        uri: { toString: () => uri },
+        version,
+    } as unknown as vscode.TextDocument;
+}
+
+type InlineProvider = {
+    provideInlineCompletionItems: (
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        context: vscode.InlineCompletionContext,
+        token: vscode.CancellationToken
+    ) => vscode.InlineCompletionItem[] | undefined;
+};
+
+function registeredProvider(): InlineProvider {
+    const call = (vscode.languages.registerInlineCompletionItemProvider as jest.Mock).mock.calls[0];
+    return call[1] as InlineProvider;
+}
+
 describe('StreamingCompletionController', () => {
     let mockClient: LanguageClient;
     let controller: StreamingCompletionController;
+    let progressHandler: ((value: unknown) => void) | undefined;
 
     beforeEach(() => {
         jest.clearAllMocks();
+        progressHandler = undefined;
         // Extend mock with needed symbols for inline completions
         (vscode as Record<string, unknown>).Position = class {
             constructor(public line: number, public character: number) {}
         };
+        (vscode as Record<string, unknown>).Range = class {
+            constructor(public start: unknown, public end: unknown) {}
+        };
         (vscode as Record<string, unknown>).InlineCompletionItem = class {
             constructor(public insertText: string, public range?: unknown) {}
+        };
+        (vscode as Record<string, unknown>).CancellationTokenSource = class {
+            token = { isCancellationRequested: false };
+            cancel = jest.fn();
+            dispose = jest.fn();
         };
         (vscode.languages as Record<string, unknown>).registerInlineCompletionItemProvider = jest.fn(() => ({
             dispose: jest.fn(),
@@ -51,8 +85,21 @@ describe('StreamingCompletionController', () => {
         (vscode.workspace as Record<string, unknown>).onDidChangeTextDocument = jest.fn(() => ({
             dispose: jest.fn(),
         }));
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn((key: string, defaultValue?: boolean) => {
+                if (key === 'aiCompletion.enabled') {
+                    return true;
+                }
+                if (key === 'aiCompletion.streaming.enabled') {
+                    return true;
+                }
+                return defaultValue;
+            }),
+        });
 
-        mockClient = createMockClient();
+        mockClient = createMockClient(handler => {
+            progressHandler = handler;
+        });
         controller = new StreamingCompletionController(mockClient);
     });
 
@@ -109,6 +156,97 @@ describe('StreamingCompletionController', () => {
             'perl/didShowInlineCompletion',
             { sessionId: 'session-2' }
         );
+    });
+
+    test('returns cached stream candidates for the matching document version', () => {
+        const provider = registeredProvider();
+        const document = makeDocument('file:///workspace/lib/App.pm', 4);
+        const position = new vscode.Position(10, 8);
+
+        const initial = provider.provideInlineCompletionItems(
+            document,
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+        expect(initial).toBeUndefined();
+
+        progressHandler?.({
+            kind: 'perlInlineCompletionStream',
+            sessionId: 'session-1',
+            sequence: 1,
+            isFinal: false,
+            items: [{ insertText: '->find_user($id)' }],
+        });
+
+        const cached = provider.provideInlineCompletionItems(
+            document,
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+
+        expect(cached?.[0]?.insertText).toBe('->find_user($id)');
+        expect(mockClient.sendRequest as jest.Mock).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not show cached stream candidates in another document', () => {
+        const provider = registeredProvider();
+        const position = new vscode.Position(10, 8);
+
+        provider.provideInlineCompletionItems(
+            makeDocument('file:///workspace/lib/App.pm', 4),
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+        progressHandler?.({
+            kind: 'perlInlineCompletionStream',
+            sessionId: 'session-1',
+            sequence: 1,
+            isFinal: false,
+            items: [{ insertText: '->find_user($id)' }],
+        });
+
+        const otherDocumentResult = provider.provideInlineCompletionItems(
+            makeDocument('file:///workspace/lib/Other.pm', 4),
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+
+        expect(otherDocumentResult).toBeUndefined();
+        expect(mockClient.sendRequest as jest.Mock).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not show cached stream candidates after the document version changes', () => {
+        const provider = registeredProvider();
+        const uri = 'file:///workspace/lib/App.pm';
+        const position = new vscode.Position(10, 8);
+
+        provider.provideInlineCompletionItems(
+            makeDocument(uri, 4),
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+        progressHandler?.({
+            kind: 'perlInlineCompletionStream',
+            sessionId: 'session-1',
+            sequence: 1,
+            isFinal: false,
+            items: [{ insertText: '->find_user($id)' }],
+        });
+
+        const newVersionResult = provider.provideInlineCompletionItems(
+            makeDocument(uri, 5),
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+
+        expect(newVersionResult).toBeUndefined();
+        expect(mockClient.sendRequest as jest.Mock).toHaveBeenCalledTimes(2);
     });
 });
 


### PR DESCRIPTION
Problem: Streaming inline completion candidates can be reused in another document at the same cursor position because the cache is keyed only by line and character.\nFix: Store the request document URI/version with cached candidates and return cached ghost text only when the active document version still matches.\nVerification: `npm test -- --runInBand src/test/streamingCompletion.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `just agent-pr-fast` passes.\n\nCloses EffortlessMetrics/perl-lsp-swarm#2683