### PR TITLE
docs(release): reconstruct v0.14.0 channel closeout (#9968)

### DIFF
--- a/docs/releases/0.14.0-closeout-audit.md
+++ b/docs/releases/0.14.0-closeout-audit.md
@@ -1,131 +1,297 @@
 ---
 tag: "v0.14.0"
+tag_commit: "977709e0bd23fd13b1c3db309b7a925098226eaf"
 tag_date_utc: "2026-05-12"
-audited_at: "2026-05-21"
-audited_by: "perl-lsp-swarm release audit; publishing-repo access required"
-audit_status: open
-template_version: 1
+original_audit_at: "2026-05-21"
+audited_at: "2026-07-12"
+audited_by: "publishing-repository evidence reconstruction"
+audit_status: closed
+template_version: 2
+tracking_issue: 9968
 ---
 
 # 0.14.0 Closeout Audit
 
-> Status: **OPEN**. Tag `v0.14.0` cut 2026-05-12. As of the audit date
-> in the frontmatter, several distribution channels remained on prior
-> versions. This is the populated instance of
-> [`RELEASE_CLOSEOUT_AUDIT.md`](RELEASE_CLOSEOUT_AUDIT.md) for
-> `v0.14.0`, used as the worked example that motivated the template.
+> Status: **CLOSED — reconstructed with channel defects**. GitHub Release,
+> crates.io, VS Code Marketplace, Open VSX, and Docker Hub are independently
+> verified. GHCR published both expected tags, but each retained only the
+> `linux/arm64` image plus provenance metadata; the expected `linux/amd64` image
+> is missing. Homebrew, Scoop, Chocolatey, and Winget did not publish `0.14.0`.
 
-## Why this matters
+This document preserves the original May 21 audit and adds the stronger evidence
+recovered on July 12. It supersedes earlier assumptions where later workflow,
+registry, package, and downstream-repository receipts establish a different
+outcome.
 
-A user filing the LSP4IJ file-watcher crash bug against perl-lsp was
-running **0.13.3**, not 0.14.0. 0.14.0 had been tagged and partially
-published for 9 days at that point. The root cause was not delayed
-adoption - it was incomplete release closeout.
+“Closed” means every channel now has an evidenced classification. It does not
+mean every channel succeeded.
 
-## Channel-by-channel reconstruction
+## Current classification
 
-From `docs/releases/v0.14.0.md` frontmatter at cut time:
+| Channel | Classification | Evidence boundary |
+|---|---|---|
+| GitHub Release | **verified complete** | Published May 12 at live tag commit `977709e0bd23fd13b1c3db309b7a925098226eaf`. The release ledger records one uploaded VSIX; GitHub also supplies generated source archives. |
+| crates.io — complete allow-list | **verified complete** | Issue #8736 records all 31 allow-listed crates live at `0.14.0`; publish workflow run `25716911656` completed successfully. |
+| VS Code Marketplace | **verified complete** | Issue #8736 records version `0.14.0` from the Marketplace gallery API after the packaging repair. |
+| Open VSX | **verified complete** | Issue #8736 records version `0.14.0` from the Open VSX API after the packaging repair. |
+| Docker Hub | **verified complete** | The `0.14.0` builder and `0.14.0-perl` runtime tags were pushed May 12 after the Rust 1.95 repair. Both expose `linux/amd64` and `linux/arm64` manifests. |
+| GHCR | **verified partial / defective** | Both `0.14.0` package versions were created May 12. Authenticated manifest reads show only `linux/arm64` plus provenance attestation for each tag; `linux/amd64` is absent. |
+| Homebrew | **not published** | The owned tap moved directly from merged `0.13.3` PR #8 to merged `0.15.0` PR #10. No `0.14.0` formula commit or PR exists between those states. |
+| Scoop | **not published** | The release workflow produced only a repo-local template. No `perl-lsp` manifest, PR, or commit was located in `ScoopInstaller/Main`, and no `0.14.0` upstream acceptance receipt exists. |
+| Chocolatey | **not published** | The contemporaneous #2089 verification found no official `perl-lsp` package. The repo-local nuspec remained a placeholder template and no `0.14.0` registry receipt exists. |
+| Winget | **not published** | The v0.14 workflow refreshed only a repo-local template and explicitly left upstream `winget-pkgs` submission manual. No local refresh PR or upstream package submission exists for `0.14.0`. |
 
-```yaml
-channels:
-  github_release: "published 2026-05-12"
-  crates_io: "0.14.0 primary packages visible; full 31-crate receipt pending"
-  vscode_marketplace: "EffortlessMetrics.perl-lsp-rs"
-  open_vsx: pending
-  docker: pending
-```
+A workflow completion is not treated as public availability unless the channel
+was also observed through its registry, package API, public manifest, or an
+immutable downstream merge. Conversely, a failed first attempt does not prove
+final failure when later registry evidence exists.
 
-Mapped against the audit template:
+A channel classified **not published** or **verified partial / defective** is a
+resolved outcome, not a successful closeout.
 
-| Channel | Reported state | Trigger gap | Action |
-|---|---|---|---|
-| GitHub Release | published 2026-05-12 | none | no action |
-| crates.io (primary 4 crates) | visible | none | no action |
-| crates.io (full 31-crate allow-list) | "receipt pending" | new-crate burst cap (5/10min); remaining allow-listed crates may have hit HTTP 429 | `just publish-new-crates` (10-min spacing per `MANUAL_PUBLISH_NEW_CRATES.md`); verify with the `cargo metadata` enumeration in the template |
-| VS Code Marketplace | name only, no status | `publish-extension.yml` is **workflow_dispatch only** - never fires on tag | `gh workflow run publish-extension.yml -f version=0.14.0` (requires `VSCE_PAT`) |
-| Open VSX | pending | same workflow as VS Code Marketplace | same dispatch (also publishes to Open VSX); requires `OVSX_PAT` |
-| Docker | pending | `docker-publish.yml` is **workflow_dispatch only** - never fires on tag | `gh workflow run docker-publish.yml -f version=0.14.0` (requires `DOCKER_USERNAME`, `DOCKER_PASSWORD`) |
-| Homebrew tap | unverified | auto-fires on `release:published`; tap-repo PR may be open and unmerged | `gh pr list -R EffortlessMetrics/homebrew-perllsp --state all --limit 5`; merge if open |
-| Scoop bucket | unverified | same shape as Homebrew | `gh pr list -R EffortlessMetrics/scoop-perllsp --state all --limit 5` |
-| Chocolatey | unverified | auto-fires; moderation queue can delay | `choco search perllsp --exact` |
+## Evidence reconstruction
 
-## Potential user-facing impact
+### GitHub Release
 
-If the bug reporter was on Linux/macOS: they installed via either
-`cargo install perllsp` (worked - primary crates were at 0.14.0) or
-`brew install effortlessmetrics/tap/perllsp` (possibly stale - tap PR may have been unmerged) or
-downloaded the GitHub Release binary (worked).
+The canonical release is
+[`v0.14.0`](https://github.com/EffortlessMetrics/perl-lsp/releases/tag/v0.14.0),
+published on May 12, 2026 at live tag commit
+`977709e0bd23fd13b1c3db309b7a925098226eaf`.
 
-If the reporter was using the VS Code extension: at 9 days post-tag,
-the Marketplace listing may still have been on 0.13.x because
-`publish-extension.yml` is dispatch-only. Same for Open VSX.
+The historical release ledger records one uploaded VSIX for this release. GitHub
+also renders its generated source ZIP and source tarball. Those generated source
+archives are not additional uploaded release artifacts.
 
-The Docker channel being stale would only affect users running perl-lsp
-in containers (CI integration, IDE plugins that bundle the server).
-LSP4IJ doesn't use the Docker image directly, so this is not the
-documented crash-report channel - but it's still 0.14.0 unfinished business.
+### crates.io
 
-## Remediation steps (run from `EffortlessMetrics/perl-lsp`)
+Issue [#8736](https://github.com/EffortlessMetrics/perl-lsp/issues/8736)
+records:
 
-1. Dispatch the three missing channels:
-   ```bash
-   gh workflow run publish-extension.yml -f version=0.14.0
-   gh workflow run docker-publish.yml    -f version=0.14.0
-   ```
-2. Manually clear the new-crate rate-limit backlog:
-   ```bash
-   just publish-new-crates
-   ```
-3. Verify Homebrew/Scoop/Chocolatey tap PRs merged:
-   ```bash
-   gh pr list -R EffortlessMetrics/homebrew-perllsp --state all --limit 5
-   gh pr list -R EffortlessMetrics/scoop-perllsp    --state all --limit 5
-   ```
-4. Re-run the per-channel verification block from
-   [`RELEASE_CLOSEOUT_AUDIT.md`](RELEASE_CLOSEOUT_AUDIT.md) and update
-   the `channels` frontmatter in
-   [`v0.14.0.md`](v0.14.0.md) to reflect actuals.
-5. Flip `notes_status: canonical -> closed` in `v0.14.0.md` only when
-   every channel resolves to `0.14.0` or is documented as deliberately
-   skipped.
+- publish workflow run `25716911656` completed successfully;
+- all 31 crates in `[workspace.metadata.publish.allow]` were visible at
+  `0.14.0` through the crates.io API;
+- the workflow's post-publish smoke failures referenced stale hardcoded crate
+  names, so they did not indicate missing publication.
 
-## What must run from `EffortlessMetrics/perl-lsp`
+This supersedes the original audit's “primary packages visible; full receipt
+pending” classification.
 
-The workflows above all live in `EffortlessMetrics/perl-lsp` (the
-publishing repo). `perl-lsp-swarm` does not own release secrets or
-publishing workflow dispatch, so:
+### VS Code Marketplace and Open VSX
 
-- Dispatching `publish-extension.yml`, `docker-publish.yml`, or the
-  `*-bump.yml` workflows requires publishing-repo access and the
-  relevant release-secret scope.
-- Marketplace, registry, and tap state must be verified by the release
-  operator at closeout time.
+The first extension publish attempt, run `25721140145`, failed before
+publication because `@types/vscode ^1.118.0` was greater than the extension's
+`engines.vscode ^1.116.0` declaration.
 
-The remediation has to be driven by someone with access to the
-publishing repo. This doc is the runbook for that work.
+PR [#8732](https://github.com/EffortlessMetrics/perl-lsp/pull/8732) aligned the
+constraint at commit `a910ac44c61345ed81849ab33ee3e7c1ac531bce`.
 
-## Lessons applied to 0.15.0
+Issue [#8736](https://github.com/EffortlessMetrics/perl-lsp/issues/8736) then
+records independent API results for both registries:
 
-The 0.15.0 release notes staged in PR #232 inherit the `channels` block
-with all entries set to `pending`. The 0.15.0 cut workflow:
+- VS Code Marketplace gallery API: `0.14.0`;
+- Open VSX API: `0.14.0`.
 
-1. Tag `v0.15.0` in publishing repo
-2. `release-orchestration.yml` dispatches binary builds, GitHub release,
-   crates.io publish (will hit the same new-crate cap if any new crates
-   added - none planned for 0.15.0, but verify)
-3. **Immediately** dispatch the three dispatch-only workflows:
-   ```bash
-   gh workflow run publish-extension.yml -f version=0.15.0
-   gh workflow run docker-publish.yml    -f version=0.15.0
-   ```
-4. Verify the brew/scoop/chocolatey bump PRs land in their respective
-   tap repos
-5. Run `RELEASE_CLOSEOUT_AUDIT.md` verification block, populate
-   `0.15.0-closeout-audit.md`, flip `notes_status` to `closed`
+Those registry observations prove that the recovery completed. The original
+claim that the editor workflow was never dispatched is superseded.
+
+### Initial container failure and repair
+
+Issue [#8734](https://github.com/EffortlessMetrics/perl-lsp/issues/8734)
+records the failed Docker publish on source commit `c2d5ae22`:
+
+- the builder image succeeded;
+- the `linux/amd64` runtime image failed;
+- the `linux/arm64` runtime image failed;
+- the dependent Docker Hub runtime publication did not complete in that attempt.
+
+The root cause was an MSRV mismatch: the Dockerfiles still used
+`rust:1.92-slim-bookworm` after the workspace moved to Rust 1.95. Commit
+`d125c2934094156d5701880981a3bcb1ff965348` updated both Dockerfiles to
+`rust:1.95-slim-bookworm` at 09:42 UTC on May 12.
+
+The repair commit alone was not publication proof. The registry probes below
+establish the post-repair outcome.
+
+### Docker Hub — complete multi-architecture publication
+
+A read-only registry probe in workflow run
+[`29191625417`](https://github.com/EffortlessMetrics/perl-lsp/actions/runs/29191625417)
+queried Docker Hub's tag API and inspected both public manifests.
+
+#### Builder / Rust CI image
+
+`effortlessmetrics/perl-lsp:0.14.0`:
+
+- tag pushed: `2026-05-12T11:08:37.028852Z`;
+- index digest: `sha256:d7c0e5be0b64729151260cd2bde14a88a3f990c3e9a30faa765d94e1482d5e20`;
+- `linux/amd64` digest: `sha256:e2be72ff03b5763cd2c4e714f6f4536f6421396acac22c75b9bd61197546dcc0`;
+- `linux/arm64` digest: `sha256:089f55e0b989d2488436f26fc070ce66fd53e13df46963dcfed0c8f4d0062171`.
+
+#### Runtime image
+
+`effortlessmetrics/perl-lsp:0.14.0-perl`:
+
+- tag pushed: `2026-05-12T10:20:40.191260Z`;
+- index digest: `sha256:526d6b55093bcb7c23f3e09f459ac49189dbeba29b0cd1a935d7bc6939c9012e`;
+- both `linux/amd64` and `linux/arm64` manifests are present.
+
+Both Docker Hub tags were therefore published after the Rust 1.95 repair and
+meet the v0.14 workflow's two-platform contract.
+
+### GHCR — published, but missing amd64
+
+An authenticated package-API probe in workflow run
+[`29191709521`](https://github.com/EffortlessMetrics/perl-lsp/actions/runs/29191709521)
+found both package versions:
+
+| Package | Version ID | Created | Tags |
+|---|---:|---|---|
+| `ghcr.io/effortlessmetrics/perl-lsp` | `858710173` | `2026-05-12T11:04:31Z` | `0.14`, `0.14.0` |
+| `ghcr.io/effortlessmetrics/perl-lsp-perl` | `858601832` | `2026-05-12T10:22:28Z` | `0.14`, `0.14.0` |
+
+A separate authenticated manifest inspection in workflow run
+[`29191747341`](https://github.com/EffortlessMetrics/perl-lsp/actions/runs/29191747341)
+resolved both tags successfully. Each is an OCI image index with two entries:
+
+- `linux/arm64`; and
+- an `unknown/unknown` provenance or attestation entry.
+
+Neither live index contains `linux/amd64`.
+
+The v0.14 workflow pushed the same GHCR tag independently from each platform
+matrix job rather than assembling a consolidated multi-platform index. The live
+registry outcome is arm64-only for both tags. This audit records the observable
+result without claiming when or why the amd64 entry was displaced.
+
+GHCR is therefore **published but defective**, not absent and not complete.
+
+### Package-manager trigger boundary
+
+The `v0.14.0` release orchestrator explicitly dispatched four workflows:
+
+1. binary build and GitHub Release;
+2. crates.io publication;
+3. VS Code Marketplace / Open VSX publication; and
+4. Docker publication.
+
+It did **not** dispatch the Homebrew, Scoop, Chocolatey, or Winget workflows.
+Those workflows appeared only as static links in the orchestration summary.
+Earlier distribution reviews (#2089 and #2596) had already recorded that the
+release-event path had not produced package-manager runs and that external
+acceptance remained outside the repo-contained automation.
+
+PR #3004 added shared manifest generation and a repo-local Winget refresh, but
+its stated boundary left external community-repository approvals and submissions
+as separate work. PR #3010 likewise classified upstream acceptance and real
+Windows installs as manual verification. PR #3106 fixed the Windows release-asset
+filename mismatch, while its test plan still deferred the first workflow-dispatch
+test to a later release.
+
+### Homebrew — direct version skip
+
+The canonical workflow target at the `v0.14.0` cut was the owned
+[`EffortlessMetrics/homebrew-tap`](https://github.com/EffortlessMetrics/homebrew-tap)
+repository, not the obsolete `homebrew-perllsp` name in the original audit.
+
+Its immutable PR sequence resolves the outcome:
+
+- PR #8, **perllsp 0.13.3**, merged May 3 at
+  `a6de8a20912f663f9d83360d8204dd5f2a6b4ad3`;
+- PR #10, **perllsp 0.15.0**, was opened directly from that same base and merged
+  May 22 at `0b7fe79be11916d2c28f1921a569c2d12cdff29c`.
+
+There is no intervening `0.14.0` formula PR or commit. The tap therefore skipped
+`0.14.0`; this channel is resolved as **not published**.
+
+### Scoop — no accepted upstream manifest
+
+The v0.14 Scoop workflow targeted `ScoopInstaller/Main`, not the obsolete
+`scoop-perllsp` repository name in the original audit. It updated the
+repo-local `distribution/scoop/perl-lsp.json` template before attempting an
+external PR.
+
+No `perl-lsp` manifest, PR, or commit was located in `ScoopInstaller/Main`.
+The repo-local file remained a placeholder template rather than a committed
+`0.14.0` manifest. Together with the undispatched package-manager path, this
+resolves the release as **not published through Scoop**.
+
+### Chocolatey — no official package
+
+The repo-local Chocolatey files described a package named `perl-lsp`, but the
+contemporaneous #2089 verification found no package at the official Chocolatey
+community registry. The nuspec remained a placeholder template and no later
+`0.14.0` publication receipt was found.
+
+The workflow's existence is not publication evidence. The channel is resolved
+as **not published through Chocolatey**.
+
+### Winget — local template only
+
+The v0.14 Winget workflow was narrower than its name suggested. It refreshed
+`distribution/winget/perl-lsp.yaml` in the source repository and stated in its
+PR body that upstream `winget-pkgs` submission remained a manual follow-up.
+
+No repo-local `0.14.0` refresh PR was found; the manifest remained populated
+with release placeholders. No matching package or PR was found in
+`microsoft/winget-pkgs`. The channel is resolved as **not published through
+Winget**.
+
+## Correction to the original user-impact inference
+
+The original audit noted that an LSP4IJ bug reporter was still running `0.13.3`
+nine days after the tag. That observation remains valid, but it does not prove
+that VS Code Marketplace or Open VSX remained stale.
+
+The recovered API evidence shows that `0.14.0` reached both editor registries
+after the first publish attempt was repaired. A user's older installed version
+can also result from editor choice, update timing, channel selection, or manual
+installation. This audit therefore removes the prior causal inference while
+preserving the user report.
+
+## Closeout result
+
+All channels now have an evidenced final classification:
+
+- **complete:** GitHub Release, crates.io, VS Code Marketplace, Open VSX,
+  Docker Hub;
+- **published but defective:** GHCR, missing `linux/amd64` from both tags;
+- **not published:** Homebrew, Scoop, Chocolatey, Winget.
+
+No unresolved channel remains. The follow-up work is record propagation rather
+than further historical discovery:
+
+1. update `docs/releases/v0.14.0.md` frontmatter with these actuals;
+2. add an append-only `RELEASE_HISTORY.md` correction rather than rewriting the
+   original row;
+3. extend `policy/release-channel-actuals.json` so the permanent drift guard
+   preserves the reconstructed state;
+4. retain the GHCR amd64 omission as a historical release defect rather than
+   silently calling the channel complete.
+
+## Claim boundary
+
+This audit proves five complete channels and one partial channel. It also proves
+that four package-manager channels did not publish `0.14.0`.
+
+It does not claim that later versions repair the historical v0.14.0 channel
+state, and it does not treat current tag presence alone as sufficient evidence:
+Docker Hub and GHCR creation timestamps tie the observed tags to May 12, 2026.
 
 ## Tracking
 
-- 0.14.0 release notes: [`v0.14.0.md`](v0.14.0.md)
-- 0.14.0 readiness queue: [`0.14.0-readiness.md`](0.14.0-readiness.md)
-- 0.15.0 staging PR: #232
+- Reconstruction issue: [#9968](https://github.com/EffortlessMetrics/perl-lsp/issues/9968)
+- Audit reconstruction PR: [#9969](https://github.com/EffortlessMetrics/perl-lsp/pull/9969)
+- Editor/crate recovery receipt: [#8736](https://github.com/EffortlessMetrics/perl-lsp/issues/8736)
+- Initial editor publish failure: [#8731](https://github.com/EffortlessMetrics/perl-lsp/issues/8731)
+- Editor packaging repair: [#8732](https://github.com/EffortlessMetrics/perl-lsp/pull/8732)
+- Docker failure: [#8734](https://github.com/EffortlessMetrics/perl-lsp/issues/8734)
+- Docker MSRV repair commit: [`d125c293`](https://github.com/EffortlessMetrics/perl-lsp/commit/d125c2934094156d5701880981a3bcb1ff965348)
+- Docker Hub receipt run: [`29191625417`](https://github.com/EffortlessMetrics/perl-lsp/actions/runs/29191625417)
+- GHCR package receipt run: [`29191709521`](https://github.com/EffortlessMetrics/perl-lsp/actions/runs/29191709521)
+- GHCR manifest receipt run: [`29191747341`](https://github.com/EffortlessMetrics/perl-lsp/actions/runs/29191747341)
+- Windows distribution verification: [#2089](https://github.com/EffortlessMetrics/perl-lsp/issues/2089)
+- Windows package automation: [#2596](https://github.com/EffortlessMetrics/perl-lsp/issues/2596)
+- Homebrew `0.13.3` state: [`homebrew-tap#8`](https://github.com/EffortlessMetrics/homebrew-tap/pull/8)
+- Homebrew `0.15.0` state: [`homebrew-tap#10`](https://github.com/EffortlessMetrics/homebrew-tap/pull/10)
+- Release notes: [`v0.14.0.md`](v0.14.0.md)
 - Audit template: [`RELEASE_CLOSEOUT_AUDIT.md`](RELEASE_CLOSEOUT_AUDIT.md)


### PR DESCRIPTION
## Objective

Reconstruct the actual `v0.14.0` distribution-channel outcome from immutable repository, workflow, downstream-PR, registry, package-API, and authenticated manifest receipts.

Fixes #9968.

This PR is stacked on #9966 so it inherits the release-channel actuals guard and restored closeout framework. It changes only `docs/releases/0.14.0-closeout-audit.md`.

## Final classification

### Verified complete

- **GitHub Release:** published May 12, 2026 at live tag commit `977709e0bd23fd13b1c3db309b7a925098226eaf`.
- **crates.io:** all 31 allow-listed crates at `0.14.0`; issue #8736 preserves publish run `25716911656` and the API enumeration.
- **VS Code Marketplace / Open VSX:** both returned version `0.14.0` through their APIs after #8732 repaired the first packaging failure.
- **Docker Hub:** both expected tags were pushed on May 12 after the Rust 1.95 repair. `0.14.0` and `0.14.0-perl` each expose `linux/amd64` and `linux/arm64` manifests.

### Published but defective

- **GHCR:** both expected `0.14.0` package versions exist with May 12 creation timestamps. Authenticated manifest reads show only `linux/arm64` plus provenance attestation for each tag; `linux/amd64` is missing.

### Not published

- **Homebrew:** the owned tap moved directly from merged `0.13.3` PR `homebrew-tap#8` to merged `0.15.0` PR `homebrew-tap#10`; no `0.14.0` formula state exists.
- **Scoop:** no `perl-lsp` manifest, PR, or commit exists in `ScoopInstaller/Main`; the repo-local file remained a template.
- **Chocolatey:** the contemporaneous #2089 verification found no official `perl-lsp` package, and no later `0.14.0` receipt exists.
- **Winget:** the workflow only refreshed a repo-local template and explicitly left upstream submission manual; no local refresh PR or upstream package exists for `0.14.0`.

Every channel now has an evidenced final classification. The audit is closed **with defects**, not declared all-green.

## Container receipts

Read-only probe runs recorded the registry state:

- `29191625417` — Docker Hub API metadata and public manifests:
  - `effortlessmetrics/perl-lsp:0.14.0`, pushed `2026-05-12T11:08:37Z`, amd64 + arm64;
  - `effortlessmetrics/perl-lsp:0.14.0-perl`, pushed `2026-05-12T10:20:40Z`, amd64 + arm64.
- `29191709521` — GitHub Packages API:
  - `perl-lsp` version `858710173`, created `2026-05-12T11:04:31Z`;
  - `perl-lsp-perl` version `858601832`, created `2026-05-12T10:22:28Z`.
- `29191747341` — authenticated GHCR manifests: both tags resolve, but each index contains arm64 plus attestation and no amd64 image.

## Corrections to the old audit

- Replaces obsolete repository names with the actual v0.14 workflow targets.
- Records that the release orchestrator dispatched binary, crates, editor, and Docker workflows but did not dispatch package-manager workflows; those appeared only as summary links.
- Corrects the first editor failure to the actual `@types/vscode ^1.118.0` versus `engines.vscode ^1.116.0` mismatch.
- Removes the unsupported inference that a user remaining on 0.13.3 proved the editor registries were stale.
- Distinguishes complete publication, partial/defective publication, and negative resolution.

## Claim boundary

This PR does not alter `v0.14.0.md`, `RELEASE_HISTORY.md`, or the machine-readable channel ledger. Those canonical updates remain sequenced after the 0.13 lineage/tag-provenance stack and #9966/#9967 converge.

It does not infer historical success from later releases. Docker Hub and GHCR creation timestamps tie the observed container tags to May 12, 2026.

## Merge order

1. Merge #9956.
2. Merge #9966.
3. Retarget this PR to `master` if GitHub does not do so automatically.
4. Merge this audit reconstruction.
5. Propagate the final v0.14 classifications into the note frontmatter, append-only ledger correction, and permanent channel-actuals manifest.