### PR TITLE
fix(format): match leading closers to opener stack (#9992)

### DIFF
--- a/crates/perl-lsp-perltidy/src/lib.rs
+++ b/crates/perl-lsp-perltidy/src/lib.rs
@@ -370,7 +370,7 @@ impl BuiltInFormatter {
     #[must_use]
     pub fn format(&self, code: &str) -> String {
         let mut result = String::new();
-        let mut indent_level: i32 = 0;
+        let mut delimiter_stack = Vec::new();
         let lines: Vec<&str> = code.lines().collect();
         let had_trailing_newline = code.ends_with('\n');
         let indent_str = if self.config.tabs.unwrap_or(false) {
@@ -381,8 +381,8 @@ impl BuiltInFormatter {
 
         for (index, line) in lines.iter().enumerate() {
             let trimmed = line.trim();
-            let leading_closers = count_leading_closers(trimmed) as i32;
-            indent_level = indent_level.saturating_sub(leading_closers);
+            let leading_closers = count_matching_leading_closers(trimmed, &delimiter_stack);
+            let indent_level = delimiter_stack.len().saturating_sub(leading_closers);
 
             if !trimmed.is_empty() {
                 for _ in 0..indent_level {
@@ -396,23 +396,58 @@ impl BuiltInFormatter {
                 result.push('\n');
             }
 
-            // net_delimiter_delta counts all delimiters including leading closers.
-            // We already decremented by leading_closers before printing, so add them
-            // back to avoid double-counting: the net change for the *next* line is
-            // delta + leading_closers (leading closers cancel in the net formula).
-            indent_level = (indent_level + net_delimiter_delta(trimmed) + leading_closers).max(0);
+            apply_delimiter_events(trimmed, &mut delimiter_stack);
         }
 
         result
     }
 }
 
-fn count_leading_closers(line: &str) -> usize {
-    line.chars().take_while(|ch| matches!(ch, '}' | ')' | ']')).count()
+fn count_matching_leading_closers(line: &str, delimiter_stack: &[char]) -> usize {
+    let mut stack_index = delimiter_stack.len();
+    let mut matched = 0;
+
+    for closer in line.chars().take_while(|ch| matches!(ch, '}' | ')' | ']')) {
+        let Some(&opening) =
+            stack_index.checked_sub(1).and_then(|index| delimiter_stack.get(index))
+        else {
+            break;
+        };
+        if matching_closer(opening) != Some(closer) {
+            break;
+        }
+        matched += 1;
+        stack_index -= 1;
+    }
+
+    matched
 }
 
-fn net_delimiter_delta(line: &str) -> i32 {
-    let mut delta = 0_i32;
+fn apply_delimiter_events(line: &str, delimiter_stack: &mut Vec<char>) {
+    for delimiter in significant_delimiters(line) {
+        match delimiter {
+            opening @ ('{' | '(' | '[') => delimiter_stack.push(opening),
+            closer @ ('}' | ')' | ']') => {
+                if delimiter_stack.last().copied().and_then(matching_closer) == Some(closer) {
+                    delimiter_stack.pop();
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn matching_closer(opening: char) -> Option<char> {
+    match opening {
+        '{' => Some('}'),
+        '(' => Some(')'),
+        '[' => Some(']'),
+        _ => None,
+    }
+}
+
+fn significant_delimiters(line: &str) -> Vec<char> {
+    let mut delimiters = Vec::new();
     let mut in_single = false;
     let mut in_double = false;
     let mut escaped = false;
@@ -456,12 +491,10 @@ fn net_delimiter_delta(line: &str) -> i32 {
             break;
         }
 
-        match ch {
-            '{' | '(' | '[' => delta += 1,
-            '}' | ')' | ']' => delta -= 1,
-            _ => {}
+        if matches!(ch, '{' | '(' | '[' | '}' | ')' | ']') {
+            delimiters.push(ch);
         }
     }
 
-    delta
+    delimiters
 }

--- a/crates/perl-lsp-perltidy/tests/config_tests.rs
+++ b/crates/perl-lsp-perltidy/tests/config_tests.rs
@@ -345,6 +345,20 @@ fn builtin_formatter_multi_closer_line_does_not_over_decrement() {
     assert_eq!(lines[6], "print 3;"); // at level 0, not negative
 }
 
+#[test]
+fn builtin_formatter_ignores_unmatched_leading_closers_for_indentation() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("if ($ok) {\n)\nprint 1;\n}\n");
+    assert_eq!(formatted, "if ($ok) {\n    )\n    print 1;\n}\n");
+}
+
+#[test]
+fn builtin_formatter_matches_nested_mixed_delimiters() {
+    let formatter = BuiltInFormatter::new(PerlTidyConfig::default());
+    let formatted = formatter.format("foo({\nbar();\n});\nprint 1;\n");
+    assert_eq!(formatted, "foo({\n        bar();\n});\nprint 1;\n");
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn with_os_runtime_clamps_zero_timeout() {


### PR DESCRIPTION
Problem: unmatched leading closing delimiters could reduce formatter indentation below the active opener context.\nFix: track delimiter types, match leading closers against the opener stack, and preserve unmatched closers at the current indentation.\nVerification: full perl-lsp-perltidy tests, all-target check, library clippy, formatting, and diff checks pass.