### PR TITLE
docs(release): reconcile 0.15.0–0.17.0 channel ledger (#9965)

### DIFF
--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -92,7 +92,7 @@ records observable repository state and installs a drift guard.
 
 ## Release-channel corrections
 
-### 2026-07-12 — v0.15.0 through v0.17.0 GitHub Release actuals
+### 2026-07-12 — v0.15.0 through v0.17.0 release-channel actuals
 
 The original ledger rows remain visible as historical records. The following
 facts supersede their `pending` GitHub Release, release-date, live-tag, asset, and
@@ -100,11 +100,11 @@ selected channel cells where stated:
 
 | Version | GitHub Release actual | Live tag commit | Asset accounting at audit | Other channel boundary |
 |---|---|---|---|---|
-| `0.15.0` | [published 2026-05-22][gh-0.15.0] | `ac8e281e73c6e14ae9d94ddf010ae0d45d1187d2` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io, editor marketplaces, and containers remain unreconciled. |
-| `0.15.1` | [published 2026-05-26][gh-0.15.1] | `15cbe7e6295a67ea0cba506c3cade628ee4847f6` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | GitHub binaries remain usable. The crates.io package is superseded by `0.15.2` for fresh Cargo installs; marketplace and container state remain unreconciled. |
-| `0.15.2` | [published 2026-05-26][gh-0.15.2] | `746edcb78fe0fa8f48d87386fd4f110502588a87` | Original closeout verified 10 uploaded artifacts; GitHub UI reported 12 entries after including its two generated source archives. | PR #9617 verified crates.io install smokes, VS Code Marketplace, Open VSX, and Docker Hub. GHCR publish CI succeeded, but public manifest verification returned `denied`. |
-| `0.16.0` | [published 2026-06-06][gh-0.16.0] | `b6d9f12b995ad8ad78ca641940bd73e4b1a3c26d` | GitHub UI reported 11 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io, editor marketplaces, and containers remain unreconciled. |
-| `0.17.0` | [published 2026-06-28][gh-0.17.0] | `ffee2824938f415e54923112c7b79e3f22040699` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io, editor marketplaces, and containers remain unreconciled. |
+| `0.15.0` | [published 2026-05-22][gh-0.15.0] | `ac8e281e73c6e14ae9d94ddf010ae0d45d1187d2` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io and editor marketplaces remain unreconciled. Docker Hub builder/runtime tags expose `linux/amd64` and `linux/arm64`; GHCR builder/runtime tags exist but are `linux/arm64`-only. |
+| `0.15.1` | [published 2026-05-26][gh-0.15.1] | `15cbe7e6295a67ea0cba506c3cade628ee4847f6` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | GitHub binaries remain usable. The crates.io package is superseded by `0.15.2` for fresh Cargo installs; marketplace state remains unreconciled. Docker Hub is amd64/arm64; GHCR is arm64-only. |
+| `0.15.2` | [published 2026-05-26][gh-0.15.2] | `746edcb78fe0fa8f48d87386fd4f110502588a87` | Original closeout verified 10 uploaded artifacts; GitHub UI reported 12 entries after including its two generated source archives. | PR #9617 verified crates.io install smokes, VS Code Marketplace, Open VSX, and Docker Hub. A later authenticated audit resolved GHCR as published but incomplete: both tags are arm64-only and lack amd64. |
+| `0.16.0` | [published 2026-06-06][gh-0.16.0] | `b6d9f12b995ad8ad78ca641940bd73e4b1a3c26d` | GitHub UI reported 11 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io and editor marketplaces remain unreconciled. Docker Hub builder/runtime tags expose amd64/arm64; GHCR builder/runtime tags are arm64-only. |
+| `0.17.0` | [published 2026-06-28][gh-0.17.0] | `ffee2824938f415e54923112c7b79e3f22040699` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io and editor marketplaces remain unreconciled. Docker Hub builder/runtime tags expose amd64/arm64; GHCR builder/runtime tags are arm64-only. |
 
 GitHub's rendered `Assets N` value and this ledger's uploaded-artifact count are
 not interchangeable. The UI total includes the generated source ZIP and tarball;
@@ -112,8 +112,11 @@ the ledger records uploaded artifacts only when an independent inventory or
 closeout receipt exists.
 
 The note-level channel actuals and restored `v0.15.2` closeout receipt are tracked
-in #9965. A GitHub Release page is not evidence that crates.io, Marketplace,
-Open VSX, Docker Hub, or GHCR completed.
+in #9965. The container classifications come from the read-only registry audit in
+#9973 (workflow runs `29192188862` and `29192323459`); #9972 fixes the GHCR
+multi-architecture publishing defect going forward. A GitHub Release page alone
+is not evidence that crates.io, Marketplace, Open VSX, Docker Hub, or GHCR
+completed.
 
 ## Legend
 

--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -90,7 +90,32 @@ Key corrections:
 No cause, actor, or rewrite date is inferred from the mismatch. The correction
 records observable repository state and installs a drift guard.
 
-### Legend
+## Release-channel corrections
+
+### 2026-07-12 — v0.15.0 through v0.17.0 GitHub Release actuals
+
+The original ledger rows remain visible as historical records. The following
+facts supersede their `pending` GitHub Release, release-date, live-tag, asset, and
+selected channel cells where stated:
+
+| Version | GitHub Release actual | Live tag commit | Asset accounting at audit | Other channel boundary |
+|---|---|---|---|---|
+| `0.15.0` | [published 2026-05-22][gh-0.15.0] | `ac8e281e73c6e14ae9d94ddf010ae0d45d1187d2` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io, editor marketplaces, and containers remain unreconciled. |
+| `0.15.1` | [published 2026-05-26][gh-0.15.1] | `15cbe7e6295a67ea0cba506c3cade628ee4847f6` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | GitHub binaries remain usable. The crates.io package is superseded by `0.15.2` for fresh Cargo installs; marketplace and container state remain unreconciled. |
+| `0.15.2` | [published 2026-05-26][gh-0.15.2] | `746edcb78fe0fa8f48d87386fd4f110502588a87` | Original closeout verified 10 uploaded artifacts; GitHub UI reported 12 entries after including its two generated source archives. | PR #9617 verified crates.io install smokes, VS Code Marketplace, Open VSX, and Docker Hub. GHCR publish CI succeeded, but public manifest verification returned `denied`. |
+| `0.16.0` | [published 2026-06-06][gh-0.16.0] | `b6d9f12b995ad8ad78ca641940bd73e4b1a3c26d` | GitHub UI reported 11 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io, editor marketplaces, and containers remain unreconciled. |
+| `0.17.0` | [published 2026-06-28][gh-0.17.0] | `ffee2824938f415e54923112c7b79e3f22040699` | GitHub UI reported 12 entries, including its two generated source archives; uploaded-artifact inventory was not separately reconciled. | crates.io, editor marketplaces, and containers remain unreconciled. |
+
+GitHub's rendered `Assets N` value and this ledger's uploaded-artifact count are
+not interchangeable. The UI total includes the generated source ZIP and tarball;
+the ledger records uploaded artifacts only when an independent inventory or
+closeout receipt exists.
+
+The note-level channel actuals and restored `v0.15.2` closeout receipt are tracked
+in #9965. A GitHub Release page is not evidence that crates.io, Marketplace,
+Open VSX, Docker Hub, or GHCR completed.
+
+## Legend
 
 - **"—"** = does not exist / not applicable
 - **"deferred"** = release published to GitHub but crates.io publish intentionally postponed
@@ -100,7 +125,7 @@ records observable repository state and installs a drift guard.
 - Versions without a tag or GitHub Release are CHANGELOG-only scope markers that never shipped as distinct artifacts
 - The v0.11.0 release included two VSIX files (`perl-lsp-0.11.0.vsix` and `perl-lsp-rs-0.11.0.vsix`) due to the extension rename
 
-### Eras
+## Eras
 
 | Era | Versions | Period | Focus |
 |-----|----------|--------|-------|


### PR DESCRIPTION
## Objective

Add an append-only release-ledger correction for `v0.15.0` through `v0.17.0`, recording verified GitHub Release and container actuals while restoring the channel closeout facts previously merged for `v0.15.2`.

Part of #9965. This PR is intentionally separate from #9966, which restores note-level channel fields and the lost closeout receipt.

## Findings

- The original ledger rows still show `pending` GitHub Release state for all five releases.
- Formal GitHub Releases exist for `v0.15.0`, `v0.15.1`, `v0.15.2`, `v0.16.0`, and `v0.17.0`.
- PR #9617 independently verified the `v0.15.2` crates.io install path, VS Code Marketplace, Open VSX, and Docker Hub.
- A later authenticated registry audit resolved the container boundary for all five releases: Docker Hub builder/runtime tags are amd64 + arm64; GHCR builder/runtime tags exist but are arm64-only.
- GitHub’s rendered asset total includes its generated source ZIP and tarball. The ledger must not treat that number as an uploaded-artifact count without an independent inventory.

## Changes

### Additive correction

Adds a dated `Release-channel corrections` section beneath the existing lineage and tag-provenance corrections. The original table rows remain untouched.

For each release, the correction records:

- GitHub Release publication date;
- exact live 40-character tag commit;
- asset-accounting boundary;
- crates/editor status where known;
- audited Docker Hub and GHCR platform state.

### Container actuals

The correction now records:

- Docker Hub builder and runtime tags expose `linux/amd64` and `linux/arm64` for every release from `0.15.0` through `0.17.0`;
- GHCR builder and runtime tags exist for every release but expose only `linux/arm64` as an application platform;
- the read-only evidence is preserved by workflow runs `29192188862` and `29192323459`;
- #9972 fixes the GHCR multi-architecture publishing defect going forward without mutating historical tags.

### v0.15.2 restoration

Records the original closeout result from merged PR #9617 and the later authenticated container finding:

- 10 uploaded release artifacts;
- GitHub UI total of 12 after its two generated source archives;
- crates.io install smokes verified;
- VS Code Marketplace and Open VSX verified;
- Docker Hub verified amd64 + arm64;
- GHCR published but incomplete: builder and runtime tags are arm64-only and lack amd64.

### Ledger structure

- Adds the missing `gh-0.17.0` release link.
- Keeps `Legend` and `Eras` as top-level sections after introducing the new correction section.

## Claim boundary

A GitHub Release page alone does not prove crates.io, Marketplace, Open VSX, Docker Hub, or GHCR publication. Container claims here come from the independent registry audit, not the release page.

The rendered GitHub asset count is not treated as an uploaded-artifact count except where a separate closeout receipt exists.

## Verification

- Exact-match additive edits completed.
- `policy/release-tag-provenance.toml` validation passed.
- `scripts/check_release_history.sh` passed on the original ledger correction, including the install-surface xtask.
- The container follow-up reran the provenance validator, shell syntax check, exact receipt assertions, and `git diff --check` before committing.
- Temporary workflows and editing scripts were removed; the final diff changes only `RELEASE_HISTORY.md`.
- All prior inline review threads are resolved; comments against deleted one-shot machinery are outdated and closed.

## Merge order

1. Merge #9962.
2. Merge #9964.
3. Retarget this PR to `master` if GitHub does not do so automatically.
4. Merge this PR.

#9966 can merge independently after #9956 because it does not touch `RELEASE_HISTORY.md`. #9973 carries the corresponding note-level container actuals and permanent drift guard.