### PR TITLE
fix(format): fail closed on empty statement spans (#9980)

### DIFF
--- a/crates/perl-lsp-perltidy/src/native.rs
+++ b/crates/perl-lsp-perltidy/src/native.rs
@@ -982,6 +982,13 @@ fn format_simple_statement_block(
             continue;
         }
 
+        // Empty statements are valid Perl, but the safe subset has no layout
+        // representation for them. Fail closed before dispatching to a
+        // statement formatter that expects a non-empty token span.
+        if tokens[start].kind == TokenKind::Semicolon {
+            return None;
+        }
+
         let statement_tokens = &tokens[start..=idx];
         statements.push(format_simple_statement_tokens(statement_tokens, config)?);
         start = idx + 1;

--- a/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/native_formatter_layout_tests.rs
@@ -658,6 +658,50 @@ fn native_formatter_expands_simple_subroutine_blocks() {
 }
 
 #[test]
+fn native_formatter_handles_consecutive_empty_statements() {
+    let formatter = NativeFormatter::new();
+    let sources = [
+        "if($ok){;}\n",
+        "if($ok){;;}\n",
+        "if($ok){print 1;;}\n",
+        "if($ok){if($nested){;;}}\n",
+        "sub answer{;;}\n",
+        "sub answer{if($ok){;;}}\n",
+        "while($ok){;;}continue{;;}\n",
+        "for(;;){;;}\n",
+        "for($i=0;;$i++){;;}\n",
+        "foreach $x(@xs){;;}\n",
+        "if($ok){print 1;}else{;;}\n",
+    ];
+
+    for source in sources {
+        let result = std::panic::catch_unwind(|| {
+            formatter.format_document(source, &FormatConfig::default())
+        });
+        assert!(result.is_ok(), "native formatter panicked for {source:?}");
+    }
+
+    let bodies = [
+        ";",
+        ";;",
+        ";;;",
+        "print 1;;",
+        ";print 1;",
+        "if($nested){;;};",
+        "if($nested){print 1;;};",
+        "for(;;){;;};",
+    ];
+    for body in bodies {
+        for source in [format!("sub answer{{{body}}}\n"), format!("if($ok){{{body}}}\n")] {
+            let result = std::panic::catch_unwind(|| {
+                formatter.format_document(&source, &FormatConfig::default())
+            });
+            assert!(result.is_ok(), "native formatter panicked for {source:?}");
+        }
+    }
+}
+
+#[test]
 fn native_formatter_places_opening_braces_on_next_line_when_configured() {
     let formatter = NativeFormatter::new();
     let config =


### PR DESCRIPTION
Problem: The native formatter's safe statement-block path passed leading and consecutive semicolon spans to formatters that require non-empty token ranges, allowing valid Perl empty statements to trigger a panic.

Fix: Detect an empty span before dispatch and return the existing unsupported/unchanged result. Added regression coverage for empty and consecutive statements across conditional, subroutine, loop, nested, and `for(;;)` bodies.

Behavior boundaries:
- Unsupported empty-statement layouts fail closed; no formatting layout is invented.
- The current `for`-based statement parser is preserved; no unrelated nested-control refactor is included.
- No changes to literal, comment, POD, heredoc, range-format, or external perltidy handling.

Verification:
- `RUSTC_WRAPPER=/usr/bin/env ./scripts/cargo-safe test -p perl-lsp-perltidy --profile agent --locked --test native_formatter_layout_tests native_formatter_handles_consecutive_empty_statements` passes
- `RUSTC_WRAPPER=/usr/bin/env ./scripts/cargo-safe test -p perl-lsp-perltidy --profile agent --locked --test native_formatter_layout_tests` passes (69 tests)
- `RUSTC_WRAPPER=/usr/bin/env ./scripts/cargo-safe test -p perl-lsp-perltidy --profile agent --locked` passes
- All-target check and library Clippy pass with `-D warnings -A missing_docs`
- All-target Clippy is blocked only by the unchanged existing trailing-comma violation at `crates/perl-lsp-perltidy/src/native.rs:2277`
- `rustfmt --edition 2024 --check` and `git diff --check` pass

Non-goals: no formatter expansion, no critic, Kwalitee, TAP, URI, or profile work.

Fixes #9980