### PR TITLE
fix(lsp): guide hover request-shape errors (#9893)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -4,7 +4,7 @@
 
 use super::super::*;
 use crate::cancellation::RequestCleanupGuard;
-use crate::protocol::{req_position, req_uri};
+use crate::protocol::{invalid_params, req_position, req_uri};
 mod hover_cards;
 mod hover_extracted;
 #[cfg(test)]
@@ -14,6 +14,16 @@ mod regex_hover;
 mod signature_help;
 
 use hover_extracted::HoverExtracted;
+
+fn invalid_hover_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameters: textDocument.uri and position\n\n\
+         textDocument/hover expects params.textDocument.uri plus params.position.line and \
+         params.position.character to identify the symbol under the cursor.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"},\
+         \"position\":{\"line\":10,\"character\":4}}",
+    )
+}
 
 impl LspServer {
     /// Handle textDocument/hover request for symbol information display
@@ -39,8 +49,20 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = req_uri(&params)?;
-            let (line, character) = req_position(&params)?;
+            let uri = params
+                .pointer("/textDocument/uri")
+                .and_then(|v| v.as_str())
+                .ok_or_else(invalid_hover_params)?;
+            let line = params
+                .pointer("/position/line")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(invalid_hover_params)?;
+            let character = params
+                .pointer("/position/character")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(invalid_hover_params)?;
 
             // Reject stale requests
             let req_version =
@@ -141,6 +163,8 @@ impl LspServer {
                     }
                 }
             }
+        } else {
+            return Err(invalid_hover_params());
         }
 
         Ok(Some(json!(null)))

--- a/crates/perl-lsp-rs/src/runtime/language/hover/hover_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover/hover_tests.rs
@@ -1,6 +1,55 @@
 use super::LspServer;
+use crate::protocol::JsonRpcError;
 use perl_tdd_support::must_some;
 use serde_json::json;
+
+fn expect_hover_shape_guidance(err: JsonRpcError) -> Result<(), String> {
+    assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+    for expected in [
+        "Missing required parameters: textDocument.uri and position",
+        "textDocument/hover",
+        "params.textDocument.uri",
+        "params.position.line",
+        "params.position.character",
+        "file:///workspace/lib/My/Module.pm",
+    ] {
+        if !err.message.contains(expected) {
+            return Err(format!("expected error message to contain {expected:?}; got {err}"));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn hover_missing_params_error_includes_shape_guidance() -> Result<(), String> {
+    let server = LspServer::new();
+    match server.handle_hover(None) {
+        Err(err) => expect_hover_shape_guidance(err),
+        Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+    }
+}
+
+#[test]
+fn hover_missing_position_error_includes_shape_guidance() -> Result<(), String> {
+    let server = LspServer::new();
+    match server.handle_hover(Some(json!({
+        "textDocument": { "uri": "file:///workspace/lib/My/Module.pm" }
+    }))) {
+        Err(err) => expect_hover_shape_guidance(err),
+        Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+    }
+}
+
+#[test]
+fn hover_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+    let server = LspServer::new();
+    match server.handle_hover(Some(json!({
+        "position": { "line": 10, "character": 4 }
+    }))) {
+        Err(err) => expect_hover_shape_guidance(err),
+        Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+    }
+}
 
 #[test]
 fn test_internal_pl_sv_yes_hover_from_sigiled_token() {


### PR DESCRIPTION
Problem: `textDocument/hover` can turn missing params, `textDocument.uri`, or `position` request-shape mistakes into a null hover result.
Fix: Return `INVALID_PARAMS` with the expected `textDocument.uri` and `position` payload shape while preserving `null` for valid requests with no hover content.
Verification: `./scripts/cargo-safe test -p perl-lsp-rs hover_missing_ --profile agent --locked --lib` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `just agent-pr-fast` passes. Direct clippy still fails on the pre-existing `clone_on_copy` lint in `perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.