### PR TITLE
build(changelog): adopt Changie for future releases (#9958)

### DIFF
--- a/.changes/header.tpl.md
+++ b/.changes/header.tpl.md
@@ -1,1 +1,8 @@
-## [{{.VersionNoPrefix}}] - {{.Time.Format "2006-01-02"}}
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/.changes/unreleased/20260712-054500-changie.yaml
+++ b/.changes/unreleased/20260712-054500-changie.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Adopt Changie fragments for future releases while preserving the curated pre-Changie changelog as an immutable historical tail.
+time: 2026-07-12T05:45:00Z

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -1,84 +1,42 @@
-# Changie configuration — PR-time release-note ledger (issue #3768).
-#
-# FOUNDATION / ADVISORY: this config is wired into an ADVISORY xtask check
-# (`cargo xtask changelog check`) that never blocks a PR. Release execution
-# (Cargo versions, publishing, the git-cliff path documented in
-# docs/CHANGELOG_WORKFLOW.md) is UNCHANGED by this file. A follow-up PR decides
-# whether/when to make fragments merge-blocking and whether Changie replaces the
-# git-cliff generation step.
-#
-# Model: each merged PR adds a file-based fragment under `.changes/unreleased/`
-# (`changie new`) OR carries an evidenced "no changelog needed" exemption. At
-# release time `changie batch <version> --project <p>` folds the fragments into
-# the project's Keep-a-Changelog file. Version selection stays a manual product
-# decision in 0.x — there is deliberately NO `auto:` version-bump mapping here.
-
 changesDir: .changes
 unreleasedDir: unreleased
 headerPath: header.tpl.md
-
-# Two projects share this repo. Each project's batched notes flow into its own
-# Keep-a-Changelog file. Fragments live in the shared `.changes/unreleased/`
-# directory and carry a `project:` field; `changie batch --project <key>`
-# filters by it.
-projects:
-  - label: Product (perl-lsp workspace)
-    key: product
-    changelog: CHANGELOG.md
-  - label: VS Code extension
-    key: vscode
-    changelog: vscode-extension/CHANGELOG.md
-projectsVersionSeparator: "-"
-
-# Filesystem-friendly fragment filenames: <project>-<PR>-<kind>-<HHMMSS>.yaml
-# (the default format interpolates component names, which contain spaces).
-fragmentFileFormat: '{{.Project}}-{{.Custom.PR}}-{{.Kind}}-{{.Time.Format "150405"}}'
-
-# Area of the project a change touches (monorepo-style organization layer).
-components:
-  - Language intelligence
-  - Editor behavior
-  - Performance and reliability
-  - Packaging and distribution
-  - Compatibility
-  - Developer experience
-
-# Keep-a-Changelog kinds. No `auto:` — the version bump is a manual product call.
+changelogPath: CHANGELOG.md
+versionExt: md
+versionFormat: '## [{{.VersionNoPrefix}}] - {{.Time.Format "2006-01-02"}}'
+kindFormat: '### {{.Kind}}'
+changeFormat: '- {{.Body}}'
 kinds:
   - label: Added
+    key: added
+    auto: minor
   - label: Changed
-  - label: Fixed
-  - label: Performance
+    key: changed
+    auto: minor
   - label: Deprecated
+    key: deprecated
+    auto: minor
   - label: Removed
+    key: removed
+    auto: minor
+  - label: Fixed
+    key: fixed
+    auto: patch
   - label: Security
-
-# Require a substantive one-line body.
+    key: security
+    auto: patch
+  - label: Documentation
+    key: documentation
+    auto: patch
+  - label: Internal
+    key: internal
+    auto: patch
+newlines:
+  afterChangelogHeader: 1
+  afterChangelogVersion: 1
+  beforeKind: 1
+  afterKind: 1
+  endOfVersion: 1
 body:
-  minLength: 12
-
-# Custom metadata attached to every fragment.
-custom:
-  - key: PR
-    label: Pull request number
-    type: int
-    minInt: 1
-  - key: Slug
-    label: Short slug (optional grouping hint)
-    type: string
-    optional: true
-  - key: Breaking
-    label: Breaking change?
-    type: enum
-    enumOptions:
-      - "no"
-      - "yes"
-
-# Rendered change line. Breaking changes get a bold prefix; every line links its
-# PR. Custom values are strings, so Breaking is compared against the string
-# "yes".
-changeFormat: '- {{if eq .Custom.Breaking "yes"}}**Breaking:** {{end}}{{.Body}} ([#{{.Custom.PR}}](https://github.com/EffortlessMetrics/perl-lsp-swarm/pull/{{.Custom.PR}}))'
-
-# Version-file layout: group by component, then kind.
-componentFormat: '### {{.Component}}'
-kindFormat: '#### {{.Kind}}'
+  minLength: 10
+  maxLength: 600

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,11 @@ like (#0000) or (#9999) will fail CI.
 - [ ] scoped pilot
 - [ ] live behavior change
 
+## Changelog
+<!-- Choose one. User-visible and protocol/config changes normally require a fragment. -->
+- [ ] Added a Changie fragment under `.changes/unreleased/`.
+- [ ] No fragment required. Reason:
+
 ## Risk Surfaces
 - [ ] edit-producing
 - [ ] provider behavior

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,13 +1,7 @@
 name: Version Bump & Changelog Generation
 
-# Automated version bumping and changelog generation.
-# Triggered by workflow_dispatch.
-#
-# Single source of truth: `cargo xtask bump-version <VERSION>` handles all
-# version sites (workspace.package, workspace.dependencies, doc badges,
-# RELEASE_HISTORY ledger, release-notes scaffold). cargo-release is NOT used
-# for the bump — it missed [workspace.package] and [workspace.dependencies]
-# during the 0.17.0 cut (issue #3155).
+# Automated version bumping and Changie release batching.
+# Triggered by workflow_dispatch or after successful release.
 
 on:
   workflow_dispatch:
@@ -17,7 +11,7 @@ on:
         required: false
         type: string
       bump_type:
-        description: 'Version bump type (ignored when version is set explicitly)'
+        description: 'Version bump type'
         required: false
         type: choice
         options:
@@ -41,9 +35,9 @@ concurrency:
 
 jobs:
   version-bump:
-    name: Bump Version & Generate Changelog
+    name: Bump Version & Batch Changelog
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -53,32 +47,43 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # stable (master)
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537  # stable (master)
         with:
           toolchain: stable
 
-      - name: Install git-cliff
+      - name: Install cargo-release
         run: |
           install_dir="$(mktemp -d)"
-          GIT_CLIFF_TAG="$(curl -s https://api.github.com/repos/orhun/git-cliff/releases/latest | jq -r '.tag_name // ""')"
-          if [ -z "$GIT_CLIFF_TAG" ] || [ "$GIT_CLIFF_TAG" = "null" ]; then
-            echo "::error::Failed to resolve latest git-cliff release tag"
+          CARGO_RELEASE_TAG="$(curl -s https://api.github.com/repos/crate-ci/cargo-release/releases/latest | jq -r '.tag_name // ""')"
+          if [ -z "$CARGO_RELEASE_TAG" ] || [ "$CARGO_RELEASE_TAG" = "null" ]; then
+            echo "::error::Failed to resolve latest cargo-release tag"
             exit 1
           fi
 
-          ASSET_URL="$(curl -s "https://api.github.com/repos/orhun/git-cliff/releases/tags/${GIT_CLIFF_TAG}" | \
-            jq -r '.assets[].browser_download_url | select(test("x86_64-unknown-linux-gnu\\.tar\\.gz$"))' | head -n 1)"
-          if [ -z "$ASSET_URL" ] || [ "$ASSET_URL" = "null" ]; then
-            echo "::error::Failed to resolve linux x86_64 git-cliff asset from ${GIT_CLIFF_TAG}"
+          CARGO_RELEASE_ASSET_URL="$(curl -s "https://api.github.com/repos/crate-ci/cargo-release/releases/tags/${CARGO_RELEASE_TAG}" | \
+            jq -r '.assets[].browser_download_url | select(test("x86_64-unknown-linux-musl\\.tar\\.gz$"))' | head -n 1)"
+          if [ -z "$CARGO_RELEASE_ASSET_URL" ] || [ "$CARGO_RELEASE_ASSET_URL" = "null" ]; then
+            echo "::error::Failed to resolve linux x86_64 cargo-release asset from ${CARGO_RELEASE_TAG}"
             exit 1
           fi
 
-          curl -fsSL "$ASSET_URL" -o "${install_dir}/git-cliff.tar.gz"
-          tar -xzf "${install_dir}/git-cliff.tar.gz" -C "$install_dir"
-          extracted_dir="$(tar -tzf "${install_dir}/git-cliff.tar.gz" | head -n 1 | cut -d'/' -f1)"
+          curl -fsSL "$CARGO_RELEASE_ASSET_URL" -o "${install_dir}/cargo-release.tar.gz"
+          tar -xzf "${install_dir}/cargo-release.tar.gz" -C "$install_dir"
+          cargo_release_dir="$(tar -tzf "${install_dir}/cargo-release.tar.gz" | head -n 1 | cut -d'/' -f1)"
           mkdir -p /usr/local/bin
-          sudo mv "${install_dir}/${extracted_dir}/git-cliff" /usr/local/bin/
-          sudo chmod +x /usr/local/bin/git-cliff
+          sudo mv "${install_dir}/${cargo_release_dir}/cargo-release" /usr/local/bin/
+          sudo chmod +x /usr/local/bin/cargo-release
+
+      - name: Install Changie
+        env:
+          CHANGIE_VERSION: v1.24.0
+        run: |
+          set -euo pipefail
+          changie_bin="$RUNNER_TEMP/changie-bin"
+          mkdir -p "$changie_bin"
+          GOBIN="$changie_bin" go install "github.com/miniscruff/changie@${CHANGIE_VERSION}"
+          echo "$changie_bin" >> "$GITHUB_PATH"
+          "$changie_bin/changie" --version
 
       - name: Resolve release target
         id: resolved-version
@@ -93,6 +98,7 @@ jobs:
             fi
             echo "mode=explicit" >> "$GITHUB_OUTPUT"
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "bump_type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -101,79 +107,53 @@ jobs:
             exit 1
           fi
 
-          # Auto-bump: derive the new version from the current workspace version.
-          CURRENT=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          if [ -z "$CURRENT" ]; then
-            echo "::error::Could not read current version from [workspace.package] in Cargo.toml"
-            exit 1
-          fi
-
-          IFS='.' read -ra PARTS <<< "$CURRENT"
-          MAJOR="${PARTS[0]}"
-          MINOR="${PARTS[1]}"
-          PATCH="${PARTS[2]}"
-          case "$BUMP_TYPE" in
-            major) VERSION="$((MAJOR+1)).0.0" ;;
-            minor) VERSION="${MAJOR}.$((MINOR+1)).0" ;;
-            patch) VERSION="${MAJOR}.${MINOR}.$((PATCH+1))" ;;
-            *) echo "::error::Unknown bump_type: ${BUMP_TYPE}"; exit 1 ;;
-          esac
-
           echo "mode=auto" >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Computed version: ${CURRENT} --${BUMP_TYPE}--> ${VERSION}"
+          echo "bump_type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"
 
       - name: Bump workspace version
         id: bump-version
         run: |
