### PR TITLE
feat(code-actions): add PL410 quick-fix to drop undefined loop-control label

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -202,6 +202,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL410: next/last/redo targeting an undefined loop label
+        c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
+        }
         _ => {}
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -1964,6 +1964,44 @@ fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
     specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
+/// Drop the undefined label from a `next LABEL`, `last LABEL`, or `redo LABEL`
+/// statement (PL410 / `LoopControlUndefinedLabel`).
+///
+/// A labelled loop-control whose target label is not defined anywhere in the
+/// file is a runtime-fatal error in Perl.  Dropping the label converts the
+/// statement to its bare form (`next`, `last`, or `redo`), which targets the
+/// innermost enclosing loop — the most conservative safe fix.
+pub fn fix_loop_control_undefined_label(
+    source: &str,
+    diagnostic: &QuickFixDiagnostic,
+) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(text) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+
+    // The operator is the first whitespace-delimited token in the range.
+    let op = text.split_ascii_whitespace().next().unwrap_or("");
+    if !matches!(op, "next" | "last" | "redo") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: format!("Drop undefined label — replace `{text}` with bare `{op}`"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::LoopControlUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: range_start, end: range_end },
+                new_text: op.to_string(),
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 fn diagnostic_line_range(source: &str, range: (usize, usize)) -> Option<(usize, usize)> {
     let (start, end) = valid_diagnostic_range(source, range)?;
     let line_start = source[..start].rfind('\n').map_or(0, |idx| idx + 1);

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl410_bdd.rs
@@ -1,0 +1,261 @@
+//! BDD tests for the PL410 quick-fix handler (`fix_loop_control_undefined_label`).
+//!
+//! Each scenario follows:
+//!   GIVEN  source with a `next`/`last`/`redo LABEL` targeting an undefined label
+//!   WHEN   a PL410 diagnostic is supplied and code actions are requested
+//!   THEN   exactly one preferred action is returned that drops the label
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors the pattern from quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL410 — next LABEL → next
+// ===========================================================================
+
+#[test]
+fn next_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a `next OUTER` where OUTER is not defined in the file
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN there is exactly one action offering to drop the label
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {:?}", actions))?;
+
+    assert!(
+        action.title.contains("next OUTER"),
+        "title should include original text: {}",
+        action.title
+    );
+    assert!(
+        action.title.contains("bare `next`"),
+        "title should mention bare form: {}",
+        action.title
+    );
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "the drop-label action should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn next_undefined_label_edit_replaces_with_bare_next() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN source with `next MISSING`
+    let source = "for my $i (1..5) { next MISSING; }\n";
+    let stmt_start = source.find("next MISSING").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next MISSING".len();
+
+    let diag =
+        make_diag(stmt_start, stmt_end, "PL410", "`next MISSING` references undefined label");
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("next"))
+        .ok_or_else(|| format!("no 'next' action in: {actions:?}"))?;
+    let result = edited(source, action);
+
+    // THEN `next MISSING` becomes `next`
+    assert_eq!(result, "for my $i (1..5) { next; }\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — last LABEL → last
+// ===========================================================================
+
+#[test]
+fn last_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN `last PHANTOM` inside a while loop where PHANTOM is not defined
+    let source = "while (1) { last PHANTOM; }\n";
+    let stmt_start = source.find("last PHANTOM").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "last PHANTOM".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`last PHANTOM` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("last"))
+        .ok_or_else(|| format!("no 'last' action in: {actions:?}"))?;
+
+    assert!(
+        action.title.contains("last PHANTOM"),
+        "title should include original: {}",
+        action.title
+    );
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "while (1) { last; }\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// PL410 — redo LABEL → redo
+// ===========================================================================
+
+#[test]
+fn redo_undefined_label_produces_drop_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN `redo NOWHERE` where NOWHERE is not defined
+    let source = "for my $i (1..5) { redo NOWHERE; }\n";
+    let stmt_start = source.find("redo NOWHERE").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "redo NOWHERE".len();
+
+    let diag = make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`redo NOWHERE` references a label that is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diag]);
+    let action = find_action(&actions, |t| t.contains("redo"))
+        .ok_or_else(|| format!("no 'redo' action in: {actions:?}"))?;
+
+    assert!(
+        action.title.contains("redo NOWHERE"),
+        "title should include original: {}",
+        action.title
+    );
+    assert!(action.is_preferred);
+
+    let result = edited(source, action);
+    assert_eq!(result, "for my $i (1..5) { redo; }\n");
+
+    Ok(())
+}
+
+// ===========================================================================
+// Guard: invalid / non-char-boundary range returns no action
+// ===========================================================================
+
+#[test]
+fn invalid_range_returns_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic whose byte range falls on a non-char boundary
+    let source = "for my $i (1..3) { next GHOST; }\nmy $x = \"\u{e9}\";\n";
+    let char_start = source.find('\u{e9}').ok_or("marker not found")?;
+
+    // Range deliberately split inside the multi-byte character
+    let diag = make_diag(
+        char_start + 1,
+        char_start + 2,
+        "PL410",
+        "`next GHOST` references undefined label",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    assert!(
+        !actions.iter().any(|a| a.title.contains("Drop undefined label")),
+        "expected no PL410 action for non-char-boundary range, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Guard: non-loop-control operator does not produce an action
+// ===========================================================================
+
+#[test]
+fn non_loop_control_op_range_returns_no_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a PL410 diagnostic pointing at source text that is NOT next/last/redo
+    let source = "print \"hello\";\n";
+    let diag = make_diag(0, 5, "PL410", "`print LABEL` — should never fire, just a guard test");
+    let actions = actions_for(source, &[diag]);
+
+    assert!(
+        !actions.iter().any(|a| a.title.contains("Drop undefined label")),
+        "expected no PL410 action when text is not a loop-control op, got: {actions:?}"
+    );
+
+    Ok(())
+}
+
+// ===========================================================================
+// Dispatch smoke test: PL410 route is wired up
+// ===========================================================================
+
+#[test]
+fn pl410_dispatch_route_is_wired() -> Result<(), Box<dyn std::error::Error>> {
+    // Smoke test: a correctly-positioned PL410 diagnostic produces at least one action.
+    let source = "for my $i (1..10) { next OUTER; }\n";
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+
+    let stmt_start = source.find("next OUTER").ok_or("marker not found")?;
+    let stmt_end = stmt_start + "next OUTER".len();
+
+    let diags = vec![make_diag(
+        stmt_start,
+        stmt_end,
+        "PL410",
+        "`next OUTER` references a label that is not defined in this file",
+    )];
+
+    let actions = provider.get_code_actions(&ast, (0, source.len()), &diags);
+
+    assert!(
+        actions.iter().any(|a| a.title.contains("next")),
+        "PL410 dispatch route did not produce an action; actions: {actions:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes #9612.

`next LABEL`, `last LABEL`, and `redo LABEL` statements that reference an undefined label produce a PL410 diagnostic, but the editor lightbulb previously returned **no code actions** because `diagnostic_routes.rs` had no arm for `DiagnosticCode::LoopControlUndefinedLabel`.

This PR wires the missing route and implements the quick-fix handler.

---

## What changed

### `quick_fixes.rs` — new `fix_loop_control_undefined_label`

The fix extracts the loop-control operator (`next`, `last`, or `redo`) from the diagnostic range and replaces the entire `OP LABEL` token sequence with the bare operator:

```
next OUTER  →  next
last GHOST  →  last
redo NOWHERE → redo
```

Guards applied before producing any action:
- `valid_diagnostic_range` — rejects non-char-boundary or out-of-bounds ranges
- operator check — only `next`, `last`, `redo` proceed; anything else returns `vec[]`

`is_preferred: true` — there is exactly one sensible automated repair for this runtime-fatal condition.

### `diagnostic_routes.rs` — new route arm

```rust
c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
    actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));
}
```

### `tests/quick_fix_pl410_bdd.rs` — 7 BDD tests

| Test | Covers |
|------|--------|
| `next_undefined_label_produces_drop_action` | Action title contains original text and bare form; `is_preferred` true |
| `next_undefined_label_edit_replaces_with_bare_next` | Edit correctness: `next MISSING` → `next` |
| `last_undefined_label_produces_drop_action` | `last PHANTOM` → `last`; action + edit correct |
| `redo_undefined_label_produces_drop_action` | `redo NOWHERE` → `redo`; action + edit correct |
| `invalid_range_returns_no_action` | Non-char-boundary range is silently ignored |
| `non_loop_control_op_range_returns_no_action` | Non-loop-control text at range produces no action |
| `pl410_dispatch_route_is_wired` | Smoke test: dispatch table routes PL410 to handler |

---

## Why this design

- **Drop the label, not invent one.** Suggesting a `LABEL:` insertion requires knowing which enclosing loop to annotate — that's a multi-node AST rewrite outside the quick-fix contract. Dropping the label is safe (targets innermost loop), deterministic, and reversible by the user.
- **Mirrors the PL602 pattern** (`fix_security_signal_handler`) — validate range, check text at position, emit one preferred action.
- **Title format** — `"Drop undefined label — replace \`next OUTER\` with bare \`next\`"` mirrors the spec's intent to clearly show before/after.

---

## Test results

```
running 7 tests   (quick_fix_pl410_bdd)      — 7 passed
running 17 tests  (quick_fix_new_codes_bdd)  — 17 passed, 0 regressions
cargo clippy -p perl-lsp-rs-core             — clean
cargo fmt --check -p perl-lsp-rs-core        — clean
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYwsWHrFXjdaUaiEaYKaiH)_