### PR TITLE
fix(lsp): guide document link resolve errors (#9853)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/document_links.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/document_links.rs
@@ -77,6 +77,31 @@ fn normalize_document_link_file_path(file_path: &str) -> Cow<'_, str> {
     Cow::Owned(normalized)
 }
 
+fn document_link_resolve_missing_params_message() -> String {
+    "Missing parameters for documentLink/resolve: pass the DocumentLink object returned by textDocument/documentLink; request fresh document links if the link is stale"
+        .to_string()
+}
+
+fn document_link_resolve_data_message(summary: &str) -> String {
+    format!(
+        "{summary}: documentLink/resolve expects a DocumentLink returned by textDocument/documentLink with data.type set to `module`, `file`, or `url`; request fresh document links before retrying"
+    )
+}
+
+fn document_link_resolve_module_data_message() -> String {
+    document_link_resolve_data_message(
+        "Missing module name in data; module links require data.module such as `Data::Dumper`",
+    )
+}
+
+fn document_link_resolve_file_path_message() -> String {
+    document_link_resolve_data_message("Missing file path in data; file links require data.path")
+}
+
+fn document_link_resolve_base_uri_message() -> String {
+    document_link_resolve_data_message("Missing base URI in data; file links require data.baseUri")
+}
+
 impl LspServer {
     /// Handle textDocument/documentLink request
     pub(crate) fn handle_document_links(
@@ -142,7 +167,7 @@ impl LspServer {
                             .and_then(|m| m.as_str())
                             .ok_or_else(|| JsonRpcError {
                                 code: INVALID_PARAMS,
-                                message: "Missing module name in data".into(),
+                                message: document_link_resolve_module_data_message(),
                                 data: None,
                             })?;
 
@@ -161,7 +186,7 @@ impl LspServer {
                             data_obj.get("path").and_then(|p| p.as_str()).ok_or_else(|| {
                                 JsonRpcError {
                                     code: INVALID_PARAMS,
-                                    message: "Missing file path in data".into(),
+                                    message: document_link_resolve_file_path_message(),
                                     data: None,
                                 }
                             })?;
@@ -172,7 +197,7 @@ impl LspServer {
                             .and_then(|u| u.as_str())
                             .ok_or_else(|| JsonRpcError {
                                 code: INVALID_PARAMS,
-                                message: "Missing base URI in data".into(),
+                                message: document_link_resolve_base_uri_message(),
                                 data: None,
                             })?;
 
@@ -192,7 +217,9 @@ impl LspServer {
                         // Unknown link type - return error
                         return Err(JsonRpcError {
                             code: INVALID_PARAMS,
-                            message: "Unknown link type in data field".into(),
+                            message: document_link_resolve_data_message(
+                                "Unknown link type in data field",
+                            ),
                             data: Some(json!({"linkType": link_type})),
                         });
                     }
@@ -203,7 +230,7 @@ impl LspServer {
         } else {
             Err(JsonRpcError {
                 code: INVALID_PARAMS,
-                message: "Missing parameters for documentLink/resolve".into(),
+                message: document_link_resolve_missing_params_message(),
                 data: None,
             })
         }
@@ -245,7 +272,12 @@ impl LspServer {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_document_link_file_path, resolve_file_link_target};
+    use super::{
+        document_link_resolve_base_uri_message, document_link_resolve_data_message,
+        document_link_resolve_file_path_message, document_link_resolve_missing_params_message,
+        document_link_resolve_module_data_message, normalize_document_link_file_path,
+        resolve_file_link_target,
+    };
 
     #[test]
     fn normalize_document_link_file_path_collapses_windows_separators() {
@@ -276,5 +308,28 @@ mod tests {
             "//server/share/lib/Thing.pm",
         );
         assert_eq!(resolved, Some("file://server/share/lib/Thing.pm".to_string()));
+    }
+
+    #[test]
+    fn document_link_resolve_error_messages_include_recovery_guidance() {
+        let missing = document_link_resolve_missing_params_message();
+        assert!(missing.contains("pass the DocumentLink object"));
+        assert!(missing.contains("request fresh document links"));
+
+        let unknown = document_link_resolve_data_message("Unknown link type in data field");
+        assert!(unknown.contains("data.type"));
+        assert!(unknown.contains("module"));
+        assert!(unknown.contains("file"));
+        assert!(unknown.contains("url"));
+
+        let module = document_link_resolve_module_data_message();
+        assert!(module.contains("data.module"));
+        assert!(module.contains("Data::Dumper"));
+
+        let file_path = document_link_resolve_file_path_message();
+        assert!(file_path.contains("data.path"));
+
+        let base_uri = document_link_resolve_base_uri_message();
+        assert!(base_uri.contains("data.baseUri"));
     }
 }

--- a/crates/perl-lsp-rs/tests/lsp_document_link_resolve_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_document_link_resolve_tests.rs
@@ -3,10 +3,47 @@
 //! Tests the deferred resolution pattern where initial documentLink returns
 //! links with data fields, and documentLink/resolve fills in the target.
 
-use perl_lsp::{JsonRpcRequest, LspServer};
-use serde_json::json;
+use perl_lsp::{JsonRpcError, JsonRpcRequest, LspServer};
+use serde_json::{Value, json};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn initialized_server() -> LspServer {
+    let server = LspServer::new();
+
+    let init_params = json!({
+        "capabilities": {},
+        "rootUri": "file:///workspace"
+    });
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: Some(perl_lsp::protocol::JsonRpcId::Integer((1) as i64)),
+        method: "initialize".to_string(),
+        params: Some(init_params),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "initialized".to_string(),
+        params: Some(json!({})),
+    });
+
+    server
+}
+
+fn document_link_resolve_error(params: Option<Value>) -> Result<JsonRpcError, String> {
+    let server = initialized_server();
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: Some(perl_lsp::protocol::JsonRpcId::Integer((2) as i64)),
+        method: "documentLink/resolve".to_string(),
+        params,
+    });
+
+    let resp = response.ok_or_else(|| "Expected response from documentLink/resolve".to_string())?;
+    resp.error.ok_or_else(|| format!("Expected error field in response: {:?}", resp.result))
+}
 
 /// Test that documentLink/resolve returns target for deferred module links
 #[test]
