### PR TITLE
fix(critic): align recommended profile helper with its name (#9978)

### DIFF
--- a/crates/perl-lsp-rs-core/src/tooling/native_compat.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/native_compat.rs
@@ -6,7 +6,7 @@
 //! artifacts; this module provides the small stable report model needed by the
 //! installed `perllsp` binary.
 
-use super::perl_critic::NativeCriticRegistry;
+use super::perl_critic::{NativeCriticProfile, NativeCriticRegistry};
 use serde::Serialize;
 use std::collections::BTreeSet;
 
@@ -153,7 +153,7 @@ pub fn classify_perltidy_profile(raw: &str) -> PerltidyCompatReport {
 /// Classify a `.perlcriticrc`-style profile against native critic support.
 #[must_use]
 pub fn classify_perlcritic_profile(raw: &str) -> PerlcriticCompatReport {
-    let native_rules = NativeCriticRegistry::recommended()
+    let native_rules = NativeCriticRegistry::for_profile(NativeCriticProfile::Strict)
         .rule_ids()
         .into_iter()
         .map(ToOwned::to_owned)

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native.rs
@@ -2755,7 +2755,7 @@ mod tests {
         assert!(!recommended_ids.contains(&"native.variables.unused_lexical"));
         assert!(!recommended_ids.contains(&"native.syntax.unquoted_bareword"));
         assert!(recommended_ids.len() < strict_ids.len());
-        assert_eq!(strict_ids.len(), NativeCriticRegistry::recommended().len());
+        assert_eq!(recommended_ids.len(), NativeCriticRegistry::recommended().len());
     }
 
     #[test]
@@ -4341,7 +4341,7 @@ mod tests {
         let ast = parse_source(source);
         let config = CriticConfig::default();
         let ctx = CriticContext::new(source, &ast, &config);
-        let registry = NativeCriticRegistry::recommended();
+        let registry = NativeCriticRegistry::for_profile(NativeCriticProfile::Recommended);
 
         let findings = registry.check(&ctx);
 
@@ -4363,19 +4363,7 @@ mod tests {
                 "native.security.qx_readpipe",
                 "native.security.backtick_exec",
                 "native.security.string_eval",
-                "native.security.system_exec",
-                "native.variables.unused_lexical",
-                "native.variables.unused_parameter",
-                "native.variables.duplicate_parameter",
-                "native.variables.parameter_shadows_global",
-                "native.variables.duplicate_lexical",
-                "native.variables.shadowed_lexical",
-                "native.regex.capture_without_match",
-                "native.variables.undeclared",
-                "native.variables.uninitialized",
-                "native.syntax.unquoted_bareword",
-                "native.documentation.require_pod_sections",
-                "native.syntax.prohibit_leading_zeros"
+                "native.security.system_exec"
             ]
         );
         assert_eq!(findings.len(), 2);

--- a/crates/perl-lsp-rs-core/src/tooling/perl_critic/native/native_registry.rs
+++ b/crates/perl-lsp-rs-core/src/tooling/perl_critic/native/native_registry.rs
@@ -70,19 +70,17 @@ impl NativeCriticRegistry {
 
     /// Create the default recommended native critic registry.
     ///
-    /// This is the opt-in bundle for callers migrating from ad hoc built-in
-    /// policy execution to the native rule contract. Keep ordering stable so
-    /// diagnostics and receipts are deterministic.
+    /// This is the lower-noise bundle intended for normal editor diagnostics.
+    /// Keep ordering stable so diagnostics and receipts are deterministic.
     #[must_use]
     pub fn recommended() -> Self {
-        Self::for_profile(NativeCriticProfile::Strict)
+        Self::for_profile(NativeCriticProfile::Recommended)
     }
 
     /// Create a native critic registry for a named profile.
     ///
-    /// Runtime diagnostics still use `recommended()` for compatibility. The
-    /// explicit profile entry point lets receipts and readiness checks measure
-    /// lower-noise default candidates without changing the opt-in runtime path.
+    /// The explicit profile entry point lets receipts and readiness checks
+    /// measure either the lower-noise default or the full strict rule set.
     #[must_use]
     pub fn for_profile(profile: NativeCriticProfile) -> Self {
         match profile {

--- a/crates/perl-lsp-rs-core/tests/native_critic_registry.rs
+++ b/crates/perl-lsp-rs-core/tests/native_critic_registry.rs
@@ -138,13 +138,11 @@ fn registry_built_in_profiles_have_unique_rule_ids() {
 }
 
 #[test]
-fn registry_recommended_helper_matches_strict_profile() {
-    // `NativeCriticRegistry::recommended()` is documented as a compatibility
-    // shim: it currently returns the strict profile. Pin that contract here
-    // so a quiet roster change doesn't slip past.
+fn registry_recommended_helper_matches_recommended_profile() {
     let recommended_helper = NativeCriticRegistry::recommended().rule_ids();
-    let strict_profile = NativeCriticRegistry::for_profile(NativeCriticProfile::Strict).rule_ids();
-    assert_eq!(recommended_helper, strict_profile);
+    let recommended_profile =
+        NativeCriticRegistry::for_profile(NativeCriticProfile::Recommended).rule_ids();
+    assert_eq!(recommended_helper, recommended_profile);
 }
 
 // ---- NativeCriticRegistry::check: include / exclude / severity gates --------

--- a/xtask/src/tasks/native_tooling.rs
+++ b/xtask/src/tasks/native_tooling.rs
@@ -9,7 +9,7 @@ use perl_lsp_rs_core::tooling::native_compat::{
     PerlcriticCompatItem, PerlcriticCompatReport, PerlcriticNativeConfigSuggestion,
     classify_perlcritic_profile, render_perlcritic_compat_markdown,
 };
-use perl_lsp_rs_core::tooling::perl_critic::NativeCriticRegistry;
+use perl_lsp_rs_core::tooling::perl_critic::{NativeCriticProfile, NativeCriticRegistry};
 use perl_lsp_rs_core::tooling::perltidy::FormatConfig;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -985,7 +985,7 @@ fn critic_status(
     critic_check_receipt: &Path,
     critic_false_positive_receipt: &Path,
 ) -> Result<CriticStatus> {
-    let registry = NativeCriticRegistry::recommended();
+    let registry = NativeCriticRegistry::for_profile(NativeCriticProfile::Strict);
     let native_rules = registry.rule_ids().into_iter().map(ToOwned::to_owned).collect::<Vec<_>>();
     let fixable = fixable_rule_ids();
     let missing_fix_rules = fixable


### PR DESCRIPTION
Problem: On current `master`, `NativeCriticRegistry::recommended()` is documented as the default lower-noise bundle but returns the Strict profile. Compatibility and release-readiness callers therefore depend on an ambiguous helper, and tests encode the mismatch.

Fix: Make `recommended()` delegate to `NativeCriticProfile::Recommended`. Make the compatibility classifier and native-tooling readiness task explicitly request `Strict` where they measure the full catalog. Update registry tests and the native rule-check fixture to assert the intended profile.

Behavior boundaries:
- Runtime production code has no remaining `NativeCriticRegistry::recommended()` callers; editor diagnostic behavior is unchanged.
- No rules are added, removed, promoted, or reordered.
- Strict readiness and compatibility coverage remain strict; normal registry semantics now match the method name.

Verification:
- `RUSTC_WRAPPER=/usr/bin/env ./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked --test native_critic_registry` passes (22 tests)
- `RUSTC_WRAPPER=/usr/bin/env ./scripts/cargo-safe test -p perl-lsp-rs-core --profile agent --locked --lib native_compat` passes (10 tests)
- `RUSTC_WRAPPER=/usr/bin/env ./scripts/cargo-safe test -p xtask --bin xtask --profile agent --locked native_tooling -- --nocapture` passes (6 tests)
- Core and `xtask` all-target checks pass
- Core library and `xtask` binary Clippy pass with `-D warnings -A missing_docs`
- `rustfmt --edition 2024 --check` passes for all five changed Rust files
- `git diff --check` passes
- `RUSTC_WRAPPER=/usr/bin/env just agent-pr-fast` completed 17 gates successfully; its routed test gate reproduces the unchanged baseline failure `crates/perl-lsp-rs/tests/file_discovery_tests.rs::skips_target_and_cache_directories` at line 159.

Non-goals: no new critic rules, profile promotions, editor diagnostics, formatter, Kwalitee, TAP, URI, or broad policy changes.

Fixes #9978