### PR TITLE
sync: merge swarm workspace capability cut bd3eb11b2 (#0000)

### DIFF
--- a/docs/agents/bounded-subagent-brief-v1.fixtures.json
+++ b/docs/agents/bounded-subagent-brief-v1.fixtures.json
@@ -1,0 +1,216 @@
+{
+  "schema": "bounded-subagent-brief-v1-fixtures",
+  "contract": "docs/agents/bounded-subagent-brief-v1.schema.json",
+  "cases": [
+    {
+      "name": "valid-read-only-explorer",
+      "valid": true,
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234",
+        "basis": {"issue": 1234, "base_sha": "0123456789abcdef"},
+        "role": "explorer",
+        "lifecycle_action": "ResearchIssue",
+        "objective": "Find current ownership evidence for the named seam.",
+        "read_scope": ["issue:1234", "docs/reference/OWNERSHIP.md"],
+        "authorities": ["issue:1234", "repo:origin/main@0123456789abcdef"],
+        "proof_obligations": ["Cite each ownership claim."],
+        "non_goals": ["Do not edit files."],
+        "stop_when": ["The named seam is answered or the basis changes."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "valid-admitted-writer",
+      "valid": true,
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234",
+        "basis": {"issue": 1234, "pr": 5678, "base_sha": "0123456789abcdef", "head_sha": "89abcdef01234567"},
+        "role": "writer",
+        "lifecycle_action": "BuildIssue",
+        "objective": "Implement only the accepted change in the compiled builder view.",
+        "read_scope": ["issue:1234", ".spec/1234-example/context.md"],
+        "write_scope": {"spec": ".spec/1234-example", "branch": "impl/1234-example", "worktree": ".claude/worktrees/1234-example", "edit_cage": "crates/example/src/example.rs"},
+        "compiled_work_order": {"work_order_id": "work-order-1234-v2", "spec_ref": ".spec/1234-example/context.md", "basis_sha": "0123456789abcdef", "freshness": "current", "scope_ref": ".spec/1234-example/context.md#scope", "invariant_refs": [".spec/1234-example/acceptance.md#invariants"], "proof_obligation_refs": [".spec/1234-example/acceptance.md#proof"], "latitude_ref": ".spec/1234-example/context.md#latitude", "return_to_issue_refs": [".spec/1234-example/context.md#return-conditions"]},
+        "admission": {"admission_id": "admission-1234-v1", "outcome": "ADMIT", "ownership_ref": "github:issue/1234#writer-admission"},
+        "authorities": ["issue:1234", "spec:.spec/1234-example/context.md", "admission:admission-1234-v1"],
+        "proof_obligations": ["Run the focused proof and report the exact head."],
+        "non_goals": ["Do not widen the API."],
+        "stop_when": ["The accepted premise changes or the edit cage is insufficient."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "valid-exact-head-reviewer",
+      "valid": true,
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234-review",
+        "basis": {"issue": 1234, "pr": 5678, "base_sha": "0123456789abcdef", "head_sha": "89abcdef01234567"},
+        "role": "reviewer",
+        "lifecycle_action": "ReviewPr",
+        "objective": "Review the exact published head.",
+        "read_scope": ["PR:5678@89abcdef01234567", "required checks"],
+        "authorities": ["github:PR/5678@89abcdef01234567"],
+        "proof_obligations": ["Name the reviewed head in every conclusion."],
+        "non_goals": ["Do not edit the branch."],
+        "stop_when": ["The head changes."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "valid-external-oracle",
+      "valid": true,
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-4196-capability",
+        "basis": {"issue": 4196, "base_sha": "0123456789abcdef"},
+        "role": "oracle",
+        "lifecycle_action": "ResearchIssue",
+        "objective": "Verify the installed runtime capability before configuration.",
+        "read_scope": ["installed runtime help"],
+        "authorities": ["runtime:installed-supported-version"],
+        "proof_obligations": ["Record the supported capability or an explicit unavailable result."],
+        "non_goals": ["Do not edit repository configuration."],
+        "stop_when": ["The capability is verified or unsupported."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "valid-ci-triage",
+      "valid": true,
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234-ci",
+        "basis": {"issue": 1234, "pr": 5678, "base_sha": "0123456789abcdef", "head_sha": "89abcdef01234567"},
+        "role": "ci_triager",
+        "lifecycle_action": "VerifyCurrentHead",
+        "objective": "Classify the failing check against the current PR head.",
+        "read_scope": ["PR:5678@89abcdef01234567", "check logs"],
+        "authorities": ["github:check-run@89abcdef01234567"],
+        "proof_obligations": ["Distinguish product, test, policy, instrument, flaky, and stale-head failures."],
+        "non_goals": ["Do not repair production code."],
+        "stop_when": ["The failure class is evidenced or logs are unavailable."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "valid-cleanup-audit",
+      "valid": true,
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234-cleanup",
+        "basis": {"issue": 1234, "base_sha": "0123456789abcdef"},
+        "role": "cleanup_auditor",
+        "lifecycle_action": "Reconcile",
+        "objective": "Classify only artifacts created by the completed lane.",
+        "read_scope": ["worktree list", "issue:1234", "PR metadata"],
+        "authorities": ["git:worktree-list", "github:issue/1234"],
+        "proof_obligations": ["Preserve ambiguous or unpublished work."],
+        "non_goals": ["Do not remove unrelated worktrees or branches."],
+        "stop_when": ["Every lane-created artifact is KEEP, REMOVE, SALVAGE, or REVIEW."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "invalid-read-only-write-scope",
+      "valid": false,
+      "expected": "non-writer roles cannot carry write_scope",
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234",
+        "basis": {"issue": 1234, "base_sha": "0123456789abcdef"},
+        "role": "reviewer",
+        "lifecycle_action": "ReviewPr",
+        "objective": "Review the supplied head.",
+        "read_scope": ["PR:5678"],
+        "write_scope": {"spec": ".spec/1234-example", "branch": "impl/1234-example", "worktree": ".claude/worktrees/1234-example", "edit_cage": "crates/example/src/example.rs"},
+        "authorities": ["PR:5678"],
+        "proof_obligations": ["Report findings against the inspected head."],
+        "non_goals": ["Do not edit."],
+        "stop_when": ["The head changes."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "invalid-writer-without-admission",
+      "valid": false,
+      "expected": "writer requires compiled work-order, admission, and complete write cage",
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234",
+        "basis": {"issue": 1234, "base_sha": "0123456789abcdef"},
+        "role": "writer",
+        "lifecycle_action": "BuildIssue",
+        "objective": "Implement the requested change.",
+        "read_scope": ["issue:1234"],
+        "authorities": ["issue:1234"],
+        "proof_obligations": ["Run the focused proof."],
+        "non_goals": ["Do not widen scope."],
+        "stop_when": ["The issue changes."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "invalid-pr-without-exact-head",
+      "valid": false,
+      "expected": "a PR basis requires head_sha",
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234-review",
+        "basis": {"issue": 1234, "pr": 5678, "base_sha": "0123456789abcdef"},
+        "role": "reviewer",
+        "lifecycle_action": "ReviewPr",
+        "objective": "Review the exact published head.",
+        "read_scope": ["PR:5678"],
+        "authorities": ["PR:5678"],
+        "proof_obligations": ["Name the reviewed head."],
+        "non_goals": ["Do not edit."],
+        "stop_when": ["The head changes."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "invalid-review-without-pr",
+      "valid": false,
+      "expected": "reviewer roles require PR and exact head identity",
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234-review",
+        "basis": {"issue": 1234, "base_sha": "0123456789abcdef"},
+        "role": "reviewer",
+        "lifecycle_action": "ReviewPr",
+        "objective": "Review the exact published head.",
+        "read_scope": ["current PR metadata"],
+        "authorities": ["issue:1234"],
+        "proof_obligations": ["Name the reviewed PR head."],
+        "non_goals": ["Do not edit."],
+        "stop_when": ["The head changes."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    },
+    {
+      "name": "invalid-stale-writer-work-order",
+      "valid": false,
+      "expected": "writer admission requires a current compiled work order",
+      "packet": {
+        "schema": "bounded-subagent-brief-v1",
+        "work_item": "issue-1234",
+        "basis": {"issue": 1234, "base_sha": "0123456789abcdef"},
+        "role": "writer",
+        "lifecycle_action": "BuildIssue",
+        "objective": "Implement the accepted change.",
+        "read_scope": ["issue:1234", ".spec/1234-example/context.md"],
+        "write_scope": {"spec": ".spec/1234-example", "branch": "impl/1234-example", "worktree": ".claude/worktrees/1234-example", "edit_cage": "crates/example/src/example.rs"},
+        "compiled_work_order": {"work_order_id": "work-order-1234-v1", "spec_ref": ".spec/1234-example/context.md", "basis_sha": "0123456789abcdef", "freshness": "stale", "scope_ref": ".spec/1234-example/context.md#scope", "invariant_refs": [".spec/1234-example/acceptance.md#invariants"], "proof_obligation_refs": [".spec/1234-example/acceptance.md#proof"], "latitude_ref": ".spec/1234-example/context.md#latitude", "return_to_issue_refs": [".spec/1234-example/context.md#return-conditions"]},
+        "admission": {"admission_id": "admission-1234-v1", "outcome": "ADMIT", "ownership_ref": "github:issue/1234#writer-admission"},
+        "authorities": ["issue:1234", "spec:.spec/1234-example/context.md", "admission:admission-1234-v1"],
+        "proof_obligations": ["Run the focused proof."],
+        "non_goals": ["Do not widen scope."],
+        "stop_when": ["The basis changes."],
+        "return_schema": "bounded-subagent-result-v1"
+      }
+    }
+  ]
+}

--- a/docs/agents/bounded-subagent-brief-v1.schema.json
+++ b/docs/agents/bounded-subagent-brief-v1.schema.json
@@ -1,0 +1,437 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/EffortlessMetrics/perl-lsp-swarm/blob/main/docs/agents/bounded-subagent-brief-v1.schema.json",
+  "title": "Bounded Subagent Brief v1",
+  "description": "A compact input packet for one bounded investigation, proof pass, review, or writer mutation. The packet references existing authorities and is not a work or claim database.",
+  "type": "object",
+  "required": [
+    "schema",
+    "work_item",
+    "basis",
+    "role",
+    "lifecycle_action",
+    "objective",
+    "read_scope",
+    "authorities",
+    "proof_obligations",
+    "non_goals",
+    "stop_when",
+    "return_schema"
+  ],
+  "properties": {
+    "schema": {
+      "const": "bounded-subagent-brief-v1"
+    },
+    "work_item": {
+      "type": "string",
+      "description": "Stable issue/spec/PR identity carried into the child result.",
+      "minLength": 1
+    },
+    "basis": {
+      "$ref": "#/definitions/basis"
+    },
+    "role": {
+      "type": "string",
+      "enum": [
+        "explorer",
+        "oracle",
+        "planner",
+        "writer",
+        "verifier",
+        "reviewer",
+        "ci_triager",
+        "cleanup_auditor"
+      ]
+    },
+    "lifecycle_action": {
+      "type": "string",
+      "description": "The root-selected transition this packet supports. This is descriptive, not a scheduler instruction.",
+      "enum": [
+        "EstablishIssue",
+        "ResearchIssue",
+        "SynthesizePlan",
+        "ReviewPlan",
+        "CompileSpec",
+        "PrepareBuild",
+        "WriteRedProof",
+        "BuildIssue",
+        "AddEdgeProof",
+        "ReviewPr",
+        "RepairReview",
+        "VerifyCurrentHead",
+        "Merge",
+        "Reconcile",
+        "Blocked",
+        "Complete"
+      ]
+    },
+    "objective": {
+      "type": "string",
+      "description": "One bounded question or mutation objective.",
+      "minLength": 1
+    },
+    "read_scope": {
+      "type": "array",
+      "description": "Files, symbols, issues, specs, PRs, or external authorities the child may read.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "write_scope": {
+      "$ref": "#/definitions/write_scope"
+    },
+    "compiled_work_order": {
+      "$ref": "#/definitions/compiled_work_order"
+    },
+    "admission": {
+      "$ref": "#/definitions/admission"
+    },
+    "authorities": {
+      "type": "array",
+      "description": "Accepted sources that govern the bounded work. Labels and private conversation are not authorities.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "proof_obligations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "non_goals": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "stop_when": {
+      "type": "array",
+      "description": "Conditions that return control to the root instead of widening the packet.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "return_schema": {
+      "const": "bounded-subagent-result-v1"
+    }
+  },
+  "definitions": {
+    "basis": {
+      "type": "object",
+      "required": [
+        "issue",
+        "base_sha"
+      ],
+      "properties": {
+        "issue": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "pr": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "base_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,64}$"
+        },
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,64}$"
+        }
+      },
+      "dependencies": {
+        "pr": ["head_sha"],
+        "head_sha": ["pr"]
+      },
+      "additionalProperties": false
+    },
+    "write_scope": {
+      "type": "object",
+      "description": "The explicit mutation cage. Read-only briefs omit this property entirely.",
+      "required": [
+        "spec",
+        "branch",
+        "worktree",
+        "edit_cage"
+      ],
+      "properties": {
+        "spec": {
+          "type": "string",
+          "minLength": 1
+        },
+        "branch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "worktree": {
+          "type": "string",
+          "minLength": 1
+        },
+        "edit_cage": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "compiled_work_order": {
+      "type": "object",
+      "description": "A reference to #3983's current builder projection. It carries identities and links, not a duplicate spec.",
+      "required": [
+        "work_order_id",
+        "spec_ref",
+        "basis_sha",
+        "freshness",
+        "scope_ref",
+        "invariant_refs",
+        "proof_obligation_refs",
+        "latitude_ref",
+        "return_to_issue_refs"
+      ],
+      "properties": {
+        "work_order_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "spec_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "basis_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,64}$"
+        },
+        "freshness": {
+          "type": "string",
+          "enum": ["current", "stale", "not_proven"]
+        },
+        "scope_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "invariant_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "minItems": 1
+        },
+        "proof_obligation_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "minItems": 1
+        },
+        "latitude_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "return_to_issue_refs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "admission": {
+      "type": "object",
+      "description": "The #3982 writer-admission identity. The branch/worktree/edit cage remain explicit in write_scope.",
+      "required": ["admission_id", "outcome", "ownership_ref"],
+      "properties": {
+        "admission_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outcome": {
+          "type": "string",
+          "enum": ["ADMIT", "RESUME", "REUSE"]
+        },
+        "ownership_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "role": {
+            "const": "writer"
+          }
+        },
+        "required": ["role"]
+      },
+      "then": {
+        "required": ["write_scope", "compiled_work_order", "admission"],
+        "properties": {
+          "compiled_work_order": {
+            "properties": {
+              "freshness": {
+                "const": "current"
+              }
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "write_scope": false,
+          "admission": false
+        }
+      }
+    },
+    {
+      "if": {
+        "anyOf": [
+          {
+            "properties": {"role": {"const": "reviewer"}},
+            "required": ["role"]
+          },
+          {
+            "properties": {"lifecycle_action": {"const": "ReviewPr"}},
+            "required": ["lifecycle_action"]
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "basis": {
+            "required": ["pr", "head_sha"]
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false,
+  "examples": [
+    {
+      "schema": "bounded-subagent-brief-v1",
+      "work_item": "issue-1234",
+      "basis": {
+        "issue": 1234,
+        "base_sha": "0123456789abcdef"
+      },
+      "role": "explorer",
+      "lifecycle_action": "ResearchIssue",
+      "objective": "Identify the named ownership and current-head evidence for the supplied seam.",
+      "read_scope": [
+        "issue 1234",
+        "docs/reference/OWNERSHIP.md",
+        "current PR metadata"
+      ],
+      "authorities": [
+        "issue 1234",
+        "live GitHub PR state"
+      ],
+      "proof_obligations": [
+        "Cite each ownership claim and distinguish missing evidence."
+      ],
+      "non_goals": [
+        "Do not edit files or choose another issue."
+      ],
+      "stop_when": [
+        "The named seam is answered or the current head changes."
+      ],
+      "return_schema": "bounded-subagent-result-v1"
+    },
+    {
+      "schema": "bounded-subagent-brief-v1",
+      "work_item": "issue-1234-review",
+      "basis": {
+        "issue": 1234,
+        "pr": 5678,
+        "base_sha": "0123456789abcdef",
+        "head_sha": "89abcdef01234567"
+      },
+      "role": "reviewer",
+      "lifecycle_action": "ReviewPr",
+      "objective": "Review the exact published head for correctness and integration hazards.",
+      "read_scope": [
+        "PR 5678 at 89abcdef01234567",
+        "linked issue and compiled builder view",
+        "required checks"
+      ],
+      "authorities": [
+        "github:PR/5678@89abcdef01234567",
+        "issue 1234"
+      ],
+      "proof_obligations": [
+        "Bind every finding and proof reference to the inspected head."
+      ],
+      "non_goals": [
+        "Do not edit the branch or review a later head."
+      ],
+      "stop_when": [
+        "The PR head changes or the exact-head review is complete."
+      ],
+      "return_schema": "bounded-subagent-result-v1"
+    },
+    {
+      "schema": "bounded-subagent-brief-v1",
+      "work_item": "issue-1234",
+      "basis": {
+        "issue": 1234,
+        "pr": 5678,
+        "base_sha": "0123456789abcdef",
+        "head_sha": "89abcdef01234567"
+      },
+      "role": "writer",
+      "lifecycle_action": "BuildIssue",
+      "objective": "Implement only the accepted change in the compiled builder view.",
+      "read_scope": [
+        "issue 1234",
+        ".spec/1234-example/context.md",
+        ".spec/1234-example/acceptance.md"
+      ],
+      "write_scope": {
+        "spec": ".spec/1234-example",
+        "branch": "impl/1234-example",
+        "worktree": ".claude/worktrees/1234-example",
+        "edit_cage": "crates/example/src/example.rs and its focused tests"
+      },
+      "compiled_work_order": {
+        "work_order_id": "work-order-1234-v2",
+        "spec_ref": ".spec/1234-example/context.md",
+        "basis_sha": "0123456789abcdef",
+        "freshness": "current",
+        "scope_ref": ".spec/1234-example/context.md#scope",
+        "invariant_refs": [".spec/1234-example/acceptance.md#invariants"],
+        "proof_obligation_refs": [".spec/1234-example/acceptance.md#proof"],
+        "latitude_ref": ".spec/1234-example/context.md#latitude",
+        "return_to_issue_refs": [".spec/1234-example/context.md#return-conditions"]
+      },
+      "admission": {
+        "admission_id": "admission-1234-v1",
+        "outcome": "ADMIT",
+        "ownership_ref": "github:issue/1234#writer-admission"
+      },
+      "authorities": [
+        ".spec/1234-example",
+        "issue 1234"
+      ],
+      "proof_obligations": [
+        "Run the named focused tests and report the exact head."
+      ],
+      "non_goals": [
+        "Do not widen the API or repair unrelated failures."
+      ],
+      "stop_when": [
+        "The accepted premise changes or the edit cage is insufficient."
+      ],
+      "return_schema": "bounded-subagent-result-v1"
+    }
+  ]
+}

--- a/docs/swarm/source-syncs/2026-07-15-workspace-capabilities-bd3eb11b2.md
+++ b/docs/swarm/source-syncs/2026-07-15-workspace-capabilities-bd3eb11b2.md
@@ -1,0 +1,61 @@
+# Source Sync Receipt: 2026-07-15 workspace capability proof
+
+## Sync identity
+
+| Field | Value |
+|---|---|
+| Swarm repository | `perl-lsp-swarm` |
+| Pinned swarm cut | `sync/vscode-workspace-capabilities-cut-bd3eb11b2` |
+| Swarm cut SHA | `bd3eb11b221e18e9914c326326ee1515620bfae2` |
+| Target repository | `perl-lsp` |
+| Target base SHA | `2aefabe2d6c114864b5048fcb5d4c4302d3ddbf9` |
+| Target sync merge SHA | `fc6acaf513675042744c5de1066abc597d3aa79f` |
+| Merge parents | `2aefabe2d6c114864b5048fcb5d4c4302d3ddbf9`, `bd3eb11b221e18e9914c326326ee1515620bfae2` |
+| Direction | swarm → target, history-preserving complete-tree merge |
+
+## Modernization follow-up
+
+The pinned cut contains the exact-source trusted multi-root and genuinely
+untrusted workspace-host proof, normalized trust-mode handling, safe
+workspace-claim validation, and server artifact fingerprint receipts added
+after the prior modernization sync.
+
+## Exclusions
+
+The complete-tree difference from the pinned cut is limited to the approved
+target-owned or swarm-only exclusions:
+
+- `.claude/` restored from target `master`;
+- `scripts/agent-cleanup.ps1` removed;
+- `scripts/agent-preflight.ps1` removed;
+- `scripts/swarm-clean` removed;
+- target-owned sync ledgers retained under `docs/swarm/source-syncs/`.
+
+No per-file resolution was used for shared source files. Release-lineage
+documents remain governed by the target repository's sync protocol.
+
+## Verification
+
+The following checks are run against this sync tree before opening the target
+sync PR:
+
+```text
+git log -1 --format='%p'                 # exactly two parents
+git diff --name-only <swarm-cut>        # approved exclusions only
+cargo check --workspace --locked
+Node 26.5.0 / npm 11.18.0 doctor
+npm ci
+npm run fmt:check
+npm run lint                             # Oxlint 0 errors / 0 warnings
+npm run typecheck:all
+npm run compile
+npm run test:ci                           # current count recorded below
+npm run package
+npm run check:package-inventory
+npm run check:source-map
+npm run test:workspace-capabilities      # exact-source trusted multi-root/untrusted
+```
+
+The final target merge SHA and target-side receipt will be appended after the
+sync PR merges. This receipt does not authorize publishing, tagging,
+Marketplace or Open VSX upload, Docker publication, or release creation.

--- a/docs/swarm/source-syncs/2026-07-15-workspace-capabilities-bd3eb11b2.md
+++ b/docs/swarm/source-syncs/2026-07-15-workspace-capabilities-bd3eb11b2.md
@@ -36,7 +36,7 @@ documents remain governed by the target repository's sync protocol.
 
 ## Verification
 
-The following checks are run against this sync tree before opening the target
+The following checks passed against this sync tree before opening the target
 sync PR:
 
 ```text
@@ -49,13 +49,29 @@ npm run fmt:check
 npm run lint                             # Oxlint 0 errors / 0 warnings
 npm run typecheck:all
 npm run compile
-npm run test:ci                           # current count recorded below
+npm run test:ci                           # 794 passed, 1 documented skip
 npm run package
-npm run check:package-inventory
+npm run check:package-inventory           # 28 files, 1,472,504 bytes
 npm run check:source-map
 npm run test:workspace-capabilities      # exact-source trusted multi-root/untrusted
 ```
 
-The final target merge SHA and target-side receipt will be appended after the
-sync PR merges. This receipt does not authorize publishing, tagging,
+Observed results:
+
+- `cargo check --workspace --locked` passed.
+- Node 26.5.0/npm 11.18.0 doctor, Oxfmt, Oxlint (0 errors / 0 warnings), all
+  TS7 configurations, compile, test, package, inventory, and source-map checks
+  passed after clean `npm ci`.
+- Exact-source capability smoke passed in both modes on Windows with VS Code
+  1.128.1: trusted multi-root (2 folders) and genuinely untrusted single-root
+  (1 folder). Both receipts recorded initialize, provider requests, restart,
+  and shutdown as successful.
+- Target smoke source/server revision: `12bc6e16412dd73a10c109566b664bcae5b548f1`.
+- Target smoke server artifact SHA-256:
+  `2a08086218e81a52fdbd8c011972d416309e9cabd63fd7e323e5231cbe8b2074`.
+- Target smoke VSIX SHA-256:
+  `3df72e8e427fa690ac27b5b896a54098ea985cb3515c68b025d784f5f555bc9b`.
+
+The final target merge SHA will be appended after the sync PR merges. This
+receipt does not authorize publishing, tagging,
 Marketplace or Open VSX upload, Docker publication, or release creation.

--- a/vscode-extension/docs/migrations/workspace-capability-matrix.md
+++ b/vscode-extension/docs/migrations/workspace-capability-matrix.md
@@ -5,14 +5,14 @@ untrusted workspaces. The runtime now records a `workspace_topology.v1` object
 in client trust reports and first-hour receipts so those claims can be checked
 against the host state that was actually exercised.
 
-| Host/workspace mode        | Contract                                                                                  | Current evidence                               | Claim boundary                                                                |
-| -------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------- |
-| Trusted local single-root  | Supported                                                                                 | Exact-source smoke and topology contract tests | Exercises one file-backed folder                                              |
-| Trusted local multi-root   | Supported                                                                                 | Topology contract tests and receipt schema     | Does not yet replace a real multi-root host smoke                             |
-| Untrusted file workspace   | Supported with host restrictions                                                          | Topology contract tests record `untrusted`     | A local smoke launched with trust automation is not an untrusted-host receipt |
-| Virtual workspace/document | Degraded for file-backed operations; language-server document handling remains observable | URI classification tests                       | No claim that a local Rust process can start for every virtual host           |
-| Untitled Perl document     | Degraded for file-backed operations                                                       | Untitled URI classification tests              | No workspace-root path is invented                                            |
-| Remote workspace host      | Not promoted by local proof                                                               | Remote-host classification test                | Requires a scheduled real remote-host receipt                                 |
+| Host/workspace mode        | Contract                                                                                  | Current evidence                                 | Claim boundary                                                                        |
+| -------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| Trusted local single-root  | Supported                                                                                 | Exact-source smoke and topology contract tests   | Exercises one file-backed folder                                                      |
+| Trusted local multi-root   | Supported                                                                                 | Exact-source capability smoke and topology tests | Exercises two file-backed folders in a real host                                      |
+| Untrusted file workspace   | Supported with host restrictions                                                          | Exact-source capability smoke and topology tests | Exercises a genuinely untrusted file workspace; virtual/remote claims remain separate |
+| Virtual workspace/document | Degraded for file-backed operations; language-server document handling remains observable | URI classification tests                         | No claim that a local Rust process can start for every virtual host                   |
+| Untitled Perl document     | Degraded for file-backed operations                                                       | Untitled URI classification tests                | No workspace-root path is invented                                                    |
+| Remote workspace host      | Not promoted by local proof                                                               | Remote-host classification test                  | Requires a scheduled real remote-host receipt                                         |
 
 The classifier records workspace mode, trust state, host kind, folder count,
 URI schemes, untitled/virtual document counts, capability statuses, and

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1335,6 +1335,7 @@
     "test:integration": "npm run typecheck && npm run compile && tsc -p ./tsconfig.integration.json && node ./out/test/integration/runTest.js",
     "test:published": "tsc -p ./tsconfig.published-smoke.json && node ./out/test/published/runPublishedSmoke.js",
     "test:published:local": "node ./scripts/run-local-vsix-smoke.js",
+    "test:workspace-capabilities": "node ./scripts/run-workspace-capability-smoke.js",
     "bundle-lsp": "node ./scripts/bundle-lsp.js",
     "check:publisher-tools": "node scripts/check-publisher-tools.js",
     "package": "npm exec --offline --no -- @vscode/vsce package && npm run check:package-inventory",

--- a/vscode-extension/scripts/run-workspace-capability-smoke.js
+++ b/vscode-extension/scripts/run-workspace-capability-smoke.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const crypto = require('crypto');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const extensionRoot = path.resolve(__dirname, '..');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const serverPath = process.env.PERL_LSP_FIRST_HOUR_SERVER_PATH;
+const serverSha = process.env.PERL_LSP_SERVER_SOURCE_SHA;
+
+if (!serverPath || !fs.existsSync(serverPath) || !serverSha) {
+  throw new Error(
+    'PERL_LSP_FIRST_HOUR_SERVER_PATH and PERL_LSP_SERVER_SOURCE_SHA must identify the matching server build.',
+  );
+}
+const serverArtifactSha256 = crypto
+  .createHash('sha256')
+  .update(fs.readFileSync(serverPath))
+  .digest('hex');
+
+function writePerlFixture(directory, name) {
+  const fixturePath = path.join(directory, name);
+  fs.writeFileSync(fixturePath, 'use strict;\nuse warnings;\nprint "ok\\n";\n');
+}
+
+function runSmoke(label, workspace, expectedTrust, expectedMode, expectedFolderCount, trustMode) {
+  const result = spawnSync(npmCommand, ['run', 'test:published:local'], {
+    cwd: extensionRoot,
+    env: {
+      ...process.env,
+      PERL_LSP_SMOKE_WORKSPACE: workspace,
+      PERL_LSP_SMOKE_SOURCE_LABEL: label,
+      PERL_LSP_SERVER_ARTIFACT_SHA256: serverArtifactSha256,
+      PERL_LSP_SMOKE_WORKSPACE_TRUST: trustMode,
+      PERL_LSP_EXPECTED_WORKSPACE_TRUST: expectedTrust,
+      PERL_LSP_EXPECTED_WORKSPACE_MODE: expectedMode,
+      PERL_LSP_EXPECTED_FOLDER_COUNT: String(expectedFolderCount),
+    },
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+    windowsHide: true,
+  });
+  if (result.status !== 0) {
+    throw new Error(`${label} workspace capability smoke failed with exit ${result.status}`);
+  }
+}
+
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-workspace-capabilities-'));
+try {
+  const multiRoot = path.join(fixtureRoot, 'multi-root');
+  const multiRootA = path.join(multiRoot, 'workspace-a');
+  const multiRootB = path.join(multiRoot, 'workspace-b');
+  fs.mkdirSync(multiRootA, { recursive: true });
+  fs.mkdirSync(multiRootB, { recursive: true });
+  writePerlFixture(multiRootA, 'smoke.pl');
+  writePerlFixture(multiRootB, 'smoke.pl');
+  const descriptorPath = path.join(multiRoot, 'multi-root.code-workspace');
+  fs.writeFileSync(
+    descriptorPath,
+    `${JSON.stringify({ folders: [{ path: 'workspace-a' }, { path: 'workspace-b' }] }, null, 2)}\n`,
+  );
+
+  runSmoke('workspace-multi-root', descriptorPath, 'trusted', 'multi-root', 2, 'disabled');
+
+  const untrustedRoot = path.join(fixtureRoot, 'untrusted');
+  fs.mkdirSync(untrustedRoot, { recursive: true });
+  writePerlFixture(untrustedRoot, 'smoke.pl');
+  runSmoke('workspace-untrusted', untrustedRoot, 'untrusted', 'single-root', 1, 'untrusted');
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/vscode-extension/scripts/vsix-inventory-baseline.json
+++ b/vscode-extension/scripts/vsix-inventory-baseline.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
   "total_files": 28,
-  "total_bytes": 1472417,
+  "total_bytes": 1472504,
   "files": {
     "README.md": 21701,
-    "package.json": 53821,
+    "package.json": 53908,
     "LICENSE": 1069,
     "language-configuration.json": 1010,
     "icon.png": 8358,

--- a/vscode-extension/src/test/integration/firstHourReceipt.test.ts
+++ b/vscode-extension/src/test/integration/firstHourReceipt.test.ts
@@ -358,6 +358,34 @@ suite('First-hour VS Code receipt', function () {
         `extension must be loaded from the clean installed profile: ${extensionPath}`,
       );
     }
+    const topology = describeWorkspaceTopology({
+      folders: vscode.workspace.workspaceFolders ?? [],
+      documents: vscode.workspace.textDocuments,
+      isTrusted: vscode.workspace.isTrusted,
+      remoteName: vscode.env.remoteName,
+    });
+    const expectedMode = process.env.PERL_LSP_EXPECTED_WORKSPACE_MODE?.trim();
+    if (expectedMode) {
+      assert.equal(topology.mode, expectedMode, 'workspace smoke mode should match its claim');
+    }
+    const expectedTrust = process.env.PERL_LSP_EXPECTED_WORKSPACE_TRUST?.trim();
+    if (expectedTrust) {
+      assert.equal(topology.trust, expectedTrust, 'workspace smoke trust should match its claim');
+    }
+    const expectedFolderCount = process.env.PERL_LSP_EXPECTED_FOLDER_COUNT?.trim();
+    if (expectedFolderCount) {
+      const parsedFolderCount = Number(expectedFolderCount);
+      assert.ok(
+        Number.isSafeInteger(parsedFolderCount),
+        'workspace smoke folder count must be an integer',
+      );
+      assert.equal(
+        topology.folder_count,
+        parsedFolderCount,
+        'workspace smoke folder count should match its claim',
+      );
+    }
+
     const baseReceipt = {
       schema_version: 1,
       sample_count: 1,
@@ -378,16 +406,12 @@ suite('First-hour VS Code receipt', function () {
         server_path: serverPath,
         source_revision: process.env.PERL_LSP_CURRENT_SOURCE_SHA ?? null,
         server_source_revision: process.env.PERL_LSP_SERVER_SOURCE_SHA ?? null,
+        server_artifact_sha256: process.env.PERL_LSP_SERVER_ARTIFACT_SHA256 ?? null,
         vsix_sha256: process.env.PERL_LSP_VSIX_SHA256 ?? null,
       },
       workspace: {
         path: workspacePath,
-        topology: describeWorkspaceTopology({
-          folders: vscode.workspace.workspaceFolders ?? [],
-          documents: vscode.workspace.textDocuments,
-          isTrusted: vscode.workspace.isTrusted,
-          remoteName: vscode.env.remoteName,
-        }),
+        topology,
         file_count_sampled: walkFiles(workspacePath, 10_000).length,
         perl_file_count_sampled: perlFiles.length,
         module_under_probe: moduleName,

--- a/vscode-extension/src/test/integration/runTest.ts
+++ b/vscode-extension/src/test/integration/runTest.ts
@@ -2,8 +2,10 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { runTests } from '@vscode/test-electron';
+import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
 import { resolveVSCodeTestVersion } from '../vscodeHostVersion';
+import { runWithoutForcedWorkspaceTrust } from '../runVsCodeTests';
+import { workspaceSmokeLaunchArgs, workspaceSmokeTrustMode } from '../workspaceSmokeOptions';
 
 function toolchainNpmVersion(): string {
   const npmUserAgent = process.env.npm_config_user_agent ?? '';
@@ -39,10 +41,17 @@ async function main(): Promise<void> {
   const vscodeVersion = resolveVSCodeTestVersion(process.env.PERL_LSP_VSCODE_VERSION);
   const toolchainNodeVersion = process.version;
   const toolchainNpmVersionValue = toolchainNpmVersion();
-  const configuredWorkspace = process.env.PERL_LSP_SMOKE_WORKSPACE;
+  const configuredWorkspace = process.env.PERL_LSP_SMOKE_WORKSPACE?.trim();
+  const workspaceTrustMode = workspaceSmokeTrustMode();
+  const generatedWorkspacePath = configuredWorkspace
+    ? undefined
+    : fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-vscode-smoke-workspace-'));
   const workspacePath = configuredWorkspace
     ? path.resolve(configuredWorkspace)
-    : fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-vscode-smoke-workspace-'));
+    : generatedWorkspacePath!;
+  if (!fs.existsSync(workspacePath)) {
+    throw new Error(`Configured smoke workspace does not exist: ${workspacePath}`);
+  }
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-vscode-smoke-user-'));
   const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-vscode-smoke-extensions-'));
   const grep = getGrepArg(process.argv.slice(2));
@@ -51,52 +60,76 @@ async function main(): Promise<void> {
     path.join(repoRoot, 'target', 'receipts', 'vscode-smoke');
   fs.mkdirSync(receiptsRoot, { recursive: true });
 
-  if (!configuredWorkspace) {
-    fs.writeFileSync(
-      path.join(workspacePath, 'smoke.pl'),
-      'use strict;\nuse warnings;\nprint "ok\\n";\n',
-    );
-  }
+  try {
+    if (!configuredWorkspace) {
+      fs.writeFileSync(
+        path.join(workspacePath, 'smoke.pl'),
+        'use strict;\nuse warnings;\nprint "ok\\n";\n',
+      );
+    }
 
-  const configuredServerPath = process.env.PERL_LSP_FIRST_HOUR_SERVER_PATH;
-  if (configuredServerPath) {
-    const settingsDir = path.join(userDataDir, 'User');
-    fs.mkdirSync(settingsDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(settingsDir, 'settings.json'),
-      JSON.stringify(
-        {
-          'perl-lsp.autoDownload': false,
-          'perl-lsp.perlcritic.enabled': false,
-          'perl-lsp.serverPath': path.resolve(configuredServerPath),
-        },
-        null,
-        2,
-      ),
-    );
-  }
+    const configuredServerPath = process.env.PERL_LSP_FIRST_HOUR_SERVER_PATH;
+    if (configuredServerPath) {
+      const settingsDir = path.join(userDataDir, 'User');
+      fs.mkdirSync(settingsDir, { recursive: true });
+      const settings: Record<string, unknown> = {
+        'perl-lsp.autoDownload': false,
+        'perl-lsp.perlcritic.enabled': false,
+        'perl-lsp.serverPath': path.resolve(configuredServerPath),
+      };
+      if (workspaceTrustMode === 'untrusted') {
+        settings['security.workspace.trust.enabled'] = true;
+        settings['security.workspace.trust.startupPrompt'] = 'never';
+      }
+      fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify(settings, null, 2));
+    }
 
-  await runTests({
-    version: vscodeVersion,
-    extensionDevelopmentPath,
-    extensionTestsPath,
-    extensionTestsEnv: {
-      ...process.env,
-      PERL_LSP_EXTENSION_TEST_SKIP_STARTUP: process.env.PERL_LSP_EXTENSION_TEST_SKIP_STARTUP ?? '1',
-      PERL_LSP_SMOKE_RECEIPTS_DIR: receiptsRoot,
-      PERL_LSP_SMOKE_SOURCE_LABEL: process.env.PERL_LSP_SMOKE_SOURCE_LABEL || 'integration',
-      PERL_LSP_TOOLCHAIN_NODE_VERSION: toolchainNodeVersion,
-      PERL_LSP_TOOLCHAIN_NPM_VERSION: toolchainNpmVersionValue,
-      PERL_LSP_VSCODE_VERSION: vscodeVersion,
-      VSCODE_TEST_GREP: grep ?? '',
-    },
-    launchArgs: [
-      workspacePath,
-      '--disable-workspace-trust',
-      `--user-data-dir=${userDataDir}`,
-      `--extensions-dir=${extensionsDir}`,
-    ],
-  });
+    const testOptions = {
+      version: vscodeVersion,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      extensionTestsEnv: {
+        ...process.env,
+        PERL_LSP_EXTENSION_TEST_SKIP_STARTUP:
+          process.env.PERL_LSP_EXTENSION_TEST_SKIP_STARTUP ?? '1',
+        PERL_LSP_SMOKE_RECEIPTS_DIR: receiptsRoot,
+        PERL_LSP_SMOKE_SOURCE_LABEL: process.env.PERL_LSP_SMOKE_SOURCE_LABEL || 'integration',
+        PERL_LSP_TOOLCHAIN_NODE_VERSION: toolchainNodeVersion,
+        PERL_LSP_TOOLCHAIN_NPM_VERSION: toolchainNpmVersionValue,
+        PERL_LSP_VSCODE_VERSION: vscodeVersion,
+        VSCODE_TEST_GREP: grep ?? '',
+      },
+      launchArgs: [
+        ...workspaceSmokeLaunchArgs(workspacePath),
+        `--user-data-dir=${userDataDir}`,
+        `--extensions-dir=${extensionsDir}`,
+      ],
+    };
+    if (workspaceTrustMode === 'untrusted') {
+      const vscodeExecutablePath = await downloadAndUnzipVSCode({ version: vscodeVersion });
+      await runWithoutForcedWorkspaceTrust({
+        vscodeExecutablePath,
+        extensionDevelopmentPath,
+        extensionTestsPath,
+        extensionTestsEnv: testOptions.extensionTestsEnv,
+        launchArgs: testOptions.launchArgs,
+      });
+    } else {
+      await runTests(testOptions);
+    }
+  } finally {
+    for (const directory of [generatedWorkspacePath, userDataDir, extensionsDir]) {
+      if (!directory) {
+        continue;
+      }
+      try {
+        fs.rmSync(directory, { recursive: true, force: true });
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        process.stderr.write(`[integration-smoke] cleanup failed for ${directory}: ${message}\n`);
+      }
+    }
+  }
 }
 
 main().catch((error: unknown) => {

--- a/vscode-extension/src/test/published/runPublishedSmoke.ts
+++ b/vscode-extension/src/test/published/runPublishedSmoke.ts
@@ -9,6 +9,8 @@ import {
   runTests,
 } from '@vscode/test-electron';
 import { resolveVSCodeTestVersion } from '../vscodeHostVersion';
+import { runWithoutForcedWorkspaceTrust } from '../runVsCodeTests';
+import { workspaceSmokeLaunchArgs, workspaceSmokeTrustMode } from '../workspaceSmokeOptions';
 
 const EXTENSION_ID = 'EffortlessMetrics.perl-lsp-rs';
 
@@ -206,7 +208,11 @@ async function installExtension(
   throw new Error(`Failed to install published extension ${installTarget}\n${lastFailure}`);
 }
 
-function configureCurrentSourceSmoke(userDataDir: string, extensionsDir: string): void {
+function configureCurrentSourceSmoke(
+  userDataDir: string,
+  extensionsDir: string,
+  workspaceTrustMode: 'disabled' | 'untrusted',
+): void {
   const serverPath = envValue('PERL_LSP_FIRST_HOUR_SERVER_PATH');
   if (!serverPath) {
     return;
@@ -218,19 +224,17 @@ function configureCurrentSourceSmoke(userDataDir: string, extensionsDir: string)
 
   const settingsDir = path.join(userDataDir, 'User');
   fs.mkdirSync(settingsDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(settingsDir, 'settings.json'),
-    JSON.stringify(
-      {
-        'perl-lsp.autoDownload': false,
-        'perl-lsp.serverPath': path.resolve(serverPath),
-        'perl-lsp.includePaths': [],
-        'perl-lsp.critic.enabled': false,
-      },
-      null,
-      2,
-    ),
-  );
+  const settings: Record<string, unknown> = {
+    'perl-lsp.autoDownload': false,
+    'perl-lsp.serverPath': path.resolve(serverPath),
+    'perl-lsp.includePaths': [],
+    'perl-lsp.critic.enabled': false,
+  };
+  if (workspaceTrustMode === 'untrusted') {
+    settings['security.workspace.trust.enabled'] = true;
+    settings['security.workspace.trust.startupPrompt'] = 'never';
+  }
+  fs.writeFileSync(path.join(settingsDir, 'settings.json'), JSON.stringify(settings, null, 2));
   process.env.PERL_LSP_PUBLISHED_EXTENSIONS_DIR = extensionsDir;
 }
 
@@ -239,9 +243,17 @@ async function main(): Promise<void> {
   const vscodeVersion = resolveVSCodeTestVersion(process.env.PERL_LSP_VSCODE_VERSION);
   const toolchainNodeVersion = process.version;
   const toolchainNpmVersionValue = toolchainNpmVersion();
-  const workspacePath = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'perl-lsp-published-smoke-workspace-'),
-  );
+  const configuredWorkspace = envValue('PERL_LSP_SMOKE_WORKSPACE');
+  const workspaceTrustMode = workspaceSmokeTrustMode();
+  const generatedWorkspacePath = configuredWorkspace
+    ? undefined
+    : fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-published-smoke-workspace-'));
+  const workspacePath = configuredWorkspace
+    ? path.resolve(configuredWorkspace)
+    : generatedWorkspacePath!;
+  if (!fs.existsSync(workspacePath)) {
+    throw new Error(`Configured smoke workspace does not exist: ${workspacePath}`);
+  }
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perl-lsp-published-smoke-user-'));
   const extensionsDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'perl-lsp-published-smoke-extensions-'),
@@ -255,18 +267,20 @@ async function main(): Promise<void> {
     path.join(repoRoot, 'target', 'receipts', 'vscode-smoke');
   fs.mkdirSync(receiptsRoot, { recursive: true });
 
-  fs.writeFileSync(
-    path.join(workspacePath, 'smoke.pl'),
-    'use strict;\nuse warnings;\nprint "ok\\n";\n',
-  );
+  if (!configuredWorkspace) {
+    fs.writeFileSync(
+      path.join(workspacePath, 'smoke.pl'),
+      'use strict;\nuse warnings;\nprint "ok\\n";\n',
+    );
+  }
 
   try {
     const vscodeExecutablePath = await downloadAndUnzipVSCode({ version: vscodeVersion });
     const installTarget = await resolveInstallTarget(source, downloadDir);
-    configureCurrentSourceSmoke(userDataDir, extensionsDir);
+    configureCurrentSourceSmoke(userDataDir, extensionsDir, workspaceTrustMode);
     await installExtension(vscodeExecutablePath, installTarget, userDataDir, extensionsDir);
 
-    await runTests({
+    const testOptions = {
       vscodeExecutablePath,
       extensionDevelopmentPath: harnessExtensionPath,
       extensionTestsPath,
@@ -283,14 +297,21 @@ async function main(): Promise<void> {
         PERL_LSP_VSCODE_VERSION: vscodeVersion,
       },
       launchArgs: [
-        workspacePath,
-        '--disable-workspace-trust',
+        ...workspaceSmokeLaunchArgs(workspacePath),
         `--user-data-dir=${userDataDir}`,
         `--extensions-dir=${extensionsDir}`,
       ],
-    });
+    };
+    if (workspaceTrustMode === 'untrusted') {
+      await runWithoutForcedWorkspaceTrust(testOptions);
+    } else {
+      await runTests(testOptions);
+    }
   } finally {
-    for (const directory of [workspacePath, userDataDir, extensionsDir, downloadDir]) {
+    for (const directory of [generatedWorkspacePath, userDataDir, extensionsDir, downloadDir]) {
+      if (!directory) {
+        continue;
+      }
       try {
         fs.rmSync(directory, { recursive: true, force: true });
       } catch (error: unknown) {

--- a/vscode-extension/src/test/runVsCodeTests.ts
+++ b/vscode-extension/src/test/runVsCodeTests.ts
@@ -1,0 +1,42 @@
+import { spawn } from 'child_process';
+
+export interface UntrustedHostTestOptions {
+  vscodeExecutablePath: string;
+  extensionDevelopmentPath: string;
+  extensionTestsPath: string;
+  extensionTestsEnv: NodeJS.ProcessEnv;
+  launchArgs: string[];
+}
+
+/**
+ * Runs the extension host without the test-electron package's forced
+ * `--disable-workspace-trust` argument. This is intentionally test-only: the
+ * normal runner remains authoritative for every other smoke mode.
+ */
+export function runWithoutForcedWorkspaceTrust(options: UntrustedHostTestOptions): Promise<void> {
+  const args = [
+    ...options.launchArgs,
+    '--no-sandbox',
+    '--disable-gpu-sandbox',
+    '--disable-updates',
+    '--skip-welcome',
+    '--skip-release-notes',
+    `--extensionTestsPath=${options.extensionTestsPath}`,
+    `--extensionDevelopmentPath=${options.extensionDevelopmentPath}`,
+  ];
+  return new Promise((resolve, reject) => {
+    const child = spawn(options.vscodeExecutablePath, args, {
+      env: { ...process.env, ...options.extensionTestsEnv },
+      stdio: 'inherit',
+      windowsHide: true,
+    });
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`VS Code extension host exited with ${code ?? signal ?? 'unknown'}`));
+    });
+  });
+}

--- a/vscode-extension/src/test/workspaceSmokeOptions.test.ts
+++ b/vscode-extension/src/test/workspaceSmokeOptions.test.ts
@@ -1,0 +1,34 @@
+import { workspaceSmokeLaunchArgs } from './workspaceSmokeOptions';
+
+describe('workspace smoke launch options', () => {
+  const originalTrustMode = process.env.PERL_LSP_SMOKE_WORKSPACE_TRUST;
+
+  afterEach(() => {
+    if (originalTrustMode === undefined) {
+      delete process.env.PERL_LSP_SMOKE_WORKSPACE_TRUST;
+    } else {
+      process.env.PERL_LSP_SMOKE_WORKSPACE_TRUST = originalTrustMode;
+    }
+  });
+
+  test('keeps the existing trust-disabled default explicit', () => {
+    delete process.env.PERL_LSP_SMOKE_WORKSPACE_TRUST;
+
+    expect(workspaceSmokeLaunchArgs('workspace.code-workspace')).toEqual([
+      'workspace.code-workspace',
+      '--disable-workspace-trust',
+    ]);
+  });
+
+  test('can launch a genuinely untrusted workspace', () => {
+    process.env.PERL_LSP_SMOKE_WORKSPACE_TRUST = '  untrusted  ';
+
+    expect(workspaceSmokeLaunchArgs('workspace')).toEqual(['workspace']);
+  });
+
+  test('rejects an unknown trust mode instead of silently changing the claim', () => {
+    process.env.PERL_LSP_SMOKE_WORKSPACE_TRUST = 'maybe';
+
+    expect(() => workspaceSmokeLaunchArgs('workspace')).toThrow(/disabled or untrusted/);
+  });
+});

--- a/vscode-extension/src/test/workspaceSmokeOptions.ts
+++ b/vscode-extension/src/test/workspaceSmokeOptions.ts
@@ -1,0 +1,17 @@
+export type WorkspaceSmokeTrustMode = 'disabled' | 'untrusted';
+
+export function workspaceSmokeTrustMode(): WorkspaceSmokeTrustMode {
+  const trustMode = process.env.PERL_LSP_SMOKE_WORKSPACE_TRUST?.trim() || 'disabled';
+  if (trustMode === 'disabled' || trustMode === 'untrusted') {
+    return trustMode;
+  }
+  throw new Error(`PERL_LSP_SMOKE_WORKSPACE_TRUST must be disabled or untrusted, got ${trustMode}`);
+}
+
+export function workspaceSmokeLaunchArgs(workspacePath: string): string[] {
+  const trustMode = workspaceSmokeTrustMode();
+  if (trustMode === 'disabled') {
+    return [workspacePath, '--disable-workspace-trust'];
+  }
+  return [workspacePath];
+}


### PR DESCRIPTION
Problem: The target repository is missing the post-sync workspace capability proof that is now merged on swarm main.

Fix: Preserve the swarm cut as a two-parent complete-tree merge, retain target-owned `.claude` and release lineage, remove swarm-only cleanup scripts, and retain the sync ledger. The cut includes exact-source trusted multi-root and genuinely untrusted workspace smoke coverage plus Node 26/npm 11 toolchain proof.

Verification:
- sync merge `fc6acaf513675042744c5de1066abc597d3aa79f` has exactly two parents: target `2aefabe2d6c114864b5048fcb5d4c4302d3ddbf9` and swarm `bd3eb11b221e18e9914c326326ee1515620bfae2`
- `cargo check --workspace --locked` passes
- clean `npm ci`, doctor, fmt, Oxlint 0/0, all TS7 typechecks, compile, test:ci (794 passed, 1 documented skip), package, inventory, and source-map checks pass
- target exact-source smoke passes for trusted multi-root and genuinely untrusted single-root, including initialize, provider, restart, and shutdown

Claim boundary: This is a history-preserving source sync. It does not publish, tag, release, or upload artifacts.

Merge protocol: Do not squash this PR. The merge commit and both parent histories are the deliverable.