### PR TITLE
fix(dap): include supported command list when no typo suggestion exists (#9901) (#9921)

### DIFF
--- a/crates/perl-dap/src/debug_adapter/dispatch.rs
+++ b/crates/perl-dap/src/debug_adapter/dispatch.rs
@@ -144,7 +144,8 @@ impl DebugAdapter {
         if let Some(suggestion) = Self::suggested_command(command) {
             format!("Unknown command: {command}. Did you mean '{suggestion}'?")
         } else {
-            format!("Unknown command: {command}")
+            let supported = Self::SUPPORTED_COMMANDS.join(", ");
+            format!("Unknown command: {command}. Supported commands: {supported}")
         }
     }
 

--- a/crates/perl-dap/tests/dap_dispatcher_removal_regression_tests.rs
+++ b/crates/perl-dap/tests/dap_dispatcher_removal_regression_tests.rs
@@ -366,6 +366,32 @@ fn unknown_command_returns_unknown_command_prefix() {
     }
 }
 
+/// When the unknown command name is not a close typo of any supported command,
+/// the error message must include the supported command list so users know what
+/// commands are available without consulting external docs.
+#[test]
+fn unknown_command_includes_supported_commands_when_no_suggestion() {
+    let mut adapter = DebugAdapter::new();
+    let response = adapter.handle_request(43, "totallyMadeUpCommandXYZ123", None);
+
+    match response {
+        DapMessage::Response { success, command, message, .. } => {
+            assert!(!success);
+            assert_eq!(command, "totallyMadeUpCommandXYZ123");
+            let message = must_some(message);
+            assert!(
+                message.contains("Supported commands:"),
+                "expected supported-commands list in message, got: {message}"
+            );
+            // Spot-check a few well-known commands appear in the list
+            assert!(message.contains("initialize"), "expected 'initialize' in supported list");
+            assert!(message.contains("launch"), "expected 'launch' in supported list");
+            assert!(message.contains("evaluate"), "expected 'evaluate' in supported list");
+        }
+        other => must(Err::<(), _>(format!("expected Response, got {other:?}"))),
+    }
+}
+
 // --- sequence numbers ---------------------------------------------------------
 
 /// Mirrors `dispatcher::tests::test_response_sequence_numbers` /


### PR DESCRIPTION
## Summary

Resolves #9901.

When a DAP client sends an unrecognised command that is **not** a close typo of any known command, the error response previously contained only:

```
Unknown command: <name>
```

This left the client with no way to know what commands are supported without reading source code or external docs. The fix adds the full supported-command list to the no-suggestion response branch:

```
Unknown command: <name>. Supported commands: initialize, launch, attach, disconnect, ...
```

The existing "Did you mean '...'" path (close-typo detection) is unchanged.

## What changed

### `crates/perl-dap/src/debug_adapter/dispatch.rs`

One-line change in `unknown_command_message`: the `else` branch now joins `SUPPORTED_COMMANDS` and appends them to the error message instead of returning the bare name.

```rust
// Before
format!("Unknown command: {command}")

// After
let supported = Self::SUPPORTED_COMMANDS.join(", ");
format!("Unknown command: {command}. Supported commands: {supported}")
```

### `crates/perl-dap/tests/dap_dispatcher_removal_regression_tests.rs`

New test `unknown_command_includes_supported_commands_when_no_suggestion` that:
- Sends a command name with no plausible typo match (`"totallyMadeUpCommandXYZ123"`)
- Asserts the error message contains `"Supported commands:"`
- Spot-checks three well-known commands appear in the list (`initialize`, `launch`, `evaluate`)

## Why this matters

DAP clients that probe or send incorrect commands get actionable feedback immediately, without requiring docs lookup. This is especially useful during integration development where command names are discovered iteratively. The fix mirrors the pattern already used by many LSP servers.

## Backward compatibility

All existing tests pass unchanged:
- `unknown_command_returns_unknown_command_prefix` — checks `starts_with("Unknown command: <name>")` ✓ (prefix is preserved)
- `test_dap_unknown_command` — checks `starts_with("Unknown command")` ✓
- `test_unknown_command_returns_structured_error_response` — checks `message.is_some()` ✓
- `test_response_error_serde_round_trip` — checks `contains("Unknown command")` ✓

## Test plan

- [x] `cargo test -p perl-dap --test dap_dispatcher_removal_regression_tests` — 11/11 passed
- [x] `cargo test -p perl-dap --test dap_protocol_compliance_tests -- test_unknown_command` — passed
- [x] `cargo test -p perl-dap --test dap_coverage_audit_tests` — 79/79 passed
- [x] `cargo test -p perl-dap --test dap_comprehensive_test -- test_dap_unknown_command` — passed
- [x] `cargo test -p perl-dap --lib` — 415/415 passed
- [x] `cargo clippy -p perl-dap` — no new warnings (pre-existing `missing_docs` on `handle_request` unrelated to this change)

https://claude.ai/code/session_01QCk9B1AgqJX7bmspHDZzEj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCk9B1AgqJX7bmspHDZzEj)_