### PR TITLE
fix(dap): restore snapshot-fallback guard accidentally reverted by train-3 consolidation

### DIFF
--- a/crates/perl-dap/src/debug_adapter/frames.rs
+++ b/crates/perl-dap/src/debug_adapter/frames.rs
@@ -45,13 +45,21 @@ impl DebugAdapter {
             let framed_frames =
                 Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output));
             if framed_frames.is_empty() {
-                let output_lines = self.snapshot_recent_output_lines();
-                if output_lines.is_empty() {
-                    Vec::new()
-                } else {
-                    let output = output_lines.join("\n");
-                    Self::filter_user_visible_frames(Self::parse_stack_frames_from_text(&output))
-                }
+                // The framed T output contained only internal debugger frames (e.g.
+                // `@ = DB::DB called from file '...' line N` at top-level stops) or
+                // none at all.  These are filtered out by filter_user_visible_frames.
+                //
+                // Do NOT fall back to snapshot parsing here: the snapshot buffer
+                // contains the entire session history, including the initial implicit
+                // stop context line (e.g. line 4 in a 7-line fixture), which appears
+                // BEFORE the current breakpoint context line (e.g. line 5).
+                // Snapshot-based parsing returns frames in output order, so the FIRST
+                // frame would be the stale line-4 context, not the current line-5 stop.
+                //
+                // The output reader already parsed the most recent context line and
+                // stored it in session.stack_frames.  Returning an empty vec here
+                // causes the caller to fall through to that authoritative source.
+                Vec::new()
             } else {
                 framed_frames
             }


### PR DESCRIPTION
## Summary

PR #9918 (train-3 set A consolidation) contained an accidental revert of a correctness fix that had landed in the sync commit `6925335fa` between the source-branch fork point (`a539017f8`) and the consolidation merge.

**Root cause**: The 9 source branches (#9824–#9846) forked from `a539017f8`.  The sync commit landed at `6925335fa` changed `frames.rs` to replace a snapshot-fallback with `Vec::new()` plus an explanatory safety comment.  When the consolidation squash resolved conflicts, it kept branch-side content, silently restoring the snapshot fallback and discarding the safety comment.

**What was reverted** (`frames.rs`, `framed_frames.is_empty()` branch):

The sync commit replaced the 7-line snapshot-fallback path with `Vec::new()` and a comment explaining why snapshot fallback is dangerous here: the snapshot buffer contains the entire session history in output order, so if T-framed output returns only internal DB frames (filtered empty by `filter_user_visible_frames`), falling back returns the stale prior context line as frame 0 instead of the current stop line. Returning `Vec::new()` lets the caller fall through to the authoritative `session.stack_frames`.

**The dispatch.rs revert was already repaired** by #9921 (merged). This PR repairs the only remaining accidental revert.

## What changed

`crates/perl-dap/src/debug_adapter/frames.rs` — one branch of `handle_stack_trace`:
- Replaces the 7-line snapshot fallback in the `framed_frames.is_empty()` arm with `Vec::new()`
- Restores the "Do NOT fall back to snapshot parsing here" safety comment from `6925335fa`

The `else` branch (when `framed_output_lines` is `None` — no live session) retains its snapshot fallback; that is correct and intentional.

## Verification

```
cargo check -p perl-dap --locked        → OK (1 pre-existing missing_docs warning)
cargo test -p perl-dap --lib            → 409 passed
cargo clippy -p perl-dap -A missing_docs → clean
cargo fmt -p perl-dap                   → no diff
```