### PR TITLE
feat(code-actions): PL304 missing-POD quick-fix (#9642 adapted) (#9916)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -204,6 +204,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         {
             actions.extend(quick_fixes::fix_printf_format_arity(source, &qf_diag));
         }
+        // PL304: Exported subroutine lacks POD documentation
+        c if c == DiagnosticCode::MissingPodCoverage.as_str() => {
+            actions.extend(quick_fixes::fix_missing_pod_coverage(source, &qf_diag));
+        }
         // PL410: loop-control statement targets an undefined label
         c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
             actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -2133,6 +2133,46 @@ fn parse_printf_format_mismatch(message: &str) -> Option<(usize, String)> {
     specifiers.checked_sub(supplied).filter(|&n| n > 0).map(|n| (n, call_name))
 }
 
+/// Insert a POD documentation stub before an exported subroutine (PL304).
+///
+/// Extracts the sub name from the diagnostic message and inserts a minimal but
+/// valid `=head2` skeleton immediately before the `sub` line.  The developer
+/// fills in the description; the structure is already correct POD.
+///
+/// Inserted stub form:
+/// ```text
+/// =head2 name
+///
+/// Description.
+///
+/// =cut
+///
+/// ```
+pub fn fix_missing_pod_coverage(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let Some(sub_name) = diagnostic.message.split('\'').nth(1) else {
+        return Vec::new();
+    };
+    let Some((range_start, _)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+
+    let insert_pos = source[..range_start].rfind('\n').map_or(0, |p| p + 1);
+    let pod_stub = format!("=head2 {sub_name}\n\nDescription.\n\n=cut\n\n");
+
+    vec![CodeAction {
+        title: format!("Add '=head2 {sub_name}' POD documentation stub"),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::MissingPodCoverage.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: insert_pos, end: insert_pos },
+                new_text: pod_stub,
+            }],
+        },
+        is_preferred: true,
+    }]
+}
+
 /// Remove an undefined label from a `next`, `last`, or `redo` statement (PL410).
 ///
 /// The diagnostic range is expected to cover the loop-control statement. The

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl304_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl304_bdd.rs
@@ -1,0 +1,247 @@
+//! BDD tests for the PL304 quick-fix handler: add POD documentation stub
+//!
+//! PL304 fires when an exported subroutine has no corresponding `=head2` or
+//! `=item` POD documentation.  The quick-fix inserts a `=head2 name` skeleton
+//! immediately before the `sub` line so the developer only has to fill in the
+//! description.
+//!
+//! Each scenario follows the pattern:
+//!   GIVEN  source with an exported sub that lacks POD documentation
+//!   WHEN   a PL304 diagnostic is produced and code actions are requested
+//!   THEN   the expected action(s) are returned with correct edits
+//!
+//! Tests are taken verbatim from draft PR #9642; #9620 (superseded duplicate)
+//! had the same 6 scenarios with only minor format-arg style differences.
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{Diagnostic, DiagnosticSeverity};
+use perl_parser::Parser;
+use perl_tdd_support::must;
+
+// ---------------------------------------------------------------------------
+// Helpers  (identical structure to quick_fix_new_codes_bdd.rs)
+// ---------------------------------------------------------------------------
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn actions_for(source: &str, diags: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diags)
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by(|a, b| b.location.start.cmp(&a.location.start));
+    let mut out = source.to_string();
+    for edit in edits {
+        out.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    out
+}
+
+fn find_action<'a>(
+    actions: &'a [CodeAction],
+    pred: impl Fn(&str) -> bool,
+) -> Option<&'a CodeAction> {
+    actions.iter().find(|a| pred(&a.title))
+}
+
+// ===========================================================================
+// PL304 — Missing POD coverage
+// ===========================================================================
+
+#[test]
+fn pl304_exported_sub_produces_add_pod_action() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN an exported subroutine that has no POD documentation
+    let source = "package MyMod;\nuse Exporter 'import';\nour @EXPORT = qw(frobnicate);\n\nsub frobnicate { 1 }\n";
+
+    let sub_start = source.find("sub frobnicate").ok_or("sub not found")?;
+    let sub_end = source.find('}').ok_or("closing brace not found")? + 1;
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'frobnicate' has no POD documentation",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN an action is returned that offers to add a POD stub
+    let action = find_action(&actions, |t| t.contains("frobnicate"))
+        .ok_or_else(|| format!("no PL304 action in: {actions:?}"))?;
+
+    assert!(
+        action.title.contains("=head2"),
+        "title should reference =head2, got: {}",
+        action.title
+    );
+    assert_eq!(action.kind, CodeActionKind::QuickFix);
+    assert!(action.is_preferred, "adding POD is the only fix, so it should be preferred");
+
+    Ok(())
+}
+
+#[test]
+fn pl304_edit_inserts_pod_stub_before_sub_line() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a module with an undocumented exported sub
+    let source =
+        "package MyMod;\nuse Exporter 'import';\nour @EXPORT = qw(run);\n\nsub run { 42 }\n";
+
+    let sub_start = source.find("sub run").ok_or("sub not found")?;
+    let sub_end = sub_start + "sub run { 42 }".len();
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'run' has no POD documentation",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("run"))
+        .ok_or_else(|| format!("no action in: {actions:?}"))?;
+
+    // WHEN the edit is applied
+    let result = edited(source, action);
+
+    // THEN =head2 appears on the line immediately before `sub run`
+    let pod_pos = result.find("=head2 run").ok_or("=head2 run not found in result")?;
+    let sub_pos = result.find("sub run").ok_or("sub run not found in result")?;
+    assert!(pod_pos < sub_pos, "=head2 should appear before sub run");
+
+    // AND the stub ends with =cut before the sub
+    let between = &result[pod_pos..sub_pos];
+    assert!(between.contains("=cut"), "stub should end with =cut before the sub");
+
+    Ok(())
+}
+
+#[test]
+fn pl304_pod_stub_format_is_correct() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a minimal source with an exported sub
+    let source = "package M;\nuse Exporter;\nour @EXPORT = qw(greet);\nsub greet { 'hello' }\n";
+
+    let sub_start = source.find("sub greet").ok_or("sub not found")?;
+    let sub_end = source.rfind('}').ok_or("} not found")? + 1;
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'greet' has no POD documentation",
+    );
+    let actions = actions_for(source, &[diag]);
+
+    let action = find_action(&actions, |t| t.contains("greet"))
+        .ok_or_else(|| format!("no action in: {actions:?}"))?;
+    let result = edited(source, action);
+
+    // THEN the stub has the exact expected format
+    assert!(
+        result.contains("=head2 greet\n\nDescription.\n\n=cut\n"),
+        "stub format wrong; result:\n{result}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pl304_sub_name_appears_in_action_title() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic for a sub named process_data
+    let source = "package Proc;\nuse Exporter 'import';\nour @EXPORT = qw(process_data);\nsub process_data { }\n";
+
+    let sub_start = source.find("sub process_data").ok_or("sub not found")?;
+    let sub_end = source.rfind('}').ok_or("} not found")? + 1;
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'process_data' has no POD documentation",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN the action title contains the exact sub name and format
+    let action = find_action(&actions, |t| t.contains("process_data"))
+        .ok_or_else(|| format!("no action in: {actions:?}"))?;
+
+    assert_eq!(action.title, "Add '=head2 process_data' POD documentation stub");
+
+    Ok(())
+}
+
+#[test]
+fn pl304_invalid_range_returns_no_actions() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a diagnostic with an out-of-bounds byte range
+    let source = "sub foo { }\n";
+    let oob_start = source.len() + 10;
+    let oob_end = oob_start + 5;
+
+    let diag = make_diag(
+        oob_start,
+        oob_end,
+        "PL304",
+        "Exported subroutine 'foo' has no POD documentation",
+    );
+
+    // WHEN code actions are requested
+    let actions = actions_for(source, &[diag]);
+
+    // THEN no PL304 actions are returned (range guard fires)
+    let pl304_actions: Vec<_> = actions.iter().filter(|a| a.title.contains("=head2")).collect();
+    assert!(
+        pl304_actions.is_empty(),
+        "OOB range should produce no PL304 actions, got: {pl304_actions:?}",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pl304_dispatch_smoke_test_reaches_handler() -> Result<(), Box<dyn std::error::Error>> {
+    // GIVEN a valid PL304 diagnostic delivered through the full provider pipeline
+    let source =
+        "package Smoke;\nuse Exporter 'import';\nour @EXPORT = qw(smoke_fn);\nsub smoke_fn { 1 }\n";
+
+    let sub_start = source.find("sub smoke_fn").ok_or("sub not found")?;
+    let sub_end = source.rfind('}').ok_or("} not found")? + 1;
+
+    let diag = make_diag(
+        sub_start,
+        sub_end,
+        "PL304",
+        "Exported subroutine 'smoke_fn' has no POD documentation",
+    );
+
+    // WHEN code actions are collected via the full provider
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    let actions = provider.get_code_actions(&ast, (sub_start, sub_end), &[diag]);
+
+    // THEN at least one QuickFix action is returned — the routing table wires up the handler
+    let quick_fix_actions: Vec<_> =
+        actions.iter().filter(|a| a.kind == CodeActionKind::QuickFix).collect();
+    assert!(
+        !quick_fix_actions.is_empty(),
+        "PL304 dispatch must reach fix_missing_pod_coverage; got actions: {actions:?}",
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adapts draft PR #9642 onto current master. Closes the gap where PL304 (`MissingPodCoverage`) diagnostics had no code-action handler — the lightbulb returned nothing, forcing developers to type POD boilerplate by hand.

- `diagnostic_routes.rs`: inserts PL304 arm between PL405 and PL410 (master gained PL410 since #9642's base)
- `quick_fixes.rs`: inserts `pub fn fix_missing_pod_coverage` between `parse_printf_format_mismatch` and `fix_loop_control_undefined_label`
- `tests/quick_fix_pl304_bdd.rs`: new file, 6 BDD scenarios taken verbatim from #9642 (inline format args)

## Provenance

- Source draft: **#9642** — original implementation, verbatim intent preserved
- Superseded duplicate: **#9620** — had identical test coverage (same 6 scenarios, only `{:?}` vs `{actions:?}` format-arg style); no superior edge cases to graft; closing #9620 as duplicate with cross-ref

## Adaptation notes

Master grew since #9642's base:
1. `diagnostic_routes.rs`: gained PL410 (`LoopControlUndefinedLabel`) arm between PL405 and `_ => {}`. PL304 arm inserted between PL405 and PL410 (not before catch-all as in original, which would have been after PL410 on master).
2. `quick_fixes.rs`: `parse_printf_format_mismatch` now at ~2121, `diagnostic_line_range` at ~2210 (vs 1964 in PR base). `fix_loop_control_undefined_label` also new between them. PL304 function inserted between `parse_printf_format_mismatch` and `fix_loop_control_undefined_label`.
3. `tests/quick_fix_pl304_bdd.rs`: clean new-file add, no conflicts.

All APIs unchanged on master: `CodeAction`, `CodeActionEdit`, `TextEdit`, `SourceLocation`, `valid_diagnostic_range` — no adaptation needed in the implementation body.

## Verification output

```
cargo test -p perl-lsp-rs-core --test quick_fix_pl304_bdd
running 6 tests
test pl304_dispatch_smoke_test_reaches_handler ... ok
test pl304_edit_inserts_pod_stub_before_sub_line ... ok
test pl304_exported_sub_produces_add_pod_action ... ok
test pl304_invalid_range_returns_no_actions ... ok
test pl304_pod_stub_format_is_correct ... ok
test pl304_sub_name_appears_in_action_title ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo test -p perl-lsp-rs-core
test result: 2121 passed (1 pre-existing Windows env failure unrelated to this change)

cargo xtask fmt — clean (no formatting changes)
cargo clippy -p perl-lsp-rs-core — No issues found
```

## Test coverage

| # | Test | What it pins |
|---|------|-------------|
| 1 | `pl304_exported_sub_produces_add_pod_action` | Action returned, kind = QuickFix, is_preferred = true |
| 2 | `pl304_edit_inserts_pod_stub_before_sub_line` | `=head2` appears before `sub`, stub contains `=cut` |
| 3 | `pl304_pod_stub_format_is_correct` | Exact format: `=head2 name\n\nDescription.\n\n=cut\n` |
| 4 | `pl304_sub_name_appears_in_action_title` | Title is `"Add '=head2 name' POD documentation stub"` |
| 5 | `pl304_invalid_range_returns_no_actions` | OOB range → no actions (range guard) |
| 6 | `pl304_dispatch_smoke_test_reaches_handler` | End-to-end: PL304 through `get_code_actions` → QuickFix action |