### PR TITLE
fix(inline): remove range clone-on-copy lint (#9899)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs
+++ b/crates/perl-lsp-rs-core/src/providers/inline_completion/mod.rs
@@ -223,7 +223,7 @@ impl InlineCompletionProvider {
 
         for item in &mut list.items {
             if item.range.is_none() && item_matches_fragment(item, fragment.text) {
-                item.range = Some(range.clone());
+                item.range = Some(range);
             }
         }
 


### PR DESCRIPTION
Problem: The direct `perl-lsp-rs` clippy command fails on a pre-existing `clone_on_copy` lint in inline completion replacement range assignment.
Fix: Assign the Copy `Range` value directly instead of cloning it.
Verification: `./scripts/cargo-safe clippy -p perl-lsp-rs --profile agent --locked -- -D warnings -A missing_docs` passes; `./scripts/cargo-safe test -p perl-lsp-rs-core inline_completion --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs-core --profile agent --locked` passes; `just agent-pr-fast` passes.