### PR TITLE
fix(dap): guide inlineValues arguments (#9845)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/output.rs
+++ b/crates/perl-dap/src/debug_adapter/output.rs
@@ -2,6 +2,9 @@
 
 use super::*;
 
+const INLINE_VALUES_ARGUMENTS_GUIDANCE: &str = "Send `source.path`, `startLine`, and `endLine`, \
+    for example `{ \"source\": { \"path\": \"script.pl\" }, \"startLine\": 1, \"endLine\": 3 }`.";
+
 impl DebugAdapter {
     /// Handle inlineValues request (custom)
     ///
@@ -20,7 +23,7 @@ impl DebugAdapter {
                 success: false,
                 command: "inlineValues".to_string(),
                 body: None,
-                message: Some("Missing arguments".to_string()),
+                message: Some(format!("Missing arguments. {INLINE_VALUES_ARGUMENTS_GUIDANCE}")),
             };
         };
 
@@ -33,7 +36,9 @@ impl DebugAdapter {
                     success: false,
                     command: "inlineValues".to_string(),
                     body: None,
-                    message: Some(format!("Invalid arguments: {}", e)),
+                    message: Some(format!(
+                        "Invalid arguments: {e}. {INLINE_VALUES_ARGUMENTS_GUIDANCE}"
+                    )),
                 };
             }
         };
@@ -45,7 +50,9 @@ impl DebugAdapter {
                 success: false,
                 command: "inlineValues".to_string(),
                 body: None,
-                message: Some("inlineValues requires source.path".to_string()),
+                message: Some(format!(
+                    "inlineValues requires source.path. {INLINE_VALUES_ARGUMENTS_GUIDANCE}"
+                )),
             };
         };
 
@@ -56,7 +63,9 @@ impl DebugAdapter {
                 success: false,
                 command: "inlineValues".to_string(),
                 body: None,
-                message: Some("inlineValues requires positive startLine/endLine".to_string()),
+                message: Some(format!(
+                    "inlineValues requires positive startLine/endLine. {INLINE_VALUES_ARGUMENTS_GUIDANCE}"
+                )),
             };
         }
 

--- a/crates/perl-dap/tests/session_lifecycle_tests.rs
+++ b/crates/perl-dap/tests/session_lifecycle_tests.rs
@@ -779,8 +779,42 @@ fn test_session_lifecycle_inline_values_missing_arguments() {
         DapMessage::Response { success, command, message, .. } => {
             assert!(!success, "inlineValues should fail without arguments");
             assert_eq!(command, "inlineValues");
-            assert!(message.is_some());
-            assert!(must_some(message).contains("Missing arguments"));
+            let message = must_some(message);
+            assert!(message.contains("Missing arguments"));
+            assert!(
+                message.contains("startLine") && message.contains("endLine"),
+                "inlineValues missing-arguments guidance should include the line range fields: {message}"
+            );
+            assert!(
+                message.contains("source.path"),
+                "inlineValues missing-arguments guidance should include source.path: {message}"
+            );
+        }
+        _ => must(Err::<(), _>("Expected Response message".to_string())),
+    }
+}
+
+#[test]
+// AC:5.5
+fn test_session_lifecycle_inline_values_invalid_arguments_guidance() {
+    let (mut adapter, _rx) = create_test_adapter();
+
+    let response = adapter.handle_request(1, "inlineValues", Some(json!({})));
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success, "inlineValues should fail with malformed arguments");
+            assert_eq!(command, "inlineValues");
+            let message = must_some(message);
+            assert!(message.contains("Invalid arguments"));
+            assert!(
+                message.contains("source.path"),
+                "inlineValues invalid-arguments guidance should include source.path: {message}"
+            );
+            assert!(
+                message.contains("\"startLine\": 1"),
+                "inlineValues invalid-arguments guidance should include a request example: {message}"
+            );
         }
         _ => must(Err::<(), _>("Expected Response message".to_string())),
     }
@@ -803,8 +837,12 @@ fn test_session_lifecycle_inline_values_missing_source_path() {
         DapMessage::Response { success, command, message, .. } => {
             assert!(!success, "inlineValues should fail without source.path");
             assert_eq!(command, "inlineValues");
-            assert!(message.is_some());
-            assert!(must_some(message).contains("source.path"));
+            let message = must_some(message);
+            assert!(message.contains("source.path"));
+            assert!(
+                message.contains("startLine") && message.contains("endLine"),
+                "inlineValues source.path error should keep the request-shape guidance: {message}"
+            );
         }
         _ => must(Err::<(), _>("Expected Response message".to_string())),
     }
@@ -827,8 +865,12 @@ fn test_session_lifecycle_inline_values_invalid_line_range() {
         DapMessage::Response { success, command, message, .. } => {
             assert!(!success, "inlineValues should reject non-positive line numbers");
             assert_eq!(command, "inlineValues");
-            assert!(message.is_some());
-            assert!(must_some(message).contains("startLine/endLine"));
+            let message = must_some(message);
+            assert!(message.contains("startLine/endLine"));
+            assert!(
+                message.contains("source.path"),
+                "inlineValues line-range error should keep the request-shape guidance: {message}"
+            );
         }
         _ => must(Err::<(), _>("Expected Response message".to_string())),
     }


### PR DESCRIPTION
Problem: `inlineValues` argument errors did not show the request shape needed by users or editor integrations.
Fix: Add shared guidance for `source.path`, `startLine`, and `endLine`, and assert it across missing, malformed, missing-path, and invalid-line cases.
Verification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-dap test_session_lifecycle_inline_values --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target dirs at 0.0G. Direct clippy is blocked by the existing unrelated `clone_on_copy` lint in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.