### PR TITLE
queue: merge train 2 — stranded branches + retries (#9915)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/execution.rs
+++ b/crates/perl-dap/src/debug_adapter/execution.rs
@@ -172,6 +172,7 @@ impl DebugAdapter {
         arguments: Option<Value>,
     ) -> DapMessage {
         let _args: Option<PauseArguments> = arguments.and_then(|v| serde_json::from_value(v).ok());
+        let mut failure_message = None;
         let success = if let Some(ref mut session) =
             *lock_or_recover(&self.session, "debug_adapter.session")
         {
@@ -183,6 +184,7 @@ impl DebugAdapter {
             self.send_interrupt_signal(pid)
         } else {
             tracing::warn!("No active debug session to pause");
+            failure_message = Some(Self::no_active_debug_session_message("pause"));
             false
         };
 
@@ -192,7 +194,11 @@ impl DebugAdapter {
             success,
             command: "pause".to_string(),
             body: None,
-            message: if !success { Some("Failed to pause debugger".to_string()) } else { None },
+            message: if success {
+                None
+            } else {
+                failure_message.or_else(|| Some("Failed to pause debugger".to_string()))
+            },
         }
     }
 
@@ -384,7 +390,7 @@ impl DebugAdapter {
                 success: false,
                 command: "goto".to_string(),
                 body: None,
-                message: Some("No active debug session".to_string()),
+                message: Some(Self::no_active_debug_session_message("goto")),
             }
         }
     }
@@ -513,5 +519,66 @@ impl DebugAdapter {
                     .to_string(),
             ),
         }
+    }
+
+    fn no_active_debug_session_message(action: &str) -> String {
+        format!(
+            "Cannot {action} because no Perl debug session is active. Start a launch or attach \
+             request first, wait for the debug session to start, then retry {action}."
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+    #[test]
+    fn pause_without_session_guides_recovery() -> TestResult {
+        let mut adapter = DebugAdapter::new();
+
+        let response = adapter.handle_request(1, "pause", None);
+
+        match response {
+            DapMessage::Response { success, command, message, .. } => {
+                assert_eq!(command, "pause");
+                assert!(!success, "pause without a session should fail");
+                let message = message.ok_or("pause failure should include guidance")?;
+                assert!(message.contains("no Perl debug session is active"));
+                assert!(message.contains("Start a launch or attach request"));
+                assert!(message.contains("retry pause"));
+            }
+            other => return Err(format!("expected pause response, got {other:?}").into()),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn goto_without_session_guides_recovery_after_target_lookup() -> TestResult {
+        let mut adapter = DebugAdapter::new();
+        {
+            let mut goto_targets = lock_or_recover(&adapter.goto_targets, "test.goto_targets");
+            goto_targets.insert(42, ("script.pl".to_string(), 12));
+        }
+
+        let response =
+            adapter.handle_request(1, "goto", Some(json!({ "threadId": 1, "targetId": 42 })));
+
+        match response {
+            DapMessage::Response { success, command, message, .. } => {
+                assert_eq!(command, "goto");
+                assert!(!success, "goto without a session should fail");
+                let message = message.ok_or("goto failure should include guidance")?;
+                assert!(message.contains("no Perl debug session is active"));
+                assert!(message.contains("Start a launch or attach request"));
+                assert!(message.contains("retry goto"));
+            }
+            other => return Err(format!("expected goto response, got {other:?}").into()),
+        }
+
+        Ok(())
     }
 }

--- a/crates/perl-dap/src/debug_adapter/process.rs
+++ b/crates/perl-dap/src/debug_adapter/process.rs
@@ -237,6 +237,13 @@ impl DebugAdapter {
             );
         }
 
+        if has_surrounding_quotes(program) {
+            return Err(format!(
+                "The launch.json 'program' value includes surrounding quotes: {program}. \
+                 Remove the extra quotes so it is just the script path."
+            ));
+        }
+
         // Validate that the program is a regular file (not a directory, device, etc.)
         // Using metadata().is_file() is more robust than exists() because:
         // - exists() returns true for directories
@@ -1680,10 +1687,17 @@ impl DebugAdapter {
     }
 }
 
+fn has_surrounding_quotes(value: &str) -> bool {
+    value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        DebugAdapter, detect_perl_info, format_perl_spawn_error, is_valid_perl_interpreter,
+        DebugAdapter, detect_perl_info, format_perl_spawn_error, has_surrounding_quotes,
+        is_valid_perl_interpreter,
     };
 
     #[test]
@@ -1720,6 +1734,40 @@ mod tests {
         assert!(message.contains("Module Some::Missing::Module not found"));
         assert!(message.contains("cpan Some::Missing::Module"));
         assert!(message.contains("metacpan.org/pod/Some::Missing::Module"));
+    }
+
+    #[test]
+    fn detects_surrounding_program_quotes() -> Result<(), Box<dyn std::error::Error>> {
+        assert!(has_surrounding_quotes("\"script.pl\""));
+        assert!(has_surrounding_quotes("'script.pl'"));
+        assert!(!has_surrounding_quotes("script.pl"));
+        assert!(!has_surrounding_quotes("\"script.pl"));
+        assert!(!has_surrounding_quotes("script.pl\""));
+        Ok(())
+    }
+
+    #[test]
+    fn launch_debugger_rejects_quoted_program_path_with_guidance()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use std::collections::HashMap;
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut tmp = NamedTempFile::new()?;
+        writeln!(tmp, "# placeholder")?;
+        let tmp_path = tmp.path().to_str().ok_or("temp path is not valid UTF-8")?;
+        let quoted = format!("\"{tmp_path}\"");
+
+        let mut adapter = DebugAdapter::new();
+        let error = adapter
+            .launch_debugger(&quoted, "perl", Vec::new(), false, HashMap::new())
+            .err()
+            .ok_or("expected quoted program path to be rejected")?;
+
+        assert!(error.contains("surrounding quotes"), "message was: {error}");
+        assert!(error.contains("launch.json 'program'"), "message was: {error}");
+        assert!(error.contains("Remove the extra quotes"), "message was: {error}");
+        Ok(())
     }
 
     /// Verify that `detect_perl_info()` runs without panicking.

