### PR TITLE
feat(code-actions): add quick-fix for PL409 undefined goto label (#9919)

### DIFF
--- a/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs
@@ -212,6 +212,10 @@ fn quick_fixes_for_diagnostic(source: &str, diagnostic: &Diagnostic) -> Vec<Code
         c if c == DiagnosticCode::MissingPodCoverage.as_str() => {
             actions.extend(quick_fixes::fix_missing_pod_coverage(source, &qf_diag));
         }
+        // PL409: goto statement targets an undefined label
+        c if c == DiagnosticCode::GotoUndefinedLabel.as_str() => {
+            actions.extend(quick_fixes::fix_goto_undefined_label(source, &qf_diag));
+        }
         // PL410: loop-control statement targets an undefined label
         c if c == DiagnosticCode::LoopControlUndefinedLabel.as_str() => {
             actions.extend(quick_fixes::fix_loop_control_undefined_label(source, &qf_diag));

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -2186,6 +2186,47 @@ pub fn fix_missing_pod_coverage(source: &str, diagnostic: &QuickFixDiagnostic) -
             changes: vec![TextEdit {
                 location: SourceLocation { start: insert_pos, end: insert_pos },
                 new_text: pod_stub,
+}
+
+/// Remove an entire `goto LABEL` statement when the target label is undefined (PL409).
+///
+/// The diagnostic range covers the label identifier inside the `goto` statement.
+/// Since `goto` without a label target is invalid Perl, the entire statement line
+/// is deleted. The check ensures that `goto` appears on the same line before the
+/// label position and that the label text looks like a valid Perl identifier.
+pub fn fix_goto_undefined_label(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
+    let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
+        return Vec::new();
+    };
+    let Some(label_text) = source.get(range_start..range_end) else {
+        return Vec::new();
+    };
+
+    if label_text.is_empty()
+        || !label_text.chars().all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return Vec::new();
+    }
+
+    let line_start = source[..range_start].rfind('\n').map_or(0, |idx| idx + 1);
+    let line_end = source[range_end..]
+        .find('\n')
+        .map_or(source.len(), |offset| range_end + offset + 1);
+
+    let before_label = &source[line_start..range_start];
+    if !before_label.contains("goto") {
+        return Vec::new();
+    }
+
+    vec![CodeAction {
+        title: "Remove goto to undefined label".to_string(),
+        kind: CodeActionKind::QuickFix,
+        diagnostics: vec![DiagnosticCode::GotoUndefinedLabel.as_str().to_string()],
+        edit: CodeActionEdit {
+            changes: vec![TextEdit {
+                location: SourceLocation { start: line_start, end: line_end },
+                new_text: String::new(),
+
             }],
         },
         is_preferred: true,

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -2186,6 +2186,10 @@ pub fn fix_missing_pod_coverage(source: &str, diagnostic: &QuickFixDiagnostic) -
             changes: vec![TextEdit {
                 location: SourceLocation { start: insert_pos, end: insert_pos },
                 new_text: pod_stub,
+            }],
+        },
+        is_preferred: true,
+    }]
 }
 
 /// Remove an entire `goto LABEL` statement when the target label is undefined (PL409).

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -2194,6 +2194,11 @@ pub fn fix_missing_pod_coverage(source: &str, diagnostic: &QuickFixDiagnostic) -
 /// Since `goto` without a label target is invalid Perl, the entire statement line
 /// is deleted. The check ensures that `goto` appears on the same line before the
 /// label position and that the label text looks like a valid Perl identifier.
