### PR TITLE
fix(dap): guide breakpoint read errors (#9823)

### DIFF
--- a/crates/perl-dap/src/breakpoints.rs
+++ b/crates/perl-dap/src/breakpoints.rs
@@ -157,6 +157,30 @@ fn file_paths_match(stored: &str, observed: &str) -> bool {
     false
 }
 
+fn format_source_read_error(source_path: &str, error: &std::io::Error) -> String {
+    let mut message = format!("Unable to read source file '{source_path}': {error}");
+    if let Some(guidance) = source_read_error_guidance(error) {
+        message.push_str(". ");
+        message.push_str(guidance);
+    }
+    message
+}
+
+fn source_read_error_guidance(error: &std::io::Error) -> Option<&'static str> {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => {
+            Some("Check that the file still exists, then set the breakpoint again.")
+        }
+        std::io::ErrorKind::PermissionDenied => {
+            Some("Check file permissions before setting breakpoints.")
+        }
+        std::io::ErrorKind::IsADirectory => {
+            Some("Breakpoints can only be set in Perl script files.")
+        }
+        _ => None,
+    }
+}
+
 /// Thread-safe breakpoint storage
 ///
 /// Stores breakpoints indexed by source file path. Provides methods for
@@ -233,10 +257,9 @@ impl BreakpointStore {
         let source_breakpoints = args.breakpoints.as_deref().unwrap_or(&[]);
 
         // Read source file and parse once for AST validation (AC7).
-        let source_content = std::fs::read_to_string(&source_path).ok();
-        let validator = source_content
-            .as_ref()
-            .map(|content| AstBreakpointValidator::new(content).map_err(|e| e.to_string()));
+        let validator = std::fs::read_to_string(&source_path)
+            .map_err(|error| format_source_read_error(&source_path, &error))
+            .and_then(|content| AstBreakpointValidator::new(&content).map_err(|e| e.to_string()));
         let mut validation_cache: HashMap<(i64, Option<i64>), (bool, i64, Option<String>)> =
             HashMap::new();
 
@@ -331,15 +354,11 @@ impl BreakpointStore {
                     cached.clone()
                 } else {
                     let computed = match &validator {
-                        Some(Ok(v)) => {
+                        Ok(v) => {
                             let result = v.validate_with_column(bp.line, bp.column);
                             (result.verified, result.line, result.message)
                         }
-                        Some(Err(error)) => (false, bp.line, Some(error.clone())),
-                        None => {
-                            // Can't read file - mark as unverified but still create breakpoint.
-                            (false, bp.line, Some("Unable to read source file".to_string()))
-                        }
+                        Err(error) => (false, bp.line, Some(error.clone())),
                     };
                     validation_cache.insert((bp.line, bp.column), computed.clone());
                     computed
@@ -348,7 +367,7 @@ impl BreakpointStore {
             let mut verified = verified;
             let message = if verified
                 && bp.condition.is_some()
-                && let Some(Ok(v)) = &validator
+                && let Ok(v) = &validator
                 && let Some(condition) = bp.condition.as_deref()
             {
                 let condition_validation = v.validate_condition(resolved_line, condition);
@@ -525,7 +544,7 @@ mod tests {
     use super::*;
     use crate::protocol::{SetBreakpointsArguments, Source, SourceBreakpoint};
     use perl_tdd_support::must;
-    use std::io::Write;
+    use std::io::{Error as IoError, ErrorKind, Write};
     use tempfile::NamedTempFile;
 
     /// Create a temp file with valid Perl code for testing breakpoints.
@@ -932,6 +951,46 @@ print "result: $final\n";
         assert_eq!(evaluate_hit_condition(Some("%2"), 4), Some(true));
         assert_eq!(evaluate_hit_condition(Some("%0"), 4), None);
         assert_eq!(evaluate_hit_condition(Some("invalid"), 1), None);
+    }
+
+    #[test]
+    fn source_read_error_message_keeps_path_error_and_guidance()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let error = IoError::from(ErrorKind::NotFound);
+
+        let message = format_source_read_error("/workspace/missing.pl", &error);
+
+        assert!(
+            message.contains("Unable to read source file '/workspace/missing.pl'"),
+            "expected path in message, got: {message}"
+        );
+        assert!(
+            message.contains("No such file") || message.contains("not found"),
+            "expected OS error detail in message, got: {message}"
+        );
+        assert!(
+            message.contains("file still exists"),
+            "expected recovery guidance in message, got: {message}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn source_read_error_message_keeps_unknown_errors_unembellished()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let error = IoError::from(ErrorKind::Interrupted);
+
+        let message = format_source_read_error("/workspace/script.pl", &error);
+
+        assert!(
+            message.contains("Unable to read source file '/workspace/script.pl'"),
+            "expected path in message, got: {message}"
+        );
+        assert!(
+            !message.contains("file still exists") && !message.contains("file permissions"),
+            "unexpected guidance for unknown error kind, got: {message}"
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/perl-dap/tests/dap_breakpoint_matrix_tests.rs
+++ b/crates/perl-dap/tests/dap_breakpoint_matrix_tests.rs
@@ -318,7 +318,9 @@ fn test_breakpoint_file_not_found() -> Result<()> {
         .message
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("Expected breakpoint message"))?;
-    assert!(message.contains("Unable to read"));
+    assert!(message.contains("Unable to read source file"), "message was: {message}");
+    assert!(message.contains("/nonexistent/file.pl"), "message was: {message}");
+    assert!(message.contains("file still exists"), "message was: {message}");
 
     Ok(())
 }


### PR DESCRIPTION
Problem: DAP breakpoint verification hid source read details behind a generic "Unable to read source file" message.\nFix: Preserve the file path and OS read error in breakpoint messages, with concise guidance for missing files, permission issues, and directory inputs.\nVerification: `./scripts/cargo-safe test -p perl-dap source_read_error_message --profile agent --locked` passes; `./scripts/cargo-safe test -p perl-dap test_breakpoint_file_not_found --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes with existing dead-code warnings in `crates/perl-dap/tests/common/mod.rs`; `./scripts/cargo-safe xtask fmt` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` shows repo-local target dirs at 0.0G. `./scripts/cargo-safe clippy -p perl-dap --profile agent --locked -- -D warnings -A missing_docs` currently fails on an existing untouched `clone_on_copy` warning at `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.