### PR TITLE
fix(lsp): guide rename target errors (#9863)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/rename.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/rename.rs
@@ -37,6 +37,16 @@ fn strip_perl_sigil(name: &str) -> &str {
     }
 }
 
+fn invalid_rename_target(summary: &str) -> JsonRpcError {
+    JsonRpcError {
+        code: -32602,
+        message: format!(
+            "{summary}: textDocument/rename expects newName to be a valid Perl identifier, for example renamed_value, $renamed_value, @renamed_values, or %renamed_values; for variables, keep the current sigil or omit it so perl-lsp preserves the existing sigil"
+        ),
+        data: None,
+    }
+}
+
 fn lexical_declaration_keyword_before(source: &str, symbol_start: usize) -> bool {
     let line_start =
         if symbol_start == 0 { 0 } else { source[..symbol_start].rfind('\n').map_or(0, |p| p + 1) };
@@ -511,11 +521,7 @@ impl LspServer {
         requested_name: &str,
     ) -> Result<String, JsonRpcError> {
         if requested_name.is_empty() {
-            return Err(JsonRpcError {
-                code: -32602,
-                message: "Invalid identifier: empty rename target".to_string(),
-                data: None,
-            });
+            return Err(invalid_rename_target("Invalid identifier: empty rename target"));
         }
 
         let current_sigil =
@@ -528,14 +534,10 @@ impl LspServer {
                 let bare_name = if let Some(first) = requested_first {
                     if is_perl_sigil(first) {
                         if first != sigil {
-                            return Err(JsonRpcError {
-                                code: -32602,
-                                message: format!(
-                                    "Invalid identifier: sigil '{}' does not match '{}'",
-                                    first, sigil
-                                ),
-                                data: None,
-                            });
+                            return Err(invalid_rename_target(&format!(
+                                "Invalid identifier: sigil '{}' does not match '{}'",
+                                first, sigil
+                            )));
                         }
                         requested_chars.collect::<String>()
                     } else {
@@ -546,22 +548,20 @@ impl LspServer {
                 };
 
                 if !self.is_valid_identifier(&bare_name) {
-                    return Err(JsonRpcError {
-                        code: -32602,
-                        message: format!("Invalid identifier: {}", requested_name),
-                        data: None,
-                    });
+                    return Err(invalid_rename_target(&format!(
+                        "Invalid identifier: {}",
+                        requested_name
+                    )));
                 }
 
                 Ok(format!("{}{}", sigil, bare_name))
             }
             None => {
                 if !self.is_valid_identifier(requested_name) {
-                    return Err(JsonRpcError {
-                        code: -32602,
-                        message: format!("Invalid identifier: {}", requested_name),
-                        data: None,
-                    });
+                    return Err(invalid_rename_target(&format!(
+                        "Invalid identifier: {}",
+                        requested_name
+                    )));
                 }
                 Ok(requested_name.to_string())
             }

--- a/crates/perl-lsp-rs/tests/lsp_rename_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_rename_tests.rs
@@ -14,6 +14,30 @@ use support::lsp_harness::LspHarness;
 
 type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
+fn assert_rename_target_guidance(message: &str) {
+    assert!(
+        message.contains("textDocument/rename"),
+        "rename error should name the request, got: {message}"
+    );
+    assert!(message.contains("newName"), "rename error should name newName, got: {message}");
+    assert!(
+        message.contains("valid Perl identifier"),
+        "rename error should explain identifier shape, got: {message}"
+    );
+    assert!(
+        message.contains("renamed_value"),
+        "rename error should include a bare identifier example, got: {message}"
+    );
+    assert!(
+        message.contains("$renamed_value"),
+        "rename error should include a scalar example, got: {message}"
+    );
+    assert!(
+        message.contains("preserves the existing sigil"),
+        "rename error should explain sigil preservation, got: {message}"
+    );
+}
+
 #[derive(Debug, Clone)]
 struct InverseTextEdit {
     start: usize,
@@ -479,6 +503,7 @@ fn test_rename_mismatched_sigil_is_rejected() -> TestResult {
                 msg.contains("sigil") || msg.contains("Invalid") || msg.contains("32602"),
                 "error should mention sigil mismatch or invalid identifier, got: {msg}"
             );
+            assert_rename_target_guidance(&msg);
         }
         Ok(response) => {
             // If it didn't error, the edits must not contain the mismatched sigil.
@@ -529,6 +554,7 @@ print $x;
                 msg.contains("empty") || msg.contains("Invalid") || msg.contains("32602"),
                 "empty newName should error with invalid-identifier, got: {msg}"
             );
+            assert_rename_target_guidance(&msg);
         }
         Ok(response) => {
             // If the server accepted it, the edits must not have empty newText.
@@ -584,6 +610,7 @@ fn test_rename_invalid_identifier_is_rejected() -> TestResult {
                 msg.contains("Invalid") || msg.contains("32602"),
                 "digit-leading identifier should error, got: {msg}"
             );
+            assert_rename_target_guidance(&msg);
         }
         Ok(response) => {
             if let Some(changes) = response.get("changes").and_then(|v| v.as_object()) {


### PR DESCRIPTION
Problem: textDocument/rename rejected empty, invalid, or mismatched-sigil newName values with terse identifier errors.\nFix: Preserve InvalidParams reasons while adding accepted newName examples and sigil-preservation guidance for variable renames.\nVerification: `./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked --test lsp_rename_tests test_rename_mismatched_sigil_is_rejected` passes; `./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked --test lsp_rename_tests test_rename_empty_new_name_is_rejected` passes; `./scripts/cargo-safe test -p perl-lsp-rs --profile agent --locked --test lsp_rename_tests test_rename_invalid_identifier_is_rejected` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `./scripts/cargo-safe xtask fmt` passes; `git diff --check` passes; `just agent-pr-fast` passes; `./scripts/storage-doctor` reports repo-local target 0.0G. Direct clippy still fails on the pre-existing `clone_on_copy` warning in `crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.