### PR TITLE
fix(dap): guide unsupported command names (#9901)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/dispatch.rs
+++ b/crates/perl-dap/src/debug_adapter/dispatch.rs
@@ -144,7 +144,10 @@ impl DebugAdapter {
         if let Some(suggestion) = Self::suggested_command(command) {
             format!("Unknown command: {command}. Did you mean '{suggestion}'?")
         } else {
-            format!("Unknown command: {command}")
+            format!(
+                "Unknown command: {command}. Supported commands: {}",
+                Self::SUPPORTED_COMMANDS.join(", ")
+            )
         }
     }
 

--- a/crates/perl-dap/tests/control_flow_handlers_tests.rs
+++ b/crates/perl-dap/tests/control_flow_handlers_tests.rs
@@ -583,6 +583,35 @@ fn test_unknown_command_includes_typo_suggestion() {
     }
 }
 
+#[test]
+fn test_unknown_command_without_suggestion_lists_supported_commands() {
+    let mut adapter = DebugAdapter::new();
+
+    let response = adapter.handle_request(1, "frobnicateDebugger", None);
+
+    match response {
+        DapMessage::Response { success, message, .. } => {
+            assert!(!success, "Unexpected success for unknown command");
+            let msg = must_some(message);
+            assert!(
+                msg.contains("Unknown command: frobnicateDebugger"),
+                "Error should include unknown command: {msg}"
+            );
+            assert!(
+                msg.contains("Supported commands:"),
+                "Error should include supported command guidance: {msg}"
+            );
+            for expected in ["initialize", "launch", "setBreakpoints", "stackTrace", "evaluate"] {
+                assert!(msg.contains(expected), "Error should list {expected}: {msg}");
+            }
+        }
+        _ => {
+            must(Err::<(), _>("Expected Response for unknown command"));
+            unreachable!()
+        }
+    }
+}
+
 // AC9.4: Test that handlers are thread-safe (can be called multiple times)
 #[test]
 fn test_control_flow_handlers_thread_safe() {


### PR DESCRIPTION
Problem: Unknown DAP commands that are not close typos only report the command name, leaving users without an obvious list of valid commands.
Fix: Include the supported DAP command list in the no-suggestion unknown-command response while preserving close-match suggestions.
Verification: `./scripts/cargo-safe test -p perl-dap --test control_flow_handlers_tests --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-dap --profile agent --locked` passes; `just agent-pr-fast` passes. Direct clippy still fails on the pre-existing `clone_on_copy` lint in `perl-lsp-rs-core/src/providers/inline_completion/mod.rs:226`, which is fixed separately in #9900.