### PR TITLE
fix(dap): guide setBreakpoints arguments (#9843)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/breakpoints/line.rs
+++ b/crates/perl-dap/src/debug_adapter/breakpoints/line.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+const SET_BREAKPOINTS_ARGUMENTS_GUIDANCE: &str = "Send `source.path` and a `breakpoints` array \
+    (empty to clear breakpoints), for example `{ \"source\": { \"path\": \"script.pl\" }, \"breakpoints\": [{ \"line\": 1 }] }`.";
+
 impl DebugAdapter {
     /// Handle setBreakpoints request
     pub(in crate::debug_adapter) fn handle_set_breakpoints(
@@ -15,7 +18,7 @@ impl DebugAdapter {
                 success: false,
                 command: "setBreakpoints".to_string(),
                 body: None,
-                message: Some("Missing arguments".to_string()),
+                message: Some(format!("Missing arguments. {SET_BREAKPOINTS_ARGUMENTS_GUIDANCE}")),
             };
         };
 
@@ -29,7 +32,9 @@ impl DebugAdapter {
                         success: false,
                         command: "setBreakpoints".to_string(),
                         body: None,
-                        message: Some(format!("Invalid arguments: {}", e)),
+                        message: Some(format!(
+                            "Invalid arguments: {e}. {SET_BREAKPOINTS_ARGUMENTS_GUIDANCE}"
+                        )),
                     };
                 }
             };

--- a/crates/perl-dap/tests/dap_dispatcher_removal_regression_tests.rs
+++ b/crates/perl-dap/tests/dap_dispatcher_removal_regression_tests.rs
@@ -216,7 +216,8 @@ fn set_breakpoints_preserves_request_order_through_dispatch() {
 /// the dispatch handler must reject `arguments: None` with a structured
 /// failure response - never panic, never return success.
 #[test]
-fn set_breakpoints_with_missing_arguments_fails_structured() {
+fn set_breakpoints_with_missing_arguments_fails_structured()
+-> Result<(), Box<dyn std::error::Error>> {
     let mut adapter = DebugAdapter::new();
     let response = adapter.handle_request(1, "setBreakpoints", None);
 
@@ -224,10 +225,46 @@ fn set_breakpoints_with_missing_arguments_fails_structured() {
         DapMessage::Response { success, command, message, .. } => {
             assert!(!success, "missing arguments must produce success=false");
             assert_eq!(command, "setBreakpoints");
-            assert!(message.is_some(), "missing arguments must include an error message");
+            let message = message.ok_or("missing arguments must include an error message")?;
+            assert!(
+                message.contains("source.path"),
+                "missing arguments should name the required source path field: {message}"
+            );
+            assert!(
+                message.contains("\"breakpoints\""),
+                "missing arguments should show the breakpoints array shape: {message}"
+            );
         }
         other => must(Err::<(), _>(format!("expected Response, got {other:?}"))),
     }
+
+    Ok(())
+}
+
+#[test]
+fn set_breakpoints_with_invalid_arguments_guides_request_shape()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut adapter = DebugAdapter::new();
+    let response = adapter.handle_request(1, "setBreakpoints", Some(json!({})));
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "invalid arguments must produce success=false");
+            assert_eq!(command, "setBreakpoints");
+            let message = message.ok_or("invalid arguments must include an error message")?;
+            assert!(
+                message.contains("source.path"),
+                "invalid arguments should name the required source path field: {message}"
+            );
+            assert!(
+                message.contains("\"line\": 1"),
+                "invalid arguments should show a breakpoint line example: {message}"
+            );
+        }
+        other => must(Err::<(), _>(format!("expected Response, got {other:?}"))),
+    }
+
+    Ok(())
 }
 
 // --- inlineValues -------------------------------------------------------------


### PR DESCRIPTION
Problem: `setBreakpoints` missing/invalid argument errors did not show the request shape users need to send.
Fix: Add guidance naming `source.path`, the `breakpoints` array, clear behavior, and a minimal line example, with dispatcher regression coverage.
Verification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-dap set_breakpoints_with_missing_arguments_fails_structured --profile agent --locked` passes; `./scripts/cargo-safe test -p perl-dap set_breakpoints_with_invalid_arguments_guides_request_shape --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G. Direct clippy is blocked by the existing unrelated `clone_on_copy` lint in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.