+          BUMP_TYPE="${{ steps.resolved-version.outputs.bump_type }}"
           VERSION="${{ steps.resolved-version.outputs.version }}"
-          echo "Bumping workspace to ${VERSION} via cargo xtask bump-version..."
-          cargo xtask bump-version "${VERSION}"
-          # Regenerate Cargo.lock to reflect the new [workspace.package] version.
-          cargo update --workspace --quiet
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Bump complete: ${VERSION}"
 
-      - name: Assert bump completeness
-        run: |
-          VERSION="${{ steps.bump-version.outputs.version }}"
-
-          # 1. Verify [workspace.package] version in root Cargo.toml.
-          CARGO_VER=$(grep -m1 '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          if [ "$CARGO_VER" != "$VERSION" ]; then
-            echo "::error::[workspace.package] version is '${CARGO_VER}', expected '${VERSION}'"
-            exit 1
+          if [ -n "$VERSION" ]; then
+            cargo release version "$VERSION" --workspace -x --no-confirm
+          else
+            cargo release version "$BUMP_TYPE" --workspace -x --no-confirm
           fi
 
-          # 2. Verify RELEASE_HISTORY.md has a ledger row for the new version.
-          if ! grep -qF "| [${VERSION}]" RELEASE_HISTORY.md; then
-            echo "::error::RELEASE_HISTORY.md is missing ledger row for ${VERSION}"
-            exit 1
+          if [ -z "$VERSION" ]; then
+            VERSION=$(grep '^version' Cargo.toml | head -1 | cut -d'"' -f2)
           fi
 
-          echo "Assertion passed: [workspace.package]=${VERSION}, RELEASE_HISTORY.md updated"
+          if [ -n "${VERSION}" ]; then
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "Current workspace version: ${VERSION}"
+          fi
 
-      - name: Generate changelog
+      - name: Batch Changie fragments
         id: changelog
         run: |
+          set -euo pipefail
           VERSION="${{ steps.bump-version.outputs.version }}"
           PRERELEASE="${{ github.event.inputs.prerelease }}"
 
-          git cliff --tag "v${VERSION}" --config cliff.toml > CHANGELOG.new.md
-
-          if [ -f CHANGELOG.md ]; then
-            cat CHANGELOG.new.md CHANGELOG.md > CHANGELOG.md.tmp
-            mv CHANGELOG.md.tmp CHANGELOG.md
-          else
-            mv CHANGELOG.new.md CHANGELOG.md
+          fragment_count="$(find .changes/unreleased -maxdepth 1 -type f -name '*.yaml' | wc -l)"
+          if [ "$fragment_count" -eq 0 ]; then
+            echo "::error::No unreleased Changie fragments exist for v${VERSION}"
+            exit 1
           fi
 
-          rm -f CHANGELOG.new.md
+          python3 scripts/tests/test_changie_merge_legacy.py
+          changie batch "v${VERSION}"
+          test -f ".changes/v${VERSION}.md"
+          python3 scripts/changie_merge_legacy.py "v${VERSION}"
+          grep -Fq "## [${VERSION}]" CHANGELOG.md
 
           if [ "${PRERELEASE}" = "true" ]; then
-            echo "Release ${VERSION} changelog generated (prerelease)."
+            echo "Release ${VERSION} fragments batched (prerelease)."
           else
-            echo "Changelog generated for v${VERSION}"
+            echo "Changie fragments batched for v${VERSION}"
           fi
 
       - name: Create version branch
@@ -192,26 +172,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Stage all tracked file modifications (bump-version touches many files:
-          # Cargo.toml, crate Cargo.tomls, features.toml, RELEASE_HISTORY.md,
-          # CLAUDE.md, README.md, ROADMAP.md, copilot-instructions.md,
-          # book/src/introduction.md, vscode-extension/package*.json, flake.nix).
-          git add -u
-          # Stage Cargo.lock (updated by cargo update --workspace above).
-          git add Cargo.lock
-          # Stage the new release notes scaffold (untracked until created by bump).
-          git add "docs/releases/v${VERSION}.md" 2>/dev/null || true
+          git add Cargo.toml
+          git add CHANGELOG.md .changes
 
           printf '%s\n' \
             "chore(release): bump version to v${VERSION}" \
             "" \
-            "- Update [workspace.package] version to ${VERSION}" \
-            "- Update all [workspace.dependencies] version requirements" \
-            "- Update version-doc badges (CLAUDE.md, README, ROADMAP, copilot-instructions.md, book)" \
-            "- Append RELEASE_HISTORY.md ledger row + 4 link defs" \
-            "- Scaffold docs/releases/v${VERSION}.md" \
-            "- Regenerate Cargo.lock" \
-            "- Generate changelog for v${VERSION}" \
+            "- Update workspace version to ${VERSION}" \
+            "- Batch reviewed Changie fragments for release" \
             > /tmp/release-commit-message.txt
           git commit -F /tmp/release-commit-message.txt
 
@@ -228,15 +196,13 @@ jobs:
             ## Release v${{ steps.bump-version.outputs.version }}
 
             This PR prepares the release with:
-            - Version bump to ${{ steps.bump-version.outputs.version }} (all sites: workspace.package, workspace.dependencies, doc badges)
-            - Updated RELEASE_HISTORY.md ledger row
-            - Scaffolded docs/releases/v${{ steps.bump-version.outputs.version }}.md
-            - Regenerated Cargo.lock
-            - Updated changelog
+            - Version bump to ${{ steps.bump-version.outputs.version }}
+            - Batched Changie fragments and updated rendered changelog
 
             ### Checklist
             - [ ] All tests passing
-            - [ ] Documentation updated
+            - [ ] `.changes/v${{ steps.bump-version.outputs.version }}.md` is complete
+            - [ ] Rendered changelog is complete
             - [ ] Breaking changes documented
             - [ ] Migration guide updated (if needed)
 
@@ -254,11 +220,9 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## Version Bump Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Version Bump Complete :rocket:" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Version**: v${{ steps.bump-version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Branch**: ${{ steps.branch.outputs.branch }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **PR**: Created" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Changelog**: Generated" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **RELEASE_HISTORY.md**: Ledger row appended" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Release notes scaffold**: docs/releases/v${{ steps.bump-version.outputs.version }}.md" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Changelog**: Changie fragments batched" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,262 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- changelog coverage: retrospective_covered_through = da86c123a (this PR's
+     base commit, conservative floor for the audited range). Post-audit
+     user-facing PRs merged after this PR was authored are NOT covered here
+     and are bridge-backfill candidates for the Changie ledger (#3784). -->
+
+### Changed
+
+- **VS Code extension toolchain modernized to TypeScript 7 / Oxc / Rolldown**,
+  shrinking the packaged VSIX by ~77% (1.25 MB to 291 KB). See
+  [vscode-extension/CHANGELOG.md](vscode-extension/CHANGELOG.md) for detail.
+  (#3645, #3690, #3721, #3736, #3755)
+
+### Added
+
+- **Test2 framework awareness (reader/integration, not a Test2 runtime).**
+  `perl-lsp` now reads Test2 source and Test2 runner output and drives the
+  project's real runner, without replacing `yath`/`prove`/`perl` or executing
+  `subtest` blocks in isolation:
+  - **Imports** — `use Test2::V0;` (and common `Test2::Tools::*`) are understood
+    so assertions like `ok`/`is`/`subtest`/`done_testing` are in scope, with
+    exclusion (`!ok`), rename (`ok => {-as => 'my_ok'}`), and
+    `-no_strict`/`-no_warnings`/`-no_pragmas` handled. Export lists are verified
+    against the canonical Test2-Suite source.
+  - **Critic** — `use Test2::V0;` satisfies the native `require_use_strict` /
+    `require_use_warnings` rules (unless disabled via an import option).
+  - **Subtest structure** — nested subtests are discovered as a tree and appear
+    in the document-symbol outline and code lenses; dynamic names are reported
+    as dynamic rather than guessed.
+  - **TAP output** — runner output is parsed into structured failures mapped to
+    source (`file`/`line`/`got`/`expected`); TODO/SKIP are not hard failures;
+    raw output/exit code/runner are preserved.
+  - **Run/Debug** — "Run Subtest" runs the whole file and focuses output on the
+    named subtest; `perl.debugTestFile` returns a real `perl-dap` launch
+    configuration for `.t` files (replacing the previous placeholder). Test2
+    editor snippets (`usetest2`, `dies`, `lives`)
+    are shipped. See [docs/reference/TEST2_INTEGRATION.md](docs/reference/TEST2_INTEGRATION.md).
+- **Hover docs and completion for Perl 5.36–5.40 `use builtin` functions.**
+  All 16 functions introduced by the `builtin` pragma (`true`/`false`/
+  `is_bool`, `weaken`/`unweaken`/`is_weak`, `refaddr`/`reftype`,
+  `ceil`/`floor`, `inf`/`nan`, `trim`, `indexed`, `load_module`,
+  `export_lexically`) now have typed signatures, versioned descriptions, and
+  resolve identically whether called bare or as `builtin::name(...)`.
+  (#3118) `blessed` (5.36) and `is_tainted` (5.38) were added to the same
+  catalog. (#3275)
+- **`textDocument/semanticTokens/full/delta` support.** The server previously
+  advertised `semanticTokensProvider.full` with no working delta handler and no
+  `resultId`, so delta-capable clients had nothing to request against. Full
+  requests now mint a tracked `resultId`, and the new delta handler returns the
+  minimal edit set between a client's cached prior result and the current
+  tokens (falling back to a full response when the prior result is unknown).
+  (#1917)
+- **Named-function-call semantic token class.** Bareword calls (`name(...)`)
+  now participate in the same live-verified semantic-token cutover as
+  sub/package/method/variable names, continuing the token-accuracy series.
+  (#2609)
+- **Native class fields (Perl 5.38+) extracted into symbols.** Fields declared
+  with the native `field` keyword are now indexed and appear in document/
+  workspace symbols and hover, alongside existing Moo/Moose `has` attributes.
+  (#3218)
+- **Perl 5.44 named-parameter signature help.** Signature help now models
+  Perl 5.44 named/optional/slurpy subroutine parameters and the `//=`/`||=`
+  named-parameter default operators, instead of treating them as positional.
+  (#3331, #3352, #3354)
+- **Completions route indirect-object calls through method completion.**
+  `new Foo::Bar->` -style indirect-object call sites now offer the same method
+  completions as `Foo::Bar->new->`. (#1914)
+- **Declared-but-unindexed CPAN dependencies surface as advisory hover/
+  completion text.** The server now statically extracts declared dependency
+  facts from `cpanfile`, `Makefile.PL`, `Build.PL`, `dist.ini`, `META.json`,
+  and `META.yml`, and when a module is declared but not indexed (not yet
+  installed/vendored), hover and completion mention it instead of treating it
+  as fully unknown. Per-folder config reload now also clears stale
+  metadata-derived state instead of leaking it across reloads. (#3137, #3170,
+  #3171)
+- **`perl-dap` external debugger peer seam (ptkdb-ready).** A backend-neutral
+  debug model plus a small Content-Length-framed peer protocol let `perl-dap`
+  host an external Perl debugger frontend/backend (`Devel::ptkdb` is the first
+  partner), reachable via `perl-dap --external-peer HOST:PORT` or a VS Code
+  launch config's `externalPeer`. The native `DebugAdapter`/`DapServer` path is
+  unchanged; this first cut wires a live, drivable **mirror-mode** listen
+  session (proven with fake-peer tests), with real end-to-end `ptkdb` sessions
+  deferred. (#3321, #3404)
+- **Native analyzer/formatter/debugger stack is now the only shipped default.**
+  `perl.runCritic` defaults to the native critic analyzer even when
+  `perlcritic` happens to be on `PATH` (external only when explicitly
+  configured); native-engine critic code actions carry native diagnostic
+  identity (`perl-lsp-critic` / `native.*` codes) instead of the external
+  tool's brand; the shipped `perl-dap` CLI no longer exposes `--bridge`
+  (`Perl::LanguageServer`/`Devel::TSPerlDAP` bridging remains a library-only
+  conformance reference, never a shipped path); and release archives now fail
+  validation if they bundle external Perl tooling or legacy bridge payloads.
+  (#3277, #3279, #3282, #3348)
+
+### Fixed
+
+#### LSP integration
+
+- **"Find All References" no longer silently degrades for its default request
+  shape.** VS Code's default `includeDeclaration: true` request bailed out of
+  the high-fidelity source-backed references tier entirely, falling through to
+  the lower-fidelity workspace-index tier on every "Find All References" call.
+  (#3050)
+- **Stale post-edit index answers are guarded against.** Providers now wait on
+  index readiness instead of racing a just-applied edit. (#3149)
+- **Package rename fails closed on a partial index** instead of silently
+  applying an incomplete rename. (#3176)
+- **`callHierarchy/incomingCalls` returns top-level and script callers**
+  instead of omitting call sites outside a named sub. (#3191)
+- **Cross-construct sub resolution** now covers anonymous subs, typeglobs, and
+  `use constant`-declared subs. (#3199)
+- **Dynamic typeglob dereferences (`*{...}`) emit a `DynamicBoundary` fact**
+  instead of being reported as a literal symbol. (#3209)
+- **Completion keeps resolved imports when an export tag is unresolvable**
+  instead of dropping the whole import. (#3213)
+- **Same-package `our` redeclaration is flagged.** (#3217)
+- **`ModuleNotFound` diagnostics use a boundary-aware `.pm` match** instead of
+  a substring match that could misclassify unrelated paths. (#3221)
+- **The outbound notification queue is bounded**, closing a DoS vector where
+  an unbounded queue could grow without limit. (#3223)
+- **`documentSymbol` `selectionRange` covers just the name**, not the whole
+  declaration. (#3226)
+- **Lexical `my`/`state` declarations are excluded from the bare-name unused
+  check**, removing false-positive "unused" warnings. (#3227)
+- **Malformed pull-diagnostic requests return `InvalidParams`** instead of a
+  generic error. (#3229)
+- **Completion adds regex-match array special variables** (`@-`/`@+` family)
+  to the special-variable set. (#3255)
+- **`eval`-scoped sub suppression for PL109 is now order-aware**, closing a
+  false-negative where sub order affected suppression. (#3286)
+- **Bare-block package context is scoped to the block** instead of leaking
+  into sibling scopes. (#3353)
+- **Clicking the package-prefix of a qualified name no longer navigates to the
+  sub** — only the sub-name segment does. (#3360)
+- **`typeHierarchy` operations support cancellation.** (#3455)
+- **References refuse exact-tier promotion across dynamic boundaries**,
+  avoiding a false-precision result where the reference set can't actually be
+  proven exact. (#3461)
+- **Hover and references guards restored** after a regression reintroduced the
+  gap they closed. (#3466)
+- **The PIR-A lexical references slice is promoted**, raising fidelity for
+  lexical-variable "Find All References". (#3478)
+- **`textDocument/typeDefinition` and `/implementation` fallback is pinned to
+  the document generation captured at request time**, preventing a
+  stale-vs-fresh mismatch mid-edit. (#3622)
+- **Completion emits its analyze span on cancellation** instead of dropping
+  timing data for cancelled requests. (#3623)
+- **Hover documents `@+`, `@-`, `@EXPORT`, `@EXPORT_OK`, `%!`, and
+  `%EXPORT_TAGS`** special variables, which previously returned no
+  documentation. (#1866)
+- **`DESTROY`/`AUTOLOAD` are recognized as special method hooks**, not
+  ordinary `UNIVERSAL` methods, in hover and navigation. (#1836)
+- **`positionEncoding` negotiation honors the client's preference list**
+  instead of ignoring it. (#1856)
+- **Document symbols nested under an offset-0 package are deduplicated.**
+  (#1583)
+- **Folding ranges are deduplicated**, and a region-start-line assertion
+  corrected. (#3168)
+- **Rename ignores non-code package text during scope lookup.** (#3112)
+- **Rename validates keywords by context** — `$if`/`@while` are allowed as
+  variable names, while `sub if` is still rejected. (#3109)
+- **The workspace reference index no longer silently drops references inside
+  block-form `package Foo { ... }`/`class Foo { ... }` bodies, typeglob
+  aliasing, `goto &coderef`, regex-bind expressions (`=~`), `tie` argument
+  lists, indirect-object call arguments, subroutine signature default
+  values, and non-variable assignment/increment targets** — "Find All
+  References", rename, and `workspace/symbol` now see these previously
+  unindexed reference sites. Consolidating the workspace indexer's two
+  independent reference walks into one traversal closed these
+  pre-existing coverage gaps as a side effect. (#1711)
+
+#### Debugger (DAP)
+
+- **Breakpoint line-adjustment messages are preserved when the breakpoint
+  condition is invalid**, instead of being dropped. (#3216)
+- **Breakpoint file matching requires a path boundary**, preventing an
+  unrelated file with a matching suffix from being treated as the same file.
+  (#3225)
+- **Process/thread ID casts saturate instead of silently truncating.** (#3233)
+- **Launch remediation guidance points at the configured `perlPath`.** (#3245)
+- **`DebugAdapter` implements `Drop`**, ensuring session cleanup runs even on
+  an unclean shutdown path. (#3247)
+- **Stale `Child` `variablesReference`s are short-circuited on a cache miss
+  after resume**, instead of serving a reference from before the resume.
+  (#3369)
+
+#### Diagnostics
+
+- **PL401 (two-argument `open` security check) fires for the parenthesized
+  2-arg form** (`open(FH, ">file")`), which previously slipped through because
+  the parser wraps parenthesized call args in a single `ArrayLiteral` node.
+  (#3674)
+- **PL404 no longer false-positives on sub-local lexicals**, and ties between
+  same-offset scopes are now broken deterministically (innermost scope wins)
+  instead of depending on hash-iteration order. (#3659, #3705)
+- **PL100/PL101's implicit-strict module list corrected** against real Perl
+  module behavior — several modules on the "implies `use strict`/`use
+  warnings`" allowlist did not actually do so. (#3729)
+- **Regexes with nested quantifiers no longer downgrade a document to partial
+  semantics.** They're now recorded as an advisory diagnostic (still a warning
+  in the editor) rather than a blocking parse error. (#3682, #3698)
+
+#### Parser correctness
+
+- **`goto &sub` frame replacement is distinguished from `goto LABEL` and `goto
+  EXPR`.** (#1923)
+- **`NodeKind::VString` added** for v-string literals, distinguishing them
+  from other string forms. (#1871)
+- **Incomplete-brace recovery marks the error explicitly** instead of masking
+  it. (#1906)
+- **A reversed `HashLiteral` span is fixed** by capturing the closing `}`
+  token directly. (#3364)
+- **Parenthesized `try` calls are disambiguated** from the `try`/`catch`
+  statement form. (#3572)
+- **`${name}` parses as a scalar variable**, not a symbolic dereference.
+  (#3590)
+- **Unparenthesized declaration lists are supported** (e.g. `my $a, $b`
+  parses as a declaration list). (#3627)
+- **Heredoc body offsets are tracked**, fixing downstream position mapping for
+  heredoc content. (#3650)
+- **Unparenthesized `my`/`our`/`state` declares only the first variable**,
+  matching real Perl semantics instead of treating the remaining
+  comma-separated names as part of the declaration. (#3738)
+- **Encoding-aware file reading is consolidated**, fixing a crash on Latin-1
+  and UTF-16 Perl source files. (#3054)
+- **`line_index` overflow/panic sites hardened** against out-of-range offsets.
+  (#3042)
+- **Mid-surrogate UTF-16 columns are clamped** in `position_to_offset` instead
+  of panicking. (#3040)
+- **AST traversal recursion depth is bounded**, preventing a stack overflow on
+  deeply nested or adversarial input. (#3207)
+
+### Performance
+
+- **Editor responsiveness: `didChange` returns before parsing completes.**
+  Moved full parsing and parent-map construction out of the
+  `textDocument/didChange` critical path and onto a bounded, latest-only
+  background worker. Stale parses and parse-derived effects remain
+  generation-gated. In the 78 KB, 20-edit Neovim receipt, maximum
+  `didChange` handler time fell from about 269 ms to 1.6 ms. (#3618, Fresh
+  Facts Fast program #3396)
+- **Type inference is cached per document.** Hover and completion previously
+  rebuilt the type-inference engine on every request for an unchanged
+  document; it's now cached by URI and content hash and invalidated on
+  `didChange`/`didClose`. (#3254)
+- **`workspace/symbol` lookup is indexed** instead of an O(n) scan over every
+  file's symbols on every query. (#3211)
+- **Workspace-symbol search exits early once the result cap is reached**,
+  instead of collecting and cloning every match before truncating. (#3228)
+
+### Security
+
+- **`anyhow` updated** to resolve RUSTSEC-2026-0190. (#3195)
+- **Heredoc anti-pattern detector regexes bounded to a single line**, closing
+  a ReDoS vector where an unclosed heredoc delimiter in a large document could
+  trigger catastrophic backtracking. (#3568)
+
 ## [0.17.0] - 2026-06-28
 
 Release notes: [v0.17.0](docs/releases/v0.17.0.md)
@@ -846,6 +1102,14 @@ this to a minor version under 0.x semver.
 
 Release notes: [v0.14.0](docs/releases/v0.14.0.md)
 
+> **Release boundary correction.** No `v0.13.4` tag was cut. The previous
+> actual tag is `v0.13.3`, so the valid cumulative comparison is
+> [`v0.13.3...v0.14.0`](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.3...v0.14.0).
+> That range includes the source state prepared while the workspace carried
+> version `0.13.4`; it is not a narrow 0.14-only logical ledger.
+>
+> <!-- lineage-correction:0.13 -->
+
 ### Added
 
 - **Rust 1.95 MSRV** — Minimum supported Rust version raised to 1.95.
@@ -892,7 +1156,13 @@ Release notes: [v0.14.0](docs/releases/v0.14.0.md)
 
 ## [0.13.4] - 2026-05-07
 
-Release notes: [v0.13.4](docs/releases/v0.13.4.md)
+Release notes: [0.13.4 prepared milestone](docs/releases/v0.13.4.md)
+
+> **Prepared milestone, not a tagged release.** The repository has no
+> `v0.13.4` ref. This section records changes staged while the workspace carried
+> version `0.13.4`; those changes first appear in the later tagged `v0.14.0`
+> tree. Do not infer a standalone asset, package, or compare boundary from this
+> heading.
 
 ### Fixed
 
@@ -1018,9 +1288,14 @@ Release notes: [v0.13.2](docs/releases/v0.13.2.md)
 
 Release notes: [v0.13.1](docs/releases/v0.13.1.md)
 
+> **Release boundary correction.** No final `v0.13.0` tag was cut. The release
+> line moved directly from `v0.13.0-rc1` to `v0.13.1`; use
+> [`v0.13.0-rc1...v0.13.1`](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...v0.13.1)
+> for source comparison.
+
 ### Changed
 
-- Hardened public-alpha release channels after the `v0.13.0` launch.
+- Hardened public-alpha release channels after the `v0.13.0-rc1` rehearsal.
 - Decoupled Open VSX publishing from VS Code Marketplace publishing.
 - Clarified release naming: package versions use normal SemVer while product
   posture remains public alpha.
@@ -1031,6 +1306,10 @@ Release notes: [v0.13.1](docs/releases/v0.13.1.md)
 ## [0.13.0-rc1] - 2026-04-30
 
 Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md)
+
+> **Historical outcome.** This remained the only `0.13.0` tag. No final
+> `v0.13.0` source boundary was created; the next tagged release was
+> `v0.13.1` on May 1, 2026.
 
 ### Fixed
 
@@ -1054,7 +1333,8 @@ Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md)
 
 ### Migration
 
-- **Microcrate collapse complete — migration guide available** — v0.13.0 drops the
+- **Microcrate collapse complete — migration guide available** — The 0.13.0-rc1/0.13
+  train drops the
   published crate count from 132 to 32 across 10+ collapse waves. All ~100 retired
   crate names stop appearing on crates.io after this release; their code lives as
   subfolder modules inside the owning published crate. See
@@ -2078,6 +2358,13 @@ For the detailed receipts behind this release, see [docs/project/CURRENT_STATUS.
 
 Release notes: [v0.11.0](docs/releases/v0.11.0.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.11.0)
 
+> **Tag provenance correction.** The live `v0.11.0` ref is
+> `8dfa68860cdf8fc220b1345d3b943668d1393ad2`; the previously recorded
+> `d22ac7346c832db6b92c41d354eb90099f8b5d53` no longer resolves. The current
+> tagged predecessor is `v0.9.1`, because `0.10.0` was changelog-only and the
+> current `v0.8.5` / `v0.9.1` refs are divergent. Use
+> [`v0.9.1...v0.11.0`](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.9.1...v0.11.0).
+
 This release finalizes the 0.11.0 distribution pipeline across GitHub releases,
 crates.io, and the VS Code extension so the workspace can ship from a single,
 repeatable release flow.
@@ -2192,6 +2479,12 @@ security hardening, crates.io publishing readiness, documentation, and code qual
 
 Release notes: [v0.9.1](docs/releases/v0.9.1.md) (tag only — no GitHub Release)
 
+> **Tag provenance correction.** The live `v0.9.1` ref is
+> `0e52877de7763d8654e0fb6d7afe6a257639e584`; the previously recorded
+> `c82a1604987f315868973a4e5804112e031cec92` no longer resolves. The current
+> tag is on a divergent line from `v0.8.5`, so no forward comparison from
+> `v0.8.5` is claimed.
+
 ### Added
 - **Initial Public Alpha Release**: Substantially complete feature set for early testing.
 - **Enhanced LSP Features**: 99% coverage of LSP 3.18 methods (alpha-validated).
@@ -2263,7 +2556,7 @@ For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HIS
 
 <!-- Compare ranges -->
 [0.13.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.1...v0.13.2
-[0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0...v0.13.1
+[0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...v0.13.1
 [0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,262 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- changelog coverage: retrospective_covered_through = da86c123a (this PR's
-     base commit, conservative floor for the audited range). Post-audit
-     user-facing PRs merged after this PR was authored are NOT covered here
-     and are bridge-backfill candidates for the Changie ledger (#3784). -->
-
-### Changed
-
-- **VS Code extension toolchain modernized to TypeScript 7 / Oxc / Rolldown**,
-  shrinking the packaged VSIX by ~77% (1.25 MB to 291 KB). See
-  [vscode-extension/CHANGELOG.md](vscode-extension/CHANGELOG.md) for detail.
-  (#3645, #3690, #3721, #3736, #3755)
-
-### Added
-
-- **Test2 framework awareness (reader/integration, not a Test2 runtime).**
-  `perl-lsp` now reads Test2 source and Test2 runner output and drives the
-  project's real runner, without replacing `yath`/`prove`/`perl` or executing
-  `subtest` blocks in isolation:
-  - **Imports** — `use Test2::V0;` (and common `Test2::Tools::*`) are understood
-    so assertions like `ok`/`is`/`subtest`/`done_testing` are in scope, with
-    exclusion (`!ok`), rename (`ok => {-as => 'my_ok'}`), and
-    `-no_strict`/`-no_warnings`/`-no_pragmas` handled. Export lists are verified
-    against the canonical Test2-Suite source.
-  - **Critic** — `use Test2::V0;` satisfies the native `require_use_strict` /
-    `require_use_warnings` rules (unless disabled via an import option).
-  - **Subtest structure** — nested subtests are discovered as a tree and appear
-    in the document-symbol outline and code lenses; dynamic names are reported
-    as dynamic rather than guessed.
-  - **TAP output** — runner output is parsed into structured failures mapped to
-    source (`file`/`line`/`got`/`expected`); TODO/SKIP are not hard failures;
-    raw output/exit code/runner are preserved.
-  - **Run/Debug** — "Run Subtest" runs the whole file and focuses output on the
-    named subtest; `perl.debugTestFile` returns a real `perl-dap` launch
-    configuration for `.t` files (replacing the previous placeholder). Test2
-    editor snippets (`usetest2`, `dies`, `lives`)
-    are shipped. See [docs/reference/TEST2_INTEGRATION.md](docs/reference/TEST2_INTEGRATION.md).
-- **Hover docs and completion for Perl 5.36–5.40 `use builtin` functions.**
-  All 16 functions introduced by the `builtin` pragma (`true`/`false`/
-  `is_bool`, `weaken`/`unweaken`/`is_weak`, `refaddr`/`reftype`,
-  `ceil`/`floor`, `inf`/`nan`, `trim`, `indexed`, `load_module`,
-  `export_lexically`) now have typed signatures, versioned descriptions, and
-  resolve identically whether called bare or as `builtin::name(...)`.
-  (#3118) `blessed` (5.36) and `is_tainted` (5.38) were added to the same
-  catalog. (#3275)
-- **`textDocument/semanticTokens/full/delta` support.** The server previously
-  advertised `semanticTokensProvider.full` with no working delta handler and no
-  `resultId`, so delta-capable clients had nothing to request against. Full
-  requests now mint a tracked `resultId`, and the new delta handler returns the
-  minimal edit set between a client's cached prior result and the current
-  tokens (falling back to a full response when the prior result is unknown).
-  (#1917)
-- **Named-function-call semantic token class.** Bareword calls (`name(...)`)
-  now participate in the same live-verified semantic-token cutover as
-  sub/package/method/variable names, continuing the token-accuracy series.
-  (#2609)
-- **Native class fields (Perl 5.38+) extracted into symbols.** Fields declared
-  with the native `field` keyword are now indexed and appear in document/
-  workspace symbols and hover, alongside existing Moo/Moose `has` attributes.
-  (#3218)
-- **Perl 5.44 named-parameter signature help.** Signature help now models
-  Perl 5.44 named/optional/slurpy subroutine parameters and the `//=`/`||=`
-  named-parameter default operators, instead of treating them as positional.
-  (#3331, #3352, #3354)
-- **Completions route indirect-object calls through method completion.**
-  `new Foo::Bar->` -style indirect-object call sites now offer the same method
-  completions as `Foo::Bar->new->`. (#1914)
-- **Declared-but-unindexed CPAN dependencies surface as advisory hover/
-  completion text.** The server now statically extracts declared dependency
-  facts from `cpanfile`, `Makefile.PL`, `Build.PL`, `dist.ini`, `META.json`,
-  and `META.yml`, and when a module is declared but not indexed (not yet
-  installed/vendored), hover and completion mention it instead of treating it
-  as fully unknown. Per-folder config reload now also clears stale
-  metadata-derived state instead of leaking it across reloads. (#3137, #3170,
-  #3171)
-- **`perl-dap` external debugger peer seam (ptkdb-ready).** A backend-neutral
-  debug model plus a small Content-Length-framed peer protocol let `perl-dap`
-  host an external Perl debugger frontend/backend (`Devel::ptkdb` is the first
-  partner), reachable via `perl-dap --external-peer HOST:PORT` or a VS Code
-  launch config's `externalPeer`. The native `DebugAdapter`/`DapServer` path is
-  unchanged; this first cut wires a live, drivable **mirror-mode** listen
-  session (proven with fake-peer tests), with real end-to-end `ptkdb` sessions
-  deferred. (#3321, #3404)
-- **Native analyzer/formatter/debugger stack is now the only shipped default.**
-  `perl.runCritic` defaults to the native critic analyzer even when
-  `perlcritic` happens to be on `PATH` (external only when explicitly
-  configured); native-engine critic code actions carry native diagnostic
-  identity (`perl-lsp-critic` / `native.*` codes) instead of the external
-  tool's brand; the shipped `perl-dap` CLI no longer exposes `--bridge`
-  (`Perl::LanguageServer`/`Devel::TSPerlDAP` bridging remains a library-only
-  conformance reference, never a shipped path); and release archives now fail
-  validation if they bundle external Perl tooling or legacy bridge payloads.
-  (#3277, #3279, #3282, #3348)
-
-### Fixed
-
-#### LSP integration
-
-- **"Find All References" no longer silently degrades for its default request
-  shape.** VS Code's default `includeDeclaration: true` request bailed out of
-  the high-fidelity source-backed references tier entirely, falling through to
-  the lower-fidelity workspace-index tier on every "Find All References" call.
-  (#3050)
-- **Stale post-edit index answers are guarded against.** Providers now wait on
-  index readiness instead of racing a just-applied edit. (#3149)
-- **Package rename fails closed on a partial index** instead of silently
-  applying an incomplete rename. (#3176)
-- **`callHierarchy/incomingCalls` returns top-level and script callers**
-  instead of omitting call sites outside a named sub. (#3191)
-- **Cross-construct sub resolution** now covers anonymous subs, typeglobs, and
-  `use constant`-declared subs. (#3199)
-- **Dynamic typeglob dereferences (`*{...}`) emit a `DynamicBoundary` fact**
-  instead of being reported as a literal symbol. (#3209)
-- **Completion keeps resolved imports when an export tag is unresolvable**
-  instead of dropping the whole import. (#3213)
-- **Same-package `our` redeclaration is flagged.** (#3217)
-- **`ModuleNotFound` diagnostics use a boundary-aware `.pm` match** instead of
-  a substring match that could misclassify unrelated paths. (#3221)
-- **The outbound notification queue is bounded**, closing a DoS vector where
-  an unbounded queue could grow without limit. (#3223)
-- **`documentSymbol` `selectionRange` covers just the name**, not the whole
-  declaration. (#3226)
-- **Lexical `my`/`state` declarations are excluded from the bare-name unused
-  check**, removing false-positive "unused" warnings. (#3227)
-- **Malformed pull-diagnostic requests return `InvalidParams`** instead of a
-  generic error. (#3229)
-- **Completion adds regex-match array special variables** (`@-`/`@+` family)
-  to the special-variable set. (#3255)
-- **`eval`-scoped sub suppression for PL109 is now order-aware**, closing a
-  false-negative where sub order affected suppression. (#3286)
-- **Bare-block package context is scoped to the block** instead of leaking
-  into sibling scopes. (#3353)
-- **Clicking the package-prefix of a qualified name no longer navigates to the
-  sub** — only the sub-name segment does. (#3360)
-- **`typeHierarchy` operations support cancellation.** (#3455)
-- **References refuse exact-tier promotion across dynamic boundaries**,
-  avoiding a false-precision result where the reference set can't actually be
-  proven exact. (#3461)
-- **Hover and references guards restored** after a regression reintroduced the
-  gap they closed. (#3466)
-- **The PIR-A lexical references slice is promoted**, raising fidelity for
-  lexical-variable "Find All References". (#3478)
-- **`textDocument/typeDefinition` and `/implementation` fallback is pinned to
-  the document generation captured at request time**, preventing a
-  stale-vs-fresh mismatch mid-edit. (#3622)
-- **Completion emits its analyze span on cancellation** instead of dropping
-  timing data for cancelled requests. (#3623)
-- **Hover documents `@+`, `@-`, `@EXPORT`, `@EXPORT_OK`, `%!`, and
-  `%EXPORT_TAGS`** special variables, which previously returned no
-  documentation. (#1866)
-- **`DESTROY`/`AUTOLOAD` are recognized as special method hooks**, not
-  ordinary `UNIVERSAL` methods, in hover and navigation. (#1836)
-- **`positionEncoding` negotiation honors the client's preference list**
-  instead of ignoring it. (#1856)
-- **Document symbols nested under an offset-0 package are deduplicated.**
-  (#1583)
-- **Folding ranges are deduplicated**, and a region-start-line assertion
-  corrected. (#3168)
-- **Rename ignores non-code package text during scope lookup.** (#3112)
-- **Rename validates keywords by context** — `$if`/`@while` are allowed as
-  variable names, while `sub if` is still rejected. (#3109)
-- **The workspace reference index no longer silently drops references inside
-  block-form `package Foo { ... }`/`class Foo { ... }` bodies, typeglob
-  aliasing, `goto &coderef`, regex-bind expressions (`=~`), `tie` argument
-  lists, indirect-object call arguments, subroutine signature default
-  values, and non-variable assignment/increment targets** — "Find All
-  References", rename, and `workspace/symbol` now see these previously
-  unindexed reference sites. Consolidating the workspace indexer's two
-  independent reference walks into one traversal closed these
-  pre-existing coverage gaps as a side effect. (#1711)
-
-#### Debugger (DAP)
-
-- **Breakpoint line-adjustment messages are preserved when the breakpoint
-  condition is invalid**, instead of being dropped. (#3216)
-- **Breakpoint file matching requires a path boundary**, preventing an
-  unrelated file with a matching suffix from being treated as the same file.
-  (#3225)
-- **Process/thread ID casts saturate instead of silently truncating.** (#3233)
-- **Launch remediation guidance points at the configured `perlPath`.** (#3245)
-- **`DebugAdapter` implements `Drop`**, ensuring session cleanup runs even on
-  an unclean shutdown path. (#3247)
-- **Stale `Child` `variablesReference`s are short-circuited on a cache miss
-  after resume**, instead of serving a reference from before the resume.
-  (#3369)
-
-#### Diagnostics
-
-- **PL401 (two-argument `open` security check) fires for the parenthesized
-  2-arg form** (`open(FH, ">file")`), which previously slipped through because
-  the parser wraps parenthesized call args in a single `ArrayLiteral` node.
-  (#3674)
-- **PL404 no longer false-positives on sub-local lexicals**, and ties between
-  same-offset scopes are now broken deterministically (innermost scope wins)
-  instead of depending on hash-iteration order. (#3659, #3705)
-- **PL100/PL101's implicit-strict module list corrected** against real Perl
-  module behavior — several modules on the "implies `use strict`/`use
-  warnings`" allowlist did not actually do so. (#3729)
-- **Regexes with nested quantifiers no longer downgrade a document to partial
-  semantics.** They're now recorded as an advisory diagnostic (still a warning
-  in the editor) rather than a blocking parse error. (#3682, #3698)
-
-#### Parser correctness
-
-- **`goto &sub` frame replacement is distinguished from `goto LABEL` and `goto
-  EXPR`.** (#1923)
-- **`NodeKind::VString` added** for v-string literals, distinguishing them
-  from other string forms. (#1871)
-- **Incomplete-brace recovery marks the error explicitly** instead of masking
-  it. (#1906)
-- **A reversed `HashLiteral` span is fixed** by capturing the closing `}`
-  token directly. (#3364)
-- **Parenthesized `try` calls are disambiguated** from the `try`/`catch`
-  statement form. (#3572)
-- **`${name}` parses as a scalar variable**, not a symbolic dereference.
-  (#3590)
-- **Unparenthesized declaration lists are supported** (e.g. `my $a, $b`
-  parses as a declaration list). (#3627)
-- **Heredoc body offsets are tracked**, fixing downstream position mapping for
-  heredoc content. (#3650)
-- **Unparenthesized `my`/`our`/`state` declares only the first variable**,
-  matching real Perl semantics instead of treating the remaining
-  comma-separated names as part of the declaration. (#3738)
-- **Encoding-aware file reading is consolidated**, fixing a crash on Latin-1
-  and UTF-16 Perl source files. (#3054)
-- **`line_index` overflow/panic sites hardened** against out-of-range offsets.
-  (#3042)
-- **Mid-surrogate UTF-16 columns are clamped** in `position_to_offset` instead
-  of panicking. (#3040)
-- **AST traversal recursion depth is bounded**, preventing a stack overflow on
-  deeply nested or adversarial input. (#3207)
-
-### Performance
-
-- **Editor responsiveness: `didChange` returns before parsing completes.**
-  Moved full parsing and parent-map construction out of the
-  `textDocument/didChange` critical path and onto a bounded, latest-only
-  background worker. Stale parses and parse-derived effects remain
-  generation-gated. In the 78 KB, 20-edit Neovim receipt, maximum
-  `didChange` handler time fell from about 269 ms to 1.6 ms. (#3618, Fresh
-  Facts Fast program #3396)
-- **Type inference is cached per document.** Hover and completion previously
-  rebuilt the type-inference engine on every request for an unchanged
-  document; it's now cached by URI and content hash and invalidated on
-  `didChange`/`didClose`. (#3254)
-- **`workspace/symbol` lookup is indexed** instead of an O(n) scan over every
-  file's symbols on every query. (#3211)
-- **Workspace-symbol search exits early once the result cap is reached**,
-  instead of collecting and cloning every match before truncating. (#3228)
-
-### Security
-
-- **`anyhow` updated** to resolve RUSTSEC-2026-0190. (#3195)
-- **Heredoc anti-pattern detector regexes bounded to a single line**, closing
-  a ReDoS vector where an unclosed heredoc delimiter in a large document could
-  trigger catastrophic backtracking. (#3568)
-
 ## [0.17.0] - 2026-06-28
 
 Release notes: [v0.17.0](docs/releases/v0.17.0.md)
@@ -1102,14 +846,6 @@ this to a minor version under 0.x semver.
 
 Release notes: [v0.14.0](docs/releases/v0.14.0.md)
 
-> **Release boundary correction.** No `v0.13.4` tag was cut. The previous
-> actual tag is `v0.13.3`, so the valid cumulative comparison is
-> [`v0.13.3...v0.14.0`](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.3...v0.14.0).
-> That range includes the source state prepared while the workspace carried
-> version `0.13.4`; it is not a narrow 0.14-only logical ledger.
->
-> <!-- lineage-correction:0.13 -->
-
 ### Added
 
 - **Rust 1.95 MSRV** — Minimum supported Rust version raised to 1.95.
@@ -1156,13 +892,7 @@ Release notes: [v0.14.0](docs/releases/v0.14.0.md)
 
 ## [0.13.4] - 2026-05-07
 
-Release notes: [0.13.4 prepared milestone](docs/releases/v0.13.4.md)
-
-> **Prepared milestone, not a tagged release.** The repository has no
-> `v0.13.4` ref. This section records changes staged while the workspace carried
-> version `0.13.4`; those changes first appear in the later tagged `v0.14.0`
-> tree. Do not infer a standalone asset, package, or compare boundary from this
-> heading.
+Release notes: [v0.13.4](docs/releases/v0.13.4.md)
 
 ### Fixed
 
@@ -1288,14 +1018,9 @@ Release notes: [v0.13.2](docs/releases/v0.13.2.md)
 
 Release notes: [v0.13.1](docs/releases/v0.13.1.md)
 
-> **Release boundary correction.** No final `v0.13.0` tag was cut. The release
-> line moved directly from `v0.13.0-rc1` to `v0.13.1`; use
-> [`v0.13.0-rc1...v0.13.1`](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...v0.13.1)
-> for source comparison.
-
 ### Changed
 
-- Hardened public-alpha release channels after the `v0.13.0-rc1` rehearsal.
+- Hardened public-alpha release channels after the `v0.13.0` launch.
 - Decoupled Open VSX publishing from VS Code Marketplace publishing.
 - Clarified release naming: package versions use normal SemVer while product
   posture remains public alpha.
@@ -1306,10 +1031,6 @@ Release notes: [v0.13.1](docs/releases/v0.13.1.md)
 ## [0.13.0-rc1] - 2026-04-30
 
 Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md)
-
-> **Historical outcome.** This remained the only `0.13.0` tag. No final
-> `v0.13.0` source boundary was created; the next tagged release was
-> `v0.13.1` on May 1, 2026.
 
 ### Fixed
 
@@ -1333,8 +1054,7 @@ Release notes: [v0.13.0-rc1](docs/releases/v0.13.0-rc1.md)
 
 ### Migration
 
-- **Microcrate collapse complete — migration guide available** — The 0.13.0-rc1/0.13
-  train drops the
+- **Microcrate collapse complete — migration guide available** — v0.13.0 drops the
   published crate count from 132 to 32 across 10+ collapse waves. All ~100 retired
   crate names stop appearing on crates.io after this release; their code lives as
   subfolder modules inside the owning published crate. See
@@ -2358,13 +2078,6 @@ For the detailed receipts behind this release, see [docs/project/CURRENT_STATUS.
 
 Release notes: [v0.11.0](docs/releases/v0.11.0.md) · [GitHub Release](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.11.0)
 
-> **Tag provenance correction.** The live `v0.11.0` ref is
-> `8dfa68860cdf8fc220b1345d3b943668d1393ad2`; the previously recorded
-> `d22ac7346c832db6b92c41d354eb90099f8b5d53` no longer resolves. The current
-> tagged predecessor is `v0.9.1`, because `0.10.0` was changelog-only and the
-> current `v0.8.5` / `v0.9.1` refs are divergent. Use
-> [`v0.9.1...v0.11.0`](https://github.com/EffortlessMetrics/perl-lsp/compare/v0.9.1...v0.11.0).
-
 This release finalizes the 0.11.0 distribution pipeline across GitHub releases,
 crates.io, and the VS Code extension so the workspace can ship from a single,
 repeatable release flow.
@@ -2479,12 +2192,6 @@ security hardening, crates.io publishing readiness, documentation, and code qual
 
 Release notes: [v0.9.1](docs/releases/v0.9.1.md) (tag only — no GitHub Release)
 
-> **Tag provenance correction.** The live `v0.9.1` ref is
-> `0e52877de7763d8654e0fb6d7afe6a257639e584`; the previously recorded
-> `c82a1604987f315868973a4e5804112e031cec92` no longer resolves. The current
-> tag is on a divergent line from `v0.8.5`, so no forward comparison from
-> `v0.8.5` is claimed.
-
 ### Added
 - **Initial Public Alpha Release**: Substantially complete feature set for early testing.
 - **Enhanced LSP Features**: 99% coverage of LSP 3.18 methods (alpha-validated).
@@ -2556,7 +2263,7 @@ For the full cross-channel release history, see [RELEASE_HISTORY.md](RELEASE_HIS
 
 <!-- Compare ranges -->
 [0.13.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.1...v0.13.2
-[0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0-rc1...v0.13.1
+[0.13.1]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.13.0...v0.13.1
 [0.12.4]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/EffortlessMetrics/perl-lsp/compare/v0.12.1...v0.12.2

--- a/docs/CHANGELOG_WORKFLOW.md
+++ b/docs/CHANGELOG_WORKFLOW.md
@@ -1,531 +1,176 @@
-# Changelog Workflow
+# Changelog workflow
 
-This document describes changelog generation for perl-lsp. Two mechanisms
-coexist:
+`perl-lsp` uses [Changie](https://changie.dev/) for new changelog fragments and
+release batching. `CHANGELOG.md` remains the published, human-readable history.
 
-1. **PR-time release-note fragments ([Changie](https://changie.dev)) — the new
-   direction.** Each PR records its own release note as a file-based fragment
-   (or an evidenced exemption) at the moment the change is made. See
-   [PR-time release notes (Changie)](#pr-time-release-notes-changie) below.
-2. **Release-time generation ([git-cliff](https://git-cliff.org)) — the current
-   execution path.** Unchanged. The sections after the Changie block document
-   it.
+The migration is intentionally forward-only:
 
----
+- the curated pre-Changie sections in `CHANGELOG.md` remain an immutable legacy
+  tail;
+- new PRs add structured files under `.changes/unreleased/`;
+- release automation runs `changie batch` and inserts that version immediately
+  after `## [Unreleased]`;
+- the adapter does not regenerate or reinterpret older release prose.
 
-## PR-time release notes (Changie)
+This boundary matters because some historical source-tag ranges are incomplete
+or inflated by cross-repository synchronization. A new renderer must not erase
+or silently rewrite the corrected archive.
 
-> **Status: FOUNDATION / ADVISORY (tracking issue #3784 — the Changie
-> program; #3768 is the retrospective baseline artifact only).** This flow is
-> wired into a check that always exits 0 or 2 today — never 1 — because the
-> blocking boundary (`blocking_enforced_from` in `policy/changelog.toml`) is
-> unset. This PR does not change release execution: Cargo versions,
-> publishing, and the git-cliff generation documented below remain the
-> versioning/tag/publish authority, and git-cliff remains an audit lens. A
-> later reviewed cutover makes Changie batching the changelog-preparation
-> authority; a follow-up PR decides whether/when fragments become
-> merge-blocking.
+## Contributor flow
 
-### Why
+### Add a fragment
 
-Reconstructing a release changelog from hundreds of merged PRs is a release-time
-archaeology exercise. Changie moves the release-note decision to **PR time**:
-the author who made the change writes its note while the context is fresh, as a
-small YAML fragment under `.changes/unreleased/`. At release time
-`changie batch <version> --project <p>` folds every fragment into the project's
-Keep-a-Changelog file.
-
-### The disposition rule
-
-**Every PR carries exactly one explicit *disposition* — a fragment OR an
-exemption-with-reason.** This is *not* "every PR needs a fragment": an evidenced
-exemption is a first-class disposition.
-
-**Option A — add a fragment** (user-facing change):
+Run:
 
 ```bash
-changie new    # interactive: pick project, component, kind; write the body
+changie new
 ```
 
-This writes `.changes/unreleased/<project>-<PR>-<kind>-<HHMMSS>.yaml`. Fragments
-carry a `project:` field (`product` → `CHANGELOG.md`, `vscode` →
-`vscode-extension/CHANGELOG.md`), a `component`, a `kind`
-(Added/Changed/Fixed/Performance/Deprecated/Removed/Security), a body, and custom
-metadata (`PR`, optional `Slug`, `Breaking: no|yes`). See `.changes/samples/`
-for two worked examples. Do **not** hand-edit `CHANGELOG.md` /
-`vscode-extension/CHANGELOG.md` directly in a feature PR — add a fragment
-instead; those files are generated.
+Choose the narrowest applicable kind and describe the user-observable change.
+A useful fragment says what changed, when it activates, and—where material—what
+fallback or failure behavior remains.
 
-**Option B — declare an exemption** (no user-facing change). Add a marker line
-to the **PR body**:
-
-```
-changelog-exempt: <category> — <reason>
-```
-
-or add a tracked note under `.changes/exemptions/<slug>.md`. Recognized
-`<category>` values (see `policy/changelog.toml`):
-
-| Category | For |
-|----------|-----|
-| `tests` | test-only changes |
-| `ci` | CI / workflow / policy plumbing |
-| `refactor` | behavior-preserving internal refactor |
-| `generated-status` | auto-generated status / metrics surfaces |
-| `docs-no-contract-change` | docs that change no user-facing contract |
-| `deps` | dependency lockfile / version bumps |
-| `release-prep` | version bump + changelog batch PRs |
-| `changelog-tooling` | changes to the changelog tooling itself |
-
-### The advisory check
+Commit the generated YAML file with the implementation PR:
 
 ```bash
-# Check the current branch's disposition against origin/main.
-cargo xtask changelog check
-
-# Validate + render the sample fragments end-to-end (requires `changie`).
-cargo xtask changelog check --self-test
+git add .changes/unreleased
 ```
 
-The check, for a PR's changed files, verifies that: (a) a valid fragment was
-added, OR (b) an explicit exemption is present, OR (c) the PR is a recognized
-release-prep. It validates each fragment's project/kind/component/PR metadata,
-confirms it renders via `changie batch --dry-run --keep`, and warns when a
-feature PR hand-edits a generated changelog. It runs in CI as the non-required
-**Changelog Ledger (Advisory)** workflow (`.github/workflows/changelog-advisory.yml`).
+A fragment is normally required for:
 
-`changie` is pinned via the nix devShell (`flake.nix`) for local use and
-downloaded at a pinned, checksum-verified version in the advisory CI workflow.
+- user-visible LSP, DAP, parser, formatter, CLI, extension, or install changes;
+- protocol and configuration changes;
+- security fixes;
+- deprecations, removals, and breaking public API changes.
 
-**Exit codes** (see `xtask/src/tasks/changelog.rs` module docs for the full
-contract): `0` = policy satisfied or an advisory finding was reported; `1` =
-blocking violation (unreachable today — `blocking_enforced_from` is unset);
-`2` = instrument/config failure (malformed config, unresolvable changed-file
-list, `changie` render crash) — never a policy verdict.
+A fragment is normally unnecessary for:
 
-### The three-clock cutoff model
+- test-only receipts with no behavior change;
+- internal refactors that preserve externally visible behavior;
+- formatting-only changes;
+- generated-file refreshes.
 
-A single "cutoff SHA" is the wrong model: it silently drops any PR merged
-between when #3768's manual catalog was *authored* and when #3768 itself
-*merged* (e.g. #3765). `policy/changelog.toml` instead declares three
-independent clocks:
+When classification is uncertain, prefer a short `Internal` fragment over
+silence. Release reviewers can omit or reclassify it with an explicit reason.
 
-| Field | Meaning |
-|-------|---------|
-| `retrospective_covered_through` | Last `main` SHA #3768's manual catalog actually audited (a conservative floor). |
-| `advisory_expected_from` | This PR's (#3775) own merge SHA. A disposition is *expected* (missing = reported finding, exit 0) only for PRs whose base is at/after this commit. Empty = not yet armed. |
-| `blocking_enforced_from` | A future SHA. A missing disposition is a *blocking* violation (exit 1) only for PRs whose base is at/after this commit. Empty = no blocking path is reachable, ever. |
+### Non-interactive fragment creation
 
-The half-open interval `(retrospective_covered_through, advisory_expected_from]`
-— PRs merged after the retrospective floor but before the advisory boundary
-armed — is covered by a separate bridge audit (a later PR), not by this
-policy file.
-
----
-
-## Overview
-
-The perl-lsp project uses automated changelog generation to:
-- Maintain consistent, high-quality release notes
-- Reduce manual effort during releases
-- Ensure all changes are properly documented
-- Follow [Keep a Changelog](https://keepachangelog.com) format
-- Integrate seamlessly with GitHub releases
-
-## Quick Start
+CI and scripted work may pass values directly:
 
 ```bash
-# Preview unreleased changes
-just changelog-preview
-
-# Generate full changelog (overwrites CHANGELOG.md)
-just changelog
-
-# Update changelog with unreleased changes (for releases)
-just changelog-append
+changie new --kind fixed --body \
+  'Prevent stale completion results after the document generation advances.'
 ```
 
-## Conventional Commits
+Fragment files have this shape:
 
-The changelog is generated from conventional commit messages. Follow this format:
-
-```
-<type>(<scope>): <subject>
-
-[optional body]
-
-[optional footer]
+```yaml
+kind: fixed
+body: Prevent stale completion results after the document generation advances.
+time: 2026-07-12T05:45:00Z
 ```
 
-### Commit Types
+Do not hand-author timestamps or filenames when `changie new` is available.
 
-| Type | Description | Changelog Section | Example |
-|------|-------------|-------------------|---------|
-| `feat` | New feature | ✨ Features | `feat(lsp): add hover support` |
-| `fix` | Bug fix | 🐛 Bug Fixes | `fix(parser): handle empty strings` |
-| `perf` | Performance improvement | ⚡ Performance | `perf: optimize AST traversal` |
-| `refactor` | Code refactoring | ♻️ Refactoring | `refactor(lexer): simplify tokenizer` |
-| `docs` | Documentation | 📚 Documentation | `docs: update LSP guide` |
-| `test` | Testing | 🧪 Testing | `test(parser): add edge cases` |
-| `build` | Build system | 🏗️ Build System | `build: update cargo dependencies` |
-| `ci` | CI/CD | 👷 CI/CD | `ci: add benchmark workflow` |
-| `chore` | Maintenance | 🔧 Chore | `chore: update gitignore` |
-| `security` | Security fix | 🔒 Security | `security: fix path traversal` |
-| `revert` | Revert previous commit | ⏪ Reverts | `revert: "feat: add feature X"` |
-| `ux` | UX/UI improvement | 🎨 UX/UI | `ux: improve error messages` |
-| `style` | Code style (skipped) | _(skipped)_ | `style: format code` |
+## Release flow
 
-### Scopes
-
-Scopes indicate which part of the codebase is affected:
-
-- `parser` - Parser library (perl-parser)
-- `lsp` - LSP server (perl-lsp)
-- `dap` - Debug adapter (perl-dap)
-- `lexer` - Lexer (perl-lexer)
-- `corpus` - Test corpus
-- `extension` - VS Code extension
-- `ci` - CI/CD pipelines
-- `docs` - Documentation
-
-### Breaking Changes
-
-Mark breaking changes by adding `!` after the type/scope or including `BREAKING CHANGE:` in the footer:
+The version-bump workflow resolves the workspace version, then runs:
 
 ```bash
-# Method 1: ! syntax
-git commit -m "feat(lsp)!: change API signature"
-
-# Method 2: Footer
-git commit -m "feat(lsp): change API signature
-
-BREAKING CHANGE: The `parse()` function now returns Result<T, Error>
-instead of Option<T>. Update all callers to handle errors."
+changie batch vX.Y.Z
+python3 scripts/changie_merge_legacy.py vX.Y.Z
 ```
 
-## Commit Message Examples
+`changie batch` consumes unreleased fragments into `.changes/vX.Y.Z.md`.
+The adapter inserts that rendered version after `[Unreleased]` while proving the
+existing historical tail is copied without textual transformation.
 
-### Good Examples
+The workflow fails when:
 
-```bash
-# Feature with scope
-feat(parser): add support for heredoc syntax
+- no unreleased fragments exist;
+- the expected `.changes/vX.Y.Z.md` file is absent;
+- the version heading does not match the requested version;
+- the changelog already contains that version;
+- `[Unreleased]` is missing or duplicated;
+- the legacy-tail renderer tests fail.
 
-# Bug fix with detailed description
-fix(lsp): prevent crash on empty file
-Handles edge case where document is empty during initialization.
-Fixes #123
+The release PR must review both files:
 
-# Performance improvement
-perf(parser): optimize AST traversal in ScopeAnalyzer
-Reduces parse time by 30% for large files by using stack-based tracking.
-
-# Breaking change
-feat(lsp)!: require Rust 1.70+
-Updates MSRV to 1.70 for better error handling support.
-
-BREAKING CHANGE: Minimum supported Rust version is now 1.70.0
+```text
+.changes/vX.Y.Z.md
+CHANGELOG.md
 ```
 
-### Bad Examples
+The version file is the structured release input. `CHANGELOG.md` is the rendered
+public history.
 
-```bash
-# Too vague
-fix: stuff
+## Release-note provenance is separate
 
-# Missing type
-added feature
+Changie solves fragment capture; it does not determine the true release
+boundary. Release notes still begin from the logical `perl-lsp-swarm`
+first-parent range and are verified against the final `perl-lsp` release tree.
 
-# Not following convention
-updated code for issue 123
-```
+Use the release checklist and release-note guidance to record:
 
-## Justfile Commands
+- previous and new immutable swarm RC SHAs;
+- the two-parent source sync commit;
+- documented source-only exclusions;
+- user-visible changes represented or explicitly excluded;
+- claim boundaries for disabled, shadow-only, and proof-only work.
 
-### `just changelog-preview`
-
-Preview unreleased changes without modifying files:
-
-```bash
-just changelog-preview
-```
-
-This shows what would be included in the next release.
-
-### `just changelog`
-
-Generate complete changelog (overwrites CHANGELOG.md):
-
-```bash
-just changelog
-```
-
-**Warning**: This regenerates the entire changelog from git history. Use with caution.
-
-### `just changelog-append`
-
-Update CHANGELOG.md with unreleased changes (recommended for releases):
-
-```bash
-just changelog-append
-```
-
-This prepends new changes to the existing CHANGELOG.md.
-
-### `just changelog-latest`
-
-Show changelog for the latest tag:
-
-```bash
-just changelog-latest
-```
-
-### `just changelog-range FROM TO`
-
-Generate changelog for a specific range:
-
-```bash
-just changelog-range <previous-release> <next-release>
-```
-
-## Release Workflow Integration
-
-The changelog is automatically generated during releases via the release orchestration flow:
-
-1. **Trigger**: Dispatch `Version Bump & Changelog Generation` with `version=<0.x.y>`.
-2. **Generate**: The workflow bumps `Cargo.toml`, runs `git-cliff`, and creates a PR to merge changelog updates.
-3. **Release Orchestration**: After PR merge, dispatch `Release Orchestration` with `version=<0.x.y>`.
-4. **Release Workflow**: `release.yml` creates a GitHub release and includes generated release notes.
-5. **Publish**: `publish-crates.yml`, `publish-extension`, and `publish-docker` are triggered as configured.
-
-### Turnkey Release Flow
-
-```bash
-# Recommended: run both workflow steps through gh automation.
-# Canonical command for RC orchestration:
-cargo xtask release-turnkey <0.x.y>
-```
-
-### Alternative Manual Release Process
-
-```bash
-# 1. Generate changelog content
-# Use the same canonical flow entrypoint:
-cargo xtask release-turnkey <0.x.y> --no-auto-merge --no-wait-release
-
-# 2. Manually review and merge the generated version bump PR.
-
-# 3. Dispatch Release Orchestration manually
-gh workflow run "Release Orchestration" \
-  --ref master \
-  --field version=<0.x.y> \
-  --field prerelease=false \
-  --field skip_crates=false \
-  --field skip_extension=false \
-  --field skip_docker=false
-
-# 4. Optionally monitor release/publish workflows in GitHub Actions.
-
-# 5. GitHub Actions creates release notes and publishes artifacts.
-```
+A complete fragment set is necessary but not sufficient evidence that the
+release note is complete.
 
 ## Configuration
 
-The changelog generation is configured in `cliff.toml`:
+Changie is configured by [`.changie.yaml`](../.changie.yaml). The active kinds
+are:
 
-```toml
-[changelog]
-header = "# Changelog\n\n..."
-body = "{% for group, commits in commits | group_by(attribute=\"group\") %}..."
-footer = "<!-- Generated by git-cliff -->"
+| Key | Rendered section | Automatic SemVer signal |
+|---|---|---|
+| `added` | Added | minor |
+| `changed` | Changed | minor |
+| `deprecated` | Deprecated | minor |
+| `removed` | Removed | minor (0.x breaking change) |
+| `fixed` | Fixed | patch |
+| `security` | Security | patch |
+| `documentation` | Documentation | patch |
+| `internal` | Internal | patch |
 
-[git]
-conventional_commits = true
-commit_parsers = [
-    { message = "^feat", group = "✨ Features" },
-    # ... more parsers
-]
-```
-
-### Customization
-
-To customize changelog generation:
-
-1. Edit `cliff.toml` to modify:
-   - Commit parsers (what goes in which section)
-   - Template formatting (emojis, headers, etc.)
-   - Filtering rules (skip certain commits)
-
-2. Test changes:
-   ```bash
-   just changelog-preview
-   ```
-
-3. Commit the updated configuration:
-   ```bash
-   git add cliff.toml
-   git commit -m "chore: update changelog config"
-   ```
-
-## Installation
-
-### git-cliff
-
-Install git-cliff to use changelog commands:
+The release workflow pins Changie `v1.24.0`. Local installation:
 
 ```bash
-# Via cargo
-cargo install git-cliff --locked
-
-# Via homebrew (macOS/Linux)
-brew install git-cliff
-
-# Via nix
-nix-shell -p git-cliff
+GOBIN="$HOME/.local/bin" go install github.com/miniscruff/changie@v1.24.0
 ```
 
-### CI/CD
+## Validation
 
-git-cliff is automatically installed in the release workflow, no manual setup required.
-
-## Best Practices
-
-### 1. Write Clear Commit Messages
+Run the adapter tests directly:
 
 ```bash
-# Good: Specific, actionable
-feat(lsp): add semantic token support for variables
-
-# Bad: Vague, no context
-update code
+python3 scripts/tests/test_changie_merge_legacy.py
 ```
 
-### 2. Use Conventional Commits Consistently
-
-Every commit should follow the conventional commit format. This ensures:
-- Accurate changelog generation
-- Proper categorization
-- Automatic semantic versioning
-
-### 3. Keep Squash Merges Explicitly Conventional
-
-Use explicit subject/body on squash merges so merged history stays descriptive:
+Inspect pending fragments without changing them:
 
 ```bash
-pr=2943
-gh pr merge "$pr" --squash \
-  --subject "feat(lsp): improve type definition and implementation with OO inheritance support" \
-  --body "PR summary:
-- improve OO lookup fallback for type definitions and implementations
-- add coverage for inherited methods and signatures
-- preserve existing behavior for non-OO dispatch paths"
-  --delete-branch
+find .changes/unreleased -maxdepth 1 -type f -name '*.yaml' -print -exec cat {} \;
 ```
 
-### 4. Document Breaking Changes
+Test a batch only on a disposable branch or worktree: batching consumes the
+unreleased YAML files.
 
-Always document breaking changes in the commit message:
+## Migration boundary
 
-```bash
-feat(lsp)!: change configuration format
+`cliff.toml` and the old `just changelog*` shortcuts remain transitional files
+until their dedicated cleanup lands. They are no longer used by the version-bump
+workflow and must not be used to prepare a release.
 
-BREAKING CHANGE: Configuration now uses TOML instead of JSON.
-See [docs/how-to/UPGRADING.md](how-to/UPGRADING.md) for upgrade instructions.
-```
+Do not run `changie merge` against the repository yet. The historical versions
+have not been converted into native Changie version files; a raw merge would
+omit the legacy tail. Use `scripts/changie_merge_legacy.py` through the release
+workflow.
 
-### 5. Review Before Release
-
-Always preview the changelog before releasing:
-
-```bash
-just changelog-preview
-```
-
-## Troubleshooting
-
-### "git-cliff not installed"
-
-Install git-cliff:
-```bash
-cargo install git-cliff --locked
-```
-
-### "No commits found"
-
-Ensure you have commits since the last tag:
-```bash
-git log $(git describe --tags --abbrev=0)..HEAD
-```
-
-### Changelog Missing Commits
-
-Check if commits follow conventional format:
-```bash
-git log --oneline --pretty=format:"%s" | grep -v "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|security|ux)"
-```
-
-### Unwanted Commits in Changelog
-
-Edit `cliff.toml` to add skip rules:
-
-```toml
-commit_parsers = [
-    # Skip merge commits
-    { message = "^Merge", skip = true },
-    # Skip style commits
-    { message = "^style", skip = true },
-]
-```
-
-## Examples
-
-### Generate Changelog for v<0.x.y> Release
-
-```bash
-# 1. Check what will be included
-just changelog-preview
-
-# 2. Update CHANGELOG.md
-just changelog-append
-
-# 3. Review the changes
-git diff CHANGELOG.md
-
-# 4. Commit and tag
-git add CHANGELOG.md
-git commit -m "chore: prepare v<0.x.y> release"
-git tag v<0.x.y>
-git push origin master --tags
-```
-
-### View Changes Between Two Versions
-
-```bash
-just changelog-range <previous-release> <next-release>
-```
-
-### Regenerate Full Changelog
-
-```bash
-# Backup current changelog
-cp CHANGELOG.md CHANGELOG.md.backup
-
-# Regenerate from git history
-just changelog
-
-# Compare and restore if needed
-diff CHANGELOG.md CHANGELOG.md.backup
-```
-
-## References
-
-- [git-cliff documentation](https://git-cliff.org/docs/)
-- [Conventional Commits](https://www.conventionalcommits.org/)
-- [Keep a Changelog](https://keepachangelog.com/)
-- [Semantic Versioning](https://semver.org/)
-
-## Related Documentation
-
-- [Release Process](./RELEASE_PROCESS.md) - Complete release workflow
-- [Contributing Guide](../CONTRIBUTING.md) - Commit message guidelines
-- [CI/CD Documentation](./CI_README.md) - CI pipeline integration
+A later cleanup may import old releases into `.changes/v*.md` after a separate,
+byte-for-byte reconciliation. That is archival maintenance, not a release
+prerequisite.

--- a/scripts/changie_merge_legacy.py
+++ b/scripts/changie_merge_legacy.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Insert one Changie version ahead of the immutable legacy changelog tail.
+
+The repository adopted Changie after a curated historical backfill. Re-rendering
+all older releases from a new structured archive would create unnecessary drift,
+so Changie owns new fragments and version files while this small adapter keeps
+pre-adoption history byte-for-byte intact from its first release heading onward.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+
+UNRELEASED_HEADING = b"## [Unreleased]"
+SEMVER = re.compile(r"^v?(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$")
+
+
+class ChangelogMergeError(RuntimeError):
+    """Raised when the version file or changelog violates the merge contract."""
+
+
+def normalize_version(raw: str) -> tuple[str, str]:
+    """Return `(version_without_prefix, version_with_prefix)`."""
+
+    match = SEMVER.fullmatch(raw.strip())
+    if match is None:
+        raise ChangelogMergeError(f"invalid release version: {raw!r}")
+    version = match.group("version")
+    return version, f"v{version}"
+
+
+def _newline_for_insertion(separator: bytes, changelog: bytes) -> bytes:
+    """Choose a newline for new content without rewriting existing bytes."""
+
+    if separator.startswith(b"\r\n"):
+        return b"\r\n"
+    if separator.startswith(b"\n"):
+        return b"\n"
+    if separator.startswith(b"\r"):
+        return b"\r"
+    if b"\r\n" in changelog:
+        return b"\r\n"
+    if b"\n" in changelog:
+        return b"\n"
+    if b"\r" in changelog:
+        return b"\r"
+    return b"\n"
+
+
+def _with_newline_style(content: bytes, newline: bytes) -> bytes:
+    """Normalize only newly inserted content to the changelog's local style."""
+
+    normalized = content.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return normalized.replace(b"\n", newline)
+
+
+def merge_version(
+    *,
+    changelog_path: Path,
+    changes_dir: Path,
+    raw_version: str,
+) -> None:
+    """Insert the batched version immediately after `[Unreleased]`.
+
+    Everything from the first non-newline byte after `[Unreleased]` onward is
+    treated as the legacy tail and copied byte-for-byte. The function fails
+    closed on duplicate headings, malformed version files, or ambiguous markers.
+    """
+
+    version, prefixed = normalize_version(raw_version)
+    version_path = changes_dir / f"{prefixed}.md"
+    if not version_path.is_file():
+        raise ChangelogMergeError(f"missing Changie version file: {version_path}")
+
+    release_text = version_path.read_bytes().strip(b"\r\n")
+    expected_heading = f"## [{version}] - ".encode("ascii")
+    if not release_text.startswith(expected_heading):
+        raise ChangelogMergeError(
+            f"{version_path} must begin with {expected_heading.decode('ascii')!r}"
+        )
+
+    changelog = changelog_path.read_bytes()
+    marker_count = changelog.count(UNRELEASED_HEADING)
+    if marker_count != 1:
+        heading = UNRELEASED_HEADING.decode("ascii")
+        raise ChangelogMergeError(
+            f"expected one {heading!r} heading, found {marker_count}"
+        )
+
+    release_heading = re.compile(
+        rb"(?m)^## \["
+        + re.escape(version.encode("ascii"))
+        + rb"\](?: -|\r?$)"
+    )
+    if release_heading.search(changelog) is not None:
+        raise ChangelogMergeError(f"CHANGELOG already contains release {version}")
+
+    marker_start = changelog.index(UNRELEASED_HEADING)
+    marker_end = marker_start + len(UNRELEASED_HEADING)
+    prefix = changelog[:marker_end]
+    suffix = changelog[marker_end:]
+
+    separator_length = len(suffix) - len(suffix.lstrip(b"\r\n"))
+    separator = suffix[:separator_length]
+    legacy_tail = suffix[separator_length:]
+    newline = _newline_for_insertion(separator, changelog)
+    if not separator:
+        separator = newline + newline
+
+    release_text = _with_newline_style(release_text, newline)
+    rendered = prefix + separator + release_text
+    if legacy_tail:
+        rendered += separator + legacy_tail
+    elif not rendered.endswith(newline):
+        rendered += newline
+
+    if legacy_tail and not rendered.endswith(legacy_tail):
+        raise ChangelogMergeError("legacy changelog tail changed during render")
+
+    changelog_path.write_bytes(rendered)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Insert a batched Changie release before legacy history"
+    )
+    parser.add_argument("version", help="Release version, with or without v prefix")
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=Path("CHANGELOG.md"),
+        help="Rendered changelog path",
+    )
+    parser.add_argument(
+        "--changes-dir",
+        type=Path,
+        default=Path(".changes"),
+        help="Changie changes directory",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        merge_version(
+            changelog_path=args.changelog,
+            changes_dir=args.changes_dir,
+            raw_version=args.version,
+        )
+    except ChangelogMergeError as exc:
+        raise SystemExit(f"changelog merge failed: {exc}") from exc
+
+    print(f"Inserted {args.version} into {args.changelog}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_changie_merge_legacy.py
+++ b/scripts/tests/test_changie_merge_legacy.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS))
+
+from changie_merge_legacy import ChangelogMergeError, merge_version  # noqa: E402
+
+
+class ChangieLegacyMergeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.changes = self.root / ".changes"
+        self.changes.mkdir()
+        self.changelog = self.root / "CHANGELOG.md"
+        self.legacy_tail = (
+            "## [0.17.0] - 2026-06-28\n\n"
+            "### Fixed\n\n"
+            "- Historical text remains unchanged.\n"
+        )
+        self.changelog.write_text(
+            "# Changelog\n\n## [Unreleased]\n\n" + self.legacy_tail,
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_release(self, version: str = "v0.18.0") -> None:
+        (self.changes / f"{version}.md").write_text(
+            "## [0.18.0] - 2026-07-12\n\n"
+            "### Changed\n\n"
+            "- Changie now owns future release fragments.\n",
+            encoding="utf-8",
+        )
+
+    def test_inserts_release_before_legacy_tail(self) -> None:
+        self.write_release()
+
+        merge_version(
+            changelog_path=self.changelog,
+            changes_dir=self.changes,
+            raw_version="v0.18.0",
+        )
+
+        rendered = self.changelog.read_text(encoding="utf-8")
+        self.assertLess(rendered.index("## [0.18.0]"), rendered.index("## [0.17.0]"))
+        self.assertTrue(rendered.endswith(self.legacy_tail))
+
+    def test_preserves_crlf_legacy_tail_byte_for_byte(self) -> None:
+        legacy_tail = (
+            "## [0.17.0] - 2026-06-28\r\n\r\n"
+            "### Fixed\r\n\r\n"
+            "- Historical café text remains unchanged.\r\n"
+        ).encode("utf-8")
+        self.changelog.write_bytes(
+            b"# Changelog\r\n\r\n## [Unreleased]\r\n\r\n" + legacy_tail
+        )
+        self.write_release()
+
+        merge_version(
+            changelog_path=self.changelog,
+            changes_dir=self.changes,
+            raw_version="v0.18.0",
+        )
+
+        rendered = self.changelog.read_bytes()
+        self.assertTrue(rendered.endswith(legacy_tail))
+        self.assertIn(
+            b"## [0.18.0] - 2026-07-12\r\n\r\n### Changed",
+            rendered,
+        )
+        self.assertEqual(rendered.count(b"\n"), rendered.count(b"\r\n"))
+
+    def test_rejects_duplicate_release(self) -> None:
+        self.write_release()
+        merge_version(
+            changelog_path=self.changelog,
+            changes_dir=self.changes,
+            raw_version="0.18.0",
+        )
+
+        with self.assertRaisesRegex(ChangelogMergeError, "already contains"):
+            merge_version(
+                changelog_path=self.changelog,
+                changes_dir=self.changes,
+                raw_version="0.18.0",
+            )
+
+    def test_rejects_mismatched_version_file_heading(self) -> None:
+        (self.changes / "v0.18.0.md").write_text(
+            "## [0.19.0] - 2026-07-12\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(ChangelogMergeError, "must begin"):
+            merge_version(
+                changelog_path=self.changelog,
+                changes_dir=self.changes,
+                raw_version="v0.18.0",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Objective

Move future changelog capture and release batching from commit-derived git-cliff output to reviewed Changie fragments, without rewriting the curated historical changelog.

Fixes #9958.

## Summary

This is stacked on #9957 so the first Changie-managed release starts from the corrected v0.15.1–v0.17.0 history.

### Fragment model

- Adds `.changie.yaml` with Keep-a-Changelog sections and SemVer signals.
- Adds `.changes/header.tpl.md` and an initial unreleased fragment recording the migration.
- Updates the PR template so every PR declares whether it carries a Changie fragment or why one is unnecessary.

### Release automation

- Replaces the active git-cliff step in `version-bump.yml` with pinned Changie `v1.24.0` installed from source via Go.
- Fails the release-prep workflow when no unreleased YAML fragments exist; Changie's own empty-batch default cannot silently create an empty release.
- Runs `changie batch vX.Y.Z`, stages `.changes/vX.Y.Z.md`, and renders the public changelog.
- Updates the generated release PR to require review of both the structured version file and `CHANGELOG.md`.

### Historical safety boundary

The repository has corrected historical prose whose logical ancestry does not always map cleanly to source tag ranges. This PR therefore does **not** run `changie merge` across old releases.

`scripts/changie_merge_legacy.py` inserts each new Changie version immediately after `[Unreleased]` while leaving the existing release tail byte-for-byte unchanged. The adapter reads and writes bytes, preserves LF or CRLF line endings in the legacy tail, and applies the existing local newline style only to the newly inserted version. Focused tests cover:

- new-version ordering ahead of the legacy tail;
- LF and CRLF byte preservation;
- duplicate-version rejection;
- mismatched version-heading rejection.

### Guidance

Rewrites `docs/CHANGELOG_WORKFLOW.md` around fragment creation, non-interactive use, release batching, release-note provenance, validation, and the forward-only migration boundary.

## Claim boundary

This PR changes the active version-bump workflow. It does not:

- regenerate historical versions as native Changie files;
- replace the separate release-note provenance review;
- delete `cliff.toml` or old `just changelog*` shortcuts yet.

Those transitional git-cliff surfaces are explicitly marked non-canonical and can be removed after the first successful Changie-batched release.

## Verification

- `python3 scripts/tests/test_changie_merge_legacy.py` — 4 tests pass locally, including CRLF preservation.
- `.changie.yaml` parses as YAML and follows Changie's documented field names and version template model.
- Branch diff is limited to Changie configuration/fragments, the release workflow, PR guidance, contributor documentation, and the tested legacy-tail adapter.
- The active release workflow no longer invokes git-cliff.

## Merge order

1. Merge #9957 (historical changelog backfill).
2. Retarget this PR to `master` if GitHub does not do so automatically.
3. Merge this PR.

PR #9956, which improves standalone release notes and provenance guidance, is complementary and may merge independently.