### PR TITLE
fix(vscode): render whats-new markdown links (#9817)

### DIFF
--- a/vscode-extension/src/test/whatsNew.test.ts
+++ b/vscode-extension/src/test/whatsNew.test.ts
@@ -269,6 +269,19 @@ describe('markdownToHtml', () => {
         expect(html).toContain('<code>perltidy</code>');
     });
 
+    test('converts http markdown links to anchors', () => {
+        const html = markdownToHtml('Read the [release notes](https://example.com/notes)');
+        expect(html).toContain(
+            '<a href="https://example.com/notes" rel="noopener noreferrer">release notes</a>',
+        );
+    });
+
+    test('leaves non-http markdown links as text', () => {
+        const html = markdownToHtml('Avoid [unsafe](javascript:alert(1)) links');
+        expect(html).not.toContain('<a href=');
+        expect(html).toContain('[unsafe](javascript:alert(1))');
+    });
+
     test('escapes HTML special characters', () => {
         const html = markdownToHtml('Use <br> & "quotes"');
         expect(html).not.toContain('<br>');

--- a/vscode-extension/src/whatsNew.ts
+++ b/vscode-extension/src/whatsNew.ts
@@ -311,6 +311,11 @@ export function markdownToHtml(md: string): string {
 function inlineMarkdown(text: string): string {
     // Escape HTML first, then apply Markdown inline rules.
     let s = escapeHtml(text);
+    // [label](https://example.com)
+    s = s.replace(
+        /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
+        '<a href="$2" rel="noopener noreferrer">$1</a>',
+    );
     // `code`
     s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
     // **bold**


### PR DESCRIPTION
Problem: The VS Code What's New panel renders CHANGELOG Markdown links as raw text.\nFix: Render safe http and https Markdown links as anchors while leaving unsupported schemes as plain text.\nVerification: `npm test -- --runInBand src/test/whatsNew.test.ts` passes; `npm run compile` passes; `npm run lint` passes; `git diff --check` passes; `just agent-pr-fast` passes.