### PR TITLE
fix(dap): guide inactive variable updates (#9833)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/variables.rs
+++ b/crates/perl-dap/src/debug_adapter/variables.rs
@@ -343,7 +343,7 @@ impl DebugAdapter {
                     success: false,
                     command: "setVariable".to_string(),
                     body: None,
-                    message: Some("No debugger session active".to_string()),
+                    message: Some(Self::no_debugger_session_message("setVariable")),
                 };
             }
         } else if let Some(pid) = *lock_or_recover(&self.attached_pid, "debug_adapter.attached_pid")
@@ -365,7 +365,7 @@ impl DebugAdapter {
                 success: false,
                 command: "setVariable".to_string(),
                 body: None,
-                message: Some("No debugger session".to_string()),
+                message: Some(Self::no_debugger_session_message("setVariable")),
             };
         };
 
@@ -403,6 +403,13 @@ impl DebugAdapter {
             body: serde_json::to_value(&set_var_body).ok(),
             message: None,
         }
+    }
+
+    fn no_debugger_session_message(command: &str) -> String {
+        format!(
+            "No debugger session is active. Start a launch or attach request first, wait for the \
+             debugger to stop at a breakpoint, then retry {command}."
+        )
     }
 }
 
@@ -474,4 +481,40 @@ fn is_numeric_literal(value: &str) -> bool {
         .all(|ch| ch.is_ascii_digit() || matches!(ch, '+' | '-' | '.' | 'e' | 'E'));
 
     has_digit && allowed_chars && normalized.parse::<f64>().is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn set_variable_without_session_guides_recovery() -> TestResult {
+        let mut adapter = DebugAdapter::new();
+
+        let response = adapter.handle_request(
+            1,
+            "setVariable",
+            Some(json!({
+                "variablesReference": 11,
+                "name": "$x",
+                "value": "2"
+            })),
+        );
+
+        match response {
+            DapMessage::Response { success, command, message, .. } => {
+                assert_eq!(command, "setVariable");
+                assert!(!success, "setVariable without a session should fail");
+                let message = message.ok_or("setVariable failure should include guidance")?;
+                assert!(message.contains("No debugger session is active"));
+                assert!(message.contains("Start a launch or attach request"));
+                assert!(message.contains("retry setVariable"));
+            }
+            other => return Err(format!("expected setVariable response, got {other:?}").into()),
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Problem: DAP setVariable failures before launch or attach only said no debugger session existed.\nFix: Add inactive-session recovery guidance for setVariable and lock it with a focused regression test.\nVerification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-dap set_variable_without_session_guides_recovery --profile agent --locked` passes; `./scripts/cargo-safe test -p perl-dap test_set_variable_without_session_returns_error --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes; `just agent-pr-fast` passes. Clippy still fails on the pre-existing `clone_on_copy` lint in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.