### PR TITLE
fix(uri): accept local file paths (#9904)

### DIFF
--- a/crates/perl-lsp-rs-core/src/uri/mod.rs
+++ b/crates/perl-lsp-rs-core/src/uri/mod.rs
@@ -4,6 +4,7 @@
 //! `perl-lsp-rs-core::uri` in Wave G3 (#4535).
 
 use lsp_types::Uri;
+use std::path::Path;
 use url::Url;
 
 fn fallback_uri() -> Uri {
@@ -24,15 +25,41 @@ fn fallback_uri() -> Uri {
     }
 }
 
+fn file_path_uri(s: &str) -> Option<Uri> {
+    let url = Url::from_file_path(Path::new(s)).ok()?;
+    url.as_str().parse::<Uri>().ok()
+}
+
+fn windows_file_path_uri(s: &str) -> Option<Uri> {
+    let mut chars = s.chars();
+    let drive = chars.next()?;
+    if !drive.is_ascii_alphabetic() || chars.next()? != ':' {
+        return None;
+    }
+    let separator = chars.next()?;
+    if separator != '\\' && separator != '/' {
+        return None;
+    }
+
+    let normalized = s.replace('\\', "/");
+    let url = Url::parse(&format!("file:///{normalized}")).ok()?;
+    url.as_str().parse::<Uri>().ok()
+}
+
 /// Parse a URI string into [`lsp_types::Uri`].
 ///
-/// Falls back to a guaranteed-valid URI if parsing fails.
+/// Accepts valid URI strings and absolute local file paths. Falls back to a
+/// guaranteed-valid URI if parsing fails.
 #[must_use]
 pub fn parse_uri(s: &str) -> Uri {
     let sanitized = s.trim_start_matches('\u{feff}').trim();
 
     if sanitized.is_empty() {
         return fallback_uri();
+    }
+
+    if let Some(uri) = file_path_uri(sanitized).or_else(|| windows_file_path_uri(sanitized)) {
+        return uri;
     }
 
     match sanitized.parse::<Uri>() {

--- a/crates/perl-lsp-rs-core/tests/uri_module_shape.rs
+++ b/crates/perl-lsp-rs-core/tests/uri_module_shape.rs
@@ -21,6 +21,21 @@ fn uri_module_parse_uri_handles_windows_paths() {
     assert_eq!(uri.as_str(), input, "parse_uri should preserve Windows paths verbatim");
 }
 
+#[cfg(unix)]
+#[test]
+fn uri_module_parse_uri_accepts_unix_file_paths() -> Result<(), Box<dyn std::error::Error>> {
+    let uri = parse_uri("/tmp/perl-lsp/lib/PlainPath.pm");
+    assert_eq!(uri.as_str(), "file:///tmp/perl-lsp/lib/PlainPath.pm");
+    Ok(())
+}
+
+#[test]
+fn uri_module_parse_uri_accepts_windows_file_paths() -> Result<(), Box<dyn std::error::Error>> {
+    let uri = parse_uri(r"C:\Users\dev\lib\PlainPath.pm");
+    assert_eq!(uri.as_str(), "file:///C:/Users/dev/lib/PlainPath.pm");
+    Ok(())
+}
+
 #[test]
 fn uri_module_parse_uri_handles_invalid_input() {
     // Verify that parse_uri gracefully handles invalid input post-absorption


### PR DESCRIPTION
Problem: Plain local file paths passed through URI helpers can remain non-clickable path strings instead of file URIs.
Fix: Convert absolute Unix and Windows-style file paths to file:// URIs before the permissive URI fallback, while preserving empty-input fallback behavior.
Verification: `./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked` passes; `./scripts/cargo-safe check --all-targets -p perl-lsp-rs-core --profile agent --locked` passes; `./scripts/cargo-safe clippy -p perl-lsp-rs-core --profile agent --locked -- -D warnings -A missing_docs` passes; `git diff --check origin/master...HEAD` passes; `./scripts/storage-doctor` passes. `./scripts/cargo-safe xtask fmt --check` currently fails on pre-existing PL409 formatting drift in `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs` and `crates/perl-lsp-rs-core/tests/quick_fix_pl409_bdd.rs`; left out of this URI PR to keep scope clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to URI parsing with new tests; no auth or data-path changes beyond normalizing document identifiers.
> 
> **Overview**
> **`parse_uri`** now turns **absolute local paths** into **`file://` URIs** before the existing URI parse and fallback logic, so plain path strings become clickable LSP file URIs instead of invalid or fallback values.
> 
> Unix paths use **`Url::from_file_path`**; Windows **`C:\...`** / **`C:/...`** paths get a dedicated normalizer (backslashes to slashes, **`file:///`** prefix). Empty input and the existing fallback behavior are unchanged.
> 
> Integration tests cover Unix (cfg-gated) and Windows plain-path inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 285866215fbce0b042d2bec8b20b43e4f8431796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->