### PR TITLE
fix(lsp): guide virtual content URI errors (#9851)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/virtual_content.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/virtual_content.rs
@@ -16,20 +16,20 @@ impl LspServer {
     ) -> Result<Option<Value>, JsonRpcError> {
         let params = params.ok_or_else(|| JsonRpcError {
             code: crate::protocol::INVALID_PARAMS,
-            message: "Missing params".to_string(),
+            message: missing_virtual_content_uri_message("Missing params"),
             data: None,
         })?;
 
         let uri = params.get("uri").and_then(|u| u.as_str()).ok_or_else(|| JsonRpcError {
             code: crate::protocol::INVALID_PARAMS,
-            message: "Missing or invalid URI".to_string(),
+            message: missing_virtual_content_uri_message("Missing or invalid URI"),
             data: None,
         })?;
 
         if !is_valid_virtual_content_uri(uri) {
             return Err(JsonRpcError {
                 code: crate::protocol::INVALID_PARAMS,
-                message: "Missing or invalid URI".to_string(),
+                message: missing_virtual_content_uri_message("Missing or invalid URI"),
                 data: None,
             });
         }
@@ -40,7 +40,7 @@ impl LspServer {
         } else {
             Err(JsonRpcError {
                 code: -32600,
-                message: format!("Unsupported URI scheme or content not found: {}", uri),
+                message: unsupported_virtual_content_uri_message(uri),
                 data: None,
             })
         }
@@ -51,6 +51,18 @@ impl LspServer {
         self.send_request("workspace/textDocumentContent/refresh", json!({ "uri": uri }))
             .map(|_| ())
     }
+}
+
+fn missing_virtual_content_uri_message(summary: &str) -> String {
+    format!(
+        "{summary}: workspace/textDocumentContent expects params.uri such as `perldoc://strict` or `perldoc://Module::Name`"
+    )
+}
+
+fn unsupported_virtual_content_uri_message(uri: &str) -> String {
+    format!(
+        "Unsupported URI scheme or content not found: {uri}\nhelp: use a perldoc URI such as `perldoc://strict`; for perldoc URIs, install perldoc and check that the module exists"
+    )
 }
 
 fn is_valid_virtual_content_uri(uri: &str) -> bool {
@@ -157,6 +169,18 @@ mod tests {
         assert!(!is_valid_virtual_content_uri("perldoc://"));
         assert!(is_valid_virtual_content_uri("perldoc://strict"));
         assert!(is_valid_virtual_content_uri("perldoc://Module::Name"));
+    }
+
+    #[test]
+    fn parser_virtual_content_error_messages_include_perldoc_uri_guidance() {
+        let missing = missing_virtual_content_uri_message("Missing or invalid URI");
+        assert!(missing.contains("workspace/textDocumentContent expects params.uri"));
+        assert!(missing.contains("perldoc://strict"));
+
+        let unsupported = unsupported_virtual_content_uri_message("unsupported://some/path");
+        assert!(unsupported.contains("Unsupported URI scheme or content not found"));
+        assert!(unsupported.contains("help: use a perldoc URI"));
+        assert!(unsupported.contains("install perldoc"));
     }
 
     #[test]

--- a/crates/perl-lsp-rs/tests/lsp_text_document_content_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_text_document_content_tests.rs
@@ -72,6 +72,19 @@ fn assert_error_code(response: &Value, expected_code: i32) -> TestResult {
     Ok(())
 }
 
+fn assert_error_message_contains(response: &Value, expected: &[&str]) -> TestResult {
+    let message = response
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("missing error message in response: {response}"))?;
+
+    for needle in expected {
+        assert!(message.contains(*needle), "expected `{needle}` in error message: {message}");
+    }
+
+    Ok(())
+}
+
 fn wait_for_method(output: &OutputCapture, method: &str) -> TestResult<Value> {
     let deadline = Instant::now() + Duration::from_millis(250);
     loop {
@@ -108,19 +121,31 @@ fn initialize_advertises_perldoc_text_document_content_scheme() -> TestResult {
 #[test]
 fn text_document_content_missing_params_returns_invalid_params() -> TestResult {
     let response = text_document_content_response(None)?;
-    assert_error_code(&response, INVALID_PARAMS)
+    assert_error_code(&response, INVALID_PARAMS)?;
+    assert_error_message_contains(
+        &response,
+        &["workspace/textDocumentContent expects params.uri", "perldoc://strict"],
+    )
 }
 
 #[test]
 fn text_document_content_missing_uri_returns_invalid_params() -> TestResult {
     let response = text_document_content_response(Some(json!({})))?;
-    assert_error_code(&response, INVALID_PARAMS)
+    assert_error_code(&response, INVALID_PARAMS)?;
+    assert_error_message_contains(
+        &response,
+        &["workspace/textDocumentContent expects params.uri", "perldoc://Module::Name"],
+    )
 }
 
 #[test]
 fn text_document_content_invalid_uri_returns_invalid_params() -> TestResult {
     let response = text_document_content_response(Some(json!({ "uri": "not a uri" })))?;
-    assert_error_code(&response, INVALID_PARAMS)
+    assert_error_code(&response, INVALID_PARAMS)?;
+    assert_error_message_contains(
+        &response,
+        &["Missing or invalid URI", "workspace/textDocumentContent expects params.uri"],
+    )
 }
 
 #[test]
@@ -128,15 +153,14 @@ fn text_document_content_unsupported_scheme_returns_deterministic_error() -> Tes
     let response =
         text_document_content_response(Some(json!({ "uri": "unsupported://some/path" })))?;
     assert_error_code(&response, INVALID_REQUEST)?;
-    let message = response
-        .pointer("/error/message")
-        .and_then(Value::as_str)
-        .ok_or_else(|| format!("missing error message in response: {response}"))?;
-    assert!(
-        message.contains("Unsupported URI scheme or content not found"),
-        "unexpected unsupported-scheme error: {message}"
-    );
-    Ok(())
+    assert_error_message_contains(
+        &response,
+        &[
+            "Unsupported URI scheme or content not found",
+            "help: use a perldoc URI",
+            "perldoc://strict",
+        ],
+    )
 }
 
 #[test]
@@ -145,14 +169,10 @@ fn text_document_content_perldoc_strict_returns_text_or_explicit_unavailable_err
 
     if response.get("error").is_some() {
         assert_error_code(&response, INVALID_REQUEST)?;
-        let message = response
-            .pointer("/error/message")
-            .and_then(Value::as_str)
-            .ok_or_else(|| format!("missing error message in response: {response}"))?;
-        assert!(
-            message.contains("Unsupported URI scheme or content not found"),
-            "perldoc unavailable path should be explicit, got: {message}"
-        );
+        assert_error_message_contains(
+            &response,
+            &["Unsupported URI scheme or content not found", "install perldoc", "module exists"],
+        )?;
         return Ok(());
     }
 


### PR DESCRIPTION
Problem: `workspace/textDocumentContent` URI errors did not show a valid perldoc URI shape.
Fix: Add `params.uri` guidance, `perldoc://` examples, and perldoc/module recovery text while preserving existing JSON-RPC codes.
Verification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-lsp-rs parser_virtual_content_error_messages_include_perldoc_uri_guidance --profile agent --locked` passes; `./scripts/cargo-safe test -p perl-lsp-rs --test lsp_text_document_content_tests --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target 0.0G. Direct clippy still fails on pre-existing `clone_on_copy` in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.