### PR TITLE
feat(code-actions): add quick-fix for PL410 undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo targets an undefined label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1983,3 +1983,37 @@ fn valid_diagnostic_range(source: &str, range: (usize, usize)) -> Option<(usize,
     }
     Some((start, end))
 }
+
+/// Drop an undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL`
+/// statement (PL410).
+///
+/// At runtime, targeting a label that does not exist is fatal. The only safe
+/// mechanical fix is to drop the label so the statement targets the innermost
+/// enclosing loop. A "suggest defining the label" alternative would require
+/// AST-rewrite guidance and is out of scope.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let snippet = &source[start..end];
+    let op = match snippet.split_ascii_whitespace().next() {
+        Some(op) if matches!(op, "next" | "last" | "redo") => op,
+        _ => return Vec::new(),
+    };
+
+    vec![CodeAction {
+        title: format!("Drop label — use bare '{op}' to target innermost loop"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,274 @@
+//! BDD tests for the PL410 quick-fix handler.
+//!
+//!   PL410 - `next`/`last`/`redo LABEL` references a label not defined in the file.
+//!   Fix: drop the label so the statement targets the innermost enclosing loop.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source containing a loop-control statement with an undefined label
+//!   WHEN   a PL410 diagnostic is produced and code actions are requested
+//!   THEN   exactly one preferred action is returned that strips the label
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirror the pattern used in quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply every edit from an action (largest offset first) and return the result.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL
+// ===========================================================================
+
+#[test]
+fn next_label_produces_drop_label_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next OUTER` where OUTER is not defined
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is a preferred action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "drop-label action must be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn next_label_edit_leaves_bare_next() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next MISSING` in a for-loop
+    let source = "for my $i (1..10) { next MISSING; }\n";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next MISSING` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {actions:?}"))?;
+    let result = edited(source, action);
+
+    // THEN the label is removed; `next` becomes bare
+    assert!(result.contains("next;"), "expected bare 'next;' after edit, got: {result:?}");
+    assert!(!result.contains("MISSING"), "label name should be gone after edit");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL
+// ===========================================================================
+
+#[test]
+fn last_label_edit_leaves_bare_last() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `last PHANTOM` in a while-loop
+    let source = "while (1) { last PHANTOM; }\n";
+    let stmt_start = source.find("last PHANTOM").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no 'last' action in: {actions:?}"))?;
+    let result = edited(source, action);
+
+    assert!(result.contains("last;"), "expected bare 'last;', got: {result:?}");
+    assert!(!result.contains("PHANTOM"), "label should be gone");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL
+// ===========================================================================
+
+#[test]
+fn redo_label_edit_leaves_bare_redo() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `redo NOWHERE` inside a loop body
+    let source = "for my $i (1..5) { redo NOWHERE; }\n";
+    let stmt_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no 'redo' action in: {actions:?}"))?;
+    let result = edited(source, action);
+
+    assert!(result.contains("redo;"), "expected bare 'redo;', got: {result:?}");
+    assert!(!result.contains("NOWHERE"), "label should be gone");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — title naming
+// ===========================================================================
+
+#[test]
+fn action_title_names_the_operator() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic for `last GHOST`
+    let source = "while (1) { last GHOST; }\n";
+    let stmt_start = source.find("last GHOST").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last GHOST".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last GHOST` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title mentions 'last' so the user knows which operator is fixed
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no 'last' action in: {actions:?}"))?;
+    assert!(
+        action.title.contains("last"),
+        "title should name the operator, got: {:?}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — invalid-range guard
+// ===========================================================================
+
+#[test]
+fn invalid_range_produces_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic whose byte range points past the end of the source
+    let source = "for my $i (1..3) { next OUTER; }\n";
+    let out_of_bounds_start = source.len() + 1;
+    let out_of_bounds_end = source.len() + 10;
+
+    let diag = make_diag(
+        out_of_bounds_start,
+        out_of_bounds_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no action is produced — invalid ranges must be silently ignored
+    assert!(
+        !actions.iter().any(|a| a.title.contains("next")
+            || a.title.contains("last")
+            || a.title.contains("redo")),
+        "expected no PL410 action for out-of-bounds range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — dispatch smoke test
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: the routing table dispatches PL410 to the handler.
+    // Mix PL410 with a known-good PL700 diagnostic; both must produce actions.
+    let source = "use Foo;\nfor my $i (1..3) { next GHOST; }\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let foo_start = source.find("use Foo;").ok_or("use Foo not found")?;
+    let next_start = source.find("next GHOST").ok_or("next GHOST not found")?;
+    let next_end = next_start + "next GHOST".len();
+
+    let diags = vec![
+        make_diag(
+            foo_start,
+            foo_start + "use Foo;".len(),
+            "PL700",
+            "Module 'Foo' appears to be unused",
+        ),
+        make_diag(
+            next_start,
+            next_end,
+            "PL410",
+            "`next GHOST` references a label that is not defined in this file",
+        ),
+    ];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    let has_pl700 = actions.iter().any(|a| a.title.contains("use Foo"));
+    let has_pl410 = actions.iter().any(|a| a.title.contains("next"));
+
+    assert!(has_pl700, "PL700 route must produce an action; got: {actions:?}");
+    assert!(has_pl410, "PL410 route must produce an action; got: {actions:?}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label produce a PL410 diagnostic but previously returned **no code actions** — the lightbulb was empty because `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`.

At runtime this is fatal: Perl dies with `Label not found for "next LABEL"`. The only safe mechanical fix is to drop the label so the statement targets the innermost enclosing loop, which is exactly what bare `next;` / `last;` / `redo;` do.

### Changes

**`quick_fixes.rs`** — new `fix_loop_control_undefined_label`:
- Validates the byte range via `valid_diagnostic_range` before touching source text; invalid/non-char-boundary ranges return no actions.
- Extracts the operator from the leading whitespace-split token of the diagnostic range.
- Guards that the operator is one of `next | last | redo`; anything unexpected returns no actions.
- Replaces the full `OP LABEL` span with the bare operator string.
- `is_preferred: true` — there is exactly one sensible mechanical fix.

**`diagnostic_routes.rs`** — wire `PL410` / `LoopControlUndefinedLabel` to the new handler, consistent with how every other diagnostic code is routed in the match arm chain.

**`tests/quick_fix_pl410_bdd.rs`** (new) — 7 BDD integration tests:
| Test | What it covers |
|------|---------------|
| `next_label_produces_drop_label_action` | action produced for `next OUTER`, kind=QuickFix, is_preferred |
| `next_label_edit_leaves_bare_next` | applying the edit produces `next;`, removes the label name |
| `last_label_edit_leaves_bare_last` | same for `last PHANTOM` |
| `redo_label_edit_leaves_bare_redo` | same for `redo NOWHERE` |
| `action_title_names_the_operator` | title includes the operator so users know what is being fixed |
| `invalid_range_produces_no_action` | out-of-bounds range → no action (guard works) |
| `pl410_dispatch_reaches_handler` | smoke test: PL410 + PL700 diagnostics both produce actions |

## Test plan

- [x] 7 new `quick_fix_pl410_bdd` tests pass
- [x] 17 pre-existing `quick_fix_new_codes_bdd` tests remain green
- [x] `cargo clippy -p perl-lsp-rs-core` — no new warnings introduced
- [x] `cargo fmt -p perl-lsp-rs-core` — no formatting changes needed in production code; test file auto-formatted

## What was not done (per spec)

- No "suggest defining a label" alternative fix — that would require AST-rewrite guidance and is explicitly out of scope in the issue.
- No changes to the diagnostic emission logic in `loop_control_label.rs` — that is correct and untouched.

https://claude.ai/code/session_01BT6QBZpp941sLqa8KeqpbD

---
_Generated by [Claude Code](https://claude.ai/code/session_01BT6QBZpp941sLqa8KeqpbD)_