### PR TITLE
fix(lsp): guide executeCommand request-shape errors (#9855)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/misc.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/misc.rs
@@ -1068,6 +1068,12 @@ impl LspServer {
         Ok(Some(json!([])))
     }
 
+    fn execute_command_request_shape_message(summary: &str) -> String {
+        format!(
+            "{summary}: workspace/executeCommand expects params.command plus params.arguments, for example {{\"command\":\"perl.runFile\",\"arguments\":[\"file:///path/to/script.pl\"]}}; include \"arguments\": [] when the command takes no arguments"
+        )
+    }
+
     /// Handle execute command request
     pub(crate) fn handle_execute_command(
         &self,
@@ -1076,16 +1082,19 @@ impl LspServer {
         use crate::execute_command::ExecuteCommandProvider;
 
         if let Some(params) = params {
-            let command = params["command"]
-                .as_str()
-                .ok_or_else(|| invalid_params("Missing required parameter: command"))?;
+            let command = params["command"].as_str().ok_or_else(|| {
+                invalid_params(&Self::execute_command_request_shape_message(
+                    "Missing required parameter: command",
+                ))
+            })?;
 
             // LSP 3.17 compliance: arguments field is required even if empty
             if !params.as_object().unwrap_or(&serde_json::Map::new()).contains_key("arguments") {
                 return Err(JsonRpcError {
                     code: -32602, // InvalidParams
-                    message: "Missing required 'arguments' field in executeCommand request"
-                        .to_string(),
+                    message: Self::execute_command_request_shape_message(
+                        "Missing required 'arguments' field in executeCommand request",
+                    ),
                     data: Some(json!({
                         "command": command,
                         "errorType": "executeCommand",
@@ -1317,7 +1326,9 @@ impl LspServer {
         // Missing params entirely
         Err(JsonRpcError {
             code: -32602, // InvalidParams
-            message: "Missing parameters for executeCommand request".to_string(),
+            message: Self::execute_command_request_shape_message(
+                "Missing parameters for executeCommand request",
+            ),
             data: Some(json!({
                 "errorType": "executeCommand",
                 "originalError": "Missing params"

--- a/crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_execute_command_tests.rs
@@ -1,5 +1,5 @@
 //! Tests for LSP execute command functionality
-use perl_lsp::{JsonRpcRequest, LspServer};
+use perl_lsp::{JsonRpcError, JsonRpcRequest, LspServer};
 use serde_json::{Value, json};
 use std::fs;
 use tempfile::TempDir;
@@ -36,6 +36,33 @@ fn setup_server(root_path: Option<String>) -> LspServer {
 
 fn test_error(message: impl Into<String>) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, message.into())
+}
+
+fn execute_command_error(
+    params: Option<Value>,
+) -> Result<JsonRpcError, Box<dyn std::error::Error>> {
+    let server = setup_server(None);
+    let response = server
+        .handle_request(JsonRpcRequest {
+            _jsonrpc: "2.0".to_string(),
+            method: "workspace/executeCommand".to_string(),
+            params,
+            id: Some(perl_lsp::protocol::JsonRpcId::Integer((2) as i64)),
+        })
+        .ok_or_else(|| test_error("expected executeCommand response"))?;
+
+    response.error.ok_or_else(|| {
+        test_error(format!("expected executeCommand error, got {:?}", response.result)).into()
+    })
+}
+
+fn assert_execute_command_shape_guidance(error: &JsonRpcError, summary: &str) {
+    assert_eq!(error.code, -32602);
+    assert!(error.message.contains(summary), "unexpected message: {}", error.message);
+    assert!(error.message.contains("params.command"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("params.arguments"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("perl.runFile"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("\"arguments\": []"), "unexpected message: {}", error.message);
 }
 
 fn sorted_object_keys_at(
@@ -267,6 +294,39 @@ fn test_execute_command_unknown() -> Result<(), Box<dyn std::error::Error>> {
     assert!(response.is_some());
     let response = response.ok_or("Expected a response for unknown command")?;
     assert!(response.error.is_some());
+
+    Ok(())
+}
+
+#[test]
+fn test_execute_command_request_shape_errors_include_guidance()
+-> Result<(), Box<dyn std::error::Error>> {
+    let missing_params = execute_command_error(None)?;
+    assert_execute_command_shape_guidance(
+        &missing_params,
+        "Missing parameters for executeCommand request",
+    );
+
+    let missing_command = execute_command_error(Some(json!({
+        "arguments": []
+    })))?;
+    assert_execute_command_shape_guidance(&missing_command, "Missing required parameter: command");
+
+    let missing_arguments = execute_command_error(Some(json!({
+        "command": "perl.runCritic"
+    })))?;
+    assert_execute_command_shape_guidance(
+        &missing_arguments,
+        "Missing required 'arguments' field in executeCommand request",
+    );
+    assert_eq!(
+        missing_arguments
+            .data
+            .as_ref()
+            .and_then(|data| data.pointer("/command"))
+            .and_then(Value::as_str),
+        Some("perl.runCritic")
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Problem: Malformed workspace/executeCommand requests returned terse missing-parameter errors that did not show clients the required params.command/params.arguments shape.\nFix: Add shared request-shape guidance for missing params, command, or arguments and cover the messages in LSP tests.\nVerification: `./scripts/cargo-safe test -p perl-lsp-rs test_execute_command_request_shape_errors_include_guidance --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `./scripts/cargo-safe xtask fmt` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target 0.0G. Direct clippy still fails on the pre-existing `clone_on_copy` warning in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.