### PR TITLE
fix(lsp): guide moniker request-shape errors (#9895)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/moniker.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/moniker.rs
@@ -1,8 +1,18 @@
 //! Moniker request handling and symbol import/export classification
 
 use super::super::*;
-use crate::protocol::{req_position, req_uri};
+use crate::protocol::invalid_params;
 use perl_module::import::resolve_known_export_tag;
+
+fn invalid_moniker_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameters: textDocument.uri and position\n\n\
+         textDocument/moniker expects params.textDocument.uri plus params.position.line and \
+         params.position.character to identify the symbol under the cursor.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"},\
+         \"position\":{\"line\":10,\"character\":4}}",
+    )
+}
 
 impl LspServer {
     /// Handle textDocument/moniker request
@@ -18,8 +28,20 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = req_uri(&params)?;
-            let (line, character) = req_position(&params)?;
+            let uri = params
+                .pointer("/textDocument/uri")
+                .and_then(|v| v.as_str())
+                .ok_or_else(invalid_moniker_params)?;
+            let line = params
+                .pointer("/position/line")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(invalid_moniker_params)?;
+            let character = params
+                .pointer("/position/character")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(invalid_moniker_params)?;
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
@@ -95,6 +117,8 @@ impl LspServer {
                     }
                 }
             }
+        } else {
+            return Err(invalid_moniker_params());
         }
 
         Ok(Some(json!([])))

--- a/crates/perl-lsp-rs/tests/lsp_moniker_e2e_test.rs
+++ b/crates/perl-lsp-rs/tests/lsp_moniker_e2e_test.rs
@@ -48,6 +48,50 @@ fn find_moniker_of_kind<'a>(monikers: &'a [Value], kind: &str) -> Option<&'a Val
     monikers.iter().find(|m| m.get("kind").and_then(Value::as_str) == Some(kind))
 }
 
+fn moniker_shape_error(harness: &mut LspHarness, params: Option<Value>) -> Result<String, String> {
+    let mut request = json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/moniker"
+    });
+    if let Some(params) = params {
+        request["params"] = params;
+    }
+
+    let response = harness.request_raw(request);
+    let error =
+        response.get("error").ok_or_else(|| format!("expected error response, got {response}"))?;
+    let code = error
+        .get("code")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| format!("error response missing numeric code: {response}"))?;
+    if code != -32602 {
+        return Err(format!("expected INVALID_PARAMS (-32602), got {code}: {response}"));
+    }
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("error response missing message: {response}"))?;
+    Ok(message.to_string())
+}
+
+fn assert_moniker_shape_guidance(case: &str, message: &str) -> Result<(), String> {
+    for expected in [
+        "Missing required parameters: textDocument.uri and position",
+        "textDocument/moniker",
+        "params.textDocument.uri",
+        "params.position.line",
+        "params.position.character",
+        "file:///workspace/lib/My/Module.pm",
+    ] {
+        if !message.contains(expected) {
+            return Err(format!(
+                "{case}: expected error message to contain {expected:?}; got {message:?}"
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn assert_moniker_shape(moniker: &Value) {
     assert_eq!(
         moniker.get("scheme").and_then(Value::as_str),
@@ -68,6 +112,34 @@ fn assert_moniker_shape(moniker: &Value) {
         matches!(unique, "document" | "project" | "global" | "scheme"),
         "unique must be a recognized LSP value, got {unique:?}"
     );
+}
+
+#[test]
+fn moniker_request_shape_errors_include_payload_guidance() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    for (case, params) in [
+        ("missing params", None),
+        (
+            "missing uri",
+            Some(json!({
+                "position": { "line": 10, "character": 4 }
+            })),
+        ),
+        (
+            "missing position",
+            Some(json!({
+                "textDocument": { "uri": "file:///workspace/lib/My/Module.pm" }
+            })),
+        ),
+    ] {
+        let message = moniker_shape_error(&mut harness, params)?;
+        assert_moniker_shape_guidance(case, &message)?;
+    }
+
+    harness.shutdown_gracefully();
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
Problem: `textDocument/moniker` can return an empty moniker list or generic parameter errors when clients omit `params`, `textDocument.uri`, or `position`.
Fix: Return `INVALID_PARAMS` with the expected `textDocument.uri` and `position` payload shape while preserving an empty array for valid requests with no moniker at the cursor.
Verification: `./scripts/cargo-safe test -p perl-lsp-rs --test lsp_moniker_e2e_test --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `just agent-pr-fast` passes. Direct clippy still fails on the pre-existing `clone_on_copy` lint in `perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.