### PR TITLE
fix(dap): guide missing scope frame ids (#9835)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/frames.rs
+++ b/crates/perl-dap/src/debug_adapter/frames.rs
@@ -136,7 +136,7 @@ impl DebugAdapter {
                     success: false,
                     command: "scopes".to_string(),
                     body: None,
-                    message: Some("Missing frameId".to_string()),
+                    message: Some(Self::missing_scope_frame_id_message()),
                 };
             }
         };
@@ -181,6 +181,12 @@ impl DebugAdapter {
             message: None,
         }
     }
+
+    fn missing_scope_frame_id_message() -> String {
+        "Missing frameId for scopes request. Request stackTrace first and pass one of the returned \
+         stackFrames[].id values as frameId."
+            .to_string()
+    }
 }
 
 impl DebugAdapter {
@@ -194,5 +200,33 @@ impl DebugAdapter {
             Some(limit) => iter.take(limit).collect(),
             None => iter.collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn scopes_missing_frame_id_guides_recovery() -> TestResult {
+        let mut adapter = DebugAdapter::new();
+
+        let response = adapter.handle_request(1, "scopes", None);
+
+        match response {
+            DapMessage::Response { success, command, message, .. } => {
+                assert_eq!(command, "scopes");
+                assert!(!success, "scopes without frameId should fail");
+                let message = message.ok_or("scopes failure should include guidance")?;
+                assert!(message.contains("Missing frameId"));
+                assert!(message.contains("Request stackTrace first"));
+                assert!(message.contains("stackFrames[].id"));
+            }
+            other => return Err(format!("expected scopes response, got {other:?}").into()),
+        }
+
+        Ok(())
     }
 }

--- a/crates/perl-dap/tests/dap_comprehensive_test.rs
+++ b/crates/perl-dap/tests/dap_comprehensive_test.rs
@@ -507,7 +507,9 @@ fn test_dap_scopes_missing_frame() {
         DapMessage::Response { success, command, message, .. } => {
             assert!(!success);
             assert_eq!(command, "scopes");
-            assert_eq!(must_some(message), "Missing frameId");
+            let message = must_some(message);
+            assert!(message.contains("Missing frameId"));
+            assert!(message.contains("Request stackTrace first"));
         }
         _ => must(Err::<(), _>("Expected response message")),
     }


### PR DESCRIPTION
Problem: DAP scopes failures without frameId only said frameId was missing.\nFix: Tell clients to request stackTrace first and pass a returned stackFrames[].id, with focused regression coverage.\nVerification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-dap scopes_missing_frame_id_guides_recovery --profile agent --locked` passes; `./scripts/cargo-safe test -p perl-dap test_dap_scopes_missing_frame --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes; `just agent-pr-fast` passes. Clippy still fails on the pre-existing `clone_on_copy` lint in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.