### PR TITLE
fix(dap): guide attach config errors (#9827)

### DIFF
--- a/crates/perl-dap/src/config/mod.rs
+++ b/crates/perl-dap/src/config/mod.rs
@@ -284,23 +284,31 @@ impl AttachConfiguration {
     pub fn validate(&self) -> Result<()> {
         // Verify host is not empty
         if self.host.trim().is_empty() {
-            anyhow::bail!("Host cannot be empty");
+            anyhow::bail!(
+                "Host cannot be empty. Set attach host to a hostname or IP address, for example `localhost`."
+            );
         }
 
         // Port is u16, so it's automatically in range 0-65535
         // But we should reject port 0 as it's not valid for connecting
         if self.port == 0 {
-            anyhow::bail!("Port must be in range 1-65535");
+            anyhow::bail!(
+                "Port must be in range 1-65535. Use the port printed by the Perl debug adapter, usually 13603."
+            );
         }
 
         // Verify timeout is reasonable (if specified)
         if let Some(timeout) = self.timeout_ms {
             if timeout == 0 {
-                anyhow::bail!("Timeout must be greater than 0 milliseconds");
+                anyhow::bail!(
+                    "Timeout must be greater than 0 milliseconds. Use 5000 for the default 5 second wait."
+                );
             }
             if timeout > 300_000 {
                 // 5 minutes max
-                anyhow::bail!("Timeout cannot exceed 300000 milliseconds (5 minutes)");
+                anyhow::bail!(
+                    "Timeout cannot exceed 300000 milliseconds (5 minutes). Omit timeout to use the default 5000ms wait."
+                );
             }
         }
 

--- a/crates/perl-dap/src/tcp_attach/config.rs
+++ b/crates/perl-dap/src/tcp_attach/config.rs
@@ -34,23 +34,36 @@ impl TcpAttachConfig {
     pub fn validate(&self) -> Result<()> {
         let host = self.host.trim_matches(' ');
         if host.is_empty() {
-            anyhow::bail!("Host cannot be empty");
+            anyhow::bail!(
+                "Host cannot be empty. Set attach host to a hostname or IP address, for example `localhost`."
+            );
         }
         if host.chars().any(char::is_whitespace) {
-            anyhow::bail!("Host cannot contain whitespace");
+            anyhow::bail!(
+                "Host cannot contain whitespace. Use a single hostname or IP address, for example `localhost`."
+            );
         }
         if host.chars().any(char::is_control) {
-            anyhow::bail!("Host cannot contain control characters");
+            anyhow::bail!(
+                "Host cannot contain control characters. Remove line breaks or pasted hidden characters."
+            );
         }
         if self.port == 0 {
-            anyhow::bail!("Port must be in range 1-65535");
+            anyhow::bail!(
+                "Port must be in range 1-65535. Use the port printed by the Perl debug adapter, usually 13603."
+            );
         }
         if let Some(timeout) = self.timeout_ms {
             if timeout == 0 {
-                anyhow::bail!("Timeout must be greater than 0 milliseconds");
+                anyhow::bail!(
+                    "Timeout must be greater than 0 milliseconds. Use 5000 for the default 5 second wait."
+                );
             }
             if timeout > MAX_TIMEOUT_MS {
-                anyhow::bail!("Timeout cannot exceed {} milliseconds (5 minutes)", MAX_TIMEOUT_MS);
+                anyhow::bail!(
+                    "Timeout cannot exceed {} milliseconds (5 minutes). Omit timeout to use the default 5000ms wait.",
+                    MAX_TIMEOUT_MS
+                );
             }
         }
         Ok(())
@@ -104,5 +117,32 @@ mod tests {
 
         let config = TcpAttachConfig::new("localhost".to_string(), 13603).with_timeout(10000);
         assert_eq!(config.timeout_duration(), Duration::from_millis(10000));
+    }
+
+    #[test]
+    fn validation_errors_include_recovery_guidance() -> Result<(), Box<dyn std::error::Error>> {
+        let empty_host = TcpAttachConfig::new("".to_string(), 13603)
+            .validate()
+            .err()
+            .ok_or("expected empty host error")?
+            .to_string();
+        assert!(empty_host.contains("hostname or IP address"), "message was: {empty_host}");
+
+        let zero_port = TcpAttachConfig::new("localhost".to_string(), 0)
+            .validate()
+            .err()
+            .ok_or("expected zero port error")?
+            .to_string();
+        assert!(zero_port.contains("usually 13603"), "message was: {zero_port}");
+
+        let zero_timeout = TcpAttachConfig::new("localhost".to_string(), 13603)
+            .with_timeout(0)
+            .validate()
+            .err()
+            .ok_or("expected zero timeout error")?
+            .to_string();
+        assert!(zero_timeout.contains("default 5 second wait"), "message was: {zero_timeout}");
+
+        Ok(())
     }
 }

--- a/crates/perl-dap/tests/config_attach_config_tests.rs
+++ b/crates/perl-dap/tests/config_attach_config_tests.rs
@@ -137,6 +137,48 @@ fn test_attach_config_validation_no_timeout() {
 }
 
 #[test]
+fn test_attach_config_validation_errors_include_recovery_guidance()
+-> Result<(), Box<dyn std::error::Error>> {
+    let empty_host = AttachConfiguration {
+        host: "".to_string(),
+        port: 13603,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    }
+    .validate()
+    .err()
+    .ok_or("expected empty host error")?
+    .to_string();
+    assert!(empty_host.contains("hostname or IP address"), "message was: {empty_host}");
+
+    let zero_port = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 0,
+        timeout_ms: Some(5000),
+        stop_on_entry: None,
+    }
+    .validate()
+    .err()
+    .ok_or("expected zero port error")?
+    .to_string();
+    assert!(zero_port.contains("usually 13603"), "message was: {zero_port}");
+
+    let zero_timeout = AttachConfiguration {
+        host: "localhost".to_string(),
+        port: 13603,
+        timeout_ms: Some(0),
+        stop_on_entry: None,
+    }
+    .validate()
+    .err()
+    .ok_or("expected zero timeout error")?
+    .to_string();
+    assert!(zero_timeout.contains("default 5 second wait"), "message was: {zero_timeout}");
+
+    Ok(())
+}
+
+#[test]
 fn test_attach_json_snippet_valid_json() -> Result<(), Box<dyn std::error::Error>> {
     // Test: attach JSON snippet is valid and complete
     let snippet = create_attach_json_snippet();


### PR DESCRIPTION
Problem: DAP attach configuration validation returned terse failures for common launch.json mistakes like empty hosts, port 0, and invalid timeouts.\nFix: Add concise recovery guidance and expected-value examples to the public and TCP attach configuration validators.\nVerification: `./scripts/cargo-safe test -p perl-dap validation_errors_include_recovery_guidance --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes with existing dead-code warnings in `crates/perl-dap/tests/common/mod.rs`; `./scripts/cargo-safe xtask fmt` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` shows repo-local target dirs at 0.0G. `./scripts/cargo-safe clippy -p perl-dap --profile agent --locked -- -D warnings -A missing_docs` currently fails on an existing untouched `clone_on_copy` warning at `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.