### PR TITLE
fix(lsp): guide text sync URI errors (#9871)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/text_sync.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync.rs
@@ -24,6 +24,12 @@ use document_state::{empty_state, minimal_state, minimal_state_from_rope};
 use srp_helpers::build_incremental_edit_set;
 use srp_helpers::{is_embedded_template_uri, is_perl_language_id};
 
+fn missing_text_document_uri_params(method: &str) -> JsonRpcError {
+    invalid_params(&format!(
+        "Missing required parameter: textDocument.uri: {method} expects params.textDocument.uri to be a document URI string, for example {{\"textDocument\":{{\"uri\":\"file:///workspace/lib/Foo.pm\"}}}}"
+    ))
+}
+
 impl LspServer {
     /// Handle textDocument/didOpen notification.
     ///
@@ -47,7 +53,7 @@ impl LspServer {
             let uri = params
                 .pointer("/textDocument/uri")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| invalid_params("Missing required parameter: textDocument.uri"))?;
+                .ok_or_else(|| missing_text_document_uri_params("textDocument/didOpen"))?;
             let text = params
                 .pointer("/textDocument/text")
                 .and_then(|v| v.as_str())
@@ -375,7 +381,7 @@ impl LspServer {
             let uri = params
                 .pointer("/textDocument/uri")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| invalid_params("Missing required parameter: textDocument.uri"))?;
+                .ok_or_else(|| missing_text_document_uri_params("textDocument/didChange"))?;
             let incoming_version_i64 =
                 params.pointer("/textDocument/version").and_then(|v| v.as_i64());
             let incoming_version = incoming_version_i64.and_then(|v| i32::try_from(v).ok());

--- a/crates/perl-lsp-rs/src/runtime/text_sync/lifecycle.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync/lifecycle.rs
@@ -10,7 +10,7 @@ impl LspServer {
             let uri = params
                 .pointer("/textDocument/uri")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| invalid_params("Missing required parameter: textDocument.uri"))?;
+                .ok_or_else(|| missing_text_document_uri_params("textDocument/didClose"))?;
 
             tracing::debug!("Document closed: {}", uri);
 
@@ -69,7 +69,7 @@ impl LspServer {
             let uri = params
                 .pointer("/textDocument/uri")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| invalid_params("Missing required parameter: textDocument.uri"))?;
+                .ok_or_else(|| missing_text_document_uri_params("textDocument/didSave"))?;
             let normalized_uri = self.normalize_uri_key(uri);
             let _version = params
                 .pointer("/textDocument/version")

--- a/crates/perl-lsp-rs/src/runtime/text_sync/tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/text_sync/tests.rs
@@ -1540,6 +1540,23 @@ fn test_semantic_analyzer_cache_separates_document_versions()
 // returns and explicit Err-branch assertions rather than #[should_panic].
 // =========================================================================
 
+fn assert_text_sync_uri_guidance(err: &JsonRpcError, method: &str) {
+    assert!(
+        err.message.contains("Missing required parameter: textDocument.uri"),
+        "error message must preserve missing field summary; got: {}",
+        err.message
+    );
+    for expected in
+        [method, "params.textDocument.uri", "document URI string", "file:///workspace/lib/Foo.pm"]
+    {
+        assert!(
+            err.message.contains(expected),
+            "error message must mention {expected}; got: {}",
+            err.message
+        );
+    }
+}
+
 /// handle_did_close with no textDocument.uri must return INVALID_PARAMS.
 #[test]
 fn handle_did_close_missing_uri_returns_invalid_params() {
@@ -1558,6 +1575,7 @@ fn handle_did_close_missing_uri_returns_invalid_params() {
             "error message must name the missing field; got: {}",
             err.message
         );
+        assert_text_sync_uri_guidance(&err, "textDocument/didClose");
     }
 }
 
@@ -1591,6 +1609,7 @@ fn handle_did_save_missing_uri_returns_invalid_params() {
             "error code must be INVALID_PARAMS; got {}",
             err.code
         );
+        assert_text_sync_uri_guidance(&err, "textDocument/didSave");
     }
 }
 
@@ -1643,6 +1662,7 @@ fn did_open_missing_uri_returns_invalid_params() {
             "error code must be INVALID_PARAMS; got {}",
             err.code
         );
+        assert_text_sync_uri_guidance(&err, "textDocument/didOpen");
     }
 }
 
@@ -1662,6 +1682,7 @@ fn handle_did_change_missing_uri_returns_invalid_params() {
             "error code must be INVALID_PARAMS; got {}",
             err.code
         );
+        assert_text_sync_uri_guidance(&err, "textDocument/didChange");
     }
 }
 


### PR DESCRIPTION
Problem: text sync missing-URI errors only name textDocument.uri without showing the expected notification payload shape.
Fix: Add method-specific guidance for didOpen, didChange, didClose, and didSave while preserving the original InvalidParams summary.
Verification: `./scripts/cargo-safe test -p perl-lsp-rs missing_uri_returns_invalid_params --profile agent --locked --lib` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `just agent-pr-fast` passes. Direct clippy still fails on the pre-existing inline-completion `clone_on_copy` baseline.