### PR TITLE
fix(lsp): guide unknown method errors (#9859)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/mod.rs
@@ -78,6 +78,7 @@ impl LspServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use perl_tdd_support::must_some;
 
     fn request(id: i64, method: &str, params: Option<Value>) -> JsonRpcRequest {
         JsonRpcRequest {
@@ -104,10 +105,39 @@ mod tests {
             "initialize request should succeed"
         );
 
-        let after_initialize = server
-            .handle_request(request(3, "custom/unknown", None))
-            .and_then(|response| response.error)
-            .map(|error| error.code);
-        assert_eq!(after_initialize, Some(-32601));
+        let after_initialize = must_some(
+            server
+                .handle_request(request(3, "custom/unknown", None))
+                .and_then(|response| response.error),
+        );
+        assert_eq!(after_initialize.code, -32601);
+        assert!(
+            after_initialize.message.contains("custom/unknown"),
+            "unexpected message: {}",
+            after_initialize.message
+        );
+        assert!(
+            after_initialize.message.contains("LSP method spelling"),
+            "unexpected message: {}",
+            after_initialize.message
+        );
+        assert!(
+            after_initialize.message.contains("capabilities returned by initialize"),
+            "unexpected message: {}",
+            after_initialize.message
+        );
+        assert!(
+            after_initialize.message.contains("workspace/executeCommand"),
+            "unexpected message: {}",
+            after_initialize.message
+        );
+        assert_eq!(
+            after_initialize
+                .data
+                .as_ref()
+                .and_then(|data| data.pointer("/method"))
+                .and_then(Value::as_str),
+            Some("custom/unknown")
+        );
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/dispatch/routing.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/routing.rs
@@ -6,6 +6,12 @@
 use super::super::*;
 use super::response::RoutedResponse;
 
+fn unsupported_method_message(method: &str) -> String {
+    format!(
+        "Method '{method}' not found or not supported: check the LSP method spelling and the capabilities returned by initialize; supported examples include textDocument/hover, textDocument/completion, textDocument/formatting, and workspace/executeCommand"
+    )
+}
+
 impl LspServer {
     pub(super) fn route_request(
         &self,
@@ -197,7 +203,7 @@ impl LspServer {
                 // Enhanced error response with comprehensive context
                 Err(enhanced_error(
                     METHOD_NOT_FOUND,
-                    &format!("Method '{}' not found or not supported", method),
+                    &unsupported_method_message(&method),
                     "method_not_found",
                     Some(&method),
                 ))


### PR DESCRIPTION
Problem: Unknown or unsupported LSP methods returned a terse not-found message that did not help client authors recover.\nFix: Keep MethodNotFound semantics and data.method, but add guidance to check method spelling and initialize capabilities with common supported examples.\nVerification: `./scripts/cargo-safe test -p perl-lsp-rs requests_are_accepted_after_initialize_even_without_initialized_notification --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `./scripts/cargo-safe xtask fmt` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target 0.0G. Direct clippy still fails on the pre-existing `clone_on_copy` warning in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.