### PR TITLE
fix(lsp): guide signatureHelp request-shape errors (#9897)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/hover/signature_help.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover/signature_help.rs
@@ -1,6 +1,17 @@
 //! Signature help handlers and signature extraction helpers.
 
 use super::*;
+use crate::protocol::invalid_params;
+
+fn invalid_signature_help_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameters: textDocument.uri and position\n\n\
+         textDocument/signatureHelp expects params.textDocument.uri plus params.position.line and \
+         params.position.character to identify the call site under the cursor.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"},\
+         \"position\":{\"line\":10,\"character\":14}}",
+    )
+}
 
 impl LspServer {
     /// Handle textDocument/signatureHelp request for function parameter hints
@@ -26,8 +37,20 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = req_uri(&params)?;
-            let (line, character) = req_position(&params)?;
+            let uri = params
+                .pointer("/textDocument/uri")
+                .and_then(|v| v.as_str())
+                .ok_or_else(invalid_signature_help_params)?;
+            let line = params
+                .pointer("/position/line")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(invalid_signature_help_params)?;
+            let character = params
+                .pointer("/position/character")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(invalid_signature_help_params)?;
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
@@ -129,6 +152,8 @@ impl LspServer {
                     })));
                 }
             }
+        } else {
+            return Err(invalid_signature_help_params());
         }
 
         Ok(None)

--- a/crates/perl-lsp-rs/tests/lsp_signature_help_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_signature_help_tests.rs
@@ -23,10 +23,85 @@
 
 mod support;
 
-use serde_json::json;
+use serde_json::{Value, json};
 use support::lsp_harness::LspHarness;
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn signature_help_shape_error(
+    harness: &mut LspHarness,
+    params: Option<Value>,
+) -> Result<String, String> {
+    let mut request = json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/signatureHelp"
+    });
+    if let Some(params) = params {
+        request["params"] = params;
+    }
+
+    let response = harness.request_raw(request);
+    let error =
+        response.get("error").ok_or_else(|| format!("expected error response, got {response}"))?;
+    let code = error
+        .get("code")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| format!("error response missing numeric code: {response}"))?;
+    if code != -32602 {
+        return Err(format!("expected INVALID_PARAMS (-32602), got {code}: {response}"));
+    }
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("error response missing message: {response}"))?;
+    Ok(message.to_string())
+}
+
+fn assert_signature_help_shape_guidance(case: &str, message: &str) -> Result<(), String> {
+    for expected in [
+        "Missing required parameters: textDocument.uri and position",
+        "textDocument/signatureHelp",
+        "params.textDocument.uri",
+        "params.position.line",
+        "params.position.character",
+        "file:///workspace/lib/My/Module.pm",
+    ] {
+        if !message.contains(expected) {
+            return Err(format!(
+                "{case}: expected error message to contain {expected:?}; got {message:?}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_signature_help_request_shape_errors_include_payload_guidance() -> TestResult {
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    for (case, params) in [
+        ("missing params", None),
+        (
+            "missing uri",
+            Some(json!({
+                "position": { "line": 10, "character": 14 }
+            })),
+        ),
+        (
+            "missing position",
+            Some(json!({
+                "textDocument": { "uri": "file:///workspace/lib/My/Module.pm" }
+            })),
+        ),
+    ] {
+        let message = signature_help_shape_error(&mut harness, params)?;
+        assert_signature_help_shape_guidance(case, &message)?;
+    }
+
+    harness.shutdown_gracefully();
+    Ok(())
+}
 
 /// Tests feature spec: signature_help.rs#user-defined-function
 ///


### PR DESCRIPTION
Problem: `textDocument/signatureHelp` can return `null` or generic parameter errors when clients omit `params`, `textDocument.uri`, or `position`.
Fix: Return `INVALID_PARAMS` with the expected `textDocument.uri` and `position` payload shape while preserving `null` for valid requests outside a call context.
Verification: `./scripts/cargo-safe test -p perl-lsp-rs --test lsp_signature_help_tests --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs --profile agent --locked` passes; `just agent-pr-fast` passes. Direct clippy still fails on the pre-existing `clone_on_copy` lint in `perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`.