@@ -240,6 +277,57 @@ fn test_document_link_resolve_invalid_data() -> TestResult {
     assert!(resp.error.is_some());
     let error = resp.error.ok_or("Expected error field in response")?;
     assert_eq!(error.code, -32602); // INVALID_PARAMS
+    assert!(error.message.contains("data.type"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("module"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("file"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("url"), "unexpected message: {}", error.message);
+
+    Ok(())
+}
+
+#[test]
+fn test_document_link_resolve_missing_data_fields_include_guidance() -> TestResult {
+    let missing_module = document_link_resolve_error(Some(json!({
+        "range": {
+            "start": {"line": 0, "character": 4},
+            "end": {"line": 0, "character": 16}
+        },
+        "data": {
+            "type": "module"
+        }
+    })))?;
+    assert_eq!(missing_module.code, -32602);
+    assert!(missing_module.message.contains("data.module"));
+    assert!(missing_module.message.contains("Data::Dumper"));
+    assert!(missing_module.message.contains("request fresh document links"));
+
+    let missing_path = document_link_resolve_error(Some(json!({
+        "range": {
+            "start": {"line": 0, "character": 4},
+            "end": {"line": 0, "character": 16}
+        },
+        "data": {
+            "type": "file",
+            "baseUri": "file:///workspace/script.pl"
+        }
+    })))?;
+    assert_eq!(missing_path.code, -32602);
+    assert!(missing_path.message.contains("data.path"));
+    assert!(missing_path.message.contains("request fresh document links"));
+
+    let missing_base_uri = document_link_resolve_error(Some(json!({
+        "range": {
+            "start": {"line": 0, "character": 4},
+            "end": {"line": 0, "character": 16}
+        },
+        "data": {
+            "type": "file",
+            "path": "lib/Foo.pm"
+        }
+    })))?;
+    assert_eq!(missing_base_uri.code, -32602);
+    assert!(missing_base_uri.message.contains("data.baseUri"));
+    assert!(missing_base_uri.message.contains("request fresh document links"));
 
     Ok(())
 }
@@ -283,6 +371,8 @@ fn test_document_link_resolve_missing_params() -> TestResult {
     assert!(resp.error.is_some());
     let error = resp.error.ok_or("Expected error field in response")?;
     assert_eq!(error.code, -32602); // INVALID_PARAMS
+    assert!(error.message.contains("pass the DocumentLink object"));
+    assert!(error.message.contains("request fresh document links"));
 
     Ok(())
 }


### PR DESCRIPTION
Problem: `documentLink/resolve` invalid-parameter errors did not tell clients how to recover from stale or malformed link data.
Fix: Add guidance that names required `data` fields, lists supported link types, and tells clients to pass a DocumentLink from `textDocument/documentLink` or request fresh links before retrying.
Verification: `./scripts/cargo-safe xtask fmt` passes; `./scripts/cargo-safe test -p perl-lsp-rs --test lsp_document_link_resolve_tests --profile agent --locked` passes; `./scripts/cargo-safe test -p perl-lsp-rs document_link_resolve_error_messages_include_recovery_guidance --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target 0.0G. Direct clippy still fails on pre-existing `clone_on_copy` in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.