### PR TITLE
fix(cli): hint check-project eof errors (#9819)

### DIFF
--- a/crates/perl-lsp-rs/src/cli/check_project.rs
+++ b/crates/perl-lsp-rs/src/cli/check_project.rs
@@ -168,7 +168,12 @@ fn emit_category_section(category_counts: &HashMap<String, usize>) {
 }
 
 fn categorize_error(msg: &str) -> String {
-    if msg.contains("Unexpected end of input") {
+    let normalized = msg.to_ascii_lowercase();
+    if normalized.contains("end of input")
+        || normalized.contains("unexpected eof")
+        || normalized.contains("found eof")
+        || normalized.contains("reached eof")
+    {
         "Unexpected EOF".to_string()
     } else if msg.contains("expected") && msg.contains("found") {
         "Unexpected token".to_string()
@@ -216,6 +221,11 @@ mod tests {
     #[test]
     fn categorize_error_maps_known_cases() {
         assert_eq!(categorize_error("Unexpected end of input while parsing"), "Unexpected EOF");
+        assert_eq!(
+            categorize_error("Unclosed block: expected '}' but reached end of input"),
+            "Unexpected EOF"
+        );
+        assert_eq!(categorize_error("expected expression, found EOF"), "Unexpected EOF");
         assert_eq!(categorize_error("expected ; but found }"), "Unexpected token");
         assert_eq!(categorize_error("Invalid syntax near token"), "Syntax error");
         assert_eq!(categorize_error("Lexer error: invalid byte"), "Lexer error");


### PR DESCRIPTION
Problem: `perllsp --check-project` classifies end-of-input parse failures as `Other`, so users miss the existing unclosed-block remediation hint.\nFix: Classify `end of input` and EOF variants as `Unexpected EOF` before the generic token bucket.\nVerification: `./scripts/cargo-safe test -p perl-lsp-rs categorize_error_maps_known_cases --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `./scripts/cargo-safe xtask fmt` passes; `git diff --check` passes; `just agent-pr-fast` passes. Clippy note: `./scripts/cargo-safe clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs` fails in untouched `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226` for `clone_on_copy`.