### PR TITLE
fix(vscode): allow gherkin class captures (#9815)

### DIFF
--- a/vscode-extension/src/gherkinProviders.ts
+++ b/vscode-extension/src/gherkinProviders.ts
@@ -62,7 +62,7 @@ const STEP_DEFINITION_EXCLUDE_GLOB = '{**/node_modules/**,**/blib/**,**/.git/**}
 const STEP_DEFINITION_FILE_LIMIT = 1000;
 const MAX_MATCH_REGEX_LENGTH = 256;
 const MAX_MATCH_STEP_TEXT_LENGTH = 512;
-const POTENTIALLY_EXPENSIVE_REGEX_RE = /(?:\([^)]*[+*][^)]*\)|\[[^\]]+\])[+*{]|\\[1-9]|\(\?<[=!]|(\(\?[!=])/;
+const POTENTIALLY_EXPENSIVE_REGEX_RE = /\([^)]*[+*][^)]*\)[+*{]|\\[1-9]|\(\?<[=!]|\(\?[!=]/;
 const DELIMITER_PAIRS: Record<string, string> = {
     '{': '}',
     '[': ']',


### PR DESCRIPTION
Problem: VS Code Gherkin step navigation rejects common parameterized regex captures such as ([^"]+).\nFix: Keep nested quantified groups rejected while allowing linear character-class captures.\nVerification: `npm test -- --runInBand src/test/gherkinProviders.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `git diff --check` passes; `just agent-pr-fast` passes.