### PR TITLE
fix(dap): guide invalid function breakpoints (#9839)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/breakpoints/function.rs
+++ b/crates/perl-dap/src/debug_adapter/breakpoints/function.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+const FUNCTION_BREAKPOINT_NAME_GUIDANCE: &str =
+    "Use a Perl subroutine name such as `main::run`, `Foo::bar`, or `My::Package::handler`.";
+
 impl DebugAdapter {
     /// Handle setFunctionBreakpoints request.
     ///
@@ -44,12 +47,16 @@ impl DebugAdapter {
             };
 
             let invalid_reason = if name.is_empty() {
-                Some("Function breakpoint name is required".to_string())
+                Some(format!(
+                    "Function breakpoint name is required. {FUNCTION_BREAKPOINT_NAME_GUIDANCE}"
+                ))
             } else if name.contains('\n') || name.contains('\r') {
-                Some("Function breakpoint name cannot contain newlines".to_string())
+                Some(format!(
+                    "Function breakpoint name cannot contain newlines. {FUNCTION_BREAKPOINT_NAME_GUIDANCE}"
+                ))
             } else if !is_valid_function_breakpoint_name(&name) {
                 Some(format!(
-                    "Invalid function breakpoint name `{name}` (expected package-qualified Perl symbol)"
+                    "Invalid function breakpoint name `{name}`. {FUNCTION_BREAKPOINT_NAME_GUIDANCE}"
                 ))
             } else {
                 None

--- a/crates/perl-dap/tests/dap_comprehensive_test.rs
+++ b/crates/perl-dap/tests/dap_comprehensive_test.rs
@@ -311,6 +311,26 @@ fn test_dap_set_function_breakpoints_validation() -> TestResult {
             assert_eq!(breakpoints[1].get("verified").and_then(|v| v.as_bool()), Some(true));
             assert_eq!(breakpoints[2].get("verified").and_then(|v| v.as_bool()), Some(false));
             assert_eq!(breakpoints[3].get("verified").and_then(|v| v.as_bool()), Some(false));
+            let invalid_name_message = breakpoints[2]
+                .get("message")
+                .and_then(|v| v.as_str())
+                .ok_or("Invalid function breakpoint should include a message")?;
+            assert!(
+                invalid_name_message.contains("main::run"),
+                "invalid function breakpoint should suggest a package-qualified example"
+            );
+            assert!(
+                invalid_name_message.contains("Foo::bar"),
+                "invalid function breakpoint should suggest a common package method example"
+            );
+            let newline_message = breakpoints[3]
+                .get("message")
+                .and_then(|v| v.as_str())
+                .ok_or("Newline function breakpoint should include a message")?;
+            assert!(
+                newline_message.contains("My::Package::handler"),
+                "newline function breakpoint should still include recovery guidance"
+            );
         }
         _ => must(Err::<(), _>("Expected response message")),
     }


### PR DESCRIPTION
Problem: Invalid DAP function breakpoint names did not show users valid Perl subroutine-name forms.
Fix: Add shared recovery guidance with examples and assert it for invalid function breakpoint responses.
Verification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-dap test_dap_set_function_breakpoints_validation --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G. Direct clippy is blocked by the existing unrelated `clone_on_copy` lint in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.