### PR TITLE
fix(lsp): guide definition fallback errors (#9889)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -5,7 +5,7 @@
 
 use super::super::*;
 use crate::cancellation::RequestCleanupGuard;
-use crate::protocol::{req_position, req_uri};
+use crate::protocol::{invalid_params, req_position, req_uri};
 use crate::util::{read_text_file_with_encoding, token_under_cursor};
 use perl_parser_core::source_file::is_binary_content;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -61,6 +61,16 @@ fn lsp_location_count(value: Option<&Value>) -> usize {
     }
 }
 
+fn invalid_definition_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameters: textDocument.uri and position\n\n\
+         textDocument/definition expects params.textDocument.uri plus params.position.line and \
+         params.position.character to identify the symbol under the cursor.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"},\
+         \"position\":{\"line\":10,\"character\":4}}",
+    )
+}
+
 #[derive(Debug)]
 struct NavigationDecisionTraceContext {
     provider: &'static str,
@@ -101,6 +111,63 @@ impl Default for TypeDefinitionFallbackTrace {
             current_document_version: None,
             trace_only_no_live_behavior_change: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn expect_definition_shape_guidance(err: JsonRpcError) -> Result<(), String> {
+        assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+        for expected in [
+            "Missing required parameters: textDocument.uri and position",
+            "textDocument/definition",
+            "params.textDocument.uri",
+            "params.position.line",
+            "params.position.character",
+            "file:///workspace/lib/My/Module.pm",
+        ] {
+            if !err.message.contains(expected) {
+                return Err(format!("expected error message to contain {expected:?}; got {err}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn definition_fallback_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.on_definition(json!({})) {
+            Err(err) => expect_definition_shape_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn definition_fallback_missing_position_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.on_definition(json!({
+            "textDocument": { "uri": "file:///workspace/lib/My/Module.pm" }
+        })) {
+            Err(err) => expect_definition_shape_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn definition_fallback_valid_unknown_document_still_returns_empty_result() -> Result<(), String>
+    {
+        let server = LspServer::new();
+        let result = server
+            .on_definition(json!({
+                "textDocument": { "uri": "file:///workspace/lib/Missing.pm" },
+                "position": { "line": 10, "character": 4 }
+            }))
+            .map_err(|err| format!("expected empty definition result; got {err}"))?;
+        assert_eq!(result, json!([]));
+        Ok(())
     }
 }
 
@@ -1902,10 +1969,18 @@ impl LspServer {
         &self,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, JsonRpcError> {
-        let uri = params.pointer("/textDocument/uri").and_then(|v| v.as_str()).unwrap_or("");
-        let line = params.pointer("/position/line").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-        let ch =
-            params.pointer("/position/character").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        let uri = params
+            .pointer("/textDocument/uri")
+            .and_then(|v| v.as_str())
+            .ok_or_else(invalid_definition_params)?;
+        let line = params
+            .pointer("/position/line")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(invalid_definition_params)? as usize;
+        let ch = params
+            .pointer("/position/character")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(invalid_definition_params)? as usize;
 
         let text = self.buffer_text(uri).unwrap_or_default();
         let module = token_under_cursor(&text, line, ch).filter(|s| s.contains("::"));


### PR DESCRIPTION
Problem: `textDocument/definition` fallback handling can turn missing `textDocument.uri` or `position` request-shape mistakes into an empty result.
Fix: Validate the fallback path and return `INVALID_PARAMS` with the expected `textDocument.uri` and `position` payload shape while preserving empty results for valid unknown documents.
Verification: `./scripts/cargo-safe test -p perl-lsp-rs definition_fallback_ --profile agent --locked --lib` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `just agent-pr-fast` passes. Direct clippy still fails on the pre-existing `clone_on_copy` lint in `perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.