### PR TITLE
ci: Codecov verdict from local receipt; token wiring + non-fatal upload (#9923)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -529,13 +529,36 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
-        if: github.event_name != 'pull_request' || steps.coverage_route.outputs.coverage_required == 'true'
+        id: codecov_upload
+        # Non-fatal telemetry: the job verdict comes from the local quality-gate
+        # receipt produced above (just coverage-proof-routed / quality-gate step).
+        # An upload failure (flake, rate-limit, empty token on re-run) must never
+        # fail this required check when the gate passed.
+        # Token wiring: CODECOV_TOKEN is set in env so the action can read it via
+        # both the `with: token:` path AND the env-var fallback that Codecov v6
+        # uses internally. The `env.CODECOV_TOKEN != ''` guard skips the upload
+        # entirely when secrets are unavailable (fork PRs, certain re-run contexts).
+        if: |
+          env.CODECOV_TOKEN != '' &&
+          (github.event_name != 'pull_request' ||
+           steps.coverage_route.outputs.coverage_required == 'true')
+        continue-on-error: true
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/lcov.info
           name: workspace-patch-coverage
-          fail_ci_if_error: true
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Warn on Codecov upload failure
+        if: always() && steps.codecov_upload.outcome == 'failure'
+        shell: bash
+        run: |
+          printf '> [!WARNING]\n> Codecov telemetry upload failed. The job verdict is determined by the\n> local quality-gate receipt above, not by this upload. Upload failures\n> (flake, rate-limit, empty token on re-run) are non-fatal.\n' \
+            >> "$GITHUB_STEP_SUMMARY"
+          echo "::warning::Codecov telemetry upload failed. Verdict comes from local quality-gate receipt — this is non-fatal."
 
       - name: Upload coverage proof artifacts
         if: always()


### PR DESCRIPTION
## Summary

Port of swarm PR [EffortlessMetrics/perl-lsp-swarm#1231](https://github.com/EffortlessMetrics/perl-lsp-swarm/pull/1231) (merged, commit `a6b7c1832`) to the source repo.

**Problem:** The `Upload coverage to Codecov` step had `fail_ci_if_error: true` and no token guard. When the secret is unavailable (fork PRs, re-run contexts where GitHub does not re-inject secrets), the upload fails and kills the required "Codecov / Patch 95" check — even when the local quality-gate receipt already recorded `decision: pass`. This is a CI flake, not a coverage failure.

**Fix — three parts:**

1. **Token wiring**: Add `env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}` to the upload step. Codecov v6 reads from both `with: token:` and the env-var fallback. Add `if: env.CODECOV_TOKEN != ''` guard that merges with the existing step conditions — skips upload entirely when secrets are unavailable rather than attempting a tokenless upload that Codecov rate-limits.

2. **Non-fatal telemetry**: Change `fail_ci_if_error: true` → `fail_ci_if_error: false` + `continue-on-error: true`. The job verdict comes from `just coverage-proof-routed` (local quality-gate receipt), not from Codecov.io. Upload failures are pure telemetry.

3. **Visible warning**: Add a `Warn on Codecov upload failure` step that fires when the upload step's outcome is `failure`, writing a `[!WARNING]` callout to the step summary and a `::warning::` annotation to the log — failures stay auditable without being fatal.

## Trigger-path coverage

| Trigger | Secret available? | Token guard | Upload step | Job outcome |
|---------|------------------|-------------|-------------|-------------|
| `pull_request` (internal) | Yes | `env.CODECOV_TOKEN != ''` → true | runs, `continue-on-error: true` | Quality-gate step |
| `pull_request` re-run (internal) | May be empty | → false | **skipped** | Quality-gate step |
| `pull_request` from fork | No | → false | **skipped** | Quality-gate step |
| `schedule` / `workflow_dispatch` | Yes | → true | runs, `continue-on-error: true` | Quality-gate step |
| Upload flakes | Yes | true | fails → absorbed | Warning posted, job succeeds |

## Files changed

- `.github/workflows/ci-nightly.yml` — 1 file, +25/-2 lines

## References

- Swarm PR: EffortlessMetrics/perl-lsp-swarm#1231
- `CODECOV_TOKEN` secret verified present in `EffortlessMetrics/perl-lsp` (created 2026-05-03)