### PR TITLE
sync: finalize modernization closeout cut bdfde90d7 (#0000)

### DIFF
--- a/docs/swarm/source-syncs/2026-07-15-final-closeout-bdfde90d7.md
+++ b/docs/swarm/source-syncs/2026-07-15-final-closeout-bdfde90d7.md
@@ -1,0 +1,32 @@
+# Source Sync Receipt: 2026-07-15 final modernization closeout
+
+## Sync identity
+
+| Field | Value |
+|---|---|
+| Swarm repository | `perl-lsp-swarm` |
+| Pinned swarm cut | `sync/vscode-modernization-final-cut-bdfde90d7` |
+| Swarm cut SHA | `bdfde90d7e078f6e94d0acd946328c53fd55269b` |
+| Target repository | `perl-lsp` |
+| Target base SHA | `1240ccac4cd24aedef85bb03f76951b8cf72e46a` |
+| Target sync merge SHA | `496e8e6998c684156000f2e0f5b5ab13449de64c` |
+| Merge parents | `1240ccac4cd24aedef85bb03f76951b8cf72e46a`, `bdfde90d7e078f6e94d0acd946328c53fd55269b` |
+| Direction | swarm → target, history-preserving complete-tree merge |
+
+## Scope and proof
+
+This cut contains the final swarm closeout reconciliation: PR #4375 and the
+completed target sync PRs #10001/#10002 are now recorded as delivered, with
+the current 794-test and 1,472,504-byte package evidence. It is a
+documentation-only delta on top of the already-tested modernization cut.
+
+The previous target receipt
+`docs/swarm/source-syncs/2026-07-15-workspace-capabilities-bd3eb11b2.md`
+records the Node 26 extension gate, cargo check, package/source-map contracts,
+and exact-source trusted multi-root/untrusted host smoke. No implementation
+or generated package files changed in this final cut.
+
+The complete-tree difference from the pinned cut contains only the approved
+`.claude/`, swarm-only cleanup scripts, and target-owned sync-ledger paths.
+No per-file resolution was used for shared source files. This receipt does not
+authorize publishing, tagging, Docker publication, or release creation.

--- a/vscode-extension/docs/migrations/lane-closeout.md
+++ b/vscode-extension/docs/migrations/lane-closeout.md
@@ -1,12 +1,13 @@
 # VS Code client/toolchain modernization lane closeout
 
-Status: implementation hardening is current on `main`; cross-repository sync is
-REMAINING. This reconciliation supersedes the earlier premature sync claim and
-records the remaining handoff boundary.
+Status: implementation hardening and the first history-preserving
+cross-repository sync are complete on `main`. The synchronized code cut is
+recorded in target PR [#10001](https://github.com/EffortlessMetrics/perl-lsp/pull/10001)
+and the final target ledger is maintained in `perl-lsp`.
 
-This closeout records the reviewable PR trail and the evidence boundary for
-the modernization lane. It does not publish, tag, release, or synchronize this
-repository; the two-parent history-preserving sync remains a later operation.
+This closeout records the reviewable PR trail, the evidence boundary, and the
+completed handoff for the modernization lane. It does not publish, tag, or
+release either repository.
 
 ## Delivered PR trail
 
@@ -63,6 +64,7 @@ repository; the two-parent history-preserving sync remains a later operation.
 | #4302 | Typed POD preview contract                           | Merged |
 | #4333 | VS Code host-floor compatibility proof               | Merged |
 | #4335 | Workspace topology capability receipts               | Merged |
+| #4375 | Workspace capability host-mode proof                  | Merged |
 | #4336 | Bundle source-map evidence archive                   | Merged |
 | #4338 | Feature activation timing attribution                | Merged |
 | #4339 | Server command composition                           | Merged |
@@ -124,14 +126,20 @@ npm run test:ci
 ```
 
 The focused downloader run passed 113 tests; the latest full extension gate on
-the current hardening head passed 791 tests with one documented packaged-server
+the current hardening head passed 794 tests with one documented packaged-server
 skip. The focused command-composition slices add isolated delegation and
 disposal proof for the server, critic, test, onboarding, navigation,
 diagnostic, document, refactoring, and support groups. The final package
-evidence contains 28 inventoried files, 1,472,417 bytes total, and a
+evidence contains 28 inventoried files, 1,472,504 bytes total, and a
 1,314,887-byte bundle; the inventory and source-map checks pass. These checks prove the
 exercised behavior and packaging paths; they do not establish a performance
 budget or prove every platform-specific release condition.
+
+The workspace capability proof also records exact-source Windows host receipts
+for trusted multi-root workspaces (two folders) and genuinely untrusted
+single-root workspaces (one folder), including initialization, provider,
+restart, and shutdown. Receipts retain separate Git source identity and server
+artifact SHA-256 fields.
 
 PR #4042's required routed Rust result was merged through the maintainer
 override path because both routed attempts failed in the unchanged
@@ -143,14 +151,16 @@ was kept as a separate workflow PR.
 
 ## Handoff and release boundary
 
-The modernization implementation has not yet been synchronized into
-`perl-lsp`. No immutable sync cut, target synchronization merge, or target
-sync ledger exists for this current history. The next handoff must pin the
-tested `swarm/main` SHA, rerun the final extension/workspace proofs against
-that cut, and then use the documented two-parent complete-tree merge with the
-target-repository exclusions rather than an opaque content-state snapshot.
+The reviewed implementation cut `bd3eb11b221e18e9914c326326ee1515620bfae2`
+was pinned, tested, and synchronized into `perl-lsp` through target PR #10001.
+Its two-parent target merge is `90d6fb5614841a621a5950e0f9b92044406320a8`,
+with the target-owned `.claude/`, swarm-only cleanup scripts, and sync ledgers
+as the only approved tree differences. The exact ancestry and tree audit are
+recorded in `perl-lsp/docs/swarm/source-syncs/2026-07-15-workspace-capabilities-bd3eb11b2.md`.
+The final target ledger update merged as target PR #10002.
+
 Issue #4120 was closed by merged PR #4121; that historical issue state does not
-mean the current swarm history has already been synchronized.
+change the current Node 26/npm 11 authority.
 
 No publish, tag, or release operation has been performed. Historical receipts
 retain the toolchain versions they actually tested; current development and


### PR DESCRIPTION
Problem: The final swarm closeout reconciliation landed after target PR #10001, leaving the target one documentation slice behind the current source-of-truth history.

Fix: Preserve the final closeout as a two-parent complete-tree sync. The delta is documentation-only and adds the final target sync ledger; no implementation or generated package files changed.

Verification:
- sync merge `496e8e6998c684156000f2e0f5b5ab13449de64c` has parents target `1240ccac4cd24aedef85bb03f76951b8cf72e46a` and swarm `bdfde90d7e078f6e94d0acd946328c53fd55269b`
- `git diff --check` passes
- tree difference is limited to approved `.claude/`, swarm cleanup, and sync-ledger paths

Merge protocol: Do not squash. Preserve the two-parent merge commit.