### PR TITLE
fix(cli): guide check file read errors (#9821)

### DIFF
--- a/crates/perl-lsp-rs/src/cli.rs
+++ b/crates/perl-lsp-rs/src/cli.rs
@@ -204,6 +204,9 @@ fn run_check(command_name: &str, files: &[String]) -> i32 {
             Ok(s) => s,
             Err(e) => {
                 eprintln!("{path}: error reading file: {e}");
+                if let Some(guidance) = file_read_error_guidance(&e) {
+                    eprintln!("help: {guidance}");
+                }
                 errors += 1;
                 continue;
             }
@@ -230,6 +233,21 @@ fn run_check(command_name: &str, files: &[String]) -> i32 {
     }
 
     if errors > 0 { 1 } else { 0 }
+}
+
+fn file_read_error_guidance(error: &std::io::Error) -> Option<&'static str> {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => {
+            Some("check the path, or use `--check-project <dir>` to scan a project directory")
+        }
+        std::io::ErrorKind::IsADirectory => {
+            Some("`--check` expects files; use `--check-project <dir>` to scan a directory")
+        }
+        std::io::ErrorKind::PermissionDenied => {
+            Some("check file permissions, then rerun with a readable Perl file")
+        }
+        _ => None,
+    }
 }
 
 fn format_parse_error_context(source: &str, error: &perl_parser::ParseError) -> Vec<String> {
@@ -454,9 +472,11 @@ fn print_version(command_name: &str) {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_parse_error_context, invocation_name, render_help_text, render_shell_completion,
+        file_read_error_guidance, format_parse_error_context, invocation_name, render_help_text,
+        render_shell_completion,
     };
     use std::ffi::OsString;
+    use std::io::ErrorKind;
 
     #[test]
     fn invocation_name_uses_file_stem_from_first_arg() {
@@ -497,6 +517,30 @@ mod tests {
         assert!(rendered.contains("_my_perl_lsp"));
         assert!(rendered.contains("my-perl-lsp"));
         assert!(!rendered.contains("complete -F _perl_lsp perl-lsp"));
+    }
+
+    #[test]
+    fn file_read_error_guidance_covers_common_user_actions()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let missing = std::io::Error::from(ErrorKind::NotFound);
+        let directory = std::io::Error::from(ErrorKind::IsADirectory);
+        let denied = std::io::Error::from(ErrorKind::PermissionDenied);
+        let interrupted = std::io::Error::from(ErrorKind::Interrupted);
+
+        assert_eq!(
+            file_read_error_guidance(&missing),
+            Some("check the path, or use `--check-project <dir>` to scan a project directory")
+        );
+        assert_eq!(
+            file_read_error_guidance(&directory),
+            Some("`--check` expects files; use `--check-project <dir>` to scan a directory")
+        );
+        assert_eq!(
+            file_read_error_guidance(&denied),
+            Some("check file permissions, then rerun with a readable Perl file")
+        );
+        assert_eq!(file_read_error_guidance(&interrupted), None);
+        Ok(())
     }
 
     #[test]

--- a/crates/perl-lsp-rs/tests/cli_smoke.rs
+++ b/crates/perl-lsp-rs/tests/cli_smoke.rs
@@ -57,7 +57,8 @@ fn check_nonexistent_file() {
         .arg("/nonexistent/path/to/file.pl")
         .assert()
         .failure()
-        .stderr(predicates::str::contains("error reading file"));
+        .stderr(predicates::str::contains("error reading file"))
+        .stderr(predicates::str::contains("help: check the path"));
 }
 
 #[test]


### PR DESCRIPTION
Problem: `perllsp --check <file>` read failures only surfaced the raw OS error, leaving users to infer the next step.\nFix: Add targeted help guidance for missing paths, directory inputs, and permission-denied files while preserving the OS error.\nVerification: `./scripts/cargo-safe test -p perl-lsp-rs file_read_error_guidance --profile agent --locked` passes; `./scripts/cargo-safe test -p perl-lsp-rs check_nonexistent_file --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `./scripts/cargo-safe xtask fmt` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` shows repo-local target dirs at 0.0G. `./scripts/cargo-safe clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs` currently fails on an existing untouched `clone_on_copy` warning at `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.