### PR TITLE
fix(dap): guide breakpoint location arguments (#9841)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/breakpoints/locations.rs
+++ b/crates/perl-dap/src/debug_adapter/breakpoints/locations.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+const BREAKPOINT_LOCATIONS_ARGUMENTS_GUIDANCE: &str = "Missing or invalid arguments. Send a \
+    `source.path` and `line`, for example `{ \"source\": { \"path\": \"script.pl\" }, \"line\": 1 }`.";
+
 impl DebugAdapter {
     pub(in crate::debug_adapter) fn handle_breakpoint_locations(
         &self,
@@ -17,7 +20,7 @@ impl DebugAdapter {
                         success: false,
                         command: "breakpointLocations".to_string(),
                         body: None,
-                        message: Some("Missing or invalid arguments".to_string()),
+                        message: Some(BREAKPOINT_LOCATIONS_ARGUMENTS_GUIDANCE.to_string()),
                     };
                 }
             };

--- a/crates/perl-dap/tests/dap_protocol_message_tests.rs
+++ b/crates/perl-dap/tests/dap_protocol_message_tests.rs
@@ -53,6 +53,11 @@ fn test_breakpoint_locations_missing_arguments() -> Result<(), Box<dyn std::erro
         err.to_lowercase().contains("missing") || err.to_lowercase().contains("invalid"),
         "error should describe missing/invalid arguments: {err}"
     );
+    assert!(err.contains("source.path"), "error should name the required source path field: {err}");
+    assert!(
+        err.contains("\"line\": 1"),
+        "error should show a breakpointLocations line example: {err}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Problem: `breakpointLocations` missing-argument errors did not tell users which request fields to provide.
Fix: Include `source.path`, `line`, and a minimal request example in the failure response, with protocol test coverage.
Verification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-dap test_breakpoint_locations_missing_arguments --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G. Direct clippy is blocked by the existing unrelated `clone_on_copy` lint in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.