--- a/crates/perl-lsp-rs/src/cli.rs
+++ b/crates/perl-lsp-rs/src/cli.rs
@@ -204,6 +204,9 @@ fn run_check(command_name: &str, files: &[String]) -> i32 {
             Ok(s) => s,
             Err(e) => {
                 eprintln!("{path}: error reading file: {e}");
+                if let Some(guidance) = file_read_error_guidance(&e) {
+                    eprintln!("help: {guidance}");
+                }
                 errors += 1;
                 continue;
             }
@@ -230,6 +233,21 @@ fn run_check(command_name: &str, files: &[String]) -> i32 {
     }
 
     if errors > 0 { 1 } else { 0 }
+}
+
+fn file_read_error_guidance(error: &std::io::Error) -> Option<&'static str> {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => {
+            Some("check the path, or use `--check-project <dir>` to scan a project directory")
+        }
+        std::io::ErrorKind::IsADirectory => {
+            Some("`--check` expects files; use `--check-project <dir>` to scan a directory")
+        }
+        std::io::ErrorKind::PermissionDenied => {
+            Some("check file permissions, then rerun with a readable Perl file")
+        }
+        _ => None,
+    }
 }
 
 fn format_parse_error_context(source: &str, error: &perl_parser::ParseError) -> Vec<String> {
@@ -454,9 +472,11 @@ fn print_version(command_name: &str) {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_parse_error_context, invocation_name, render_help_text, render_shell_completion,
+        file_read_error_guidance, format_parse_error_context, invocation_name, render_help_text,
+        render_shell_completion,
     };
     use std::ffi::OsString;
+    use std::io::ErrorKind;
 
     #[test]
     fn invocation_name_uses_file_stem_from_first_arg() {
@@ -497,6 +517,30 @@ mod tests {
         assert!(rendered.contains("_my_perl_lsp"));
         assert!(rendered.contains("my-perl-lsp"));
         assert!(!rendered.contains("complete -F _perl_lsp perl-lsp"));
+    }
+
+    #[test]
+    fn file_read_error_guidance_covers_common_user_actions()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let missing = std::io::Error::from(ErrorKind::NotFound);
+        let directory = std::io::Error::from(ErrorKind::IsADirectory);
+        let denied = std::io::Error::from(ErrorKind::PermissionDenied);
+        let interrupted = std::io::Error::from(ErrorKind::Interrupted);
+
+        assert_eq!(
+            file_read_error_guidance(&missing),
+            Some("check the path, or use `--check-project <dir>` to scan a project directory")
+        );
+        assert_eq!(
+            file_read_error_guidance(&directory),
+            Some("`--check` expects files; use `--check-project <dir>` to scan a directory")
+        );
+        assert_eq!(
+            file_read_error_guidance(&denied),
+            Some("check file permissions, then rerun with a readable Perl file")
+        );
+        assert_eq!(file_read_error_guidance(&interrupted), None);
+        Ok(())
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/cli/check_project.rs
+++ b/crates/perl-lsp-rs/src/cli/check_project.rs
@@ -168,7 +168,12 @@ fn emit_category_section(category_counts: &HashMap<String, usize>) {
 }
 
 fn categorize_error(msg: &str) -> String {
-    if msg.contains("Unexpected end of input") {
+    let normalized = msg.to_ascii_lowercase();
+    if normalized.contains("end of input")
+        || normalized.contains("unexpected eof")
+        || normalized.contains("found eof")
+        || normalized.contains("reached eof")
+    {
         "Unexpected EOF".to_string()
     } else if msg.contains("expected") && msg.contains("found") {
         "Unexpected token".to_string()
@@ -216,6 +221,11 @@ mod tests {
     #[test]
     fn categorize_error_maps_known_cases() {
         assert_eq!(categorize_error("Unexpected end of input while parsing"), "Unexpected EOF");
+        assert_eq!(
+            categorize_error("Unclosed block: expected '}' but reached end of input"),
+            "Unexpected EOF"
+        );
+        assert_eq!(categorize_error("expected expression, found EOF"), "Unexpected EOF");
         assert_eq!(categorize_error("expected ; but found }"), "Unexpected token");
         assert_eq!(categorize_error("Invalid syntax near token"), "Syntax error");
         assert_eq!(categorize_error("Lexer error: invalid byte"), "Lexer error");

--- a/crates/perl-lsp-rs/src/runtime/diagnostics.rs
+++ b/crates/perl-lsp-rs/src/runtime/diagnostics.rs
@@ -9,6 +9,7 @@ use crate::features::diagnostics::{
     Diagnostic as InternalDiagnostic, DiagnosticTag as InternalDiagnosticTag,
     PullDiagnosticsContext,
 };
+use crate::protocol::invalid_params;
 use perl_diagnostics::codes::DiagnosticCode;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -61,6 +62,14 @@ fn find_workspace_perlcritic_profile(
         dir = current.parent().map(|p| p.to_path_buf());
     }
     None
+}
+
+fn invalid_document_diagnostic_uri_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameter: textDocument.uri\n\n\
+         textDocument/diagnostic expects params.textDocument.uri to identify the document to diagnose.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"}}",
+    )
 }
 
 /// Orchestrator for pull diagnostics operations.
@@ -945,18 +954,16 @@ impl LspServer {
         use lsp_types::Uri;
 
         if let Some(params) = params {
-            let uri_str = params["textDocument"]["uri"].as_str().unwrap_or("");
+            let uri_str = params
+                .pointer("/textDocument/uri")
+                .and_then(Value::as_str)
+                .ok_or_else(invalid_document_diagnostic_uri_params)?;
             let previous_result_id = params["previousResultId"].as_str().map(|s| s.to_string());
 
             // Parse URI
             let uri: Uri = match uri_str.parse() {
-                Ok(u) => u,
-                Err(_) => {
-                    return Ok(Some(json!({
-                        "kind": "full",
-                        "items": []
-                    })));
-                }
+                Ok(uri) => uri,
+                Err(_) => return Err(invalid_document_diagnostic_uri_params()),
             };
 
             // Syntax-only short-circuit for pull diagnostics. Mirrors the
@@ -1021,9 +1028,11 @@ impl LspServer {
                     &perlcritic_diags,
                 )));
             }
+        } else {
+            return Err(invalid_document_diagnostic_uri_params());
         }
 
-        // Return empty diagnostics if document not found
+        // Return empty diagnostics if document not found.
         Ok(Some(json!({
             "kind": "full",
             "items": []
@@ -1967,6 +1976,50 @@ mod tests {
         let server =
             LspServer::with_io(Box::new(std::io::Cursor::new(Vec::<u8>::new())), Box::new(writer));
         (server, buf)
+    }
+
+    fn expect_document_diagnostic_uri_guidance(err: JsonRpcError) -> Result<(), String> {
+        assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+        for expected in [
+            "Missing required parameter: textDocument.uri",
+            "textDocument/diagnostic",
+            "params.textDocument.uri",
+            "file:///workspace/lib/My/Module.pm",
+        ] {
+            if !err.message.contains(expected) {
+                return Err(format!("expected error message to contain {expected:?}; got {err}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn document_diagnostic_missing_params_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.test_handle_document_diagnostic(None) {
+            Err(err) => expect_document_diagnostic_uri_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn document_diagnostic_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.test_handle_document_diagnostic(Some(json!({}))) {
+            Err(err) => expect_document_diagnostic_uri_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn document_diagnostic_invalid_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.test_handle_document_diagnostic(Some(json!({
+            "textDocument": { "uri": "file:// bad uri" }
+        }))) {
+            Err(err) => expect_document_diagnostic_uri_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
     }
 
     /// Positive case: when no concurrent change arrives during diagnostic computation,

--- a/crates/perl-lsp-rs/src/runtime/dispatch/ast_explorer.rs
+++ b/crates/perl-lsp-rs/src/runtime/dispatch/ast_explorer.rs
@@ -20,6 +20,29 @@
 
 use super::super::*;
 
+fn invalid_show_ast_uri_params() -> JsonRpcError {
+    JsonRpcError {
+        code: INVALID_PARAMS,
+        message: "Missing required parameter: uri\n\n\
+                  perl/showAst expects params.uri to identify an open Perl document.\n\n\
+                  Example: {\"uri\":\"file:///workspace/lib/My/Module.pm\"}"
+            .to_string(),
+        data: None,
+    }
+}
+
+fn show_ast_document_not_found(uri: &str) -> JsonRpcError {
+    JsonRpcError {
+        code: INVALID_PARAMS,
+        message: format!(
+            "Document is not open: {uri}\n\n\
+             perl/showAst can only inspect documents opened with textDocument/didOpen. \
+             Send textDocument/didOpen first or use the URI of an already-open document."
+        ),
+        data: None,
+    }
+}
+
 impl LspServer {
     /// Handle the `perl/showAst` custom request.
     ///
@@ -35,13 +58,11 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         // Extract the `uri` string from params
-        let uri = params.as_ref().and_then(|p| p.get("uri")).and_then(|u| u.as_str()).ok_or_else(
-            || JsonRpcError {
-                code: INVALID_PARAMS,
-                message: "Missing required 'uri' parameter".to_string(),
-                data: None,
-            },
-        )?;
+        let uri = params
+            .as_ref()
+            .and_then(|p| p.get("uri"))
+            .and_then(|u| u.as_str())
+            .ok_or_else(invalid_show_ast_uri_params)?;
 
         let docs = self.documents_guard();
 
@@ -61,11 +82,7 @@ impl LspServer {
                     }
                 }
             }
-            None => Err(JsonRpcError {
-                code: INVALID_PARAMS,
-                message: format!("Document not found: {uri}"),
-                data: None,
-            }),
+            None => Err(show_ast_document_not_found(uri)),
         }
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -14,7 +14,7 @@ use crate::completion::{
     CompletionItemKind, CompletionProvider, add_xs_api_completions_for_prefix,
 };
 use crate::{
-    protocol::{JsonRpcError, JsonRpcId, REQUEST_CANCELLED, req_position, req_uri},
+    protocol::{JsonRpcError, JsonRpcId, REQUEST_CANCELLED, invalid_params, req_position, req_uri},
     runtime::routing::{IndexAccessMode, route_index_access},
     state::{completion_cap, completion_deadline},
 };
@@ -38,6 +38,15 @@ use super::super::LspServer;
 /// global cancellation registry — it exists only as a local handle that the
 /// provider's cancel-check closure can read.
 const UNCANCELLABLE_LOCAL_TOKEN_ID: JsonRpcId = JsonRpcId::Integer(-1);
+
+fn invalid_completion_resolve_params() -> JsonRpcError {
+    invalid_params(
+        "Missing or invalid completionItem/resolve params\n\n\
+         completionItem/resolve expects params to be a CompletionItem object returned by \
+         textDocument/completion.\n\n\
+         Example: {\"label\":\"print\",\"kind\":3,\"data\":{\"source\":\"perl-lsp\"}}",
+    )
+}
 
 static SNIPPET_PLACEHOLDER_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
 static SNIPPET_SIMPLE_RE: OnceLock<Result<Regex, regex::Error>> = OnceLock::new();
@@ -1321,8 +1330,11 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         let Some(mut item) = params else {
-            return Ok(None);
+            return Err(invalid_completion_resolve_params());
         };
+        if !item.is_object() {
+            return Err(invalid_completion_resolve_params());
+        }
 
         // Extract the label and kind upfront (clone to avoid borrow issues)
         let label = item.get("label").and_then(|v| v.as_str()).unwrap_or("").to_string();
@@ -1921,6 +1933,40 @@ mod tests {
         // Kind should be preserved
         assert_eq!(resolved.get("kind").and_then(|v| v.as_u64()), Some(3));
         Ok(())
+    }
+
+    fn expect_completion_resolve_guidance(err: JsonRpcError) -> Result<(), String> {
+        assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+        for expected in [
+            "Missing or invalid completionItem/resolve params",
+            "CompletionItem object",
+            "textDocument/completion",
+            "\"label\"",
+            "\"kind\"",
+        ] {
+            if !err.message.contains(expected) {
+                return Err(format!("expected error message to contain {expected:?}; got {err}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn completion_resolve_missing_params_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::default();
+        match server.handle_completion_resolve(None) {
+            Err(err) => expect_completion_resolve_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn completion_resolve_non_object_params_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::default();
+        match server.handle_completion_resolve(Some(json!([]))) {
+            Err(err) => expect_completion_resolve_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
     }
 
     #[test]

--- a/crates/perl-lsp-rs/src/runtime/language/document_links.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/document_links.rs
@@ -77,6 +77,31 @@ fn normalize_document_link_file_path(file_path: &str) -> Cow<'_, str> {
     Cow::Owned(normalized)
 }
 
+fn document_link_resolve_missing_params_message() -> String {
+    "Missing parameters for documentLink/resolve: pass the DocumentLink object returned by textDocument/documentLink; request fresh document links if the link is stale"
+        .to_string()
+}
+
+fn document_link_resolve_data_message(summary: &str) -> String {
+    format!(
+        "{summary}: documentLink/resolve expects a DocumentLink returned by textDocument/documentLink with data.type set to `module`, `file`, or `url`; request fresh document links before retrying"
+    )
+}
+
+fn document_link_resolve_module_data_message() -> String {
+    document_link_resolve_data_message(
+        "Missing module name in data; module links require data.module such as `Data::Dumper`",
+    )
+}
+
+fn document_link_resolve_file_path_message() -> String {
+    document_link_resolve_data_message("Missing file path in data; file links require data.path")
+}
+
+fn document_link_resolve_base_uri_message() -> String {
+    document_link_resolve_data_message("Missing base URI in data; file links require data.baseUri")
+}
+
 impl LspServer {
     /// Handle textDocument/documentLink request
     pub(crate) fn handle_document_links(
@@ -142,7 +167,7 @@ impl LspServer {
                             .and_then(|m| m.as_str())
                             .ok_or_else(|| JsonRpcError {
                                 code: INVALID_PARAMS,
-                                message: "Missing module name in data".into(),
+                                message: document_link_resolve_module_data_message(),
                                 data: None,
                             })?;
 
@@ -161,7 +186,7 @@ impl LspServer {
                             data_obj.get("path").and_then(|p| p.as_str()).ok_or_else(|| {
                                 JsonRpcError {
                                     code: INVALID_PARAMS,
-                                    message: "Missing file path in data".into(),
+                                    message: document_link_resolve_file_path_message(),
                                     data: None,
                                 }
                             })?;
@@ -172,7 +197,7 @@ impl LspServer {
                             .and_then(|u| u.as_str())
                             .ok_or_else(|| JsonRpcError {
                                 code: INVALID_PARAMS,
-                                message: "Missing base URI in data".into(),
+                                message: document_link_resolve_base_uri_message(),
                                 data: None,
                             })?;
 
@@ -192,7 +217,9 @@ impl LspServer {
                         // Unknown link type - return error
                         return Err(JsonRpcError {
                             code: INVALID_PARAMS,
-                            message: "Unknown link type in data field".into(),
+                            message: document_link_resolve_data_message(
+                                "Unknown link type in data field",
+                            ),
                             data: Some(json!({"linkType": link_type})),
                         });
                     }
@@ -203,7 +230,7 @@ impl LspServer {
         } else {
             Err(JsonRpcError {
                 code: INVALID_PARAMS,
-                message: "Missing parameters for documentLink/resolve".into(),
+                message: document_link_resolve_missing_params_message(),
                 data: None,
             })
         }
@@ -245,7 +272,12 @@ impl LspServer {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_document_link_file_path, resolve_file_link_target};
+    use super::{
+        document_link_resolve_base_uri_message, document_link_resolve_data_message,
+        document_link_resolve_file_path_message, document_link_resolve_missing_params_message,
+        document_link_resolve_module_data_message, normalize_document_link_file_path,
+        resolve_file_link_target,
+    };
 
     #[test]
     fn normalize_document_link_file_path_collapses_windows_separators() {
@@ -276,5 +308,28 @@ mod tests {
             "//server/share/lib/Thing.pm",
         );
         assert_eq!(resolved, Some("file://server/share/lib/Thing.pm".to_string()));
+    }
+
+    #[test]
+    fn document_link_resolve_error_messages_include_recovery_guidance() {
+        let missing = document_link_resolve_missing_params_message();
+        assert!(missing.contains("pass the DocumentLink object"));
+        assert!(missing.contains("request fresh document links"));
+
+        let unknown = document_link_resolve_data_message("Unknown link type in data field");
+        assert!(unknown.contains("data.type"));
+        assert!(unknown.contains("module"));
+        assert!(unknown.contains("file"));
+        assert!(unknown.contains("url"));
+
+        let module = document_link_resolve_module_data_message();
+        assert!(module.contains("data.module"));
+        assert!(module.contains("Data::Dumper"));
+
+        let file_path = document_link_resolve_file_path_message();
+        assert!(file_path.contains("data.path"));
+
+        let base_uri = document_link_resolve_base_uri_message();
+        assert!(base_uri.contains("data.baseUri"));
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/language/hover.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover.rs
@@ -4,7 +4,7 @@
 
 use super::super::*;
 use crate::cancellation::RequestCleanupGuard;
-use crate::protocol::{req_position, req_uri};
+use crate::protocol::{invalid_params, req_position, req_uri};
 mod hover_cards;
 mod hover_extracted;
 #[cfg(test)]
@@ -14,6 +14,16 @@ mod regex_hover;
 mod signature_help;
 
 use hover_extracted::HoverExtracted;
+
+fn invalid_hover_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameters: textDocument.uri and position\n\n\
+         textDocument/hover expects params.textDocument.uri plus params.position.line and \
+         params.position.character to identify the symbol under the cursor.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"},\
+         \"position\":{\"line\":10,\"character\":4}}",
+    )
+}
 
 impl LspServer {
     /// Handle textDocument/hover request for symbol information display
@@ -39,8 +49,20 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = req_uri(&params)?;
-            let (line, character) = req_position(&params)?;
+            let uri = params
+                .pointer("/textDocument/uri")
+                .and_then(|v| v.as_str())
+                .ok_or_else(invalid_hover_params)?;
+            let line = params
+                .pointer("/position/line")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(invalid_hover_params)?;
+            let character = params
+                .pointer("/position/character")
+                .and_then(|v| v.as_u64())
+                .and_then(|n| u32::try_from(n).ok())
+                .ok_or_else(invalid_hover_params)?;
 
             // Reject stale requests
             let req_version =
@@ -141,6 +163,8 @@ impl LspServer {
                     }
                 }
             }
+        } else {
+            return Err(invalid_hover_params());
         }
 
         Ok(Some(json!(null)))

--- a/crates/perl-lsp-rs/src/runtime/language/hover/hover_tests.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/hover/hover_tests.rs
@@ -1,6 +1,55 @@
 use super::LspServer;
+use crate::protocol::JsonRpcError;
 use perl_tdd_support::must_some;
 use serde_json::json;
+
+fn expect_hover_shape_guidance(err: JsonRpcError) -> Result<(), String> {
+    assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+    for expected in [
+        "Missing required parameters: textDocument.uri and position",
+        "textDocument/hover",
+        "params.textDocument.uri",
+        "params.position.line",
+        "params.position.character",
+        "file:///workspace/lib/My/Module.pm",
+    ] {
+        if !err.message.contains(expected) {
+            return Err(format!("expected error message to contain {expected:?}; got {err}"));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn hover_missing_params_error_includes_shape_guidance() -> Result<(), String> {
+    let server = LspServer::new();
+    match server.handle_hover(None) {
+        Err(err) => expect_hover_shape_guidance(err),
+        Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+    }
+}
+
+#[test]
+fn hover_missing_position_error_includes_shape_guidance() -> Result<(), String> {
+    let server = LspServer::new();
+    match server.handle_hover(Some(json!({
+        "textDocument": { "uri": "file:///workspace/lib/My/Module.pm" }
+    }))) {
+        Err(err) => expect_hover_shape_guidance(err),
+        Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+    }
+}
+
+#[test]
+fn hover_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+    let server = LspServer::new();
+    match server.handle_hover(Some(json!({
+        "position": { "line": 10, "character": 4 }
+    }))) {
+        Err(err) => expect_hover_shape_guidance(err),
+        Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+    }
+}
 
 #[test]
 fn test_internal_pl_sv_yes_hover_from_sigiled_token() {

--- a/crates/perl-lsp-rs/src/runtime/language/navigation.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/navigation.rs
@@ -5,7 +5,7 @@
 
 use super::super::*;
 use crate::cancellation::RequestCleanupGuard;
-use crate::protocol::{req_position, req_uri};
+use crate::protocol::{invalid_params, req_position, req_uri};
 use crate::util::{read_text_file_with_encoding, token_under_cursor};
 use perl_parser_core::source_file::is_binary_content;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -61,6 +61,16 @@ fn lsp_location_count(value: Option<&Value>) -> usize {
     }
 }
 
+fn invalid_definition_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameters: textDocument.uri and position\n\n\
+         textDocument/definition expects params.textDocument.uri plus params.position.line and \
+         params.position.character to identify the symbol under the cursor.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"},\
+         \"position\":{\"line\":10,\"character\":4}}",
+    )
+}
+
 #[derive(Debug)]
 struct NavigationDecisionTraceContext {
     provider: &'static str,
@@ -101,6 +111,63 @@ impl Default for TypeDefinitionFallbackTrace {
             current_document_version: None,
             trace_only_no_live_behavior_change: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn expect_definition_shape_guidance(err: JsonRpcError) -> Result<(), String> {
+        assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+        for expected in [
+            "Missing required parameters: textDocument.uri and position",
+            "textDocument/definition",
+            "params.textDocument.uri",
+            "params.position.line",
+            "params.position.character",
+            "file:///workspace/lib/My/Module.pm",
+        ] {
+            if !err.message.contains(expected) {
+                return Err(format!("expected error message to contain {expected:?}; got {err}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn definition_fallback_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.on_definition(json!({})) {
+            Err(err) => expect_definition_shape_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn definition_fallback_missing_position_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.on_definition(json!({
+            "textDocument": { "uri": "file:///workspace/lib/My/Module.pm" }
+        })) {
+            Err(err) => expect_definition_shape_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn definition_fallback_valid_unknown_document_still_returns_empty_result() -> Result<(), String>
+    {
+        let server = LspServer::new();
+        let result = server
+            .on_definition(json!({
+                "textDocument": { "uri": "file:///workspace/lib/Missing.pm" },
+                "position": { "line": 10, "character": 4 }
+            }))
+            .map_err(|err| format!("expected empty definition result; got {err}"))?;
+        assert_eq!(result, json!([]));
+        Ok(())
     }
 }
 
@@ -1902,10 +1969,18 @@ impl LspServer {
         &self,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, JsonRpcError> {
-        let uri = params.pointer("/textDocument/uri").and_then(|v| v.as_str()).unwrap_or("");
-        let line = params.pointer("/position/line").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-        let ch =
-            params.pointer("/position/character").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        let uri = params
+            .pointer("/textDocument/uri")
+            .and_then(|v| v.as_str())
+            .ok_or_else(invalid_definition_params)?;
+        let line = params
+            .pointer("/position/line")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(invalid_definition_params)? as usize;
+        let ch = params
+            .pointer("/position/character")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(invalid_definition_params)? as usize;
 
         let text = self.buffer_text(uri).unwrap_or_default();
         let module = token_under_cursor(&text, line, ch).filter(|s| s.contains("::"));

--- a/crates/perl-lsp-rs/src/runtime/language/references.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/references.rs
@@ -9,7 +9,7 @@
 //! - **Building/Degraded state**: Same-file semantic analysis + open document scan
 
 use super::super::{byte_to_utf16_col, *};
-use crate::protocol::{req_position, req_uri};
+use crate::protocol::{invalid_params, req_position, req_uri};
 use crate::state::{reference_search_deadline, references_cap};
 use crate::util::{is_word_boundary, token_under_cursor};
 use std::sync::OnceLock;
@@ -33,6 +33,16 @@ fn lsp_location_count(value: Option<&Value>) -> usize {
         Some(Value::Object(obj)) if obj.contains_key("uri") || obj.contains_key("targetUri") => 1,
         _ => 0,
     }
+}
+
+fn invalid_references_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameters: textDocument.uri and position\n\n\
+         textDocument/references expects params.textDocument.uri plus params.position.line and \
+         params.position.character to identify the symbol under the cursor.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"},\
+         \"position\":{\"line\":10,\"character\":4},\"context\":{\"includeDeclaration\":true}}",
+    )
 }
 
 #[derive(Debug)]
@@ -898,10 +908,18 @@ impl LspServer {
         &self,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, JsonRpcError> {
-        let uri = params.pointer("/textDocument/uri").and_then(|v| v.as_str()).unwrap_or("");
-        let line = params.pointer("/position/line").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-        let ch =
-            params.pointer("/position/character").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        let uri = params
+            .pointer("/textDocument/uri")
+            .and_then(|v| v.as_str())
+            .ok_or_else(invalid_references_params)?;
+        let line = params
+            .pointer("/position/line")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(invalid_references_params)? as usize;
+        let ch = params
+            .pointer("/position/character")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(invalid_references_params)? as usize;
 
         let text = self.buffer_text(uri).unwrap_or_default();
         let needle = token_under_cursor(&text, line, ch).unwrap_or_default();
@@ -946,5 +964,64 @@ impl LspServer {
         out.dedup();
 
         Ok(serde_json::Value::Array(out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn expect_references_shape_guidance(err: JsonRpcError) -> Result<(), String> {
+        assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+        for expected in [
+            "Missing required parameters: textDocument.uri and position",
+            "textDocument/references",
+            "params.textDocument.uri",
+            "params.position.line",
+            "params.position.character",
+            "includeDeclaration",
+            "file:///workspace/lib/My/Module.pm",
+        ] {
+            if !err.message.contains(expected) {
+                return Err(format!("expected error message to contain {expected:?}; got {err}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn references_fallback_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.on_references(json!({})) {
+            Err(err) => expect_references_shape_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn references_fallback_missing_position_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.on_references(json!({
+            "textDocument": { "uri": "file:///workspace/lib/My/Module.pm" }
+        })) {
+            Err(err) => expect_references_shape_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn references_fallback_valid_unknown_document_still_returns_empty_result() -> Result<(), String>
+    {
+        let server = LspServer::new();
+        let result = server
+            .on_references(json!({
+                "textDocument": { "uri": "file:///workspace/lib/Missing.pm" },
+                "position": { "line": 10, "character": 4 },
+                "context": { "includeDeclaration": true }
+            }))
+            .map_err(|err| format!("expected empty references result; got {err}"))?;
+        assert_eq!(result, json!([]));
+        Ok(())
     }
 }

--- a/crates/perl-lsp-rs/src/runtime/language/symbols.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/symbols.rs
@@ -4,7 +4,7 @@
 
 use super::super::{byte_to_utf16_col, *};
 use crate::fallback::text::folding_ranges_from_text;
-use crate::protocol::req_uri;
+use crate::protocol::{invalid_params, req_uri};
 use crate::state::document_symbol_cap;
 use std::sync::OnceLock;
 
@@ -25,6 +25,14 @@ fn get_package_regex() -> Option<&'static regex::Regex> {
 
 fn get_head_regex() -> Option<&'static regex::Regex> {
     HEAD_REGEX.get_or_init(|| regex::Regex::new(r"^=(head[1-4])\s+(.+)$")).as_ref().ok()
+}
+
+fn invalid_folding_range_uri_params() -> JsonRpcError {
+    invalid_params(
+        "Missing required parameter: textDocument.uri\n\n\
+         textDocument/foldingRange expects params.textDocument.uri to identify the document to fold.\n\n\
+         Example: {\"textDocument\":{\"uri\":\"file:///workspace/lib/My/Module.pm\"}}",
+    )
 }
 
 /// Scan source text for POD =head1..=head4 directives and return them as document symbols.
@@ -131,7 +139,10 @@ impl LspServer {
         params: Option<Value>,
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
-            let uri = req_uri(&params)?;
+            let uri = params
+                .pointer("/textDocument/uri")
+                .and_then(Value::as_str)
+                .ok_or_else(invalid_folding_range_uri_params)?;
 
             let documents = self.documents_guard();
             if let Some(doc) = self.get_document(&documents, uri) {
@@ -210,6 +221,8 @@ impl LspServer {
                     return Ok(Some(json!(folding_ranges_from_text(&doc.text, 1000))));
                 }
             }
+        } else {
+            return Err(invalid_folding_range_uri_params());
         }
 
         Ok(Some(json!([])))
@@ -220,7 +233,10 @@ impl LspServer {
         &self,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, JsonRpcError> {
-        let uri = params.pointer("/textDocument/uri").and_then(|v| v.as_str()).unwrap_or("");
+        let uri = params
+            .pointer("/textDocument/uri")
+            .and_then(|v| v.as_str())
+            .ok_or_else(invalid_folding_range_uri_params)?;
         let text = self.buffer_text(uri).unwrap_or_default();
         let ranges = folding_ranges_from_text(&text, 128);
         Ok(serde_json::to_value(ranges).unwrap_or(serde_json::json!([])))
@@ -393,4 +409,52 @@ fn document_symbols_empty_compiler_receipt(reason: &str) -> Value {
         "reason": reason,
         "fact_source_traces": [],
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn expect_folding_range_uri_guidance(err: JsonRpcError) -> Result<(), String> {
+        assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+        for expected in [
+            "Missing required parameter: textDocument.uri",
+            "textDocument/foldingRange",
+            "params.textDocument.uri",
+            "file:///workspace/lib/My/Module.pm",
+        ] {
+            if !err.message.contains(expected) {
+                return Err(format!("expected error message to contain {expected:?}; got {err}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn folding_range_missing_params_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.handle_folding_range(None) {
+            Err(err) => expect_folding_range_uri_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn folding_range_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.handle_folding_range(Some(json!({}))) {
+            Err(err) => expect_folding_range_uri_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn folding_range_fallback_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.on_folding_range(json!({})) {
+            Err(err) => expect_folding_range_uri_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
 }

--- a/crates/perl-lsp-rs/src/runtime/notebook.rs
+++ b/crates/perl-lsp-rs/src/runtime/notebook.rs
@@ -224,6 +224,15 @@ impl Default for NotebookStore {
     }
 }
 
+fn missing_notebook_document_uri_params(method: &str) -> JsonRpcError {
+    let message = format!(
+        "Missing required parameter: notebookDocument.uri\n\n\
+         {method} expects params.notebookDocument.uri to identify the notebook document.\n\n\
+         Example: {{\"notebookDocument\":{{\"uri\":\"file:///workspace/notebook.ipynb\"}}}}"
+    );
+    invalid_params(&message)
+}
+
 impl Clone for NotebookStore {
     fn clone(&self) -> Self {
         Self {
@@ -267,13 +276,14 @@ impl LspServer {
         &self,
         params: Option<Value>,
     ) -> Result<(), JsonRpcError> {
-        let params = params.ok_or_else(|| invalid_params("Missing params"))?;
+        let params = params
+            .ok_or_else(|| missing_notebook_document_uri_params("notebookDocument/didOpen"))?;
 
         // Extract notebook document metadata
         let notebook_uri = params
             .pointer("/notebookDocument/uri")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| invalid_params("Missing notebookDocument.uri"))?;
+            .ok_or_else(|| missing_notebook_document_uri_params("notebookDocument/didOpen"))?;
 
         let notebook_type = params
             .pointer("/notebookDocument/notebookType")
@@ -363,12 +373,13 @@ impl LspServer {
         &self,
         params: Option<Value>,
     ) -> Result<(), JsonRpcError> {
-        let params = params.ok_or_else(|| invalid_params("Missing params"))?;
+        let params = params
+            .ok_or_else(|| missing_notebook_document_uri_params("notebookDocument/didChange"))?;
 
         let notebook_uri = params
             .pointer("/notebookDocument/uri")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| invalid_params("Missing notebookDocument.uri"))?;
+            .ok_or_else(|| missing_notebook_document_uri_params("notebookDocument/didChange"))?;
 
         // Update notebook version
         if let Some(version) = params
@@ -564,12 +575,13 @@ impl LspServer {
         &self,
         params: Option<Value>,
     ) -> Result<(), JsonRpcError> {
-        let params = params.ok_or_else(|| invalid_params("Missing params"))?;
+        let params = params
+            .ok_or_else(|| missing_notebook_document_uri_params("notebookDocument/didSave"))?;
 
         let notebook_uri = params
             .pointer("/notebookDocument/uri")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| invalid_params("Missing notebookDocument.uri"))?;
+            .ok_or_else(|| missing_notebook_document_uri_params("notebookDocument/didSave"))?;
 
         tracing::debug!(uri = notebook_uri, "Notebook saved");
 
@@ -584,12 +596,13 @@ impl LspServer {
         &self,
         params: Option<Value>,
     ) -> Result<(), JsonRpcError> {
-        let params = params.ok_or_else(|| invalid_params("Missing params"))?;
+        let params = params
+            .ok_or_else(|| missing_notebook_document_uri_params("notebookDocument/didClose"))?;
 
         let notebook_uri = params
             .pointer("/notebookDocument/uri")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| invalid_params("Missing notebookDocument.uri"))?;
+            .ok_or_else(|| missing_notebook_document_uri_params("notebookDocument/didClose"))?;
 
         // Get cell URIs that need closing
         if let Some(cell_docs) = params.pointer("/cellTextDocuments").and_then(|v| v.as_array()) {
@@ -624,6 +637,57 @@ impl LspServer {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn expect_notebook_uri_guidance(err: JsonRpcError, method: &str) -> Result<(), String> {
+        assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+        for expected in [
+            "Missing required parameter: notebookDocument.uri",
+            method,
+            "params.notebookDocument.uri",
+            "file:///workspace/notebook.ipynb",
+        ] {
+            if !err.message.contains(expected) {
+                return Err(format!("expected error message to contain {expected:?}; got {err}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn notebook_did_open_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.handle_notebook_did_open(Some(json!({}))) {
+            Err(err) => expect_notebook_uri_guidance(err, "notebookDocument/didOpen"),
+            Ok(()) => Err("expected INVALID_PARAMS".to_string()),
+        }
+    }
+
+    #[test]
+    fn notebook_did_change_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.handle_notebook_did_change(Some(json!({}))) {
+            Err(err) => expect_notebook_uri_guidance(err, "notebookDocument/didChange"),
+            Ok(()) => Err("expected INVALID_PARAMS".to_string()),
+        }
+    }
+
+    #[test]
+    fn notebook_did_save_missing_params_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.handle_notebook_did_save(None) {
+            Err(err) => expect_notebook_uri_guidance(err, "notebookDocument/didSave"),
+            Ok(()) => Err("expected INVALID_PARAMS".to_string()),
+        }
+    }
+
+    #[test]
+    fn notebook_did_close_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+        let server = LspServer::new();
+        match server.handle_notebook_did_close(Some(json!({}))) {
+            Err(err) => expect_notebook_uri_guidance(err, "notebookDocument/didClose"),
+            Ok(()) => Err("expected INVALID_PARAMS".to_string()),
+        }
+    }
 
     #[test]
     fn register_notebook_replaces_stale_cell_mappings() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/perl-lsp-rs/src/runtime/workspace.rs
+++ b/crates/perl-lsp-rs/src/runtime/workspace.rs
@@ -9,6 +9,7 @@
 //! - **Building/Degraded state**: Open document search only (partial results)
 
 use super::*;
+use crate::protocol::invalid_params;
 #[cfg(feature = "workspace")]
 use crate::runtime::routing::{IndexAccessMode, route_index_access};
 use crate::runtime::workspace_progress::{
@@ -45,6 +46,17 @@ mod configuration_response;
 mod text_decode;
 
 const WORKSPACE_CONFIGURATION_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn invalid_workspace_symbol_resolve_params() -> JsonRpcError {
+    invalid_params(
+        "Missing or invalid workspaceSymbol/resolve params\n\n\
+         workspaceSymbol/resolve expects params to be a WorkspaceSymbol object returned by \
+         workspace/symbol.\n\n\
+         Example: {\"name\":\"main\",\"kind\":12,\"location\":{\"uri\":\"file:///workspace/main.pl\",\
+         \"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":0,\"character\":8}}}}",
+    )
+}
+
 // Note: WalkDir logic has been extracted to super::file_discovery.
 // These helper functions are retained for potential future use by
 // other workspace operations (e.g., file watcher filtering).
@@ -721,11 +733,7 @@ impl LspServer {
     ) -> Result<Option<Value>, JsonRpcError> {
         if let Some(params) = params {
             // Extract the symbol to resolve
-            let symbol = params.as_object().ok_or_else(|| JsonRpcError {
-                code: -32602,
-                message: "Invalid params".to_string(),
-                data: None,
-            })?;
+            let symbol = params.as_object().ok_or_else(invalid_workspace_symbol_resolve_params)?;
 
             // Get the URI and name from the symbol
             let uri = symbol
@@ -828,7 +836,7 @@ impl LspServer {
             // Return the original symbol if we couldn't enhance it
             Ok(Some(json!(symbol)))
         } else {
-            Err(JsonRpcError { code: -32602, message: "Missing params".to_string(), data: None })
+            Err(invalid_workspace_symbol_resolve_params())
         }
     }
 
@@ -2503,7 +2511,7 @@ pub(super) fn path_to_module_name(uri: &str) -> String {
 mod tests {
     #[cfg(feature = "workspace")]
     use super::read_text_with_encoding_fallback;
-    use super::{LspServer, module_name_appears_in_text};
+    use super::{JsonRpcError, LspServer, module_name_appears_in_text};
     use serde_json::json;
     #[cfg(feature = "workspace")]
     use std::io::Write;
@@ -2558,6 +2566,64 @@ mod tests {
     fn test_module_name_unicode_letter_after_rejected() {
         // Unicode letters still extend identifiers; do not match inside "BaseΔ".
         assert!(!module_name_appears_in_text("use BaseΔ;", "Base"));
+    }
+
+    fn expect_workspace_symbol_resolve_guidance(err: JsonRpcError) -> Result<(), String> {
+        assert_eq!(err.code, crate::protocol::INVALID_PARAMS);
+        for expected in [
+            "Missing or invalid workspaceSymbol/resolve params",
+            "WorkspaceSymbol object",
+            "workspace/symbol",
+            "\"location\"",
+            "\"range\"",
+        ] {
+            if !err.message.contains(expected) {
+                return Err(format!("expected error message to contain {expected:?}; got {err}"));
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_symbol_resolve_missing_params_error_includes_shape_guidance() -> Result<(), String>
+    {
+        let server = LspServer::new();
+        match server.handle_workspace_symbol_resolve(None) {
+            Err(err) => expect_workspace_symbol_resolve_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn workspace_symbol_resolve_non_object_params_error_includes_shape_guidance()
+    -> Result<(), String> {
+        let server = LspServer::new();
+        match server.handle_workspace_symbol_resolve(Some(json!([]))) {
+            Err(err) => expect_workspace_symbol_resolve_guidance(err),
+            Ok(result) => Err(format!("expected INVALID_PARAMS; got {result:?}")),
+        }
+    }
+
+    #[test]
+    fn workspace_symbol_resolve_accepts_workspace_symbol_objects() -> Result<(), String> {
+        let server = LspServer::new();
+        let symbol = json!({
+            "name": "main",
+            "kind": 12,
+            "location": {
+                "uri": "file:///workspace/main.pl",
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 8}
+                }
+            }
+        });
+
+        match server.handle_workspace_symbol_resolve(Some(symbol.clone())) {
+            Ok(Some(resolved)) if resolved == symbol => Ok(()),
+            Ok(result) => Err(format!("expected unresolved symbol echo; got {result:?}")),
+            Err(err) => Err(format!("expected valid WorkspaceSymbol object; got {err}")),
+        }
     }
 
     #[test]

--- a/crates/perl-lsp-rs/tests/ast_explorer_tests.rs
+++ b/crates/perl-lsp-rs/tests/ast_explorer_tests.rs
@@ -79,6 +79,15 @@ fn show_ast_error(
     response.error
 }
 
+fn expect_error_contains(err: perl_lsp::JsonRpcError, expected: &[&str]) -> Result<(), String> {
+    for text in expected {
+        if !err.message.contains(text) {
+            return Err(format!("expected error message to contain {text:?}; got {err}"));
+        }
+    }
+    Ok(())
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -165,4 +174,40 @@ fn show_ast_null_params_returns_invalid_params() {
     assert!(err.is_some(), "Should return an error for null params");
     let code = err.unwrap().code;
     assert_eq!(code, -32602, "Expected INVALID_PARAMS (-32602) for null params, got {code}");
+}
+
+#[test]
+fn show_ast_missing_uri_error_includes_shape_guidance() -> Result<(), String> {
+    let server = create_and_init_server();
+
+    let err = show_ast_error(&server, Some(json!({ "other": "value" })))
+        .ok_or_else(|| "expected INVALID_PARAMS".to_string())?;
+    assert_eq!(err.code, -32602);
+    expect_error_contains(
+        err,
+        &[
+            "Missing required parameter: uri",
+            "perl/showAst",
+            "params.uri",
+            "file:///workspace/lib/My/Module.pm",
+        ],
+    )
+}
+
+#[test]
+fn show_ast_unknown_document_error_explains_open_document_requirement() -> Result<(), String> {
+    let server = create_and_init_server();
+
+    let err = show_ast_error(&server, Some(json!({ "uri": "file:///never_opened.pl" })))
+        .ok_or_else(|| "expected INVALID_PARAMS".to_string())?;
+    assert_eq!(err.code, -32602);
+    expect_error_contains(
+        err,
+        &[
+            "Document is not open: file:///never_opened.pl",
+            "perl/showAst",
+            "textDocument/didOpen",
+            "already-open document",
+        ],
+    )
 }

--- a/crates/perl-lsp-rs/tests/cli_smoke.rs
+++ b/crates/perl-lsp-rs/tests/cli_smoke.rs
@@ -57,7 +57,8 @@ fn check_nonexistent_file() {
         .arg("/nonexistent/path/to/file.pl")
         .assert()
         .failure()
-        .stderr(predicates::str::contains("error reading file"));
+        .stderr(predicates::str::contains("error reading file"))
+        .stderr(predicates::str::contains("help: check the path"));
 }
 
 #[test]

--- a/crates/perl-lsp-rs/tests/lsp_document_link_resolve_tests.rs
+++ b/crates/perl-lsp-rs/tests/lsp_document_link_resolve_tests.rs
@@ -3,10 +3,47 @@
 //! Tests the deferred resolution pattern where initial documentLink returns
 //! links with data fields, and documentLink/resolve fills in the target.
 
-use perl_lsp::{JsonRpcRequest, LspServer};
-use serde_json::json;
+use perl_lsp::{JsonRpcError, JsonRpcRequest, LspServer};
+use serde_json::{Value, json};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+fn initialized_server() -> LspServer {
+    let server = LspServer::new();
+
+    let init_params = json!({
+        "capabilities": {},
+        "rootUri": "file:///workspace"
+    });
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: Some(perl_lsp::protocol::JsonRpcId::Integer((1) as i64)),
+        method: "initialize".to_string(),
+        params: Some(init_params),
+    });
+
+    let _ = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: None,
+        method: "initialized".to_string(),
+        params: Some(json!({})),
+    });
+
+    server
+}
+
+fn document_link_resolve_error(params: Option<Value>) -> Result<JsonRpcError, String> {
+    let server = initialized_server();
+    let response = server.handle_request(JsonRpcRequest {
+        _jsonrpc: "2.0".to_string(),
+        id: Some(perl_lsp::protocol::JsonRpcId::Integer((2) as i64)),
+        method: "documentLink/resolve".to_string(),
+        params,
+    });
+
+    let resp = response.ok_or_else(|| "Expected response from documentLink/resolve".to_string())?;
+    resp.error.ok_or_else(|| format!("Expected error field in response: {:?}", resp.result))
+}
 
 /// Test that documentLink/resolve returns target for deferred module links
 #[test]
@@ -240,6 +277,57 @@ fn test_document_link_resolve_invalid_data() -> TestResult {
     assert!(resp.error.is_some());
     let error = resp.error.ok_or("Expected error field in response")?;
     assert_eq!(error.code, -32602); // INVALID_PARAMS
+    assert!(error.message.contains("data.type"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("module"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("file"), "unexpected message: {}", error.message);
+    assert!(error.message.contains("url"), "unexpected message: {}", error.message);
+
+    Ok(())
+}
+
+#[test]
+fn test_document_link_resolve_missing_data_fields_include_guidance() -> TestResult {
+    let missing_module = document_link_resolve_error(Some(json!({
+        "range": {
+            "start": {"line": 0, "character": 4},
+            "end": {"line": 0, "character": 16}
+        },
+        "data": {
+            "type": "module"
+        }
+    })))?;
+    assert_eq!(missing_module.code, -32602);
+    assert!(missing_module.message.contains("data.module"));
+    assert!(missing_module.message.contains("Data::Dumper"));
+    assert!(missing_module.message.contains("request fresh document links"));
+
+    let missing_path = document_link_resolve_error(Some(json!({
+        "range": {
+            "start": {"line": 0, "character": 4},
+            "end": {"line": 0, "character": 16}
+        },
+        "data": {
+            "type": "file",
+            "baseUri": "file:///workspace/script.pl"
+        }
+    })))?;
+    assert_eq!(missing_path.code, -32602);
+    assert!(missing_path.message.contains("data.path"));
+    assert!(missing_path.message.contains("request fresh document links"));
+
+    let missing_base_uri = document_link_resolve_error(Some(json!({
+        "range": {
+            "start": {"line": 0, "character": 4},
+            "end": {"line": 0, "character": 16}
+        },
+        "data": {
+            "type": "file",
+            "path": "lib/Foo.pm"
+        }
+    })))?;
+    assert_eq!(missing_base_uri.code, -32602);
+    assert!(missing_base_uri.message.contains("data.baseUri"));
+    assert!(missing_base_uri.message.contains("request fresh document links"));
 
     Ok(())
 }
@@ -283,6 +371,8 @@ fn test_document_link_resolve_missing_params() -> TestResult {
     assert!(resp.error.is_some());
     let error = resp.error.ok_or("Expected error field in response")?;
     assert_eq!(error.code, -32602); // INVALID_PARAMS
+    assert!(error.message.contains("pass the DocumentLink object"));
+    assert!(error.message.contains("request fresh document links"));
 
     Ok(())
 }

--- a/vscode-extension/src/streamingCompletion.ts
+++ b/vscode-extension/src/streamingCompletion.ts
@@ -33,6 +33,14 @@ interface CachedCandidate {
     isFinal: boolean;
 }
 
+/** Document position that owns the active stream request. */
+interface ActiveStreamContext {
+    uri: string;
+    version: number;
+    line: number;
+    character: number;
+}
+
 /**
  * Progress type marker used with `LanguageClient.onProgress`.
  *
@@ -56,6 +64,7 @@ export class StreamingCompletionController implements vscode.Disposable {
     private cachedCandidate: CachedCandidate | null = null;
     private activeTokenSource: vscode.CancellationTokenSource | null = null;
     private activeProgressToken: string | null = null;
+    private activeStreamContext: ActiveStreamContext | null = null;
     private activeProgressDisposable: vscode.Disposable | null = null;
     private disposables: vscode.Disposable[] = [];
 
@@ -122,6 +131,10 @@ export class StreamingCompletionController implements vscode.Disposable {
             return;
         }
 
+        if (!this.activeStreamContext) {
+            return;
+        }
+
         // Update cached candidate if it's newer
         if (
             this.cachedCandidate &&
@@ -132,10 +145,10 @@ export class StreamingCompletionController implements vscode.Disposable {
         }
 
         this.cachedCandidate = {
-            uri: '',
-            version: 0,
-            line: item.range?.start.line ?? 0,
-            character: item.range?.start.character ?? 0,
+            uri: this.activeStreamContext.uri,
+            version: this.activeStreamContext.version,
+            line: item.range?.start.line ?? this.activeStreamContext.line,
+            character: item.range?.start.character ?? this.activeStreamContext.character,
             text: item.insertText,
             sessionId: value.sessionId,
             sequence: value.sequence,
@@ -164,6 +177,8 @@ export class StreamingCompletionController implements vscode.Disposable {
         // If we have a cached candidate for this position, return it
         if (
             this.cachedCandidate &&
+            this.cachedCandidate.uri === document.uri.toString() &&
+            this.cachedCandidate.version === document.version &&
             this.cachedCandidate.line === position.line &&
             this.cachedCandidate.character === position.character
         ) {
@@ -197,6 +212,12 @@ export class StreamingCompletionController implements vscode.Disposable {
 
         const partialResultToken = `stream-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
         this.activeProgressToken = partialResultToken;
+        this.activeStreamContext = {
+            uri: document.uri.toString(),
+            version: document.version,
+            line: position.line,
+            character: position.character,
+        };
 
         // Register progress handler for this specific token
         this.activeProgressDisposable = this.client.onProgress(
@@ -246,6 +267,7 @@ export class StreamingCompletionController implements vscode.Disposable {
             this.activeProgressDisposable = null;
         }
         this.activeProgressToken = null;
+        this.activeStreamContext = null;
         if (this.activeTokenSource) {
             this.activeTokenSource.cancel();
             this.activeTokenSource.dispose();

--- a/vscode-extension/src/test/streamingCompletion.test.ts
+++ b/vscode-extension/src/test/streamingCompletion.test.ts
@@ -21,26 +21,60 @@ import { StreamingCompletionController } from '../streamingCompletion';
 import { LanguageClient } from 'vscode-languageclient/node';
 
 /** Create a mock LanguageClient with the methods needed by StreamingCompletionController. */
-function createMockClient(): LanguageClient {
+function createMockClient(captureProgress?: (handler: (value: unknown) => void) => void): LanguageClient {
     return {
-        onProgress: jest.fn(() => ({ dispose: jest.fn() })),
+        onProgress: jest.fn((_type, _token, handler: (value: unknown) => void) => {
+            captureProgress?.(handler);
+            return { dispose: jest.fn() };
+        }),
         sendRequest: jest.fn(async () => ({})),
         sendNotification: jest.fn(),
     } as unknown as LanguageClient;
 }
 
+function makeDocument(uri: string, version: number): vscode.TextDocument {
+    return {
+        uri: { toString: () => uri },
+        version,
+    } as unknown as vscode.TextDocument;
+}
+
+type InlineProvider = {
+    provideInlineCompletionItems: (
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        context: vscode.InlineCompletionContext,
+        token: vscode.CancellationToken
+    ) => vscode.InlineCompletionItem[] | undefined;
+};
+
+function registeredProvider(): InlineProvider {
+    const call = (vscode.languages.registerInlineCompletionItemProvider as jest.Mock).mock.calls[0];
+    return call[1] as InlineProvider;
+}
+
 describe('StreamingCompletionController', () => {
     let mockClient: LanguageClient;
     let controller: StreamingCompletionController;
+    let progressHandler: ((value: unknown) => void) | undefined;
 
     beforeEach(() => {
         jest.clearAllMocks();
+        progressHandler = undefined;
         // Extend mock with needed symbols for inline completions
         (vscode as Record<string, unknown>).Position = class {
             constructor(public line: number, public character: number) {}
         };
+        (vscode as Record<string, unknown>).Range = class {
+            constructor(public start: unknown, public end: unknown) {}
+        };
         (vscode as Record<string, unknown>).InlineCompletionItem = class {
             constructor(public insertText: string, public range?: unknown) {}
+        };
+        (vscode as Record<string, unknown>).CancellationTokenSource = class {
+            token = { isCancellationRequested: false };
+            cancel = jest.fn();
+            dispose = jest.fn();
         };
         (vscode.languages as Record<string, unknown>).registerInlineCompletionItemProvider = jest.fn(() => ({
             dispose: jest.fn(),
@@ -51,8 +85,21 @@ describe('StreamingCompletionController', () => {
         (vscode.workspace as Record<string, unknown>).onDidChangeTextDocument = jest.fn(() => ({
             dispose: jest.fn(),
         }));
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn((key: string, defaultValue?: boolean) => {
+                if (key === 'aiCompletion.enabled') {
+                    return true;
+                }
+                if (key === 'aiCompletion.streaming.enabled') {
+                    return true;
+                }
+                return defaultValue;
+            }),
+        });
 
-        mockClient = createMockClient();
+        mockClient = createMockClient(handler => {
+            progressHandler = handler;
+        });
         controller = new StreamingCompletionController(mockClient);
     });
 
@@ -109,6 +156,97 @@ describe('StreamingCompletionController', () => {
             'perl/didShowInlineCompletion',
             { sessionId: 'session-2' }
         );
+    });
+
+    test('returns cached stream candidates for the matching document version', () => {
+        const provider = registeredProvider();
+        const document = makeDocument('file:///workspace/lib/App.pm', 4);
+        const position = new vscode.Position(10, 8);
+
+        const initial = provider.provideInlineCompletionItems(
+            document,
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+        expect(initial).toBeUndefined();
+
+        progressHandler?.({
+            kind: 'perlInlineCompletionStream',
+            sessionId: 'session-1',
+            sequence: 1,
+            isFinal: false,
+            items: [{ insertText: '->find_user($id)' }],
+        });
+
+        const cached = provider.provideInlineCompletionItems(
+            document,
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+
+        expect(cached?.[0]?.insertText).toBe('->find_user($id)');
+        expect(mockClient.sendRequest as jest.Mock).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not show cached stream candidates in another document', () => {
+        const provider = registeredProvider();
+        const position = new vscode.Position(10, 8);
+
+        provider.provideInlineCompletionItems(
+            makeDocument('file:///workspace/lib/App.pm', 4),
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+        progressHandler?.({
+            kind: 'perlInlineCompletionStream',
+            sessionId: 'session-1',
+            sequence: 1,
+            isFinal: false,
+            items: [{ insertText: '->find_user($id)' }],
+        });
+
+        const otherDocumentResult = provider.provideInlineCompletionItems(
+            makeDocument('file:///workspace/lib/Other.pm', 4),
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+
+        expect(otherDocumentResult).toBeUndefined();
+        expect(mockClient.sendRequest as jest.Mock).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not show cached stream candidates after the document version changes', () => {
+        const provider = registeredProvider();
+        const uri = 'file:///workspace/lib/App.pm';
+        const position = new vscode.Position(10, 8);
+
+        provider.provideInlineCompletionItems(
+            makeDocument(uri, 4),
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+        progressHandler?.({
+            kind: 'perlInlineCompletionStream',
+            sessionId: 'session-1',
+            sequence: 1,
+            isFinal: false,
+            items: [{ insertText: '->find_user($id)' }],
+        });
+
+        const newVersionResult = provider.provideInlineCompletionItems(
+            makeDocument(uri, 5),
+            position,
+            {} as vscode.InlineCompletionContext,
+            { isCancellationRequested: false } as vscode.CancellationToken
+        );
+
+        expect(newVersionResult).toBeUndefined();
+        expect(mockClient.sendRequest as jest.Mock).toHaveBeenCalledTimes(2);
     });
 });
 

--- a/vscode-extension/src/test/whatsNew.test.ts
+++ b/vscode-extension/src/test/whatsNew.test.ts
@@ -269,6 +269,19 @@ describe('markdownToHtml', () => {
         expect(html).toContain('<code>perltidy</code>');
     });
 
+    test('converts http markdown links to anchors', () => {
+        const html = markdownToHtml('Read the [release notes](https://example.com/notes)');
+        expect(html).toContain(
+            '<a href="https://example.com/notes" rel="noopener noreferrer">release notes</a>',
+        );
+    });
+
+    test('leaves non-http markdown links as text', () => {
+        const html = markdownToHtml('Avoid [unsafe](javascript:alert(1)) links');
+        expect(html).not.toContain('<a href=');
+        expect(html).toContain('[unsafe](javascript:alert(1))');
+    });
+
     test('escapes HTML special characters', () => {
         const html = markdownToHtml('Use <br> & "quotes"');
         expect(html).not.toContain('<br>');

--- a/vscode-extension/src/whatsNew.ts
+++ b/vscode-extension/src/whatsNew.ts
@@ -311,6 +311,11 @@ export function markdownToHtml(md: string): string {
 function inlineMarkdown(text: string): string {
     // Escape HTML first, then apply Markdown inline rules.
     let s = escapeHtml(text);
+    // [label](https://example.com)
+    s = s.replace(
+        /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g,
+        '<a href="$2" rel="noopener noreferrer">$1</a>',
+    );
     // `code`
     s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
     // **bold**


### PR DESCRIPTION
## Summary

Merge train #2 landing 16 stranded codex branches from wrongly-closed PRs (close-audit 2026-06-06) plus retrying 11 conflict-dropped open PRs from train #1 against the new master.

**Included (16 PRs)**: VSCode streaming cache, check project/file guidance, DAP quoted program/execution, code action/workspace/completion resolve, notebook sync, folding/show AST/definition/references/hover guidance.

**Dropped (21 PRs)**:
- **Conflicts (12)**: All Set B open PRs conflict on shared UX test fixtures — indicates need for fixture merge strategy.
- **Compile (9)**: Set A DAP batch — duplicate no_debugger_session_message function in perl-dap.

## Provenance

**Set A**: 27 stranded codex branches from wrongly-closed PRs
- Included: 9814, 9818, 9820, 9822, 9826, 9830, 9854, 9878, 9880, 9882, 9884, 9886, 9888, 9890, 9892, 9894 (16/29)
- Dropped: 9824, 9832, 9834, 9836, 9838, 9840, 9842, 9844, 9846 (9/29, compile)

**Set B**: 11 open PRs from train #1 (retried)
- All 11 now conflict on new master

## Results

Merged: 16 | Conflicts: 12 | Compile drops: 9 | Total: 40 attempted

Compile gates: ✓ perl-lsp-rs ✓ perl-dap