### PR TITLE
fix(dap): guide invalid watchpoint names (#9837)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/breakpoints/data.rs
+++ b/crates/perl-dap/src/debug_adapter/breakpoints/data.rs
@@ -32,7 +32,7 @@ impl DebugAdapter {
         } else {
             DataBreakpointInfoResponseBody {
                 data_id: None,
-                description: "Cannot watch this expression".to_string(),
+                description: Self::unwatchable_data_breakpoint_description(),
                 access_types: None,
             }
         };
@@ -45,6 +45,12 @@ impl DebugAdapter {
             body: serde_json::to_value(&body).ok(),
             message: None,
         }
+    }
+
+    fn unwatchable_data_breakpoint_description() -> String {
+        "Cannot watch this expression: data breakpoints require a Perl variable name such as \
+         `$foo`, `@items`, `%hash`, or `$Package::var`."
+            .to_string()
     }
 
     /// Handle setDataBreakpoints request — set watchpoints via Perl debugger `w` command.

--- a/crates/perl-dap/tests/dap_watchpoints_tests.rs
+++ b/crates/perl-dap/tests/dap_watchpoints_tests.rs
@@ -107,6 +107,12 @@ fn test_data_breakpoint_info_invalid_name() -> TestResult {
         data_id.is_none() || data_id.is_some_and(|v| v.is_null()),
         "Invalid name should have null dataId"
     );
+    let description =
+        body.get("description").and_then(|v| v.as_str()).ok_or("missing description")?;
+    assert!(description.contains("Perl variable name"), "got: {description}");
+    assert!(description.contains("$foo"), "got: {description}");
+    assert!(description.contains("@items"), "got: {description}");
+    assert!(description.contains("%hash"), "got: {description}");
 
     Ok(())
 }


### PR DESCRIPTION
Problem: DAP dataBreakpointInfo rejected invalid watch expressions with a terse description.\nFix: Keep the DAP success/no-dataId shape but explain valid Perl variable-name forms with examples.\nVerification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-dap test_data_breakpoint_info_invalid_name --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes; `just agent-pr-fast` passes. Clippy still fails on the pre-existing `clone_on_copy` lint in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.