### PR TITLE
fix(completion): apply starts_with prefix filter for workspace symbol completions (#6861) (#9920)

### DIFF
--- a/crates/perl-lsp-rs/src/runtime/language/completion.rs
+++ b/crates/perl-lsp-rs/src/runtime/language/completion.rs
@@ -482,8 +482,25 @@ impl LspServer {
                     Self::qualified_variable_workspace_symbols(index, &prefix);
                 let replace_prefix_range = (offset.saturating_sub(prefix.len()), offset);
                 let qualified_variable_context = qualified_variable_symbols.is_some();
-                let workspace_symbols =
-                    qualified_variable_symbols.unwrap_or_else(|| index.find_symbols(&prefix));
+                let prefix_lower = prefix.to_lowercase();
+                let workspace_symbols = qualified_variable_symbols.unwrap_or_else(|| {
+                    // Completion requires prefix (starts_with) matching, not the
+                    // substring (contains) matching that find_symbols uses for
+                    // workspace/symbol queries.  Filter here so callers typing
+                    // `bar` don't see `foobar` in their completion list.
+                    index
+                        .find_symbols(&prefix)
+                        .into_iter()
+                        .filter(|s| {
+                            let name_lower = s.name.to_lowercase();
+                            name_lower.starts_with(&prefix_lower)
+                                || s.qualified_name
+                                    .as_ref()
+                                    .map(|qn| qn.to_lowercase().starts_with(&prefix_lower))
+                                    .unwrap_or(false)
+                        })
+                        .collect()
+                });
                 use std::collections::HashSet;
                 let mut seen: HashSet<String> =
                     completions.iter().map(|completion| completion.label.clone()).collect();

--- a/crates/perl-lsp-rs/tests/lsp_workspace_completion_prefix_bdd.rs
+++ b/crates/perl-lsp-rs/tests/lsp_workspace_completion_prefix_bdd.rs
@@ -1,0 +1,272 @@
+//! BDD tests for workspace completion prefix filtering (issue #6861).
+//!
+//! The workspace index uses substring (`contains`) matching internally for
+//! `workspace/symbol` queries, which is correct per LSP 3.17 §5.3.2.  But when
+//! the same index results are used for `textDocument/completion`, only candidates
+//! whose name *starts with* the typed prefix should be offered.  Returning
+//! symbols that merely contain the prefix anywhere is noise that degrades UX
+//! on large codebases.
+//!
+//! These tests verify that the completion provider applies a `starts_with` guard
+//! before surfacing workspace symbols, while the `workspace/symbol` endpoint
+//! continues to return all substring matches.
+
+mod support;
+
+use serial_test::serial;
+use support::lsp_harness::LspHarness;
+use support::ux_bdd::{UxScenario, completion_contains_label, completion_labels};
+
+/// Extract symbol names from a `workspace/symbol` response array.
+fn workspace_symbol_names(response: &serde_json::Value) -> Vec<String> {
+    response
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|s| s.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — cross-file subroutine prefix filtering (core bug regression)
+// ---------------------------------------------------------------------------
+//
+// Two modules define subroutines that share a common fragment "bar":
+//
+//   helpers.pm: sub foobar { }     ← CONTAINS "bar" but does NOT start with it
+//   reporter.pm: sub bar_report { } ← STARTS WITH "bar"
+//
+// Typing "bar" in main.pl should surface only `bar_report`.
+// Before the fix, `foobar` would also appear because find_symbols uses contains().
+
+#[test]
+#[serial]
+fn bdd_completion_workspace_prefix_excludes_contains_only_match()
+-> Result<(), Box<dyn std::error::Error>> {
+    let scenario = UxScenario::new("Workspace completion uses starts_with, not contains");
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    scenario.given("helpers.pm defines 'foobar' — contains 'bar' but does not start with it");
+    harness
+        .open("file:///workspace/helpers.pm", "package Helpers;\nsub foobar { return 1; }\n1;\n")?;
+
+    scenario.given("reporter.pm defines 'bar_report' — starts with 'bar'");
+    harness.open(
+        "file:///workspace/reporter.pm",
+        "package Reporter;\nsub bar_report { return 1; }\n1;\n",
+    )?;
+
+    scenario.given("main.pl is the completion target with cursor after 'bar'");
+    harness.open(
+        "file:///workspace/main.pl",
+        // Line 0: use Helpers;
+        // Line 1: use Reporter;
+        // Line 2: bar   ← cursor position (line 2, col 3)
+        "use Helpers;\nuse Reporter;\nbar",
+    )?;
+    harness.barrier();
+
+    scenario.when("requesting completion at the 'bar' prefix in main.pl");
+    let completions = harness.completion_at("file:///workspace/main.pl", 2, 3)?;
+    let labels = completion_labels(&completions);
+
+    scenario.then("'bar_report' is offered — name starts with the typed prefix");
+    assert!(
+        completion_contains_label(&completions, "bar_report"),
+        "bar_report should appear (name starts with 'bar'), got: {labels:?}"
+    );
+
+    scenario.then("'foobar' is NOT offered — name merely contains 'bar', not starts with it");
+    assert!(
+        !completion_contains_label(&completions, "foobar"),
+        "foobar must be absent (name does not start with 'bar'), got: {labels:?}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — longer prefix: mid-name fragment excluded
+// ---------------------------------------------------------------------------
+//
+// Typing a prefix that appears mid-word in a cross-file subroutine name
+// should not surface that subroutine.
+//
+//   utils.pm: sub not_fix_it { }   ← contains "fix" in the middle
+//   fixer.pm: sub fix_data { }     ← starts with "fix"
+//
+// Typing "fix" must return `fix_data` only.
+
+#[test]
+#[serial]
+fn bdd_completion_workspace_mid_name_fragment_excluded() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = UxScenario::new("Mid-name fragment not offered as completion candidate");
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    scenario.given("utils.pm defines 'not_fix_it' — 'fix' appears mid-name");
+    harness
+        .open("file:///workspace/utils.pm", "package Utils;\nsub not_fix_it { return 0; }\n1;\n")?;
+
+    scenario.given("fixer.pm defines 'fix_data' — name starts with 'fix'");
+    harness
+        .open("file:///workspace/fixer.pm", "package Fixer;\nsub fix_data { return 1; }\n1;\n")?;
+
+    harness.open("file:///workspace/main2.pl", "use Utils;\nuse Fixer;\nfix")?;
+    harness.barrier();
+
+    scenario.when("requesting completion at the 'fix' prefix");
+    let completions = harness.completion_at("file:///workspace/main2.pl", 2, 3)?;
+    let labels = completion_labels(&completions);
+
+    scenario.then("'fix_data' appears — starts with 'fix'");
+    assert!(
+        completion_contains_label(&completions, "fix_data"),
+        "fix_data should appear (starts with 'fix'), got: {labels:?}"
+    );
+
+    scenario.then("'not_fix_it' does NOT appear — 'fix' is a mid-name fragment");
+    assert!(
+        !completion_contains_label(&completions, "not_fix_it"),
+        "not_fix_it must be absent ('fix' only appears mid-name), got: {labels:?}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — workspace/symbol endpoint is unaffected (uses substring match)
+// ---------------------------------------------------------------------------
+//
+// `workspace/symbol` is a distinct LSP feature whose spec says substring
+// matching is valid.  The fix to completion must NOT change symbol search.
+
+#[test]
+#[serial]
+fn bdd_workspace_symbol_still_uses_substring_match() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario =
+        UxScenario::new("workspace/symbol continues to use substring matching after the fix");
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    scenario.given("helpers.pm defines 'foobar' and reporter.pm defines 'bar_report'");
+    harness
+        .open("file:///workspace/helpers.pm", "package Helpers;\nsub foobar { return 1; }\n1;\n")?;
+    harness.open(
+        "file:///workspace/reporter.pm",
+        "package Reporter;\nsub bar_report { return 1; }\n1;\n",
+    )?;
+    harness.barrier();
+
+    scenario.when("querying workspace/symbol with 'bar'");
+    let sym_response =
+        harness.request("workspace/symbol", serde_json::json!({ "query": "bar" }))?;
+    let names = workspace_symbol_names(&sym_response);
+
+    scenario.then("'bar_report' is in the symbol list (starts with 'bar')");
+    assert!(
+        names.contains(&"bar_report".to_string()),
+        "bar_report should be in workspace symbols, got: {names:?}"
+    );
+
+    scenario.then(
+        "'foobar' is also in the symbol list — substring match is correct for workspace/symbol",
+    );
+    assert!(
+        names.contains(&"foobar".to_string()),
+        "foobar should appear in workspace/symbol (substring match), got: {names:?}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — prefix match returns workspace symbol while excluding others
+// ---------------------------------------------------------------------------
+//
+// Typing `comp` should offer `compute` from the workspace (starts with `comp`)
+// while NOT offering `decompose` (contains `comp` but starts with `de`).
+
+#[test]
+#[serial]
+fn bdd_completion_prefix_match_returns_start_with_only() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = UxScenario::new("Prefix 'comp' offers 'compute' but excludes 'decompose'");
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    scenario.given("util.pm defines 'compute' (starts with 'comp') and 'decompose' (contains 'comp' but not at start)");
+    harness.open(
+        "file:///workspace/util.pm",
+        "package Util;\nsub compute { return 42; }\nsub decompose { return 0; }\n1;\n",
+    )?;
+    // Cursor after "comp" on line 1
+    harness.open("file:///workspace/consumer.pl", "use Util;\ncomp")?;
+    harness.barrier();
+
+    scenario.when("completion is requested at 'comp' prefix");
+    // Line 1, col 4 = after "comp"
+    let completions = harness.completion_at("file:///workspace/consumer.pl", 1, 4)?;
+    let labels = completion_labels(&completions);
+
+    scenario.then("'compute' appears — its name starts with 'comp'");
+    assert!(
+        completion_contains_label(&completions, "compute"),
+        "compute should appear (starts with 'comp'), got: {labels:?}"
+    );
+
+    scenario.then("'decompose' does NOT appear — 'comp' is a mid-name fragment");
+    assert!(
+        !completion_contains_label(&completions, "decompose"),
+        "decompose must be absent ('comp' appears mid-name in decompose), got: {labels:?}"
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — qualified name prefix (Package::sub) correctly matched
+// ---------------------------------------------------------------------------
+//
+// When the user types a qualified prefix like `Reporter::bar`, only subroutines
+// in the Reporter namespace that start with `bar` should appear.  This verifies
+// that the qualified_name check in the filter is also correct.
+
+#[test]
+#[serial]
+fn bdd_completion_qualified_prefix_filters_correctly() -> Result<(), Box<dyn std::error::Error>> {
+    let scenario = UxScenario::new("Qualified prefix 'Reporter::bar' filters to bar_report only");
+    let mut harness = LspHarness::new();
+    harness.initialize(None)?;
+
+    harness.open(
+        "file:///workspace/reporter.pm",
+        "package Reporter;\nsub bar_report { return 1; }\nsub baz_other { return 2; }\n1;\n",
+    )?;
+    // Cursor after "Reporter::bar"  (line 1, col 13)
+    harness.open("file:///workspace/qualified.pl", "use Reporter;\nReporter::bar")?;
+    harness.barrier();
+
+    scenario.when("completing at 'Reporter::bar' (col 13 = after the full prefix)");
+    let completions = harness.completion_at("file:///workspace/qualified.pl", 1, 13)?;
+    let labels = completion_labels(&completions);
+
+    scenario.then("'Reporter::bar_report' or 'bar_report' is offered");
+    let has_match = completion_contains_label(&completions, "bar_report")
+        || completion_contains_label(&completions, "Reporter::bar_report");
+    assert!(
+        has_match,
+        "bar_report (or Reporter::bar_report) should appear for qualified prefix, got: {labels:?}"
+    );
+
+    scenario
+        .then("'baz_other' or 'Reporter::baz_other' is NOT offered — doesn't match 'bar' prefix");
+    let has_baz = completion_contains_label(&completions, "baz_other")
+        || completion_contains_label(&completions, "Reporter::baz_other");
+    assert!(
+        !has_baz,
+        "baz_other must not appear — 'baz_other' doesn't start with 'bar', got: {labels:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Resolves #6861.

The workspace index `find_symbols()` uses **substring (`contains`) matching**, which is correct for `workspace/symbol` queries (LSP 3.17 §5.3.2) but wrong for `textDocument/completion`. When a user types `bar`, symbols like `foobar` that contain "bar" as a mid-name fragment were incorrectly surfaced alongside true prefix matches like `bar_report`.

This was first noted in issue #6861 after PR #6860 dropped the assertion:
```rust
// Dropped by #6860:
assert!(!labels3.contains(&"$preliminary".to_string()));
```

## Root cause

In `add_runtime_workspace_completions` (`completion.rs:486`), the fallback path delegated entirely to `index.find_symbols(&prefix)`, which internally uses `contains()`:

```rust
// Before fix — `foobar` incorrectly appears when typing `bar`
let workspace_symbols =
    qualified_variable_symbols.unwrap_or_else(|| index.find_symbols(&prefix));
```

`find_symbols` → `search_symbols` → `search_source_symbols` all use `symbol.name.to_lowercase().contains(&query_lower)`.  For a query of `bar`, this matches both `bar_report` (correct) and `foobar` (incorrect — mid-name fragment only).

## Fix

Apply a `starts_with` post-filter in the completion fallback path only. The `workspace/symbol` endpoint is **not touched** and continues using substring matching as required.

```rust
// After fix — only prefix-matching symbols surface in completions
let prefix_lower = prefix.to_lowercase();
let workspace_symbols = qualified_variable_symbols.unwrap_or_else(|| {
    index
        .find_symbols(&prefix)
        .into_iter()
        .filter(|s| {
            let name_lower = s.name.to_lowercase();
            name_lower.starts_with(&prefix_lower)
                || s.qualified_name
                    .as_ref()
                    .map(|qn| qn.to_lowercase().starts_with(&prefix_lower))
                    .unwrap_or(false)
        })
        .collect()
});
```

The `qualified_name` field is also checked so typed qualified prefixes like `Reporter::bar` continue to resolve subroutines in the correct namespace.

## Files changed

| File | Change |
|------|--------|
| `crates/perl-lsp-rs/src/runtime/language/completion.rs` | 19-line fix replacing bare `find_symbols` call with `starts_with`-filtered iterator |
| `crates/perl-lsp-rs/tests/lsp_workspace_completion_prefix_bdd.rs` | 5 new BDD integration tests (new file) |

## Tests

Five BDD integration tests are added in `lsp_workspace_completion_prefix_bdd.rs`:

| Test | Scenario | Verifies |
|------|----------|----------|
| `bdd_completion_workspace_prefix_excludes_contains_only_match` | `foobar` / `bar_report` / typing `bar` | `foobar` absent, `bar_report` present |
| `bdd_completion_workspace_mid_name_fragment_excluded` | `not_fix_it` / `fix_data` / typing `fix` | `not_fix_it` absent, `fix_data` present |
| `bdd_workspace_symbol_still_uses_substring_match` | Same symbols, `workspace/symbol` query | Both `foobar` AND `bar_report` present (substring is correct here) |
| `bdd_completion_prefix_match_returns_start_with_only` | `compute` / `decompose` / typing `comp` | `compute` present, `decompose` absent |
| `bdd_completion_qualified_prefix_filters_correctly` | `bar_report` / `baz_other` / typing `Reporter::bar` | `bar_report` present, `baz_other` absent |

All 5 tests pass. The `workspace/symbol` test (scenario 3) is the explicit regression guard ensuring the index behavior is unchanged for symbol search.

## Non-goals / unchanged behavior

- `workspace/symbol` substring matching is **preserved** — this is correct per LSP spec and tested explicitly
- The `qualified_variable_workspace_symbols` path (for `$Pkg::var` completions) is **unchanged** — it already uses `starts_with` internally
- File-level completions from `CompletionProvider` are **unchanged** — local variable scoping is handled separately and correctly
- Empty prefix (`""`) is handled correctly: `starts_with("")` is always `true`, so all workspace symbols still surface when no prefix is typed

## Test plan

- [x] `cargo build -p perl-lsp-rs` — clean
- [x] 5 new BDD tests pass: `cargo test -p perl-lsp-rs --test lsp_workspace_completion_prefix_bdd`
- [ ] Full suite: `RUST_TEST_THREADS=2 cargo test -p perl-lsp-rs -- --test-threads=2` (running)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKGYW2JRXobKcDFUPrb5u6)_