### PR TITLE
feat(code-actions): PL410 quick-fix — drop undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo LABEL where label is not defined in this file
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1472,6 +1472,43 @@ fn is_simple_duplicate_hash_entry_line(line_content: &str) -> bool {
         && !line_content.contains(['(', ')', '[', ']', '{', '}'])
 }
 
+/// Drop an undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL` statement (PL410).
+///
+/// Replaces `next LABEL` / `last LABEL` / `redo LABEL` with the bare form so the
+/// statement targets the innermost enclosing loop instead of the missing label.
+/// Returns no actions when the byte range is invalid or the operator is not one of
+/// the three documented loop-control keywords.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((start, end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let snippet = &source[start..end];
+    let mut parts = snippet.split_whitespace();
+    let op = parts.next().unwrap_or("");
+    let label = parts.next().unwrap_or("");
+
+    if !matches!(op, "next" | "last" | "redo") || label.is_empty() {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Drop label '{label}' — use bare '{op}'"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start, end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 /// Fix missing return statement by adding an explicit `return` before the closing brace
 ///
 /// PL301 fires when a subroutine has no explicit return statement. The diagnostic

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,278 @@
+//! BDD integration tests for the PL410 quick-fix handler.
+//!
+//! `fix_loop_control_undefined_label` drops the undefined label from a
+//! `next LABEL`, `last LABEL`, or `redo LABEL` statement so the statement
+//! targets the innermost enclosing loop instead.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with a loop-control statement targeting an undefined label
+//!   WHEN   a PL410 diagnostic is present and code actions are requested
+//!   THEN   exactly one preferred quick-fix action is returned with the
+//!          correct edit
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (identical pattern to quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+/// Apply all edits from an action in reverse-start-position order and return the result.
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+/// Find the first action whose title satisfies the predicate.
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// Scenario 1 — `next LABEL` drops to bare `next`
+// ===========================================================================
+
+#[test]
+fn pl410_next_undefined_label_drops_to_bare_next() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source where `next OUTER` targets a label that does not exist
+    let source = "for my $i (1..10) { next OUTER; }";
+
+    let stmt_start = source.find("next OUTER").ok_or("next OUTER not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested for the PL410 diagnostic
+    let actions = actions_for(source, &[diag]);
+
+    // THEN a preferred quick-fix action is returned
+    let action = find_action(&actions, |t| t.contains("OUTER"))
+        .ok_or_else(|| format!("no action containing 'OUTER' in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "PL410 fix should be preferred");
+
+    // AND applying the edit leaves `next` without the label
+    let result = edited(source, action);
+    assert!(result.contains("next;"), "bare next should follow after label removal, got: {result}");
+    assert!(!result.contains("next OUTER"), "undefined label should be removed, got: {result}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 2 — `last LABEL` drops to bare `last`
+// ===========================================================================
+
+#[test]
+fn pl410_last_undefined_label_drops_to_bare_last() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source where `last MISSING` targets an undefined label
+    let source = "while (1) { last MISSING; }";
+
+    let stmt_start = source.find("last MISSING").ok_or("last MISSING not found")?;
+    let stmt_end = stmt_start + "last MISSING".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last MISSING` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN a quick-fix is produced
+    let action = find_action(&actions, |t| t.contains("MISSING"))
+        .ok_or_else(|| format!("no action containing 'MISSING' in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND the edit strips the label, leaving `last`
+    let result = edited(source, action);
+    assert!(result.contains("last;"), "bare last should follow after label removal, got: {result}");
+    assert!(!result.contains("last MISSING"), "label should be gone, got: {result}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 3 — `redo LABEL` drops to bare `redo`
+// ===========================================================================
+
+#[test]
+fn pl410_redo_undefined_label_drops_to_bare_redo() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a source where `redo NOWHERE` targets an undefined label
+    let source = "for my $i (1..5) { redo NOWHERE; }";
+
+    let stmt_start = source.find("redo NOWHERE").ok_or("redo NOWHERE not found")?;
+    let stmt_end = stmt_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN a quick-fix is produced
+    let action = find_action(&actions, |t| t.contains("NOWHERE"))
+        .ok_or_else(|| format!("no action containing 'NOWHERE' in: {actions:?}"))?;
+
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred);
+
+    // AND the edit leaves `redo` without the label
+    let result = edited(source, action);
+    assert!(result.contains("redo;"), "bare redo should follow after label removal, got: {result}");
+    assert!(!result.contains("redo NOWHERE"), "label should be gone, got: {result}");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 4 — action title includes both the operator and the label name
+// ===========================================================================
+
+#[test]
+fn pl410_action_title_names_op_and_label() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic for `next PHANTOM`
+    let source = "for my $x (1..3) { next PHANTOM; }";
+
+    let stmt_start = source.find("next PHANTOM").ok_or("next PHANTOM not found")?;
+    let stmt_end = stmt_start + "next PHANTOM".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next PHANTOM` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title contains both the operator ("next") and the label ("PHANTOM")
+    let action = find_action(&actions, |t| t.contains("next") && t.contains("PHANTOM"))
+        .ok_or_else(|| format!("no action with both 'next' and 'PHANTOM' in: {actions:?}"))?;
+
+    assert!(
+        action.title.contains("next"),
+        "title should name the loop-control operator: {}",
+        action.title
+    );
+    assert!(
+        action.title.contains("PHANTOM"),
+        "title should name the undefined label: {}",
+        action.title
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Scenario 5 — invalid (out-of-bounds) diagnostic range produces no actions
+// ===========================================================================
+
+#[test]
+fn pl410_invalid_range_produces_no_actions() {
+    // GIVEN a source and a diagnostic whose range extends past the end of the source
+    let source = "for my $i (1..10) { next GHOST; }";
+
+    let out_of_bounds_start = source.len() + 1;
+    let out_of_bounds_end = source.len() + 10;
+
+    let diag = make_diag(
+        out_of_bounds_start,
+        out_of_bounds_end,
+        "PL410",
+        "`next GHOST` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested with the bogus range
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL410 quick-fix action is returned (invalid range is silently ignored)
+    assert!(
+        !actions.iter().any(|a| a.diagnostics.iter().any(|c| c == "PL410")),
+        "invalid range should produce no PL410 actions, got: {actions:?}"
+    );
+}
+
+// ===========================================================================
+// Scenario 6 — dispatch smoke: full routing pipeline delivers a PL410 fix
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_smoke_routes_via_code_actions_provider() -> Result<(), Box<dyn std::error::Error>>
+{
+    // GIVEN a PL410 diagnostic constructed the same way the diagnostic engine would
+    let source = "while (1) { last PHANTOM; }";
+
+    let stmt_start = source.find("last PHANTOM").ok_or("last PHANTOM not found")?;
+    let stmt_end = stmt_start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+
+    // WHEN the full CodeActionsProvider pipeline processes it
+    let actions = actions_for(source, &[diag]);
+
+    // THEN at least one QuickFix action is returned for the PL410 code
+    let pl410_actions: Vec<&CodeAction> =
+        actions.iter().filter(|a| a.diagnostics.iter().any(|c| c == "PL410")).collect();
+
+    assert!(
+        !pl410_actions.is_empty(),
+        "dispatch should route PL410 to fix_loop_control_undefined_label, got: {actions:?}"
+    );
+    assert_eq!(
+        pl410_actions[0].kind,
+        CodeActionKind::QuickFix,
+        "routed action should be a QuickFix"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label already receive a **PL410** diagnostic, but the lightbulb returned **no actions** — the `diagnostic_routes.rs` table had no arm for `LoopControlUndefinedLabel`. This PR adds the missing handler.

The fix is the only sensible mechanical action: drop the label so the statement safely targets the innermost enclosing loop. At runtime, Perl dies with `Label not found for "next LABEL"` when the label doesn't exist, so the fix is both safe and obvious.

## What changed

### `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs`
- Added `fix_loop_control_undefined_label(source, diagnostic) -> Vec<CodeAction>`
  - Guards with `valid_diagnostic_range` before touching source bytes
  - Extracts the operator via `split_whitespace` — rejects anything other than `next` / `last` / `redo`
  - Returns one preferred `QuickFix` action that replaces `op LABEL` with the bare `op`
  - Title: `"Drop label 'LABEL' — use bare 'op'"` (includes both names for discoverability)

### `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs`
- Added routing arm for `DiagnosticCode::LoopControlUndefinedLabel` (`PL410`) → `fix_loop_control_undefined_label`

### `crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs` *(new)*
Six BDD integration tests following the exact same GIVEN/WHEN/THEN pattern as `quick_fix_new_codes_bdd.rs`:

| # | Test | Covers |
|---|------|--------|
| 1 | `pl410_next_undefined_label_drops_to_bare_next` | `next OUTER` → `next` edit is correct |
| 2 | `pl410_last_undefined_label_drops_to_bare_last` | `last MISSING` → `last` edit is correct |
| 3 | `pl410_redo_undefined_label_drops_to_bare_redo` | `redo NOWHERE` → `redo` edit is correct |
| 4 | `pl410_action_title_names_op_and_label` | Title contains both operator and label name |
| 5 | `pl410_invalid_range_produces_no_actions` | Out-of-bounds range returns no actions |
| 6 | `pl410_dispatch_smoke_routes_via_code_actions_provider` | Full `CodeActionsProvider` dispatch delivers a PL410 `QuickFix` |

## Test results

```
running 6 tests
test pl410_action_title_names_op_and_label ... ok
test pl410_next_undefined_label_drops_to_bare_next ... ok
test pl410_dispatch_smoke_routes_via_code_actions_provider ... ok
test pl410_redo_undefined_label_drops_to_bare_redo ... ok
test pl410_last_undefined_label_drops_to_bare_last ... ok
test pl410_invalid_range_produces_no_actions ... ok

test result: ok. 6 passed; 0 failed
```

All 17 pre-existing `quick_fix_new_codes_bdd` tests remain green. `cargo fmt --check` and `cargo clippy -p perl-lsp-rs-core --lib` clean.

## Design notes

- `is_preferred: true` — there is exactly one sensible fix (drop the label); no alternative is offered
- No changes to the diagnostic emission logic in `loop_control_label.rs`
- Does not add a "suggest defining a label" alternative (would require AST rewrite guidance — out of scope per issue)
- Range validation reuses the existing `valid_diagnostic_range` helper already used by `fix_security_signal_handler` and `fix_printf_format_arity`

https://claude.ai/code/session_01QffwJWWBPc3s1jY1HveYeF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QffwJWWBPc3s1jY1HveYeF)_