+///
+/// The fix is only offered when the `goto` statement occupies the whole line
+/// (optional leading whitespace, then `goto LABEL`, nothing else before the label).
+/// If other code precedes `goto` on the same line the line-deletion would remove
+/// those statements too, so the action is suppressed in that case.
 pub fn fix_goto_undefined_label(source: &str, diagnostic: &QuickFixDiagnostic) -> Vec<CodeAction> {
     let Some((range_start, range_end)) = valid_diagnostic_range(source, diagnostic.range) else {
         return Vec::new();
@@ -2214,7 +2219,11 @@ pub fn fix_goto_undefined_label(source: &str, diagnostic: &QuickFixDiagnostic) -
         .map_or(source.len(), |offset| range_end + offset + 1);
 
     let before_label = &source[line_start..range_start];
-    if !before_label.contains("goto") {
+
+    // Accept only `<whitespace>goto ` before the label. Anything else on the line
+    // (other statements, closing braces, etc.) means line-deletion would be unsafe.
+    let before_trimmed = before_label.trim_start();
+    if before_trimmed != "goto " && before_trimmed != "goto" {
         return Vec::new();
     }
 

--- a/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
+++ b/crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs
@@ -2220,10 +2220,11 @@ pub fn fix_goto_undefined_label(source: &str, diagnostic: &QuickFixDiagnostic) -
 
     let before_label = &source[line_start..range_start];
 
-    // Accept only `<whitespace>goto ` before the label. Anything else on the line
-    // (other statements, closing braces, etc.) means line-deletion would be unsafe.
+    // Accept only `<whitespace>goto<whitespace>` before the label. Anything else
+    // on the line (other statements, closing braces, etc.) means line-deletion would
+    // be unsafe. trim_end() handles both space- and tab-separated goto.
     let before_trimmed = before_label.trim_start();
-    if before_trimmed != "goto " && before_trimmed != "goto" {
+    if before_trimmed.trim_end() != "goto" {
         return Vec::new();
     }
 

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl409_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl409_bdd.rs
@@ -1,0 +1,171 @@
+//! BDD tests for PL409 quick fixes.
+//!
+//! PL409 fires when a `goto LABEL` statement references a label that is not
+//! defined anywhere in the current file. Since `goto` without a label target is
+//! invalid Perl, the only sensible quick fix is to remove the entire
+//! `goto LABEL;` statement line.
+
+use std::cmp::Reverse;
+use std::sync::Arc;
+
+use perl_lsp_rs_core::providers::code_actions::{CodeAction, CodeActionKind, CodeActionsProvider};
+use perl_lsp_rs_core::providers::diagnostics::{
+    Diagnostic, DiagnosticSeverity, DiagnosticsProvider,
+};
+use perl_parser::Parser;
+use perl_tdd_support::{must, must_some};
+
+fn make_diag(start: usize, end: usize, code: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        range: (start, end),
+        severity: DiagnosticSeverity::Warning,
+        code: Some(code.to_string()),
+        message: message.to_string(),
+        related_information: Vec::new(),
+        tags: Vec::new(),
+        suggestion: None,
+    }
+}
+
+fn diagnostics_for(source: &str) -> Vec<Diagnostic> {
+    let output = Parser::new(source).parse_with_recovery();
+    let ast = Arc::new(output.ast);
+    let provider = DiagnosticsProvider::new(&ast, source.to_string());
+    provider.get_diagnostics(&ast, &output.diagnostics, source, None)
+}
+
+fn actions_for(source: &str, diagnostics: &[Diagnostic]) -> Vec<CodeAction> {
+    let mut parser = Parser::new(source);
+    let ast = must(parser.parse());
+    let provider = CodeActionsProvider::new(source.to_string());
+    provider.get_code_actions(&ast, (0, source.len()), diagnostics)
+}
+
+fn pl409_actions(actions: &[CodeAction]) -> Vec<&CodeAction> {
+    actions
+        .iter()
+        .filter(|action| action.title == "Remove goto to undefined label")
+        .collect()
+}
+
+fn edited(source: &str, action: &CodeAction) -> String {
+    let mut edits = action.edit.changes.clone();
+    edits.sort_by_key(|edit| Reverse(edit.location.start));
+
+    let mut output = source.to_string();
+    for edit in edits {
+        output.replace_range(edit.location.start..edit.location.end, &edit.new_text);
+    }
+    output
+}
+
+fn first_pl409(source: &str) -> Option<Diagnostic> {
+    diagnostics_for(source)
+        .into_iter()
+        .find(|diagnostic| diagnostic.code.as_deref() == Some("PL409"))
+}
+
+// --- Scenario 1: goto with undefined label emits a remove-statement action ---
+
+#[test]
+fn code_action_pl409_goto_missing_label_offers_remove_statement_action() {
+    let source = "sub foo { goto MISSING; }\n";
+    let diagnostic = must_some(first_pl409(source));
+
+    let actions = actions_for(source, &[diagnostic]);
+    let pl409 = pl409_actions(&actions);
+
+    assert_eq!(pl409.len(), 1, "expected one PL409 quick fix, got: {actions:?}");
+    assert_eq!(pl409[0].kind, CodeActionKind::QuickFix);
+    assert!(pl409[0].is_preferred);
+}
+
+// --- Scenario 2: the edit removes the entire goto statement line ---
+
+#[test]
+fn code_action_pl409_edit_removes_goto_statement_line() {
+    let source = "sub foo {\n    goto NOWHERE;\n    return 1;\n}\n";
+    let diagnostic = must_some(first_pl409(source));
+
+    let actions = actions_for(source, &[diagnostic]);
+    let pl409 = pl409_actions(&actions);
+
+    assert_eq!(pl409.len(), 1, "expected one PL409 quick fix, got: {actions:?}");
+    let result = edited(source, pl409[0]);
+    assert_eq!(result, "sub foo {\n    return 1;\n}\n");
+}
+
+// --- Scenario 3: action title is exactly "Remove goto to undefined label" ---
+
+#[test]
+fn code_action_pl409_action_title_is_remove_goto_to_undefined_label() {
+    let source = "goto PHANTOM;\n";
+    let diagnostic = must_some(first_pl409(source));
+
+    let actions = actions_for(source, &[diagnostic]);
+    let pl409 = pl409_actions(&actions);
+
+    assert_eq!(
+        pl409.len(),
+        1,
+        "expected one action titled 'Remove goto to undefined label', got: {actions:?}"
+    );
+    assert_eq!(pl409[0].title, "Remove goto to undefined label");
+}
+
+// --- Scenario 4: defined goto label does not produce an action ---
+
+#[test]
+fn code_action_pl409_defined_label_has_no_remove_statement_action() {
+    let source = "FOUND: my $x = 1;\ngoto FOUND;\n";
+    let diagnostics = diagnostics_for(source);
+
+    let actions = actions_for(source, &diagnostics);
+
+    assert!(
+        pl409_actions(&actions).is_empty(),
+        "defined label should not offer PL409 quick fix, got: {actions:?}"
+    );
+}
+
+// --- Scenario 5: a bad (non-char-boundary) diagnostic range returns no action ---
+
+#[test]
+fn code_action_pl409_bad_diagnostic_range_returns_no_action() {
+    let source = "goto MISSING;\nmy $s = \"\u{e9}\";\n";
+    let char_start = must_some(source.find('\u{e9}'));
+    let diagnostic = make_diag(
+        char_start + 1,
+        char_start + 2,
+        "PL409",
+        "Goto label 'MISSING' is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diagnostic]);
+
+    assert!(
+        pl409_actions(&actions).is_empty(),
+        "bad diagnostic range should not offer PL409 quick fix, got: {actions:?}"
+    );
+}
+
+// --- Scenario 6: dispatch smoke test — wrong diagnostic code produces no PL409 action ---
+
+#[test]
+fn code_action_pl409_wrong_diagnostic_code_produces_no_remove_goto_action() {
+    let source = "goto MISSING;\n";
+    let label_start = must_some(source.find("MISSING"));
+    let diagnostic = make_diag(
+        label_start,
+        label_start + "MISSING".len(),
+        "PL410",
+        "Goto label 'MISSING' is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diagnostic]);
+
+    assert!(
+        pl409_actions(&actions).is_empty(),
+        "PL410 diagnostic code should not produce 'Remove goto to undefined label' action, got: {actions:?}"
+    );
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl409_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl409_bdd.rs
@@ -193,3 +193,30 @@ fn code_action_pl409_goto_on_shared_line_produces_no_action() {
         "goto on a shared line should not offer PL409 quick fix (unsafe deletion), got: {actions:?}"
     );
 }
+
+// --- Scenario 8: goto with tab whitespace before label is offered ---
+
+#[test]
+fn code_action_pl409_goto_with_tab_whitespace_offers_action() {
+    // A tab between goto and the label is valid Perl whitespace.
+    // The guard uses trim_end() so this case is handled correctly.
+    let source = "    goto	MISSING;\n";
+    let label_start = must_some(source.find("MISSING"));
+    let diagnostic = make_diag(
+        label_start,
+        label_start + "MISSING".len(),
+        "PL409",
+        "Goto label 'MISSING' is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diagnostic]);
+    let pl409 = pl409_actions(&actions);
+
+    assert_eq!(
+        pl409.len(),
+        1,
+        "tab-separated goto should offer PL409 quick fix, got: {actions:?}"
+    );
+    let result = edited(source, pl409[0]);
+    assert_eq!(result, "");
+}

--- a/crates/perl-lsp-rs-core/tests/quick_fix_pl409_bdd.rs
+++ b/crates/perl-lsp-rs-core/tests/quick_fix_pl409_bdd.rs
@@ -69,7 +69,7 @@ fn first_pl409(source: &str) -> Option<Diagnostic> {
 
 #[test]
 fn code_action_pl409_goto_missing_label_offers_remove_statement_action() {
-    let source = "sub foo { goto MISSING; }\n";
+    let source = "sub foo {\n    goto MISSING;\n}\n";
     let diagnostic = must_some(first_pl409(source));
 
     let actions = actions_for(source, &[diagnostic]);
@@ -167,5 +167,29 @@ fn code_action_pl409_wrong_diagnostic_code_produces_no_remove_goto_action() {
     assert!(
         pl409_actions(&actions).is_empty(),
         "PL410 diagnostic code should not produce 'Remove goto to undefined label' action, got: {actions:?}"
+    );
+}
+
+// --- Scenario 7: goto on a line shared with other statements is not offered ---
+
+#[test]
+fn code_action_pl409_goto_on_shared_line_produces_no_action() {
+    // When goto shares a line with other code (e.g. inside a one-liner sub body),
+    // line-deletion would remove the surrounding statements too. The fix must be
+    // suppressed in that case to avoid data loss.
+    let source = "sub foo { goto MISSING; }\n";
+    let label_start = must_some(source.find("MISSING"));
+    let diagnostic = make_diag(
+        label_start,
+        label_start + "MISSING".len(),
+        "PL409",
+        "Goto label 'MISSING' is not defined in this file",
+    );
+
+    let actions = actions_for(source, &[diagnostic]);
+
+    assert!(
+        pl409_actions(&actions).is_empty(),
+        "goto on a shared line should not offer PL409 quick fix (unsafe deletion), got: {actions:?}"
     );
 }


### PR DESCRIPTION
## Summary

Implements the missing quick-fix for **PL409 (`GotoUndefinedLabel`)** diagnostics. When an editor shows a lightbulb on `goto LABEL` where the label isn't defined, this adds a "Remove goto to undefined label" code action that deletes the entire unreachable statement.

### Why this matters

`goto LABEL` with an undefined label will cause a runtime fatal error in Perl (`Can't find label "LABEL"`). The LSP already emits the PL409 warning via the `check_goto_labels` lint. Until now, clicking the lightbulb produced no actions — the diagnostic had no arm in `diagnostic_routes.rs`. This PR closes that gap.

### Design

Unlike PL410 (`next`/`last`/`redo LABEL`) where removing the label yields valid bare operators, a bare `goto` without a target is invalid Perl syntax. The only safe mechanical fix is to **remove the entire `goto LABEL;` statement line**.

The fix function (`fix_goto_undefined_label`) is careful:
- Validates the diagnostic byte range is a valid char boundary (guard against malformed diagnostics)
- Checks the range text looks like a Perl identifier (all alphanumeric/underscore) — rejects non-label ranges silently
- Confirms `goto` appears on the same line before the label position (rejects misrouted diagnostics)
- Deletes the full statement line (from line-start to after the newline), preserving surrounding indentation in multi-line blocks

## Changes

| File | What changed |
|------|-------------|
| `crates/perl-lsp-rs-core/src/providers/code_actions/quick_fixes.rs` | New `pub fn fix_goto_undefined_label` (44 lines) |
| `crates/perl-lsp-rs-core/src/providers/code_actions/diagnostic_routes.rs` | New arm for `GotoUndefinedLabel` / PL409 |
| `crates/perl-lsp-rs-core/tests/quick_fix_pl409_bdd.rs` | 6 new BDD integration tests |

## Test plan

All 6 BDD tests in `quick_fix_pl409_bdd.rs` pass:

- [x] **Scenario 1** — `goto MISSING;` inside a function body offers the remove-statement action
- [x] **Scenario 2** — The edit removes exactly the `goto MISSING;` line, leaving surrounding lines intact
- [x] **Scenario 3** — Action title is exactly `"Remove goto to undefined label"`
- [x] **Scenario 4** — `goto FOUND;` with a defined `FOUND:` label produces no action (no false positives)
- [x] **Scenario 5** — A bad diagnostic range (mid-multibyte character) returns no action (range guard)
- [x] **Scenario 6** — A PL410-coded diagnostic on a goto statement produces no PL409 action (dispatch boundary)

Pre-existing regression checks:
- [x] 17 `quick_fix_new_codes_bdd` tests green
- [x] 8 `quick_fix_pl410_bdd` tests green
- [x] `cargo clippy -p perl-lsp-rs-core --lib` clean
- [x] `cargo xtask fmt` clean (no diff)

## Scope

- Only touches code-actions surface; diagnostic emission logic in `goto_label/mod.rs` is unchanged
- No new external dependencies
- Does not add "suggest defining a label" alternative (that requires AST rewrite guidance, out of scope)

https://claude.ai/code/session_01EQXTt3fLaf59QoBh9rRiQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQXTt3fLaf59QoBh9rRiQD)_