### PR TITLE
fix(lsp): guide showAst URI errors (#9887)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/dispatch/ast_explorer.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/ast_explorer.rs
@@ -20,6 +20,29 @@
 
 use super::super::*;
 
+fn invalid_show_ast_uri_params() -> JsonRpcError {
+    JsonRpcError {
+        code: INVALID_PARAMS,
+        message: "Missing required parameter: uri\n\n\
+                  perl/showAst expects params.uri to identify an open Perl document.\n\n\
+                  Example: {\"uri\":\"file:///workspace/lib/My/Module.pm\"}"
+            .to_string(),
+        data: None,
+    }
+}
+
+fn show_ast_document_not_found(uri: &str) -> JsonRpcError {
+    JsonRpcError {
+        code: INVALID_PARAMS,
+        message: format!(
+            "Document is not open: {uri}\n\n\
+             perl/showAst can only inspect documents opened with textDocument/didOpen. \
+             Send textDocument/didOpen first or use the URI of an already-open document."
+        ),
+        data: None,
+    }
+}
+
 impl LspServer {
     /// Handle the `perl/showAst` custom request.
     ///
@@ -35,13 +58,11 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         // Extract the `uri` string from params
-        let uri = params.as_ref().and_then(|p| p.get("uri")).and_then(|u| u.as_str()).ok_or_else(
-            || JsonRpcError {
-                code: INVALID_PARAMS,
-                message: "Missing required 'uri' parameter".to_string(),
-                data: None,
-            },
-        )?;
+        let uri = params
+            .as_ref()
+            .and_then(|p| p.get("uri"))
+            .and_then(|u| u.as_str())
+            .ok_or_else(invalid_show_ast_uri_params)?;
 
         let docs = self.documents_guard();
 
@@ -61,11 +82,7 @@ impl LspServer {
                     }
                 }
             }
-            None => Err(JsonRpcError {
-                code: INVALID_PARAMS,
-                message: format!("Document not found: {uri}"),
-                data: None,
-            }),
+            None => Err(show_ast_document_not_found(uri)),
         }
     }
 }

--- a/crates/perl-lsp-rs/tests/ast_explorer_tests.rs
+++ b/crates/perl-lsp-rs/tests/ast_explorer_tests.rs
@@ -79,6 +79,15 @@ fn show_ast_error(
     response.error
 }
 
+fn expect_error_contains(err: perl_lsp::JsonRpcError, expected: &[&str]) -> Result<(), String> {
+    for text in expected {
+        if !err.message.contains(text) {
+            return Err(format!("expected error message to contain {text:?}; got {err}"));
+        }
+    }
+    Ok(())
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -165,4 +174,40 @@ fn show_ast_null_params_returns_invalid_params() {
     assert!(err.is_some(), "Should return an error for null params");
     let code = err.unwrap().code;
     assert_eq!(code, -32602, "Expected INVALID_PARAMS (-32602) for null params, got {code}");
+}
+
+#[test]
+fn show_ast_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+    let server = create_and_init_server();
+
+    let err = show_ast_error(&server, Some(json!({ "other": "value" })))
+        .ok_or_else(|| "expected INVALID_PARAMS".to_string())?;
+    assert_eq!(err.code, -32602);
+    expect_error_contains(
+        err,
+        &[
+            "Missing required parameter: uri",
+            "perl/showAst",
+            "params.uri",
+            "file:///workspace/lib/My/Module.pm",
+        ],
+    )
+}
+
+#[test]
+fn show_ast_unknown_document_error_explains_open_document_requirement() -> Result<(), String> {
+    let server = create_and_init_server();
+
+    let err = show_ast_error(&server, Some(json!({ "uri": "file:///never_opened.pl" })))
+        .ok_or_else(|| "expected INVALID_PARAMS".to_string())?;
+    assert_eq!(err.code, -32602);
+    expect_error_contains(
+        err,
+        &[
+            "Document is not open: file:///never_opened.pl",
+            "perl/showAst",
+            "textDocument/didOpen",
+            "already-open document",
+        ],
+    )
 }


### PR DESCRIPTION
Problem: `perl/showAst` reports missing URI and unopened-document failures with terse messages that do not show the expected request shape or recovery step.
Fix: Return `INVALID_PARAMS` messages that include the `params.uri` shape and explain that the target document must be opened with `textDocument/didOpen` first.
Verification: `./scripts/cargo-safe test -p perl-lsp-rs --test ast_explorer_tests --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `just agent-pr-fast` passes. Direct clippy still fails on the pre-existing `clone_on_copy` lint in `perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.