### PR TITLE
release: prepare v0.16.0 (#9911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,86 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-06
+
+Release notes: [v0.16.0](docs/releases/v0.16.0.md)
+
+Minor release. Perldoc virtual-document links, inline completion hardening,
+LSP 3.18 applyEdit metadata and receipt locks, DAP improvements, quality and
+proof infrastructure.
+
 ### Added
 
-- 0.15.1 Neovim latency lane:
-  - `--runtime-mode e2e` / `PERL_LSP_E2E=1` for latency-focused editor
-    harnesses. Defaults: zero diagnostic debounce, syntax-only
-    diagnostics, no eager workspace indexing, no file watchers.
-  - `--diagnostic-mode syntax-only` /
-    `PERL_LSP_DIAGNOSTIC_MODE=syntax-only` restricts diagnostics to
-    parse errors only; skips semantic / native critic / external
-    perlcritic / module-resolution / workspace dead-code passes. Both
-    push and pull diagnostic paths honour the gate.
-  - `--diagnostic-debounce-ms <ms>` /
-    `PERL_LSP_DIAGNOSTIC_DEBOUNCE_MS=<ms>` configurable diagnostic
-    publish debounce window. `0` bypasses the debouncer entirely.
-  - E2E startup gate: `initialized` no longer kicks off eager workspace
-    indexing under e2e mode (override with `--eager-workspace-indexing
-    true`).
-  - Generation-aware stale read cancellation in the scheduler. Hover,
-    completion, definition, declaration, typeDefinition, implementation,
-    and references are cancelled with `RequestCancelled` when the
-    document generation advances between ingress and dispatch. Turns
-    typing storms into "latest request wins" instead of "every cursor
-    position gets its own work item."
-  - Raw-RPC latency receipts in `perl-lsp-ux-tests::ux_latency_raw_rpc`
-    and a Neovim lean smoke script at
-    `scripts/ux/neovim_lean_smoke.sh`.
-- Added the conservative `perl.explainProviderDecision` LSP execute-command
-  surface. It returns the structured provider decision explanation payload and
-  reports a low-confidence `missing_fact` / `no_result` fallback when no
-  provider-specific receipt is attached, avoiding false certainty while the
-  live provider receipt wiring lands.
+- **Perldoc / POD virtual documents** — `perldoc://` document links now resolve
+  to POD content from the workspace. Labels in `=head2` and `=item` sections are
+  linked targets within the virtual document; module links prefer workspace-local
+  POD before falling back to external `perldoc`. (`workspace/textDocumentContent`
+  extended with labeled-target link generation.) (#1186)
+- **LSP 3.18 applyEdit metadata** — `workspace/applyEdit` requests from the
+  server now include `metadata` (`label`, `description`, `isRefactoring`) when
+  the client advertises support, providing editors with descriptive undo labels
+  for server-originated refactors. (#1184)
+- **LSP 3.18 receipt locks** — New negative-claim and contract-lock tests verify
+  that capability-gated LSP 3.18 fields (`CompletionList.itemDefaults.data`,
+  `CompletionList.applyKind`, `CodeActionOptions.documentation`,
+  `SnippetTextEdit` workspace edits, `ApplyWorkspaceEditParams.metadata`,
+  `textDocument.codeLens.resolveSupport.properties`) are only emitted when the
+  client advertises the relevant capability. Accidental emission is now a test
+  failure. (#9628)
+- **Semantic tokens: label token type** — Perl statement and control labels
+  (`LOOP:`, `BLOCK:`) are now classified with a `label` token type. The semantic
+  token type count grows from 23 to 24.
+- **Quality gate enforce-new-RIPR+** — The transition gate now blocks new RIPR+
+  gaps on every PR. Existing gaps are tracked under a burndown exception
+  (expires 2026-09-30). New gaps are hard-blocked immediately. (#8197)
+- **Product smoke harness** — 30 UX fixture files and a 40-request smoke script
+  provide a deterministic release-readiness check. 6 fixtures / 40 requests
+  pass at the RC freeze commit.
+- **`perl.explainProviderDecision` execute-command** — Returns the structured
+  provider decision explanation payload; reports a low-confidence fallback when
+  no provider-specific receipt is attached.
 
 ### Fixed
 
-- LSP4IJ inline completion now follows the LSP 3.18 registration model:
-  static clients receive top-level `inlineCompletionProvider`, dynamic-capable
-  clients receive `client/registerCapability` for
-  `textDocument/inlineCompletion`, and `experimental.inlineCompletionProvider`
-  is never emitted.
-- `textDocument/inlineCompletion` has a runtime JSON-RPC receipt proving a
-  dynamic LSP4IJ-shaped client receives deterministic suggestions, including
-  `strict;` for a `use ` prefix. Disabling `lsp.inline_completion` suppresses
-  advertisement, registration, and execution.
-- Inline completion now treats automatic trigger requests conservatively by
-  returning only the top deterministic candidate, while explicit invoked
-  requests keep the richer deterministic candidate set.
-- Inline completion now returns explicit single-line UTF-16 replacement ranges
-  for matching partial tokens such as `use str` and `$obj->n`, preventing ghost
-  text from duplicating text the user already typed.
-- Lean editor mode now honors `--file-watchers=false` during dynamic watcher
-  registration while leaving feature-specific dynamic registrations, such as
-  inline completion, available. Semantic tokens advertise full-only support
-  until the delta/result-id path is implemented.
+- **Inline completion hard reject zones** — The server now returns an empty
+  result for positions inside string literals, comments, heredoc bodies, and
+  regex literals, preventing spurious suggestions in non-code contexts. (#9631)
+- **Inline completion replacement range safety** — Replacement ranges are now
+  clamped to the current line and validated against the document length before
+  being emitted, preventing out-of-range positions from reaching the client.
+  (#9626)
+- **Inline completion trigger-kind policy** — Automatic trigger requests receive
+  only the single top deterministic candidate; explicit invoked requests keep the
+  richer set. This matches the LSP 3.18 `triggerKind` intent. (#9621)
+- **Inline completion LSP 3.18 registration** — Static clients receive top-level
+  `inlineCompletionProvider`; dynamic-capable clients receive
+  `client/registerCapability`; `experimental.inlineCompletionProvider` is never
+  emitted.
+- **Folding range refresh receipt** — The server correctly handles
+  `workspace/foldingRange/refresh` round-trips in the test harness. (#9633)
+- **vscode-extension: Perl-missing remediation message** — The extension now
+  shows a corrected message when the `perl` executable is not found.
 
 ### Documentation
 
 - Updated JetBrains/LSP4IJ setup docs to prefer the upstream LSP4IJ `perl-lsp`
-  integration when available, with manual `perllsp --stdio` registration
-  moved to separate fallback and development guidance.
-- Added the semantic inline-completion roadmap, defining deterministic
-  project-aware ghost text as the lane goal while keeping AI optional and
-  gated behind parse-safety, ranking, and fixture receipts.
-
-### Notes (0.15.1)
-
-- This release does not implement true incremental AST reuse. The live
-  LSP path still full-parses after text changes; latency improvements
-  come from skipping avoidable background work and cancelling stale
-  reads earlier.
-- For latency testing, use a release binary with
-  `--runtime-mode e2e --diagnostic-mode syntax-only
-  --diagnostic-debounce-ms 0`, disable file watchers, and disable
-  semantic tokens at the client unless you are explicitly testing
-  semantic highlighting.
-
-### Planned
-
-- Documented the Rust 1.95 / 0.14.0 rollout sequence before implementation: compatibility spike first, then MSRV/toolchain, lint, no-panic, file-policy, CI routing, and release-prep lanes.
-- Added the proactive CI integrity guards rail ([`docs/development/RUST_1_95_PROACTIVE_GUARDS.md`](docs/development/RUST_1_95_PROACTIVE_GUARDS.md)) as a sibling rollout. Six guard PRs (PG-1 through PG-6) covering label enforcement, risk-pack referential integrity, lane mapping with matrix expansion, net-new workflow-allowlist ledger, CI Actuals emitter + subscription coverage check, and broad-glob justification tightening. Each row mirrors a sibling-repo proven shape.
-- Consolidated the remaining Rust 1.95 → 0.14.0 work into a single canonical roadmap: rewrote [`docs/development/RUST_1_95_ROLLOUT.md`](docs/development/RUST_1_95_ROLLOUT.md) into a post-landing source of truth (already landed / remaining implementation ladder / per-rail acceptance contracts / Claude-Codex operating contract); slimmed [`docs/ci/perl-lsp-rust-1.95-rollout.md`](docs/ci/perl-lsp-rust-1.95-rollout.md) to a historical pointer; added [`docs/ci/test-evidence-lanes.md`](docs/ci/test-evidence-lanes.md) defining the five evidence-lane shapes (PR-fast required / PR-targeted / nightly cron / release-only / advisory) with risk-pack auto-routing, skipped-by-policy receipts, and LEM cost framing. Umbrella tracking: **#8663**.
+  integration when available.
+- Added the semantic inline-completion roadmap (deterministic project-aware
+  ghost text as the lane goal; AI optional and gated).
 
 ## [0.15.2] - 2026-05-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-**Latest Release**: 0.15.0 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
+**Latest Release**: 0.16.0 | **Metrics**: [status/index.md](docs/project/status/index.md) | **API Stability**: [STABILITY.md](docs/reference/STABILITY.md) | **Implementation agents**: [AGENTS.md](AGENTS.md)
 
 ## Orchestration Model
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perl-ast"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-ast-v2",
  "perl-position-tracking",
@@ -1471,14 +1471,14 @@ dependencies = [
 
 [[package]]
 name = "perl-ast-v2"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-position-tracking",
 ]
 
 [[package]]
 name = "perl-ci-hygiene"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "perl-corpus"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dap"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "perl-dead-code"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-uri",
  "perl-workspace",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "perl-diagnostics"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-test-must",
  "serde",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "perl-incremental-parsing"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "lsp-types",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lexer"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "memchr",
@@ -1590,14 +1590,14 @@ dependencies = [
 
 [[package]]
 name = "perl-line-index"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-lsp-perltidy"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-parser-core",
  "perl-subprocess-runtime",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-rs-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "perl-lsp-ux-tests"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "perl-module"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-parser-core",
  "perl-tdd-support",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-bench"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-parser",
  "walkdir",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-comparison"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-ast",
  "perl-parser-core",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-ast",
  "perl-ast-v2",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "perl-parser-pest"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-tdd-support",
  "pest",
@@ -1808,14 +1808,14 @@ dependencies = [
 
 [[package]]
 name = "perl-pod"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "perl-position-tracking"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "lsp-types",
  "perl-tdd-support",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "perl-pragma"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "perl-ast",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "perl-refactoring"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "perl-regex"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "proptest",
  "thiserror",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-analyzer"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-module",
  "perl-parser-core",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "perl-semantic-facts"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1885,14 +1885,14 @@ dependencies = [
 
 [[package]]
 name = "perl-subprocess-runtime"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-tdd-support",
 ]
 
 [[package]]
 name = "perl-symbol"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "perl-tdd-support"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "lsp-types",
  "perl-parser-core",
@@ -1919,18 +1919,18 @@ dependencies = [
 
 [[package]]
 name = "perl-test-generators"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "proptest",
 ]
 
 [[package]]
 name = "perl-test-must"
-version = "0.15.0"
+version = "0.16.0"
 
 [[package]]
 name = "perl-token"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "criterion",
  "perl-lexer",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "perl-uri"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "percent-encoding",
  "perl-tdd-support",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "perl-workspace"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "perllsp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "perl-lsp-rs",
 ]
@@ -3168,7 +3168,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-perl-c"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "cc",
  "insta",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-perl-rs"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "insta",
  "perl-ast",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ allow = [
 
 # Workspace-level package metadata
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.95"
 authors = ["Steven Zimmerman, CPA <git@effortlesssteven.com>"]
@@ -214,26 +214,26 @@ repository = "https://github.com/EffortlessMetrics/perl-lsp"
 homepage = "https://github.com/EffortlessMetrics/perl-lsp"
 
 [workspace.dependencies]
-perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.15.0" }
+perl-ast-v2 = { path = "crates/perl-ast-v2", version = "0.16.0" }
 # Tier 1: Leaf crates (no internal dependencies)
-perl-token = { path = "crates/perl-token", version = "0.15.0" }
-perl-regex = { path = "crates/perl-regex", version = "0.15.0" }
-perl-pragma = { path = "crates/perl-pragma", version = "0.15.0" }
-perl-lexer = { path = "crates/perl-lexer", version = "0.15.0" }
-perl-ast = { path = "crates/perl-ast", version = "0.15.0" }
+perl-token = { path = "crates/perl-token", version = "0.16.0" }
+perl-regex = { path = "crates/perl-regex", version = "0.16.0" }
+perl-pragma = { path = "crates/perl-pragma", version = "0.16.0" }
+perl-lexer = { path = "crates/perl-lexer", version = "0.16.0" }
+perl-ast = { path = "crates/perl-ast", version = "0.16.0" }
 # Wave D absorbed (internal modules in perl-parser/src/):
 #   perl-heredoc-anti-patterns → perl-parser::heredoc_anti_patterns
 # Wave D absorbed (internal modules in perl-parser-core/src/syntax/):
 #   perl-quote, perl-heredoc, perl-error, perl-edit
-perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.15.0" }
-perl-symbol = { path = "crates/perl-symbol", version = "0.15.0" }
-perl-module = { path = 'crates/perl-module', version = "0.15.0" }
+perl-position-tracking = { path = "crates/perl-position-tracking", version = "0.16.0" }
+perl-symbol = { path = "crates/perl-symbol", version = "0.16.0" }
+perl-module = { path = 'crates/perl-module', version = "0.16.0" }
 # Wave D absorbed: perl-qualified-name → perl-parser::qualified_name
-perl-line-index = { path = "crates/perl-line-index", version = "0.15.0" }
+perl-line-index = { path = "crates/perl-line-index", version = "0.16.0" }
 # Wave D absorbed: perl-source-file → perl-parser::source_file
 # Wave D absorbed: perl-text-line → perl-parser-core::text_line
 # (perl-content-length-framing absorbed into perl-lsp-rs-core::transport::framing — Wave Final PR B)
-perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.15.0" }
+perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "0.16.0" }
 # (perl-lsp-document-highlight absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-document-links absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-performance absorbed into perl-lsp-rs-core::tooling::performance — Wave G3 step 5)
@@ -241,31 +241,31 @@ perl-subprocess-runtime = { path = "crates/perl-subprocess-runtime", version = "
 # Wave D absorbed: perl-ast-utils → perl-parser::ast_utils
 # (perl-lsp-input-validation absorbed into perl-lsp-rs-core::runtime::input_validation — Wave G2)
 # (perl-lsp-text-utils absorbed into perl-lsp-rs-core::runtime::text_utils — Wave G2)
-perl-uri = { path = "crates/perl-uri", version = "0.15.0" }
+perl-uri = { path = "crates/perl-uri", version = "0.16.0" }
 # Wave D absorbed: perl-percentile → perl-parser::percentile
 # (perl-lsp-import-management absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-critic-parser absorbed into perl-lsp-rs-core::critic_parser — Wave G3 step 7)
 # (perl-lsp-protocol absorbed into perl-lsp-rs-core::protocol — Wave G3 step 2)
 # Wave D absorbed: perl-path-normalize → perl-parser-core::path_normalize
 # Wave D absorbed: perl-path-security → perl-parser-core::path_security
-perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.15.0" }
-perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.15.0" }
-perl-pod = { path = "crates/perl-pod", version = "0.15.0" }
-perl-corpus = { path = "crates/perl-corpus", version = "0.15.0" }
-perl-dap = { path = "crates/perl-dap", version = "0.15.0" }
-perl-dead-code = { path = "crates/perl-dead-code", version = "0.15.0" }
+perl-lsp-rs-core = { path = "crates/perl-lsp-rs-core", version = "0.16.0" }
+perl-ci-hygiene = { path = "crates/perl-ci-hygiene", version = "0.16.0" }
+perl-pod = { path = "crates/perl-pod", version = "0.16.0" }
+perl-corpus = { path = "crates/perl-corpus", version = "0.16.0" }
+perl-dap = { path = "crates/perl-dap", version = "0.16.0" }
+perl-dead-code = { path = "crates/perl-dead-code", version = "0.16.0" }
 # (perl-feature-catalog absorbed into perl-lsp-rs-core::feature_catalog — Wave Final PR B)
 # Tier 2: Single-level dependencies
-perl-parser-core = { path = "crates/perl-parser-core", version = "0.15.0" }
+perl-parser-core = { path = "crates/perl-parser-core", version = "0.16.0" }
 # (perl-lsp-transport absorbed into perl-lsp-rs-core::transport — Wave G3 step 4)
 # (perl-lsp-tooling absorbed into perl-lsp-rs-core::tooling — Wave G3 step 6)
-perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.15.0" }
+perl-lsp-perltidy = { path = "crates/perl-lsp-perltidy", version = "0.16.0" }
 # (perl-lsp-on-type-formatting absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting-types absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-formatting absorbed into perl-lsp-rs-core::providers::formatting — Wave G1b)
-perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.15.0" }
-perl-test-must = { path = "crates/perl-test-must", version = "0.15.0" }
-perl-test-generators = { path = "crates/perl-test-generators", version = "0.15.0" }
+perl-tdd-support = { path = "crates/perl-tdd-support", version = "0.16.0" }
+perl-test-must = { path = "crates/perl-test-must", version = "0.16.0" }
+perl-test-generators = { path = "crates/perl-test-generators", version = "0.16.0" }
 # (perl-lsp-diagnostics absorbed into perl-lsp-rs-core::providers::diagnostics — Wave G1b)
 # (perl-lsp-semantic-tokens absorbed into perl-lsp-rs-core::providers::semantic_tokens — Wave G1b)
 # (perl-lsp-inlay-hints absorbed into perl-lsp-rs-core::providers — Wave G1a)
@@ -289,28 +289,28 @@ perl-test-generators = { path = "crates/perl-test-generators", version = "0.15.0
 # (perl-lsp-code-actions absorbed into perl-lsp-rs-core::providers::code_actions — Wave G1b)
 # (perl-lsp-folding absorbed into perl-lsp-rs-core::providers — Wave G1a)
 # (perl-lsp-selection-range absorbed into perl-lsp-rs-core::providers — Wave G1a)
-perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.15.0" }
+perl-diagnostics = { path = "crates/perl-diagnostics", version = "0.16.0" }
 # Tier 3: Two-level dependencies
-perl-workspace = { path = "crates/perl-workspace", version = "0.15.0" }
-perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.15.0" }
-perl-refactoring = { path = "crates/perl-refactoring", version = "0.15.0" }
+perl-workspace = { path = "crates/perl-workspace", version = "0.16.0" }
+perl-incremental-parsing = { path = "crates/perl-incremental-parsing", version = "0.16.0" }
+perl-refactoring = { path = "crates/perl-refactoring", version = "0.16.0" }
 
 # Tier 4: Three-level dependencies
-perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.15.0" }
-perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.15.0" }
+perl-semantic-analyzer = { path = "crates/perl-semantic-analyzer", version = "0.16.0" }
+perl-semantic-facts = { path = "crates/perl-semantic-facts", version = "0.16.0" }
 # (perl-lsp-providers absorbed into perl-lsp-rs-core::providers::lsp_compat — Wave G1b)
 
 # Tier 5: Application crates
-perl-parser = { path = "crates/perl-parser", version = "0.15.0" }
-perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.15.0" }
-perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.15.0" }
+perl-parser = { path = "crates/perl-parser", version = "0.16.0" }
+perl-lsp-rs = { path = "crates/perl-lsp-rs", version = "0.16.0" }
+perl-lsp-ux-tests = { path = "crates/perl-lsp-ux-tests", version = "0.16.0" }
 
 # Legacy/Compatibility crates
-perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.15.0" }
+perl-parser-pest = { path = "crates/perl-parser-pest", version = "0.16.0" }
 
 # External dependencies
-tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.15.0" }
-tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.15.0" }
+tree-sitter-perl-c = { path = "crates/tree-sitter-perl-c", version = "0.16.0" }
+tree-sitter-perl-rs = { path = "crates/tree-sitter-perl-rs", version = "0.16.0" }
 tree-sitter = "0.26.9"
 ropey = "1.6.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -14,6 +14,7 @@ Tag commit timestamps may differ from release dates.
 
 | Version | Tag | GitHub Release | Released | Tag commit | Compare | Assets | crates.io | VS Code Marketplace | Notes file |
 |---------|-----|----------------|----------|------------|---------|--------|-----------|---------------------|------------|
+| [0.16.0] | `v0.16.0` | pending | pending | `pending` | [v0.15.2...v0.16.0] | pending | pending | pending | [v0.16.0][n-0.16.0] |
 | [0.15.2] | `v0.15.2` | pending | 2026-05-26 | `746edcb7` | [v0.15.1...v0.15.2] | pending | pending | pending | [v0.15.2][n-0.15.2] |
 | [0.15.1] | `v0.15.1` | pending | 2026-05-26 | `15cbe7e6` | [v0.15.0...v0.15.1] | pending | pending | pending | [v0.15.1][n-0.15.1] |
 | [0.15.0] | `v0.15.0` | pending | pending | `pending` | [v0.14.0...v0.15.0] | pending | pending | pending | [v0.15.0][n-0.15.0] |
@@ -63,6 +64,7 @@ Tag commit timestamps may differ from release dates.
 ## Links
 
 <!-- Notes files -->
+[n-0.16.0]: docs/releases/v0.16.0.md
 [n-0.15.2]: docs/releases/v0.15.2.md
 [n-0.15.1]: docs/releases/v0.15.1.md
 [n-0.15.0]: docs/releases/v0.15.0.md
@@ -85,6 +87,7 @@ Tag commit timestamps may differ from release dates.
 [n-0.8.3]: docs/releases/v0.8.3.md
 
 <!-- Version links (to notes files) -->
+[0.16.0]: docs/releases/v0.16.0.md
 [0.15.2]: docs/releases/v0.15.2.md
 [0.15.1]: docs/releases/v0.15.1.md
 [0.15.0]: docs/releases/v0.15.0.md
@@ -107,6 +110,9 @@ Tag commit timestamps may differ from release dates.
 [0.8.3]: docs/releases/v0.8.3.md
 
 <!-- GitHub Releases -->
+[gh-0.16.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.16.0
+[gh-0.15.2]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.15.2
+[gh-0.15.1]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.15.1
 [gh-0.15.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.15.0
 [gh-0.14.0]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.14.0
 [gh-0.13.4]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.13.4
@@ -123,6 +129,7 @@ Tag commit timestamps may differ from release dates.
 [gh-0.8.3]: https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.8.3
 
 <!-- Compare ranges -->
+[v0.15.2...v0.16.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.2...v0.16.0
 [v0.15.1...v0.15.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.1...v0.15.2
 [v0.15.0...v0.15.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.0...v0.15.1
 [v0.14.0...v0.15.0]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.14.0...v0.15.0

--- a/crates/perl-module/Cargo.toml
+++ b/crates/perl-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perl-module"
-version = "0.15.0"
+version = "0.16.0"
 publish = true
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/docs/releases/v0.16.0.md
+++ b/docs/releases/v0.16.0.md
@@ -1,0 +1,125 @@
+---
+version: "0.16.0"
+tag: "v0.16.0"
+release_date_utc: "pending"
+previous_tag: "v0.15.2"
+compare: "https://github.com/EffortlessMetrics/perl-lsp/compare/v0.15.2...v0.16.0"
+notes_status: draft
+release_track: public-alpha
+release_kind: minor
+channels:
+  github_release: pending
+  crates_io: pending
+  vscode_marketplace: pending
+  open_vsx: pending
+  docker: pending
+---
+
+# v0.16.0
+
+## Summary
+
+Minor release. Perldoc virtual-document links, inline completion hardening,
+LSP 3.18 applyEdit metadata and receipt locks, DAP improvements, quality gate
+infrastructure (enforce-new-RIPR+), and product smoke harness.
+
+## What improved for users
+
+- **Perldoc / POD virtual documents** — The `perldoc://` document-link scheme
+  now resolves to POD content from the workspace. Labeled targets within
+  `=head2` and `=item` sections are navigable links inside the virtual document.
+  Module links prefer workspace-local POD before falling back to external
+  `perldoc`. This makes `K` (hover-docs) and document-link navigation on
+  `use Module` lines produce navigable, content-rich results in supporting
+  editors. (#1186)
+
+- **Inline completion hard reject zones** — Ghost text no longer appears inside
+  string literals, comments, heredoc bodies, or regex literals. Spurious
+  suggestions in non-code contexts are suppressed at the server. (#9631)
+
+- **Inline completion replacement range safety** — Replacement ranges are now
+  validated and clamped before being sent to the client, preventing
+  out-of-range positions from causing client-side errors. (#9626)
+
+- **Inline completion trigger-kind policy** — Automatic (typing) trigger returns
+  only the single top candidate; explicit (manual) invocation returns the full
+  deterministic set. This matches LSP 3.18 `triggerKind` intent. (#9621)
+
+- **Semantic token label type** — Perl statement and control labels (`LOOP:`,
+  `BLOCK:`) are now classified with a `label` semantic token type, giving
+  editors correct syntax highlighting for labeled blocks.
+
+- **vscode-extension: Perl-missing remediation message** — The VS Code extension
+  now shows a corrected message when the `perl` executable is not found.
+
+## What changed for editor integrations
+
+- **LSP 3.18 applyEdit metadata** — `workspace/applyEdit` requests now include
+  `metadata` (`label`, `description`, `isRefactoring`) when the client
+  advertises `workspace.applyEdit` support with metadata fields. Editors that
+  support this will show descriptive undo-stack labels for server-originated
+  refactors (e.g., "Rename symbol", "Extract subroutine"). (#1184)
+
+- **LSP 3.18 receipt locks** — Capability-gated LSP 3.18 fields are now
+  contract-locked: `CompletionList.itemDefaults.data`,
+  `CompletionList.applyKind`, `CodeActionOptions.documentation`,
+  `SnippetTextEdit` workspace edits, `ApplyWorkspaceEditParams.metadata`, and
+  `textDocument.codeLens.resolveSupport.properties` are emitted **only** when
+  the client advertises the relevant capability. Accidental emission is blocked
+  at the test level. (#9628)
+
+- **Inline completion LSP 3.18 registration** — Static clients receive top-level
+  `inlineCompletionProvider`; dynamic-capable clients (those advertising
+  `textDocument.inlineCompletion.dynamicRegistration`) receive
+  `client/registerCapability`. `experimental.inlineCompletionProvider` is never
+  emitted.
+
+- **Folding range refresh** — `workspace/foldingRange/refresh` round-trips are
+  now tested in the receipt harness. (#9633)
+
+## Install / package / release path
+
+No changes to the install path or packaging in this release. `cargo install
+perllsp` and `cargo install perl-dap` are expected to work; the package-content
+CI gate introduced in 0.15.2 continues to guard the crates.io publish.
+
+Channels are pending publish; this PR prepares the version strings and release
+artifacts only. No tag or publish happens in this PR.
+
+## Known limitations
+
+### Proof burndown exceptions (active)
+
+Two proof-lane burndown exceptions are active as of this release. Both are
+documented in `policy/quality-gate-exceptions.toml`.
+
+**`ripr-total-burndown`** (id: `ripr-total-burndown`, expires: `2026-09-30`):
+> Existing repo-wide RIPR+ gaps predate the transition gate. New gaps are
+> blocked first while existing clusters are burned down with focused proof PRs.
+> Final target: repo-wide RIPR+ unresolved total = 0.
+> Issue: #8197. Review after: 2026-06-28.
+
+**`project-coverage-burndown`** (id: `project-coverage-burndown`, expires: `2026-09-30`):
+> Project coverage is below the final 95% floor while patch coverage becomes
+> blocking first.
+> Final target: workspace project coverage >= 95%.
+> Issue: #8197. Review after: 2026-06-28.
+
+Both exceptions expire 2026-09-30. Neither exception permits new RIPR+ gaps on
+incoming PRs — new gaps are hard-blocked by the quality gate.
+
+## Validation performed
+
+- **pr-fast 10/10 PASS** at swarm commit `a87f766ab` (the RC freeze point for
+  this release).
+- **Product smoke** 6 fixtures / 40 requests green at `a87f766ab`.
+- **quality-gate enforce-new-RIPR+ PASS** — new RIPR+ gaps = 0 at RC freeze.
+- **publish dry-run packaging gate** green on sync PR #9909 (workspace resolves
+  at the promoted version; `cargo check --locked` passes on the unpacked
+  `perl-lsp-rs-core` crate).
+
+## Related
+
+- Previous release: [v0.15.2](v0.15.2.md)
+- Sync promote PR: #9909
+- Quality gate exceptions: `policy/quality-gate-exceptions.toml`

--- a/features.toml
+++ b/features.toml
@@ -3,7 +3,7 @@
 # Used to generate capabilities, documentation, and compliance reports
 
 [meta]
-version = "0.15.0"
+version = "0.16.0"
 lsp_version = "3.18"
 compliance_percent = 100  # 119 total features (88 LSP + 24 DAP + 7 perl-lsp extensions), 118/119 advertised
 

--- a/flake.nix
+++ b/flake.nix
@@ -204,7 +204,7 @@
 
           perl-lsp = pkgs.rustPlatform.buildRustPackage {
             pname = "perl-lsp";
-            version = "0.15.0";
+            version = "0.16.0";
             src = self;
             cargoLock.lockFile = ./Cargo.lock;
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perl-lsp-rs",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perl-lsp-rs",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.17",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "perl-lsp-rs",
   "displayName": "Perl Language Server (perl-lsp)",
   "description": "Native Perl 5 language server. Fast. Feature-rich. Zero dependencies.",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publisher": "EffortlessMetrics",
   "preview": true,
   "markdown": "github",


### PR DESCRIPTION
## Version table

| Field | Value |
|-------|-------|
| Previous shipped | 0.15.2 |
| This PR prepares | **0.16.0** |
| Version kind | minor |
| Base commit | `6925335fa` (source/master — sync promote from swarm a87f766ab) |

## Files changed in this PR

| File | Change |
|------|--------|
| `Cargo.toml` | workspace.package.version 0.15.0 → 0.16.0 |
| `Cargo.lock` | regenerated at 0.16.0 |
| `crates/perl-module/Cargo.toml` | standalone version 0.15.0 → 0.16.0 |
| `CHANGELOG.md` | new [0.16.0] section; [Unreleased] cleared |
| `RELEASE_HISTORY.md` | new 0.16.0 row + missing gh-0.15.2/gh-0.15.1 link refs added |
| `docs/releases/v0.16.0.md` | new release notes file |
| `CLAUDE.md` | Latest Release marker 0.15.0 → 0.16.0 |
| `features.toml` | meta.version 0.15.0 → 0.16.0 |
| `flake.nix` | version string 0.15.0 → 0.16.0 |
| `vscode-extension/package.json` | version 0.15.0 → 0.16.0 |
| `vscode-extension/package-lock.json` | version 0.15.0 �� 0.16.0 |

## Changelog summary (0.16.0)

**Added:**
- Perldoc / POD virtual documents — `perldoc://` links resolve to workspace POD with labeled targets (#1186)
- LSP 3.18 applyEdit metadata — `workspace/applyEdit` includes `metadata` when client advertises support (#1184)
- LSP 3.18 receipt locks — capability-gated fields locked by contract tests (#9628)
- Semantic token `label` type for Perl statement/control labels
- Quality gate enforce-new-RIPR+ — new gaps hard-blocked on every PR (#8197)
- Product smoke harness — 30 fixtures / 40 requests deterministic check

**Fixed:**
- Inline completion hard reject zones (strings, comments, heredocs, regex) (#9631)
- Inline completion replacement range safety (#9626)
- Inline completion trigger-kind policy (#9621)
- Inline completion LSP 3.18 registration model
- Folding range refresh receipt (#9633)
- vscode-extension: Perl-missing remediation message

## Proof posture

| Gate | Result |
|------|--------|
| pr-fast (swarm a87f766ab) | 10/10 PASS |
| Product smoke | 6 fixtures / 40 requests green |
| quality-gate enforce-new-RIPR+ | new gaps = 0 (PASS) |
| publish dry-run packaging | green (sync PR #9909) |
| check-version-sync | 43/43 sites agree on 0.16.0 |
| cargo check -p perl-lsp-rs --locked | clean |
| check_release_history.sh | passed |

**Two burndown exceptions active** (documented in `policy/quality-gate-exceptions.toml` and release notes):
- `ripr-total-burndown` — existing RIPR+ gaps being burned down; new gaps hard-blocked; expires 2026-09-30
- `project-coverage-burndown` — project coverage below 95% floor; patch coverage blocking first; expires 2026-09-30

## What this PR does NOT do

- **No tag** — v0.16.0 tag is not created in this PR.
- **No publish** — No crates.io or VS Code Marketplace publish happens here.
- **No merge without approval** — Release orchestration dispatch requires explicit approval from the maintainer.

Channels section in `docs/releases/v0.16.0.md` reads `pending` on all channels. Publishing requires a separate explicit step.