### PR TITLE
fix(inline): guide streaming request-shape errors (#9861)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/streaming.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/streaming.rs
@@ -9,6 +9,16 @@ use super::super::*;
 use crate::protocol::{invalid_params, req_position, req_uri};
 use crate::runtime::stream_session::SessionKey;
 
+fn streaming_inline_completion_request_shape_message(summary: &str) -> String {
+    format!(
+        "{summary}: textDocument/perlInlineCompletionStream expects params.textDocument.uri plus params.position.line and params.position.character; include params.partialResultToken to receive $/progress chunks, otherwise use textDocument/inlineCompletion for one-shot results"
+    )
+}
+
+fn invalid_streaming_inline_completion_params(summary: &str) -> JsonRpcError {
+    invalid_params(&streaming_inline_completion_request_shape_message(summary))
+}
+
 impl LspServer {
     /// Handle `textDocument/perlInlineCompletionStream` custom request.
     ///
@@ -21,10 +31,13 @@ impl LspServer {
         &self,
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
-        let params = params.ok_or_else(|| invalid_params("missing params"))?;
+        let params =
+            params.ok_or_else(|| invalid_streaming_inline_completion_params("Missing params"))?;
 
-        let uri = req_uri(&params)?;
-        let (line, character) = req_position(&params)?;
+        let uri = req_uri(&params)
+            .map_err(|error| invalid_streaming_inline_completion_params(&error.message))?;
+        let (line, character) = req_position(&params)
+            .map_err(|error| invalid_streaming_inline_completion_params(&error.message))?;
         let partial_result_token =
             params.get("partialResultToken").and_then(|v| v.as_str()).map(|s| s.to_string());
         let document_version = params

--- a/crates/perl-lsp-rs/tests/lsp_streaming_completion_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_streaming_completion_tests.rs
@@ -11,7 +11,8 @@
 
 mod support;
 
-use serde_json::json;
+use perl_lsp::{JsonRpcError, JsonRpcRequest, LspServer};
+use serde_json::{Value, json};
 use std::time::Duration;
 use support::lsp_harness::LspHarness;
 
@@ -22,6 +23,74 @@ fn init_harness() -> Result<LspHarness, String> {
     let mut harness = LspHarness::new();
     harness.initialize(None)?;
     Ok(harness)
+}
+
+fn test_error(message: impl Into<String>) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, message.into())
+}
+
+fn initialized_server() -> LspServer {
+    let server = LspServer::new();
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: Some(perl_lsp::protocol::JsonRpcId::Integer(1)),
+        method: "initialize".to_string(),
+        params: Some(json!({})),
+    });
+    server
+}
+
+fn streaming_completion_error(
+    params: Option<Value>,
+) -> Result<JsonRpcError, Box<dyn std::error::Error>> {
+    let server = initialized_server();
+    let response = server
+        .handle_request(JsonRpcRequest {
+            _jsonrpc: "2.0".to_string(),
+            id: Some(perl_lsp::protocol::JsonRpcId::Integer(2)),
+            method: "textDocument/perlInlineCompletionStream".to_string(),
+            params,
+        })
+        .ok_or_else(|| test_error("expected streaming completion response"))?;
+
+    response.error.ok_or_else(|| {
+        test_error(format!("expected streaming completion error, got {:?}", response.result)).into()
+    })
+}
+
+fn assert_streaming_completion_shape_guidance(error: &JsonRpcError, summary: &str) {
+    assert_eq!(error.code, -32602);
+    assert!(error.message.contains(summary), "unexpected message: {}", error.message);
+    assert!(
+        error.message.contains("textDocument/perlInlineCompletionStream"),
+        "unexpected message: {}",
+        error.message
+    );
+    assert!(
+        error.message.contains("params.textDocument.uri"),
+        "unexpected message: {}",
+        error.message
+    );
+    assert!(
+        error.message.contains("params.position.line"),
+        "unexpected message: {}",
+        error.message
+    );
+    assert!(
+        error.message.contains("params.position.character"),
+        "unexpected message: {}",
+        error.message
+    );
+    assert!(
+        error.message.contains("params.partialResultToken"),
+        "unexpected message: {}",
+        error.message
+    );
+    assert!(
+        error.message.contains("textDocument/inlineCompletion"),
+        "unexpected message: {}",
+        error.message
+    );
 }
 
 /// Helper: enable AI streaming completion via didChangeConfiguration.
@@ -415,6 +484,20 @@ fn streaming_completion_missing_params_returns_error() -> TestResult {
 
     // Should return an error (missing textDocument.uri).
     assert!(result.is_err(), "streaming request with empty params should error");
+
+    Ok(())
+}
+
+#[test]
+fn streaming_completion_request_shape_errors_include_guidance() -> TestResult {
+    let missing_params = streaming_completion_error(None)?;
+    assert_streaming_completion_shape_guidance(&missing_params, "Missing params");
+
+    let missing_uri = streaming_completion_error(Some(json!({})))?;
+    assert_streaming_completion_shape_guidance(
+        &missing_uri,
+        "Missing required parameter: textDocument.uri",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Problem: Malformed textDocument/perlInlineCompletionStream requests returned terse missing-parameter errors without the custom request shape.\nFix: Wrap missing params, URI, and position validation with guidance for required fields, partialResultToken streaming, and the one-shot inlineCompletion fallback.\nVerification: `./scripts/cargo-safe test -p perl-lsp-rs streaming_completion_request_shape_errors_include_guidance --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `./scripts/cargo-safe xtask fmt` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target 0.0G. Direct clippy still fails on the pre-existing `clone_on_copy` warning in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.